### PR TITLE
filter paths with values

### DIFF
--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -265,24 +265,25 @@ mod fetch {
 
                 let mut paths = Vec::new();
                 let mut values = Vec::new();
-                data.select_values_and_paths(current_dir, |_path, value| {
-                    paths.push(_path);
-                    values.push(value)
-                })?;
-
-                let representations = Value::Array(
-                    values
-                        .into_iter()
-                        .flat_map(|value| match value {
-                            Value::Object(content) => {
-                                select_object(content, requires, schema).transpose()
+                data.select_values_and_paths(current_dir, |path, value| {
+                    match value {
+                        Value::Object(content) => {
+                            let object = select_object(content, requires, schema)?;
+                            if let Some(value) = object {
+                                paths.push(path);
+                                values.push(value)
                             }
-                            _ => Some(Err(FetchError::ExecutionInvalidContent {
+                        }
+                        _ => {
+                            return Err(FetchError::ExecutionInvalidContent {
                                 reason: "not an object".to_string(),
-                            })),
-                        })
-                        .collect::<Result<Vec<_>, _>>()?,
-                );
+                            })
+                        }
+                    }
+                    Ok(())
+                })?;
+                let representations = Value::Array(values);
+
                 variables.insert("representations", representations);
 
                 Ok(Variables { variables, paths })

--- a/apollo-router-core/src/query_planner/selection.rs
+++ b/apollo-router-core/src/query_planner/selection.rs
@@ -127,7 +127,10 @@ mod tests {
         let mut values = Vec::new();
         response
             .data
-            .select_values_and_paths(path, |_path, value| values.push(value))?;
+            .select_values_and_paths(path, |_path, value| {
+                values.push(value);
+                Ok(())
+            })?;
 
         Ok(Value::Array(
             values


### PR DESCRIPTION
Fix #451 

in the query plan's fetch nodes, for entities queries, we must create a list of
variables and paths at which they must be inserted in the final
response. In the previous version of the code, we were creating both
lists, then filtering the values depending on the query.

In the case where the entities are different types implementing the same
interface, provided by different subgraphs, we could have the
following query:

```graphql
query {
  nodes(ids: ["UHJvZHVjdDox", "UmV2aWV3OjI="]) {
    id
    ... on Product {
      name
    }
    ... on Review {
      body
    }
  }
}
```

We would get the response

```json
[
  { "__typename": "Product", "id": "UHJvZHVjdDox"},
  {"__typename": "Review", "id": "UmV2aWV3OjI="}
]
```

This would make a subquery to the products subgraph, and one to the
review subgraph.

The failing code was generating for the reviews query a list of paths
for the indexes 0 and 1 in that array, and both values, then
filtering the list to only keep `{"__typename": "Review", "id":
"UmV2aWV3OjI="}`

When returning the response, it would be inserted at the index 0, in the
product entity.

This commit fixes variable creation to filter both path and value at the
same time
