### PR TITLE
update to opentelemetry 0.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,7 +112,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
  "opentelemetry-otlp",
- "prost-types 0.9.0",
+ "prost-types",
  "reqwest",
  "reqwest-middleware",
  "reqwest-tracing",
@@ -131,7 +131,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util 0.7.0 (git+https://github.com/tokio-rs/tokio.git?rev=91b9850)",
- "tonic 0.5.2",
+ "tonic",
  "tower",
  "tower-http",
  "tower-service",
@@ -212,15 +212,15 @@ dependencies = [
  "bytes",
  "clap 3.0.14",
  "flate2",
- "prost 0.9.0",
- "prost-types 0.9.0",
+ "prost",
+ "prost-types",
  "reqwest",
  "serde",
  "serde_json",
  "sys-info",
  "tokio",
- "tonic 0.6.2",
- "tonic-build 0.6.2",
+ "tonic",
+ "tonic-build",
  "tracing",
  "tracing-subscriber",
  "uname",
@@ -1922,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "integer-encoding"
-version = "1.1.7"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
+checksum = "90c11140ffea82edce8dcd74137ce9324ec24b3cf0175fc9d7e29164da9915b8"
 
 [[package]]
 name = "iovec"
@@ -2533,12 +2533,15 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.16.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust.git?rev=6b3aa02aa#6b3aa02aab0bec980b738dd6b390ae94bc37ebca"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
- "futures",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
  "js-sys",
  "lazy_static",
  "percent-encoding",
@@ -2552,42 +2555,29 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50ceb0b0e8b75cb3e388a2571a807c8228dabc5d6670f317b6eb21301095373"
+checksum = "449048140ee61e28f57abe6e9975eedc1f3a29855c7407bd6c12b18578863379"
 dependencies = [
  "async-trait",
  "bytes",
- "futures-util",
  "http",
  "opentelemetry",
  "reqwest",
 ]
 
 [[package]]
-name = "opentelemetry-http"
-version = "0.5.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust.git?rev=6b3aa02aa#6b3aa02aab0bec980b738dd6b390ae94bc37ebca"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "opentelemetry",
-]
-
-[[package]]
 name = "opentelemetry-jaeger"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db22f492873ea037bc267b35a0e8e4fb846340058cb7c864efe3d0bf23684593"
+checksum = "f8c0b12cd9e3f9b35b52f6e0dac66866c519b26f424f4bbf96e3fe8bfbdc5229"
 dependencies = [
  "async-trait",
  "headers",
  "http",
  "lazy_static",
  "opentelemetry",
- "opentelemetry-http 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "opentelemetry-http",
  "opentelemetry-semantic-conventions",
  "reqwest",
  "thiserror",
@@ -2597,27 +2587,29 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.9.0"
-source = "git+https://github.com/open-telemetry/opentelemetry-rust.git?rev=6b3aa02aa#6b3aa02aab0bec980b738dd6b390ae94bc37ebca"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1a6ca9de4c8b00aa7f1a153bd76cb263287155cec642680d79d98706f3d28a"
 dependencies = [
  "async-trait",
  "futures",
+ "futures-util",
  "http",
  "opentelemetry",
- "opentelemetry-http 0.5.0 (git+https://github.com/open-telemetry/opentelemetry-rust.git?rev=6b3aa02aa)",
- "prost 0.8.0",
- "prost-build 0.8.0",
+ "opentelemetry-http",
+ "prost",
+ "prost-build",
  "serde",
  "thiserror",
- "tonic 0.5.2",
- "tonic-build 0.5.2",
+ "tonic",
+ "tonic-build",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffeac823339e8b0f27b961f4385057bf9f97f2863bc745bd015fd6091f2270e9"
+checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
 dependencies = [
  "opentelemetry",
 ]
@@ -2888,40 +2880,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5e2533f59d08fcf364fd374ebda0692a70bd6d7e66ef97f306f45c6c5d8020"
-dependencies = [
- "bytes",
- "prost-derive 0.8.0",
-]
-
-[[package]]
-name = "prost"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "444879275cb4fd84958b1a1d5420d15e6fcf7c235fe47f053c9c2a80aceb6001"
 dependencies = [
  "bytes",
- "prost-derive 0.9.0",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
-dependencies = [
- "bytes",
- "heck 0.3.3",
- "itertools",
- "log",
- "multimap",
- "petgraph 0.5.1",
- "prost 0.8.0",
- "prost-types 0.8.0",
- "tempfile",
- "which",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2937,24 +2901,11 @@ dependencies = [
  "log",
  "multimap",
  "petgraph 0.6.0",
- "prost 0.9.0",
- "prost-types 0.9.0",
+ "prost",
+ "prost-types",
  "regex",
  "tempfile",
  "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2972,22 +2923,12 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603bbd6394701d13f3f25aada59c7de9d35a6a5887cfc156181234a44002771b"
-dependencies = [
- "bytes",
- "prost 0.8.0",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534b7a0e836e3c482d2693070f982e39e7611da9695d4d1f5a4b186b51faef0a"
 dependencies = [
  "bytes",
- "prost 0.9.0",
+ "prost",
 ]
 
 [[package]]
@@ -3194,9 +3135,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08fe1a72661921ea08c6929537571b6c19295b4f279812073fbe074cd390f50"
+checksum = "3b58621b8223cfc85b63d38b8d335c69b96a666d9b7561aa30a3b070ce1df31c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3210,9 +3151,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-tracing"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89af431b8c46776b5071a9a739c2b5fadbed6be2c6158d1ac5f71c4da3d2261c"
+checksum = "03f32bd53de59d66d157bd974bafbb69fbb9e98f665d14218b5b991e7dba8d75"
 dependencies = [
  "async-trait",
  "opentelemetry",
@@ -3977,9 +3918,9 @@ dependencies = [
 
 [[package]]
 name = "thrift"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b"
+checksum = "b82ca8f46f95b3ce96081fe3dd89160fdea970c254bb72925255d1b62aae692e"
 dependencies = [
  "byteorder",
  "integer-encoding",
@@ -4148,38 +4089,6 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "796c5e1cd49905e65dd8e700d4cb1dffcbfdb4fc9d017de08c1a537afd83627c"
-dependencies = [
- "async-stream",
- "async-trait",
- "base64",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost 0.8.0",
- "prost-derive 0.8.0",
- "tokio",
- "tokio-rustls",
- "tokio-stream",
- "tokio-util 0.6.9",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
- "tracing-futures",
-]
-
-[[package]]
-name = "tonic"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
@@ -4197,9 +4106,10 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.9.0",
- "prost-derive 0.9.0",
+ "prost",
+ "prost-derive",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util 0.6.9",
  "tower",
@@ -4211,24 +4121,12 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12b52d07035516c2b74337d2ac7746075e7dcae7643816c1b12c5ff8a7484c08"
-dependencies = [
- "proc-macro2",
- "prost-build 0.8.0",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tonic-build"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9403f1bafde247186684b230dc6f38b5cd514584e8bec1dd32514be4745fa757"
 dependencies = [
  "proc-macro2",
- "prost-build 0.9.0",
+ "prost-build",
  "quote",
  "syn",
 ]
@@ -4355,9 +4253,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ffbf13a0f8b054a4e59df3a173b818e9c6177c02789871f2073977fd0062076"
+checksum = "a73d0f08e0d227c4c63e6d003804946767f4c4f01f52098b56821ae22e336bfc"
 dependencies = [
  "opentelemetry",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -130,7 +130,7 @@ dependencies = [
  "test-span",
  "thiserror",
  "tokio",
- "tokio-util 0.7.0 (git+https://github.com/tokio-rs/tokio.git?rev=91b9850)",
+ "tokio-util 0.7.0",
  "tonic",
  "tower",
  "tower-http",
@@ -3966,7 +3966,8 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 [[package]]
 name = "tokio"
 version = "1.16.1"
-source = "git+https://github.com/tokio-rs/tokio.git?rev=91b9850#91b98505059017808221aa6432aa7437b7100497"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c27a64b625de6d309e8c57716ba93021dccf1b3b5c97edd6d3dd2d2135afc0a"
 dependencies = [
  "bytes",
  "libc",
@@ -3994,7 +3995,8 @@ dependencies = [
 [[package]]
 name = "tokio-macros"
 version = "1.7.0"
-source = "git+https://github.com/tokio-rs/tokio.git?rev=91b9850#91b98505059017808221aa6432aa7437b7100497"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4075,19 +4077,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.0"
-source = "git+https://github.com/tokio-rs/tokio.git?rev=91b9850#91b98505059017808221aa6432aa7437b7100497"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tonic"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4145,7 +4134,7 @@ dependencies = [
  "rand",
  "slab",
  "tokio",
- "tokio-util 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-util 0.7.0",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,5 @@ members = [
 ]
 
 [patch.crates-io]
-opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "6b3aa02aa" }
-opentelemetry-otlp = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "6b3aa02aa" }
 # TODO wait for tokio-util > 0.6.9 to release
 tokio = { git = "https://github.com/tokio-rs/tokio.git", rev = "91b9850" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,3 @@ members = [
     "xtask",
 ]
 
-[patch.crates-io]
-# TODO wait for tokio-util > 0.6.9 to release
-tokio = { git = "https://github.com/tokio-rs/tokio.git", rev = "91b9850" }

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -64,8 +64,7 @@ task-local-extensions = "0.1.1"
 thiserror = "1.0.30"
 tokio = { version = "1.16.1", features = ["full"] }
 # TODO wait for tokio-util > 0.6.9 to release
-tokio-util = { git = "https://github.com/tokio-rs/tokio.git", rev = "91b9850", features = ["net", "codec"] }
-# don't bump it to 0.6 until opentelemetry-otlp does
+tokio-util = { version = "0.7.0", features = ["net", "codec"] }
 tonic = { version = "0.6.0", optional = true }
 tower = { version="0.4.12", features = ["util"] }
 tower-http = { version = "0.2.3", features = ["trace"] }

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -63,7 +63,6 @@ structopt = "0.3.26"
 task-local-extensions = "0.1.1"
 thiserror = "1.0.30"
 tokio = { version = "1.16.1", features = ["full"] }
-# TODO wait for tokio-util > 0.6.9 to release
 tokio-util = { version = "0.7.0", features = ["net", "codec"] }
 tonic = { version = "0.6.0", optional = true }
 tower = { version="0.4.12", features = ["util"] }

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -40,19 +40,19 @@ hotwatch = "0.4.6"
 http = "0.2.6"
 hyper = { version = "0.14.17", features = ["server"] }
 once_cell = "1.9.0"
-opentelemetry = { version = "0.16.0", features = ["rt-tokio", "serialize"] }
-opentelemetry-jaeger = { version = "0.15.0", features = [
+opentelemetry = { version = "0.17.0", features = ["rt-tokio", "serialize"] }
+opentelemetry-jaeger = { version = "0.16.0", features = [
     "collector_client",
     "reqwest_collector_client",
     "rt-tokio",
 ] }
-opentelemetry-otlp = { version = "0.9.0", default-features = false, features = [
+opentelemetry-otlp = { version = "0.10.0", default-features = false, features = [
     "serialize",
 ], optional = true }
 prost-types = "0.9.0"
 reqwest = { version = "0.11.9", features = ["json", "stream"] }
 reqwest-middleware = "0.1.4"
-reqwest-tracing = { version = "0.2", features = ["opentelemetry_0_16"] }
+reqwest-tracing = { version = "0.2.1", features = ["opentelemetry_0_17"] }
 schemars = { version="0.8.8", features = ["url"] }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = "1.0.79"
@@ -66,12 +66,12 @@ tokio = { version = "1.16.1", features = ["full"] }
 # TODO wait for tokio-util > 0.6.9 to release
 tokio-util = { git = "https://github.com/tokio-rs/tokio.git", rev = "91b9850", features = ["net", "codec"] }
 # don't bump it to 0.6 until opentelemetry-otlp does
-tonic = { version = "0.5.2", optional = true }
+tonic = { version = "0.6.0", optional = true }
 tower = { version="0.4.12", features = ["util"] }
 tower-http = { version = "0.2.3", features = ["trace"] }
 tower-service = "0.3.1"
 tracing = "0.1.31"
-tracing-opentelemetry = "0.16.0"
+tracing-opentelemetry = "0.17.0"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter", "json"] }
 typed-builder = "0.9.1"
 url = { version = "2.2.2", features = ["serde"] }

--- a/apollo-router/src/apollo_telemetry.rs
+++ b/apollo-router/src/apollo_telemetry.rs
@@ -157,7 +157,11 @@ impl PipelineBuilder {
         }
         let provider = provider_builder.build();
 
-        let tracer = provider.tracer("apollo-opentelemetry", Some(env!("CARGO_PKG_VERSION")));
+        let tracer = provider.versioned_tracer(
+            "apollo-opentelemetry",
+            Some(env!("CARGO_PKG_VERSION")),
+            None,
+        );
         // This code will hang unless we execute from a separate
         // thread.  See:
         // https://github.com/apollographql/router/issues/331
@@ -186,7 +190,11 @@ impl PipelineBuilder {
         }
         let provider = provider_builder.build();
 
-        let tracer = provider.tracer("apollo-opentelemetry", Some(env!("CARGO_PKG_VERSION")));
+        let tracer = provider.versioned_tracer(
+            "apollo-opentelemetry",
+            Some(env!("CARGO_PKG_VERSION")),
+            None,
+        );
         let _prev_global_provider = global::set_tracer_provider(provider);
 
         Ok(tracer)

--- a/apollo-router/src/trace.rs
+++ b/apollo-router/src/trace.rs
@@ -97,7 +97,11 @@ pub(crate) fn try_initialize_subscriber(
 
             let provider = builder.with_span_processor(batch).build();
 
-            let tracer = provider.tracer("opentelemetry-jaeger", Some(env!("CARGO_PKG_VERSION")));
+            let tracer = provider.versioned_tracer(
+                "opentelemetry-jaeger",
+                Some(env!("CARGO_PKG_VERSION")),
+                None,
+            );
 
             // This code will hang unless we execute from a separate
             // thread.  See:

--- a/licenses.html
+++ b/licenses.html
@@ -44,7 +44,7 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#MIT">MIT License</a> (64)</li>
+            <li><a href="#MIT">MIT License</a> (65)</li>
             <li><a href="#Apache-2.0">Apache License 2.0</a> (36)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (2)</li>
             <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a> (1)</li>
@@ -4609,8 +4609,7 @@ limitations under the License.
                     <li><a href=" https://github.com/rust-lang-nursery/error-chain ">error-chain</a></li>
                     <li><a href=" https://github.com/smol-rs/event-listener ">event-listener</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/failure ">failure</a></li>
-                    <li><a href=" https://github.com/smol-rs/fastrand ">fastrand</a></li>
-                    <li><a href=" https://github.com/bluss/fixedbitset ">fixedbitset</a></li>
+                    <li><a href=" https://github.com/alexcrichton/filetime ">filetime</a></li>
                     <li><a href=" https://github.com/petgraph/fixedbitset ">fixedbitset</a></li>
                     <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv</a></li>
@@ -4644,13 +4643,10 @@ limitations under the License.
                     <li><a href=" https://github.com/dtolnay/paste ">paste</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding</a></li>
                     <li><a href=" https://github.com/petgraph/petgraph ">petgraph</a></li>
-                    <li><a href=" https://github.com/petgraph/petgraph ">petgraph</a></li>
                     <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config</a></li>
                     <li><a href=" https://github.com/rustsec/rustsec/tree/main/platforms ">platforms</a></li>
                     <li><a href=" https://github.com/smol-rs/polling ">polling</a></li>
                     <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2</a></li>
-                    <li><a href=" https://github.com/tokio-rs/prost ">prost</a></li>
-                    <li><a href=" https://github.com/tokio-rs/prost ">prost</a></li>
                     <li><a href=" https://github.com/dtolnay/quote ">quote</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-syntax</a></li>
@@ -6636,9 +6632,7 @@ limitations under the License.
                     <li><a href=" https://github.com/sfackler/rust-openssl ">openssl-sys</a></li>
                     <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float</a></li>
                     <li><a href=" https://github.com/jam1garner/owo-colors ">owo-colors</a></li>
-                    <li><a href=" https://github.com/tokio-rs/prost ">prost-build</a></li>
-                    <li><a href=" https://github.com/tokio-rs/prost ">prost-build</a></li>
-                    <li><a href=" https://github.com/tokio-rs/prost ">prost-types</a></li>
+                    <li><a href=" https://github.com/tokio-rs/prost ">prost-derive</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-types</a></li>
                     <li><a href=" https://github.com/raphlinus/pulldown-cmark ">pulldown-cmark</a></li>
                     <li><a href=" https://github.com/metrics-rs/quanta ">quanta</a></li>
@@ -6661,7 +6655,7 @@ limitations under the License.
                     <li><a href=" https://github.com/rust-cli/termtree ">termtree</a></li>
                     <li><a href=" https://github.com/mgeisler/textwrap ">textwrap</a></li>
                     <li><a href=" https://github.com/mgeisler/textwrap ">textwrap</a></li>
-                    <li><a href=" https://crates.io/crates/thrift ">thrift</a></li>
+                    <li><a href=" https://github.com/apache/thrift/tree/master/lib/rs ">thrift</a></li>
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-opentelemetry</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-serde</a></li>
@@ -7377,7 +7371,6 @@ DEALINGS IN THE SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if</a></li>
-                    <li><a href=" https://github.com/alexcrichton/filetime ">filetime</a></li>
                     <li><a href=" https://github.com/rust-lang/socket2 ">socket2</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys ">web-sys</a></li>
@@ -8379,6 +8372,61 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2021 Tokio Contributors
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the &quot;Software&quot;), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+The MIT License (MIT)
+
+Copyright (c) 2019 Yoshua Wuyts
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2022 Tokio Contributors
@@ -8559,16 +8607,13 @@ SOFTWARE.
                     <li><a href=" https://github.com/zkat/miette ">miette-derive</a></li>
                     <li><a href=" https://github.com/open-telemetry/opentelemetry-rust ">opentelemetry-http</a></li>
                     <li><a href=" https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp ">opentelemetry-otlp</a></li>
-                    <li><a href=" https://github.com/tokio-rs/prost ">prost-derive</a></li>
-                    <li><a href=" https://github.com/tokio-rs/prost ">prost-derive</a></li>
+                    <li><a href=" https://github.com/tokio-rs/prost ">prost</a></li>
+                    <li><a href=" https://github.com/tokio-rs/prost ">prost-build</a></li>
                     <li><a href=" https://github.com/dtolnay/ryu ">ryu</a></li>
                     <li><a href=" https://github.com/denoland/deno ">serde_v8</a></li>
                     <li><a href=" https://github.com/zkat/supports-color ">supports-color</a></li>
                     <li><a href=" https://github.com/zkat/supports-hyperlinks ">supports-hyperlinks</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros</a></li>
                     <li><a href=" https://github.com/hyperium/tonic ">tonic</a></li>
-                    <li><a href=" https://github.com/hyperium/tonic ">tonic</a></li>
-                    <li><a href=" https://github.com/hyperium/tonic ">tonic-build</a></li>
                     <li><a href=" https://github.com/hyperium/tonic ">tonic-build</a></li>
                     <li><a href=" https://github.com/briansmith/untrusted ">untrusted</a></li>
                     <li><a href=" https://github.com/reem/rust-void.git ">void</a></li>
@@ -8649,6 +8694,7 @@ SOFTWARE.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/smol-rs/async-lock ">async-lock</a></li>
                     <li><a href=" https://github.com/oli-obk/cargo_metadata ">cargo_metadata</a></li>
+                    <li><a href=" https://github.com/smol-rs/fastrand ">fastrand</a></li>
                     <li><a href=" https://github.com/hermitcore/libhermit-rs ">hermit-abi</a></li>
                     <li><a href=" https://github.com/matklad/once_cell ">once_cell</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/rustc-hash ">rustc-hash</a></li>


### PR DESCRIPTION
Fix #365 

At last we can remove the patch references for opentelemetry :partying_face: 

