### PR TITLE
chore: xtask and CI cleanup

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,2 +1,2 @@
 [alias]
-xtask = "run --package xtask --"
+xtask = "run --locked --package xtask --"

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -4,9 +4,9 @@ use anyhow::{ensure, Result};
 use structopt::StructOpt;
 use xtask::*;
 
-const TEST_DEFAULT_ARGS: &[&str] = &["test", "--locked", "--no-default-features", "--features"];
+const TEST_DEFAULT_ARGS: &[&str] = &["test", "--locked", "--no-default-features"];
 
-const FEATURE_SETS: &[&[&str]] = &[&["otlp-grpc"], &["otlp-http"], &[""]];
+const FEATURE_SETS: &[&[&str]] = &[&["otlp-grpc"], &["otlp-http"], &[]];
 
 #[derive(Debug, StructOpt)]
 pub struct Test {
@@ -79,7 +79,10 @@ impl Test {
 
         for features in FEATURE_SETS {
             eprintln!("Running tests with features: {}", features.join(","));
-            cargo!(TEST_DEFAULT_ARGS, features.iter());
+            cargo!(
+                TEST_DEFAULT_ARGS,
+                features.iter().flat_map(|feature| ["--features", feature])
+            );
         }
 
         Ok(())


### PR DESCRIPTION
- pass --locked to the xtask command, so we make sure the xtask cache kicks in
- remove "" from the features set in xtask test