### PR TITLE
docs: Configuring headers sent to subgraphs

### DIFF
--- a/docs/source/configuration.mdx
+++ b/docs/source/configuration.mdx
@@ -235,6 +235,10 @@ There are a few specific layers which offer different header functionality:
 - **`headers_propagate`**
 
   This allows _selectively_ adding headers which were client-originated to the requests made to _specific_ subgraphs.
+  
+  > **Note:** The Router will _never_ propagate so-called [hop-by-hop headers].
+  
+  [hop-by-hop headers]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers, like `Content-length`
 
   They can be configured based on a `matching` pattern using [`regex`]:
 

--- a/docs/source/configuration.mdx
+++ b/docs/source/configuration.mdx
@@ -99,16 +99,27 @@ Apollo Router detects if the stdout is a TTY and enables JSON logging only if it
 
 ## Configuration file
 
-Apollo Router takes an optional YAML configuration file as input via the `--config` option. All supported configuration options are listed below:
+Apollo Router takes an **optional** YAML configuration file as input via the `--config` option. To show the full possibility of options, all supported configuration options are illustrated below:
 
 ```yaml:title=configuration.yaml
-# Configuration of the router's HTTP server
+#
+# The Apollo Router doesn't require a configuration file to run.  This
+# example is a verbose representation of possible configuration.  It's
+# more of an "everything and the kitchen sink" of potential configuration
+# rather than any recommendation.
+#
+
+#
+# server: Configuration of the HTTP server
+#
 server:
   # The socket address and port to listen on
   # Defaults to 127.0.0.1:4000
   listen: 127.0.0.1:4000
 
-  # Cross origin request headers
+  #
+  # CORS (Cross Origin Resource Sharing)
+  #
   cors:
     # Set to false to disallow any origin and rely exclusively on `origins`
     # Defaults to true
@@ -124,30 +135,175 @@ server:
     # Allowed request methods
     # Defaults to GET, POST, OPTIONS.
     methods: [ GET, POST, OPTIONS ]
-    # Which response headers should be made available to scripts running in the browser,
-    # in response to a cross-origin request.
+    # Which response headers should be made available to scripts running in the
+    # browser in response to a cross-origin request.
     expose_headers:
 
-# Names and URLs of all subgraphs
-# By default, this information is parsed from the supergraph schema
-# Provide it here to override subgraph names or URLs
+#
+# Subgraphs
+#
+# This configuration affects the communication with underlying subgraphs.
+# The `subgraphs` property is a map to individual named subgraphs and should
+# map to the subgraph name that is defined in the Supergraph.
+#
+# On each named subgraph of the subgraphs map, these properties can be set:
+#
+#  - routing_url
+#  - layers
+#
+# These are explained further below.
+#
+# * routing_url *
+#
+# The URL the Router should connect to for this subgraph.
+#
+# By default, routing information is parsed from the supergraph which is
+# typically sufficient for most environments and respects the settings which
+# you've set during composition in Apollo Studio or via Rover.  Provide it here
+# only to *override* the supergraph's subgraph routing URLs.
+#
+#
+# * layers *
+#
+# This is a map of configurable layers which will be invoked.
+#
+# Layers are features (either native or extensions) which can be enabled for
+# each subgraph.  Common layers are the "headers*" layers, and an example can be
+# found for below.  For more information, see later in the documentation.
+#
+
 subgraphs:
-  # Defines a subgraph named "accounts"
+  # Specifies the runtime configuration for talking to the "accounts" subgraph.
   accounts:
-    # The URL of the accounts subgraph's GraphQL endpoint
+    # The URL of the "accounts" subgraph's GraphQL endpoint
     routing_url: http://localhost:4001/graphql
-  # Defines a second subgraph named "products"
+
+    # Layers to be applied to the "accounts" subgraph.
+    layers:
+      - headers_propagate:
+          matching:
+            regex: ^upstream-header-.*
+      - headers_propagate:
+          named:
+            name: "old-name"
+            rename: "new-name"
+            default_value: "0"
+      - headers_propagate:
+          named:
+            name: "old-name"
+            rename: "new-name"
+            default_value: "0"
+      - headers_remove:
+          name: "x-legacy-account-id"
+      - headers_remove:
+          matching:
+            regex: ^x-deprecated.*
+      - headers_insert:
+          name: "router-subgraph-name"
+          value: "accounts"
+
+  # Specifies the runtime configuration for talking to the "products" subgraph.
   products:
+    # The URL of the "products" subgraph's GraphQL endpoint
     routing_url: http://localhost:4003/graphql
 
-# graph configuration, see later section
+    # Layers to be applied to the "products" subgraph.
+    layers:
+      - headers_insert:
+          name: "router-subgraph-name"
+          value: "products"
+      - headers_remove:
+          name: "x-legacy-tracking-id"
+
+
+# graph configuration, see documentation below
 # graph:
 
-# spaceport configuration, see later section
+# spaceport configuration, see documentation below
 # spaceport:
 
-# OpenTelemetry configuration, see next section
+# OpenTelemetry configuration, see documentation below
 # opentelemetry:
+```
+
+## Configuring headers received by subgraphs
+
+Passing headers is supported by leveraging pre-built functionality in the Router known as "layers".  They are therefore defined in the pipeline as members of the named `subgraphs` member (e.g., `reviews`, `products`; often, certain headers only go to certain services) and further defined within the `layers` array.  The `layers` are an array since they're applied in an ordered fashion and later layers may override a previous layer's actions.
+
+There are a few specific layers which offer different header functionality:
+
+- **`headers_propagate`**
+
+  This allows _selectively_ adding headers which were client-originated to the requests made to _specific_ subgraphs.
+
+  They can be configured based on a `matching` pattern using [`regex`]:
+
+  ```yaml
+      - headers_propagate:
+          matching:
+            regex: .*
+  ```
+
+  [`regex`]: https://docs.rs/regex/latest/regex/
+
+  Or by a static string using the `named` option.  These `named` configurations have additional flexibility since they can have either:
+
+  * `default_value`: A value to set in the event that one was not sent by the client.
+  * `rename`: Allow the header's key to be renamed to a new name.
+
+  Additionally, both `default_value` and `rename` can be paired together:
+
+  ```yaml
+      - headers_propagate:
+          named:
+            name: "foo"
+            default_value: "bar"
+            rename: "fii"
+          named:
+            name: "Authorization"
+
+- **`headers_remove`**
+
+  The `headers_remove` layer allows removing a header that was client-originated and not sending it to a specific subgraph.  In the same way as `headers_propagate` can match either exactly or based on a regular expression using [`regex`].
+
+  ```yaml
+      # Do not send this service the "Cookie" header.
+      - headers_remove:
+          name: "Cookie"
+      - headers_remove:
+          matching:
+            # Remove headers using the legacy 'x-' prefix.
+            regex: ^x-.*$
+  ```
+
+- **`headers_insert`**
+
+  The `headers_insert` layer allows adding a header to requests going to a specific subgraph.  In this case, this header is a static string that is originated in the router, rather than a header being sent from the client.
+
+  ```yaml
+      - headers_insert:
+          name: "sent-from-our-apollo-router"
+          value: "indeed"
+  ```
+
+In order to clearly see the hierarchy, here is an example of how two headers are configured for an `accounts` and a `products` subgraph.  These two subgraphs will both be sent `router-subgraph-name` headers with either the `accounts` or `products` value, respectively.  Any other subgraph will not receive any headers at all.
+
+```yaml
+subgraphs:
+  # These headers apply to the "accounts" subgraph only.
+  # They will not be passed to the "products" subgraph (below).
+  accounts:
+    layers:
+      - headers_insert:
+          name: "router-subgraph-name"
+          value: "accounts"
+  products:
+    # Layers to be applied to the "products" subgraph only.
+  # They will not be passed to the "accounts" subgraph (above).
+    layers:
+      - headers_insert:
+          name: "router-subgraph-name"
+          value: "products"
 ```
 
 ## Tracing

--- a/docs/source/configuration.mdx
+++ b/docs/source/configuration.mdx
@@ -270,6 +270,7 @@ There are a few specific layers which offer different header functionality:
 
   The `headers_remove` layer allows removing a header that was client-originated and not sending it to a specific subgraph.  In the same way as `headers_propagate` can match either exactly or based on a regular expression using [`regex`].
 
+> **Note:** The Router will _never_ remove so-called [hop-by-hop headers].
   ```yaml
       # Do not send this service the "Cookie" header.
       - headers_remove:


### PR DESCRIPTION
This follows up on https://github.com/apollographql/router/pull/453 with a
pass at the documentation.