### PR TITLE
Improve health checks

### DIFF
--- a/apollo-router/src/snapshots/apollo_router__warp_http_server_factory__tests__health_check.snap
+++ b/apollo-router/src/snapshots/apollo_router__warp_http_server_factory__tests__health_check.snap
@@ -1,0 +1,13 @@
+---
+source: apollo-router/src/warp_http_server_factory.rs
+expression: res
+
+---
+Response {
+    status: 200,
+    version: HTTP/1.1,
+    headers: {
+        "content-type": "application/json",
+    },
+    body: b"{\"status\":\"pass\"}",
+}

--- a/apollo-router/src/snapshots/apollo_router__warp_http_server_factory__tests__it_provides_health_status_body.snap
+++ b/apollo-router/src/snapshots/apollo_router__warp_http_server_factory__tests__it_provides_health_status_body.snap
@@ -1,6 +1,0 @@
----
-source: apollo-router/src/warp_http_server_factory.rs
-expression: "String::from_utf8_lossy(res.body())"
-
----
-"{\"status\":\"pass\"}"

--- a/apollo-router/src/snapshots/apollo_router__warp_http_server_factory__tests__it_provides_health_status_header.snap
+++ b/apollo-router/src/snapshots/apollo_router__warp_http_server_factory__tests__it_provides_health_status_header.snap
@@ -1,6 +1,0 @@
----
-source: apollo-router/src/warp_http_server_factory.rs
-expression: "hdrs[\"content-type\"].to_str().unwrap()"
-
----
-application/json

--- a/apollo-router/src/warp_http_server_factory.rs
+++ b/apollo-router/src/warp_http_server_factory.rs
@@ -5,8 +5,8 @@ use apollo_router_core::prelude::*;
 use bytes::Bytes;
 use futures::{channel::oneshot, prelude::*};
 use hyper::server::conn::Http;
+use once_cell::sync::Lazy;
 use opentelemetry::propagation::Extractor;
-use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 use tokio::net::TcpListener;
@@ -237,9 +237,10 @@ fn get_health_request() -> impl Filter<Extract = (Box<dyn Reply>,), Error = Reje
         .and(warp::path("apollo"))
         .and(warp::path("server-health"))
         .and_then(move || async {
-            let mut result = HashMap::new();
-            result.insert("status", "pass");
-            let reply = Box::new(warp::reply::json(&result)) as Box<dyn Reply>;
+            static RESULT: Lazy<serde_json::Value> =
+                Lazy::new(|| serde_json::json!({"status": "pass"}));
+
+            let reply = Box::new(warp::reply::json(&*RESULT)) as Box<dyn Reply>;
             Ok::<_, Rejection>(reply)
         })
 }

--- a/apollo-router/src/warp_http_server_factory.rs
+++ b/apollo-router/src/warp_http_server_factory.rs
@@ -352,7 +352,6 @@ impl<'a> Extractor for HeaderMapCarrier<'a> {
 mod tests {
     use super::*;
     use crate::configuration::Cors;
-    use insta::{assert_json_snapshot, assert_snapshot};
     use mockall::{mock, predicate::*};
     use reqwest::header::{
         ACCEPT, ACCESS_CONTROL_ALLOW_HEADERS, ACCESS_CONTROL_ALLOW_METHODS,
@@ -694,7 +693,7 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn it_provides_health_status_body() -> Result<(), FederatedServerError> {
+    async fn test_health_check() {
         let filter = get_health_request();
 
         let res = warp::test::request()
@@ -702,26 +701,6 @@ mod tests {
             .reply(&filter)
             .await;
 
-        assert_eq!(res.status(), 200);
-        assert_json_snapshot!(String::from_utf8_lossy(res.body()));
-
-        Ok(())
-    }
-
-    #[test(tokio::test)]
-    async fn it_provides_health_status_header() -> Result<(), FederatedServerError> {
-        let filter = get_health_request();
-
-        let res = warp::test::request()
-            .path("/.well-known/apollo/server-health")
-            .reply(&filter)
-            .await;
-
-        let hdrs = res.headers();
-
-        assert_eq!(res.status(), 200);
-        assert_snapshot!(hdrs["content-type"].to_str().unwrap());
-
-        Ok(())
+        insta::assert_debug_snapshot!(res);
     }
 }


### PR DESCRIPTION
I approved the PR too fast I just wanted to comment on it and it got merge with silly changes like the use if insta for a single string:
```rust
assert_json_snapshot!(String::from_utf8_lossy(res.body()));
```
This makes no sense at all and I would have pointed it out if I did had the chance to make a second round of review. But this is my fault as I shouldn't have select "approve" in the first place.

Related to #252