### PR TITLE
docs: Add `netlify.toml` at the root of the repository

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,19 @@
+[build]
+  base    = "docs"
+  publish = "public"
+  command = "gatsby build"
+  # Netlify tries to short-circuit when the build hasn't changed, but it's
+  # presently wrong.  I would encourage removing this eventually, but for now,
+  # we'll check to see if `/bin/false` returns true (it won't) as a gauge.
+  ignore  = "/bin/false"
+[build.environment]
+  NODE_VERSION = "14"
+  NPM_VERSION  = "7"
+[context.production.environment]
+  PREFIX_PATHS = "true"
+[context.branch-deploy.environment]
+  PREFIX_PATHS = "true"
+[dev]
+  command = "npm run build"
+[context.dev.environment]
+  SKIP_INDEXING = "false"


### PR DESCRIPTION
This takes care of setting the production flag that enables path-prefixing
on the production build (whereas that doesn't happen in Netlify Previews or
locally).

Same pattern as used on the [`federation` repo], including the Node.js and
npm versions!

[`federation` repo]: https://github.com/apollographql/federation/blob/f47fd85d0b280ac26f86246c14c547ab2be68f6b/netlify.toml