### PR TITLE
fix: Introspection query panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,6 +2783,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
+source = "git+https://github.com/apollographql/federation.git?rev=075308d7021858037b03ed090ba0630766903f92#075308d7021858037b03ed090ba0630766903f92"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,7 +2783,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation.git?rev=075308d7021858037b03ed090ba0630766903f92#075308d7021858037b03ed090ba0630766903f92"
+source = "git+https://github.com/apollographql/federation.git?rev=12f44165e50cbab562424d7ef249bb8fb4561397#12f44165e50cbab562424d7ef249bb8fb4561397"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,7 +2783,6 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation.git?rev=e88ce2a8be6a9159370c972b462ef61d598c2f33#e88ce2a8be6a9159370c972b462ef61d598c2f33"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,15 +54,6 @@ dependencies = [
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -542,9 +533,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cache-padded"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
+checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "camino"
@@ -588,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "castaway"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed247d1586918e46f2bbe0f13b06498db8dab5a8c1093f156652e9f2e0a73fc3"
+checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
@@ -612,11 +603,11 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term 0.11.0",
+ "ansi_term",
  "atty",
  "bitflags",
  "strsim",
@@ -686,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3825b1e8580894917dc4468cb634a1b4e9745fddc854edad72d9c04644c0319f"
+checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -789,7 +780,7 @@ checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
 dependencies = [
  "bstr",
  "csv-core",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
@@ -846,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.110.0"
+version = "0.111.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffca9c7f3b54e5a63124fc13825d70f20f1c286fcb7440922f86566bc65edd99"
+checksum = "1fe9d54c86cb2946be373f381cb1621903711691147eaecf6b9cd95376cb8eb8"
 dependencies = [
  "anyhow",
  "futures",
@@ -981,12 +972,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bb454f0228b18c7f4c3b0ebbee346ed9c52e7443b0999cd543ff3571205701d"
 
 [[package]]
-name = "dtoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
-
-[[package]]
 name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1009,9 +994,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.29"
+version = "0.8.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74ea89a0a1b98f6332de42c95baff457ada66d1cb4030f9ff151b2041a1c746"
+checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1024,9 +1009,9 @@ checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "fastrand"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b394ed3d285a429378d3b384b9eb1285267e7df4b166df24b7a6939a04dc392e"
+checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
 dependencies = [
  "instant",
 ]
@@ -1154,9 +1139,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd0210d8c325c245ff06fd95a3b13689a1a276ac8cfa8e8720cb840bfb84b9e"
+checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1169,9 +1154,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc8cd39e3dbf865f7340dce6a2d401d24fd37c6fe6c4f0ee0de8bfca2252d27"
+checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1179,15 +1164,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629316e42fe7c2a0b9a65b47d159ceaa5453ab14e8f0a3c5eedbb8cd55b4a445"
+checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b808bf53348a36cab739d7e04755909b9fcaaa69b7d7e588b37b6ec62704c97"
+checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1197,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e481354db6b5c353246ccf6a728b0c5511d752c08da7260546fc0933869daa11"
+checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
 
 [[package]]
 name = "futures-lite"
@@ -1218,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89f17b21645bc4ed773c69af9c9a0effd4a3f1a3876eadd453469f8854e7fdd"
+checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1229,21 +1214,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "996c6442437b62d21a32cd9906f9c41e7dc1e19a9579843fad948696769305af"
+checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
 
 [[package]]
 name = "futures-task"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabf1872aaab32c886832f2276d2f5399887e2bd613698a02359e4ea83f8de12"
+checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
 
 [[package]]
 name = "futures-util"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d22213122356472061ac0f1ab2cee28d2bac8491410fd68c2af53d1cedb83e"
+checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1310,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47204a46aaff920a1ea58b11d03dec6f704287d27561724a4631e450654a891f"
+checksum = "6f16c88aa13d2656ef20d1c042086b8767bbe2bdb62526894275a1b062161b2e"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1341,16 +1326,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.9"
+source = "git+https://github.com/o0Ignition0o/h2.git?branch=igni/bump_indexmap_dependency#93be8238810539c79e7d909cb021628b7b4a16ee"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
-
-[[package]]
-name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "hashbrown"
@@ -1422,7 +1419,7 @@ checksum = "1323096b05d41827dadeaee54c9981958c0f94e670bc94ed80037d1a7b8b186b"
 dependencies = [
  "bytes",
  "fnv",
- "itoa",
+ "itoa 0.4.8",
 ]
 
 [[package]]
@@ -1479,19 +1476,18 @@ dependencies = [
 [[package]]
 name = "hyper"
 version = "0.14.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
+source = "git+https://github.com/o0Ignition0o/hyper.git?branch=igni/bump_h2_dependency#9f663511505469c2c24f9cc468c47ca769a63c85"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.9 (git+https://github.com/o0Ignition0o/h2.git?branch=igni/bump_indexmap_dependency)",
  "http",
  "http-body",
  "httparse",
  "httpdate",
- "itoa",
+ "itoa 1.0.1",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1565,9 +1561,9 @@ dependencies = [
 
 [[package]]
 name = "include_dir_macros"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "253ba5156abc78673208f900dd686e1e000e6edc5633231d309acded2b66026d"
+checksum = "5e074c19deab2501407c91ba1860fa3d6820bfde307db6d8cb851b55a10be89b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1575,12 +1571,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown 0.9.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1683,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
 dependencies = [
  "either",
 ]
@@ -1695,6 +1691,12 @@ name = "itoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
@@ -1776,9 +1778,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.108"
+version = "0.2.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8521a1b57e76b1ec69af7599e75e38e7b7fad6610f037db8c79b127201b5d119"
+checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -1829,11 +1831,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c748cfe47cb8da225c37595b3108bea1c198c84aaae8ea0ba76d01dda9fc803"
+checksum = "469898e909a1774d844793b347135a0cd344ca2f69d082013ecb8061a2229a3a"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1865,9 +1867,9 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
 ]
@@ -2124,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "oorandom"
@@ -2162,9 +2164,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.71"
+version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df13d165e607909b363a4757a6f133f8a818a74e9d3a98d09c6128e15fa4c73"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
 dependencies = [
  "autocfg",
  "cc",
@@ -2372,9 +2374,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "platforms"
@@ -2501,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba508cc11742c0dc5c1659771673afbab7a0efab23aa17e854cbab0837ed0b43"
+checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
 dependencies = [
  "unicode-xid",
 ]
@@ -2783,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation.git?rev=3de51e57d0206b18a54ee21fa7e89f59f40e7112#3de51e57d0206b18a54ee21fa7e89f59f40e7112"
+source = "git+https://github.com/apollographql/federation.git?rev=e4fd4be09efb8b16e2fdd0789b06a5cdfaafbf6b#e4fd4be09efb8b16e2fdd0789b06a5cdfaafbf6b"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -2800,7 +2802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a938f42b9c73aeece236481f37adb3debb7dfe3ae347cd6a45b5797d9ce4250"
 dependencies = [
  "countme",
- "hashbrown 0.11.2",
+ "hashbrown",
  "memoffset",
  "rustc-hash",
  "text-size",
@@ -2842,15 +2844,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
 name = "ryu"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "same-file"
@@ -2927,9 +2929,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.131"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ad69dfbd3e45369132cc64e6748c2d65cdfb001a2b1c232d128b4ad60561c1"
+checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
 dependencies = [
  "serde_derive",
 ]
@@ -2955,9 +2957,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.131"
+version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b710a83c4e0dff6a3d511946b95274ad9ca9e5d3ae497b63fda866ac955358d2"
+checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2966,12 +2968,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ffa0837f2dfa6fb90868c2b5468cad482e175f7dad97e7421951e663f2b527"
+checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
 dependencies = [
  "indexmap",
- "itoa",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -2999,16 +3001,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
  "form_urlencoded",
- "itoa",
+ "itoa 0.4.8",
  "ryu",
  "serde",
 ]
 
 [[package]]
 name = "serde_v8"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6217b505e32edf22e28516ac16ad36dc783f13053311f5fa11fbe95d47ec633"
+checksum = "1fcfe34883023386ca624a87258ae9b6e0d6db2203f8f43b09febb8e03964b63"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -3017,12 +3019,12 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.21"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c608a35705a5d3cdc9fbe403147647ff34b921f8e833e49306df898f9b20af"
+checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
 dependencies = [
- "dtoa",
  "indexmap",
+ "ryu",
  "serde",
  "yaml-rust",
 ]
@@ -3064,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c98891d737e271a2954825ef19e46bd16bdb98e2746f2eec4f7a4ef7946efd1"
+checksum = "c35dfd12afb7828318348b8c408383cf5071a086c1d4ab1c0f9840ec92dbb922"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -3228,9 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f5515d3add52e0bbdcad7b83c388bb36ba7b754dda3b5f5bc2d38640cdba5c"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
 dependencies = [
  "filetime",
  "libc",
@@ -3421,11 +3423,10 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e992e41e0d2fb9f755b37446f20900f64446ef54874f40a60c78f021ac6144"
+checksum = "fbbf1c778ec206785635ce8ad57fe52b3009ae9e0c9f574a728f3049d3e55838"
 dependencies = [
- "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -3451,9 +3452,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9efc1aba077437943f7515666aa2b882dfabfbfdf89c819ea75a8d6e9eaba5e"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3518,7 +3519,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "http",
  "http-body",
  "hyper",
@@ -3666,7 +3667,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245da694cc7fc4729f3f418b304cb57789f1bed2a78c575407ab8a23f53cb4d3"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "lazy_static",
  "matchers",
  "regex",
@@ -4068,7 +4069,7 @@ dependencies = [
 name = "xtask"
 version = "0.1.0-prealpha.1"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "anyhow",
  "assert_fs",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,7 +2783,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation.git?rev=12f44165e50cbab562424d7ef249bb8fb4561397#12f44165e50cbab562424d7ef249bb8fb4561397"
+source = "git+https://github.com/apollographql/federation.git?rev=3de51e57d0206b18a54ee21fa7e89f59f40e7112#3de51e57d0206b18a54ee21fa7e89f59f40e7112"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,24 +1326,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.9"
-source = "git+https://github.com/o0Ignition0o/h2.git?branch=igni/bump_indexmap_dependency#93be8238810539c79e7d909cb021628b7b4a16ee"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,18 +1458,19 @@ dependencies = [
 [[package]]
 name = "hyper"
 version = "0.14.16"
-source = "git+https://github.com/o0Ignition0o/hyper.git?branch=igni/bump_h2_dependency#9f663511505469c2c24f9cc468c47ca769a63c85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ec3e62bdc98a2f0393a5048e4c30ef659440ea6e0e572965103e72bd836f55"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.9 (git+https://github.com/o0Ignition0o/h2.git?branch=igni/bump_indexmap_dependency)",
+ "h2",
  "http",
  "http-body",
  "httparse",
  "httpdate",
- "itoa 1.0.1",
+ "itoa 0.4.8",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3519,7 +3502,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2",
  "http",
  "http-body",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,3 @@ members = ["apollo-router", "apollo-router-core", "apollo-router-benchmarks", "x
 [patch.crates-io]
 opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "6b3aa02aa" }
 opentelemetry-otlp = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "6b3aa02aa" }
-hyper = { git = "https://github.com/o0Ignition0o/hyper.git", branch = "igni/bump_h2_dependency" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ members = ["apollo-router", "apollo-router-core", "apollo-router-benchmarks", "x
 [patch.crates-io]
 opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "6b3aa02aa" }
 opentelemetry-otlp = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "6b3aa02aa" }
+hyper = { git = "https://github.com/o0Ignition0o/hyper.git", branch = "igni/bump_h2_dependency" }

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -22,7 +22,7 @@ include_dir = "0.7.2"
 lru = "0.7.0"
 miette = { version = "3.2.0", features = ["fancy"] }
 once_cell = "1.8.0"
-router-bridge = { git = "https://github.com/apollographql/federation.git", rev = "e88ce2a8be6a9159370c972b462ef61d598c2f33" }
+router-bridge = { path = "../../federation/router-bridge" }                                                                  # git = "https://github.com/apollographql/federation.git", rev = "a4b27cc0ca4ccd1d6ec69fa6c1d146faee3eb27a" }
 serde = { version = "1.0.131", features = ["derive", "rc"] }
 serde_json = { version = "1.0.72", features = ["preserve_order"] }
 thiserror = "1.0.30"

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -22,7 +22,7 @@ include_dir = "0.7.2"
 lru = "0.7.0"
 miette = { version = "3.2.0", features = ["fancy"] }
 once_cell = "1.8.0"
-router-bridge = { git = "https://github.com/apollographql/federation.git", rev = "075308d7021858037b03ed090ba0630766903f92" }
+router-bridge = { git = "https://github.com/apollographql/federation.git", rev = "12f44165e50cbab562424d7ef249bb8fb4561397" }
 serde = { version = "1.0.131", features = ["derive", "rc"] }
 serde_json = { version = "1.0.72", features = ["preserve_order"] }
 thiserror = "1.0.30"

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -22,7 +22,7 @@ include_dir = "0.7.2"
 lru = "0.7.0"
 miette = { version = "3.2.0", features = ["fancy"] }
 once_cell = "1.8.0"
-router-bridge = { path = "../../federation/router-bridge" }                                                                  # git = "https://github.com/apollographql/federation.git", rev = "a4b27cc0ca4ccd1d6ec69fa6c1d146faee3eb27a" }
+router-bridge = { git = "https://github.com/apollographql/federation.git", rev = "075308d7021858037b03ed090ba0630766903f92" }
 serde = { version = "1.0.131", features = ["derive", "rc"] }
 serde_json = { version = "1.0.72", features = ["preserve_order"] }
 thiserror = "1.0.30"

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -22,7 +22,7 @@ include_dir = "0.7.2"
 lru = "0.7.0"
 miette = { version = "3.2.0", features = ["fancy"] }
 once_cell = "1.8.0"
-router-bridge = { git = "https://github.com/apollographql/federation.git", rev = "3de51e57d0206b18a54ee21fa7e89f59f40e7112" }
+router-bridge = { git = "https://github.com/apollographql/federation.git", rev = "e4fd4be09efb8b16e2fdd0789b06a5cdfaafbf6b" }
 serde = { version = "1.0.131", features = ["derive", "rc"] }
 serde_json = { version = "1.0.72", features = ["preserve_order"] }
 thiserror = "1.0.30"

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -22,7 +22,7 @@ include_dir = "0.7.2"
 lru = "0.7.0"
 miette = { version = "3.2.0", features = ["fancy"] }
 once_cell = "1.8.0"
-router-bridge = { git = "https://github.com/apollographql/federation.git", rev = "12f44165e50cbab562424d7ef249bb8fb4561397" }
+router-bridge = { git = "https://github.com/apollographql/federation.git", rev = "3de51e57d0206b18a54ee21fa7e89f59f40e7112" }
 serde = { version = "1.0.131", features = ["derive", "rc"] }
 serde_json = { version = "1.0.72", features = ["preserve_order"] }
 thiserror = "1.0.30"

--- a/apollo-router-core/src/error.rs
+++ b/apollo-router-core/src/error.rs
@@ -188,6 +188,9 @@ pub enum QueryPlannerError {
 
     /// Unhandled planner result.
     UnhandledPlannerResult,
+
+    /// Router Bridge error: {0}
+    RouterBridgeError(router_bridge::error::Error),
 }
 
 impl From<PlanningErrors> for QueryPlannerError {

--- a/apollo-router-core/src/naive_introspection.rs
+++ b/apollo-router-core/src/naive_introspection.rs
@@ -49,15 +49,15 @@ impl NaiveIntrospection {
         )
         .map_err(|deno_runtime_error| {
             tracing::warn!(
-                "router-bridge returned a deno runtime error: \n {}",
+                "router-bridge returned a deno runtime error:\n{}",
                 deno_runtime_error
             );
         })
-        .map(|global_introspection_result| {
+        .and_then(|global_introspection_result| {
             global_introspection_result
                 .map_err(|general_introspection_error| {
                     tracing::warn!(
-                        "introspection returned an error: \n {}",
+                        "Introspection returned an error:\n{}",
                         general_introspection_error
                     );
                 })
@@ -71,18 +71,14 @@ impl NaiveIntrospection {
                                 Some((cache_key.into(), response))
                             }
                             Err(graphql_errors) => {
-                                let errors = graphql_errors
-                                    .iter()
-                                    .map(std::string::ToString::to_string)
-                                    .collect::<Vec<_>>()
-                                    .join("\n");
-                                tracing::warn!("introspection returned errors: \n {}", errors);
+                                for error in graphql_errors {
+                                    tracing::warn!("Introspection returned error:\n{}", error);
+                                }
                                 None
                             }
                         })
                         .collect()
                 })
-                .unwrap_or_default()
         })
         .unwrap_or_default();
 

--- a/apollo-router-core/src/naive_introspection.rs
+++ b/apollo-router-core/src/naive_introspection.rs
@@ -47,26 +47,42 @@ impl NaiveIntrospection {
             schema.as_str(),
             KNOWN_INTROSPECTION_QUERIES.iter().cloned().collect(),
         )
-        .map(|responses| {
-            KNOWN_INTROSPECTION_QUERIES
-                .iter()
-                .zip(responses)
-                .filter_map(|(cache_key, response)| match response.into_result() {
-                    Ok(value) => {
-                        let response = Response::builder().data(value).build();
-                        Some((cache_key.into(), response))
-                    }
-                    Err(e) => {
-                        let errors = e
-                            .iter()
-                            .map(std::string::ToString::to_string)
-                            .collect::<Vec<_>>()
-                            .join("\n");
-                        tracing::warn!("introspection returned errors: \n {}", errors);
-                        None
-                    }
+        .map_err(|deno_runtime_error| {
+            tracing::warn!(
+                "router-bridge returned a deno runtime error: \n {}",
+                deno_runtime_error
+            );
+        })
+        .map(|global_introspection_result| {
+            global_introspection_result
+                .map_err(|general_introspection_error| {
+                    tracing::warn!(
+                        "introspection returned an error: \n {}",
+                        general_introspection_error
+                    );
                 })
-                .collect()
+                .map(|responses| {
+                    KNOWN_INTROSPECTION_QUERIES
+                        .iter()
+                        .zip(responses)
+                        .filter_map(|(cache_key, response)| match response.into_result() {
+                            Ok(value) => {
+                                let response = Response::builder().data(value).build();
+                                Some((cache_key.into(), response))
+                            }
+                            Err(graphql_errors) => {
+                                let errors = graphql_errors
+                                    .iter()
+                                    .map(std::string::ToString::to_string)
+                                    .collect::<Vec<_>>()
+                                    .join("\n");
+                                tracing::warn!("introspection returned errors: \n {}", errors);
+                                None
+                            }
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
         })
         .unwrap_or_default();
 

--- a/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
+++ b/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
@@ -63,8 +63,6 @@ impl From<QueryPlanOptions> for plan::QueryPlanOptions {
 #[serde(tag = "kind")]
 enum PlannerResult {
     QueryPlan {
-        // Do not make it a raw PlanNode,
-        // introspection queries return an empty query plan.
         /// The hierarchical nodes that make up the query plan
         node: Option<PlanNode>,
     },
@@ -98,7 +96,8 @@ mod tests {
     fn empty_query_plan() {
         let expected = PlannerResult::QueryPlan { node: None };
         let actual: PlannerResult = serde_json::from_value(json!({ "kind": "QueryPlan"})).expect(
-            "If this test fails, It probably means QueryPlan::node isn't an Option anymore.",
+            "If this test fails, It probably means QueryPlan::node isn't an Option anymore.\n
+                 Introspection queries return an empty QueryPlan, so the node field needs to remain optional.",
         );
 
         assert_eq!(expected, actual);

--- a/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
+++ b/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
@@ -64,7 +64,7 @@ impl From<QueryPlanOptions> for plan::QueryPlanOptions {
 enum PlannerResult {
     QueryPlan {
         /// The hierarchical nodes that make up the query plan
-        node: PlanNode,
+        node: Option<PlanNode>,
     },
     #[serde(other)]
     Other,

--- a/apollo-router-core/src/query_planner/snapshots/apollo_router_core__query_planner__router_bridge_query_planner__tests__empty_query_plan_should_be_a_planner_error.snap
+++ b/apollo-router-core/src/query_planner/snapshots/apollo_router_core__query_planner__router_bridge_query_planner__tests__empty_query_plan_should_be_a_planner_error.snap
@@ -1,0 +1,9 @@
+---
+source: apollo-router-core/src/query_planner/router_bridge_query_planner.rs
+assertion_line: 109
+expression: "RouterBridgeQueryPlanner::new(Arc::new(include_str!(\"testdata/schema.graphql\").parse().unwrap())).get(include_str!(\"testdata/unknown_introspection_query.graphql\").into(),\n                                                                                                      None,\n                                                                                                      Default::default()).await"
+
+---
+Err(
+    EmptyPlan,
+)

--- a/apollo-router-core/src/query_planner/snapshots/apollo_router_core__query_planner__router_bridge_query_planner__tests__plan.snap
+++ b/apollo-router-core/src/query_planner/snapshots/apollo_router_core__query_planner__router_bridge_query_planner__tests__plan.snap
@@ -4,12 +4,14 @@ expression: result
 
 ---
 QueryPlan {
-    root: Fetch(
-        FetchNode {
-            service_name: "accounts",
-            requires: [],
-            variable_usages: [],
-            operation: "{me{name{first last}}}",
-        },
+    root: Some(
+        Fetch(
+            FetchNode {
+                service_name: "accounts",
+                requires: [],
+                variable_usages: [],
+                operation: "{me{name{first last}}}",
+            },
+        ),
     ),
 }

--- a/apollo-router-core/well_known_introspection_queries/graphql_js_introspection_query.graphql
+++ b/apollo-router-core/well_known_introspection_queries/graphql_js_introspection_query.graphql
@@ -1,0 +1,89 @@
+
+query IntrospectionQuery {
+    __schema {
+    queryType { name }
+    mutationType { name }
+    subscriptionType { name }
+    types {
+        ...FullType
+    }
+    directives {
+        name
+        ${descriptions ? 'description' : ''}
+        locations
+        args {
+        ...InputValue
+        }
+    }
+    }
+}
+fragment FullType on __Type {
+    kind
+    name
+    ${descriptions ? 'description' : ''}
+    fields(includeDeprecated: true) {
+    name
+    ${descriptions ? 'description' : ''}
+    args {
+        ...InputValue
+    }
+    type {
+        ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+    }
+    inputFields {
+    ...InputValue
+    }
+    interfaces {
+    ...TypeRef
+    }
+    enumValues(includeDeprecated: true) {
+    name
+    ${descriptions ? 'description' : ''}
+    isDeprecated
+    deprecationReason
+    }
+    possibleTypes {
+    ...TypeRef
+    }
+}
+fragment InputValue on __InputValue {
+    name
+    ${descriptions ? 'description' : ''}
+    type { ...TypeRef }
+    defaultValue
+}
+fragment TypeRef on __Type {
+    kind
+    name
+    ofType {
+    kind
+    name
+    ofType {
+        kind
+        name
+        ofType {
+        kind
+        name
+        ofType {
+            kind
+            name
+            ofType {
+            kind
+            name
+            ofType {
+                kind
+                name
+                ofType {
+                kind
+                name
+                }
+            }
+            }
+        }
+        }
+    }
+    }
+}

--- a/apollo-router-core/well_known_introspection_queries/npx_diagnose_endpoint1.graphql
+++ b/apollo-router-core/well_known_introspection_queries/npx_diagnose_endpoint1.graphql
@@ -1,0 +1,1 @@
+query Ping { __typename }

--- a/apollo-router-core/well_known_introspection_queries/npx_diagnose_endpoint2.graphql
+++ b/apollo-router-core/well_known_introspection_queries/npx_diagnose_endpoint2.graphql
@@ -5,3 +5,4 @@ query MiniIntrospectionQuery {
             subscriptionType { name }
           }
         }
+      

--- a/apollo-router-core/well_known_introspection_queries/npx_diagnose_endpoint2.graphql
+++ b/apollo-router-core/well_known_introspection_queries/npx_diagnose_endpoint2.graphql
@@ -1,0 +1,7 @@
+query MiniIntrospectionQuery {
+          __schema {
+            queryType { name }
+            mutationType { name }
+            subscriptionType { name }
+          }
+        }


### PR DESCRIPTION
Fixes https://github.com/apollographql/federation/issues/1320

Fix: router-bridge: Do not panic when serializing or deserializing to interact with deno-core
    
The router bridge used to panic under certain circumstances, one of them being when deserialization fails.
    
Gary has unfortunately found that the hard way, when querying an (unknown) introspection query against the router.
    
It turns out introspection queries return an empty query plan, because there is effectively not much to query downstream. We however thought the root node of a query plan was mandatory, which ended up in a panic on the plan() call.
    
This PR follows up on the federation counterpart: https://github.com/apollographql/federation/pull/1321
    
Federation PR TLDR: We now have one more layer of Result, indicating whether an uncaught deno runtime error occured (like a deserialization error for example)
    
There's a couple of things going on:
    - Update the router bridge dependency and rework the result types
    - Make `PlannerResult::QueryPlan { node }` an `Option<PlanNode>`
    - Handle the empty node in `QueryPlanner::get` so it now returns `QueryPlannerError::EmptyPlan` with a relevant error message.
    - Add regression tests that ensure this behavior is kept in the future.
    - Identify the queries Gary ran (it was using npx diagnose-endpoint) and add the query strings to the well_known_queries NaiveIntrospection relies on, so they hit the cache.
