### PR TITLE
Simplify fetcher

### DIFF
--- a/apollo-router-core/src/traits.rs
+++ b/apollo-router-core/src/traits.rs
@@ -1,8 +1,7 @@
 use crate::prelude::graphql::*;
 use async_trait::async_trait;
-use futures::prelude::*;
+use std::fmt::Debug;
 use std::sync::Arc;
-use std::{fmt::Debug, pin::Pin};
 
 /// A cache resolution trait.
 ///
@@ -32,10 +31,11 @@ pub trait ServiceRegistry: Send + Sync + Debug {
 ///
 /// The goal of this trait is to hide the implementation details of fetching a stream of graphql responses.
 /// We can then create multiple implementations that can be plugged into federation.
+#[async_trait]
 pub trait Fetcher: Send + Sync + Debug {
     /// Constructs a stream of responses.
     #[must_use = "streams do nothing unless polled"]
-    fn stream(&self, request: Request) -> Pin<Box<dyn Future<Output = ResponseStream> + Send>>;
+    async fn stream(&self, request: Request) -> ResponseStream;
 }
 
 /// QueryPlanner can be used to plan queries.

--- a/apollo-router/src/http_subgraph.rs
+++ b/apollo-router/src/http_subgraph.rs
@@ -1,4 +1,5 @@
 use apollo_router_core::prelude::*;
+use async_trait::async_trait;
 use bytes::BytesMut;
 use derivative::Derivative;
 use futures::prelude::*;
@@ -104,15 +105,13 @@ impl HttpSubgraphFetcher {
     }
 }
 
+#[async_trait]
 impl graphql::Fetcher for HttpSubgraphFetcher {
     /// Using reqwest fetch a stream of graphql results.
-    fn stream(
-        &self,
-        request: graphql::Request,
-    ) -> Pin<Box<dyn Future<Output = graphql::ResponseStream> + Send>> {
+    async fn stream(&self, request: graphql::Request) -> graphql::ResponseStream {
         let service_name = self.service.to_string();
         let bytes_stream = self.request_stream(request);
-        Box::pin(async { Self::map_to_graphql(service_name, bytes_stream) })
+        Self::map_to_graphql(service_name, bytes_stream)
     }
 }
 

--- a/apollo-router/src/http_subgraph.rs
+++ b/apollo-router/src/http_subgraph.rs
@@ -1,14 +1,8 @@
 use apollo_router_core::prelude::*;
 use async_trait::async_trait;
-use bytes::BytesMut;
 use derivative::Derivative;
 use futures::prelude::*;
-use std::pin::Pin;
 use tracing::Instrument;
-
-type BytesStream = Pin<
-    Box<dyn futures::Stream<Item = Result<bytes::Bytes, graphql::FetchError>> + std::marker::Send>,
->;
 
 /// A fetcher for subgraph data that uses http.
 /// Streaming via chunking is supported.

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -395,7 +395,6 @@ mod tests {
     use futures::channel::oneshot;
     use mockall::{mock, predicate::*};
     use std::net::SocketAddr;
-    use std::pin::Pin;
     use std::str::FromStr;
     use std::sync::Mutex;
     use test_log::test;
@@ -797,8 +796,9 @@ mod tests {
         #[derive(Debug)]
         MyFetcher {}
 
+        #[async_trait::async_trait]
         impl graphql::Fetcher for MyFetcher {
-            fn stream(&self, request: graphql::Request) -> Pin<Box<dyn Future<Output = graphql::ResponseStream> + Send>>;
+            async fn stream(&self, request: graphql::Request) -> graphql::ResponseStream;
         }
     }
 

--- a/apollo-router/src/warp_http_server_factory.rs
+++ b/apollo-router/src/warp_http_server_factory.rs
@@ -409,8 +409,9 @@ mod tests {
         #[derive(Debug)]
         MyFetcher {}
 
+        #[async_trait::async_trait]
         impl graphql::Fetcher for MyFetcher {
-            fn stream(&self, request: graphql::Request) -> Pin<Box<dyn Future<Output = graphql::ResponseStream> + Send>>;
+            async fn stream(&self, request: graphql::Request) -> graphql::ResponseStream;
         }
     }
 


### PR DESCRIPTION
the subgraph fetcher is going through unneeded steps to generate a `Bytes` of the response, we can avoid most of them.
This PR adds `async_trait` on the  `Fetcher` trait, this simplifies the code further.

Now this assumes that only one response will come from the subgraph, so that will need to be changed when we implement defer and stream, but since those will use multipart to separate the responses, the previous code was not complete either