### PR TITLE
set OTLP service name and namespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,8 +113,8 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-futures",
- "tracing-opentelemetry 0.16.0",
- "tracing-subscriber 0.3.2",
+ "tracing-opentelemetry",
+ "tracing-subscriber 0.2.25",
  "typed-builder",
  "url",
  "uuid",
@@ -158,7 +158,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "tracing-subscriber 0.3.2",
+ "tracing-subscriber 0.2.25",
  "typed-builder",
 ]
 
@@ -583,6 +583,18 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "clap"
@@ -1799,6 +1811,15 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
@@ -2017,6 +2038,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -2680,7 +2711,7 @@ dependencies = [
  "task-local-extensions",
  "tokio",
  "tracing",
- "tracing-opentelemetry 0.15.0",
+ "tracing-opentelemetry",
 ]
 
 [[package]]
@@ -3538,19 +3569,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-opentelemetry"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffbf13a0f8b054a4e59df3a173b818e9c6177c02789871f2073977fd0062076"
-dependencies = [
- "opentelemetry",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber 0.3.2",
-]
-
-[[package]]
 name = "tracing-serde"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3566,9 +3584,20 @@ version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
+ "ansi_term 0.12.1",
+ "chrono",
+ "lazy_static",
+ "matchers 0.0.1",
+ "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
+ "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3579,7 +3608,7 @@ checksum = "7507ec620f809cdf07cccb5bc57b13069a88031b795efd4079b1c71b66c1613d"
 dependencies = [
  "ansi_term 0.12.1",
  "lazy_static",
- "matchers",
+ "matchers 0.1.0",
  "regex",
  "serde",
  "serde_json",

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -35,7 +35,8 @@ mockall = "0.10.2"
 static_assertions = "1"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = { version = "0.3.2", default-features = false, features = [
+# don't bump to 0.3 until we bump tracing-opentelemetry to 0.16
+tracing-subscriber = { version = "0.2.25", default-features = false, features = [
     "env-filter",
     "fmt",
 ] }

--- a/apollo-router-core/src/query_planner/model.rs
+++ b/apollo-router-core/src/query_planner/model.rs
@@ -242,7 +242,6 @@ impl PlanNode {
             Arc::clone(&service_registry),
             Arc::clone(&schema),
         )
-        .instrument(tracing::info_span!("execution"))
         .await;
 
         // TODO: this is not great but there is no other way

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -58,8 +58,11 @@ tokio = { version = "1.14.0", features = ["full"] }
 tonic = { version = "0.5.2", optional = true }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
-tracing-opentelemetry = "0.16.0"
-tracing-subscriber = { version = "0.3.2", features = ["json"] }
+# don't bump to 0.16 until reqwest-tracing does
+tracing-opentelemetry = "0.15.0"
+# don't bump to 0.3 until we bump tracing-opentelemetry to 0.16
+tracing-subscriber = { version = "0.2.25", features = ["json"] }
+
 typed-builder = "0.9.1"
 url = { version = "2.2.2", features = ["serde"] }
 warp = { version = "0.3.2", default-features = false, features = [
@@ -73,7 +76,7 @@ maplit = "1.0.2"
 mockall = "0.10.2"
 reqwest = { version = "0.11.6", features = ["json", "stream"] }
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
-tracing-subscriber = { version = "0.3.2", default-features = false, features = [
+tracing-subscriber = { version = "0.2.25", default-features = false, features = [
     "env-filter",
     "fmt",
 ] }

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -208,8 +208,8 @@ pub enum OpenTelemetry {
 #[derivative(Default)]
 pub struct Jaeger {
     pub collector_endpoint: Option<Url>,
-    #[serde(default = "default_jaeger_service_name")]
-    #[derivative(Default(value = "default_jaeger_service_name()"))]
+    #[serde(default = "default_service_name")]
+    #[derivative(Default(value = "default_service_name()"))]
     pub service_name: String,
     #[serde(skip, default = "default_jaeger_username")]
     #[derivative(Default(value = "default_jaeger_username()"))]
@@ -219,8 +219,12 @@ pub struct Jaeger {
     pub password: Option<String>,
 }
 
-fn default_jaeger_service_name() -> String {
+fn default_service_name() -> String {
     "router".to_string()
+}
+
+fn default_service_namespace() -> String {
+    "apollo".to_string()
 }
 
 fn default_jaeger_username() -> Option<String> {

--- a/licenses.html
+++ b/licenses.html
@@ -4215,6 +4215,7 @@ limitations under the License.
                     <li><a href=" https://github.com/yoshuawuyts/miow ">miow</a></li>
                     <li><a href=" https://github.com/havarnov/multimap ">multimap</a></li>
                     <li><a href=" https://github.com/deprecrated/net2-rs ">net2</a></li>
+                    <li><a href=" https://github.com/rust-num/num-integer ">num-integer</a></li>
                     <li><a href=" https://github.com/rust-num/num-traits ">num-traits</a></li>
                     <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus</a></li>
                     <li><a href=" https://github.com/matklad/once_cell ">once_cell</a></li>
@@ -6590,6 +6591,7 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://crates.io/crates/apollo-parser ">apollo-parser</a></li>
+                    <li><a href=" https://github.com/chronotope/chrono ">chrono</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-build</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-derive</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-types</a></li>
@@ -7821,9 +7823,7 @@ DEALINGS IN THE SOFTWARE.
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-futures</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-log</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-opentelemetry</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-opentelemetry</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-serde</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-subscriber</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-subscriber</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019 Tokio Contributors


### PR DESCRIPTION
fix #180
related to #38

- a5b8581 sets default values for service name and namespace, to fix #180
- 26045c3 fixes a regression introduced in https://github.com/apollographql/router/commit/34f5f9ea64fdeb488e0c99a4420394cc066b7744: if reqwest-tracing uses a different tracing-opentelemetry version, tracing headers are not propagated
- 3bc699f fixes a regression introduced in 44840e4: the execute and format_response phases were appearing as their own root spans

26045c3 is temporary, I'll send a PR to reqwest-tracing to support the tracing-opentelemetry 0.16

we should get #38 implemented, to make sure those kinds of regressions do not happen