### PR TITLE
avoid cloning entities when building the response

### DIFF
--- a/crates/apollo-router-core/src/json_ext.rs
+++ b/crates/apollo-router-core/src/json_ext.rs
@@ -24,7 +24,7 @@ pub trait ValueExt {
     /// Deep merge the JSON objects, array and override the values in `&mut self` if they already
     /// exists.
     #[track_caller]
-    fn deep_merge(&mut self, other: &Self);
+    fn deep_merge(&mut self, other: Self);
 
     /// Returns `true` if the values are equal and the objects are ordered the same.
     ///
@@ -123,13 +123,13 @@ impl ValueExt for Value {
         Ok(current)
     }
 
-    fn deep_merge(&mut self, other: &Self) {
+    fn deep_merge(&mut self, other: Self) {
         match (self, other) {
             (Value::Object(a), Value::Object(b)) => {
-                for (key, value) in b.iter() {
+                for (key, value) in b.into_iter() {
                     match a.entry(key) {
                         Entry::Vacant(e) => {
-                            e.insert(value.to_owned());
+                            e.insert(value);
                         }
                         Entry::Occupied(e) => {
                             e.into_mut().deep_merge(value);
@@ -137,15 +137,13 @@ impl ValueExt for Value {
                     }
                 }
             }
-            (Value::Array(a), Value::Array(b)) => {
-                for (index, value) in a.iter_mut().enumerate() {
-                    if let Some(b) = b.get(index) {
-                        value.deep_merge(b);
-                    }
+            (Value::Array(a), Value::Array(mut b)) => {
+                for ((_index, b_value), a_value) in b.drain(..).enumerate().zip(a.iter_mut()) {
+                    a_value.deep_merge(b_value);
                 }
             }
             (a, b) => {
-                *a = b.to_owned();
+                *a = b;
             }
         }
     }
@@ -459,7 +457,7 @@ mod tests {
     #[test]
     fn test_deep_merge() {
         let mut json = json!({"obj":{"arr":[{"prop1":1},{"prop2":2}]}});
-        json.deep_merge(&json!({"obj":{"arr":[{"prop1":2,"prop3":3},{"prop4":4}]}}));
+        json.deep_merge(json!({"obj":{"arr":[{"prop1":2,"prop3":3},{"prop4":4}]}}));
         assert_eq!(
             json,
             json!({"obj":{"arr":[{"prop1":2, "prop3":3},{"prop2":2, "prop4":4}]}})

--- a/crates/apollo-router-core/src/naive_introspection.rs
+++ b/crates/apollo-router-core/src/naive_introspection.rs
@@ -88,7 +88,7 @@ mod naive_introspection_tests {
         let query_to_test = "this is a test query";
         let mut expected_data = Response::builder().build();
         expected_data
-            .insert_data(&Path::empty(), &serde_json::Value::Number(42.into()))
+            .insert_data(&Path::empty(), serde_json::Value::Number(42.into()))
             .expect("it is always possible to insert data in root path; qed");
 
         let cache = [(query_to_test.into(), expected_data.clone())]

--- a/crates/apollo-router-core/src/query_planner/model.rs
+++ b/crates/apollo-router-core/src/query_planner/model.rs
@@ -386,43 +386,46 @@ async fn fetch_node<'a>(
             Some(Response {
                 data, mut errors, ..
             }) => {
-                if let Some(entities) = data.get("_entities") {
-                    tracing::trace!(
-                        "Received entities: {}",
-                        serde_json::to_string(entities).unwrap(),
-                    );
-                    if let Some(array) = entities.as_array() {
-                        let mut response = response
-                            .lock()
-                            .instrument(tracing::trace_span!("response_lock_wait"))
-                            .await;
+                if let Value::Object(mut map) = data {
+                    if let Some(entities) = map.remove("_entities") {
+                        tracing::trace!(
+                            "Received entities: {}",
+                            serde_json::to_string(&entities).unwrap(),
+                        );
 
-                        let span = tracing::trace_span!("response_insert");
-                        let _guard = span.enter();
-                        for (i, entity) in array.iter().enumerate() {
-                            response.insert_data(
-                                &current_dir.join(Path::from(i.to_string())),
-                                entity,
-                            )?;
+                        if let Value::Array(mut array) = entities {
+                            let mut response = response
+                                .lock()
+                                .instrument(tracing::trace_span!("response_lock_wait"))
+                                .await;
+
+                            let span = tracing::trace_span!("response_insert");
+                            let _guard = span.enter();
+                            for (i, entity) in array.drain(..).enumerate() {
+                                response.insert_data(
+                                    &current_dir.join(Path::from(i.to_string())),
+                                    entity,
+                                )?;
+                            }
+
+                            return Ok(());
+                        } else {
+                            return Err(FetchError::ExecutionInvalidContent {
+                                reason: "Received invalid type for key `_entities`!".to_string(),
+                            });
                         }
-
-                        Ok(())
-                    } else {
-                        Err(FetchError::ExecutionInvalidContent {
-                            reason: "Received invalid type for key `_entities`!".to_string(),
-                        })
                     }
-                } else {
-                    let mut response = response
-                        .lock()
-                        .instrument(tracing::trace_span!("response_lock_wait"))
-                        .await;
-
-                    response.append_errors(&mut errors);
-                    Err(FetchError::ExecutionInvalidContent {
-                        reason: "Missing key `_entities`!".to_string(),
-                    })
                 }
+
+                let mut response = response
+                    .lock()
+                    .instrument(tracing::trace_span!("response_lock_wait"))
+                    .await;
+
+                response.append_errors(&mut errors);
+                Err(FetchError::ExecutionInvalidContent {
+                    reason: "Missing key `_entities`!".to_string(),
+                })
             }
             None => Err(FetchError::SubrequestNoResponse {
                 service: service_name.to_string(),
@@ -474,7 +477,7 @@ async fn fetch_node<'a>(
                 let span = tracing::trace_span!("response_insert");
                 let _guard = span.enter();
                 response.append_errors(&mut errors);
-                response.insert_data(current_dir, &data)?;
+                response.insert_data(current_dir, data)?;
 
                 Ok(())
             }

--- a/crates/apollo-router-core/src/response.rs
+++ b/crates/apollo-router-core/src/response.rs
@@ -1,6 +1,7 @@
 use crate::prelude::graphql::*;
 use futures::prelude::*;
 use serde::{Deserialize, Serialize};
+use serde_json::map::Entry;
 use std::pin::Pin;
 use typed_builder::TypedBuilder;
 
@@ -86,16 +87,18 @@ impl Response {
     }
 
     pub fn insert_data(&mut self, path: &Path, value: Value) -> Result<(), FetchError> {
-        let nodes =
+        let mut nodes =
             self.data
                 .get_at_path_mut(path)
                 .map_err(|err| FetchError::ExecutionPathNotFound {
                     reason: err.to_string(),
                 })?;
 
-        for node in nodes {
-            node.deep_merge(&value);
-        }
+        //FIXME: are there cases where we could write at multiple paths?
+        //for node in nodes {
+        let node = nodes.get_mut(0).unwrap();
+        node.deep_merge(value);
+        //}
 
         Ok(())
     }
@@ -122,10 +125,12 @@ fn select_object(
         match selection {
             Selection::Field(field) => {
                 if let Some(value) = select_field(content, field, schema)? {
-                    output
-                        .entry(field.name.to_owned())
-                        .and_modify(|existing| existing.deep_merge(&value))
-                        .or_insert(value);
+                    match output.entry(field.name.to_owned()) {
+                        Entry::Occupied(mut existing) => existing.get_mut().deep_merge(value),
+                        Entry::Vacant(vacant) => {
+                            vacant.insert(value);
+                        }
+                    }
                 }
             }
             Selection::InlineFragment(fragment) => {

--- a/crates/apollo-router-core/src/response.rs
+++ b/crates/apollo-router-core/src/response.rs
@@ -94,11 +94,16 @@ impl Response {
                     reason: err.to_string(),
                 })?;
 
+        let len = nodes.len();
         //FIXME: are there cases where we could write at multiple paths?
-        //for node in nodes {
-        let node = nodes.get_mut(0).unwrap();
-        node.deep_merge(value);
-        //}
+        for (i, node) in nodes.iter_mut().enumerate() {
+            if i == len {
+                (*node).deep_merge(value);
+                break;
+            } else {
+                (*node).deep_merge(value.clone());
+            }
+        }
 
         Ok(())
     }

--- a/crates/apollo-router-core/src/response.rs
+++ b/crates/apollo-router-core/src/response.rs
@@ -85,7 +85,7 @@ impl Response {
         ))
     }
 
-    pub fn insert_data(&mut self, path: &Path, value: &Value) -> Result<(), FetchError> {
+    pub fn insert_data(&mut self, path: &Path, value: Value) -> Result<(), FetchError> {
         let nodes =
             self.data
                 .get_at_path_mut(path)
@@ -94,7 +94,7 @@ impl Response {
                 })?;
 
         for node in nodes {
-            node.deep_merge(value);
+            node.deep_merge(&value);
         }
 
         Ok(())
@@ -285,7 +285,7 @@ mod tests {
         let data = json!({
             "name": "cook",
         });
-        response.insert_data(&Path::from("job"), &data).unwrap();
+        response.insert_data(&Path::from("job"), data).unwrap();
         assert_eq!(
             response.data,
             json!({


### PR DESCRIPTION
I see a small perf improvement here. With 10k concurrent clients (I'm working with saturated CPUs to see breaking point behaviours):

query:

```
query  {\products(limit: 5) {  upc  name  price  review { body }  } }
```
## main
854MB res memory

```
Summary:                                                         
  Total:        57.0660 secs                                     
  Slowest:      6.7271 secs                                      
  Fastest:      0.0017 secs                                      
  Average:      0.5240 secs                                      
  Requests/sec: 17523.5611                                       
                                                                 
                                                                 
Response time histogram:                                         
  0.002 [1]     |                                                
  0.674 [729343]|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  1.347 [38168] |■■                                              
  2.019 [207780]|■■■■■■■■■■■                             
  2.692 [4226]  |                                                
  3.364 [16521] |■                                               
  4.037 [3238]  |                                                
  4.709 [293]   |                                                
  5.382 [423]   |                                                
  6.055 [4]     |                                                
  6.727 [3]     |                                                
                                                                 
                                                                 
Latency distribution:                                            
  10% in 0.0463 secs                                             
  25% in 0.0654 secs                                             
  50% in 0.0934 secs                                             
  75% in 1.2584 secs                                             
  90% in 1.6843 secs                                             
  95% in 1.7897 secs                                             
  99% in 3.2215 secs                                             
```

## this PR

830MB res memory

```
Summary:                                                         
  Total:        55.0270 secs                               
  Slowest:      6.3213 secs                                
  Fastest:      0.0013 secs                                
  Average:      0.5042 secs                                
  Requests/sec: 18172.8988                                 
   
                             
Response time histogram: 
  0.001 [1]     |
  0.633 [717221]|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  1.265 [47129] |■■■
  1.897 [207444]|■■■■■■■■■■■■
  2.529 [5569]  |
  3.161 [18295] |■
  3.793 [3450]  |
  4.425 [478]   |
  5.057 [398]   |
  5.689 [7]     |
  6.321 [8]     |


Latency distribution:
  10% in 0.0447 secs
  25% in 0.0633 secs
  50% in 0.0909 secs
  75% in 1.2007 secs
  90% in 1.5761 secs
  95% in 1.6906 secs
  99% in 3.0063 secs
```

Less memory usage, less latency, increased rps