### PR TITLE
chore: use router bridge from federation-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -938,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.112.0"
+version = "0.118.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b0a532994e7d5ddfc029a33a67709c91e6c8926b97e4825e4d3056ee11abfc"
+checksum = "68be6990e070141d1413797b84d8a05d3eb426fa18a9962ecf21d2f045014db4"
 dependencies = [
  "anyhow",
  "futures",
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation.git?rev=950eb931e38746bb7cfed05382d6970a22e43cc4#950eb931e38746bb7cfed05382d6970a22e43cc4"
+source = "git+https://github.com/apollographql/federation-rs.git?rev=14ad25067091e9114d9abae03181604b8baeea6b#14ad25067091e9114d9abae03181604b8baeea6b"
 dependencies = [
  "anyhow",
  "deno_core",
@@ -3194,9 +3194,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.23.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487456399b8722492bdc4c1834397f91c935247590dae30f8e779b7f48e3181a"
+checksum = "27266c014ef9b11fcf7f1a248f25603529432aab4d0ce777d6c6f6aea2b367bb"
 dependencies = [
  "serde",
  "serde_bytes",
@@ -4101,9 +4101,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "0.36.0"
+version = "0.38.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "506523e86ccc15982be412bdde87a142771c139e94a8ecedda1da051a079b81d"
+checksum = "684e95fe02e0acfeaf630df3a1623f6ad02145f9a92c54ceae8a1923319d3273"
 dependencies = [
  "bitflags",
  "fslock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation-rs.git?rev=14ad25067091e9114d9abae03181604b8baeea6b#14ad25067091e9114d9abae03181604b8baeea6b"
+source = "git+https://github.com/apollographql/federation-rs.git?branch=igni/build_on_windows#4a9ce778179daf34007514c66e11df4c9196ebcb"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation-rs.git?rev=e72e470fa82f9edd2fc4089e6b30246d50ce5fff#e72e470fa82f9edd2fc4089e6b30246d50ce5fff"
+source = "git+https://github.com/apollographql/federation-rs.git?rev=6f1a7033d03ff7310644d033508256dcf759a602#6f1a7033d03ff7310644d033508256dcf759a602"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation-rs.git?branch=igni/build_on_windows#4a9ce778179daf34007514c66e11df4c9196ebcb"
+source = "git+https://github.com/apollographql/federation-rs.git?rev=e72e470fa82f9edd2fc4089e6b30246d50ce5fff#e72e470fa82f9edd2fc4089e6b30246d50ce5fff"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -24,7 +24,7 @@ include_dir = "0.7.2"
 lru = "0.7.2"
 miette = { version = "3.3.0", features = ["fancy"] }
 once_cell = "1.9.0"
-router-bridge = { git = "https://github.com/apollographql/federation.git", rev = "950eb931e38746bb7cfed05382d6970a22e43cc4" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "14ad25067091e9114d9abae03181604b8baeea6b" }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.78", features = ["preserve_order"] }
 serde_json_bytes = { version = "0.2.0", features = ["preserve_order"]}

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -24,7 +24,7 @@ include_dir = "0.7.2"
 lru = "0.7.2"
 miette = { version = "3.3.0", features = ["fancy"] }
 once_cell = "1.9.0"
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "14ad25067091e9114d9abae03181604b8baeea6b" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", branch = "igni/build_on_windows" }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.78", features = ["preserve_order"] }
 serde_json_bytes = { version = "0.2.0", features = ["preserve_order"]}

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -24,7 +24,7 @@ include_dir = "0.7.2"
 lru = "0.7.2"
 miette = { version = "3.3.0", features = ["fancy"] }
 once_cell = "1.9.0"
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "e72e470fa82f9edd2fc4089e6b30246d50ce5fff" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "6f1a7033d03ff7310644d033508256dcf759a602" }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.78", features = ["preserve_order"] }
 serde_json_bytes = { version = "0.2.0", features = ["preserve_order"] }

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -24,10 +24,10 @@ include_dir = "0.7.2"
 lru = "0.7.2"
 miette = { version = "3.3.0", features = ["fancy"] }
 once_cell = "1.9.0"
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", branch = "igni/build_on_windows" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "e72e470fa82f9edd2fc4089e6b30246d50ce5fff" }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.78", features = ["preserve_order"] }
-serde_json_bytes = { version = "0.2.0", features = ["preserve_order"]}
+serde_json_bytes = { version = "0.2.0", features = ["preserve_order"] }
 thiserror = "1.0.30"
 tokio = { version = "1.16.1", features = ["rt"] }
 tracing = "0.1.30"


### PR DESCRIPTION
Iterating on avery's great work moving the rust parts of federation to a separate repository, we can now target the recently public federation-rs repository, which this commit achieves.