### PR TITLE
chore: bump federation and apollo_parser dependencies.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 [[package]]
 name = "apollo-parser"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/apollo-rs.git?rev=14bb84337a8bacd5cd27d7d7df429936f104b63b#14bb84337a8bacd5cd27d7d7df429936f104b63b"
+source = "git+https://github.com/apollographql/apollo-rs.git?rev=2435c81798502813a7fd26da44e3b6ae6e9ee27e#2435c81798502813a7fd26da44e3b6ae6e9ee27e"
 dependencies = [
  "rowan",
 ]
@@ -2834,7 +2834,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation.git?rev=1ffecef9ef52f6dc127939cdc375f0465774f093#1ffecef9ef52f6dc127939cdc375f0465774f093"
+source = "git+https://github.com/apollographql/federation.git?rev=3aa8f3a533f19e31ab984c87a0674ec78c42ebb6#3aa8f3a533f19e31ab984c87a0674ec78c42ebb6"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/crates/apollo-router-core/Cargo.toml
+++ b/crates/apollo-router-core/Cargo.toml
@@ -15,7 +15,7 @@ failfast = []
 post-processing = []
 
 [dependencies]
-apollo-parser = { git = "https://github.com/apollographql/apollo-rs.git", rev = "14bb84337a8bacd5cd27d7d7df429936f104b63b" }
+apollo-parser = { git = "https://github.com/apollographql/apollo-rs.git", rev = "2435c81798502813a7fd26da44e3b6ae6e9ee27e" }
 async-trait = "0.1.51"
 derivative = "2.2.0"
 displaydoc = "0.2"
@@ -23,7 +23,7 @@ futures = "0.3.17"
 include_dir = "0.6.2"
 once_cell = "1.8.0"
 parking_lot = "0.11.2"
-router-bridge = { git = "https://github.com/apollographql/federation.git", rev = "1ffecef9ef52f6dc127939cdc375f0465774f093" }
+router-bridge = { git = "https://github.com/apollographql/federation.git", rev = "3aa8f3a533f19e31ab984c87a0674ec78c42ebb6" }
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 serde_json = { version = "1.0.69", features = ["preserve_order"] }
 thiserror = "1.0.30"


### PR DESCRIPTION
fixes #121 

The latest commit reduces router-bridge compile times, and a couple of apollo_parser fixes allow us to handle invalid schemas better, as well as comments.