### PR TITLE
feat: provide -s or --supergraph to the router cli.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It can already perform queries though, so we'd welcome experiments and feedback 
 ## Usage
 
 Apollo Federation Router requires `configuration.yaml` and `supergraph.graphql`
-to be supplied.  These are either located in the current directory or explicitly
+to be supplied. These are either located in the current directory or explicitly
 specified via flag, either by an absolute path, or a path relative to the current
 directory.
 
@@ -20,9 +20,8 @@ directory.
 OPTIONS:
     -c, --config <configuration-path>    Configuration file location [env:
                                          CONFIGURATION_PATH=]
-    -s, --schema <schema-path>           Schema location [env: SCHEMA_PATH=]
+    -s, --supergraph <supergraph-path>   Supergraph Schema location [env: SUPERGRAPH_PATH=]
 ```
-
 
 This CLI is not meant to be a long term thing, as users will likely use Rover
 to start the server in future.

--- a/crates/apollo-router/src/main.rs
+++ b/crates/apollo-router/src/main.rs
@@ -29,8 +29,8 @@ struct Opt {
     configuration_path: PathBuf,
 
     /// Schema location relative to the project directory.
-    #[structopt(long = "schema", parse(from_os_str), env)]
-    schema_path: PathBuf,
+    #[structopt(short, long = "supergraph", parse(from_os_str), env)]
+    supergraph_path: PathBuf,
 }
 
 /// Wrapper so that structop can display the default config path in the help message.
@@ -95,14 +95,14 @@ async fn main() -> Result<()> {
         delay: None,
     };
 
-    let schema_path = if opt.schema_path.is_relative() {
-        current_directory.join(opt.schema_path)
+    let supergraph_path = if opt.supergraph_path.is_relative() {
+        current_directory.join(opt.supergraph_path)
     } else {
-        opt.schema_path
+        opt.supergraph_path
     };
 
     let schema = SchemaKind::File {
-        path: schema_path,
+        path: supergraph_path,
         watch: opt.watch,
         delay: None,
     };

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -17,7 +17,7 @@ cargo install apollo-router
 ## Usage
 
 Apollo Federation Router requires `configuration.yaml` and `supergraph.graphql`
-to be supplied.  These are either located in the current directory or explicitly
+to be supplied. These are either located in the current directory or explicitly
 specified via flag, either by an absolute path, or a path relative to the current
 directory.
 
@@ -25,9 +25,8 @@ directory.
 OPTIONS:
     -c, --config <configuration-path>    Configuration file location [env:
                                          CONFIGURATION_PATH=]
-    -s, --schema <schema-path>           Schema location [env: SCHEMA_PATH=]
+    -s, --supergraph <supergraph-path>   Supergraph Schema location [env: SUPERGRAPH_PATH=]
 ```
-
 
 ### Configuration file
 
@@ -59,14 +58,14 @@ The `schema` argument is the supergraph that will be exposed by the router, it i
 
 To learn how to compose your supergraph schema with the Rover CLI, see the [Federation quickstart](https://www.apollographql.com/docs/federation/quickstart/#3-compose-the-supergraph-schema).
 
-> 🚧 For now, the router requires the supergraph to be generated separately. In the future, it might be possible to start a router with the right schema directly from Rover
+> 🚧 For now, the router requires the supergraph to be generated separately. In the future, it might be possible to start a router with the right supergraph schema directly from Rover
 
 ## Launching the router
 
 Once the configuration file and supergraph are written, start the router:
 
 ```
-$ apollo-router -c configuration.yaml --schema supergraph.graphql
+$ apollo-router -c configuration.yaml --s supergraph.graphql
 Oct 20 12:11:05.128  INFO router: Starting Apollo Federation
 Oct 20 12:11:05.581  INFO router: Listening on http://127.0.0.1:4100 🚀
 ```


### PR DESCRIPTION
Renamed --schema to --supergraph. Accept the -s shorthand for the cli.