### PR TITLE
integrate tower-http and its TraceLayer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-futures",
  "tracing-opentelemetry",
@@ -1435,6 +1437,12 @@ dependencies = [
  "http",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "httparse"
@@ -3566,6 +3574,25 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ee603d6e665ecc7e0f8d479eedb4626bd4726f0ee6119cee5b3a6bf184cac0"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -56,6 +56,8 @@ thiserror = "1.0.30"
 tokio = { version = "1.14.0", features = ["full"] }
 # don't bump it to 0.6 until opentelemetry-otlp does
 tonic = { version = "0.5.2", optional = true }
+tower = "0.4.11"
+tower-http = {version = "0.2.0", features = ["trace"] }
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
 tracing-opentelemetry = "0.16.0"

--- a/licenses.html
+++ b/licenses.html
@@ -44,7 +44,7 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#MIT">MIT License</a> (54)</li>
+            <li><a href="#MIT">MIT License</a> (55)</li>
             <li><a href="#Apache-2.0">Apache License 2.0</a> (36)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (5)</li>
             <li><a href="#ISC">ISC License</a> (5)</li>

--- a/licenses.html
+++ b/licenses.html
@@ -44,7 +44,7 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#MIT">MIT License</a> (52)</li>
+            <li><a href="#MIT">MIT License</a> (54)</li>
             <li><a href="#Apache-2.0">Apache License 2.0</a> (36)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (5)</li>
             <li><a href="#ISC">ISC License</a> (5)</li>
@@ -8158,6 +8158,39 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/tower-rs/tower-http ">tower-http</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2019-2021 Tower Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the &quot;Software&quot;), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio</a></li>
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream</a></li>
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util</a></li>
@@ -8369,6 +8402,35 @@ SOFTWARE.
                 <pre class="license-text">MIT License
 
 Copyright (c) 2019 brunoczim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/MarcusGrass/parse-range-headers ">http-range-header</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2021 MarcusGrass
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal

--- a/licenses.html
+++ b/licenses.html
@@ -4210,6 +4210,7 @@ limitations under the License.
                     <li><a href=" https://github.com/bluss/indexmap ">indexmap</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools</a></li>
                     <li><a href=" https://github.com/dtolnay/itoa ">itoa</a></li>
+                    <li><a href=" https://github.com/dtolnay/itoa ">itoa</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys ">js-sys</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static</a></li>
                     <li><a href=" https://github.com/indiv0/lazycell ">lazycell</a></li>


### PR DESCRIPTION
this adds a tower layer that creates a span covering the entire request,
from request line parsing to the end of sending the response.

This will give us better information than creating the span in the warp
service, where it covers from the moment the request is fully parsed, to
the moment the response is created (but the body is not sent yet)

Adding this dependency does not cost much since tower-service is already included by warp. And we will be able to use tower middlewares for other features like rate limiting.

~~**warning:** I have not tested yet if this messes with trace id propagation from client headers~~ good news: it does not affect trace id. bad news: trace propagation still needs some work :/