### PR TITLE
docs: asdf syntax change for installing plugins

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,8 +24,8 @@ are specified in [.tool-versions](.tool-versions). To set up your toolchain
 run:
 
 ```shell
-asdf add-plugin rust
-asdf add-plugin nodejs
+asdf plugin add rust
+asdf plugin add nodejs
 asdf install
 asdf reshim
 ```
@@ -61,13 +61,13 @@ requires that the `federation-demo` project is running:
     You will need Node.js and npm to be installed. It is known to be working on
     Node.js 16 and npm 7.18.
 
-    ```shell
-    git submodule sync --recursive
-    git submodule update --recursive --init
-    cd dockerfiles/federation-demo/federation-demo
-    npm install;
-    npm run start
-    ```
+  ```shell
+  git submodule sync --recursive
+  git submodule update --recursive --init
+  cd dockerfiles/federation-demo/federation-demo
+  npm install;
+  npm run start
+  ```
 
 ### Run Apollo Router against the docker-compose or Node.js setup
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 ## 🗺️🔭 Roadmap
 
-We'll be working to open issues and surface designs about these things and more, as the planning progresses.  Follow this file for more details as they become available and we'll link the items below to issues as we create them.  We look forward to your participation in those discsussions!
+We'll be working to open issues and surface designs about these things and more, as the planning progresses.  Follow this file for more details as they become available and we'll link the items below to issues as we create them.  We look forward to your participation in those discussions!
 
 - **Apollo Studio integrations**
 


### PR DESCRIPTION
When following the directions in `DEVELOPMENT.md` I found that the command for adding plugins to `asdf` to have deviated from the original writing of that document. Also found a stray typo while browsing the `ROADMAP.md`