### PR TITLE
docs: change protocol for localhost example

### DIFF
--- a/docs/source/configuration.mdx
+++ b/docs/source/configuration.mdx
@@ -42,7 +42,6 @@ To learn how to compose your supergraph schema with the Rover CLI, see the [Fede
 </td>
 </tr>
 
-
 <tr>
 <td style="min-width: 150px;">
 
@@ -76,7 +75,7 @@ server:
   cors:
     origins:
       - https://studio.apollographql.com
-      - https://localhost
+      - http://localhost
 ```
 
 ## Configuration file


### PR DESCRIPTION
Docs contained `https` for `localhost` rather than the more common `http` in the CORS origins