### PR TITLE
Generic dedup

### DIFF
--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -41,7 +41,7 @@ startup = "0.1.1"
 static_assertions = "1.1.0"
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["rt", "sync"] }
-tower = { version = "0.4.12", features = ["util", "buffer"] }
+tower = { version = "0.4.12", features = ["util", "buffer", "filter"] }
 tower-service = "0.3.1"
 tower-test = "0.4.0"
 tracing = "0.1.31"

--- a/apollo-router-core/src/layers/deduplication.rs
+++ b/apollo-router-core/src/layers/deduplication.rs
@@ -1,130 +1,339 @@
-use crate::{fetch::OperationKind, http_compat, Request, SubgraphRequest, SubgraphResponse};
+use futures::FutureExt;
+use futures::TryFutureExt;
 use futures::{future::BoxFuture, lock::Mutex};
+use std::hash::Hash;
 use std::{collections::HashMap, sync::Arc, task::Poll};
-use tokio::sync::broadcast::{self, Sender};
-use tower::{BoxError, Layer, ServiceExt};
+use tokio::sync::broadcast;
+use tokio::sync::broadcast::Sender;
+use tower::{BoxError, Layer};
+use tower_service::Service;
 
-pub struct QueryDeduplicationLayer;
-
-impl<S> Layer<S> for QueryDeduplicationLayer
+pub struct DeduplicationLayer<S, Request, Key>
 where
-    S: tower::Service<SubgraphRequest, Response = SubgraphResponse, Error = BoxError> + Clone,
+    Request: Send,
+    Key: Eq + Hash + Send,
+    S: Service<Request> + Send + Clone,
+    <S as Service<Request>>::Response: Clone + Send,
+    <S as Service<Request>>::Error: Into<BoxError> + Send + Sync,
+    <S as Service<Request>>::Future: Send,
 {
-    type Service = QueryDeduplicationService<S>;
+    key_fn: fn(&Request) -> Option<&Key>,
+    request_fn: fn(&Key) -> Request,
+    merge_fn: fn(Request, S::Response) -> S::Response,
+}
 
