### PR TITLE
configs which contain jaeger config will hang the router when updated

### DIFF
--- a/apollo-router/src/trace.rs
+++ b/apollo-router/src/trace.rs
@@ -65,13 +65,16 @@ pub(crate) fn try_initialize_subscriber(
 
             // The call to set_tracer_provider() manipulate a sync RwLock.
             // Even though this code is sync, it is called from within an
-            // async context. If we don't do this in a separate thread,
-            // it will cause issues with the async runtime that prevents
-            // the router from working correctly.
-            let _ = std::thread::spawn(|| {
+            // async context. If we don't call set_tracer_provider() from
+            // spawn_blocking() (or from a separate thread), it will cause
+            // issues with the async runtime which results in a router
+            // which no longer responds to input events.
+            // See https://github.com/apollographql/router/issues/331
+            // for more details and description.
+            let jh = tokio::task::spawn_blocking(|| {
                 opentelemetry::global::set_tracer_provider(provider);
-            })
-            .join();
+            });
+            futures::executor::block_on(jh)?;
 
             let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
 


### PR DESCRIPTION
If a configuration is updated which contains jaeger configuration, then
at some point a synchronous call to:
  opentelemetry::global::set_tracer_provider()
will arise. Even though this call is made from a synchronous function,
the root context is asynchronous and it seems to cause the runtime to
mis-behave: i.e.: hang...

If we make the call from a newly spawned thread (no performance concerns
here because re-configuration is not hot code) then the problem goes
away.
fixes: #331 