### PR TITLE
add the missing skip_all on instrument attributes

### DIFF
--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -45,10 +45,10 @@ pub(crate) enum PlanNode {
 
 impl QueryPlan {
     /// Validate the entire request for variables and services used.
-    #[tracing::instrument(name = "validation", level = "debug")]
+    #[tracing::instrument(name = "validation", level = "debug", skip_all)]
     pub fn validate_request(
         &self,
-        request: &Request,
+        _request: &Request,
         service_registry: Arc<dyn ServiceRegistry>,
     ) -> Result<(), Response> {
         let mut early_errors = Vec::new();

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -48,7 +48,6 @@ impl QueryPlan {
     #[tracing::instrument(name = "validation", level = "debug", skip_all)]
     pub fn validate_request(
         &self,
-        _request: &Request,
         service_registry: Arc<dyn ServiceRegistry>,
     ) -> Result<(), Response> {
         let mut early_errors = Vec::new();

--- a/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
+++ b/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
@@ -23,7 +23,7 @@ impl RouterBridgeQueryPlanner {
 
 #[async_trait]
 impl QueryPlanner for RouterBridgeQueryPlanner {
-    #[tracing::instrument(name = "plan", level = "debug")]
+    #[tracing::instrument(name = "plan", level = "debug", skip_all)]
     async fn get(
         &self,
         query: String,

--- a/apollo-router/src/apollo_router.rs
+++ b/apollo-router/src/apollo_router.rs
@@ -103,7 +103,7 @@ impl Router<ApolloPreparedQuery> for ApolloRouter {
             .await?;
 
         tracing::debug!("query plan\n{:#?}", query_plan);
-        query_plan.validate_request(request, Arc::clone(&self.service_registry))?;
+        query_plan.validate_request(Arc::clone(&self.service_registry))?;
 
         Ok(ApolloPreparedQuery {
             query_plan,

--- a/apollo-router/src/apollo_router.rs
+++ b/apollo-router/src/apollo_router.rs
@@ -74,7 +74,7 @@ impl ApolloRouter {
 
 #[async_trait::async_trait]
 impl Router<ApolloPreparedQuery> for ApolloRouter {
-    #[tracing::instrument(level = "debug")]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn prepare_query(
         &self,
         request: &Request,
@@ -125,7 +125,7 @@ pub struct ApolloPreparedQuery {
 
 #[async_trait::async_trait]
 impl PreparedQuery for ApolloPreparedQuery {
-    #[tracing::instrument(level = "debug")]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn execute(self, request: Arc<Request>) -> ResponseStream {
         let mut response = self
             .query_plan

--- a/licenses.html
+++ b/licenses.html
@@ -4210,6 +4210,7 @@ limitations under the License.
                     <li><a href=" https://github.com/bluss/indexmap ">indexmap</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools</a></li>
                     <li><a href=" https://github.com/dtolnay/itoa ">itoa</a></li>
+                    <li><a href=" https://github.com/dtolnay/itoa ">itoa</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys ">js-sys</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static</a></li>
                     <li><a href=" https://github.com/indiv0/lazycell ">lazycell</a></li>


### PR DESCRIPTION
the [telemetry ADR](https://github.com/apollographql/router/blob/main/adr/telemetry.md) specifies that we set skip_all on `#[tracing::instrument]` to avoid serializing arguments on every call