### PR TITLE
spaceport listener should be more secure by default

### DIFF
--- a/apollo-router/src/apollo_telemetry.rs
+++ b/apollo-router/src/apollo_telemetry.rs
@@ -50,7 +50,7 @@ use tokio::task::JoinError;
 use crate::configuration::{SpaceportConfig, StudioGraph};
 
 pub(crate) const DEFAULT_SERVER_URL: &str = "https://127.0.0.1:50051";
-pub(crate) const DEFAULT_LISTEN: &str = "0.0.0.0:50051";
+pub(crate) const DEFAULT_LISTEN: &str = "127.0.0.1:50051";
 
 /// Pipeline builder
 #[derive(Debug)]

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -281,7 +281,7 @@ expression: "&schema"
           "type": "boolean"
         },
         "listener": {
-          "default": "0.0.0.0:50051",
+          "default": "127.0.0.1:50051",
           "type": "string"
         }
       },

--- a/apollo-spaceport/README.md
+++ b/apollo-spaceport/README.md
@@ -36,7 +36,7 @@ like this:
 spaceport:
   external: false
   collector: https://127.0.0.1:50051
-  listener: 0.0.0.0:50051
+  listener: 127.0.0.1:50051
 ```
 
 (The above values are the defaults, so configuring like this will have the same

--- a/apollo-spaceport/src/spaceport.rs
+++ b/apollo-spaceport/src/spaceport.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 use apollo_spaceport::server::ReportSpaceport;
 use clap::Parser;
 
-const DEFAULT_LISTEN: &str = "0.0.0.0:50051";
+const DEFAULT_LISTEN: &str = "127.0.0.1:50051";
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about, long_about = None)]

--- a/docs/source/configuration.mdx
+++ b/docs/source/configuration.mdx
@@ -307,7 +307,7 @@ spaceport:
 
   # For an internal spaceport instance (when `external` is `false`), what
   # interface and port should we listen on.
-  listener: 0.0.0.0:50051
+  listener: 127.0.0.1:50051
 ```
 
 #### Internal spaceport


### PR DESCRIPTION
Configure the listener to listen at 127.0.0.1 rather than 0.0.0.0 by
default.

fixes: #487

