### PR TITLE
 improvement: Igni/test span bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,9 +193,9 @@ dependencies = [
 
 [[package]]
 name = "assert_fs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633ff1df0788db09e2087fb93d05974e93acb886ac3aec4e67be1d6932e360e4"
+checksum = "cf09bb72e00da477c2596865e8873227e2196d263cca35414048875dbbeea1be"
 dependencies = [
  "doc-comment",
  "globwalk",
@@ -499,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.3.2"
+version = "3.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71cb90ade945043d3d53597b2fc359bb063db8ade2bcffe7997351d0756e9d50"
+checksum = "f838e47a451d5a8fa552371f80024dd6ace9b7acdf25c4c3d0f9bc6816fb1c39"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -532,9 +532,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
 
 [[package]]
 name = "byteorder"
@@ -556,9 +556,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "camino"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
+checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
 dependencies = [
  "serde",
 ]
@@ -694,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738c290dfaea84fc1ca15ad9c168d083b05a714e1efddd8edaab678dc28d2836"
+checksum = "a2209c310e29876f7f0b2721e7e26b84aff178aa3da5d091f9bfbf47669e60e3"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -762,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
+checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-utils",
@@ -775,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
@@ -832,9 +832,9 @@ dependencies = [
 
 [[package]]
 name = "curl"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc6d233563261f8db6ffb83bbaad5a73837a6e6b28868e926337ebbdece0be3"
+checksum = "7de97b894edd5b5bcceef8b78d7da9b75b1d2f2f9a910569d0bde3dd31d84939"
 dependencies = [
  "curl-sys",
  "libc",
@@ -847,9 +847,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.51+curl-7.80.0"
+version = "0.4.52+curl-7.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d130987e6a6a34fe0889e1083022fa48cd90e6709a84be3fb8dd95801de5af20"
+checksum = "14b8c2d1023ea5fded5b7b892e4b8e95f70038a421126a056761a84246a28971"
 dependencies = [
  "cc",
  "libc",
@@ -1044,15 +1044,15 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.1"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
 name = "fastrand"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779d043b6a0b90cc4c0ed7ee380a6504394cee7efd7db050e3774eee387324b2"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
  "instant",
 ]
@@ -1135,9 +1135,9 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a039c3498dc930fe810151a34ba0c1c70b02b8625035592e74432f678591f2"
+checksum = "8da1b8f89c5b5a5b7e59405cfcf0bb9588e5ed19f0b57a4cd542bbba3f164a6d"
 
 [[package]]
 name = "fsevent"
@@ -1301,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -1607,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
+checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1735,9 +1735,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "js-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc9ffccd38c451a86bf13657df244e9c3f37493cce8e5e21e940963777acc84"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1763,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.6"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15174f1c529af5bf1283c3bc0058266b483a67156f79589fab2a25e23cf8988"
+checksum = "852b75a095da6b69da8c5557731c3afd06525d4f655a4fc1c799e2ec8bc4dce4"
 dependencies = [
  "ascii-canvas",
  "atty",
@@ -1786,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.6"
+version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e58cce361efcc90ba8a0a5f982c741ff86b603495bb15a998412e957dcd278"
+checksum = "d6d265705249fe209280676d8f68887859fa42e1d34f342fc05bd47726a5e188"
 dependencies = [
  "regex",
 ]
@@ -1813,9 +1813,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -2197,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
@@ -2490,9 +2490,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95e5a7689e456ab905c22c2b48225bb921aba7c8dfa58440d68ba13f6222a715"
+checksum = "a5aab5be6e4732b473071984b3164dbbfb7a3674d30ea5ff44410b6bcd960c3c"
 dependencies = [
  "difflib",
  "float-cmp",
@@ -2504,15 +2504,15 @@ dependencies = [
 
 [[package]]
 name = "predicates-core"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e35a3326b75e49aa85f5dc6ec15b41108cf5aee58eabb1f274dd18b73c2451"
+checksum = "da1c2388b1513e1b605fcec39a95e0a9e8ef088f71443ef37099fa9ae6673fcb"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338c7be2905b732ae3984a2f40032b5e94fd8f52505b186c7d4d68d193445df7"
+checksum = "4d86de6de25020a36c6d3643a86d9a6a9f552107c0559c60ea03551b5e16c032"
 dependencies = [
  "predicates-core",
  "termtree",
@@ -2604,9 +2604,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -2930,9 +2930,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
+checksum = "d09d3c15d814eda1d6a836f2f2b56a6abc1446c8a34351cb3180d3db92ffe4ce"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2943,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
+checksum = "e90dd10c41c6bfc633da6e0c659bd25d31e0791e5974ac42970267d59eba87f7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3041,21 +3041,21 @@ dependencies = [
 
 [[package]]
 name = "serde_test"
-version = "1.0.133"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8537872f576ea4a3a38ef8f8e317effb067964b526f2fa64cc3d27e89cb52d3"
+checksum = "4f822485db18894f1c1d904cae2e9769c178b3129a90d85c518ce47546c68daf"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
 dependencies = [
  "form_urlencoded",
- "itoa 0.4.8",
+ "itoa 1.0.1",
  "ryu",
  "serde",
 ]
@@ -3098,9 +3098,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d964dd36bb15bcf2f2b35694c072feab74969a54f2bbeec7a2d725d2bdcb6"
+checksum = "99c3bd8169c58782adad9290a9af5939994036b76187f7b4f0e6de91dbbfc0ec"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -3143,9 +3143,9 @@ checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
 name = "siphasher"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
+checksum = "a86232ab60fa71287d7f2ddae4a7073f6b7aac33631c3015abb556f08c6d0a3e"
 
 [[package]]
 name = "slab"
@@ -3166,9 +3166,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
+checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
 
 [[package]]
 name = "smawk"
@@ -3178,9 +3178,9 @@ checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
 name = "socket2"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
+checksum = "0f82496b90c36d70af5fcd482edaa2e0bd16fade569de1330405fecbbdac736b"
 dependencies = [
  "libc",
  "winapi 0.3.9",
@@ -3271,9 +3271,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.84"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb2e6da8ee5eb9a61068762a32fa9619cc591ceb055b3687f4cd4051ec2e06b"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3302,13 +3302,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if 1.0.0",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -3337,9 +3337,9 @@ dependencies = [
 
 [[package]]
 name = "termtree"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a4ec180a2de59b57434704ccfad967f789b12737738798fa08798cd5824c16"
+checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "test-log"
@@ -3354,9 +3354,9 @@ dependencies = [
 
 [[package]]
 name = "test-span"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9f85d34f1792565eb25be5231f457f21efe11166ea1c9f3aad0e60f1cedf59"
+checksum = "0263fb1bbc057edadcd28f05176825f9b0153df03140c3aa19bb1d68ae9fcf35"
 dependencies = [
  "daggy",
  "derivative",
@@ -3375,9 +3375,9 @@ dependencies = [
 
 [[package]]
 name = "test-span-macro"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1fd5d6b8ac468c44017cf9caf1b96b56c37c8a68bc87d21f53d9e3a47eb6e41"
+checksum = "5065878538c3c1a649a8359a450f2282be8a6067ec10892c59aba7c67d1920b3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3432,9 +3432,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
 ]
@@ -3983,9 +3983,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
 dependencies = [
  "cfg-if 1.0.0",
  "wasm-bindgen-macro",
@@ -3993,9 +3993,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a317bf8f9fba2476b4b2c85ef4c4af8ff39c3c7f0cdfeed4f82c34a880aa837b"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -4008,9 +4008,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d7523cb1f2a4c96c1317ca690031b714a51cc14e05f712446691f413f5d39"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -4020,9 +4020,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56146e7c495528bf6587663bea13a8eb588d39b36b679d83972e1a2dbbdacf9"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4030,9 +4030,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7803e0eea25835f8abdc585cd3021b3deb11543c6fe226dcd30b228857c5c5ab"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4043,15 +4043,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.78"
+version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0237232789cf037d5480773fe568aac745bfe2afbc11a863e97901780a6b47cc"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
 
 [[package]]
 name = "web-sys"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4078,9 +4078,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.2"
+version = "4.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea187a8ef279bc014ec368c27a920da2024d2a711109bfbe3440585d5cf27ad9"
+checksum = "2a5a7e487e921cf220206864a94a89b6c6905bfc19f1057fa26a4cb360e5c1d2"
 dependencies = [
  "either",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3354,9 +3354,9 @@ dependencies = [
 
 [[package]]
 name = "test-span"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0263fb1bbc057edadcd28f05176825f9b0153df03140c3aa19bb1d68ae9fcf35"
+checksum = "0253fc94d43dcc581fc5a1150683b722d469013ed0b8e79ede0046333f18d243"
 dependencies = [
  "daggy",
  "derivative",
@@ -3375,9 +3375,9 @@ dependencies = [
 
 [[package]]
 name = "test-span-macro"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065878538c3c1a649a8359a450f2282be8a6067ec10892c59aba7c67d1920b3"
+checksum = "7563c12f5cd1424ed95688dc89b638f96947111d6aacc84610857d1ee2a7a328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -77,7 +77,7 @@ mockall = "0.11.0"
 reqwest = { version = "0.11.9", features = ["json", "stream"] }
 serde_json_bytes = { version = "0.2.0", features = ["preserve_order"] }
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
-test-span = "0.1.1"
+test-span = "0.2"
 tracing-subscriber = { version = "0.3", default-features = false, features = [
     "env-filter",
     "fmt",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -77,7 +77,7 @@ mockall = "0.11.0"
 reqwest = { version = "0.11.9", features = ["json", "stream"] }
 serde_json_bytes = { version = "0.2.0", features = ["preserve_order"] }
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
-test-span = "0.2"
+test-span = "0.3"
 tracing-subscriber = { version = "0.3", default-features = false, features = [
     "env-filter",
     "fmt",

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -66,9 +66,8 @@ async fn basic_composition() {
 }
 
 #[test_span(tokio::test)]
-#[target(reqwest=tracing::Level::INFO)]
-#[target(reqwest_tracing=tracing::Level::INFO)]
-#[target(hyper::client=tracing::Level::INFO)]
+#[target(apollo_router=tracing::Level::DEBUG)]
+#[target(apollo_router_core=tracing::Level::DEBUG)]
 async fn traced_basic_request() {
     assert_federated_response!(
         r#"{ topProducts { name name2:name } }"#,
@@ -80,9 +79,8 @@ async fn traced_basic_request() {
 }
 
 #[test_span(tokio::test)]
-#[target(reqwest=tracing::Level::INFO)]
-#[target(reqwest_tracing=tracing::Level::INFO)]
-#[target(hyper::client=tracing::Level::INFO)]
+#[target(apollo_router=tracing::Level::DEBUG)]
+#[target(apollo_router_core=tracing::Level::DEBUG)]
 async fn traced_basic_composition() {
     assert_federated_response!(
         r#"{ topProducts { upc name reviews {id product { name } author { id name } } } }"#,

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -66,6 +66,9 @@ async fn basic_composition() {
 }
 
 #[test_span(tokio::test)]
+#[target(reqwest=tracing::Level::INFO)]
+#[target(reqwest_tracing=tracing::Level::INFO)]
+#[target(hyper::client=tracing::Level::INFO)]
 async fn traced_basic_request() {
     assert_federated_response!(
         r#"{ topProducts { name name2:name } }"#,
@@ -77,6 +80,9 @@ async fn traced_basic_request() {
 }
 
 #[test_span(tokio::test)]
+#[target(reqwest=tracing::Level::INFO)]
+#[target(reqwest_tracing=tracing::Level::INFO)]
+#[target(hyper::client=tracing::Level::INFO)]
 async fn traced_basic_composition() {
     assert_federated_response!(
         r#"{ topProducts { upc name reviews {id product { name } author { id name } } } }"#,

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/tests/integration_tests.rs
-assertion_line: 95
+assertion_line: 93
 expression: get_spans()
 
 ---
@@ -11,7 +11,7 @@ expression: get_spans()
     "metadata": {
       "name": "root",
       "target": "integration_tests",
-      "level": "DEBUG",
+      "level": "INFO",
       "module_path": "integration_tests",
       "fields": {
         "names": []
@@ -19,7 +19,7 @@ expression: get_spans()
     }
   },
   "children": {
-    "apollo_router::apollo_router::prepare_query - 1": {
+    "apollo_router::apollo_router::prepare_query": {
       "name": "apollo_router::apollo_router::prepare_query",
       "record": {
         "entries": [
@@ -39,7 +39,7 @@ expression: get_spans()
         }
       },
       "children": {
-        "apollo_router::apollo_router::query_parsing - 2": {
+        "apollo_router::apollo_router::query_parsing": {
           "name": "apollo_router::apollo_router::query_parsing",
           "record": {
             "entries": [],
@@ -55,7 +55,7 @@ expression: get_spans()
           },
           "children": {}
         },
-        "apollo_router_core::query_planner::router_bridge_query_planner::plan - 4": {
+        "apollo_router_core::query_planner::router_bridge_query_planner::plan": {
           "name": "apollo_router_core::query_planner::router_bridge_query_planner::plan",
           "record": {
             "entries": [],
@@ -71,7 +71,7 @@ expression: get_spans()
           },
           "children": {}
         },
-        "apollo_router_core::query_planner::validate - 5": {
+        "apollo_router_core::query_planner::validate": {
           "name": "apollo_router_core::query_planner::validate",
           "record": {
             "entries": [],
@@ -89,7 +89,7 @@ expression: get_spans()
         }
       }
     },
-    "apollo_router::apollo_router::execute - 6": {
+    "apollo_router::apollo_router::execute": {
       "name": "apollo_router::apollo_router::execute",
       "record": {
         "entries": [],
@@ -104,7 +104,7 @@ expression: get_spans()
         }
       },
       "children": {
-        "apollo_router::apollo_router::execution - 7": {
+        "apollo_router::apollo_router::execution": {
           "name": "apollo_router::apollo_router::execution",
           "record": {
             "entries": [],
@@ -119,7 +119,7 @@ expression: get_spans()
             }
           },
           "children": {
-            "apollo_router_core::query_planner::sequence - 8": {
+            "apollo_router_core::query_planner::sequence": {
               "name": "apollo_router_core::query_planner::sequence",
               "record": {
                 "entries": [],
@@ -134,7 +134,7 @@ expression: get_spans()
                 }
               },
               "children": {
-                "apollo_router_core::query_planner::fetch - 9": {
+                "apollo_router_core::query_planner::fetch": {
                   "name": "apollo_router_core::query_planner::fetch",
                   "record": {
                     "entries": [],
@@ -149,7 +149,7 @@ expression: get_spans()
                     }
                   },
                   "children": {
-                    "apollo_router_core::query_planner::fetch::subfetch - 10": {
+                    "apollo_router_core::query_planner::fetch::subfetch": {
                       "name": "apollo_router_core::query_planner::fetch::subfetch",
                       "record": {
                         "entries": [
@@ -171,7 +171,7 @@ expression: get_spans()
                         }
                       },
                       "children": {
-                        "apollo_router_core::query_planner::fetch::make_variables - 11": {
+                        "apollo_router_core::query_planner::fetch::make_variables": {
                           "name": "apollo_router_core::query_planner::fetch::make_variables",
                           "record": {
                             "entries": [],
@@ -187,7 +187,7 @@ expression: get_spans()
                           },
                           "children": {}
                         },
-                        "apollo_router_core::query_planner::fetch::subfetch_stream - 12": {
+                        "apollo_router_core::query_planner::fetch::subfetch_stream": {
                           "name": "apollo_router_core::query_planner::fetch::subfetch_stream",
                           "record": {
                             "entries": [],
@@ -202,7 +202,7 @@ expression: get_spans()
                             }
                           },
                           "children": {
-                            "apollo_router::http_subgraph::aggregate_response_data - 15": {
+                            "apollo_router::http_subgraph::aggregate_response_data": {
                               "name": "apollo_router::http_subgraph::aggregate_response_data",
                               "record": {
                                 "entries": [],
@@ -218,7 +218,7 @@ expression: get_spans()
                               },
                               "children": {}
                             },
-                            "apollo_router::http_subgraph::parse_subgraph_response - 16": {
+                            "apollo_router::http_subgraph::parse_subgraph_response": {
                               "name": "apollo_router::http_subgraph::parse_subgraph_response",
                               "record": {
                                 "entries": [],
@@ -236,7 +236,7 @@ expression: get_spans()
                             }
                           }
                         },
-                        "apollo_router_core::query_planner::fetch::response_insert - 17": {
+                        "apollo_router_core::query_planner::fetch::response_insert": {
                           "name": "apollo_router_core::query_planner::fetch::response_insert",
                           "record": {
                             "entries": [],
@@ -258,7 +258,7 @@ expression: get_spans()
                 }
               }
             },
-            "apollo_router_core::query_planner::sequence - 18": {
+            "apollo_router_core::query_planner::sequence": {
               "name": "apollo_router_core::query_planner::sequence",
               "record": {
                 "entries": [],
@@ -274,7 +274,7 @@ expression: get_spans()
               },
               "children": {}
             },
-            "apollo_router_core::query_planner::sequence - 29": {
+            "apollo_router_core::query_planner::sequence": {
               "name": "apollo_router_core::query_planner::sequence",
               "record": {
                 "entries": [],
@@ -289,7 +289,7 @@ expression: get_spans()
                 }
               },
               "children": {
-                "apollo_router_core::query_planner::parallel - 30": {
+                "apollo_router_core::query_planner::parallel": {
                   "name": "apollo_router_core::query_planner::parallel",
                   "record": {
                     "entries": [],
@@ -309,7 +309,7 @@ expression: get_spans()
             }
           }
         },
-        "apollo_router::apollo_router::format_response - 51": {
+        "apollo_router::apollo_router::format_response": {
           "name": "apollo_router::apollo_router::format_response",
           "record": {
             "entries": [],
@@ -327,7 +327,7 @@ expression: get_spans()
         }
       }
     },
-    "apollo_router::http_subgraph::aggregate_response_data - 55": {
+    "apollo_router::http_subgraph::aggregate_response_data": {
       "name": "apollo_router::http_subgraph::aggregate_response_data",
       "record": {
         "entries": [],
@@ -343,7 +343,7 @@ expression: get_spans()
       },
       "children": {}
     },
-    "apollo_router::http_subgraph::parse_subgraph_response - 56": {
+    "apollo_router::http_subgraph::parse_subgraph_response": {
       "name": "apollo_router::http_subgraph::parse_subgraph_response",
       "record": {
         "entries": [],

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/tests/integration_tests.rs
-assertion_line: 89
+assertion_line: 95
 expression: get_spans()
 
 ---

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/tests/integration_tests.rs
-assertion_line: 76
+assertion_line: 79
 expression: get_spans()
 
 ---

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/tests/integration_tests.rs
-assertion_line: 79
+assertion_line: 78
 expression: get_spans()
 
 ---
@@ -11,7 +11,7 @@ expression: get_spans()
     "metadata": {
       "name": "root",
       "target": "integration_tests",
-      "level": "DEBUG",
+      "level": "INFO",
       "module_path": "integration_tests",
       "fields": {
         "names": []
@@ -19,7 +19,7 @@ expression: get_spans()
     }
   },
   "children": {
-    "apollo_router::apollo_router::prepare_query - 1": {
+    "apollo_router::apollo_router::prepare_query": {
       "name": "apollo_router::apollo_router::prepare_query",
       "record": {
         "entries": [
@@ -39,7 +39,7 @@ expression: get_spans()
         }
       },
       "children": {
-        "apollo_router::apollo_router::query_parsing - 2": {
+        "apollo_router::apollo_router::query_parsing": {
           "name": "apollo_router::apollo_router::query_parsing",
           "record": {
             "entries": [],
@@ -55,7 +55,7 @@ expression: get_spans()
           },
           "children": {}
         },
-        "apollo_router_core::query_planner::router_bridge_query_planner::plan - 4": {
+        "apollo_router_core::query_planner::router_bridge_query_planner::plan": {
           "name": "apollo_router_core::query_planner::router_bridge_query_planner::plan",
           "record": {
             "entries": [],
@@ -71,7 +71,7 @@ expression: get_spans()
           },
           "children": {}
         },
-        "apollo_router_core::query_planner::validate - 5": {
+        "apollo_router_core::query_planner::validate": {
           "name": "apollo_router_core::query_planner::validate",
           "record": {
             "entries": [],
@@ -89,7 +89,7 @@ expression: get_spans()
         }
       }
     },
-    "apollo_router::apollo_router::execute - 6": {
+    "apollo_router::apollo_router::execute": {
       "name": "apollo_router::apollo_router::execute",
       "record": {
         "entries": [],
@@ -104,7 +104,7 @@ expression: get_spans()
         }
       },
       "children": {
-        "apollo_router::apollo_router::execution - 7": {
+        "apollo_router::apollo_router::execution": {
           "name": "apollo_router::apollo_router::execution",
           "record": {
             "entries": [],
@@ -119,7 +119,7 @@ expression: get_spans()
             }
           },
           "children": {
-            "apollo_router_core::query_planner::fetch - 8": {
+            "apollo_router_core::query_planner::fetch": {
               "name": "apollo_router_core::query_planner::fetch",
               "record": {
                 "entries": [],
@@ -134,7 +134,7 @@ expression: get_spans()
                 }
               },
               "children": {
-                "apollo_router_core::query_planner::fetch::subfetch - 9": {
+                "apollo_router_core::query_planner::fetch::subfetch": {
                   "name": "apollo_router_core::query_planner::fetch::subfetch",
                   "record": {
                     "entries": [
@@ -156,7 +156,7 @@ expression: get_spans()
                     }
                   },
                   "children": {
-                    "apollo_router_core::query_planner::fetch::make_variables - 10": {
+                    "apollo_router_core::query_planner::fetch::make_variables": {
                       "name": "apollo_router_core::query_planner::fetch::make_variables",
                       "record": {
                         "entries": [],
@@ -172,7 +172,7 @@ expression: get_spans()
                       },
                       "children": {}
                     },
-                    "apollo_router_core::query_planner::fetch::subfetch_stream - 11": {
+                    "apollo_router_core::query_planner::fetch::subfetch_stream": {
                       "name": "apollo_router_core::query_planner::fetch::subfetch_stream",
                       "record": {
                         "entries": [],
@@ -187,7 +187,7 @@ expression: get_spans()
                         }
                       },
                       "children": {
-                        "apollo_router::http_subgraph::aggregate_response_data - 14": {
+                        "apollo_router::http_subgraph::aggregate_response_data": {
                           "name": "apollo_router::http_subgraph::aggregate_response_data",
                           "record": {
                             "entries": [],
@@ -203,7 +203,7 @@ expression: get_spans()
                           },
                           "children": {}
                         },
-                        "apollo_router::http_subgraph::parse_subgraph_response - 15": {
+                        "apollo_router::http_subgraph::parse_subgraph_response": {
                           "name": "apollo_router::http_subgraph::parse_subgraph_response",
                           "record": {
                             "entries": [],
@@ -221,7 +221,7 @@ expression: get_spans()
                         }
                       }
                     },
-                    "apollo_router_core::query_planner::fetch::response_insert - 16": {
+                    "apollo_router_core::query_planner::fetch::response_insert": {
                       "name": "apollo_router_core::query_planner::fetch::response_insert",
                       "record": {
                         "entries": [],
@@ -243,7 +243,7 @@ expression: get_spans()
             }
           }
         },
-        "apollo_router::apollo_router::format_response - 17": {
+        "apollo_router::apollo_router::format_response": {
           "name": "apollo_router::apollo_router::format_response",
           "record": {
             "entries": [],
@@ -261,7 +261,7 @@ expression: get_spans()
         }
       }
     },
-    "apollo_router::http_subgraph::aggregate_response_data - 21": {
+    "apollo_router::http_subgraph::aggregate_response_data": {
       "name": "apollo_router::http_subgraph::aggregate_response_data",
       "record": {
         "entries": [],
@@ -277,7 +277,7 @@ expression: get_spans()
       },
       "children": {}
     },
-    "apollo_router::http_subgraph::parse_subgraph_response - 22": {
+    "apollo_router::http_subgraph::parse_subgraph_response": {
       "name": "apollo_router::http_subgraph::parse_subgraph_response",
       "record": {
         "entries": [],

--- a/licenses.html
+++ b/licenses.html
@@ -4181,7 +4181,7 @@ limitations under the License.
                     <li><a href=" https://github.com/bitflags/bitflags ">bitflags</a></li>
                     <li><a href=" https://github.com/BurntSushi/bstr ">bstr</a></li>
                     <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo</a></li>
-                    <li><a href=" https://github.com/withoutboats/camino ">camino</a></li>
+                    <li><a href=" https://github.com/camino-rs/camino ">camino</a></li>
                     <li><a href=" https://github.com/alexcrichton/cc-rs ">cc</a></li>
                     <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if</a></li>
                     <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if</a></li>
@@ -4193,6 +4193,7 @@ limitations under the License.
                     <li><a href=" https://github.com/mcarton/rust-derivative ">derivative</a></li>
                     <li><a href=" https://github.com/yaahc/displaydoc ">displaydoc</a></li>
                     <li><a href=" https://github.com/bluss/either ">either</a></li>
+                    <li><a href=" https://github.com/smol-rs/fastrand ">fastrand</a></li>
                     <li><a href=" https://github.com/alexcrichton/filetime ">filetime</a></li>
                     <li><a href=" https://github.com/bluss/fixedbitset ">fixedbitset</a></li>
                     <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2</a></li>
@@ -4245,6 +4246,8 @@ limitations under the License.
                     <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls</a></li>
                     <li><a href=" https://github.com/bluss/scopeguard ">scopeguard</a></li>
                     <li><a href=" https://github.com/ctz/sct.rs ">sct</a></li>
+                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework</a></li>
+                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys</a></li>
                     <li><a href=" https://github.com/dtolnay/semver ">semver</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde</a></li>
                     <li><a href=" https://github.com/serde-rs/bytes ">serde_bytes</a></li>
@@ -6606,8 +6609,6 @@ limitations under the License.
                     <li><a href=" https://github.com/TrueLayer/reqwest-middleware ">reqwest-middleware</a></li>
                     <li><a href=" https://github.com/TrueLayer/reqwest-middleware ">reqwest-tracing</a></li>
                     <li><a href=" https://github.com/ctz/rustls ">rustls</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys</a></li>
                     <li><a href=" https://crates.io/crates/thrift ">thrift</a></li>
                     <li><a href=" https://github.com/Soveu/tinyvec_macros ">tinyvec_macros</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi-i686-pc-windows-gnu</a></li>


### PR DESCRIPTION
 🔧 improvement: Test_span: add more powerful filtering capabilities, to remove non determinism in tests.

This PR bumps test-span to version 0.2.0 which allows us to add log level filters according to our dependencies; eg:

```rust
#[test_span(tokio::test)]
#[target(reqwest=tracing::Level::INFO)]
#[target(reqwest_tracing=tracing::Level::INFO)]
#[target(hyper::client=tracing::Level::INFO)]
```
etc.

This allows us to remove some deps logs that are non deterministic at the moment.