### PR TITLE
v.0.1.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## :sparkles: Features
 
-- JSON log output
+- Add support for JSON Logging [#46](https://github.com/apollographql/router/issues/46)
 
 ## :bug: Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,30 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🛠 Maintenance
 ## 📚 Documentation -->
 
+
+# [v0.1.0-alpha.1] 2021-11-18
+
+## :rocket::waxing_crescent_moon: Public alpha release
+
+> An alpha or beta release is in volatile, active development. The release might not be feature-complete, and breaking API changes are possible between individual versions.
+
+## :sparkles: Features
+
+- JSON log output
+
+## :hammer_and_wrench: Maintenance
+
+- Reduced CI build times
+- Improved overall performance by reducing the number of clones when composing and building a graphql response
+- Logging feature flags: The two remaining features available are "otlp-grpc" (on by default) and "otpl-http"
+- Move composition benchmarks to a separate crate
+- OTLP / Tracing updates
+
+## :bug: Fixes
+
+- Reworked the tests to make sure file configuration and schema updates work as indented (using the --watch flag)
+- Fix OTLP span reporting
+
 # [v0.1.0-alpha.1] 2021-11-18
 
 ## :rocket::waxing_crescent_moon: Initial public alpha release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## :bug: Fixes
 
-- Fix Open Telemetry Zipkin report errors [#180](https://github.com/apollographql/router/issues/180)
+- Fix Open Telemetry report errors when using Zipkin [#180](https://github.com/apollographql/router/issues/180)
 
 # [v0.1.0-alpha.1] 2021-11-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 📚 Documentation -->
 
 
-# [v0.1.0-alpha.1] 2021-11-18
+# [v0.1.0-alpha.2] 2021-12-03
 
 ## :rocket::waxing_crescent_moon: Public alpha release
 
@@ -23,18 +23,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - JSON log output
 
-## :hammer_and_wrench: Maintenance
-
-- Reduced CI build times
-- Improved overall performance by reducing the number of clones when composing and building a graphql response
-- Logging feature flags: The two remaining features available are "otlp-grpc" (on by default) and "otpl-http"
-- Move composition benchmarks to a separate crate
-- OTLP / Tracing updates
-
 ## :bug: Fixes
 
-- Reworked the tests to make sure file configuration and schema updates work as indented (using the --watch flag)
-- Fix OTLP span reporting
+- Fix Open Telemetry Zipkin report errors [#180](https://github.com/apollographql/router/issues/180)
 
 # [v0.1.0-alpha.1] 2021-11-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "anyhow",
  "apollo-router-core",
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.2"
 dependencies = [
  "apollo-router",
  "apollo-router-core",
@@ -137,7 +137,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-core"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 dependencies = [
  "apollo-parser",
  "async-trait",

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -38,7 +38,7 @@ in lieu of an official changelog.
 6.  Push up a commit with the `*/Cargo.toml`, `Cargo.lock` and
     `CHANGELOG.md` changes. The commit message should be "release: v#.#.#" or
     "release: v#.#.#-rc.#"
-7.  Request review from the Apollo GraphQL tooling team.
+7.  Request review from the Router team.
 
 ### Review
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -34,10 +34,11 @@ in lieu of an official changelog.
 3.  Update the version in `crates/*/Cargo.toml`.
 3.  Update the version in `deny.toml` in the `[[licenses.clarify]]` sections for `apollo-router-core` and `apollo-router`.
 4.  Run `cargo check` so the lock file gets updated.
-5.  Push up a commit with the `crates/*/Cargo.toml`, `Cargo.lock` and
+5.  Run `cargo xtask check-compliance` so the lock file gets updated.
+6.  Push up a commit with the `crates/*/Cargo.toml`, `Cargo.lock` and
     `CHANGELOG.md` changes. The commit message should be "release: v#.#.#" or
     "release: v#.#.#-rc.#"
-6.  Request review from the Apollo GraphQL tooling team.
+7.  Request review from the Apollo GraphQL tooling team.
 
 ### Review
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -31,11 +31,11 @@ in lieu of an official changelog.
 1.  Make sure you have `cargo` installed on your machine and in your `PATH`.
 2.  Create a new branch "#.#.#" where "#.#.#" is this release's version
     (release) or "#.#.#-rc.#" (release candidate)
-3.  Update the version in `crates/*/Cargo.toml`.
+3.  Update the version in `*/Cargo.toml`.
 3.  Update the version in `deny.toml` in the `[[licenses.clarify]]` sections for `apollo-router-core` and `apollo-router`.
 4.  Run `cargo check` so the lock file gets updated.
 5.  Run `cargo xtask check-compliance` so the lock file gets updated.
-6.  Push up a commit with the `crates/*/Cargo.toml`, `Cargo.lock` and
+6.  Push up a commit with the `*/Cargo.toml`, `Cargo.lock` and
     `CHANGELOG.md` changes. The commit message should be "release: v#.#.#" or
     "release: v#.#.#-rc.#"
 7.  Request review from the Apollo GraphQL tooling team.

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "0.1.0-alpha.0"
+version = "0.1.0-alpha.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"
@@ -16,7 +16,6 @@ once_cell = "1"
 serde_json = { version = "1.0.72", features = ["preserve_order"] }
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3.2", features = ["json", "env-filter"] }
-
 
 
 [[bench]]

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-core"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license-file = "./LICENSE"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license-file = "./LICENSE"

--- a/deny.toml
+++ b/deny.toml
@@ -62,13 +62,13 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 [[licenses.clarify]]
 name = "apollo-router"
 expression = "LicenseRef-ELv2"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
 
 [[licenses.clarify]]
 name = "apollo-router-core"
 expression = "LicenseRef-ELv2"
-version = "0.1.0-alpha.1"
+version = "0.1.0-alpha.2"
 license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
 
 [[licenses.clarify]]


### PR DESCRIPTION
# [v0.1.0-alpha.2] 2021-12-03

## :rocket::waxing_crescent_moon: Public alpha release

> An alpha or beta release is in volatile, active development. The release might not be feature-complete, and breaking API changes are possible between individual versions.

## :sparkles: Features

- JSON log output

## :bug: Fixes

- Fix Open Telemetry Zipkin report errors [#180](https://github.com/apollographql/router/issues/180)