### PR TITLE
fixes: decrease CI cache size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,14 +119,14 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - subgraph-node-modules-v2-windows-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
-            - subgraph-node-modules-v2-windows
+            - subgraph-node-modules-v2-windows-{{ checksum "dockerfiles/federation-demo/federation-demo/package.json" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
+            - subgraph-node-modules-v2-windows-{{ checksum "dockerfiles/federation-demo/federation-demo/package.json" }}
       - run:
           name: npm clean-install
           working_directory: dockerfiles/federation-demo/federation-demo
           command: npm clean-install
       - save_cache:
-          key: subgraph-node-modules-v2-windows-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
+          key: subgraph-node-modules-v2-windows-{{ checksum "dockerfiles/federation-demo/federation-demo/package.json" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
           paths:
             - dockerfiles/federation-demo/federation-demo/node_modules
 
@@ -200,8 +200,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rust-target-v2-xtask-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
-            - rust-target-v2-xtask-build-<< parameters.os >>
+            - rust-target-v2-xtask-build-<< parameters.os >>-{{ checksum "xtask/Cargo.toml" }}-{{ checksum "Cargo.lock" }}
+            - rust-target-v2-xtask-build-<< parameters.os >>-{{ checksum "xtask/Cargo.toml" }}
       - run: cargo xtask lint
 
   xtask_check_compliance:
@@ -211,8 +211,8 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rust-target-v2-xtask-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
-            - rust-target-v2-xtask-build-<< parameters.os >>
+            - rust-target-v2-xtask-build-<< parameters.os >>-{{ checksum "xtask/Cargo.toml" }}-{{ checksum "Cargo.lock" }}
+            - rust-target-v2-xtask-build-<< parameters.os >>-{{ checksum "xtask/Cargo.toml" }}
       - run:
           name: Install cargo sweep
           command: |
@@ -224,7 +224,7 @@ commands:
       - run: cargo xtask check-compliance
       - run: cargo sweep -f
       - save_cache:
-          key: rust-target-v2-xtask-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+          key: rust-target-v2-xtask-build-<< parameters.os >>-{{ checksum "xtask/Cargo.toml" }}-{{ checksum "Cargo.lock" }}
           paths:
             - target/
             - ~/.cargo
@@ -250,8 +250,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rust-target-v2-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
-            - rust-target-v2-build-<< parameters.os >>
+            - rust-target-v2-build-<< parameters.os >>-{{ checksum "Cargo.toml" }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+            - rust-target-v2-build-<< parameters.os >>-{{ checksum "Cargo.toml" }}-{{ .Branch }}
+            - rust-target-v2-build-<< parameters.os >>-{{ checksum "Cargo.toml" }}
       - run:
           name: Install cargo sweep
           command: |
@@ -261,7 +262,7 @@ commands:
       - build_all_permutations
       - run: cargo sweep -f
       - save_cache:
-          key: rust-target-v2-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+          key: rust-target-v2-build-<< parameters.os >>-{{ checksum "Cargo.toml" }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
           paths:
             - target/
             - ~/.cargo
@@ -269,8 +270,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rust-target-v2-build-windows-{{ checksum "Cargo.lock" }}
-            - rust-target-v2-build-windows
+            - rust-target-v2-build-windows-{{ checksum "Cargo.toml" }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+            - rust-target-v2-build-windows-{{ checksum "Cargo.toml" }}-{{ .Branch }}
+            - rust-target-v2-build-windows-{{ checksum "Cargo.toml" }}
       - run:
           name: Install cargo sweep
           command: |
@@ -284,7 +286,7 @@ commands:
       - build_common_permutations
       - run: cargo sweep -f
       - save_cache:
-          key: rust-target-v2-build-windows-{{ checksum "Cargo.lock" }}
+          key: rust-target-v2-build-windows-{{ checksum "Cargo.toml" }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
           paths:
             - target/
             - C:\\Users\\circleci\.cargo
@@ -293,9 +295,9 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rust-target-v2-test-windows-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
-            - rust-target-v2-test-windows-{{ checksum "Cargo.lock" }}
-            - rust-target-v2-test-windows
+            - rust-target-v2-test-windows-{{ checksum "Cargo.toml" }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+            - rust-target-v2-test-windows-{{ checksum "Cargo.toml" }}-{{ .Branch }}
+            - rust-target-v2-test-windows-{{ checksum "Cargo.toml" }}
       - run:
           name: Install cargo sweep
           command: |
@@ -309,7 +311,7 @@ commands:
       - run: cargo xtask test --with-demo
       - run: cargo sweep -f
       - save_cache:
-          key: rust-target-v2-test-windows-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
+          key: rust-target-v2-test-windows-{{ checksum "Cargo.toml" }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
           paths:
             - target/
             - C:\\Users\\circleci\.cargo
@@ -320,9 +322,11 @@ commands:
     steps:
       - restore_cache:
           keys:
-            - rust-target-v2-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
-            - rust-target-v2-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}
-            - rust-target-v2-test-<< parameters.os >>
+            - rust-target-v2-test-<< parameters.os >>-{{ checksum "Cargo.toml" }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package.json" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
+            - rust-target-v2-test-<< parameters.os >>-{{ checksum "Cargo.toml" }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package.json" }}
+            - rust-target-v2-test-<< parameters.os >>-{{ checksum "Cargo.toml" }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}
+            - rust-target-v2-test-<< parameters.os >>-{{ checksum "Cargo.toml" }}-{{ .Branch }}
+            - rust-target-v2-test-<< parameters.os >>-{{ checksum "Cargo.toml" }}
       - run:
           name: Install cargo sweep
           command: |
@@ -332,7 +336,7 @@ commands:
       - run: cargo xtask test --with-demo
       - run: cargo sweep -f
       - save_cache:
-          key: rust-target-v2-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
+          key: rust-target-v2-test-<< parameters.os >>-{{ checksum "Cargo.toml" }}-{{ .Branch }}-{{ checksum "Cargo.lock" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package.json" }}-{{ checksum "dockerfiles/federation-demo/federation-demo/package-lock.json" }}
           paths:
             - target/
             - ~/.cargo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,16 +233,16 @@ commands:
     steps:
       - rust/build:
           with_cache: false
-          crate: --features otlp-grpc -p apollo-router -p apollo-router-core
+          crate: --locked --features otlp-grpc -p apollo-router -p apollo-router-core
       - rust/build:
           with_cache: false
-          crate: --no-default-features --features otlp-http -p apollo-router -p apollo-router-core
+          crate: --locked --no-default-features --features otlp-http -p apollo-router -p apollo-router-core
   build_all_permutations:
     steps:
       - build_common_permutations
       - rust/build:
           with_cache: false
-          crate: --no-default-features -p apollo-router -p apollo-router-core
+          crate: --locked --no-default-features -p apollo-router -p apollo-router-core
   build_workspace:
     parameters:
       os:

--- a/xtask/src/federation_demo.rs
+++ b/xtask/src/federation_demo.rs
@@ -22,6 +22,7 @@ impl FederationDemoRunner {
     }
 
     pub fn start_background(&self) -> Result<BackgroundTask> {
+        // https://stackoverflow.com/questions/52499617/what-is-the-difference-between-npm-install-and-npm-ci#53325242
         npm!(&self.path => ["clean-install", "--no-progress"]);
 
         eprintln!("Running federation-demo in background...");

--- a/xtask/src/federation_demo.rs
+++ b/xtask/src/federation_demo.rs
@@ -22,7 +22,7 @@ impl FederationDemoRunner {
     }
 
     pub fn start_background(&self) -> Result<BackgroundTask> {
-        npm!(&self.path => ["install", "--no-progress"]);
+        npm!(&self.path => ["clean-install", "--no-progress"]);
 
         eprintln!("Running federation-demo in background...");
         let mut command = Command::new(which::which("npm")?);


### PR DESCRIPTION
fixes #181, #178

This commit fixes a bug in the way `xtask test` was running, and changes the caching strategy.

Xtask test:
Xtask was running `npm install` instead of `npm clean-install`.
NPM install does update the package-lock.json file if it is able to find updates to a package that satisfy the version requirements defined in package.json.
However the CI caching strategy is looking for a key that contains the hash of `package-lock.json`.
In this scenario the cache would:
- search for a hash of the package-lock.json
- miss the cache
- run a clean npm install (thus updating package-lock.json)
- upload the build artefact under the hash of the new package-lock.json

Subsequent CI runs would look for the previous package-lock.json, and never hit.

Caching:
Given the .yml file might be hard to read, here's a summary of how CI caching behaves since this commit:

Caches:
There are 5 steps that use caching, and 4 of them depend on the supported OS (macos, linux, windows):
- extra tools: this cache contains cargo binaries we use: "cargo-deny" and "cargo-about", that xtask will need.
- Xtask lint and check compliance (all OSes): xtask generates a `target/` which we are keeping around for each supported OS. This speeds up the compilation of xtask.
- cargo build (all OSes): this cache contains previous `target/` output, as well as `~/.cargo` because otherwise rustc would rebuild the whole project from scratch.
- cargo test (all OSes): this cache contains the same thing as the cargo build cache, plus node modules (except on windows, see below) but it's more accurate for test runs (given it is the output of cargo test).
- Node modules (windows only): Given we didn't manage to spin up federation-demo subservices during the xtask step on windows, we set it up in a separate CI step. this cache keeps the `node_modules`.

How cache behaves in CircleCI:
Restore: Cache restoration in CircleCI behaves with a list of keys, it will try to hit each one in order.
Save: If the first cache try is a miss, CircleCI will save the output.

This behavior allows us to try several scopes of keys, and upload only when the new output would be more accurate.

Strategy:
## Extra tools:
This one will always hit for the operating systems. We might want to update the tool versions manually by changing "v2" later on, thus triggering a full cache rebuild.

## Xtask build:
1. look for a cache for the same operating system, the same xtask/Cargo.toml file, and the same Cargo.lock

2.look for a fache for the same operating system, and the same xtask/Cargo.toml file

## Cargo build (all OSes):
1. look for a cache for the same operating system, the same Cargo.toml file, the same git Branch, and the same Cargo.lock

2. look for a cache for the same operating system, the same Cargo.toml file, and the same git Branch

3. look for a cache for the same operating system, and the same Cargo.toml

## Cargo test (linux and macos):
1. look for a cache for the same operating system, the same Cargo.toml file, the same Cargo.lock, the same subgraphs package.json, and the same subgraphs package-lock.json

2. look for a cache for the same operating system, the same Cargo.toml file, the same Cargo.lock, and the same subgraphs package.json

3. look for a cache for the same operating system, the same Cargo.toml file, and the same Cargo.lock

4. look for a cache for the same operating system, and the same Cargo.toml


## Cargo test (windows):
1. look for a cache for the same operating system, the same Cargo.toml file, the same git Branch, the same Cargo.lock

2. look for a cache for the same operating system, the same Cargo.toml file, and the same git Branch

3. look for a cache for the same operating system, and the same Cargo.toml

## Node modules(windows):
1. look for a cache for the same operating system, the same package.json, and the same package-lock.json

2. look for a cache for the same operating system, and the same package.json
