### PR TITLE
Update Rust edition to 2021

### DIFF
--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -2,7 +2,7 @@
 name = "apollo-router-benchmarks"
 version = "0.1.0-alpha.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
-edition = "2018"
+edition = "2021"
 license = "LicenseRef-ELv2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "apollo-router-core"
 version = "0.1.0-alpha.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
-edition = "2018"
+edition = "2021"
 license-file = "./LICENSE"
 
 [features]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -2,7 +2,7 @@
 name = "apollo-router"
 version = "0.1.0-alpha.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
-edition = "2018"
+edition = "2021"
 license-file = "./LICENSE"
 
 [[bin]]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xtask"
 version = "0.1.0-prealpha.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
-edition = "2018"
+edition = "2021"
 license = "LicenseRef-ELv2"
 publish = false
 


### PR DESCRIPTION
This will make the borrow checker easier with closures