### PR TITLE
chore: use cargo_sweep in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,8 +281,12 @@ commands:
       - run:
           name: Install cargo sweep
           command: |
-            set -e -o pipefail
-            cargo sweep --version || cargo install cargo-sweep
+            cargo sweep --version
+            if(-Not ($?))
+            {
+              cargo install cargo-sweep
+            }
+            exit $LASTEXITCODE
       - run: cargo sweep -s
       - build_common_permutations
       - run: cargo sweep -f
@@ -302,8 +306,12 @@ commands:
       - run:
           name: Install cargo sweep
           command: |
-            set -e -o pipefail
-            cargo sweep --version || cargo install cargo-sweep
+            cargo sweep --version
+            if(-Not ($?))
+            {
+              cargo install cargo-sweep
+            }
+            exit $LASTEXITCODE
       - run: cargo sweep -s
       - run: cargo xtask test --with-demo
       - run: cargo sweep -f

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,9 +217,16 @@ commands:
           keys:
             - rust-target-v1-xtask-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
             - rust-target-v1-xtask-build-<< parameters.os >>
+      - run:
+          name: Install cargo sweep
+          command: |
+            set -e -o pipefail
+            cargo sweep --version || cargo install cargo-sweep
+      - run: cargo sweep -s
       - install_extra_tools:
           os: << parameters.os >>
       - run: cargo xtask check-compliance
+      - run: cargo sweep -f
       - save_cache:
           key: rust-target-v1-xtask-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
           paths:
@@ -252,7 +259,14 @@ commands:
           keys:
             - rust-target-v1-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
             - rust-target-v1-build-<< parameters.os >>
+      - run:
+          name: Install cargo sweep
+          command: |
+            set -e -o pipefail
+            cargo sweep --version || cargo install cargo-sweep
+      - run: cargo sweep -s
       - build_all_permutations
+      - run: cargo sweep -f
       - save_cache:
           key: rust-target-v1-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
           paths:
@@ -264,7 +278,14 @@ commands:
           keys:
             - rust-target-v1-build-windows-{{ checksum "Cargo.lock" }}
             - rust-target-v1-build-windows
+      - run:
+          name: Install cargo sweep
+          command: |
+            set -e -o pipefail
+            cargo sweep --version || cargo install cargo-sweep
+      - run: cargo sweep -s
       - build_common_permutations
+      - run: cargo sweep -f
       - save_cache:
           key: rust-target-v1-build-windows-{{ checksum "Cargo.lock" }}
           paths:
@@ -278,7 +299,14 @@ commands:
             - rust-target-v1-test-windows-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
             - rust-target-v1-test-windows-{{ checksum "Cargo.lock" }}
             - rust-target-v1-test-windows
+      - run:
+          name: Install cargo sweep
+          command: |
+            set -e -o pipefail
+            cargo sweep --version || cargo install cargo-sweep
+      - run: cargo sweep -s
       - run: cargo xtask test --with-demo
+      - run: cargo sweep -f
       - save_cache:
           key: rust-target-v1-test-windows-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
           paths:
@@ -294,7 +322,14 @@ commands:
             - rust-target-v1-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
             - rust-target-v1-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}
             - rust-target-v1-test-<< parameters.os >>
+      - run:
+          name: Install cargo sweep
+          command: |
+            set -e -o pipefail
+            cargo sweep --version || cargo install cargo-sweep
+      - run: cargo sweep -s
       - run: cargo xtask test --with-demo
+      - run: cargo sweep -f
       - save_cache:
           key: rust-target-v1-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,14 +119,14 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - subgraph-node-modules-v1-windows-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
-            - subgraph-node-modules-v1-windows
+            - subgraph-node-modules-v2-windows-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
+            - subgraph-node-modules-v2-windows
       - run:
           name: npm clean-install
           working_directory: dockerfiles/federation-demo/federation-demo
           command: npm clean-install
       - save_cache:
-          key: subgraph-node-modules-v1-windows-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
+          key: subgraph-node-modules-v2-windows-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
           paths:
             - dockerfiles/federation-demo/federation-demo/node_modules
 
@@ -186,14 +186,14 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rust-v1-extra-tools-<< parameters.os >>
+            - rust-v2-extra-tools-<< parameters.os >>
       - run:
           name: Install cargo deny if not present
           command: |
             set -e -o pipefail
             cargo deny --version || cargo install cargo-deny
       - save_cache:
