### PR TITLE
do not reparse JSON responses in a loop

### DIFF
--- a/crates/apollo-router/src/http_subgraph.rs
+++ b/crates/apollo-router/src/http_subgraph.rs
@@ -89,21 +89,15 @@ impl HttpSubgraphFetcher {
                     }
                 }
 
-                match serde_json::from_slice::<graphql::Response>(&current_payload_bytes) {
-                    Ok(response) => {
-                        // Yield a graphql::Response
-
-                        response
-                    }
-                    Err(error) => {
-                        // Yield a graphql::Response
+                serde_json::from_slice::<graphql::Response>(&current_payload_bytes).unwrap_or_else(
+                    |error| {
                         graphql::FetchError::SubrequestMalformedResponse {
                             service: service_name.clone(),
                             reason: error.to_string(),
                         }
                         .to_response(is_primary)
-                    }
-                }
+                    },
+                )
             }
             .into_stream(),
         )

--- a/crates/apollo-router/src/http_subgraph.rs
+++ b/crates/apollo-router/src/http_subgraph.rs
@@ -69,89 +69,44 @@ impl HttpSubgraphFetcher {
             .boxed()
     }
 
-    fn map_to_graphql(service_name: String, bytes_stream: BytesStream) -> graphql::ResponseStream {
-        // A `BytesStream` chunk doesn't always represent a `graphql::Response`.
-        // We need to accumulate the bytes until we have a deserialization that doesn't end up in EOF, and then yield a `graphql::Response`.
-        // `stream::unfold` allows us to do just that: keep some state around, and yield `Some((new_item, new_state))` until we're done (at which point we'll yield `None`).
-        //
-        // Here's the state we're keeping around:
-        //
-        // `bytes_stream` is the actual response we're trying to deserialize, and we'll repeatedly await.
-        //
-        // `current_payload_bytes` starts empty, and will accumulate until we have a full deserialization.
-        // It will then reset to an empty `BytesMut` and accumulate for the next payload.
-        //
-        // `service_name` is useful so we can correctly track and propagate errors.
-        //
-        // `is_primary` les the graphql::ResponseStream users know whether an error occured during a graphql::Response,
-        // or during a subsequent HTTP patch that appends an update.
-        stream::unfold(
-            (bytes_stream.fuse(), BytesMut::new(), service_name, true),
-            |(mut bytes_stream, mut current_payload_bytes, service_name, is_primary)| async move {
+    fn map_to_graphql(
+        service_name: String,
+        mut bytes_stream: BytesStream,
+    ) -> graphql::ResponseStream {
+        Box::pin(
+            async move {
+                let mut current_payload_bytes = BytesMut::new();
+                let is_primary = true;
+
                 while let Some(next_chunk) = bytes_stream.next().await {
                     match next_chunk {
                         Ok(bytes) => {
                             current_payload_bytes.extend(&bytes);
-                            match serde_json::from_slice::<graphql::Response>(
-                                &current_payload_bytes,
-                            ) {
-                                Err(e) if e.is_eof() => {
-                                    // Couldn't parse a full graphql::Response. This means the message is not complete yet.
-                                    continue;
-                                }
-                                Ok(response) => {
-                                    // Yield a graphql::Response
-                                    return Some((
-                                        response,
-                                        (bytes_stream, BytesMut::new(), service_name, false),
-                                    ));
-                                }
-                                Err(error) => {
-                                    // Yield a graphql::Response
-                                    return Some((
-                                        graphql::FetchError::SubrequestMalformedResponse {
-                                            service: service_name.clone(),
-                                            reason: error.to_string(),
-                                        }
-                                        .to_response(is_primary),
-                                        (bytes_stream, BytesMut::new(), service_name, false),
-                                    ));
-                                }
-                            }
                         }
                         Err(fetch_error) => {
-                            return Some((
-                                fetch_error.to_response(is_primary),
-                                (bytes_stream, BytesMut::new(), service_name, false),
-                            ));
+                            return fetch_error.to_response(is_primary);
                         }
                     }
                 }
 
-                // we're done with the `BytesStream`, yield a last response if any.
-                // since `bytes_stream` is fused, reentering the fold will lead us here,
-                // with an empty `current_payload_bytes` thus effectively yielding None,
-                // and exiting the fold
-                if !current_payload_bytes.is_empty() {
-                    let last_response =
-                        serde_json::from_slice::<graphql::Response>(&current_payload_bytes)
-                            .unwrap_or_else(|error| {
-                                graphql::FetchError::SubrequestMalformedResponse {
-                                    service: service_name.clone(),
-                                    reason: error.to_string(),
-                                }
-                                .to_response(is_primary)
-                            });
-                    Some((
-                        last_response,
-                        (bytes_stream, BytesMut::new(), service_name, false),
-                    ))
-                } else {
-                    None
+                match serde_json::from_slice::<graphql::Response>(&current_payload_bytes) {
+                    Ok(response) => {
+                        // Yield a graphql::Response
+
+                        response
+                    }
+                    Err(error) => {
+                        // Yield a graphql::Response
+                        graphql::FetchError::SubrequestMalformedResponse {
+                            service: service_name.clone(),
+                            reason: error.to_string(),
+                        }
+                        .to_response(is_primary)
+                    }
                 }
-            },
+            }
+            .into_stream(),
         )
-        .boxed()
     }
 }
 


### PR DESCRIPTION
Potential fix for #144 
related: #33 #80

with very large responses, we were looping over HTTP chunks by
accumulating them, trying to parse the JSON response, then go for
another iteration if it was not enough, so we end up parsing the same
data very frequently

This commit first accumulates the data entirely, then parses it

:warning: **this potentially breaks @stream:** the previous code was trying to recognize an entire json response, return it, then try parsing another json response if there's still some data, and return a stream of responses. From what I see the code could not handle stream responses anyway since multipart is expected: https://github.com/graphql/graphql-over-http/blob/main/rfcs/IncrementalDelivery.md#content-type-multipartmixed
We should investigate that
**Edit:** @stream is not currently supported, so this can be merged right now, and we'll modify once we do it (we're keeping the Stream of responses to that end)

## performance results

### main d9b3c43

```
Summary:                                                     
  Total:        200.0049 secs                                
  Slowest:      20.0006 secs                                 
  Fastest:      9.0386 secs                                  
  Average:      19.1225 secs                                 
  Requests/sec: 2.4999                                       
                                                             
                                                             
Response time histogram:                                     
  9.039 [1]     |                                            
  10.135 [1]    |                                            
  11.231 [1]    |                                            
  12.327 [11]   |■                                           
  13.423 [9]    |■                                           
  14.520 [13]   |■                                           
  15.616 [10]   |■                                           
  16.712 [15]   |■                                           
  17.808 [18]   |■■                                          
  18.904 [9]    |■                                           
  20.001 [412]  |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■    
                                                             
                                                             
Latency distribution:                                        
  10% in 15.9425 secs                                        
  25% in 20.0001 secs                                        
  50% in 20.0002 secs                                        
  75% in 20.0002 secs                                        
  90% in 20.0002 secs                                        
  95% in 20.0002 secs                                        
  99% in 20.0003 secs                                        
                                                             
Details (average, fastest, slowest):                         
  DNS+dialup:   0.0003 secs, 9.0386 secs, 20.0006 secs       
  DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0000 secs        
  req write:    0.0001 secs, 0.0000 secs, 0.0008 secs        
  resp wait:    6.8858 secs, 0.0001 secs, 19.0536 secs       
  resp read:    12.2363 secs, 0.9462 secs, 19.9999 secs      
                                                             
Status code distribution:                                    
  [200] 500 responses                
```

![Screenshot from 2021-11-22 10-59-09](https://user-images.githubusercontent.com/119296/142847494-dee2b76b-369c-45fc-937c-3259836bca14.png)

spending most of the time deserializing strings (I was testing a products subgraph where the name is 40MB long)

### this PR
```
Summary:                                                  
  Total:        26.1397 secs                              
  Slowest:      5.3922 secs                               
  Fastest:      0.2809 secs                               
  Average:      2.4454 secs                               
  Requests/sec: 19.1280                                   
                                                          
                                                          
Response time histogram:                                  
  0.281 [1]     |                                         
  0.792 [6]     |■■                                       
  1.303 [17]    |■■■■■                                    
  1.814 [78]    |■■■■■■■■■■■■■■■■■■■■■■                   
  2.325 [145]   |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 
  2.837 [115]   |■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■         
  3.348 [78]    |■■■■■■■■■■■■■■■■■■■■■■                   
  3.859 [35]    |■■■■■■■■■■                               
  4.370 [14]    |■■■■                                     
  4.881 [8]     |■■                                       
  5.392 [3]     |■                                        
                                                          
                                                          
Latency distribution:                                     
  10% in 1.5380 secs                                      
  25% in 1.9118 secs                                      
  50% in 2.3362 secs                                      
  75% in 2.9391 secs                                      
  90% in 3.4465 secs                                      
  95% in 3.8630 secs                                      
  99% in 4.6872 secs                                      
                                                          
Details (average, fastest, slowest):                      
  DNS+dialup:   0.0002 secs, 0.2809 secs, 5.3922 secs     
  DNS-lookup:   0.0000 secs, 0.0000 secs, 0.0000 secs     
  req write:    0.0001 secs, 0.0000 secs, 0.0072 secs     
  resp wait:    0.4656 secs, 0.0002 secs, 2.0409 secs     
  resp read:    1.9795 secs, 0.2806 secs, 4.6103 secs     
                                                          
Status code distribution:                                 
  [200] 500 responses                                     
```

![Screenshot from 2021-11-22 11-44-07](https://user-images.githubusercontent.com/119296/142847726-335b16cd-a2cd-477d-9c82-bca602090ca4.png)

There's definitely an improvement on large responses. It probably won't have a big impact on small responses that can fit in one chunk