-    fn layer(&self, service: S) -> Self::Service {
-        QueryDeduplicationService::new(service)
+impl<S, Request, Key> DeduplicationLayer<S, Request, Key>
+where
+    Request: Send,
+    Key: Eq + Hash + Send,
+    S: Service<Request> + Send + Clone,
+    <S as Service<Request>>::Response: Clone + Send,
+    <S as Service<Request>>::Error: Into<BoxError> + Send + Sync,
+    <S as Service<Request>>::Future: Send,
+{
+    pub fn new(
+        key_fn: fn(&Request) -> Option<&Key>,
+        request_fn: fn(&Key) -> Request,
+        merge_fn: fn(Request, S::Response) -> S::Response,
+    ) -> Self {
+        Self {
+            key_fn,
+            request_fn,
+            merge_fn,
+        }
     }
 }
 
-type WaitMap =
-    Arc<Mutex<HashMap<http_compat::Request<Request>, Sender<Result<SubgraphResponse, String>>>>>;
+impl<S, Request, Key> Layer<S> for DeduplicationLayer<S, Request, Key>
+where
+    Request: Send + 'static,
+    Key: Clone + Eq + Hash + Send + 'static,
+    S: Service<Request> + Send + Clone,
+    <S as Service<Request>>::Response: Clone + Send,
+    <S as Service<Request>>::Error: Into<BoxError> + Send + Sync,
+    <S as Service<Request>>::Future: Send,
+{
+    type Service = DeduplicationService<S, Request, Key>;
 
-pub struct QueryDeduplicationService<S> {
-    service: S,
-    wait_map: WaitMap,
+    fn layer(&self, service: S) -> Self::Service {
+        DeduplicationService::new(service, self.key_fn, self.request_fn, self.merge_fn)
+    }
 }
 
-impl<S> QueryDeduplicationService<S>
+pub struct DeduplicationService<S, Request, Key>
 where
-    S: tower::Service<SubgraphRequest, Response = SubgraphResponse, Error = BoxError> + Clone,
+    Request: Send + 'static,
+    Key: Clone + Eq + Hash + Send + 'static,
+    S: Service<Request> + Send + Clone,
+    <S as Service<Request>>::Response: Clone + Send,
+    <S as Service<Request>>::Error: Into<BoxError> + Send + Sync,
+    <S as Service<Request>>::Future: Send,
 {
-    fn new(service: S) -> Self {
-        QueryDeduplicationService {
+    service: S,
+    ready_service: Option<S>,
+    key_fn: fn(&Request) -> Option<&Key>,
+    request_fn: fn(&Key) -> Request,
+    merge_fn: fn(Request, S::Response) -> S::Response,
+    #[allow(clippy::type_complexity)]
+    wait_map: Arc<Mutex<HashMap<Key, Sender<Result<S::Response, String>>>>>,
+}
+
+impl<S, Request, Key> DeduplicationService<S, Request, Key>
+where
+    Request: Send + 'static,
+    Key: Clone + Eq + Hash + Send + 'static,
+    S: Service<Request> + Send + Clone,
+    <S as Service<Request>>::Response: Clone + Send,
+    <S as Service<Request>>::Error: Into<BoxError> + Send + Sync,
+    <S as Service<Request>>::Future: Send,
+{
+    fn new(
+        service: S,
+        key_fn: fn(&Request) -> Option<&Key>,
+        request_fn: fn(&Key) -> Request,
+        merge_fn: fn(Request, S::Response) -> S::Response,
+    ) -> Self {
+        DeduplicationService {
             service,
+            ready_service: None,
+            key_fn,
+            request_fn,
+            merge_fn,
             wait_map: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
+    #[allow(clippy::type_complexity)]
     async fn dedup(
-        service: S,
-        wait_map: WaitMap,
-        request: SubgraphRequest,
-    ) -> Result<SubgraphResponse, BoxError> {
+        mut service: S,
+        wait_map: Arc<Mutex<HashMap<Key, Sender<Result<S::Response, String>>>>>,
+        key: Key,
+        request_fn: fn(&Key) -> Request,
+    ) -> Result<S::Response, BoxError> {
         loop {
             let mut locked_wait_map = wait_map.lock().await;
-            match locked_wait_map.get_mut(&request.http_request) {
+            let waiter = locked_wait_map.get_mut(&key);
+            match waiter {
                 Some(waiter) => {
                     // Register interest in key
                     let mut receiver = waiter.subscribe();
                     drop(locked_wait_map);
 
                     match receiver.recv().await {
-                        Ok(value) => {
-                            return value
-                                .map(|response| SubgraphResponse {
-                                    response: response.response,
-                                    context: request.context,
-                                })
-                                .map_err(|e| e.into())
-                        }
+                        Ok(value) => return value.map_err(Into::into),
                         // there was an issue with the broadcast channel, retry fetching
                         Err(_) => continue,
                     }
                 }
                 None => {
                     let (tx, _rx) = broadcast::channel(1);
-                    locked_wait_map.insert(request.http_request.clone(), tx.clone());
+                    locked_wait_map.insert(key.clone(), tx.clone());
                     drop(locked_wait_map);
 
-                    let context = request.context.clone();
-                    let http_request = request.http_request.clone();
-                    let res = service.ready_oneshot().await?.call(request).await;
+                    let downstream_request = (request_fn)(&key);
+                    let res = service.call(downstream_request).await;
 
                     {
                         let mut locked_wait_map = wait_map.lock().await;
-                        locked_wait_map.remove(&http_request);
+                        locked_wait_map.remove(&key);
                     }
 
                     // Let our waiters know
-                    let broadcast_value = res
-                        .as_ref()
-                        .map(|response| response.clone())
-                        .map_err(|e| e.to_string());
+                    // We map the error into a string because we can't guarantee the error type is clone.
+                    let value = res.map_err(|e| Into::<BoxError>::into(e).to_string());
 
                     // Our use case is very specific, so we are sure that
                     // we won't get any errors here.
-                    tokio::task::spawn_blocking(move || {
-                        tx.send(broadcast_value)
-                            .expect("there is always at least one receiver alive, the _rx guard; qed")
-                    }).await
-                    .expect("can only fail if the task is aborted or if the internal code panics, neither is possible here; qed");
+                    tx.send(value.clone())
+                        .map_err(|_| ())
+                        .expect("there is always at least one receiver alive, the _rx guard; qed");
 
-                    return res.map(|response| SubgraphResponse {
-                        response: response.response,
-                        context,
-                    });
+                    return value.map_err(Into::into);
                 }
             }
         }
     }
 }
 
-impl<S> tower::Service<SubgraphRequest> for QueryDeduplicationService<S>
+impl<S, Request, Key> Service<Request> for DeduplicationService<S, Request, Key>
 where
-    S: tower::Service<SubgraphRequest, Response = SubgraphResponse, Error = BoxError>
-        + Clone
-        + Send
-        + 'static,
-    <S as tower::Service<SubgraphRequest>>::Future: Send + 'static,
+    Request: Send + 'static,
+    Key: Clone + Eq + Hash + Send + 'static,
+    S: Service<Request> + Send + Clone + 'static,
+    <S as Service<Request>>::Response: Clone + Send + 'static,
+    <S as Service<Request>>::Error: Into<BoxError> + Send + Sync + 'static,
+    <S as Service<Request>>::Future: Send + 'static,
 {
-    type Response = SubgraphResponse;
+    type Response = S::Response;
     type Error = BoxError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.service.poll_ready(cx)
+        self.ready_service
+            .get_or_insert_with(|| self.service.clone())
+            .poll_ready(cx)
+            .map_err(Into::into)
     }
 
-    fn call(&mut self, request: SubgraphRequest) -> Self::Future {
-        let mut service = self.service.clone();
-
-        if request.operation_kind == OperationKind::Query {
-            let wait_map = self.wait_map.clone();
-
-            Box::pin(async move { Self::dedup(service, wait_map, request).await })
-        } else {
-            Box::pin(async move { service.call(request).await })
+    fn call(&mut self, request: Request) -> Self::Future {
+        let mut service = self.ready_service.take().unwrap();
+        let key = (self.key_fn)(&request);
+        match key {
+            Some(key) => {
+                let request_fn = self.request_fn;
+                let merge_fn = self.merge_fn;
+                let wait_map = self.wait_map.clone();
+                let key = key.clone();
+                Box::pin(async move {
+                    Self::dedup(service, wait_map, key, request_fn)
+                        .await
+                        .map(|response| (merge_fn)(request, response))
+                })
+            }
+            None => service.call(request).map_err(Into::into).boxed(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{mock_service, ServiceBuilderExt};
+    use mockall::predicate::eq;
+    use std::time::Duration;
+    use std::vec::Vec;
+    use test_log::test;
+    use tower::filter::AsyncPredicate;
+    use tower::ServiceBuilder;
+    use tower::ServiceExt;
+
+    #[derive(Clone, Eq, PartialEq, Debug)]
+    pub struct A {
+        key: String,
+        dummy: String,
+    }
+
+    #[derive(Clone, Eq, PartialEq, Debug)]
+    pub struct B {
+        key: String,
+        value: String,
+    }
+
+    #[derive(Default, Clone)]
+    struct Slow;
+
+    impl AsyncPredicate<A> for Slow {
+        type Future = BoxFuture<'static, Result<A, BoxError>>;
+        type Request = A;
+
+        fn check(&mut self, request: A) -> Self::Future {
+            Box::pin(async move {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                Ok(request)
+            })
+        }
+    }
+
+    mock_service!(AB, A, B);
+
+    #[test(tokio::test)]
+    async fn it_should_not_dedupe_non_cachable() {
+        let mut mock_service = MockABService::new();
+
+        mock_service
+            .expect_call()
+            .times(1)
+            .with(eq(A {
+                key: "Not cacheable".into(),
+                dummy: "Needed".into(),
+            }))
+            .returning(move |a| {
+                Ok(B {
+                    key: a.key,
+                    value: "there".into(),
+                })
+            });
+
+        let mut service = create_service(mock_service);
+
+        service
+            .ready()
+            .await
+            .unwrap()
+            .call(A {
+                key: "Not cacheable".into(),
+                dummy: "Needed".into(),
+            })
+            .await
+            .unwrap();
+    }
+
+    #[test(tokio::test)]
+    async fn it_should_dedupe_in_flight_calls() {
+        let mut mock_service = MockABService::new();
+
+        mock_service
+            .expect_call()
+            .times(1)
+            .with(eq(A {
+                key: "CacheableA".into(),
+                dummy: "".into(),
+            }))
+            .returning(move |a| {
+                Ok(B {
+                    key: a.key,
+                    value: "there".into(),
+                })
+            });
+
+        let mut service = create_service(mock_service);
+
+        let mut tasks = Vec::default();
+        // Our service is a little slow. It will pause for 10ms.
+        // This is enough time for our other requests to back up and enter the dedup logic.
+        // Once the first request returns the rest will all return.
+        for _ in 0..10 {
+            tasks.push(service.ready().await.unwrap().call(A {
+                key: "CacheableA".into(),
+                dummy: "Not needed".into(),
+            }));
+        }
+
+        let results = futures::future::join_all(tasks).await;
+        for result in results {
+            assert_eq!(
+                result,
+                Ok(B {
+                    key: "CacheableA".into(),
+                    value: "there".into()
+                })
+            );
+        }
+    }
+
+    fn create_service(
+        mock_service: MockABService,
+    ) -> impl Service<A, Response = B, Error = String> {
+        ServiceBuilder::new()
+            .dedup(
+                |request: &A| {
+                    if request.key.starts_with("Cacheable") {
+                        Some(&request.key)
+                    } else {
+                        None
+                    }
+                },
+                |key: &String| A {
+                    key: key.clone(),
+                    dummy: "".into(),
+                },
+                |request: A, response: B| B {
+                    key: request.key,
+                    value: response.value,
+                },
+            )
+            .filter_async(Slow::default())
+            .service(mock_service.build())
+            .map_err(|e: BoxError| e.to_string())
     }
 }

--- a/apollo-router-core/src/layers/deduplication.rs
+++ b/apollo-router-core/src/layers/deduplication.rs
@@ -144,6 +144,12 @@ where
 
                     // Our use case is very specific, so we are sure that
                     // we won't get any errors here.
+
+                    // Note that previous implementation notified in waiters in a separate thread.
+                    // However the logic in the broadcast channel is such that a single mutex
+                    // is updated and the waiting threads are notified to wake.
+                    // It introduces a reasonable performance hit to use the extra thread just to update
+                    // the mutex and woke the waiting threads.
                     tx.send(value.clone())
                         .map_err(|_| ())
                         .expect("there is always at least one receiver alive, the _rx guard; qed");

--- a/apollo-router-core/src/services/mod.rs
+++ b/apollo-router-core/src/services/mod.rs
@@ -1,5 +1,6 @@
 pub use self::execution_service::*;
 pub use self::router_service::*;
+use crate::deduplication::DeduplicationLayer;
 use crate::fetch::OperationKind;
 use crate::layers::cache::CachingLayer;
 use crate::prelude::graphql::*;
@@ -7,11 +8,13 @@ use moka::sync::Cache;
 use serde::{Deserialize, Serialize};
 use static_assertions::assert_impl_all;
 use std::convert::Infallible;
+use std::hash::Hash;
 use std::str::FromStr;
 use std::sync::Arc;
 use tower::layer::util::Stack;
 use tower::{BoxError, ServiceBuilder};
 use tower_service::Service;
+
 mod execution_service;
 pub mod http_compat;
 mod router_service;
@@ -124,38 +127,7 @@ impl AsRef<Request> for Arc<http_compat::Request<Request>> {
 }
 
 #[allow(clippy::type_complexity)]
-pub trait ServiceBuilderExt<L> {
-    fn cache<S, Request, Key, Value>(
-        self,
-        cache: Cache<Key, Result<Value, String>>,
-        key_fn: fn(&Request) -> Key,
-        value_fn: fn(&S::Response) -> Value,
-        response_fn: fn(Request, Value) -> S::Response,
-    ) -> ServiceBuilder<Stack<CachingLayer<S, Request, Key, Value>, L>>
-    where
-        Request: Send,
-        S: Service<Request> + Send,
-        <S as Service<Request>>::Error: Into<BoxError> + Send + Sync,
-        <S as Service<Request>>::Response: Send,
-        <S as Service<Request>>::Future: Send;
-
-    fn cache_query_plan<S>(
-        self,
-    ) -> ServiceBuilder<
-        Stack<
-            CachingLayer<S, QueryPlannerRequest, (Option<String>, Option<String>), Arc<QueryPlan>>,
-            L,
-        >,
-    >
-    where
-        S: Service<QueryPlannerRequest, Response = QueryPlannerResponse> + Send,
-        <S as Service<QueryPlannerRequest>>::Error: Into<BoxError> + Send + Sync,
-        <S as Service<QueryPlannerRequest>>::Response: Send,
-        <S as Service<QueryPlannerRequest>>::Future: Send;
-}
-
-#[allow(clippy::type_complexity)]
-impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
+pub trait ServiceBuilderExt<L>: Sized {
     fn cache<S, Request, Key, Value>(
         self,
         cache: Cache<Key, Result<Value, String>>,
@@ -205,5 +177,59 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
                 context: r.context,
             },
         )
+    }
+
+    fn dedup<S, Request, Key>(
+        self,
+        key_fn: fn(&Request) -> Option<&Key>,
+        request_fn: fn(&Key) -> Request,
+        merge_fn: fn(Request, S::Response) -> S::Response,
+    ) -> ServiceBuilder<Stack<DeduplicationLayer<S, Request, Key>, L>>
+    where
+        Request: Send,
+        Key: Clone + Eq + Hash + Send,
+        S: Service<Request> + Send + Clone,
+        <S as Service<Request>>::Response: Clone + Send,
+        <S as Service<Request>>::Error: Into<BoxError> + Send + Sync,
+        <S as Service<Request>>::Future: Send,
+    {
+        self.layer(DeduplicationLayer::new(key_fn, request_fn, merge_fn))
+    }
+
+    fn dedup_subgraph_requests<S>(
+        self,
+    ) -> ServiceBuilder<
+        Stack<DeduplicationLayer<S, SubgraphRequest, http_compat::Request<Request>>, L>,
+    >
+    where
+        S: Service<SubgraphRequest, Response = SubgraphResponse> + Send + Clone,
+        <S as Service<SubgraphRequest>>::Response: Clone + Send,
+        <S as Service<SubgraphRequest>>::Error: Into<BoxError> + Send + Sync,
+        <S as Service<SubgraphRequest>>::Future: Send,
+    {
+        self.dedup(
+            |request: &SubgraphRequest| match request.operation_kind {
+                OperationKind::Query => Some(&request.http_request),
+                _ => None,
+            },
+            |http_request| SubgraphRequest {
+                http_request: http_request.clone(),
+                context: Context::new()
+                    .with_request(Arc::new(http::Request::new(Request::default()).into())),
+                operation_kind: OperationKind::Query,
+            },
+            |request: SubgraphRequest, response: SubgraphResponse| SubgraphResponse {
+                response: response.response,
+                context: request.context,
+            },
+        )
+    }
+    fn layer<T>(self, layer: T) -> ServiceBuilder<Stack<T, L>>;
+}
+
+#[allow(clippy::type_complexity)]
+impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
+    fn layer<T>(self, layer: T) -> ServiceBuilder<Stack<T, L>> {
+        ServiceBuilder::layer(self, layer)
     }
 }


### PR DESCRIPTION
Make deduplication layer generic so that it can be used in other places.

This means we now have a generic caching layer as well as deduplication layer.

*Design considerations*

There are three callbacks:
1. Get the key from the request.
2. Create a downstream response from a key.
3. Create the response from the original request and the response.

**This bit is worth reading**
When deduplicating, data must not leak from an individual request to downstream that was not derived from the cache key. Otherwise there is potential for results that are dependent on the first request to hit the layer to be served to other callers. This is why a new request must be constructed from a key. 

In addition:
* Remove use of oneshot. 
* Follow tower pattern for cloning services to preserve backpressure.
* Added some basic tests.