-          key: rust-v1-extra-tools-<< parameters.os >>
+          key: rust-v2-extra-tools-<< parameters.os >>
           paths:
             - ~/.cargo/bin/cargo-deny
 
@@ -204,8 +204,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rust-target-v1-xtask-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
-            - rust-target-v1-xtask-build-<< parameters.os >>
+            - rust-target-v2-xtask-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+            - rust-target-v2-xtask-build-<< parameters.os >>
       - run: cargo xtask lint
 
   xtask_check_compliance:
@@ -215,8 +215,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rust-target-v1-xtask-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
-            - rust-target-v1-xtask-build-<< parameters.os >>
+            - rust-target-v2-xtask-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+            - rust-target-v2-xtask-build-<< parameters.os >>
       - run:
           name: Install cargo sweep
           command: |
@@ -228,7 +228,7 @@ commands:
       - run: cargo xtask check-compliance
       - run: cargo sweep -f
       - save_cache:
-          key: rust-target-v1-xtask-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+          key: rust-target-v2-xtask-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
           paths:
             - target/
             - ~/.cargo
@@ -257,8 +257,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rust-target-v1-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
-            - rust-target-v1-build-<< parameters.os >>
+            - rust-target-v2-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+            - rust-target-v2-build-<< parameters.os >>
       - run:
           name: Install cargo sweep
           command: |
@@ -268,7 +268,7 @@ commands:
       - build_all_permutations
       - run: cargo sweep -f
       - save_cache:
-          key: rust-target-v1-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+          key: rust-target-v2-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
           paths:
             - target/
             - ~/.cargo
@@ -276,8 +276,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rust-target-v1-build-windows-{{ checksum "Cargo.lock" }}
-            - rust-target-v1-build-windows
+            - rust-target-v2-build-windows-{{ checksum "Cargo.lock" }}
+            - rust-target-v2-build-windows
       - run:
           name: Install cargo sweep
           command: |
@@ -291,7 +291,7 @@ commands:
       - build_common_permutations
       - run: cargo sweep -f
       - save_cache:
-          key: rust-target-v1-build-windows-{{ checksum "Cargo.lock" }}
+          key: rust-target-v2-build-windows-{{ checksum "Cargo.lock" }}
           paths:
             - target/
             - C:\\Users\\circleci\.cargo
@@ -300,9 +300,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rust-target-v1-test-windows-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
-            - rust-target-v1-test-windows-{{ checksum "Cargo.lock" }}
-            - rust-target-v1-test-windows
+            - rust-target-v2-test-windows-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
+            - rust-target-v2-test-windows-{{ checksum "Cargo.lock" }}
+            - rust-target-v2-test-windows
       - run:
           name: Install cargo sweep
           command: |
@@ -316,7 +316,7 @@ commands:
       - run: cargo xtask test --with-demo
       - run: cargo sweep -f
       - save_cache:
-          key: rust-target-v1-test-windows-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
+          key: rust-target-v2-test-windows-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
           paths:
             - target/
             - C:\\Users\\circleci\.cargo
@@ -327,9 +327,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rust-target-v1-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
-            - rust-target-v1-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}
-            - rust-target-v1-test-<< parameters.os >>
+            - rust-target-v2-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
+            - rust-target-v2-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+            - rust-target-v2-test-<< parameters.os >>
       - run:
           name: Install cargo sweep
           command: |
@@ -339,7 +339,7 @@ commands:
       - run: cargo xtask test --with-demo
       - run: cargo sweep -f
       - save_cache:
-          key: rust-target-v1-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
+          key: rust-target-v2-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
           paths:
             - target/
             - ~/.cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3564,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00e500fff5fa1131c866b246041a6bf96da9c965f8fe4128cb1421f23e93c00"
+checksum = "5651b5f6860a99bd1adb59dbfe1db8beb433e73709d9032b413a77e2fb7c066a"
 dependencies = [
  "futures-core",
  "futures-util",


### PR DESCRIPTION
Now that the CI uses various layers of cache to speed up build times, we want to make sure the cache size doesn't grow over time, which is exactly what this does:
- Wrap each cargo build / test / xtask command with cargo sweep -s and cargo sweep -f