### PR TITLE
fix: graphql_js_introspection_query

### DIFF
--- a/apollo-router-core/src/naive_introspection.rs
+++ b/apollo-router-core/src/naive_introspection.rs
@@ -65,17 +65,17 @@ impl NaiveIntrospection {
                     KNOWN_INTROSPECTION_QUERIES
                         .iter()
                         .zip(responses)
-                        .filter_map(|(cache_key, response)| match response.into_result() {
+                        .filter_map(|(query, response)| match response.into_result() {
                             Ok(value) => {
                                 let response = Response::builder().data(value).build();
-                                Some((cache_key.into(), response))
+                                Some((query.into(), response))
                             }
                             Err(graphql_errors) => {
                                 for error in graphql_errors {
                                     tracing::warn!(
                                         "Introspection returned error:\n{}\n{}",
                                         error,
-                                        cache_key
+                                        query
                                     );
                                 }
                                 None

--- a/apollo-router-core/src/naive_introspection.rs
+++ b/apollo-router-core/src/naive_introspection.rs
@@ -72,7 +72,11 @@ impl NaiveIntrospection {
                             }
                             Err(graphql_errors) => {
                                 for error in graphql_errors {
-                                    tracing::warn!("Introspection returned error:\n{}", error);
+                                    tracing::warn!(
+                                        "Introspection returned error:\n{}\n{}",
+                                        error,
+                                        cache_key
+                                    );
                                 }
                                 None
                             }

--- a/apollo-router-core/well_known_introspection_queries/graphql_js_introspection_query_with_description.graphql
+++ b/apollo-router-core/well_known_introspection_queries/graphql_js_introspection_query_with_description.graphql
@@ -9,7 +9,7 @@ query IntrospectionQuery {
     }
     directives {
         name
-        
+        description
         locations
         args {
         ...InputValue
@@ -20,10 +20,10 @@ query IntrospectionQuery {
 fragment FullType on __Type {
     kind
     name
-    
+    description
     fields(includeDeprecated: true) {
     name
-    
+    description
     args {
         ...InputValue
     }
@@ -41,7 +41,7 @@ fragment FullType on __Type {
     }
     enumValues(includeDeprecated: true) {
     name
-    
+    description
     isDeprecated
     deprecationReason
     }
@@ -51,7 +51,7 @@ fragment FullType on __Type {
 }
 fragment InputValue on __InputValue {
     name
-    
+    description
     type { ...TypeRef }
     defaultValue
 }


### PR DESCRIPTION
I didn't notice before but the graphql_js_introspection_query was actually an interpolated string with a ternary.

This commit:
Adds the introspection query body to the raised warning so we can track them down better
Creates two variants of the graphql_js_introspection_query with descriptions and without