### PR TITLE
add more spans for internal steps

### DIFF
--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -250,6 +250,7 @@ mod fetch {
     }
 
     impl Variables {
+        #[instrument(level = "debug", name = "make_variables", skip_all)]
         fn new(
             requires: &[Selection],
             variable_usages: &[String],
@@ -324,17 +325,14 @@ mod fetch {
 
             let query_span = tracing::info_span!("subfetch", service = service_name.as_str());
 
-            let Variables { variables, paths } =
-                tracing::debug_span!("make_variables").in_scope(|| {
-                    Variables::new(
-                        &self.requires,
-                        self.variable_usages.as_ref(),
-                        data,
-                        current_dir,
-                        request,
-                        schema,
-                    )
-                })?;
+            let Variables { variables, paths } = Variables::new(
+                &self.requires,
+                self.variable_usages.as_ref(),
+                data,
+                current_dir,
+                request,
+                schema,
+            )?;
 
             let fetcher = service_registry
                 .get(service_name)

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -324,14 +324,17 @@ mod fetch {
 
             let query_span = tracing::info_span!("subfetch", service = service_name.as_str());
 
-            let Variables { variables, paths } = Variables::new(
-                &self.requires,
-                self.variable_usages.as_ref(),
-                data,
-                current_dir,
-                request,
-                schema,
-            )?;
+            let Variables { variables, paths } =
+                tracing::debug_span!("make_variables").in_scope(|| {
+                    Variables::new(
+                        &self.requires,
+                        self.variable_usages.as_ref(),
+                        data,
+                        current_dir,
+                        request,
+                        schema,
+                    )
+                })?;
 
             let fetcher = service_registry
                 .get(service_name)
@@ -366,7 +369,7 @@ mod fetch {
             self.response_at_path(current_dir, paths, subgraph_response)
         }
 
-        #[instrument(level = "trace", name = "response_insert", skip_all)]
+        #[instrument(level = "debug", name = "response_insert", skip_all)]
         fn response_at_path<'a>(
             &'a self,
             current_dir: &'a Path,

--- a/apollo-router/src/warp_http_server_factory.rs
+++ b/apollo-router/src/warp_http_server_factory.rs
@@ -302,22 +302,25 @@ where
         Err(stream) => stream,
     };
 
-    stream
-        .enumerate()
-        .map(|(index, res)| match serde_json::to_string(&res) {
-            Ok(bytes) => Ok(Bytes::from(bytes)),
-            Err(err) => {
-                // We didn't manage to serialise the response!
-                // Do our best to send some sort of error back.
-                serde_json::to_string(
-                    &graphql::FetchError::MalformedResponse {
-                        reason: err.to_string(),
-                    }
-                    .to_response(index == 0),
-                )
-                .map(Bytes::from)
+    let span = Span::current();
+    stream.enumerate().map(move |(index, res)| {
+        tracing::debug_span!(parent: &span, "serialize_response").in_scope(|| {
+            match serde_json::to_string(&res) {
+                Ok(bytes) => Ok(Bytes::from(bytes)),
+                Err(err) => {
+                    // We didn't manage to serialise the response!
+                    // Do our best to send some sort of error back.
+                    serde_json::to_string(
+                        &graphql::FetchError::MalformedResponse {
+                            reason: err.to_string(),
+                        }
+                        .to_response(index == 0),
+                    )
+                    .map(Bytes::from)
+                }
             }
         })
+    })
 }
 
 fn prefers_html(accept_header: String) -> bool {


### PR DESCRIPTION
this PR puts light on the expensive operations of the router, it provides some context on the performance related PRs I sent recently. As an example, for the perf test currently used in CI, there are 5 subgraph responses, and here is a typical run:

entire query: 11.1ms

http-subgraph-request: 9.3ms = 2.01ms + 1.79ms + 1.85ms + 1.77ms + 1.88ms
=> time spent waiting on the subgraphs: 9.3ms
=> time spent by the router: 1.8ms

query_parsing (cached): 23μs
make_variables: 124μs = 6μs + 30μs + 26μs + 28μs + 34μs
aggregate_response_data: 175μs = 109μs + 10μs + 9μs + 9μs + 38μs
parse_subgraph_response: 414μs = 209μs + 20μs + 17μs + 18μs + 150μs
response_at_path: 60μs = 4μs + 5μs + 12μs + 21μs + 18μs
format_response: 216μs
serialize_response: 63μs

I am trying to reduce the time spent on low level tasks like network and serialization, to get more time for higher level tasks like response formatting