### PR TITLE
update lru

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c748cfe47cb8da225c37595b3108bea1c198c84aaae8ea0ba76d01dda9fc803"
+checksum = "469898e909a1774d844793b347135a0cd344ca2f69d082013ecb8061a2229a3a"
 dependencies = [
  "hashbrown 0.11.2",
 ]

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -19,7 +19,7 @@ derivative = "2.2.0"
 displaydoc = "0.2"
 futures = "0.3.18"
 include_dir = "0.7.2"
-lru = "0.7.0"
+lru = "0.7.1"
 miette = { version = "3.2.0", features = ["fancy"] }
 once_cell = "1.8.0"
 router-bridge = { git = "https://github.com/apollographql/federation.git", rev = "e88ce2a8be6a9159370c972b462ef61d598c2f33" }


### PR DESCRIPTION
LRU < 0.7.1 has a use after free bug

https://github.com/jeromefroe/lru-rs/issues/120
https://rustsec.org/advisories/RUSTSEC-2021-0130