### PR TITLE
implement trace sampling

### DIFF
--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -16,6 +16,8 @@ use thiserror::Error;
 use typed_builder::TypedBuilder;
 use url::Url;
 
+use self::otlp::TraceConfig;
+
 /// Configuration error.
 #[derive(Debug, Error, Display)]
 pub enum ConfigurationError {
@@ -221,6 +223,8 @@ pub struct Jaeger {
     #[serde(skip, default = "default_jaeger_password")]
     #[derivative(Default(value = "default_jaeger_password()"))]
     pub password: Option<String>,
+    #[serde(default)]
+    pub trace_config: Option<TraceConfig>,
 }
 
 fn default_service_name() -> String {

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -6,6 +6,9 @@ pub mod otlp;
 use apollo_router_core::prelude::*;
 use derivative::Derivative;
 use displaydoc::Display;
+use opentelemetry::sdk::trace::Sampler;
+use opentelemetry::sdk::Resource;
+use opentelemetry::KeyValue;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -15,8 +18,6 @@ use std::sync::Arc;
 use thiserror::Error;
 use typed_builder::TypedBuilder;
 use url::Url;
-
-use self::otlp::TraceConfig;
 
 /// Configuration error.
 #[derive(Debug, Error, Display)]
@@ -223,7 +224,6 @@ pub struct Jaeger {
     #[serde(skip, default = "default_jaeger_password")]
     #[derivative(Default(value = "default_jaeger_password()"))]
     pub password: Option<String>,
-    #[serde(default)]
     pub trace_config: Option<TraceConfig>,
 }
 
@@ -231,7 +231,6 @@ fn default_service_name() -> String {
     "router".to_string()
 }
 
-#[cfg(any(feature = "otlp-grpc", feature = "otlp-http"))]
 fn default_service_namespace() -> String {
     "apollo".to_string()
 }
@@ -293,6 +292,53 @@ impl TlsConfig {
         }
 
         Ok(config)
+    }
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct TraceConfig {
+    pub sampler: Option<Sampler>,
+    pub max_events_per_span: Option<u32>,
+    pub max_attributes_per_span: Option<u32>,
+    pub max_links_per_span: Option<u32>,
+    pub max_attributes_per_event: Option<u32>,
+    pub max_attributes_per_link: Option<u32>,
+    pub resource: Option<Resource>,
+}
+
+impl TraceConfig {
+    pub fn trace_config(&self) -> opentelemetry::sdk::trace::Config {
+        let mut trace_config = opentelemetry::sdk::trace::config();
+        if let Some(sampler) = self.sampler.clone() {
+            trace_config = trace_config.with_sampler(sampler);
+        }
+        if let Some(n) = self.max_events_per_span {
+            trace_config = trace_config.with_max_events_per_span(n);
+        }
+        if let Some(n) = self.max_attributes_per_span {
+            trace_config = trace_config.with_max_attributes_per_span(n);
+        }
+        if let Some(n) = self.max_links_per_span {
+            trace_config = trace_config.with_max_links_per_span(n);
+        }
+        if let Some(n) = self.max_attributes_per_event {
+            trace_config = trace_config.with_max_attributes_per_event(n);
+        }
+        if let Some(n) = self.max_attributes_per_link {
+            trace_config = trace_config.with_max_attributes_per_link(n);
+        }
+
+        let resource = self.resource.clone().unwrap_or_else(|| {
+            Resource::new(vec![
+                KeyValue::new("service.name", default_service_name()),
+                KeyValue::new("service.namespace", default_service_namespace()),
+            ])
+        });
+
+        trace_config = trace_config.with_resource(resource);
+
+        trace_config
     }
 }
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-4.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-4.snap
@@ -13,4 +13,5 @@ opentelemetry:
   jaeger:
     collector_endpoint: "http://example.org/"
     service_name: bar
+    trace_config: ~
 

--- a/apollo-router/src/trace.rs
+++ b/apollo-router/src/trace.rs
@@ -5,8 +5,10 @@ use std::str::FromStr;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::EnvFilter;
 
+#[cfg(any(feature = "otlp-grpc", feature = "otlp-http"))]
+use crate::configuration::otlp;
 use crate::{
-    configuration::{self, Configuration, OpenTelemetry},
+    configuration::{Configuration, OpenTelemetry},
     GLOBAL_ENV_FILTER,
 };
 
@@ -69,11 +71,11 @@ pub(crate) fn try_initialize_subscriber(
             Ok(Arc::new(subscriber.with(telemetry)))
         }
         #[cfg(any(feature = "otlp-grpc", feature = "otlp-http"))]
-        Some(OpenTelemetry::Otlp(configuration::otlp::Otlp::Tracing(tracing))) => {
+        Some(OpenTelemetry::Otlp(otlp::Otlp::Tracing(tracing))) => {
             let tracer = if let Some(tracing) = tracing.as_ref() {
                 tracing.tracer()?
             } else {
-                configuration::otlp::Tracing::tracer_from_env()?
+                otlp::Tracing::tracer_from_env()?
             };
             let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
             opentelemetry::global::set_error_handler(handle_error)?;

--- a/docs/source/configuration.mdx
+++ b/docs/source/configuration.mdx
@@ -140,9 +140,24 @@ subgraphs:
   products:
     routing_url: http://localhost:4003/graphql
 
-# OpenTelemetry configuration. Choose either jaeger or otlp
+# OpenTelemetry configuration, see next section
+# opentelemetry:
+```
+
+## Tracing
+
+The Apollo Router supports [OpenTelemetry](https://opentelemetry.io/), it has exporters for [Jaeger](https://www.jaegertracing.io/) and for the [OpenTelemetry Protocol (OTLP)](https://aws-otel.github.io/docs/components/otlp-exporter) over HTTP or gRPC.
+It will generate a trace of the various phases of the GraphQL query and their dependencies.
+
+It will send a `TraceParent` header to subgraphs so they can create and send their own spans under the same trace.
+If the request to the Router already contains a `TraceParent` header, it will use its value as trace id instead of generating a random one.
+
+### Using Jaeger
+
+```yaml:title=configuration.yaml
+server:
+  listen: 127.0.0.1:4000
 opentelemetry:
-  # Configuration to send traces and metrics to a Jaeger service
   jaeger:
     # optional url of the jaeger collector
     collector_endpoint: "http://example.org"
@@ -151,6 +166,41 @@ opentelemetry:
     service_name: "router"
     # the username and password are obtained from the environment variables
     # JAEGER_USERNAME and JAEGER_PASSWORD
+    trace_config:
+      # trace sampling, possible values are `AlwaysOn`, `AlwaysOff` or `TraceIdRatioBased: number`
+      # the ratio sampler takes a value between 0 and 1 and decides at the trace creation if it will
+      # be recorded or not
+      sampler:
+        TraceIdRatioBased: 0.42
+      max_events_per_span: 1
+      max_attributes_per_span: 2
+      max_links_per_span: 3
+      max_attributes_per_event: 4
+      max_attributes_per_link: 5
+      resource:
+        attrs:
+          key1:
+            String: value
+          key2:
+            Bool: true
+          key3:
+            I64: 42
+          key4:
+            F64: 42.0
+          key5:
+            Array:
+              String:
+                - value1
+                - value2
+```
+
+### Using OTLP
+
+
+```yaml:title=configuration.yaml
+server:
+  listen: 127.0.0.1:4000
+opentelemetry:
   # Configuration to send traces and metrics to an OpenTelemetry Protocol compatible service
   otlp:
     tracing:
@@ -165,12 +215,12 @@ opentelemetry:
           timeout: 60
           metadata:
             - foo: bar
-            - foo: baz
-            - bar: baz
       trace_config:
+        # trace sampling, possible values are `AlwaysOn`, `AlwaysOff` or `TraceIdRatioBased: number`
+        # the ratio sampler takes a value between 0 and 1 and decides at the trace creation if it will
+        # be recorded or not
         sampler:
-          ParentBased:
-            TraceIdRatioBased: 0.42
+          TraceIdRatioBased: 0.42
         max_events_per_span: 1
         max_attributes_per_span: 2
         max_links_per_span: 3


### PR DESCRIPTION
follow up on #193
fix #228

* moves tracing configuration to the `apollo_router::trace` module