### PR TITLE
apollo-router tracing-subscriber features are missing "env-filter"

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -66,7 +66,7 @@ tower-http = { version = "0.2.2", features = ["trace"] }
 tracing = "0.1.30"
 tracing-futures = "0.2.5"
 tracing-opentelemetry = "0.16.0"
-tracing-subscriber = { version = "0.3.8", features = ["json"] }
+tracing-subscriber = { version = "0.3.8", features = ["env-filter", "json"] }
 
 typed-builder = "0.9.1"
 url = { version = "2.2.2", features = ["serde"] }


### PR DESCRIPTION
Add the "env-filter" feature to the Cargo.toml dependency.

fixes: #472 