### PR TITLE
Release 0.1.0-prealpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🛠 Maintenance
 ## 📚 Documentation -->
 
+# [v0.1.0-prealpha.4] 2021-11-05
+
+## :rocket: Features
+
+- **An updated `CHANGELOG.md`!**
+
+  As we build out the base functionality for the router, we haven't spent much time updating the `CHANGELOG`.  We should probably get better at that!
+
+## :bug: Fixes
+
+- **Potentially, many!**
+
+  But the lack of clarity goes back to not having kept track of everything thus far!  We can _fix_ our processes to keep track of these things! :smile_cat:
 
 # [0.1.0] - TBA
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,7 +66,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "0.1.0-prealpha.3"
+version = "0.1.0-prealpha.4"
 dependencies = [
  "anyhow",
  "apollo-router-core",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-core"
-version = "0.1.0-prealpha.3"
+version = "0.1.0-prealpha.4"
 dependencies = [
  "apollo-parser",
  "async-trait",

--- a/crates/apollo-router-core/Cargo.toml
+++ b/crates/apollo-router-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-core"
-version = "0.1.0-prealpha.3"
+version = "0.1.0-prealpha.4"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2018"
 license-file = "./LICENSE"

--- a/crates/apollo-router/Cargo.toml
+++ b/crates/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "0.1.0-prealpha.3"
+version = "0.1.0-prealpha.4"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2018"
 license-file = "./LICENSE"


### PR DESCRIPTION
# [v0.1.0-prealpha.4] 2021-11-05

## :rocket: Features

- **An updated `CHANGELOG.md`!**

  As we build out the base functionality for the router, we haven't spent much time updating the `CHANGELOG`.  We should probably get better at that!

## :bug: Fixes

- **Potentially, many!**

  But the lack of clarity goes back to not having kept track of everything thus far!  We can _fix_ our processes to keep track of these things! :smile_cat: