### PR TITLE
fix: Reinstall node in the circleCI release pipeline.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,6 +477,23 @@ jobs:
             - run: brew install cmake
             - rust/install:
                 version: stable
+            # Installing this with the curl nvm command was proving difficult,
+            # so I've opted to just install the .pkg.  Should be the same net
+            # result, even if liked the opportunity for symmetry with Linux.
+            - run:
+                name: Installing Node.js with a .pkg.
+                command: |
+                  curl "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}.pkg" > "$HOME/Downloads/node.pkg" && sudo installer -store -pkg "$HOME/Downloads/node.pkg" -target "/"
+            - run:
+                name: Install specific version of npm
+                command: |
+                  sudo npm install --global npm@${NPM_VERSION}
+            - run:
+                name: Assert Node.js version
+                command: test "$(node --version)" = "v${NODE_VERSION}"
+            - run:
+                name: Assert npm version
+                command: test "$(npm --version)" = "${NPM_VERSION}"
             - run:
                 command: >
                   cargo xtask dist
@@ -505,6 +522,22 @@ jobs:
                   sudo apt-get install -y libssl-dev
             - rust/install:
                 version: stable
+            - run:
+                name: Install nvm
+                command: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+            - run: echo '. ~/.nvm/nvm.sh' >> $BASH_ENV
+            - run:
+                name: Install desired Node.js version
+                command: |
+                  nvm install $NODE_VERSION
+                  nvm alias default $NODE_VERSION
+                  npm install --global npm@${NPM_VERSION}
+            - run:
+                name: Assert Node.js version
+                command: test "$(node --version)" = "v${NODE_VERSION}"
+            - run:
+                name: Assert npm version
+                command: test "$(npm --version)" = "${NPM_VERSION}"
             - run:
                 command: >
                   cargo xtask dist
@@ -538,6 +571,36 @@ jobs:
                   [net]
                   git-fetch-with-cli = true
                   "@
+            - run:
+                name: Install desired Node.js version with nvm
+                command: |
+                  nvm install ${Env:NODE_VERSION}
+                  nvm on
+            - run:
+                # https://github.com/coreybutler/nvm-windows/issues/300
+                # Have to move the command out of the way because it can't
+                # overwrite itself otherwise.   This is madness, but apparently
+                # accepted.  Other things I tried: using yarn to install npm,
+                # using http://npm.im/npm-windows-upgrade and even shouting.
+                name: Install specific version of npm in a crazy Windows way
+                command: |
+                  $node_dir = (get-item (get-command npm).source).directory.fullname
+                  foreach ($cmd in @("npm", "npx")) {
+                    foreach ($ext in @(".ps1", ".cmd", "")) {
+                      if (Test-Path "$node_dir/$cmd$ext") {
+                        rename-item -path (join-path -path $node_dir -childpath "$cmd$ext") "${cmd}-orig${ext}"
+                      }
+                    }
+                  }
+                  npm-orig install --global "npm@${Env:NPM_VERSION}"
+            - run:
+                name: Assert Node.js version
+                command: |
+                  if ((node --version) -Ne "v${Env:NODE_VERSION}") { exit 1 }
+            - run:
+                name: Assert npm version
+                command: |
+                  if ((npm --version) -Ne "${Env:NPM_VERSION}") { exit 1 }
             - run:
                 command: >
                   cargo xtask dist


### PR DESCRIPTION
During the various iterations on the build pipeline, I ended up removing nodejs, and putting it back eventually. I unfortunately forgot to put it back in the release pipeline, which causes it to fail.

We have followup work in federation that shall remove the nodejs requirement eventually, but we're not there yet.