### PR TITLE
parse the routing_url configuration option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber",
  "typed-builder",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,6 @@ dependencies = [
  "tracing-futures",
  "tracing-subscriber",
  "typed-builder",
- "url",
 ]
 
 [[package]]

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -30,7 +30,6 @@ tokio = { version = "1.14.0", features = ["rt"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
 typed-builder = "0.9.1"
-url = "2.2.2"
 
 [dev-dependencies]
 insta = "1.8.0"

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1.14.0", features = ["rt"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
 typed-builder = "0.9.1"
+url = "2.2.2"
 
 [dev-dependencies]
 insta = "1.8.0"

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -37,10 +37,7 @@ pub enum ConfigurationError {
     /// Could not find an URL for subgraph {0}
     MissingSubgraphUrl(String),
     /// Invalid URL for subgraph {subgraph}: {url}
-    InvalidSubgraphUrl {
-        subgraph: String,
-        url: String,
-    },
+    InvalidSubgraphUrl { subgraph: String, url: String },
 }
 
 /// The configuration for the router.
@@ -509,5 +506,13 @@ mod tests {
             }
             Ok(()) => panic!("expected missing subgraph URL for 'reviews'"),
         }
+    }
+
+    #[test]
+    fn invalid_subgraph_url() {
+        let err = serde_yaml::from_str::<Configuration>(include_str!("testdata/invalid_url.yaml"))
+            .unwrap_err();
+
+        assert_eq!(err.to_string(), "subgraphs.accounts.routing_url: invalid value: string \"abcd\", expected relative URL without a base at line 5 column 18");
     }
 }

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -36,8 +36,11 @@ pub enum ConfigurationError {
     MissingFeature(&'static str),
     /// Could not find an URL for subgraph {0}
     MissingSubgraphUrl(String),
-    /// Could not parse the URL for subgraph {0}
-    InvalidSubgraphUrl(String, String),
+    /// Invalid URL for subgraph {subgraph}: {url}
+    InvalidSubgraphUrl {
+        subgraph: String,
+        url: String,
+    },
 }
 
 /// The configuration for the router.
@@ -86,10 +89,10 @@ impl Configuration {
                     }
                     match Url::parse(schema_url) {
                         Err(_e) => {
-                            errors.push(ConfigurationError::InvalidSubgraphUrl(
-                                name.to_owned(),
-                                schema_url.to_owned(),
-                            ));
+                            errors.push(ConfigurationError::InvalidSubgraphUrl {
+                                subgraph: name.to_owned(),
+                                url: schema_url.to_owned(),
+                            });
                         }
                         Ok(routing_url) => {
                             self.subgraphs
@@ -426,13 +429,13 @@ mod tests {
                     (
                         "inventory".to_string(),
                         Subgraph {
-                            routing_url: Url::parse("http://inventory/graphql").expect("test"),
+                            routing_url: Url::parse("http://inventory/graphql").unwrap(),
                         },
                     ),
                     (
                         "products".to_string(),
                         Subgraph {
-                            routing_url: Url::parse("http://products/graphql").expect("test"),
+                            routing_url: Url::parse("http://products/graphql").unwrap(),
                         },
                     ),
                 ]

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-2.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-2.snap
@@ -20,6 +20,6 @@ server:
       - bar
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: "http://foo/"
 opentelemetry: ~
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-3.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-3.snap
@@ -8,7 +8,7 @@ server:
   cors: ~
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: "http://foo/"
 opentelemetry:
   jaeger: ~
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-4.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-4.snap
@@ -8,7 +8,7 @@ server:
   cors: ~
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: "http://foo/"
 opentelemetry:
   jaeger:
     collector_endpoint: "http://example.org/"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change.snap
@@ -8,6 +8,6 @@ server:
   cors: ~
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: "http://foo/"
 opentelemetry: ~
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_grpc-2.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_grpc-2.snap
@@ -8,7 +8,7 @@ server:
   cors: ~
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: "http://foo/"
 opentelemetry:
   otlp:
     tracing:

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_grpc.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_grpc.snap
@@ -8,7 +8,7 @@ server:
   cors: ~
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: "http://foo/"
 opentelemetry:
   otlp:
     tracing:

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_http-2.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_http-2.snap
@@ -8,7 +8,7 @@ server:
   cors: ~
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: "http://foo/"
 opentelemetry:
   otlp:
     tracing:

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_http.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_http.snap
@@ -8,7 +8,7 @@ server:
   cors: ~
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: "http://foo/"
 opentelemetry:
   otlp:
     tracing:

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_tls_config.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_tls_config.snap
@@ -8,7 +8,7 @@ server:
   cors: ~
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: "http://foo/"
 opentelemetry:
   otlp:
     tracing:

--- a/apollo-router/src/configuration/testdata/config_basic.yml
+++ b/apollo-router/src/configuration/testdata/config_basic.yml
@@ -2,4 +2,4 @@ server:
   listen: 1.2.3.4:5
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: http://foo

--- a/apollo-router/src/configuration/testdata/config_full.yml
+++ b/apollo-router/src/configuration/testdata/config_full.yml
@@ -5,4 +5,4 @@ server:
     methods: [foo, bar]
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: http://foo

--- a/apollo-router/src/configuration/testdata/config_opentelemetry_jaeger_basic.yml
+++ b/apollo-router/src/configuration/testdata/config_opentelemetry_jaeger_basic.yml
@@ -2,6 +2,6 @@ server:
   listen: 1.2.3.4:5
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: http://foo
 opentelemetry:
   jaeger:

--- a/apollo-router/src/configuration/testdata/config_opentelemetry_jaeger_full.yml
+++ b/apollo-router/src/configuration/testdata/config_opentelemetry_jaeger_full.yml
@@ -2,7 +2,7 @@ server:
   listen: 1.2.3.4:5
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: http://foo
 opentelemetry:
   jaeger:
     collector_endpoint: http://example.org

--- a/apollo-router/src/configuration/testdata/config_opentelemetry_otlp_tracing_grpc_basic.yml
+++ b/apollo-router/src/configuration/testdata/config_opentelemetry_otlp_tracing_grpc_basic.yml
@@ -2,7 +2,7 @@ server:
   listen: 1.2.3.4:5
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: http://foo
 opentelemetry:
   otlp:
     tracing:

--- a/apollo-router/src/configuration/testdata/config_opentelemetry_otlp_tracing_grpc_common.yml
+++ b/apollo-router/src/configuration/testdata/config_opentelemetry_otlp_tracing_grpc_common.yml
@@ -2,7 +2,7 @@ server:
   listen: 1.2.3.4:5
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: http://foo
 opentelemetry:
   otlp:
     tracing:

--- a/apollo-router/src/configuration/testdata/config_opentelemetry_otlp_tracing_grpc_full.yml
+++ b/apollo-router/src/configuration/testdata/config_opentelemetry_otlp_tracing_grpc_full.yml
@@ -2,7 +2,7 @@ server:
   listen: 1.2.3.4:5
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: http://foo
 opentelemetry:
   otlp:
     tracing:

--- a/apollo-router/src/configuration/testdata/config_opentelemetry_otlp_tracing_grpc_tls.yml
+++ b/apollo-router/src/configuration/testdata/config_opentelemetry_otlp_tracing_grpc_tls.yml
@@ -2,7 +2,7 @@ server:
   listen: 1.2.3.4:5
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: http://foo
 opentelemetry:
   otlp:
     tracing:

--- a/apollo-router/src/configuration/testdata/config_opentelemetry_otlp_tracing_http_basic.yml
+++ b/apollo-router/src/configuration/testdata/config_opentelemetry_otlp_tracing_http_basic.yml
@@ -2,7 +2,7 @@ server:
   listen: 1.2.3.4:5
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: http://foo
 opentelemetry:
   otlp:
     tracing:

--- a/apollo-router/src/configuration/testdata/config_opentelemetry_otlp_tracing_http_common.yml
+++ b/apollo-router/src/configuration/testdata/config_opentelemetry_otlp_tracing_http_common.yml
@@ -2,7 +2,7 @@ server:
   listen: 1.2.3.4:5
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: http://foo
 opentelemetry:
   otlp:
     tracing:

--- a/apollo-router/src/configuration/testdata/config_opentelemetry_otlp_tracing_http_full.yml
+++ b/apollo-router/src/configuration/testdata/config_opentelemetry_otlp_tracing_http_full.yml
@@ -2,7 +2,7 @@ server:
   listen: 1.2.3.4:5
 subgraphs:
   example:
-    routing_url: foo
+    routing_url: http://foo
 opentelemetry:
   otlp:
     tracing:

--- a/apollo-router/src/configuration/testdata/invalid_url.yaml
+++ b/apollo-router/src/configuration/testdata/invalid_url.yaml
@@ -1,0 +1,5 @@
+server:
+  listen: 127.0.0.1:0
+subgraphs:
+  accounts:
+    routing_url: abcd

--- a/apollo-router/src/http_subgraph.rs
+++ b/apollo-router/src/http_subgraph.rs
@@ -184,7 +184,7 @@ mod tests {
         });
         let fetcher = HttpSubgraphFetcher::new(
             "products".into(),
-            Url::parse(&server.url("/graphql")).expect("test"),
+            Url::parse(&server.url("/graphql")).unwrap(),
         );
         let collect = fetcher
             .stream(

--- a/apollo-router/src/http_subgraph.rs
+++ b/apollo-router/src/http_subgraph.rs
@@ -23,7 +23,9 @@ pub struct HttpSubgraphFetcher {
 
 impl HttpSubgraphFetcher {
     /// Construct a new http subgraph fetcher that will fetch from the supplied URL.
-    pub fn new(service: String, url: Url) -> Self {
+    pub fn new(service: impl Into<String>, url: Url) -> Self {
+        let service = service.into();
+
         HttpSubgraphFetcher {
             http_client: reqwest_middleware::ClientBuilder::new(
                 reqwest::Client::builder()
@@ -182,10 +184,8 @@ mod tests {
                 .header("Content-Type", "application/json")
                 .json_body_obj(&response);
         });
-        let fetcher = HttpSubgraphFetcher::new(
-            "products".into(),
-            Url::parse(&server.url("/graphql")).unwrap(),
-        );
+        let fetcher =
+            HttpSubgraphFetcher::new("products", Url::parse(&server.url("/graphql")).unwrap());
         let collect = fetcher
             .stream(
                 graphql::Request::builder()

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -558,8 +558,8 @@ mod tests {
 
     async fn query(socket: &SocketAddr, request: graphql::Request) -> graphql::ResponseStream {
         HttpSubgraphFetcher::new(
-            "federated".into(),
-            Url::parse(&format!("http://{}/graphql", socket)).expect("test"),
+            "federated",
+            Url::parse(&format!("http://{}/graphql", socket)).unwrap(),
         )
         .stream(request)
         .await

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -525,6 +525,7 @@ mod tests {
     use serde_json::to_string_pretty;
     use std::env::temp_dir;
     use test_log::test;
+    use url::Url;
 
     fn init_with_server() -> FederatedServerHandle {
         let configuration =
@@ -556,9 +557,12 @@ mod tests {
     }
 
     async fn query(socket: &SocketAddr, request: graphql::Request) -> graphql::ResponseStream {
-        HttpSubgraphFetcher::new("federated".into(), format!("http://{}/graphql", socket))
-            .stream(request)
-            .await
+        HttpSubgraphFetcher::new(
+            "federated".into(),
+            Url::parse(&format!("http://{}/graphql", socket)).expect("test"),
+        )
+        .stream(request)
+        .await
     }
 
     #[test(tokio::test)]

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -590,13 +590,13 @@ mod tests {
                                     (
                                         "accounts".to_string(),
                                         Subgraph {
-                                            routing_url: Url::parse("http://accounts/graphql").expect("test"),
+                                            routing_url: Url::parse("http://accounts/graphql").unwrap(),
                                         }
                                     ),
                                     (
                                         "products".to_string(),
                                         Subgraph {
-                                            routing_url: Url::parse("http://accounts/graphql").expect("test")
+                                            routing_url: Url::parse("http://accounts/graphql").unwrap()
                                         }
                                     )
                                 ]
@@ -680,7 +680,7 @@ mod tests {
                                     (
                                         "accounts".to_string(),
                                         Subgraph {
-                                            routing_url: Url::parse("http://accounts/graphql").expect("test")
+                                            routing_url: Url::parse("http://accounts/graphql").unwrap()
                                         }
                                     ),
                                 ]

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -400,6 +400,7 @@ mod tests {
     use std::sync::Mutex;
     use test_log::test;
     use tokio::net::TcpListener;
+    use url::Url;
 
     #[test(tokio::test)]
     async fn no_configuration() {
@@ -589,13 +590,13 @@ mod tests {
                                     (
                                         "accounts".to_string(),
                                         Subgraph {
-                                            routing_url: "http://accounts/graphql".to_string()
+                                            routing_url: Url::parse("http://accounts/graphql").expect("test"),
                                         }
                                     ),
                                     (
                                         "products".to_string(),
                                         Subgraph {
-                                            routing_url: "http://accounts/graphql".to_string()
+                                            routing_url: Url::parse("http://accounts/graphql").expect("test")
                                         }
                                     )
                                 ]
@@ -641,7 +642,12 @@ mod tests {
         router_factory
             .expect_create()
             .withf(|configuration, _schema, _previous_router| {
-                configuration.subgraphs.get("accounts").unwrap().routing_url
+                configuration
+                    .subgraphs
+                    .get("accounts")
+                    .unwrap()
+                    .routing_url
+                    .as_str()
                     == "http://accounts/graphql"
             })
             .times(1)
@@ -650,7 +656,12 @@ mod tests {
         router_factory
             .expect_create()
             .withf(|configuration, _schema, _previous_router| {
-                configuration.subgraphs.get("accounts").unwrap().routing_url
+                configuration
+                    .subgraphs
+                    .get("accounts")
+                    .unwrap()
+                    .routing_url
+                    .as_str()
                     == "http://localhost:4001/graphql"
             })
             .times(1)
@@ -669,7 +680,7 @@ mod tests {
                                     (
                                         "accounts".to_string(),
                                         Subgraph {
-                                            routing_url: "http://accounts/graphql".to_string()
+                                            routing_url: Url::parse("http://accounts/graphql").expect("test")
                                         }
                                     ),
                                 ]
@@ -716,7 +727,12 @@ mod tests {
         router_factory
             .expect_create()
             .withf(|configuration, _schema, _previous_router| {
-                configuration.subgraphs.get("accounts").unwrap().routing_url
+                configuration
+                    .subgraphs
+                    .get("accounts")
+                    .unwrap()
+                    .routing_url
+                    .as_str()
                     == "http://accounts/graphql"
             })
             .times(1)
@@ -726,7 +742,12 @@ mod tests {
             .expect_create()
             .withf(|configuration, _schema, _previous_router| {
                 println!("got configuration: {:#?}", configuration);
-                configuration.subgraphs.get("accounts").unwrap().routing_url
+                configuration
+                    .subgraphs
+                    .get("accounts")
+                    .unwrap()
+                    .routing_url
+                    .as_str()
                     == "http://localhost:4001/graphql"
             })
             .times(1)

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -157,8 +157,8 @@ async fn missing_variables() {
 
 async fn query_node(request: graphql::Request) -> graphql::ResponseStream {
     let nodejs_impl = HttpSubgraphFetcher::new(
-        "federated".into(),
-        Url::parse("http://localhost:4100/graphql").expect("test"),
+        "federated",
+        Url::parse("http://localhost:4100/graphql").unwrap(),
     );
     nodejs_impl.stream(request).await
 }

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -11,6 +11,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use test_log::test;
+use url::Url;
 
 macro_rules! assert_federated_response {
     ($query:expr, $service_requests:expr $(,)?) => {
@@ -155,8 +156,10 @@ async fn missing_variables() {
 }
 
 async fn query_node(request: graphql::Request) -> graphql::ResponseStream {
-    let nodejs_impl =
-        HttpSubgraphFetcher::new("federated".into(), "http://localhost:4100/graphql".into());
+    let nodejs_impl = HttpSubgraphFetcher::new(
+        "federated".into(),
+        Url::parse("http://localhost:4100/graphql").expect("test"),
+    );
     nodejs_impl.stream(request).await
 }
 


### PR DESCRIPTION
the URL was carried as a string from the configuration file or the
schema, up to the subgraph fetcher, without any validation.
This will fail the schema or configuration file parsing if the subgraph
URL is invalid