### PR TITLE
chore: merge apollo-rs main back to branch garypen/66-usage-agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,17 +69,17 @@ checksum = "94a45b455c14666b85fc40a019e8ab9eb75e3a124e05494f5397122bc9eb06e0"
 
 [[package]]
 name = "apollo-parser"
-version = "0.2.0"
-source = "git+https://github.com/apollographql/apollo-rs.git?rev=ff317c7e85165bb6c380284b63c55d8af877fb7b#ff317c7e85165bb6c380284b63c55d8af877fb7b"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22f151e7fd55b164af009ae0e62893a40cf159ce73d23c11a6d708749030865"
 dependencies = [
  "rowan",
 ]
 
 [[package]]
 name = "apollo-parser"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b22f151e7fd55b164af009ae0e62893a40cf159ce73d23c11a6d708749030865"
+version = "0.2.2"
+source = "git+https://github.com/apollographql/apollo-rs.git?rev=9a14371f3e5352920c74dcae85fa4e71b24f0449#9a14371f3e5352920c74dcae85fa4e71b24f0449"
 dependencies = [
  "rowan",
 ]
@@ -89,7 +89,7 @@ name = "apollo-router"
 version = "0.1.0-alpha.4"
 dependencies = [
  "anyhow",
- "apollo-parser 0.2.0",
+ "apollo-parser 0.2.2",
  "apollo-router-core",
  "apollo-spaceport",
  "async-trait",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -25,7 +25,7 @@ otlp-http = ["opentelemetry-otlp/http-proto"]
 
 [dependencies]
 anyhow = "1.0.53"
-apollo-parser = { git = "https://github.com/apollographql/apollo-rs.git", rev = "ff317c7e85165bb6c380284b63c55d8af877fb7b" }
+apollo-parser = { git = "https://github.com/apollographql/apollo-rs.git", rev = "9a14371f3e5352920c74dcae85fa4e71b24f0449" }
 apollo-router-core = { path = "../apollo-router-core" }
 async-trait = "0.1.52"
 atty = "0.2.14"

--- a/apollo-router/src/apollo_telemetry.rs
+++ b/apollo-router/src/apollo_telemetry.rs
@@ -633,7 +633,7 @@ mod test {
 
     #[test]
     fn it_handles_default_name() {
-        let expected = "# -\nquery ($limit: Int) { products(limit: $limit) { upc, name, price } }";
+        let expected = "# -\nquery ($limit: Int!) { products(limit: $limit) { upc, name, price } }";
         let op_name = Value::String("-".into());
         let query = "query ($limit: Int!) {\n  products(limit: $limit) {\n    upc,\n    name,\n    price\n  }\n}";
 
@@ -654,7 +654,7 @@ mod test {
     #[test]
     fn it_handles_query_specified_name() {
         let expected =
-            "# OneProduct\nquery OneProduct($limit: Int) { products(limit: $limit) { upc, name, price } }";
+            "# OneProduct\nquery OneProduct($limit: Int!) { products(limit: $limit) { upc, name, price } }";
         let op_name = Value::String("-".into());
         let query = "query OneProduct($limit: Int!) {\n  products(limit: $limit) {\n    upc,\n    name,\n    price\n  }\n}";
 
@@ -665,7 +665,7 @@ mod test {
     #[test]
     fn it_handles_same_out_of_band_and_query_specified_name() {
         let expected =
-            "# OneProduct\nquery OneProduct($limit: Int) { products(limit: $limit) { upc, name, price } }";
+            "# OneProduct\nquery OneProduct($limit: Int!) { products(limit: $limit) { upc, name, price } }";
         let op_name = Value::String("OneProduct".into());
         let query = "query OneProduct($limit: Int!) {\n  products(limit: $limit) {\n    upc,\n    name,\n    price\n  }\n}";
 


### PR DESCRIPTION
This updates the router to depend on apollo-rs branch which was just
updated to main.

The test change is due to the improved GraphQL spec compliance in
apollo-rs.

closes: #454 