### PR TITLE
Re-enable integration tests in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,7 +209,7 @@ jobs:
 
       - run:
           command: >
-            cargo xtask test
+            cargo xtask test --with-demo
       - run:
           command: >
             cargo xtask lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -205,7 +205,7 @@ jobs:
                 background: true
             - run:
                 name: wait for federation demo to start
-                command: npx wait-on tcp:4001 tcp:4002 tcp:4003 tcp:4004 tcp:4000
+                command: npx wait-on tcp:4001 tcp:4002 tcp:4003 tcp:4004 tcp:4100
 
       - run:
           command: >

--- a/crates/apollo-router/Cargo.toml
+++ b/crates/apollo-router/Cargo.toml
@@ -64,6 +64,7 @@ warp = { version = "0.3.2", default-features = false, features = [
 ] }
 
 [dev-dependencies]
+apollo-router-core = { path = "../apollo-router-core", features = ["post-processing"] }
 httpmock = "0.6.2"
 insta = "1.8.0"
 maplit = "1.0.2"

--- a/crates/apollo-router/tests/integration_tests.rs
+++ b/crates/apollo-router/tests/integration_tests.rs
@@ -150,7 +150,7 @@ async fn missing_variables() {
 
 async fn query_node(request: graphql::Request) -> graphql::ResponseStream {
     let nodejs_impl =
-        HttpSubgraphFetcher::new("federated".into(), "http://localhost:4000/graphql".into());
+        HttpSubgraphFetcher::new("federated".into(), "http://localhost:4100/graphql".into());
     nodejs_impl.stream(request).await
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   services:
     build: dockerfiles/federation-demo
     ports:
+      - 4100:4100
       - 4001:4001
       - 4002:4002
       - 4003:4003

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -46,7 +46,6 @@ impl Test {
             eprintln!("Running tests with features: {}", features.join(", "));
             cargo!(
                 ["test", "--workspace", "--locked", "--no-default-features"],
-                ["--features", "apollo-router-core/post-processing"],
                 features.iter().flat_map(|feature| ["--features", feature]),
             );
         }

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use structopt::StructOpt;
 use xtask::*;
 
@@ -12,13 +12,22 @@ const FEATURE_SETS: &[&[&str]] = &[
 
 #[derive(Debug, StructOpt)]
 pub struct Test {
-    /// Do not start federation demo.
-    #[structopt(long)]
+    /// Do not start federation demo (deprecated, this is the default now).
+    #[structopt(long, conflicts_with = "with-demo")]
     no_demo: bool,
+
+    /// Do start the federation demo (without docker).
+    #[structopt(long, conflicts_with = "no-demo")]
+    with_demo: bool,
 }
 
 impl Test {
     pub fn run(&self) -> Result<()> {
+        ensure!(
+            !(self.no_demo && self.with_demo),
+            "--no-demo and --with-demo are mutually exclusive",
+        );
+
         // NOTE: it worked nicely on GitHub Actions but it hangs on CircleCI on Windows
         let _guard: Box<dyn std::any::Any> = if !std::env::var("CIRCLECI")
             .ok()
@@ -29,7 +38,10 @@ impl Test {
             eprintln!("Not running federation-demo because it makes the step hang on Circle CI.");
             Box::new(())
         } else if self.no_demo {
-            eprintln!("Not running federation-demo as requested.");
+            eprintln!("Flag --no-demo is the default now. Not running federation-demo.");
+            Box::new(())
+        } else if !self.with_demo {
+            eprintln!("Not running federation-demo.");
             Box::new(())
         } else {
             let demo = FederationDemoRunner::new()?;

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -46,6 +46,7 @@ impl Test {
             eprintln!("Running tests with features: {}", features.join(", "));
             cargo!(
                 ["test", "--workspace", "--locked", "--no-default-features"],
+                ["--features", "apollo-router-core/post-processing"],
                 features.iter().flat_map(|feature| ["--features", feature]),
             );
         }

--- a/xtask/src/federation_demo.rs
+++ b/xtask/src/federation_demo.rs
@@ -33,7 +33,7 @@ impl FederationDemoRunner {
 
         eprintln!("Waiting for service to be ready...");
         loop {
-            match reqwest::blocking::get("http://localhost:4000/graphql") {
+            match reqwest::blocking::get("http://localhost:4100/graphql") {
                 Ok(_) => break,
                 Err(err) => eprintln!("{}", err),
             }


### PR DESCRIPTION
The integration tests have been disabled by #99 and broke (locally) by #111.