### PR TITLE
test trace sampling

### DIFF
--- a/crates/apollo-router-core/src/request.rs
+++ b/crates/apollo-router-core/src/request.rs
@@ -174,6 +174,7 @@ impl Query {
                 })
                 .collect()
         }
+        tracing::error!("TEST ERROR format_response");
 
         let parser = apollo_parser::Parser::new(self.as_str());
         let tree = parser.parse();

--- a/crates/apollo-router/src/apollo_router.rs
+++ b/crates/apollo-router/src/apollo_router.rs
@@ -106,6 +106,8 @@ impl PreparedQuery for ApolloPreparedQuery {
                 tracing::debug_span!("format_response")
                     .in_scope(|| self.query.format_response(&mut response));
 
+                tracing::error!("TEST ERROR");
+
                 response
             }
             .with_current_subscriber(),

--- a/crates/apollo-router/src/warp_http_server_factory.rs
+++ b/crates/apollo-router/src/warp_http_server_factory.rs
@@ -288,6 +288,8 @@ where
     Router: graphql::Router<PreparedQuery> + 'static,
     PreparedQuery: graphql::PreparedQuery,
 {
+    tracing::error!("TEST ERROR stream_request");
+
     let stream = match router.prepare_query(&request).await {
         Ok(route) => route.execute(Arc::new(request)).await,
         Err(stream) => stream,


### PR DESCRIPTION
related:
- #29
- #50

this is an exploration of trace sampling. Currently the custom sampler just prints its parameters. With the query `query ExampleQuery($topProductsFirst: Int) {  me {   id avis: reviews { body }  }  topProducts(first: $topProductsFirst) {    name  price   inStock  }}` it will print:

```
{"timestamp":"Nov 25 11:14:54.182","level":"INFO","fields":{"message":"Starting Apollo Router\n*******************************************************************\n⚠️  Experimental software, not YET recommended for production use ⚠️\n****************************************
***************************"},"target":"router"}                   
{"timestamp":"Nov 25 11:14:54.659","level":"INFO","fields":{"message":"Listening on http://127.0.0.1:4000 🚀"},"target":"router"}
Nov 25 11:15:17.822 ERROR graphql_request: apollo_router::warp_http_server_factory: TEST ERROR stream_request
should_sample:                          
parent context: Some(Context { entries: 0 })                                                                                            
trace id: TraceId(271433600488164807808896833698919480999)
name:graphql_request                                                                                                                    
span_kind: Internal                               
attributes: [                                                                                                                           
    KeyValue {                                                                                                                          
        key: Key(                         
            "code.filepath",                                                                                                            
        ),                                                                                                                              
        value: String(    
            "crates/apollo-router/src/warp_http_server_factory.rs",                                                                                                                                                                                                             
        ),                                         
    },                                                                                                                                  
    KeyValue {                                                      
        key: Key(                                                                                                                       
            "code.namespace",                
        ),                                                                                                                                                                                                                                                                              value: String(                                                                                                                  
            "apollo_router::warp_http_server_factory",                                                                                                                                                                                                                          
        ),
    },
    KeyValue {
        key: Key(
            "code.lineno",
        ),
        value: I64(
            275,
        ),
    },
]
links: []

should_sample:                                     
parent context: Some(Context { entries: 0 })                                                                                            
trace id: TraceId(10389225646006697978543566376744025668)
name:execution                                                     
span_kind: Internal         
attributes: [                                                                                                                           
    KeyValue {                                                                                                                          
        key: Key(                                                                                                                       
            "code.filepath",                                  
        ),                                                                                                                              
        value: String(                                                                                                                                                                                                                                                          
            "crates/apollo-router-core/src/query_planner/model.rs",
        ),                                                                                                                              
    },                                                                                                                                  
    KeyValue {
        key: Key(                           
            "code.namespace",                             
        ),          
        value: String(
            "apollo_router_core::query_planner::model",
        ),    
    },           
    KeyValue {              
        key: Key(
            "code.lineno",
        ),                                                         
        value: I64(
            249,
        ),    
    },           
]                            
links: [] 
                                                                    
Nov 25 11:15:18.149 ERROR format_response{self=Query { string: "query ExampleQuery($topProductsFirst: Int) {\n  me {\n    id\n avis: reviews { body } \n }\n  topProducts(first: $topProductsFirst) {\n    name\n    price\n    inStock\n  }\n}\n" } response=Response { label: 
None, data: Object({"me": Object({"__typename": String("User"), "id": String("1"), "avis": Array([Object({"body": String("Love it!")}), Object({"body": String("Too expensive.")})])}), "topProducts": Array([Object({"__typename": String("Product"), "upc": String("1"), "name
": String("Table"), "price": Number(899), "inStock": Bool(true)}), Object({"__typename": String("Product"), "upc": String("2"), "name": String("Couch"), "price": Number(1299), "inStock": Bool(false)}), Object({"__typename": String("Product"), "upc": String("3"), "name": S
tring("Chair"), "price": Number(54), "inStock": Bool(true)})])}), path: None, has_next: None, errors: [], extensions: {} }}: apollo_router_core::request: TEST ERROR format_response 

should_sample:                                            
parent context: Some(Context { entries: 0 })                                                                                                                                                                                                                                    
trace id: TraceId(272298814962264935456849981390735724192)                                                                                                                                                                                                                      
name:format_response                                                                                                                                                                                                                                                            
span_kind: Internal                                                                                                                                                                                                                                                             
attributes: [                                                                                                                                                                                                                                                                   
    KeyValue {                                                                                                                                                                                                                                                                  
        key: Key(                                                                                                                                                                                                                                                               
            "code.filepath",                                                                                                                                                                                                                                                    
        ),                                                                                                                                                                                                                                                                      
        value: String(                                                                                                                                                                                                                                                          
            "crates/apollo-router-core/src/request.rs",                                                                                                                                                                                                                         
        ),                                                                                                                                                                                                                                                                      
    },                                                                                                                                                                                                                                                                          
    KeyValue {                                                                                                                                                                                                                                                                  
        key: Key(                                                                                                                                                                                                                                                               
            "code.namespace",                                                                                                                                                                                                                                                   
        ),                                                                                                                                                                                                                                                                      
        value: String(                                                                                                                                                                                                                                                          
            "apollo_router_core::request",                                                                                                                                                                                                                                      
        ),                                                                                                                                                                                                                                                                      
    },                                                                                                                                                                                                                                                                          
    KeyValue {                                                                                                                                                                                                                                                                  
        key: Key(                                                                                                                                                                                                                                                               
            "code.lineno",                                                                                                                                                                                                                                                      
        ),                                                                                                                                                                                                                                                                      
        value: I64(                                                                                                                                                                                                                                                             
            51,                                                                                                                                                                                                                                                                 
        ),                                                                                                                                                                                                                                                                      
    },                                                                                                                                                                                                                                                                          
    KeyValue {                                                                                                                                                                                                                                                                  
        key: Key(                                                                                                                                                                                                                                                               
            "self",                                                                                                                                                                                                                                                             
        ),                                                                                                                                                                                                                                                                      
        value: String(                                                                                                                                                                                                                                                          
            "Query { string: \"query ExampleQuery($topProductsFirst: Int) {\\n  me {\\n    id\\n avis: reviews { body } \\n }\\n  topProducts(first: $topProductsFirst) {\\n    name\\n    price\\n    inStock\\n  }\\n}\\n\" }",                                               
        ),                                                                                                                                                                                                                                                                      
    },                                                                                                                                                                                                                                                                          
    KeyValue {                                                                                                                                                                                                                                                                  
        key: Key(                                                                                                                                                                                                                                                               
            "response",                                                                                                                                                                                                                                                         
        ),                                                                                                                                                                                                                                                                      
        value: String(                                                                                                                                                                                                                                                          
            "Response { label: None, data: Object({\"me\": Object({\"__typename\": String(\"User\"), \"id\": String(\"1\"), \"avis\": Array([Object({\"body\": String(\"Love it!\")}), Object({\"body\": String(\"Too expensive.\")})])}), \"topProducts\": Array([Object({\"__t
ypename\": String(\"Product\"), \"upc\": String(\"1\"), \"name\": String(\"Table\"), \"price\": Number(899), \"inStock\": Bool(true)}), Object({\"__typename\": String(\"Product\"), \"upc\": String(\"2\"), \"name\": String(\"Couch\"), \"price\": Number(1299), \"inStock\": 
Bool(false)}), Object({\"__typename\": String(\"Product\"), \"upc\": String(\"3\"), \"name\": String(\"Chair\"), \"price\": Number(54), \"inStock\": Bool(true)})])}), path: None, has_next: None, errors: [], extensions: {} }",
        ),
    },
    KeyValue {                                                      
        key: Key(                                                                                                                       
            "busy_ns",                                   
        ),                                                       
        value: I64(                                       
            504336,                                             
        ),                                              
    },                                                                                                                                  
    KeyValue {                                 
        key: Key(                                            
            "idle_ns",                               
        ),                                                                                                                              
        value: I64(
            29067,                                                                                                                      
        ),                                                                                                                              
    },                                                              
]                                                                                                                                       
links: []                                                                                                                               
                                                                    
Nov 25 11:15:18.149 ERROR apollo_router::apollo_router: TEST ERROR
```

Apparently it does not receive information that there was an error event inside a span. In its result, a sampler has a [SamplingDecision](https://docs.rs/opentelemetry/0.16.0/opentelemetry/sdk/trace/enum.SamplingDecision.html):
- Drop: delete the span from the trace
- RecordOnly: keep the span, but it is not sent
- RecordAndSample: keep the span, send it

RecordOnly is useful if we want to process the span (example: [for statistics or SLO/SLA](https://docs.rs/opentelemetry/0.16.0/opentelemetry/trace/trait.Span.html#tymethod.is_recording)) but don't want to send it because we're sampling
[The sampler can look at the parent span](https://docs.rs/opentelemetry/0.16.0/src/opentelemetry/sdk/trace/sampler.rs.html#124) to see if it should be sampled. [The sampling decision depends on the parent](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/src/sdk/trace/tracer.rs#L222-L226) so here in the logs, we have three different traces (probably a bug, they should be merged).
The spec on sampled flag usage: https://www.w3.org/TR/trace-context/#sampled-flag

## needs

The kind of sampling I'd like to integrate:
- send all traces where we saw an error (or at least most of them, we should be careful not to overwhelm the collection system during an incident)
- sample successful queries, with a configurable rate (percentage based, time based, maybe per query hash, etc)
- honor sampling orders [sent by the client in a header](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/src/sdk/propagation/trace_context.rs#L54-L103)
- indicate in the trace the sample rate

## design

- we make a sampler like the [parent based](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/src/sdk/trace/sampler.rs#L119-L134) that defers the decision to the parent if it's sampled
- our sampler looks at the attributes to see if there's one indicating it  should be sampled (can be done with `Context::current().span().set_attribute(key_value)`)
- at the end of the response processing, if there was an error, we set the attribute for it