### PR TITLE
fix: set `operation_name` tracing attribute to empty on unnamed, single-op requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## :bug: Fixes
 
-- **Anonymous operation names are now empty in tracing** ([PR #TODO](https://github.com/apollograpqhl/router/pull/TODO))
+- **Anonymous operation names are now empty in tracing** ([PR #525](https://github.com/apollograpqhl/router/pull/525))
 
   When GraphQL operation names are not nececessary to execute an operation (i.e., when there is only a single operation in a GraphQL document) and the GraphQL operation is _not_ named (i.e., it is anonymous), the `operation_name` attribute on the trace spans that are associated with the request will no longer contain a single hyphen character (`-`) but will instead be an empty string.  This matches the way that these operations are represented during the GraphQL operation's life-cycle as well.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
  -->
 
+# Upcoming
+
+> Not yet in a release!
+
+## :bug: Fixes
+
+- **Anonymous operation names are now empty in tracing** ([PR #TODO](https://github.com/apollograpqhl/router/pull/TODO))
+
+  When GraphQL operation names are not nececessary to execute an operation (i.e., when there is only a single operation in a GraphQL document) and the GraphQL operation is _not_ named (i.e., it is anonymous), the `operation_name` attribute on the trace spans that are associated with the request will no longer contain a single hyphen character (`-`) but will instead be an empty string.  This matches the way that these operations are represented during the GraphQL operation's life-cycle as well.
+
 # [v0.1.0-alpha.6] 2022-02-18
 
 ## :sparkles: Features

--- a/apollo-router/src/apollo_telemetry.rs
+++ b/apollo-router/src/apollo_telemetry.rs
@@ -438,7 +438,10 @@ fn stats_report_key(op_name: &opentelemetry::Value, query: &str) -> String {
         tracing::warn!("Could not find required definition: {}", query);
         return GRAPHQL_UNKNOWN_OPERATION_NAME.to_string();
     }
-    tracing::debug!("looking for operation: {}", if op_name.is_empty() { "{empty}" } else { &op_name });
+    tracing::debug!(
+        "looking for operation: {}",
+        if op_name.is_empty() { "-" } else { &op_name }
+    );
     let required_definition = required_definitions.pop().unwrap();
     tracing::debug!("required_definition: {:?}", required_definition);
 

--- a/apollo-router/src/apollo_telemetry.rs
+++ b/apollo-router/src/apollo_telemetry.rs
@@ -409,7 +409,7 @@ fn stats_report_key(op_name: &opentelemetry::Value, query: &str) -> String {
     // with the operation definition name.
     // If we find more than one match, then in either case we will
     // fail.
-    let filter: Box<dyn FnMut(&ast::Definition) -> bool> = if op_name == "" {
+    let filter: Box<dyn FnMut(&ast::Definition) -> bool> = if op_name.is_empty() {
         Box::new(|x| {
             if let ast::Definition::OperationDefinition(op_def) = x {
                 if let Some(v) = op_def.name() {

--- a/apollo-router/src/warp_http_server_factory.rs
+++ b/apollo-router/src/warp_http_server_factory.rs
@@ -345,7 +345,7 @@ where
     name = "graphql_request",
     fields(
         query = %request.query.clone().unwrap_or_default(),
-        operation_name = %request.operation_name.clone().unwrap_or_else(|| "-".to_string()),
+        operation_name = %request.operation_name.clone().unwrap_or_else(|| "".to_string()),
         client_name,
         client_version
     ),


### PR DESCRIPTION
When GraphQL operation names are not nececessary to execute an operation (i.e., when there is only a single operation in a GraphQL document) and the GraphQL operation is _not_ named (i.e., it is anonymous), the `operation_name` attribute on the trace spans that are associated with the request will no longer contain a single hyphen character (`-`) but will instead be an empty string.  This matches the way that these operations are represented during the GraphQL operation's life-cycle as well.

Fixes #481
