### PR TITLE
Remove the response mutex, refactor fetch_node and fix response merging

### DIFF
--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -160,7 +160,7 @@ impl ValueExt for Value {
                     a.extend(b.into_iter());
                 }
             }
-            (a, Value::Null) => {}
+            (_, Value::Null) => {}
             (a, b) => {
                 *a = b;
             }
@@ -270,7 +270,7 @@ impl ValueExt for Value {
 
                 &PathElement::Index(index) => match current_node {
                     Value::Array(a) => {
-                        for i in 0..index {
+                        for _ in 0..index {
                             a.push(Value::default());
                         }
                         a.push(Value::default());

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -26,7 +26,7 @@ pub trait ValueExt {
     #[track_caller]
     fn is_subset(&self, superset: &Value) -> bool;
 
-    /// create a Value by inserting a value at a subpath
+    /// Create a `Value` by inserting a value at a subpath.
     #[track_caller]
     fn from_path(path: &Path, value: Value) -> Value;
 }
@@ -47,7 +47,7 @@ impl ValueExt for Value {
                 }
             }
             (Value::Array(a), Value::Array(mut b)) => {
-                for (b_value, a_value) in b.drain(..min(a.len(), b.len())).zip(a.iter_mut()) {
+                for (b_value, a_value) in b.drain(..).zip(a.iter_mut()) {
                     a_value.deep_merge(b_value);
                 }
 
@@ -55,12 +55,10 @@ impl ValueExt for Value {
             }
             (_, Value::Null) => {}
             (Value::Object(_), Value::Array(_)) => {
-                #[cfg(debug)]
-                panic!("trying to replace an object with an array");
+                failfast_debug!("trying to replace an object with an array");
             }
             (Value::Array(_), Value::Object(_)) => {
-                #[cfg(debug)]
-                panic!("trying to replace an object with an array");
+                failfast_debug!("trying to replace an array with an object");
             }
             (a, b) => {
                 *a = b;

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::map::Entry;
 use serde_json::Map;
 pub use serde_json::Value;
+use std::cmp::min;
 use std::fmt;
 
 /// A JSON object.
@@ -46,19 +47,11 @@ impl ValueExt for Value {
                 }
             }
             (Value::Array(a), Value::Array(mut b)) => {
-                if a.len() > b.len() {
-                    for ((_index, b_value), a_value) in b.drain(..).enumerate().zip(a.iter_mut()) {
-                        a_value.deep_merge(b_value);
-                    }
-                } else {
-                    for ((_index, b_value), a_value) in
-                        b.drain(..a.len()).enumerate().zip(a.iter_mut())
-                    {
-                        a_value.deep_merge(b_value);
-                    }
-
-                    a.extend(b.into_iter());
+                for (b_value, a_value) in b.drain(..min(a.len(), b.len())).zip(a.iter_mut()) {
+                    a_value.deep_merge(b_value);
                 }
+
+                a.extend(b.into_iter());
             }
             (_, Value::Null) => {}
             (Value::Object(_), Value::Array(_)) => {

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -267,9 +267,7 @@ impl ValueExt for Value {
         let mut res_value = Value::default();
         let mut current_node = &mut res_value;
 
-        println!("FROM PATH: '{}'", path);
         for p in path.iter() {
-            println!("FROM PATH: '{:?}', current = {:?}", p, current_node);
             match p {
                 PathElement::Flatten => {
                     let a = Vec::new();
@@ -317,7 +315,6 @@ impl ValueExt for Value {
         }
 
         *current_node = value;
-        println!("FROM PATH: '{}' => {:?}", path, res_value);
         res_value
     }
 }

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -313,15 +313,15 @@ where
                 reason: "not an array".to_string(),
             }),
             Some(array) => {
+                // avoid reallocating a path on each iteration
+                let mut child_path = parent.append(PathElement::Flatten);
+                child_path.0.pop();
                 for (i, value) in array.iter().enumerate() {
-                    if let Some(err) = iterate_path(
-                        &parent.join(Path::from(i.to_string())),
-                        &path[1..],
-                        value,
-                        f,
-                    ) {
+                    child_path.0.push(PathElement::Index(i));
+                    if let Some(err) = iterate_path(&child_path, &path[1..], value, f) {
                         return Some(err);
                     }
+                    child_path.0.pop();
                 }
                 None
             }
@@ -329,12 +329,7 @@ where
         Some(PathElement::Index(i)) => {
             if let Value::Array(a) = data {
                 if let Some(value) = a.get(*i) {
-                    iterate_path(
-                        &parent.join(Path::from(i.to_string())),
-                        &path[1..],
-                        value,
-                        f,
-                    )
+                    iterate_path(&parent.append(PathElement::Index(*i)), &path[1..], value, f)
                 } else {
                     Some(FetchError::ExecutionPathNotFound {
                         reason: format!("index {} not found", i),
@@ -349,7 +344,12 @@ where
         Some(PathElement::Key(k)) => {
             if let Value::Object(o) = data {
                 if let Some(value) = o.get(k) {
-                    iterate_path(&parent.join(Path::from(k)), &path[1..], value, f)
+                    iterate_path(
+                        &parent.append(PathElement::Key(k.to_string())),
+                        &path[1..],
+                        value,
+                        f,
+                    )
                 } else {
                     Some(FetchError::ExecutionPathNotFound {
                         reason: format!("key {} not found", k),
@@ -475,6 +475,13 @@ impl Path {
         let mut new = Vec::with_capacity(self.len() + other.len());
         new.extend(self.iter().cloned());
         new.extend(other.iter().cloned());
+        Path(new)
+    }
+
+    pub fn append(&self, element: PathElement) -> Self {
+        let mut new = Vec::with_capacity(self.len() + 1);
+        new.extend(self.iter().cloned());
+        new.push(element);
         Path(new)
     }
 }

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -35,6 +35,10 @@ pub trait ValueExt {
     /// values in `self`.
     #[track_caller]
     fn is_subset(&self, superset: &Value) -> bool;
+
+    /// insert a specific value at a subpath
+    #[track_caller]
+    fn insert_data(&mut self, path: &Path, value: Value) -> Result<(), FetchError>;
 }
 
 impl ValueExt for Value {
@@ -211,6 +215,27 @@ impl ValueExt for Value {
             }
             (a, b) => a == b,
         }
+    }
+
+    fn insert_data(&mut self, path: &Path, value: Value) -> Result<(), FetchError> {
+        let mut nodes =
+            self.get_at_path_mut(path)
+                .map_err(|err| FetchError::ExecutionPathNotFound {
+                    reason: err.to_string(),
+                })?;
+
+        let len = nodes.len();
+        //FIXME: are there cases where we could write at multiple paths?
+        for (i, node) in nodes.iter_mut().enumerate() {
+            if i == len {
+                (*node).deep_merge(value);
+                break;
+            } else {
+                (*node).deep_merge(value.clone());
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -41,8 +41,7 @@ pub trait ValueExt {
 
     /// Select all values matching a `Path`.
     ///
-    /// this will return the values and their specific path in the `Value`:
-    /// a `Path` with a flatten node can match multiple values.
+    /// the function passed as argument will be called with the values found and their Path
     #[track_caller]
     fn select_values_and_paths<'a, F>(&'a self, path: &'a Path, f: F) -> Result<(), FetchError>
     where
@@ -366,6 +365,7 @@ where
 
 /// A GraphQL path element that is composes of strings or numbers.
 /// e.g `/book/3/name`
+#[doc(hidden)]
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PathElement {
@@ -424,6 +424,7 @@ where
 /// A path into the result document.
 ///
 /// This can be composed of strings and numbers
+#[doc(hidden)]
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(transparent)]
 pub struct Path(pub Vec<PathElement>);

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::map::Entry;
 use serde_json::Map;
 pub use serde_json::Value;
+use std::cmp::min;
 use std::fmt;
 
 /// A JSON object.

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -133,11 +133,11 @@ impl ValueExt for Value {
         }
     }
 
-    /// insert a specific value at a subpath
+    /// Insert a specific value at a subpath.
     ///
-    /// this will create objects, arrays and null nodes as needed if they
+    /// This will create objects, arrays and null nodes as needed if they
     /// are not present: the resulting Value is meant to be merged with an
-    /// existing one that contains those nodes
+    /// existing one that contains those nodes.
     #[track_caller]
     fn from_path(path: &Path, value: Value) -> Value {
         let mut res_value = Value::default();

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -146,10 +146,21 @@ impl ValueExt for Value {
                 }
             }
             (Value::Array(a), Value::Array(mut b)) => {
-                for ((_index, b_value), a_value) in b.drain(..).enumerate().zip(a.iter_mut()) {
-                    a_value.deep_merge(b_value);
+                if a.len() > b.len() {
+                    for ((_index, b_value), a_value) in b.drain(..).enumerate().zip(a.iter_mut()) {
+                        a_value.deep_merge(b_value);
+                    }
+                } else {
+                    for ((_index, b_value), a_value) in
+                        b.drain(..a.len()).enumerate().zip(a.iter_mut())
+                    {
+                        a_value.deep_merge(b_value);
+                    }
+
+                    a.extend(b.into_iter());
                 }
             }
+            (a, Value::Null) => {}
             (a, b) => {
                 *a = b;
             }

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -376,7 +376,7 @@ where
 /// This can be composed of strings and numbers
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(transparent)]
-pub struct Path(Vec<PathElement>);
+pub struct Path(pub Vec<PathElement>);
 
 impl Path {
     pub fn from_slice<T: AsRef<str>>(s: &[T]) -> Self {

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -9,6 +9,7 @@ use std::fmt;
 /// A JSON object.
 pub type Object = Map<String, Value>;
 
+#[doc(hidden)]
 /// Extension trait for [`serde_json::Value`].
 pub trait ValueExt {
     /// Deep merge the JSON objects, array and override the values in `&mut self` if they already

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -161,6 +161,14 @@ impl ValueExt for Value {
                 }
             }
             (_, Value::Null) => {}
+            (Value::Object(_), Value::Array(_)) => {
+                #[cfg(debug)]
+                panic!("trying to replace an object with an array");
+            }
+            (Value::Array(_), Value::Object(_)) => {
+                #[cfg(debug)]
+                panic!("trying to replace an object with an array");
+            }
             (a, b) => {
                 *a = b;
             }

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -36,11 +36,7 @@ pub trait ValueExt {
     #[track_caller]
     fn is_subset(&self, superset: &Value) -> bool;
 
-    /// insert a specific value at a subpath
-    #[track_caller]
-    fn insert_data(&mut self, path: &Path, value: Value) -> Result<(), FetchError>;
-
-    /// insert a specific value at a subpath
+    /// create a Value by inserting a value at a subpath
     #[track_caller]
     fn from_path(path: &Path, value: Value) -> Value;
 }
@@ -238,27 +234,6 @@ impl ValueExt for Value {
             }
             (a, b) => a == b,
         }
-    }
-
-    fn insert_data(&mut self, path: &Path, value: Value) -> Result<(), FetchError> {
-        let mut nodes =
-            self.get_at_path_mut(path)
-                .map_err(|err| FetchError::ExecutionPathNotFound {
-                    reason: err.to_string(),
-                })?;
-
-        let len = nodes.len();
-        //FIXME: are there cases where we could write at multiple paths?
-        for (i, node) in nodes.iter_mut().enumerate() {
-            if i == len {
-                (*node).deep_merge(value);
-                break;
-            } else {
-                (*node).deep_merge(value.clone());
-            }
-        }
-
-        Ok(())
     }
 
     /// insert a specific value at a subpath

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -208,17 +208,6 @@ pub(crate) fn select_values_and_paths<'a>(
     }
 }
 
-#[cfg(test)]
-pub(crate) fn select_values<'a>(
-    path: &'a Path,
-    data: &'a Value,
-) -> Result<Vec<&'a Value>, FetchError> {
-    Ok(select_values_and_paths(path, data)?
-        .into_iter()
-        .map(|r| r.1)
-        .collect())
-}
-
 fn iterate_path<'a>(
     parent: &Path,
     path: &'a [PathElement],
@@ -458,6 +447,13 @@ mod tests {
         ($a:expr, $b:expr $(,)?) => {
             assert!(!$a.is_subset(&$b));
         };
+    }
+
+    fn select_values<'a>(path: &'a Path, data: &'a Value) -> Result<Vec<&'a Value>, FetchError> {
+        Ok(select_values_and_paths(path, data)?
+            .into_iter()
+            .map(|r| r.1)
+            .collect())
     }
 
     #[test]

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::map::Entry;
 use serde_json::Map;
 pub use serde_json::Value;
-use std::cmp::min;
 use std::fmt;
 
 /// A JSON object.
@@ -47,7 +46,7 @@ impl ValueExt for Value {
                 }
             }
             (Value::Array(a), Value::Array(mut b)) => {
-                for (b_value, a_value) in b.drain(..).zip(a.iter_mut()) {
+                for (b_value, a_value) in b.drain(..min(a.len(), b.len())).zip(a.iter_mut()) {
                     a_value.deep_merge(b_value);
                 }
 

--- a/apollo-router-core/src/naive_introspection.rs
+++ b/apollo-router-core/src/naive_introspection.rs
@@ -86,10 +86,9 @@ mod naive_introspection_tests {
     #[test]
     fn test_plan() {
         let query_to_test = "this is a test query";
-        let mut expected_data = Response::builder().build();
-        expected_data
-            .insert_data(&Path::empty(), serde_json::Value::Number(42.into()))
-            .expect("it is always possible to insert data in root path; qed");
+        let expected_data = Response::builder()
+            .data(serde_json::Value::Number(42.into()))
+            .build();
 
         let cache = [(query_to_test.into(), expected_data.clone())]
             .iter()

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -162,7 +162,7 @@ impl PlanNode {
                             while let Some((v, err)) = stream.next().await {
                                 println!("PARALLEL MERGING {:?}\nwith {:?}", resv, v);
                                 resv.deep_merge(v);
-                                //FIXME errors
+                                errors.extend(err.into_iter());
                             }
                         }
 
@@ -189,7 +189,6 @@ impl PlanNode {
                         .instrument(tracing::trace_span!("flatten"))
                         .await;
 
-                    let m = Map::new();
                     println!("FLATTEN will try to insert at {}: {:?}", path, v);
                     value = Value::from_path(current_dir, v);
                     println!("FLATTEN value is now: {:?}", value);
@@ -224,7 +223,7 @@ impl PlanNode {
                         .instrument(tracing::info_span!("fetch"))
                         .await
                     {
-                        Ok(mut subgraph_response) => {
+                        Ok(subgraph_response) => {
                             /*let mut response = response.lock().await;
                             response.append_errors(&mut subgraph_response.errors);*/
                             println!("FETCH sub response: {:?}", subgraph_response);

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -332,12 +332,12 @@ mod fetch {
                 let representations = Value::Array(
                     values_and_paths
                         .into_iter()
-                        .flat_map(|(path, value)| match (value, requires) {
-                            (Value::Object(content), requires) => {
+                        .flat_map(|(path, value)| match value {
+                            Value::Object(content) => {
                                 paths.push(path);
                                 select_object(content, requires, schema).transpose()
                             }
-                            (_, _) => Some(Err(FetchError::ExecutionInvalidContent {
+                            _ => Some(Err(FetchError::ExecutionInvalidContent {
                                 reason: "not an object".to_string(),
                             })),
                         })

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -3,7 +3,6 @@ mod router_bridge_query_planner;
 mod selection;
 
 use crate::prelude::graphql::*;
-use crate::query_planner::json_ext::select_values;
 use crate::query_planner::selection::select_object;
 pub use caching_query_planner::*;
 use futures::prelude::*;
@@ -321,7 +320,7 @@ impl FetchNode {
                 })
             }));
 
-            let values_and_paths = select_values(current_dir, data)?;
+            let values_and_paths = select_values_and_paths(current_dir, data)?;
             let mut paths = Vec::new();
             let representations = Value::Array(
                 values_and_paths

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -375,7 +375,7 @@ impl FetchNode {
                 serde_json::to_string(&data).unwrap(),
             );
 
-            let values_and_paths = select_values(current_dir, data);
+            let values_and_paths = select_values(current_dir, data)?;
             let mut paths = Vec::new();
             let representations = Value::Array(
                 values_and_paths

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -317,7 +317,7 @@ impl FetchNode {
                 })
             }));
 
-            let values_and_paths = select_values_and_paths(current_dir, data)?;
+            let values_and_paths = data.select_values_and_paths(current_dir)?;
             let mut paths = Vec::new();
             let representations = Value::Array(
                 values_and_paths

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -157,7 +157,7 @@ impl PlanNode {
                     let (v, err) = node
                         .execute_recursively(
                             // this is the only command that actually changes the "current dir"
-                            path,
+                            &current_dir.join(path),
                             Arc::clone(&request),
                             Arc::clone(&service_registry),
                             Arc::clone(&schema),
@@ -166,7 +166,7 @@ impl PlanNode {
                         .instrument(tracing::trace_span!("flatten"))
                         .await;
 
-                    value = Value::from_path(current_dir, v);
+                    value = v;
                     errors.extend(err.into_iter());
                 }
                 PlanNode::Fetch(fetch_node) => {

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -217,7 +217,6 @@ impl PlanNode {
                 Box::new(nodes.iter().flat_map(|x| x.service_usage()))
             }
             Self::Fetch(fetch) => Box::new(Some(fetch.service_name()).into_iter()),
-
             Self::Flatten(flatten) => flatten.node.service_usage(),
         }
     }
@@ -274,12 +273,11 @@ mod fetch {
     use std::sync::Arc;
 
     use super::selection::{select_object, Selection};
-    use futures::StreamExt;
+    use futures::prelude::*;
     use serde::Deserialize;
-    use serde_json::{Map, Value};
     use tracing::{instrument, Instrument};
 
-    use crate::{FetchError, Object, Path, Request, Response, Schema, ServiceRegistry, ValueExt};
+    use crate::prelude::graphql::*;
 
     /// A fetch node.
     #[derive(Debug, PartialEq, Deserialize)]
@@ -300,16 +298,16 @@ mod fetch {
     }
 
     struct Variables {
-        variables: Map<String, Value>,
+        variables: Object,
         paths: Vec<Path>,
     }
 
     impl Variables {
-        fn new<'a>(
+        fn new(
             requires: Option<&Vec<Selection>>,
             variable_usages: &[String],
             data: &Value,
-            current_dir: &'a Path,
+            current_dir: &Path,
             request: &Arc<Request>,
             schema: &Arc<Schema>,
         ) -> Result<Variables, FetchError> {

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -137,6 +137,8 @@ impl PlanNode {
                                 Arc::clone(&request),
                                 Arc::clone(&service_registry),
                                 Arc::clone(&schema),
+                                // FIXME: should this use the parent_value?
+                                // that would mean we need to clone it at the beginning of the Sequence
                                 &value,
                             )
                             .instrument(tracing::info_span!("sequence"))
@@ -164,7 +166,7 @@ impl PlanNode {
                                         Arc::clone(&request),
                                         Arc::clone(&service_registry),
                                         Arc::clone(&schema),
-                                        &value,
+                                        &parent_value,
                                     )
                                 })
                                 .collect();

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -208,7 +208,7 @@ impl PlanNode {
                 Box::new(nodes.iter().flat_map(|x| x.variable_usage()))
             }
             Self::Fetch(fetch) => fetch.variable_usage(),
-            Self::Flatten(flatten) => Box::new(flatten.node.variable_usage()),
+            Self::Flatten(flatten) => flatten.node.variable_usage(),
         }
     }
 
@@ -222,7 +222,7 @@ impl PlanNode {
             }
             Self::Fetch(fetch) => Box::new(Some(fetch.service_name()).into_iter()),
 
-            Self::Flatten(flatten) => Box::new(flatten.node.service_usage()),
+            Self::Flatten(flatten) => flatten.node.service_usage(),
         }
     }
 

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -305,7 +305,7 @@ mod fetch {
 
     struct Variables {
         variables: Map<String, Value>,
-        paths: Option<Vec<Path>>,
+        paths: Vec<Path>,
     }
 
     impl Variables {
@@ -345,10 +345,7 @@ mod fetch {
                 );
                 variables.insert("representations".into(), representations);
 
-                Ok(Variables {
-                    variables,
-                    paths: Some(paths),
-                })
+                Ok(Variables { variables, paths })
             } else {
                 Ok(Variables {
                     variables: variable_usages
@@ -361,7 +358,7 @@ mod fetch {
                                 .unwrap_or_default()
                         })
                         .collect::<Object>(),
-                    paths: None,
+                    paths: Vec::new(),
                 })
             }
         }
@@ -429,7 +426,7 @@ mod fetch {
         fn response_at_path<'a>(
             &'a self,
             current_dir: &'a Path,
-            paths: Option<Vec<Path>>,
+            paths: Vec<Path>,
             subgraph_response: Response,
         ) -> Result<Value, FetchError> {
             let Response { data, .. } = subgraph_response;
@@ -450,7 +447,6 @@ mod fetch {
 
                             let mut value = Value::default();
 
-                            let paths = paths.unwrap();
                             for (entity, path) in array.into_iter().zip(paths.into_iter()) {
                                 let v = Value::from_path(&path, entity);
                                 value.deep_merge(v);

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -315,8 +315,10 @@ mod fetch {
             if !requires.is_empty() {
                 let mut variables = Object::with_capacity(1 + variable_usages.len());
                 variables.extend(variable_usages.iter().filter_map(|key| {
-                    request.variables.get(key)
-                            .map(|value| (key.clone(), value.clone()))
+                    request
+                        .variables
+                        .get(key)
+                        .map(|value| (key.clone(), value.clone()))
                 }));
 
                 let mut paths = Vec::new();
@@ -349,9 +351,8 @@ mod fetch {
                         .filter_map(|key| {
                             request
                                 .variables
-                                .as_ref()
-                                .map(|v| v.get(key).map(|value| (key.clone(), value.clone())))
-                                .unwrap_or_default()
+                                .get(key)
+                                .map(|value| (key.clone(), value.clone()))
                         })
                         .collect::<Object>(),
                     paths: Vec::new(),

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -119,7 +119,12 @@ impl PlanNode {
 
             match self {
                 PlanNode::Sequence { nodes } => {
-                    println!("{} Sequence", current_dir);
+                    println!(
+                        "{} Sequence: parent = {}",
+                        current_dir,
+                        serde_json::to_string(parent_value).unwrap()
+                    );
+                    value = parent_value.clone();
                     for node in nodes {
                         let (v, err) = node
                             .execute_recursively(
@@ -140,7 +145,11 @@ impl PlanNode {
                     }
                 }
                 PlanNode::Parallel { nodes } => {
-                    println!("{} Parallel", current_dir);
+                    println!(
+                        "{} Parallel: parent = {}",
+                        current_dir,
+                        serde_json::to_string(parent_value).unwrap()
+                    );
 
                     async {
                         let mut resv = Value::default();

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -309,8 +309,8 @@ mod fetch {
             variable_usages: &[String],
             data: &Value,
             current_dir: &Path,
-            request: &Arc<Request>,
-            schema: &Arc<Schema>,
+            request: &Request,
+            schema: &Schema,
         ) -> Result<Variables, FetchError> {
             if !requires.is_empty() {
                 let mut variables = Object::with_capacity(1 + variable_usages.len());
@@ -368,9 +368,9 @@ mod fetch {
             &'a self,
             data: &'a Value,
             current_dir: &'a Path,
-            request: &'a Arc<Request>,
+            request: &'a Request,
             service_registry: Arc<dyn ServiceRegistry>,
-            schema: &'a Arc<Schema>,
+            schema: &'a Schema,
         ) -> Result<Value, FetchError> {
             let FetchNode {
                 operation,

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -437,10 +437,7 @@ mod fetch {
                 // because we need to take ownership of the inner value
                 if let Value::Object(mut map) = data {
                     if let Some(entities) = map.remove("_entities") {
-                        tracing::trace!(
-                            "Received entities: {}",
-                            serde_json::to_string(&entities).unwrap(),
-                        );
+                        tracing::trace!("Received entities: {:?}", &entities);
 
                         if let Value::Array(array) = entities {
                             let mut value = Value::default();

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -159,14 +159,7 @@ impl PlanNode {
                         }
                     };
                     match fetch_node
-                        .fetch_node(
-                            Arc::clone(&response),
-                            current_dir,
-                            Arc::clone(&request),
-                            Arc::clone(&service_registry),
-                            Arc::clone(&schema),
-                            variables,
-                        )
+                        .fetch_node(Arc::clone(&service_registry), variables)
                         .instrument(tracing::info_span!("fetch"))
                         .await
                     {
@@ -312,7 +305,6 @@ impl FetchNode {
         data: &Value,
         current_dir: &'a Path,
         request: &Arc<Request>,
-        //service_registry: Arc<dyn ServiceRegistry>,
         schema: &Arc<Schema>,
     ) -> Result<Map<String, Value>, FetchError> {
         if let Some(requires) = &self.requires {
@@ -352,18 +344,14 @@ impl FetchNode {
 
     async fn fetch_node<'a>(
         &'a self,
-        response: Arc<Mutex<Response>>,
-        current_dir: &'a Path,
-        request: Arc<Request>,
         service_registry: Arc<dyn ServiceRegistry>,
-        schema: Arc<Schema>,
+
         variables: Map<String, Value>,
     ) -> Result<Response, FetchError> {
         let FetchNode {
-            variable_usages,
-            requires,
             operation,
             service_name,
+            ..
         } = self;
 
         let query_span = tracing::info_span!("subfetch", service = service_name.as_str());

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -443,8 +443,7 @@ mod fetch {
                             let mut value = Value::default();
 
                             for (entity, path) in array.into_iter().zip(paths.into_iter()) {
-                                let v = Value::from_path(&path, entity);
-                                value.deep_merge(v);
+                                value.insert(&path, entity)?;
                             }
                             return Ok(value);
                         } else {

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -323,14 +323,18 @@ mod fetch {
                     })
                 }));
 
-                let values_and_paths = data.select_values_and_paths(current_dir)?;
                 let mut paths = Vec::new();
+                let mut values = Vec::new();
+                data.select_values_and_paths(current_dir, |_path, value| {
+                    paths.push(_path);
+                    values.push(value)
+                })?;
+
                 let representations = Value::Array(
-                    values_and_paths
+                    values
                         .into_iter()
-                        .flat_map(|(path, value)| match value {
+                        .flat_map(|value| match value {
                             Value::Object(content) => {
-                                paths.push(path);
                                 select_object(content, requires, schema).transpose()
                             }
                             _ => Some(Err(FetchError::ExecutionInvalidContent {

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -3,7 +3,8 @@ mod router_bridge_query_planner;
 mod selection;
 
 use crate::prelude::graphql::*;
-use crate::query_planner::selection::{select_object, select_values};
+use crate::query_planner::json_ext::select_values;
+use crate::query_planner::selection::select_object;
 pub use caching_query_planner::*;
 use futures::prelude::*;
 use futures::stream::FuturesUnordered;

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -130,8 +130,6 @@ impl PlanNode {
                 PlanNode::Parallel { nodes } => {
                     value = Value::default();
                     async {
-                        let mut resv = Value::default();
-
                         {
                             let mut stream: FuturesUnordered<_> = nodes
                                 .iter()
@@ -147,12 +145,10 @@ impl PlanNode {
                                 .collect();
 
                             while let Some((v, err)) = stream.next().await {
-                                resv.deep_merge(v);
+                                value.deep_merge(v);
                                 errors.extend(err.into_iter());
                             }
                         }
-
-                        value.deep_merge(resv);
                     }
                     .instrument(tracing::info_span!("parallel"))
                     .await;

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -222,6 +222,7 @@ impl PlanNode {
                     {
                         Ok(v) => value = v,
                         Err(err) => {
+                            failfast_error!("Fetch error: {}", err);
                             errors.push(err.to_graphql_error(Some(current_dir.to_owned())));
                             return (value, errors);
                         }

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -281,7 +281,7 @@ mod fetch {
     use futures::StreamExt;
     use serde::Deserialize;
     use serde_json::{Map, Value};
-    use tracing::Instrument;
+    use tracing::{instrument, Instrument};
 
     use crate::{FetchError, Object, Path, Request, Response, Schema, ServiceRegistry, ValueExt};
 
@@ -423,6 +423,7 @@ mod fetch {
             self.response_at_path(current_dir, paths, subgraph_response)
         }
 
+        #[instrument(, level = "trace", name = "response_insert", skip_all)]
         fn response_at_path<'a>(
             &'a self,
             current_dir: &'a Path,
@@ -442,9 +443,6 @@ mod fetch {
                         );
 
                         if let Value::Array(array) = entities {
-                            let span = tracing::trace_span!("response_insert");
-                            let _guard = span.enter();
-
                             let mut value = Value::default();
 
                             for (entity, path) in array.into_iter().zip(paths.into_iter()) {
@@ -464,9 +462,6 @@ mod fetch {
                     reason: "Missing key `_entities`!".to_string(),
                 })
             } else {
-                let span = tracing::trace_span!("response_insert");
-                let _guard = span.enter();
-
                 Ok(Value::from_path(current_dir, data))
             }
         }

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -425,7 +425,7 @@ impl FetchNode {
             // because we need to take ownership of the inner value
             if let Value::Object(mut map) = data {
                 if let Some(entities) = map.remove("_entities") {
-                    tracing::info!(
+                    tracing::trace!(
                         "Received entities: {}",
                         serde_json::to_string(&entities).unwrap(),
                     );

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -5,7 +5,6 @@ mod selection;
 use crate::prelude::graphql::*;
 pub use caching_query_planner::*;
 use futures::prelude::*;
-use futures::stream::FuturesUnordered;
 pub use router_bridge_query_planner::*;
 use serde::Deserialize;
 use std::collections::HashSet;
@@ -131,7 +130,7 @@ impl PlanNode {
                     value = Value::default();
                     async {
                         {
-                            let mut stream: FuturesUnordered<_> = nodes
+                            let mut stream: stream::FuturesUnordered<_> = nodes
                                 .iter()
                                 .map(|plan| {
                                     plan.execute_recursively(
@@ -420,7 +419,7 @@ mod fetch {
             self.response_at_path(current_dir, paths, subgraph_response)
         }
 
-        #[instrument(, level = "trace", name = "response_insert", skip_all)]
+        #[instrument(level = "trace", name = "response_insert", skip_all)]
         fn response_at_path<'a>(
             &'a self,
             current_dir: &'a Path,

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -408,10 +408,6 @@ mod fetch {
         pub(crate) fn service_name(&self) -> &str {
             &self.service_name
         }
-
-        pub(crate) fn variable_usage<'a>(&'a self) -> Box<dyn Iterator<Item = &'a str> + 'a> {
-            Box::new(self.variable_usages.iter().map(|x| x.as_str()))
-        }
     }
 }
 

--- a/apollo-router-core/src/query_planner/selection.rs
+++ b/apollo-router-core/src/query_planner/selection.rs
@@ -49,9 +49,7 @@ pub(crate) fn select<'a>(
     selections: &[Selection],
     schema: &Schema,
 ) -> Result<Value, FetchError> {
-    let values = select_values(path, &response.data)?
-        .into_iter()
-        .map(|r| r.1);
+    let values = select_values(path, &response.data)?.into_iter();
 
     Ok(Value::Array(
         values

--- a/apollo-router-core/src/query_planner/selection.rs
+++ b/apollo-router-core/src/query_planner/selection.rs
@@ -60,14 +60,12 @@ pub(crate) fn select<'a>(
     selections: &[Selection],
     schema: &Schema,
 ) -> Result<Value, FetchError> {
-    let values: Vec<_> = select_values(path, &response.data)?
+    let values = select_values(path, &response.data)?
         .into_iter()
-        .map(|r| r.1)
-        .collect();
+        .map(|r| r.1);
 
     Ok(Value::Array(
         values
-            .into_iter()
             .flat_map(|value| match (value, selections) {
                 (Value::Object(content), requires) => {
                     select_object(content, requires, schema).transpose()
@@ -96,7 +94,7 @@ fn iterate_path<'a>(
                 reason: "not an array".to_string(),
             }),
             Some(array) => {
-                for (i, value) in array.into_iter().enumerate() {
+                for (i, value) in array.iter().enumerate() {
                     if let Some(err) = iterate_path(
                         &parent.join(Path::from(i.to_string())),
                         &path[1..],

--- a/apollo-router-core/src/query_planner/selection.rs
+++ b/apollo-router-core/src/query_planner/selection.rs
@@ -123,7 +123,9 @@ mod tests {
         selections: &[Selection],
         schema: &Schema,
     ) -> Result<Value, FetchError> {
-        let values = select_values_and_paths(path, &response.data)?
+        let values = response
+            .data
+            .select_values_and_paths(path)?
             .into_iter()
             .map(|r| r.1);
 

--- a/apollo-router-core/src/query_planner/selection.rs
+++ b/apollo-router-core/src/query_planner/selection.rs
@@ -133,7 +133,7 @@ mod tests {
                 .into_iter()
                 .flat_map(|value| match (value, selections) {
                     (Value::Object(content), requires) => {
-                        select_object(&content, requires, schema).transpose()
+                        select_object(content, requires, schema).transpose()
                     }
                     (_, _) => Some(Err(FetchError::ExecutionInvalidContent {
                         reason: "not an object".to_string(),

--- a/apollo-router-core/src/query_planner/selection.rs
+++ b/apollo-router-core/src/query_planner/selection.rs
@@ -42,62 +42,7 @@ pub(crate) struct InlineFragment {
     selections: Vec<Selection>,
 }
 
-pub(crate) fn select(
-    response: &Response,
-    path: &Path,
-    selections: &[Selection],
-    schema: &Schema,
-) -> Result<Value, FetchError> {
-    let values =
-        response
-            .data
-            .get_at_path(path)
-            .map_err(|err| FetchError::ExecutionPathNotFound {
-                reason: err.to_string(),
-            })?;
-
-    Ok(Value::Array(
-        values
-            .into_iter()
-            .flat_map(|value| match (value, selections) {
-                (Value::Object(content), requires) => {
-                    select_object(content, requires, schema).transpose()
-                }
-                (_, _) => Some(Err(FetchError::ExecutionInvalidContent {
-                    reason: "not an object".to_string(),
-                })),
-            })
-            .collect::<Result<Vec<_>, _>>()?,
-    ))
-}
-
-pub(crate) fn select_value(
-    data: &Value,
-    path: &Path,
-    selections: &[Selection],
-    schema: &Schema,
-) -> Result<Value, FetchError> {
-    let values = data
-        .get_at_path(path)
-        .map_err(|err| FetchError::ExecutionPathNotFound {
-            reason: err.to_string(),
-        })?;
-
-    Ok(Value::Array(
-        values
-            .into_iter()
-            .flat_map(|value| match (value, selections) {
-                (Value::Object(content), requires) => {
-                    select_object(content, requires, schema).transpose()
-                }
-                (_, _) => Some(Err(FetchError::ExecutionInvalidContent {
-                    reason: "not an object".to_string(),
-                })),
-            })
-            .collect::<Result<Vec<_>, _>>()?,
-    ))
-}
-
+//FIXME: we need to return errors on invalid fetches here
 pub(crate) fn select_values<'a>(path: &'a Path, data: &'a Value) -> Vec<(Path, &'a Value)> {
     let mut res = Vec::new();
     iterate_path(&Path::default(), &path.0, data, &mut res);

--- a/apollo-router-core/src/query_planner/selection.rs
+++ b/apollo-router-core/src/query_planner/selection.rs
@@ -123,17 +123,17 @@ mod tests {
         selections: &[Selection],
         schema: &Schema,
     ) -> Result<Value, FetchError> {
-        let values = response
+        let mut values = Vec::new();
+        response
             .data
-            .select_values_and_paths(path)?
-            .into_iter()
-            .map(|r| r.1);
+            .select_values_and_paths(path, |_path, value| values.push(value))?;
 
         Ok(Value::Array(
             values
+                .into_iter()
                 .flat_map(|value| match (value, selections) {
                     (Value::Object(content), requires) => {
-                        select_object(content, requires, schema).transpose()
+                        select_object(&content, requires, schema).transpose()
                     }
                     (_, _) => Some(Err(FetchError::ExecutionInvalidContent {
                         reason: "not an object".to_string(),

--- a/apollo-router-core/src/query_planner/snapshots/apollo_router_core__query_planner__router_bridge_query_planner__tests__plan.snap
+++ b/apollo-router-core/src/query_planner/snapshots/apollo_router_core__query_planner__router_bridge_query_planner__tests__plan.snap
@@ -7,7 +7,7 @@ QueryPlan {
     root: Fetch(
         FetchNode {
             service_name: "accounts",
-            requires: None,
+            requires: [],
             variable_usages: [],
             operation: "{me{name{first last}}}",
         },

--- a/apollo-router-core/src/query_planner/snapshots/apollo_router_core__query_planner__tests__query_plan_from_json.snap
+++ b/apollo-router-core/src/query_planner/snapshots/apollo_router_core__query_planner__tests__query_plan_from_json.snap
@@ -8,7 +8,7 @@ Sequence {
         Fetch(
             FetchNode {
                 service_name: "product",
-                requires: None,
+                requires: [],
                 variable_usages: [],
                 operation: "{topProducts{__typename ...on Book{__typename isbn}...on Furniture{name}}product(upc:\"1\"){__typename ...on Book{__typename isbn}...on Furniture{name}}}",
             },
@@ -30,33 +30,31 @@ Sequence {
                                 node: Fetch(
                                     FetchNode {
                                         service_name: "books",
-                                        requires: Some(
-                                            [
-                                                InlineFragment(
-                                                    InlineFragment {
-                                                        type_condition: Some(
-                                                            "Book",
+                                        requires: [
+                                            InlineFragment(
+                                                InlineFragment {
+                                                    type_condition: Some(
+                                                        "Book",
+                                                    ),
+                                                    selections: [
+                                                        Field(
+                                                            Field {
+                                                                alias: None,
+                                                                name: "__typename",
+                                                                selections: None,
+                                                            },
                                                         ),
-                                                        selections: [
-                                                            Field(
-                                                                Field {
-                                                                    alias: None,
-                                                                    name: "__typename",
-                                                                    selections: None,
-                                                                },
-                                                            ),
-                                                            Field(
-                                                                Field {
-                                                                    alias: None,
-                                                                    name: "isbn",
-                                                                    selections: None,
-                                                                },
-                                                            ),
-                                                        ],
-                                                    },
-                                                ),
-                                            ],
-                                        ),
+                                                        Field(
+                                                            Field {
+                                                                alias: None,
+                                                                name: "isbn",
+                                                                selections: None,
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                        ],
                                         variable_usages: [
                                             "test_variable",
                                         ],
@@ -78,47 +76,45 @@ Sequence {
                                 node: Fetch(
                                     FetchNode {
                                         service_name: "product",
-                                        requires: Some(
-                                            [
-                                                InlineFragment(
-                                                    InlineFragment {
-                                                        type_condition: Some(
-                                                            "Book",
+                                        requires: [
+                                            InlineFragment(
+                                                InlineFragment {
+                                                    type_condition: Some(
+                                                        "Book",
+                                                    ),
+                                                    selections: [
+                                                        Field(
+                                                            Field {
+                                                                alias: None,
+                                                                name: "__typename",
+                                                                selections: None,
+                                                            },
                                                         ),
-                                                        selections: [
-                                                            Field(
-                                                                Field {
-                                                                    alias: None,
-                                                                    name: "__typename",
-                                                                    selections: None,
-                                                                },
-                                                            ),
-                                                            Field(
-                                                                Field {
-                                                                    alias: None,
-                                                                    name: "isbn",
-                                                                    selections: None,
-                                                                },
-                                                            ),
-                                                            Field(
-                                                                Field {
-                                                                    alias: None,
-                                                                    name: "title",
-                                                                    selections: None,
-                                                                },
-                                                            ),
-                                                            Field(
-                                                                Field {
-                                                                    alias: None,
-                                                                    name: "year",
-                                                                    selections: None,
-                                                                },
-                                                            ),
-                                                        ],
-                                                    },
-                                                ),
-                                            ],
-                                        ),
+                                                        Field(
+                                                            Field {
+                                                                alias: None,
+                                                                name: "isbn",
+                                                                selections: None,
+                                                            },
+                                                        ),
+                                                        Field(
+                                                            Field {
+                                                                alias: None,
+                                                                name: "title",
+                                                                selections: None,
+                                                            },
+                                                        ),
+                                                        Field(
+                                                            Field {
+                                                                alias: None,
+                                                                name: "year",
+                                                                selections: None,
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                        ],
                                         variable_usages: [],
                                         operation: "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}",
                                     },
@@ -141,33 +137,31 @@ Sequence {
                                 node: Fetch(
                                     FetchNode {
                                         service_name: "books",
-                                        requires: Some(
-                                            [
-                                                InlineFragment(
-                                                    InlineFragment {
-                                                        type_condition: Some(
-                                                            "Book",
+                                        requires: [
+                                            InlineFragment(
+                                                InlineFragment {
+                                                    type_condition: Some(
+                                                        "Book",
+                                                    ),
+                                                    selections: [
+                                                        Field(
+                                                            Field {
+                                                                alias: None,
+                                                                name: "__typename",
+                                                                selections: None,
+                                                            },
                                                         ),
-                                                        selections: [
-                                                            Field(
-                                                                Field {
-                                                                    alias: None,
-                                                                    name: "__typename",
-                                                                    selections: None,
-                                                                },
-                                                            ),
-                                                            Field(
-                                                                Field {
-                                                                    alias: None,
-                                                                    name: "isbn",
-                                                                    selections: None,
-                                                                },
-                                                            ),
-                                                        ],
-                                                    },
-                                                ),
-                                            ],
-                                        ),
+                                                        Field(
+                                                            Field {
+                                                                alias: None,
+                                                                name: "isbn",
+                                                                selections: None,
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                        ],
                                         variable_usages: [],
                                         operation: "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename isbn title year}}}",
                                     },
@@ -186,47 +180,45 @@ Sequence {
                                 node: Fetch(
                                     FetchNode {
                                         service_name: "product",
-                                        requires: Some(
-                                            [
-                                                InlineFragment(
-                                                    InlineFragment {
-                                                        type_condition: Some(
-                                                            "Book",
+                                        requires: [
+                                            InlineFragment(
+                                                InlineFragment {
+                                                    type_condition: Some(
+                                                        "Book",
+                                                    ),
+                                                    selections: [
+                                                        Field(
+                                                            Field {
+                                                                alias: None,
+                                                                name: "__typename",
+                                                                selections: None,
+                                                            },
                                                         ),
-                                                        selections: [
-                                                            Field(
-                                                                Field {
-                                                                    alias: None,
-                                                                    name: "__typename",
-                                                                    selections: None,
-                                                                },
-                                                            ),
-                                                            Field(
-                                                                Field {
-                                                                    alias: None,
-                                                                    name: "isbn",
-                                                                    selections: None,
-                                                                },
-                                                            ),
-                                                            Field(
-                                                                Field {
-                                                                    alias: None,
-                                                                    name: "title",
-                                                                    selections: None,
-                                                                },
-                                                            ),
-                                                            Field(
-                                                                Field {
-                                                                    alias: None,
-                                                                    name: "year",
-                                                                    selections: None,
-                                                                },
-                                                            ),
-                                                        ],
-                                                    },
-                                                ),
-                                            ],
-                                        ),
+                                                        Field(
+                                                            Field {
+                                                                alias: None,
+                                                                name: "isbn",
+                                                                selections: None,
+                                                            },
+                                                        ),
+                                                        Field(
+                                                            Field {
+                                                                alias: None,
+                                                                name: "title",
+                                                                selections: None,
+                                                            },
+                                                        ),
+                                                        Field(
+                                                            Field {
+                                                                alias: None,
+                                                                name: "year",
+                                                                selections: None,
+                                                            },
+                                                        ),
+                                                    ],
+                                                },
+                                            ),
+                                        ],
                                         variable_usages: [],
                                         operation: "query($representations:[_Any!]!){_entities(representations:$representations){...on Book{name}}}",
                                     },

--- a/apollo-router-core/src/response.rs
+++ b/apollo-router-core/src/response.rs
@@ -57,28 +57,6 @@ impl Response {
         self.path.is_none()
     }
 
-    pub fn insert_data(&mut self, path: &Path, value: Value) -> Result<(), FetchError> {
-        let mut nodes =
-            self.data
-                .get_at_path_mut(path)
-                .map_err(|err| FetchError::ExecutionPathNotFound {
-                    reason: err.to_string(),
-                })?;
-
-        let len = nodes.len();
-        //FIXME: are there cases where we could write at multiple paths?
-        for (i, node) in nodes.iter_mut().enumerate() {
-            if i == len {
-                (*node).deep_merge(value);
-                break;
-            } else {
-                (*node).deep_merge(value.clone());
-            }
-        }
-
-        Ok(())
-    }
-
     /// append_errors default the errors `path` with the one provided.
     pub fn append_errors(&mut self, errors: &mut Vec<Error>) {
         self.errors.append(errors)
@@ -95,29 +73,6 @@ impl From<Response> for ResponseStream {
 mod tests {
     use super::*;
     use serde_json::json;
-
-    #[test]
-    fn test_insert_data() {
-        let mut response = Response::builder()
-            .data(json!({
-                "name": "SpongeBob",
-                "job": {},
-            }))
-            .build();
-        let data = json!({
-            "name": "cook",
-        });
-        response.insert_data(&Path::from("job"), data).unwrap();
-        assert_eq!(
-            response.data,
-            json!({
-                "name": "SpongeBob",
-                "job": {
-                    "name": "cook",
-                },
-            }),
-        );
-    }
 
     #[test]
     fn test_append_errors_path_fallback_and_override() {

--- a/apollo-router/src/apollo_router.rs
+++ b/apollo-router/src/apollo_router.rs
@@ -119,11 +119,7 @@ impl PreparedQuery for ApolloPreparedQuery {
     async fn execute(self, request: Arc<Request>) -> ResponseStream {
         let response_task = self
             .query_plan
-            .execute(
-                Arc::clone(&request),
-                Arc::clone(&self.service_registry),
-                Arc::clone(&self.schema),
-            )
+            .execute(&request, Arc::clone(&self.service_registry), &self.schema)
             .instrument(tracing::info_span!("execution"));
 
         let query_task = self

--- a/apollo-router/src/apollo_router.rs
+++ b/apollo-router/src/apollo_router.rs
@@ -119,7 +119,7 @@ impl PreparedQuery for ApolloPreparedQuery {
     async fn execute(self, request: Arc<Request>) -> ResponseStream {
         let response_task = self
             .query_plan
-            .execute(&request, Arc::clone(&self.service_registry), &self.schema)
+            .execute(&request, self.service_registry.as_ref(), &self.schema)
             .instrument(tracing::info_span!("execution"));
 
         let query_task = self

--- a/apollo-router/src/apollo_router.rs
+++ b/apollo-router/src/apollo_router.rs
@@ -130,7 +130,8 @@ impl PreparedQuery for ApolloPreparedQuery {
         let mut response = self
             .query_plan
             .execute(&request, self.service_registry.as_ref(), &self.schema)
-            .instrument(tracing::info_span!("execution")).await;;
+            .instrument(tracing::info_span!("execution"))
+            .await;
 
         if let Some(query) = self.query {
             tracing::debug_span!("format_response").in_scope(|| {


### PR DESCRIPTION
Fix: #248

This PR gets rid of the response mutex and simplify response merging.

- separate tasks of `fetch_node` in different methods to extract the mutex usage more easily
- refactor `execute_recursively` to merge response data incrementally from smaller subsets of the response
- use `FuturesUnordered` to transform parallel queries in a stream of subgraph responses that are then merged one by one
- generate with representations data a path for each entity, so that we know exactly where to insert it in the response data. This fixes #248