### PR TITLE
Add jaeger for development again

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,7 +74,7 @@ requires that the `federation-demo` project is running:
 Once the subgraphs are up and running, run Apollo Router with this command:
 
 ```shell
-cargo run -- -s ./examples/local.graphql
+cargo run --release -- -s ./examples/local.graphql -c examples/config-jaeger.yml
 ```
 
 Go to https://studio.apollographql.com/sandbox/explorer to make queries and

--- a/examples/config-jaeger.yml
+++ b/examples/config-jaeger.yml
@@ -1,0 +1,2 @@
+opentelemetry:
+  jaeger:


### PR DESCRIPTION
This was enabled by default in the past. Even the doc still documents it as it should be enabled by default.

> Go to https://studio.apollographql.com/sandbox/explorer to make queries and http://localhost:16686/ to reach Jaeger.