### PR TITLE
Cache the parsed query

### DIFF
--- a/crates/apollo-router-core/Cargo.toml
+++ b/crates/apollo-router-core/Cargo.toml
@@ -10,9 +10,6 @@ license-file = "./LICENSE"
 # the data of a subgraph. This is useful in development as you want to be
 # alerted early when something is wrong instead of receiving an invalid result.
 failfast = []
-# activates the response post-processing feature. It is deactivated by default
-# until we solve performance issues
-post-processing = []
 
 [dependencies]
 apollo-parser = { git = "https://github.com/apollographql/apollo-rs.git", rev = "14bb84337a8bacd5cd27d7d7df429936f104b63b" }

--- a/crates/apollo-router-core/src/federated.rs
+++ b/crates/apollo-router-core/src/federated.rs
@@ -108,7 +108,7 @@ impl Fetcher for FederatedGraph {
 
         Box::pin(
             async move {
-                let (plan, operations, fragments) = {
+                let (plan, mut operations, fragments) = {
                     match query_planner
                         .get(
                             request.query.as_str().to_owned(),
@@ -187,12 +187,22 @@ impl Fetcher for FederatedGraph {
                             .expect("todo: how to prove?")
                             .into_inner();
 
+                    
                         #[cfg(feature = "post-processing")]
-                        tracing::debug_span!("format_response").in_scope(|| {
-                            request
-                                .query
-                                .format_response(&mut response, &operations, &fragments)
-                        });
+                        {
+                            let operation = match &request.operation_name {
+                                // operations is never empty
+                                None => operations.remove(0),
+                                Some(name) => operations.drain(..).find(|op| op.name.as_deref() == Some(name)).expect("the query plan was already validated, if there's no operation name there's a query shorthand, while if there are named queries there's an operation name"),
+                            };
+                            
+                            
+                            tracing::info_span!("format_response").in_scope(|| {
+                                request
+                                    .query
+                                    .format_response(&mut response, operation, &fragments)
+                            });
+                        }
 
                         response
                     }

--- a/crates/apollo-router-core/src/federated.rs
+++ b/crates/apollo-router-core/src/federated.rs
@@ -188,8 +188,11 @@ impl Fetcher for FederatedGraph {
                             .into_inner();
 
                         #[cfg(feature = "post-processing")]
-                        tracing::debug_span!("format_response")
-                            .in_scope(|| request.query.format_response(&mut response));
+                        tracing::debug_span!("format_response").in_scope(|| {
+                            request
+                                .query
+                                .format_response(&mut response, &operations, &fragments)
+                        });
 
                         response
                     }

--- a/crates/apollo-router-core/src/federated.rs
+++ b/crates/apollo-router-core/src/federated.rs
@@ -187,22 +187,17 @@ impl Fetcher for FederatedGraph {
                             .expect("todo: how to prove?")
                             .into_inner();
 
-                    
-                        #[cfg(feature = "post-processing")]
-                        {
-                            let operation = match &request.operation_name {
-                                // operations is never empty
-                                None => operations.remove(0),
-                                Some(name) => operations.drain(..).find(|op| op.name.as_deref() == Some(name)).expect("the query plan was already validated, if there's no operation name there's a query shorthand, while if there are named queries there's an operation name"),
-                            };
-                            
-                            
-                            tracing::info_span!("format_response").in_scope(|| {
-                                request
-                                    .query
-                                    .format_response(&mut response, operation, &fragments)
-                            });
-                        }
+                        let operation = match &request.operation_name {
+                            // operations is never empty
+                            None => operations.remove(0),
+                            Some(name) => operations.drain(..).find(|op| op.name.as_deref() == Some(name)).expect("the query plan was already validated, if there's no operation name there's a query shorthand, while if there are named queries there's an operation name"),
+                        };
+
+                        tracing::info_span!("format_response").in_scope(|| {
+                            request
+                                .query
+                                .format_response(&mut response, operation, &fragments)
+                        });
 
                         response
                     }

--- a/crates/apollo-router-core/src/query_planner/model.rs
+++ b/crates/apollo-router-core/src/query_planner/model.rs
@@ -3,6 +3,8 @@
 //!
 //! QueryPlans are a set of operations that describe how a federated query is processed.
 
+use std::collections::HashMap;
+
 use crate::prelude::graphql::*;
 use apollo_parser::ast;
 use serde::{Deserialize, Serialize};
@@ -46,7 +48,7 @@ pub struct QueryPlan {
     pub operations: Vec<Operation>,
     // list of fragments to apply on the final response
     #[serde(default)]
-    pub fragments: Vec<Fragment>,
+    pub fragments: HashMap<String, Fragment>,
 }
 
 /// Query plans are composed of a set of nodes.
@@ -280,8 +282,8 @@ impl From<ast::FragmentSpread> for FragmentSpread {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Operation {
-    name: Option<String>,
-    selection_set: SelectionSet,
+    pub name: Option<String>,
+    pub selection_set: SelectionSet,
 }
 
 impl From<ast::OperationDefinition> for Operation {
@@ -298,7 +300,7 @@ impl From<ast::OperationDefinition> for Operation {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SelectionSet {
-    selections: Vec<Selection>,
+    pub selections: Vec<Selection>,
 }
 
 impl From<ast::SelectionSet> for SelectionSet {

--- a/crates/apollo-router-core/src/query_planner/model.rs
+++ b/crates/apollo-router-core/src/query_planner/model.rs
@@ -45,9 +45,11 @@ pub struct QueryPlan {
     pub node: Option<PlanNode>,
     // list of operations to apply on the final response
     #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub operations: Vec<Operation>,
     // list of fragments to apply on the final response
     #[serde(default)]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub fragments: HashMap<String, Fragment>,
 }
 
@@ -455,7 +457,7 @@ mod tests {
                     }]
             }),
             operations: Vec::new(),
-            fragments: Vec::new(),
+            fragments: HashMap::new(),
         }
     }
 

--- a/crates/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
+++ b/crates/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
@@ -133,17 +133,13 @@ mod tests {
             )
             .await;
         assert_eq!(
-            QueryPlan {
-                node: Some(PlanNode::Fetch(FetchNode {
-                    service_name: "accounts".into(),
-                    requires: None,
-                    variable_usages: vec![],
-                    operation: "{me{name{first last}}}".into()
-                })),
-                operations: Vec::new(),
-                fragments: Vec::new(),
-            },
-            result.unwrap()
+            Some(PlanNode::Fetch(FetchNode {
+                service_name: "accounts".into(),
+                requires: None,
+                variable_usages: vec![],
+                operation: "{me{name{first last}}}".into()
+            })),
+            result.unwrap().node
         );
     }
 

--- a/crates/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
+++ b/crates/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
@@ -1,6 +1,6 @@
 //! Calls out to nodejs query planner
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use crate::prelude::graphql::*;
 use apollo_parser::ast;
@@ -43,7 +43,7 @@ impl QueryPlanner for RouterBridgeQueryPlanner {
             let mut query_plan = QueryPlan {
                 node: js_query_plan.node,
                 operations: Vec::new(),
-                fragments: Vec::new(),
+                fragments: HashMap::new(),
             };
 
             let parser = apollo_parser::Parser::new(&query);
@@ -67,7 +67,10 @@ impl QueryPlanner for RouterBridgeQueryPlanner {
                         query_plan.operations.push(operation.into());
                     }
                     ast::Definition::FragmentDefinition(fragment_definition) => {
-                        query_plan.fragments.push(fragment_definition.into());
+                        let fragment: Fragment = fragment_definition.into();
+                        query_plan
+                            .fragments
+                            .insert(fragment.fragment_name.clone(), fragment);
                     }
                     _ => {}
                 }

--- a/crates/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
+++ b/crates/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
@@ -33,7 +33,7 @@ impl QueryPlanner for RouterBridgeQueryPlanner {
         let context = plan::OperationalContext {
             schema: self.schema.as_str().to_string(),
             query: query.clone(),
-            operation_name: operation.unwrap_or_default(),
+            operation_name: operation.clone().unwrap_or_default(),
         };
 
         let schema = self.schema.as_str().to_string();
@@ -62,14 +62,11 @@ impl QueryPlanner for RouterBridgeQueryPlanner {
 
             let document = schema_tree.document();
             for definition in document.definitions() {
-                match definition {
-                    ast::Definition::FragmentDefinition(fragment_definition) => {
-                        let fragment: Fragment = fragment_definition.into();
-                        query_plan
-                            .fragments
-                            .insert(fragment.fragment_name.clone(), fragment);
-                    }
-                    _ => {}
+                if let ast::Definition::FragmentDefinition(fragment_definition) = definition {
+                    let fragment: Fragment = fragment_definition.into();
+                    query_plan
+                        .fragments
+                        .insert(fragment.fragment_name.clone(), fragment);
                 }
             }
 

--- a/crates/apollo-router-core/src/request.rs
+++ b/crates/apollo-router-core/src/request.rs
@@ -449,4 +449,34 @@ mod tests {
             }}
         );
     }
+
+    #[test]
+    fn field_ordering() {
+        let query = Query::from(
+            r#"{
+                identifiant: id
+                reviews { body }
+                id
+            }"#,
+        );
+        let mut response = Response::builder()
+            .data(json! {{
+                "id": "1",
+                "reviews": {"body": "awesome"},
+                "identifiant": "1",
+
+            }})
+            .build();
+        let (mut operations, fragments) = fragments_and_operations(&query.string);
+
+        query.format_response(&mut response, operations.remove(0), &fragments);
+        assert_eq_and_ordered!(
+            response.data,
+            json! {{
+                "identifiant": "1",
+                "reviews": {"body": "awesome"},
+                "id": "1",
+            }},
+        );
+    }
 }

--- a/crates/apollo-router-core/src/response.rs
+++ b/crates/apollo-router-core/src/response.rs
@@ -128,6 +128,9 @@ fn select_object(
                     output.append(&mut value.to_owned())
                 }
             }
+            Selection::FragmentSpread(_fragment) => {
+                unimplemented!("do we get in a case where it is used in the router?")
+            }
         };
     }
     if output.is_empty() {


### PR DESCRIPTION
fix #100

This pregenerates the selection sets and fragments from the query, during the query planning phase, so they can be cached and reused during response formatting.

TODO:
- [ ] fix missing unwraps
- [ ] fix some weird error when communicating with the JS. I guess it's linked to deserialization? https://github.com/apollographql/router/compare/cache-the-parsed-query?expand=1#diff-6c99c7a1d88dc1e9d7ff05e00cc0c3af250c8b14644502779313f360a854d2daR20
- [x] fragments can be defined in the supergraph (this is the most common case) so fragments definition should be obtained from there too, not only in the query
- [x] we should check the operation name, to apply the correct selection set (a query can contain multiple operations)
- [ ] there's a lot of copies and allocations that could be removed
- [ ] should the query planner return a `Arc<QueryPlan>`? This would allow us to cache things more efficiently, maybe?