### PR TITLE
fix(context): change context methods about extensions to avoid deadlock

### DIFF
--- a/apollo-router-core/src/context.rs
+++ b/apollo-router-core/src/context.rs
@@ -1,10 +1,9 @@
 use crate::prelude::graphql::*;
 use crate::services::http_compat;
-use futures::Future;
 use serde_json_bytes::ByteString;
 use std::hash::Hash;
 use std::{borrow::Borrow, sync::Arc};
-use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use tokio::sync::RwLock;
 
 #[derive(Clone, Debug)]
 pub struct Context<T = Arc<http_compat::Request<Request>>> {

--- a/apollo-router-core/src/context.rs
+++ b/apollo-router-core/src/context.rs
@@ -91,6 +91,14 @@ impl<T> Context<T> {
     {
         self.extensions.write().await.remove(k)
     }
+
+    pub async fn get_extension<Q>(&self, k: &Q) -> Option<Value>
+    where
+        ByteString: Borrow<Q>,
+        Q: ?Sized + Ord + Eq + Hash,
+    {
+        self.extensions.read().await.get(k).cloned()
+    }
 }
 
 impl Default for Context<()> {

--- a/apollo-router-core/src/context.rs
+++ b/apollo-router-core/src/context.rs
@@ -81,7 +81,7 @@ impl<T> Context<T> {
         self.extensions.write().await.insert(k, v)
     }
 
-    /// Inserts a key-value pair into extensions.
+    /// Removes a key-value pair from extensions.
     /// If extensions did not have this key present, None is returned.
     /// If extensions did have this key present, the value is updated, and the old value is returned.
     pub async fn remove_extension<Q>(&self, k: &Q) -> Option<Value>

--- a/apollo-router-core/src/context.rs
+++ b/apollo-router-core/src/context.rs
@@ -1,7 +1,9 @@
 use crate::prelude::graphql::*;
 use crate::services::http_compat;
 use futures::Future;
-use std::sync::Arc;
+use serde_json_bytes::ByteString;
+use std::hash::Hash;
+use std::{borrow::Borrow, sync::Arc};
 use tokio::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 #[derive(Clone, Debug)]
@@ -44,12 +46,50 @@ impl From<Context<http_compat::Request<Request>>> for Context<Arc<http_compat::R
 }
 
 impl<T> Context<T> {
-    pub fn extensions(&self) -> impl Future<Output = RwLockReadGuard<Object>> {
+    /// Take a read lock of extensions
+    /// Be careful when using this method, you could create deadlock if you use `lock_extensions_mut` in the same scope
+    pub fn lock_extensions(&self) -> impl Future<Output = RwLockReadGuard<Object>> {
         self.extensions.read()
     }
 
-    pub fn extensions_mut(&self) -> impl Future<Output = RwLockWriteGuard<Object>> {
+    /// Take a write lock of extensions
+    /// Be careful when using this method, you could create deadlock if you use `lock_extensions` in the same scope
+    pub fn lock_extensions_mut(&self) -> impl Future<Output = RwLockWriteGuard<Object>> {
         self.extensions.write()
+    }
+
+    pub async fn cloned_extensions(&self) -> Object {
+        self.extensions.read().await.clone()
+    }
+
+    pub async fn extensions_len(&self) -> usize {
+        self.extensions.read().await.len()
+    }
+
+    pub async fn is_extensions_empty(&self) -> bool {
+        self.extensions.read().await.is_empty()
+    }
+
+    pub async fn clear(&self) {
+        self.extensions.write().await.clear()
+    }
+
+    /// Inserts a key-value pair into extensions.
+    /// If extensions did not have this key present, None is returned.
+    /// If extensions did have this key present, the value is updated, and the old value is returned.
+    pub async fn insert_extension(&self, k: String, v: Value) -> Option<Value> {
+        self.extensions.write().await.insert(k, v)
+    }
+
+    /// Inserts a key-value pair into extensions.
+    /// If extensions did not have this key present, None is returned.
+    /// If extensions did have this key present, the value is updated, and the old value is returned.
+    pub async fn remove_extension<Q>(&self, k: &Q) -> Option<Value>
+    where
+        ByteString: Borrow<Q>,
+        Q: ?Sized + Ord + Eq + Hash,
+    {
+        self.extensions.write().await.remove(k)
     }
 }
 

--- a/apollo-router-core/src/context.rs
+++ b/apollo-router-core/src/context.rs
@@ -46,16 +46,8 @@ impl From<Context<http_compat::Request<Request>>> for Context<Arc<http_compat::R
 }
 
 impl<T> Context<T> {
-    /// Take a read lock of extensions
-    /// Be careful when using this method, you could create deadlock if you use `lock_extensions_mut` in the same scope
-    pub fn lock_extensions(&self) -> impl Future<Output = RwLockReadGuard<Object>> {
-        self.extensions.read()
-    }
-
-    /// Take a write lock of extensions
-    /// Be careful when using this method, you could create deadlock if you use `lock_extensions` in the same scope
-    pub fn lock_extensions_mut(&self) -> impl Future<Output = RwLockWriteGuard<Object>> {
-        self.extensions.write()
+    pub fn extensions(&self) -> Arc<RwLock<Object>> {
+        self.extensions.clone()
     }
 
     pub async fn cloned_extensions(&self) -> Object {

--- a/licenses.html
+++ b/licenses.html
@@ -45,7 +45,7 @@
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
             <li><a href="#MIT">MIT License</a> (64)</li>
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (36)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (37)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (2)</li>
             <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a> (1)</li>
             <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a> (1)</li>
@@ -6367,6 +6367,14 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
+                </ul>
+                <pre class="license-text">../../LICENSE-APACHE</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi</a></li>
                 </ul>
                 <pre class="license-text">// Licensed under the Apache License, Version 2.0
@@ -6589,7 +6597,6 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
                     <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
                     <li><a href=" https://crates.io/crates/apollo-router-benchmarks ">apollo-router-benchmarks</a></li>
                     <li><a href=" https://crates.io/crates/apollo-router-core ">apollo-router-core</a></li>


### PR DESCRIPTION
resolves #476

Renamed `extensions()` and `extensions_mut()` with a prefix `lock_` to let users know they are locking the resources
Add common methods to context for extensions to avoid as much as possible to use `lock_extensions()` and `lock_extensions_mut()`
