### PR TITLE
Bryn/migrate caching layer to box error

### DIFF
--- a/apollo-router-core/src/services/router_service.rs
+++ b/apollo-router-core/src/services/router_service.rs
@@ -238,6 +238,7 @@ impl PluggableRouterServiceBuilder {
         // various iterators that we create for folding and leave
         // the plugins in their original order.
 
+        //QueryPlannerService takes an UnplannedRequest and outputs PlannedRequest
         let plan_cache_limit = std::env::var("ROUTER_PLAN_CACHE_LIMIT")
             .ok()
             .and_then(|x| x.parse().ok())

--- a/licenses.html
+++ b/licenses.html
@@ -45,7 +45,7 @@
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
             <li><a href="#MIT">MIT License</a> (65)</li>
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (36)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (37)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (2)</li>
             <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a> (1)</li>
             <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a> (1)</li>
@@ -4639,6 +4639,8 @@ limitations under the License.
                     <li><a href=" https://github.com/alexcrichton/openssl-probe ">openssl-probe</a></li>
                     <li><a href=" https://github.com/stjepang/parking ">parking</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot</a></li>
+                    <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot</a></li>
+                    <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core</a></li>
                     <li><a href=" https://github.com/dtolnay/paste ">paste</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding</a></li>
@@ -6363,6 +6365,14 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
+                </ul>
+                <pre class="license-text">../../LICENSE-APACHE</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi</a></li>
                 </ul>
                 <pre class="license-text">// Licensed under the Apache License, Version 2.0
@@ -6586,7 +6596,6 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
-                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
                     <li><a href=" https://crates.io/crates/apollo-router-benchmarks ">apollo-router-benchmarks</a></li>
                     <li><a href=" https://crates.io/crates/apollo-router-core ">apollo-router-core</a></li>
                     <li><a href=" https://crates.io/crates/apollo-spaceport ">apollo-spaceport</a></li>
@@ -6669,8 +6678,14 @@ limitations under the License.
                     <li><a href=" https://github.com/seanmonstar/warp ">warp</a></li>
                     <li><a href=" https://github.com/briansmith/webpki ">webpki</a></li>
                     <li><a href=" https://github.com/harryfei/which-rs.git ">which</a></li>
+                    <li><a href=" https://github.com/retep998/winapi-rs ">winapi-build</a></li>
+                    <li><a href=" https://github.com/retep998/winapi-rs ">winapi-i686-pc-windows-gnu</a></li>
                     <li><a href=" https://github.com/BurntSushi/winapi-util ">winapi-util</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi-x86_64-pc-windows-gnu</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys</a></li>
+                    <li><a href=" https://crates.io/crates/windows_aarch64_msvc ">windows_aarch64_msvc</a></li>
+                    <li><a href=" https://crates.io/crates/windows_x86_64_gnu ">windows_x86_64_gnu</a></li>
+                    <li><a href=" https://crates.io/crates/windows_x86_64_msvc ">windows_x86_64_msvc</a></li>
                 </ul>
                 <pre class="license-text">Apache License
 Version 2.0, January 2004
@@ -8617,8 +8632,8 @@ SOFTWARE.
                     <li><a href=" https://github.com/hyperium/tonic ">tonic-build</a></li>
                     <li><a href=" https://github.com/briansmith/untrusted ">untrusted</a></li>
                     <li><a href=" https://github.com/reem/rust-void.git ">void</a></li>
-                    <li><a href=" https://github.com/retep998/winapi-rs ">winapi-build</a></li>
-                    <li><a href=" https://github.com/retep998/winapi-rs ">winapi-i686-pc-windows-gnu</a></li>
+                    <li><a href=" https://crates.io/crates/windows_i686_gnu ">windows_i686_gnu</a></li>
+                    <li><a href=" https://crates.io/crates/windows_i686_msvc ">windows_i686_msvc</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 


### PR DESCRIPTION
Migrate the caching layer to BoxError
Tower layers mostly take Into<BoxError> services and output BoxError services.

~~I've added a commit to convert the query planner cache temporarily so that perf can be obtained.~~

This is still not code that is actually used, the existing query plan caching also does deduplication.
Possibly there is an argument for using the layer if deduplication was also a generic layer. 