### PR TITLE
set a lower log level for tracing::instrument attributes

### DIFF
--- a/crates/apollo-router-core/src/query_planner/model.rs
+++ b/crates/apollo-router-core/src/query_planner/model.rs
@@ -196,11 +196,7 @@ impl PlanNode {
                     .instrument(tracing::info_span!("fetch"))
                     .await
                     {
-                        Ok(()) => {
-                            let received =
-                                serde_json::to_string_pretty(&response.lock().await.data).unwrap();
-                            tracing::trace!("New data:\n{}", received,);
-                        }
+                        Ok(()) => {}
                         Err(err) => {
                             failfast_error!("Fetch error: {}", err);
                             response

--- a/crates/apollo-router-core/src/query_planner/model.rs
+++ b/crates/apollo-router-core/src/query_planner/model.rs
@@ -124,7 +124,7 @@ impl PlanNode {
     }
 
     /// Validate the entire request for variables and services used.
-    #[tracing::instrument(name = "validation")]
+    #[tracing::instrument(name = "validation", level = "debug")]
     pub fn validate_request(
         &self,
         request: &Request,

--- a/crates/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
+++ b/crates/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
@@ -22,7 +22,7 @@ impl RouterBridgeQueryPlanner {
 
 #[async_trait]
 impl QueryPlanner for RouterBridgeQueryPlanner {
-    #[tracing::instrument(name = "plan")]
+    #[tracing::instrument(name = "plan", level = "debug")]
     async fn get(
         &self,
         query: String,

--- a/crates/apollo-router-core/src/request.rs
+++ b/crates/apollo-router-core/src/request.rs
@@ -48,7 +48,7 @@ impl Query {
     ///
     /// This will discard unrequested fields and re-order the output to match the order of the
     /// query.
-    #[tracing::instrument]
+    #[tracing::instrument(level = "trace")]
     pub fn format_response(&self, response: &mut Response) {
         fn apply_selection_set(
             selection_set: &ast::SelectionSet,

--- a/crates/apollo-router/src/apollo_router.rs
+++ b/crates/apollo-router/src/apollo_router.rs
@@ -37,7 +37,7 @@ impl ApolloRouter {
 
 #[async_trait::async_trait]
 impl Router<ApolloPreparedQuery> for ApolloRouter {
-    #[tracing::instrument]
+    #[tracing::instrument(level = "debug")]
     async fn prepare_query(
         &self,
         request: &Request,
@@ -88,7 +88,7 @@ pub struct ApolloPreparedQuery {
 
 #[async_trait::async_trait]
 impl PreparedQuery for ApolloPreparedQuery {
-    #[tracing::instrument]
+    #[tracing::instrument(level = "debug")]
     async fn execute(self, request: Arc<Request>) -> ResponseStream {
         stream::once(
             async move {


### PR DESCRIPTION
we had a performance regression in
44543703cabf20920b68c1092c7d9693c9772136, where the router was suddenly
spending a lot of time serializing data to JSON. This was due to
the #[tracing::instrument] annotation, that will generate by default a
span at INFO level, with a field for each argument and return value,
through debug printing.

The issue was already there before JSON logging was added, but it made
it much more expensive, enough to be noticeable

Now those spans are at the DEBUG or TRACE levels so they do not cost much