### PR TITLE
fix: osx file reload

### DIFF
--- a/crates/apollo-router/src/files.rs
+++ b/crates/apollo-router/src/files.rs
@@ -83,6 +83,5 @@ pub(crate) mod tests {
         file.seek(SeekFrom::Start(0)).unwrap();
         file.write_all(contents.as_bytes()).unwrap();
         file.flush().unwrap();
-        tokio::time::sleep(Duration::from_millis(20)).await;
     }
 }

--- a/crates/apollo-router/src/files.rs
+++ b/crates/apollo-router/src/files.rs
@@ -42,8 +42,8 @@ pub(crate) fn watch(path: PathBuf, delay: Option<Duration>) -> impl Stream<Item 
             }
         })
         .expect("Failed to watch file.");
-    // Tell watchers once they should fetch the data once,
-    // then start sending fs events.
+    // Tell watchers once they should read the file once,
+    // then listen to fs events.
     stream::once(future::ready(()))
         .chain(watch_receiver)
         .chain(stream::once(async move {
@@ -69,8 +69,9 @@ pub(crate) mod tests {
     async fn basic_watch() {
         let (path, mut file) = create_temp_file();
         let mut watch = watch(path, Some(Duration::from_millis(10)));
-        // Signal telling us ot fetch the data.
+        // Signal telling us to read the file once, and then poll.
         assert!(futures::poll!(watch.next()).is_ready());
+
         assert!(futures::poll!(watch.next()).is_pending());
         write_and_flush(&mut file, "Some data").await;
         assert!(futures::poll!(watch.next()).is_pending());

--- a/crates/apollo-router/src/lib.rs
+++ b/crates/apollo-router/src/lib.rs
@@ -204,7 +204,6 @@ impl ConfigurationKind {
                             if watch {
                                 files::watch(path.to_owned(), delay)
                                     .filter_map(move |_| {
-                                        eprintln!("received something!");
                                         future::ready(ConfigurationKind::read_config(&path).ok())
                                     })
                                     .map(UpdateConfiguration)


### PR DESCRIPTION
fixes #60 

As explained in the [notify documentation](https://github.com/notify-rs/notify/blob/ded07f442a96f33c6b7fefe3195396a33a28ddc3/src/lib.rs#L413) the file Create event has a higher priority than the Write event.

However our tests create the file and almost immediately start writing to it. The watcher did not propagate Create events, which lead to flakiness in these tests.

I'm lacking context but given the  `tokio::time::sleep()`s in the tests, this issue might have been seen on Linux as well, and worked around.

This commit removes the sleep()s in the test write functions, allows us to listen to Create events as well as Write events, and re enables the tests on osx.
