### PR TITLE
fix(plugin): add required Deserialize trait bound on the plugin's config

### DIFF
--- a/apollo-router-core/src/plugin.rs
+++ b/apollo-router-core/src/plugin.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use once_cell::sync::Lazy;
 use schemars::gen::SchemaGenerator;
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{de::DeserializeOwned, Deserialize};
 use std::collections::HashMap;
 use std::sync::Mutex;
 use tower::util::BoxService;
@@ -60,7 +60,7 @@ pub fn plugins() -> HashMap<String, PluginFactory> {
 
 #[async_trait]
 pub trait Plugin: Send + Sync + 'static + Sized {
-    type Config: JsonSchema;
+    type Config: JsonSchema + DeserializeOwned;
 
     fn new(configuration: Self::Config) -> Result<Self, BoxError>;
 

--- a/licenses.html
+++ b/licenses.html
@@ -45,7 +45,7 @@
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
             <li><a href="#MIT">MIT License</a> (63)</li>
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (35)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (34)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (2)</li>
             <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a> (1)</li>
             <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a> (1)</li>
@@ -5948,14 +5948,6 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
-                </ul>
-                <pre class="license-text">../../LICENSE-APACHE</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi</a></li>
                 </ul>
                 <pre class="license-text">// Licensed under the Apache License, Version 2.0
@@ -6178,6 +6170,8 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
+                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
                     <li><a href=" https://crates.io/crates/apollo-router ">apollo-router</a></li>
                     <li><a href=" https://crates.io/crates/apollo-router-benchmarks ">apollo-router-benchmarks</a></li>
                     <li><a href=" https://crates.io/crates/apollo-router-core ">apollo-router-core</a></li>


### PR DESCRIPTION
Quick fix to provide a better diagnostic error from the compiler. The `Deserialize` trait for the plugin's config is needed because when you're registering a plugin it uses `let plugin = $value::new(serde_json::from_value(configuration.clone())?)?;`  then I think the experience is better to directly have feedbacks from compiler on the Config trait bound instead of a weird error coming from the `register_plugin` macro.