### PR TITLE
Reduce cloning in Response composition

### DIFF
--- a/crates/apollo-router-core/src/federated.rs
+++ b/crates/apollo-router-core/src/federated.rs
@@ -363,7 +363,7 @@ async fn fetch_node<'a>(
                         for (i, entity) in array.iter().enumerate() {
                             response.insert_data(
                                 &current_dir.join(Path::from(i.to_string())),
-                                entity.to_owned(),
+                                entity,
                             )?;
                         }
 
@@ -435,7 +435,7 @@ async fn fetch_node<'a>(
                 let span = tracing::trace_span!("response_insert");
                 let _guard = span.enter();
                 response.append_errors(&mut errors);
-                response.insert_data(current_dir, data)?;
+                response.insert_data(current_dir, &data)?;
 
                 Ok(())
             }

--- a/crates/apollo-router-core/src/naive_introspection.rs
+++ b/crates/apollo-router-core/src/naive_introspection.rs
@@ -71,10 +71,10 @@ impl NaiveIntrospection {
         Self { cache }
     }
 
-    pub fn get(&self, request: &Request) -> Option<serde_json::Value> {
+    pub fn get(&self, request: &Request) -> Option<&serde_json::Value> {
         let span = tracing::info_span!("introspection_cache");
         let _guard = span.enter();
-        self.cache.get(&request.query).map(std::clone::Clone::clone)
+        self.cache.get(&request.query)
     }
 }
 
@@ -95,7 +95,7 @@ mod naive_introspection_tests {
 
         let request = Request::builder().query(query_to_test).build();
 
-        assert_eq!(expected_data, naive_introspection.get(&request).unwrap());
+        assert_eq!(&expected_data, naive_introspection.get(&request).unwrap());
     }
 
     #[test]

--- a/crates/apollo-router-core/src/response.rs
+++ b/crates/apollo-router-core/src/response.rs
@@ -84,7 +84,7 @@ impl Response {
         ))
     }
 
-    pub fn insert_data(&mut self, path: &Path, value: Value) -> Result<(), FetchError> {
+    pub fn insert_data(&mut self, path: &Path, value: &Value) -> Result<(), FetchError> {
         let nodes =
             self.data
                 .get_at_path_mut(path)
@@ -93,7 +93,7 @@ impl Response {
                 })?;
 
         for node in nodes {
-            node.deep_merge(&value);
+            node.deep_merge(value);
         }
 
         Ok(())
@@ -275,14 +275,10 @@ mod tests {
                 "job": {},
             }))
             .build();
-        response
-            .insert_data(
-                &Path::from("job"),
-                json!({
-                    "name": "cook",
-                }),
-            )
-            .unwrap();
+        let data = json!({
+            "name": "cook",
+        });
+        response.insert_data(&Path::from("job"), &data).unwrap();
         assert_eq!(
             response.data,
             json!({


### PR DESCRIPTION
I noticed that we are cloning cached naiveintrospection values when we
don't need to. If we modify that behaviour to return a reference we can
avoid unnecessary work.

resolves #168