### PR TITLE
serialize spans snapshots as YAML to save space

### DIFF
--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -75,7 +75,7 @@ async fn traced_basic_request() {
             "products".to_string()=>1,
         },
     );
-    insta::assert_json_snapshot!(get_spans());
+    insta::assert_yaml_snapshot!(get_spans());
 }
 
 #[test_span(tokio::test)]
@@ -90,7 +90,7 @@ async fn traced_basic_composition() {
             "accounts".to_string()=>1,
         },
     );
-    insta::assert_json_snapshot!(get_spans());
+    insta::assert_yaml_snapshot!(get_spans());
 }
 
 #[tokio::test]

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
@@ -4,360 +4,149 @@ assertion_line: 93
 expression: get_spans()
 
 ---
-{
-  "name": "integration_tests::root",
-  "record": {
-    "entries": [],
-    "metadata": {
-      "name": "root",
-      "target": "integration_tests",
-      "level": "INFO",
-      "module_path": "integration_tests",
-      "fields": {
-        "names": []
-      }
-    }
-  },
-  "children": {
-    "apollo_router::apollo_router::prepare_query": {
-      "name": "apollo_router::apollo_router::prepare_query",
-      "record": {
-        "entries": [
-          [
-            "message",
-            "query plan\nQueryPlan {\n    root: Sequence {\n        nodes: [\n            Fetch(\n                FetchNode {\n                    service_name: \"products\",\n                    requires: [],\n                    variable_usages: [],\n                    operation: \"{topProducts{__typename upc name}}\",\n                },\n            ),\n            Flatten(\n                FlattenNode {\n                    path: Path(\n                        [\n                            Key(\n                                \"topProducts\",\n                            ),\n                            Flatten,\n                        ],\n                    ),\n                    node: Fetch(\n                        FetchNode {\n                            service_name: \"reviews\",\n                            requires: [\n                                InlineFragment(\n                                    InlineFragment {\n                                        type_condition: Some(\n                                            \"Product\",\n                                        ),\n                                        selections: [\n                                            Field(\n                                                Field {\n                                                    alias: None,\n                                                    name: \"__typename\",\n                                                    selections: None,\n                                                },\n                                            ),\n                                            Field(\n                                                Field {\n                                                    alias: None,\n                                                    name: \"upc\",\n                                                    selections: None,\n                                                },\n                                            ),\n                                        ],\n                                    },\n                                ),\n                            ],\n                            variable_usages: [],\n                            operation: \"query($representations:[_Any!]!){_entities(representations:$representations){...on Product{reviews{id product{__typename upc}author{__typename id}}}}}\",\n                        },\n                    ),\n                },\n            ),\n            Parallel {\n                nodes: [\n                    Flatten(\n                        FlattenNode {\n                            path: Path(\n                                [\n                                    Key(\n                                        \"topProducts\",\n                                    ),\n                                    Flatten,\n                                    Key(\n                                        \"reviews\",\n                                    ),\n                                    Flatten,\n                                    Key(\n                                        \"product\",\n                                    ),\n                                ],\n                            ),\n                            node: Fetch(\n                                FetchNode {\n                                    service_name: \"products\",\n                                    requires: [\n                                        InlineFragment(\n                                            InlineFragment {\n                                                type_condition: Some(\n                                                    \"Product\",\n                                                ),\n                                                selections: [\n                                                    Field(\n                                                        Field {\n                                                            alias: None,\n                                                            name: \"__typename\",\n                                                            selections: None,\n                                                        },\n                                                    ),\n                                                    Field(\n                                                        Field {\n                                                            alias: None,\n                                                            name: \"upc\",\n                                                            selections: None,\n                                                        },\n                                                    ),\n                                                ],\n                                            },\n                                        ),\n                                    ],\n                                    variable_usages: [],\n                                    operation: \"query($representations:[_Any!]!){_entities(representations:$representations){...on Product{name}}}\",\n                                },\n                            ),\n                        },\n                    ),\n                    Flatten(\n                        FlattenNode {\n                            path: Path(\n                                [\n                                    Key(\n                                        \"topProducts\",\n                                    ),\n                                    Flatten,\n                                    Key(\n                                        \"reviews\",\n                                    ),\n                                    Flatten,\n                                    Key(\n                                        \"author\",\n                                    ),\n                                ],\n                            ),\n                            node: Fetch(\n                                FetchNode {\n                                    service_name: \"accounts\",\n                                    requires: [\n                                        InlineFragment(\n                                            InlineFragment {\n                                                type_condition: Some(\n                                                    \"User\",\n                                                ),\n                                                selections: [\n                                                    Field(\n                                                        Field {\n                                                            alias: None,\n                                                            name: \"__typename\",\n                                                            selections: None,\n                                                        },\n                                                    ),\n                                                    Field(\n                                                        Field {\n                                                            alias: None,\n                                                            name: \"id\",\n                                                            selections: None,\n                                                        },\n                                                    ),\n                                                ],\n                                            },\n                                        ),\n                                    ],\n                                    variable_usages: [],\n                                    operation: \"query($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}\",\n                                },\n                            ),\n                        },\n                    ),\n                ],\n            },\n        ],\n    },\n}"
-          ]
-        ],
-        "metadata": {
-          "name": "prepare_query",
-          "target": "apollo_router::apollo_router",
-          "level": "DEBUG",
-          "module_path": "apollo_router::apollo_router",
-          "fields": {
-            "names": []
-          }
-        }
-      },
-      "children": {
-        "apollo_router::apollo_router::query_parsing": {
-          "name": "apollo_router::apollo_router::query_parsing",
-          "record": {
-            "entries": [],
-            "metadata": {
-              "name": "query_parsing",
-              "target": "apollo_router::apollo_router",
-              "level": "INFO",
-              "module_path": "apollo_router::apollo_router",
-              "fields": {
-                "names": []
-              }
-            }
-          },
-          "children": {}
-        },
-        "apollo_router_core::query_planner::router_bridge_query_planner::plan": {
-          "name": "apollo_router_core::query_planner::router_bridge_query_planner::plan",
-          "record": {
-            "entries": [],
-            "metadata": {
-              "name": "plan",
-              "target": "apollo_router_core::query_planner::router_bridge_query_planner",
-              "level": "DEBUG",
-              "module_path": "apollo_router_core::query_planner::router_bridge_query_planner",
-              "fields": {
-                "names": []
-              }
-            }
-          },
-          "children": {}
-        },
-        "apollo_router_core::query_planner::validate": {
-          "name": "apollo_router_core::query_planner::validate",
-          "record": {
-            "entries": [],
-            "metadata": {
-              "name": "validate",
-              "target": "apollo_router_core::query_planner",
-              "level": "DEBUG",
-              "module_path": "apollo_router_core::query_planner",
-              "fields": {
-                "names": []
-              }
-            }
-          },
-          "children": {}
-        }
-      }
-    },
-    "apollo_router::apollo_router::execute": {
-      "name": "apollo_router::apollo_router::execute",
-      "record": {
-        "entries": [],
-        "metadata": {
-          "name": "execute",
-          "target": "apollo_router::apollo_router",
-          "level": "DEBUG",
-          "module_path": "apollo_router::apollo_router",
-          "fields": {
-            "names": []
-          }
-        }
-      },
-      "children": {
-        "apollo_router::apollo_router::execution": {
-          "name": "apollo_router::apollo_router::execution",
-          "record": {
-            "entries": [],
-            "metadata": {
-              "name": "execution",
-              "target": "apollo_router::apollo_router",
-              "level": "INFO",
-              "module_path": "apollo_router::apollo_router",
-              "fields": {
-                "names": []
-              }
-            }
-          },
-          "children": {
-            "apollo_router_core::query_planner::sequence": {
-              "name": "apollo_router_core::query_planner::sequence",
-              "record": {
-                "entries": [],
-                "metadata": {
-                  "name": "sequence",
-                  "target": "apollo_router_core::query_planner",
-                  "level": "INFO",
-                  "module_path": "apollo_router_core::query_planner",
-                  "fields": {
-                    "names": []
-                  }
-                }
-              },
-              "children": {
-                "apollo_router_core::query_planner::fetch": {
-                  "name": "apollo_router_core::query_planner::fetch",
-                  "record": {
-                    "entries": [],
-                    "metadata": {
-                      "name": "fetch",
-                      "target": "apollo_router_core::query_planner",
-                      "level": "INFO",
-                      "module_path": "apollo_router_core::query_planner",
-                      "fields": {
-                        "names": []
-                      }
-                    }
-                  },
-                  "children": {
-                    "apollo_router_core::query_planner::fetch::subfetch": {
-                      "name": "apollo_router_core::query_planner::fetch::subfetch",
-                      "record": {
-                        "entries": [
-                          [
-                            "service",
-                            "products"
-                          ]
-                        ],
-                        "metadata": {
-                          "name": "subfetch",
-                          "target": "apollo_router_core::query_planner::fetch",
-                          "level": "INFO",
-                          "module_path": "apollo_router_core::query_planner::fetch",
-                          "fields": {
-                            "names": [
-                              "service"
-                            ]
-                          }
-                        }
-                      },
-                      "children": {
-                        "apollo_router_core::query_planner::fetch::make_variables": {
-                          "name": "apollo_router_core::query_planner::fetch::make_variables",
-                          "record": {
-                            "entries": [],
-                            "metadata": {
-                              "name": "make_variables",
-                              "target": "apollo_router_core::query_planner::fetch",
-                              "level": "DEBUG",
-                              "module_path": "apollo_router_core::query_planner::fetch",
-                              "fields": {
-                                "names": []
-                              }
-                            }
-                          },
-                          "children": {}
-                        },
-                        "apollo_router_core::query_planner::fetch::subfetch_stream": {
-                          "name": "apollo_router_core::query_planner::fetch::subfetch_stream",
-                          "record": {
-                            "entries": [],
-                            "metadata": {
-                              "name": "subfetch_stream",
-                              "target": "apollo_router_core::query_planner::fetch",
-                              "level": "INFO",
-                              "module_path": "apollo_router_core::query_planner::fetch",
-                              "fields": {
-                                "names": []
-                              }
-                            }
-                          },
-                          "children": {
-                            "apollo_router::http_subgraph::aggregate_response_data": {
-                              "name": "apollo_router::http_subgraph::aggregate_response_data",
-                              "record": {
-                                "entries": [],
-                                "metadata": {
-                                  "name": "aggregate_response_data",
-                                  "target": "apollo_router::http_subgraph",
-                                  "level": "DEBUG",
-                                  "module_path": "apollo_router::http_subgraph",
-                                  "fields": {
-                                    "names": []
-                                  }
-                                }
-                              },
-                              "children": {}
-                            },
-                            "apollo_router::http_subgraph::parse_subgraph_response": {
-                              "name": "apollo_router::http_subgraph::parse_subgraph_response",
-                              "record": {
-                                "entries": [],
-                                "metadata": {
-                                  "name": "parse_subgraph_response",
-                                  "target": "apollo_router::http_subgraph",
-                                  "level": "DEBUG",
-                                  "module_path": "apollo_router::http_subgraph",
-                                  "fields": {
-                                    "names": []
-                                  }
-                                }
-                              },
-                              "children": {}
-                            }
-                          }
-                        },
-                        "apollo_router_core::query_planner::fetch::response_insert": {
-                          "name": "apollo_router_core::query_planner::fetch::response_insert",
-                          "record": {
-                            "entries": [],
-                            "metadata": {
-                              "name": "response_insert",
-                              "target": "apollo_router_core::query_planner::fetch",
-                              "level": "DEBUG",
-                              "module_path": "apollo_router_core::query_planner::fetch",
-                              "fields": {
-                                "names": []
-                              }
-                            }
-                          },
-                          "children": {}
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "apollo_router_core::query_planner::sequence": {
-              "name": "apollo_router_core::query_planner::sequence",
-              "record": {
-                "entries": [],
-                "metadata": {
-                  "name": "sequence",
-                  "target": "apollo_router_core::query_planner",
-                  "level": "INFO",
-                  "module_path": "apollo_router_core::query_planner",
-                  "fields": {
-                    "names": []
-                  }
-                }
-              },
-              "children": {}
-            },
-            "apollo_router_core::query_planner::sequence": {
-              "name": "apollo_router_core::query_planner::sequence",
-              "record": {
-                "entries": [],
-                "metadata": {
-                  "name": "sequence",
-                  "target": "apollo_router_core::query_planner",
-                  "level": "INFO",
-                  "module_path": "apollo_router_core::query_planner",
-                  "fields": {
-                    "names": []
-                  }
-                }
-              },
-              "children": {
-                "apollo_router_core::query_planner::parallel": {
-                  "name": "apollo_router_core::query_planner::parallel",
-                  "record": {
-                    "entries": [],
-                    "metadata": {
-                      "name": "parallel",
-                      "target": "apollo_router_core::query_planner",
-                      "level": "INFO",
-                      "module_path": "apollo_router_core::query_planner",
-                      "fields": {
-                        "names": []
-                      }
-                    }
-                  },
-                  "children": {}
-                }
-              }
-            }
-          }
-        },
-        "apollo_router::apollo_router::format_response": {
-          "name": "apollo_router::apollo_router::format_response",
-          "record": {
-            "entries": [],
-            "metadata": {
-              "name": "format_response",
-              "target": "apollo_router::apollo_router",
-              "level": "DEBUG",
-              "module_path": "apollo_router::apollo_router",
-              "fields": {
-                "names": []
-              }
-            }
-          },
-          "children": {}
-        }
-      }
-    },
-    "apollo_router::http_subgraph::aggregate_response_data": {
-      "name": "apollo_router::http_subgraph::aggregate_response_data",
-      "record": {
-        "entries": [],
-        "metadata": {
-          "name": "aggregate_response_data",
-          "target": "apollo_router::http_subgraph",
-          "level": "DEBUG",
-          "module_path": "apollo_router::http_subgraph",
-          "fields": {
-            "names": []
-          }
-        }
-      },
-      "children": {}
-    },
-    "apollo_router::http_subgraph::parse_subgraph_response": {
-      "name": "apollo_router::http_subgraph::parse_subgraph_response",
-      "record": {
-        "entries": [],
-        "metadata": {
-          "name": "parse_subgraph_response",
-          "target": "apollo_router::http_subgraph",
-          "level": "DEBUG",
-          "module_path": "apollo_router::http_subgraph",
-          "fields": {
-            "names": []
-          }
-        }
-      },
-      "children": {}
-    }
-  }
-}
+name: "integration_tests::root"
+record:
+  entries: []
+  metadata:
+    name: root
+    target: integration_tests
+    level: INFO
+    module_path: integration_tests
+    fields:
+      names: []
+children:
+  "apollo_router::apollo_router::prepare_query":
+    name: "apollo_router::apollo_router::prepare_query"
+    record:
+      entries:
+        - - message
+          - "query plan\nQueryPlan {\n    root: Sequence {\n        nodes: [\n            Fetch(\n                FetchNode {\n                    service_name: \"products\",\n                    requires: [],\n                    variable_usages: [],\n                    operation: \"{topProducts{__typename upc name}}\",\n                },\n            ),\n            Flatten(\n                FlattenNode {\n                    path: Path(\n                        [\n                            Key(\n                                \"topProducts\",\n                            ),\n                            Flatten,\n                        ],\n                    ),\n                    node: Fetch(\n                        FetchNode {\n                            service_name: \"reviews\",\n                            requires: [\n                                InlineFragment(\n                                    InlineFragment {\n                                        type_condition: Some(\n                                            \"Product\",\n                                        ),\n                                        selections: [\n                                            Field(\n                                                Field {\n                                                    alias: None,\n                                                    name: \"__typename\",\n                                                    selections: None,\n                                                },\n                                            ),\n                                            Field(\n                                                Field {\n                                                    alias: None,\n                                                    name: \"upc\",\n                                                    selections: None,\n                                                },\n                                            ),\n                                        ],\n                                    },\n                                ),\n                            ],\n                            variable_usages: [],\n                            operation: \"query($representations:[_Any!]!){_entities(representations:$representations){...on Product{reviews{id product{__typename upc}author{__typename id}}}}}\",\n                        },\n                    ),\n                },\n            ),\n            Parallel {\n                nodes: [\n                    Flatten(\n                        FlattenNode {\n                            path: Path(\n                                [\n                                    Key(\n                                        \"topProducts\",\n                                    ),\n                                    Flatten,\n                                    Key(\n                                        \"reviews\",\n                                    ),\n                                    Flatten,\n                                    Key(\n                                        \"product\",\n                                    ),\n                                ],\n                            ),\n                            node: Fetch(\n                                FetchNode {\n                                    service_name: \"products\",\n                                    requires: [\n                                        InlineFragment(\n                                            InlineFragment {\n                                                type_condition: Some(\n                                                    \"Product\",\n                                                ),\n                                                selections: [\n                                                    Field(\n                                                        Field {\n                                                            alias: None,\n                                                            name: \"__typename\",\n                                                            selections: None,\n                                                        },\n                                                    ),\n                                                    Field(\n                                                        Field {\n                                                            alias: None,\n                                                            name: \"upc\",\n                                                            selections: None,\n                                                        },\n                                                    ),\n                                                ],\n                                            },\n                                        ),\n                                    ],\n                                    variable_usages: [],\n                                    operation: \"query($representations:[_Any!]!){_entities(representations:$representations){...on Product{name}}}\",\n                                },\n                            ),\n                        },\n                    ),\n                    Flatten(\n                        FlattenNode {\n                            path: Path(\n                                [\n                                    Key(\n                                        \"topProducts\",\n                                    ),\n                                    Flatten,\n                                    Key(\n                                        \"reviews\",\n                                    ),\n                                    Flatten,\n                                    Key(\n                                        \"author\",\n                                    ),\n                                ],\n                            ),\n                            node: Fetch(\n                                FetchNode {\n                                    service_name: \"accounts\",\n                                    requires: [\n                                        InlineFragment(\n                                            InlineFragment {\n                                                type_condition: Some(\n                                                    \"User\",\n                                                ),\n                                                selections: [\n                                                    Field(\n                                                        Field {\n                                                            alias: None,\n                                                            name: \"__typename\",\n                                                            selections: None,\n                                                        },\n                                                    ),\n                                                    Field(\n                                                        Field {\n                                                            alias: None,\n                                                            name: \"id\",\n                                                            selections: None,\n                                                        },\n                                                    ),\n                                                ],\n                                            },\n                                        ),\n                                    ],\n                                    variable_usages: [],\n                                    operation: \"query($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}\",\n                                },\n                            ),\n                        },\n                    ),\n                ],\n            },\n        ],\n    },\n}"
+      metadata:
+        name: prepare_query
+        target: "apollo_router::apollo_router"
+        level: DEBUG
+        module_path: "apollo_router::apollo_router"
+        fields:
+          names: []
+    children:
+      "apollo_router::apollo_router::query_parsing":
+        name: "apollo_router::apollo_router::query_parsing"
+        record:
+          entries: []
+          metadata:
+            name: query_parsing
+            target: "apollo_router::apollo_router"
+            level: INFO
+            module_path: "apollo_router::apollo_router"
+            fields:
+              names: []
+        children: {}
+      "apollo_router_core::query_planner::router_bridge_query_planner::plan":
+        name: "apollo_router_core::query_planner::router_bridge_query_planner::plan"
+        record:
+          entries: []
+          metadata:
+            name: plan
+            target: "apollo_router_core::query_planner::router_bridge_query_planner"
+            level: DEBUG
+            module_path: "apollo_router_core::query_planner::router_bridge_query_planner"
+            fields:
+              names: []
+        children: {}
+      "apollo_router_core::query_planner::validate":
+        name: "apollo_router_core::query_planner::validate"
+        record:
+          entries: []
+          metadata:
+            name: validate
+            target: "apollo_router_core::query_planner"
+            level: DEBUG
+            module_path: "apollo_router_core::query_planner"
+            fields:
+              names: []
+        children: {}
+  "apollo_router::apollo_router::execute":
+    name: "apollo_router::apollo_router::execute"
+    record:
+      entries: []
+      metadata:
+        name: execute
+        target: "apollo_router::apollo_router"
+        level: DEBUG
+        module_path: "apollo_router::apollo_router"
+        fields:
+          names: []
+    children:
+      "apollo_router::apollo_router::execution":
+        name: "apollo_router::apollo_router::execution"
+        record:
+          entries: []
+          metadata:
+            name: execution
+            target: "apollo_router::apollo_router"
+            level: INFO
+            module_path: "apollo_router::apollo_router"
+            fields:
+              names: []
+        children:
+          "apollo_router_core::query_planner::sequence":
+            name: "apollo_router_core::query_planner::sequence"
+            record:
+              entries: []
+              metadata:
+                name: sequence
+                target: "apollo_router_core::query_planner"
+                level: INFO
+                module_path: "apollo_router_core::query_planner"
+                fields:
+                  names: []
+            children:
+              "apollo_router_core::query_planner::parallel":
+                name: "apollo_router_core::query_planner::parallel"
+                record:
+                  entries: []
+                  metadata:
+                    name: parallel
+                    target: "apollo_router_core::query_planner"
+                    level: INFO
+                    module_path: "apollo_router_core::query_planner"
+                    fields:
+                      names: []
+                children: {}
+      "apollo_router::apollo_router::format_response":
+        name: "apollo_router::apollo_router::format_response"
+        record:
+          entries: []
+          metadata:
+            name: format_response
+            target: "apollo_router::apollo_router"
+            level: DEBUG
+            module_path: "apollo_router::apollo_router"
+            fields:
+              names: []
+        children: {}
+  "apollo_router::http_subgraph::aggregate_response_data":
+    name: "apollo_router::http_subgraph::aggregate_response_data"
+    record:
+      entries: []
+      metadata:
+        name: aggregate_response_data
+        target: "apollo_router::http_subgraph"
+        level: DEBUG
+        module_path: "apollo_router::http_subgraph"
+        fields:
+          names: []
+    children: {}
+  "apollo_router::http_subgraph::parse_subgraph_response":
+    name: "apollo_router::http_subgraph::parse_subgraph_response"
+    record:
+      entries: []
+      metadata:
+        name: parse_subgraph_response
+        target: "apollo_router::http_subgraph"
+        level: DEBUG
+        module_path: "apollo_router::http_subgraph"
+        fields:
+          names: []
+    children: {}
+

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
@@ -4,294 +4,212 @@ assertion_line: 78
 expression: get_spans()
 
 ---
-{
-  "name": "integration_tests::root",
-  "record": {
-    "entries": [],
-    "metadata": {
-      "name": "root",
-      "target": "integration_tests",
-      "level": "INFO",
-      "module_path": "integration_tests",
-      "fields": {
-        "names": []
-      }
-    }
-  },
-  "children": {
-    "apollo_router::apollo_router::prepare_query": {
-      "name": "apollo_router::apollo_router::prepare_query",
-      "record": {
-        "entries": [
-          [
-            "message",
-            "query plan\nQueryPlan {\n    root: Fetch(\n        FetchNode {\n            service_name: \"products\",\n            requires: [],\n            variable_usages: [],\n            operation: \"{topProducts{name name2:name}}\",\n        },\n    ),\n}"
-          ]
-        ],
-        "metadata": {
-          "name": "prepare_query",
-          "target": "apollo_router::apollo_router",
-          "level": "DEBUG",
-          "module_path": "apollo_router::apollo_router",
-          "fields": {
-            "names": []
-          }
-        }
-      },
-      "children": {
-        "apollo_router::apollo_router::query_parsing": {
-          "name": "apollo_router::apollo_router::query_parsing",
-          "record": {
-            "entries": [],
-            "metadata": {
-              "name": "query_parsing",
-              "target": "apollo_router::apollo_router",
-              "level": "INFO",
-              "module_path": "apollo_router::apollo_router",
-              "fields": {
-                "names": []
-              }
-            }
-          },
-          "children": {}
-        },
-        "apollo_router_core::query_planner::router_bridge_query_planner::plan": {
-          "name": "apollo_router_core::query_planner::router_bridge_query_planner::plan",
-          "record": {
-            "entries": [],
-            "metadata": {
-              "name": "plan",
-              "target": "apollo_router_core::query_planner::router_bridge_query_planner",
-              "level": "DEBUG",
-              "module_path": "apollo_router_core::query_planner::router_bridge_query_planner",
-              "fields": {
-                "names": []
-              }
-            }
-          },
-          "children": {}
-        },
-        "apollo_router_core::query_planner::validate": {
-          "name": "apollo_router_core::query_planner::validate",
-          "record": {
-            "entries": [],
-            "metadata": {
-              "name": "validate",
-              "target": "apollo_router_core::query_planner",
-              "level": "DEBUG",
-              "module_path": "apollo_router_core::query_planner",
-              "fields": {
-                "names": []
-              }
-            }
-          },
-          "children": {}
-        }
-      }
-    },
-    "apollo_router::apollo_router::execute": {
-      "name": "apollo_router::apollo_router::execute",
-      "record": {
-        "entries": [],
-        "metadata": {
-          "name": "execute",
-          "target": "apollo_router::apollo_router",
-          "level": "DEBUG",
-          "module_path": "apollo_router::apollo_router",
-          "fields": {
-            "names": []
-          }
-        }
-      },
-      "children": {
-        "apollo_router::apollo_router::execution": {
-          "name": "apollo_router::apollo_router::execution",
-          "record": {
-            "entries": [],
-            "metadata": {
-              "name": "execution",
-              "target": "apollo_router::apollo_router",
-              "level": "INFO",
-              "module_path": "apollo_router::apollo_router",
-              "fields": {
-                "names": []
-              }
-            }
-          },
-          "children": {
-            "apollo_router_core::query_planner::fetch": {
-              "name": "apollo_router_core::query_planner::fetch",
-              "record": {
-                "entries": [],
-                "metadata": {
-                  "name": "fetch",
-                  "target": "apollo_router_core::query_planner",
-                  "level": "INFO",
-                  "module_path": "apollo_router_core::query_planner",
-                  "fields": {
-                    "names": []
-                  }
-                }
-              },
-              "children": {
-                "apollo_router_core::query_planner::fetch::subfetch": {
-                  "name": "apollo_router_core::query_planner::fetch::subfetch",
-                  "record": {
-                    "entries": [
-                      [
-                        "service",
-                        "products"
-                      ]
-                    ],
-                    "metadata": {
-                      "name": "subfetch",
-                      "target": "apollo_router_core::query_planner::fetch",
-                      "level": "INFO",
-                      "module_path": "apollo_router_core::query_planner::fetch",
-                      "fields": {
-                        "names": [
-                          "service"
-                        ]
-                      }
-                    }
-                  },
-                  "children": {
-                    "apollo_router_core::query_planner::fetch::make_variables": {
-                      "name": "apollo_router_core::query_planner::fetch::make_variables",
-                      "record": {
-                        "entries": [],
-                        "metadata": {
-                          "name": "make_variables",
-                          "target": "apollo_router_core::query_planner::fetch",
-                          "level": "DEBUG",
-                          "module_path": "apollo_router_core::query_planner::fetch",
-                          "fields": {
-                            "names": []
-                          }
-                        }
-                      },
-                      "children": {}
-                    },
-                    "apollo_router_core::query_planner::fetch::subfetch_stream": {
-                      "name": "apollo_router_core::query_planner::fetch::subfetch_stream",
-                      "record": {
-                        "entries": [],
-                        "metadata": {
-                          "name": "subfetch_stream",
-                          "target": "apollo_router_core::query_planner::fetch",
-                          "level": "INFO",
-                          "module_path": "apollo_router_core::query_planner::fetch",
-                          "fields": {
-                            "names": []
-                          }
-                        }
-                      },
-                      "children": {
-                        "apollo_router::http_subgraph::aggregate_response_data": {
-                          "name": "apollo_router::http_subgraph::aggregate_response_data",
-                          "record": {
-                            "entries": [],
-                            "metadata": {
-                              "name": "aggregate_response_data",
-                              "target": "apollo_router::http_subgraph",
-                              "level": "DEBUG",
-                              "module_path": "apollo_router::http_subgraph",
-                              "fields": {
-                                "names": []
-                              }
-                            }
-                          },
-                          "children": {}
-                        },
-                        "apollo_router::http_subgraph::parse_subgraph_response": {
-                          "name": "apollo_router::http_subgraph::parse_subgraph_response",
-                          "record": {
-                            "entries": [],
-                            "metadata": {
-                              "name": "parse_subgraph_response",
-                              "target": "apollo_router::http_subgraph",
-                              "level": "DEBUG",
-                              "module_path": "apollo_router::http_subgraph",
-                              "fields": {
-                                "names": []
-                              }
-                            }
-                          },
-                          "children": {}
-                        }
-                      }
-                    },
-                    "apollo_router_core::query_planner::fetch::response_insert": {
-                      "name": "apollo_router_core::query_planner::fetch::response_insert",
-                      "record": {
-                        "entries": [],
-                        "metadata": {
-                          "name": "response_insert",
-                          "target": "apollo_router_core::query_planner::fetch",
-                          "level": "DEBUG",
-                          "module_path": "apollo_router_core::query_planner::fetch",
-                          "fields": {
-                            "names": []
-                          }
-                        }
-                      },
-                      "children": {}
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "apollo_router::apollo_router::format_response": {
-          "name": "apollo_router::apollo_router::format_response",
-          "record": {
-            "entries": [],
-            "metadata": {
-              "name": "format_response",
-              "target": "apollo_router::apollo_router",
-              "level": "DEBUG",
-              "module_path": "apollo_router::apollo_router",
-              "fields": {
-                "names": []
-              }
-            }
-          },
-          "children": {}
-        }
-      }
-    },
-    "apollo_router::http_subgraph::aggregate_response_data": {
-      "name": "apollo_router::http_subgraph::aggregate_response_data",
-      "record": {
-        "entries": [],
-        "metadata": {
-          "name": "aggregate_response_data",
-          "target": "apollo_router::http_subgraph",
-          "level": "DEBUG",
-          "module_path": "apollo_router::http_subgraph",
-          "fields": {
-            "names": []
-          }
-        }
-      },
-      "children": {}
-    },
-    "apollo_router::http_subgraph::parse_subgraph_response": {
-      "name": "apollo_router::http_subgraph::parse_subgraph_response",
-      "record": {
-        "entries": [],
-        "metadata": {
-          "name": "parse_subgraph_response",
-          "target": "apollo_router::http_subgraph",
-          "level": "DEBUG",
-          "module_path": "apollo_router::http_subgraph",
-          "fields": {
-            "names": []
-          }
-        }
-      },
-      "children": {}
-    }
-  }
-}
+name: "integration_tests::root"
+record:
+  entries: []
+  metadata:
+    name: root
+    target: integration_tests
+    level: INFO
+    module_path: integration_tests
+    fields:
+      names: []
+children:
+  "apollo_router::apollo_router::prepare_query":
+    name: "apollo_router::apollo_router::prepare_query"
+    record:
+      entries:
+        - - message
+          - "query plan\nQueryPlan {\n    root: Fetch(\n        FetchNode {\n            service_name: \"products\",\n            requires: [],\n            variable_usages: [],\n            operation: \"{topProducts{name name2:name}}\",\n        },\n    ),\n}"
+      metadata:
+        name: prepare_query
+        target: "apollo_router::apollo_router"
+        level: DEBUG
+        module_path: "apollo_router::apollo_router"
+        fields:
+          names: []
+    children:
+      "apollo_router::apollo_router::query_parsing":
+        name: "apollo_router::apollo_router::query_parsing"
+        record:
+          entries: []
+          metadata:
+            name: query_parsing
+            target: "apollo_router::apollo_router"
+            level: INFO
+            module_path: "apollo_router::apollo_router"
+            fields:
+              names: []
+        children: {}
+      "apollo_router_core::query_planner::router_bridge_query_planner::plan":
+        name: "apollo_router_core::query_planner::router_bridge_query_planner::plan"
+        record:
+          entries: []
+          metadata:
+            name: plan
+            target: "apollo_router_core::query_planner::router_bridge_query_planner"
+            level: DEBUG
+            module_path: "apollo_router_core::query_planner::router_bridge_query_planner"
+            fields:
+              names: []
+        children: {}
+      "apollo_router_core::query_planner::validate":
+        name: "apollo_router_core::query_planner::validate"
+        record:
+          entries: []
+          metadata:
+            name: validate
+            target: "apollo_router_core::query_planner"
+            level: DEBUG
+            module_path: "apollo_router_core::query_planner"
+            fields:
+              names: []
+        children: {}
+  "apollo_router::apollo_router::execute":
+    name: "apollo_router::apollo_router::execute"
+    record:
+      entries: []
+      metadata:
+        name: execute
+        target: "apollo_router::apollo_router"
+        level: DEBUG
+        module_path: "apollo_router::apollo_router"
+        fields:
+          names: []
+    children:
+      "apollo_router::apollo_router::execution":
+        name: "apollo_router::apollo_router::execution"
+        record:
+          entries: []
+          metadata:
+            name: execution
+            target: "apollo_router::apollo_router"
+            level: INFO
+            module_path: "apollo_router::apollo_router"
+            fields:
+              names: []
+        children:
+          "apollo_router_core::query_planner::fetch":
+            name: "apollo_router_core::query_planner::fetch"
+            record:
+              entries: []
+              metadata:
+                name: fetch
+                target: "apollo_router_core::query_planner"
+                level: INFO
+                module_path: "apollo_router_core::query_planner"
+                fields:
+                  names: []
+            children:
+              "apollo_router_core::query_planner::fetch::subfetch":
+                name: "apollo_router_core::query_planner::fetch::subfetch"
+                record:
+                  entries:
+                    - - service
+                      - products
+                  metadata:
+                    name: subfetch
+                    target: "apollo_router_core::query_planner::fetch"
+                    level: INFO
+                    module_path: "apollo_router_core::query_planner::fetch"
+                    fields:
+                      names:
+                        - service
+                children:
+                  "apollo_router_core::query_planner::fetch::make_variables":
+                    name: "apollo_router_core::query_planner::fetch::make_variables"
+                    record:
+                      entries: []
+                      metadata:
+                        name: make_variables
+                        target: "apollo_router_core::query_planner::fetch"
+                        level: DEBUG
+                        module_path: "apollo_router_core::query_planner::fetch"
+                        fields:
+                          names: []
+                    children: {}
+                  "apollo_router_core::query_planner::fetch::subfetch_stream":
+                    name: "apollo_router_core::query_planner::fetch::subfetch_stream"
+                    record:
+                      entries: []
+                      metadata:
+                        name: subfetch_stream
+                        target: "apollo_router_core::query_planner::fetch"
+                        level: INFO
+                        module_path: "apollo_router_core::query_planner::fetch"
+                        fields:
+                          names: []
+                    children:
+                      "apollo_router::http_subgraph::aggregate_response_data":
+                        name: "apollo_router::http_subgraph::aggregate_response_data"
+                        record:
+                          entries: []
+                          metadata:
+                            name: aggregate_response_data
+                            target: "apollo_router::http_subgraph"
+                            level: DEBUG
+                            module_path: "apollo_router::http_subgraph"
+                            fields:
+                              names: []
+                        children: {}
+                      "apollo_router::http_subgraph::parse_subgraph_response":
+                        name: "apollo_router::http_subgraph::parse_subgraph_response"
+                        record:
+                          entries: []
+                          metadata:
+                            name: parse_subgraph_response
+                            target: "apollo_router::http_subgraph"
+                            level: DEBUG
+                            module_path: "apollo_router::http_subgraph"
+                            fields:
+                              names: []
+                        children: {}
+                  "apollo_router_core::query_planner::fetch::response_insert":
+                    name: "apollo_router_core::query_planner::fetch::response_insert"
+                    record:
+                      entries: []
+                      metadata:
+                        name: response_insert
+                        target: "apollo_router_core::query_planner::fetch"
+                        level: DEBUG
+                        module_path: "apollo_router_core::query_planner::fetch"
+                        fields:
+                          names: []
+                    children: {}
+      "apollo_router::apollo_router::format_response":
+        name: "apollo_router::apollo_router::format_response"
+        record:
+          entries: []
+          metadata:
+            name: format_response
+            target: "apollo_router::apollo_router"
+            level: DEBUG
+            module_path: "apollo_router::apollo_router"
+            fields:
+              names: []
+        children: {}
+  "apollo_router::http_subgraph::aggregate_response_data":
+    name: "apollo_router::http_subgraph::aggregate_response_data"
+    record:
+      entries: []
+      metadata:
+        name: aggregate_response_data
+        target: "apollo_router::http_subgraph"
+        level: DEBUG
+        module_path: "apollo_router::http_subgraph"
+        fields:
+          names: []
+    children: {}
+  "apollo_router::http_subgraph::parse_subgraph_response":
+    name: "apollo_router::http_subgraph::parse_subgraph_response"
+    record:
+      entries: []
+      metadata:
+        name: parse_subgraph_response
+        target: "apollo_router::http_subgraph"
+        level: DEBUG
+        module_path: "apollo_router::http_subgraph"
+        fields:
+          names: []
+    children: {}
+


### PR DESCRIPTION
this makes deeply nested spans easier to follow