### PR TITLE
feat: cargo xtask all

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,6 +2985,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b69f9a4c9740d74c5baa3fd2e547f9525fa8088a8a958e0ca2409a514e33f5fa"
+dependencies = [
+ "block-buffer",
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3941,10 +3954,10 @@ dependencies = [
  "platforms",
  "regex",
  "reqwest",
- "ring",
  "semver 1.0.4",
  "serde_json",
  "serde_json_traversal",
+ "sha2",
  "structopt",
  "tar",
  "tempfile",

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -94,6 +94,9 @@ The CI checks require `cargo-deny` and `cargo-about` which can both be installed
 - `cargo install cargo-deny`
 - `cargo install cargo-about`
 
+They also need you to have the federation-demo project up and running,
+as explained in the Getting started section above.
+
 ## Project maintainers
 
 Apollo Graph, Inc.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -88,9 +88,9 @@ This limits the noise generated while exploration is taking place.
 When you are ready to create a PR, run a build with strict checking enabled,
 and check for license compliance.
 
-Use `cargo xtask lint` and `cargo xtask check-compliance` to check this.
+Use `cargo xtask all` to run all of the checks the CI will run.
 
-Compliance checks require `cargo-deny` and `cargo-about` which can both be installed by running:
+The CI checks require `cargo-deny` and `cargo-about` which can both be installed by running:
 - `cargo install cargo-deny`
 - `cargo install cargo-about`
 

--- a/about.toml
+++ b/about.toml
@@ -10,6 +10,11 @@ accepted = [
     "MIT",
 ]
 
+# Ignore non plublished crates, such as xtask for example
+private = { ignore = true }
+# Ignore dependencies used in tests only, test-log for example
+ignore-dev-dependencies = true
+
 # apollographql licenses
 [xtask.clarify]
 license = "LicenseRef-ELv2"

--- a/licenses.html
+++ b/licenses.html
@@ -4949,6 +4949,7 @@ limitations under the License.
                     <li><a href=" https://github.com/RustCrypto/traits ">digest</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">opaque-debug</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">sha-1</a></li>
+                    <li><a href=" https://github.com/RustCrypto/hashes ">sha2</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004

--- a/licenses.html
+++ b/licenses.html
@@ -44,8 +44,8 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#MIT">MIT License</a> (65)</li>
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (37)</li>
+            <li><a href="#MIT">MIT License</a> (50)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (35)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (5)</li>
             <li><a href="#ISC">ISC License</a> (4)</li>
             <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a> (1)</li>
@@ -245,10 +245,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tormol/encode_unicode ">encode_unicode</a></li>
                     <li><a href=" https://github.com/hsivonen/encoding_rs ">encoding_rs</a></li>
-                    <li><a href=" https://github.com/mitsuhiko/rust-fragile ">fragile</a></li>
-                    <li><a href=" https://github.com/nvzqz/static-assertions-rs ">static_assertions</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -668,7 +665,6 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/assert-rs/predicates-rs ">predicates</a></li>
                     <li><a href=" https://github.com/assert-rs/predicates-rs ">predicates</a></li>
                     <li><a href=" https://github.com/assert-rs/predicates-rs/tree/master/predicates-core ">predicates-core</a></li>
                     <li><a href=" https://github.com/assert-rs/predicates-rs/tree/master/predicates-tree ">predicates-tree</a></li>
@@ -1490,8 +1486,6 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/utkarshkukreti/diff.rs ">diff</a></li>
-                    <li><a href=" https://github.com/derekdreery/normalize-line-endings ">normalize-line-endings</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
@@ -1706,8 +1700,6 @@
                     <li><a href=" https://github.com/sfackler/foreign-types ">foreign-types</a></li>
                     <li><a href=" https://github.com/sfackler/foreign-types ">foreign-types-shared</a></li>
                     <li><a href=" https://github.com/sfackler/rust-native-tls ">native-tls</a></li>
-                    <li><a href=" https://crates.io/crates/serde_regex ">serde_regex</a></li>
-                    <li><a href=" https://github.com/eminence/terminal-size ">terminal_size</a></li>
                     <li><a href=" https://github.com/sfackler/tokio-io-timeout ">tokio-io-timeout</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
@@ -1918,208 +1910,8 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/yoshuawuyts/kv-log-macro ">kv-log-macro</a></li>
-                </ul>
-                <pre class="license-text">                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   Copyright 2019 Yoshua Wuyts
-
-   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/soc/directories-rs ">directories</a></li>
-                    <li><a href=" https://github.com/xdg-rs/dirs ">dirs-next</a></li>
                     <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys</a></li>
-                    <li><a href=" https://github.com/xdg-rs/dirs/tree/master/dirs-sys ">dirs-sys-next</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -4376,52 +4168,31 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow</a></li>
-                    <li><a href=" https://github.com/nikomatsakis/ascii-canvas ">ascii-canvas</a></li>
                     <li><a href=" https://github.com/Nemo157/async-compression ">async-compression</a></li>
-                    <li><a href=" https://github.com/smol-rs/async-executor ">async-executor</a></li>
-                    <li><a href=" https://github.com/Keruspe/async-global-executor ">async-global-executor</a></li>
-                    <li><a href=" https://github.com/smol-rs/async-io ">async-io</a></li>
-                    <li><a href=" https://github.com/smol-rs/async-lock ">async-lock</a></li>
-                    <li><a href=" https://github.com/smol-rs/async-process ">async-process</a></li>
-                    <li><a href=" https://github.com/async-rs/async-std ">async-std</a></li>
-                    <li><a href=" https://github.com/stjepang/async-task ">async-task</a></li>
                     <li><a href=" https://github.com/dtolnay/async-trait ">async-trait</a></li>
-                    <li><a href=" https://github.com/stjepang/atomic-waker ">atomic-waker</a></li>
                     <li><a href=" https://github.com/cuviper/autocfg ">autocfg</a></li>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64</a></li>
                     <li><a href=" https://github.com/bitflags/bitflags ">bitflags</a></li>
-                    <li><a href=" https://github.com/smol-rs/blocking ">blocking</a></li>
                     <li><a href=" https://github.com/BurntSushi/bstr ">bstr</a></li>
                     <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo</a></li>
-                    <li><a href=" https://github.com/stjepang/cache-padded ">cache-padded</a></li>
                     <li><a href=" https://github.com/withoutboats/camino ">camino</a></li>
-                    <li><a href=" https://github.com/japaric/cast.rs ">cast</a></li>
                     <li><a href=" https://github.com/alexcrichton/cc-rs ">cc</a></li>
                     <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if</a></li>
                     <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if</a></li>
-                    <li><a href=" https://github.com/stjepang/concurrent-queue ">concurrent-queue</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation-sys</a></li>
                     <li><a href=" https://github.com/matklad/countme ">countme</a></li>
-                    <li><a href=" https://github.com/bheisler/criterion.rs ">criterion</a></li>
-                    <li><a href=" https://github.com/bheisler/criterion.rs ">criterion-plot</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-channel</a></li>
-                    <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-deque</a></li>
-                    <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-epoch</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-utils</a></li>
                     <li><a href=" https://github.com/mcarton/rust-derivative ">derivative</a></li>
                     <li><a href=" https://github.com/yaahc/displaydoc ">displaydoc</a></li>
                     <li><a href=" https://github.com/dtolnay/dtoa ">dtoa</a></li>
                     <li><a href=" https://github.com/bluss/either ">either</a></li>
-                    <li><a href=" https://github.com/rust-lang-nursery/ena ">ena</a></li>
-                    <li><a href=" https://github.com/stjepang/event-listener ">event-listener</a></li>
-                    <li><a href=" https://github.com/smol-rs/fastrand ">fastrand</a></li>
                     <li><a href=" https://github.com/alexcrichton/filetime ">filetime</a></li>
                     <li><a href=" https://github.com/bluss/fixedbitset ">fixedbitset</a></li>
                     <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">form_urlencoded</a></li>
-                    <li><a href=" https://github.com/smol-rs/futures-lite ">futures-lite</a></li>
                     <li><a href=" https://github.com/rust-lang/glob ">glob</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown</a></li>
                     <li><a href=" https://github.com/withoutboats/heck ">heck</a></li>
@@ -4432,22 +4203,16 @@ limitations under the License.
                     <li><a href=" https://github.com/hyperium/hyper-tls ">hyper-tls</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">idna</a></li>
                     <li><a href=" https://github.com/bluss/indexmap ">indexmap</a></li>
-                    <li><a href=" https://github.com/mitsuhiko/insta ">insta</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools</a></li>
                     <li><a href=" https://github.com/dtolnay/itoa ">itoa</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys ">js-sys</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static</a></li>
                     <li><a href=" https://github.com/indiv0/lazycell ">lazycell</a></li>
                     <li><a href=" https://github.com/rust-lang/libc ">libc</a></li>
-                    <li><a href=" https://github.com/alexcrichton/nghttp2-rs ">libnghttp2-sys</a></li>
-                    <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api</a></li>
-                    <li><a href=" https://github.com/bluss/maplit ">maplit</a></li>
                     <li><a href=" https://github.com/hyperium/mime ">mime</a></li>
                     <li><a href=" https://github.com/alexcrichton/miow ">miow</a></li>
                     <li><a href=" https://github.com/yoshuawuyts/miow ">miow</a></li>
-                    <li><a href=" https://github.com/asomers/mockall ">mockall</a></li>
-                    <li><a href=" https://github.com/asomers/mockall ">mockall_derive</a></li>
                     <li><a href=" https://github.com/havarnov/multimap ">multimap</a></li>
                     <li><a href=" https://github.com/deprecrated/net2-rs ">net2</a></li>
                     <li><a href=" https://github.com/rust-num/num-integer ">num-integer</a></li>
@@ -4455,7 +4220,6 @@ limitations under the License.
                     <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus</a></li>
                     <li><a href=" https://github.com/matklad/once_cell ">once_cell</a></li>
                     <li><a href=" https://github.com/alexcrichton/openssl-probe ">openssl-probe</a></li>
-                    <li><a href=" https://github.com/stjepang/parking ">parking</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding</a></li>
@@ -4463,46 +4227,35 @@ limitations under the License.
                     <li><a href=" https://github.com/petgraph/petgraph ">petgraph</a></li>
                     <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config</a></li>
                     <li><a href=" https://github.com/RustSec/platforms-crate ">platforms</a></li>
-                    <li><a href=" https://github.com/smol-rs/polling ">polling</a></li>
                     <li><a href=" https://github.com/dtolnay/proc-macro-hack ">proc-macro-hack</a></li>
                     <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost</a></li>
                     <li><a href=" https://github.com/dtolnay/quote ">quote</a></li>
-                    <li><a href=" https://github.com/rayon-rs/rayon ">rayon</a></li>
-                    <li><a href=" https://github.com/rayon-rs/rayon ">rayon-core</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-syntax</a></li>
                     <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest</a></li>
                     <li><a href=" https://github.com/rust-analyzer/rowan ">rowan</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/rustc-hash ">rustc-hash</a></li>
                     <li><a href=" https://github.com/Kimundi/rustc-version-rs ">rustc_version</a></li>
-                    <li><a href=" https://github.com/Kimundi/rustc-version-rs ">rustc_version</a></li>
-                    <li><a href=" https://github.com/dtolnay/rustversion ">rustversion</a></li>
                     <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls</a></li>
                     <li><a href=" https://github.com/bluss/scopeguard ">scopeguard</a></li>
                     <li><a href=" https://github.com/ctz/sct.rs ">sct</a></li>
                     <li><a href=" https://github.com/dtolnay/semver ">semver</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde</a></li>
-                    <li><a href=" https://github.com/pyfisch/cbor ">serde_cbor</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde_derive</a></li>
                     <li><a href=" https://github.com/serde-rs/json ">serde_json</a></li>
                     <li><a href=" https://github.com/dtolnay/serde-yaml ">serde_yaml</a></li>
-                    <li><a href=" https://github.com/vorner/signal-hook ">signal-hook</a></li>
                     <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry</a></li>
-                    <li><a href=" https://github.com/mitsuhiko/similar ">similar</a></li>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec</a></li>
                     <li><a href=" https://github.com/rust-lang/socket2 ">socket2</a></li>
-                    <li><a href=" https://github.com/servo/string-cache ">string_cache</a></li>
                     <li><a href=" https://github.com/dtolnay/syn ">syn</a></li>
                     <li><a href=" https://github.com/alexcrichton/tar-rs ">tar</a></li>
                     <li><a href=" https://github.com/Stebalien/tempfile ">tempfile</a></li>
-                    <li><a href=" https://github.com/Stebalien/term ">term</a></li>
                     <li><a href=" https://github.com/rust-analyzer/text-size ">text-size</a></li>
                     <li><a href=" https://github.com/dtolnay/thiserror ">thiserror</a></li>
                     <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl</a></li>
                     <li><a href=" https://github.com/Amanieu/thread_local-rs ">thread_local</a></li>
                     <li><a href=" https://github.com/rust-threadpool/rust-threadpool ">threadpool</a></li>
-                    <li><a href=" https://github.com/bheisler/TinyTemplate ">tinytemplate</a></li>
                     <li><a href=" https://github.com/idanarye/rust-typed-builder ">typed-builder</a></li>
                     <li><a href=" https://github.com/BurntSushi/ucd-generate ">ucd-trie</a></li>
                     <li><a href=" https://github.com/seanmonstar/unicase ">unicase</a></li>
@@ -4513,7 +4266,6 @@ limitations under the License.
                     <li><a href=" https://github.com/unicode-rs/unicode-xid ">unicode-xid</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">url</a></li>
                     <li><a href=" https://github.com/SergioBenitez/version_check ">version_check</a></li>
-                    <li><a href=" https://github.com/stjepang/waker-fn ">waker-fn</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasi ">wasi</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen ">wasm-bindgen</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend ">wasm-bindgen-backend</a></li>
@@ -4523,7 +4275,6 @@ limitations under the License.
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys ">web-sys</a></li>
                     <li><a href=" https://github.com/Stebalien/xattr ">xattr</a></li>
-                    <li><a href=" https://github.com/chyh1990/yaml-rust ">yaml-rust</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -4732,8 +4483,6 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/contain-rs/bit-set ">bit-set</a></li>
-                    <li><a href=" https://github.com/contain-rs/bit-vec ">bit-vec</a></li>
                     <li><a href=" https://github.com/contain-rs/linked-hash-map ">linked-hash-map</a></li>
                     <li><a href=" https://github.com/contain-rs/vec-map ">vec_map</a></li>
                 </ul>
@@ -5163,7 +4912,6 @@ limitations under the License.
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_core</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_hc</a></li>
-                    <li><a href=" https://github.com/d-e-s-o/test-log.git ">test-log</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5791,11 +5539,9 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/smol-rs/async-channel ">async-channel</a></li>
                     <li><a href=" https://github.com/rust-lang/log ">log</a></li>
                     <li><a href=" https://github.com/steveklabnik/semver ">semver</a></li>
                     <li><a href=" https://github.com/steveklabnik/semver-parser ">semver-parser</a></li>
-                    <li><a href=" https://github.com/uuid-rs/uuid ">uuid</a></li>
                     <li><a href=" https://github.com/sval-rs/value-bag ">value-bag</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -6414,214 +6160,6 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/aclysma/wepoll-ffi ">wepoll-ffi</a></li>
-                </ul>
-                <pre class="license-text">  Apache License
-                        Version 2.0, January 2004
-                     http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   &quot;control&quot; means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   &quot;Source&quot; form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   &quot;Object&quot; form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   &quot;Work&quot; shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   &quot;Contribution&quot; shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-   replaced with your own identifying information. (Don&#x27;t include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same &quot;printed page&quot; as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright [yyyy] [name of copyright owner]
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi</a></li>
                 </ul>
                 <pre class="license-text">// Licensed under the Apache License, Version 2.0
@@ -7054,12 +6592,7 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://crates.io/crates/apollo-parser ">apollo-parser</a></li>
-                    <li><a href=" https://github.com/stjepang/async-lock ">async-mutex</a></li>
                     <li><a href=" https://github.com/chronotope/chrono ">chrono</a></li>
-                    <li><a href=" https://github.com/rustwasm/gloo/tree/master/crates/timers ">gloo-timers</a></li>
-                    <li><a href=" https://github.com/starkat99/half-rs ">half</a></li>
-                    <li><a href=" https://github.com/lalrpop/lalrpop ">lalrpop</a></li>
-                    <li><a href=" https://github.com/lalrpop/lalrpop ">lalrpop-util</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-build</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-derive</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-types</a></li>
@@ -7068,11 +6601,11 @@ limitations under the License.
                     <li><a href=" https://github.com/ctz/rustls ">rustls</a></li>
                     <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework</a></li>
                     <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys</a></li>
-                    <li><a href=" https://github.com/jedisct1/rust-siphash ">siphasher</a></li>
                     <li><a href=" https://crates.io/crates/thrift ">thrift</a></li>
                     <li><a href=" https://github.com/Soveu/tinyvec_macros ">tinyvec_macros</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi-i686-pc-windows-gnu</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi-x86_64-pc-windows-gnu</a></li>
+                    <li><a href=" https://crates.io/crates/xtask ">xtask</a></li>
                 </ul>
                 <pre class="license-text">Apache License
 Version 2.0, January 2004
@@ -7342,7 +6875,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/notify-rs/notify.git ">notify</a></li>
-                    <li><a href=" https://crates.io/crates/tiny-keccak ">tiny-keccak</a></li>
                 </ul>
                 <pre class="license-text">Creative Commons Legal Code
 
@@ -7622,34 +7154,6 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/alexcrichton/curl-rust ">curl</a></li>
-                    <li><a href=" https://github.com/alexcrichton/curl-rust ">curl-sys</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2014 Carl Lerche
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/tokio-rs/mio ">mio</a></li>
                     <li><a href=" https://github.com/tokio-rs/mio ">mio</a></li>
                 </ul>
@@ -7740,33 +7244,6 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/mikedilger/float-cmp ">float-cmp</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2014-2020 Optimal Computing (NZ) Ltd
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the &quot;Software&quot;), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/hyperium/hyper ">hyper</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014-2021 Sean McArthur
@@ -7821,7 +7298,6 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/mbrubeck/rust-debug-unreachable ">new_debug_unreachable</a></li>
                     <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2015 Jonathan Reem
@@ -8254,21 +7730,6 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/davidpdrsn/assert-json-diff.git ">assert-json-diff</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2019 David Pedersen
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/hawkw/sharded-slab ">sharded-slab</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019 Eliza Weisman
@@ -8317,34 +7778,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/RazrFalcon/pico-args ">pico-args</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2019 Evgeniy Reizner
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
 </pre>
             </li>
             <li class="license">
@@ -8579,129 +8012,11 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/emilio/precomputed-hash ">precomputed-hash</a></li>
-                </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2017 Emilio Cobos Álvarez
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/sagebind/sluice ">sluice</a></li>
-                </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2017 Stephen M. Coakley
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/GuillaumeGomez/doc-comment ">doc-comment</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
 Copyright (c) 2018 Guillaume Gomez
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/38/plotters ">plotters</a></li>
-                    <li><a href=" https://github.com/plotters-rs/plotters-backend ">plotters-backend</a></li>
-                    <li><a href=" https://github.com/plotters-rs/plotters-svg.git ">plotters-svg</a></li>
-                </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2019 Hao Hou &lt;haohou302@gmail.com&gt;
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/sagebind/isahc ">isahc</a></li>
-                </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2019 Stephen M. Coakley
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -8755,74 +8070,12 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/alexliesenfeld/async-object-pool ">async-object-pool</a></li>
-                </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2020 Alexander Liesenfeld
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/sagebind/castaway ">castaway</a></li>
-                </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2021 Stephen M. Coakley
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/rutrum/convert-case ">convert_case</a></li>
-                    <li><a href=" https://crates.io/crates/crunchy ">crunchy</a></li>
                     <li><a href=" https://github.com/denoland/deno ">deno_core</a></li>
                     <li><a href=" https://github.com/DimaKudosh/difflib ">difflib</a></li>
                     <li><a href=" https://github.com/Michael-F-Bryan/include_dir ">include_dir</a></li>
                     <li><a href=" https://github.com/Michael-F-Bryan/include_dir ">include_dir_impl</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">kernel32-sys</a></li>
-                    <li><a href=" https://github.com/wooorm/levenshtein-rs ">levenshtein</a></li>
-                    <li><a href=" https://github.com/sfackler/rust-phf ">phf_shared</a></li>
-                    <li><a href=" https://github.com/algesten/qstring ">qstring</a></li>
                     <li><a href=" https://github.com/denoland/rusty_v8 ">rusty_v8</a></li>
                     <li><a href=" https://github.com/denoland/deno ">serde_v8</a></li>
                     <li><a href=" https://github.com/hyperium/tonic ">tonic</a></li>
@@ -8840,81 +8093,6 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 </pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/alexliesenfeld/httpmock ">httpmock</a></li>
-                </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2019 Alexander Liesenfeld
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/fkoep/downcast-rs ">downcast</a></li>
-                </ul>
-                <pre class="license-text">MIT License (MIT)
-
-Copyright (c) 2017 Felix Köpge
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/drjokepu/basic-cookies ">basic-cookies</a></li>
-                </ul>
-                <pre class="license-text">Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the &quot;Software&quot;), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
@@ -8981,7 +8159,6 @@ SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/mvdnes/spin-rs.git ">spin</a></li>
-                    <li><a href=" https://github.com/zip-rs/zip.git ">zip</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -9040,8 +8217,6 @@ SOFTWARE.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/BurntSushi/aho-corasick ">aho-corasick</a></li>
                     <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder</a></li>
-                    <li><a href=" https://github.com/BurntSushi/rust-csv ">csv</a></li>
-                    <li><a href=" https://github.com/BurntSushi/rust-csv ">csv-core</a></li>
                     <li><a href=" https://github.com/BurntSushi/ripgrep/tree/master/crates/globset ">globset</a></li>
                     <li><a href=" https://github.com/BurntSushi/ripgrep/tree/master/crates/ignore ">ignore</a></li>
                     <li><a href=" https://github.com/BurntSushi/memchr ">memchr</a></li>
@@ -9105,12 +8280,11 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/dguo/strsim-rs ">strsim</a></li>
+                    <li><a href=" https://github.com/chyh1990/yaml-rust ">yaml-rust</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
-Copyright (c) 2015 Danny Guo
-Copyright (c) 2016 Titus Wormer &lt;tituswormer@gmail.com&gt;
+Copyright (c) 2015 Chen Yuheng
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -9129,18 +8303,18 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
 </pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/johannhof/difference.rs ">difference</a></li>
+                    <li><a href=" https://github.com/dguo/strsim-rs ">strsim</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
-Copyright (c) 2015 Johann Hofmann
+Copyright (c) 2015 Danny Guo
+Copyright (c) 2016 Titus Wormer &lt;tituswormer@gmail.com&gt;
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -9345,36 +8519,6 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/mitsuhiko/console ">console</a></li>
-                </ul>
-                <pre class="license-text">The MIT License (MIT)
-
-Copyright (c) 2017 Armin Ronacher &lt;armin.ronacher@active-4.com&gt;
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://gitlab.redox-os.org/redox-os/users ">redox_users</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
@@ -9400,34 +8544,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 </pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://sr.ht/~icefox/oorandom/ ">oorandom</a></li>
-                </ul>
-                <pre class="license-text">The MIT License (MIT)
-
-Copyright (c) 2019 Simon Heath
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
@@ -9492,7 +8608,6 @@ SOFTWARE.</pre>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/BurntSushi/aho-corasick ">aho-corasick</a></li>
                     <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder</a></li>
-                    <li><a href=" https://github.com/BurntSushi/rust-csv ">csv-core</a></li>
                     <li><a href=" https://github.com/BurntSushi/ripgrep/tree/master/crates/globset ">globset</a></li>
                     <li><a href=" https://github.com/BurntSushi/ripgrep/tree/master/crates/ignore ">ignore</a></li>
                     <li><a href=" https://github.com/BurntSushi/memchr ">memchr</a></li>

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0-prealpha.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2018"
 license = "LicenseRef-ELv2"
+publish = false
 
 [dependencies]
 ansi_term = "0.12"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -30,4 +30,4 @@ tempfile = "3"
 which = "4"
 walkdir = "2"
 zip = { version = "0.5", default-features = false }
-ring = "0.16.20"
+sha2 = "0.9"

--- a/xtask/src/commands/all.rs
+++ b/xtask/src/commands/all.rs
@@ -1,0 +1,13 @@
+use structopt::StructOpt;
+
+use super::{Compliance, Lint, Test};
+
+#[derive(Debug, StructOpt)]
+pub struct All {
+    #[structopt(flatten)]
+    pub compliance: Compliance,
+    #[structopt(flatten)]
+    pub lint: Lint,
+    #[structopt(flatten)]
+    pub test: Test,
+}

--- a/xtask/src/commands/check.rs
+++ b/xtask/src/commands/check.rs
@@ -32,9 +32,9 @@ impl Compliance {
 
         ensure!(
             licenses_html_before == licences_html_after,
-            r#"🚨 licenses.html file is not up to date. 🚨
-Please run `cargo about generate --workspace -o licenses.html about.hbs` to generate an up to date licenses list, and check the file in to the repository.
-💡 You can install `cargo-about` by running `cargo install cargo-about`."#
+            "🚨 licenses.html file is not up to date. 🚨\n\
+            Please run `cargo about generate --workspace -o licenses.html about.hbs` to generate an up to date licenses list, and check the file in to the repository.\n\
+            💡 You can install `cargo-about` by running `cargo install cargo-about`."
         );
         Ok(())
     }

--- a/xtask/src/commands/check.rs
+++ b/xtask/src/commands/check.rs
@@ -32,8 +32,9 @@ impl Compliance {
 
         ensure!(
             licenses_html_before == licences_html_after,
-            r#"🚨 licenses.html file is not up to date. 🚨\n\
-            Please run `cargo about generate --workspace -o licenses.html about.hbs` to generate an up to date licenses list, and check the file in to the repository."#
+            r#"🚨 licenses.html file is not up to date. 🚨
+Please run `cargo about generate --workspace -o licenses.html about.hbs` to generate an up to date licenses list, and check the file in to the repository.
+💡 You can install `cargo-about` by running `cargo install cargo-about`."#
         );
         Ok(())
     }

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -1,9 +1,11 @@
+pub(crate) mod all;
 pub(crate) mod check;
 pub(crate) mod dist;
 pub(crate) mod lint;
 pub(crate) mod package;
 pub(crate) mod test;
 
+pub(crate) use all::All;
 pub(crate) use check::Compliance;
 pub(crate) use dist::Dist;
 pub(crate) use lint::Lint;

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -34,16 +34,6 @@ pub struct Test {
     no_pre_compile: bool,
 }
 
-impl Default for Test {
-    fn default() -> Self {
-        Self {
-            no_demo: Default::default(),
-            with_demo: true,
-            no_pre_compile: Default::default(),
-        }
-    }
-}
-
 impl Test {
     pub fn run(&self) -> Result<()> {
         ensure!(

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -34,6 +34,16 @@ pub struct Test {
     no_pre_compile: bool,
 }
 
+impl Default for Test {
+    fn default() -> Self {
+        Self {
+            no_demo: Default::default(),
+            with_demo: true,
+            no_pre_compile: Default::default(),
+        }
+    }
+}
+
 impl Test {
     pub fn run(&self) -> Result<()> {
         ensure!(

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -22,7 +22,7 @@ struct Xtask {
 #[derive(Debug, StructOpt)]
 pub enum Command {
     /// Locally run all the checks the CI will perform.
-    All,
+    All(All),
     /// Check the code for licence and security compliance.
     CheckCompliance(commands::Compliance),
 
@@ -39,16 +39,30 @@ pub enum Command {
     Package(commands::Package),
 }
 
+#[derive(Debug, StructOpt)]
+pub struct All {
+    #[structopt(flatten)]
+    compliance: commands::Compliance,
+    #[structopt(flatten)]
+    lint: commands::Lint,
+    #[structopt(flatten)]
+    test: commands::Test,
+}
+
 impl Xtask {
     pub fn run(&self) -> Result<()> {
         match &self.command {
-            Command::All => {
-                eprintln!("checking format and clippy...");
-                commands::Lint {}.run()?;
-                eprintln!("checking licenses...");
-                commands::Compliance {}.run()?;
-                eprintln!("running tests");
-                commands::Test::default().run()
+            Command::All(All {
+                compliance,
+                lint,
+                test,
+            }) => {
+                eprintln!("Checking format and clippy...");
+                lint.run()?;
+                eprintln!("Checking licenses...");
+                compliance.run()?;
+                eprintln!("Running tests");
+                test.run()
             }
             Command::CheckCompliance(command) => command.run(),
             Command::Dist(command) => command.run(),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -21,6 +21,8 @@ struct Xtask {
 
 #[derive(Debug, StructOpt)]
 pub enum Command {
+    /// Locally run all the checks the CI will perform.
+    All,
     /// Check the code for licence and security compliance.
     CheckCompliance(commands::Compliance),
 
@@ -40,6 +42,14 @@ pub enum Command {
 impl Xtask {
     pub fn run(&self) -> Result<()> {
         match &self.command {
+            Command::All => {
+                eprintln!("checking format and clippy...");
+                commands::Lint {}.run()?;
+                eprintln!("checking licenses...");
+                commands::Compliance {}.run()?;
+                eprintln!("running tests");
+                commands::Test::default().run()
+            }
             Command::CheckCompliance(command) => command.run(),
             Command::Dist(command) => command.run(),
             Command::Lint(command) => command.run(),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -22,7 +22,7 @@ struct Xtask {
 #[derive(Debug, StructOpt)]
 pub enum Command {
     /// Locally run all the checks the CI will perform.
-    All(All),
+    All(commands::All),
     /// Check the code for licence and security compliance.
     CheckCompliance(commands::Compliance),
 
@@ -39,20 +39,10 @@ pub enum Command {
     Package(commands::Package),
 }
 
-#[derive(Debug, StructOpt)]
-pub struct All {
-    #[structopt(flatten)]
-    compliance: commands::Compliance,
-    #[structopt(flatten)]
-    lint: commands::Lint,
-    #[structopt(flatten)]
-    test: commands::Test,
-}
-
 impl Xtask {
     pub fn run(&self) -> Result<()> {
         match &self.command {
-            Command::All(All {
+            Command::All(commands::All {
                 compliance,
                 lint,
                 test,
@@ -61,7 +51,7 @@ impl Xtask {
                 lint.run()?;
                 eprintln!("Checking licenses...");
                 compliance.run()?;
-                eprintln!("Running tests");
+                eprintln!("Running tests...");
                 test.run()
             }
             Command::CheckCompliance(command) => command.run(),


### PR DESCRIPTION
Local devs can now run `cargo xtask all` before opening a PR.
Xtask all does the following steps (that the CI does):
- check code format
- check against clippy lints
- check for CVEs and not allowed licenses.
- Make sure the licenses.html file is up to date.
- Start the subgraphs and run tests with the relevant features permutation for your OS.