### PR TITLE
Add a basic health check to the router

### DIFF
--- a/apollo-router/src/snapshots/apollo_router__warp_http_server_factory__tests__it_provides_health_status_body.snap
+++ b/apollo-router/src/snapshots/apollo_router__warp_http_server_factory__tests__it_provides_health_status_body.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-router/src/warp_http_server_factory.rs
+expression: "String::from_utf8_lossy(res.body())"
+
+---
+"{\"status\":\"pass\"}"

--- a/apollo-router/src/snapshots/apollo_router__warp_http_server_factory__tests__it_provides_health_status_header.snap
+++ b/apollo-router/src/snapshots/apollo_router__warp_http_server_factory__tests__it_provides_health_status_header.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-router/src/warp_http_server_factory.rs
+expression: "hdrs[\"content-type\"].to_str().unwrap()"
+
+---
+application/json

--- a/apollo-router/src/warp_http_server_factory.rs
+++ b/apollo-router/src/warp_http_server_factory.rs
@@ -239,7 +239,7 @@ fn get_health_request() -> impl Filter<Extract = (Box<dyn Reply>,), Error = Reje
         .and_then(move || async {
             let mut result = HashMap::new();
             result.insert("status", "pass");
-            let reply = Box::new(warp::reply::json(&result).into_response()) as Box<dyn Reply>;
+            let reply = Box::new(warp::reply::json(&result)) as Box<dyn Reply>;
             Ok::<_, Rejection>(reply)
         })
 }
@@ -702,6 +702,8 @@ mod tests {
             .reply(&filter)
             .await;
 
+        let hdrs = res.headers();
+        assert_eq!(hdrs["content-type"], "application/json");
         assert_eq!(res.status(), 200);
         assert_eq!(res.body().len(), expected.len());
         assert_eq!(res.body(), &expected);


### PR DESCRIPTION
Provide a health check endpoint which behaves in the same way as the
health check on the gateway.

https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-express/src/ApolloServer.ts#L85

At this point in time it always returns pass because we don't have a
different health status to set.

resolves: #54 