### PR TITLE
Fix: Documentation missing in studio.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   When GraphQL operation names are not nececessary to execute an operation (i.e., when there is only a single operation in a GraphQL document) and the GraphQL operation is _not_ named (i.e., it is anonymous), the `operation_name` attribute on the trace spans that are associated with the request will no longer contain a single hyphen character (`-`) but will instead be an empty string.  This matches the way that these operations are represented during the GraphQL operation's life-cycle as well.
 
-- **Router documentation went missing in studio** [PR #540](https://github.com/apollographql/router/pull/540)
-  This PR updates the introspection query cache to comply with recent studio updates.
+- **Resolved case of missing documentation in Apollo Studio Explorer** ([PR #540](https://github.com/apollographql/router/pull/540))
+
+   We've resolved a scenario that prevented Apollo Studio Explorer from displaying documentation by adding support for a new introspection query which also queries for deprecation (i.e., `includeDeprecated`) on `input` arguments.
   
 # [v0.1.0-alpha.6] 2022-02-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   When GraphQL operation names are not nececessary to execute an operation (i.e., when there is only a single operation in a GraphQL document) and the GraphQL operation is _not_ named (i.e., it is anonymous), the `operation_name` attribute on the trace spans that are associated with the request will no longer contain a single hyphen character (`-`) but will instead be an empty string.  This matches the way that these operations are represented during the GraphQL operation's life-cycle as well.
 
+- **Router documentation went missing in studio** [PR #540](https://github.com/apollographql/router/pull/540)
+  This PR updates the introspection query cache to comply with recent studio updates.
+  
 # [v0.1.0-alpha.6] 2022-02-18
 
 ## :sparkles: Features

--- a/apollo-router-core/well_known_introspection_queries/graphql_js_introspection_query.graphql
+++ b/apollo-router-core/well_known_introspection_queries/graphql_js_introspection_query.graphql
@@ -1,89 +1,98 @@
 
-query IntrospectionQuery {
-    __schema {
-    queryType { name }
-    mutationType { name }
-    subscriptionType { name }
-    types {
-        ...FullType
-    }
-    directives {
-        name
+    query IntrospectionQuery {
+      __schema {
         
-        locations
-        args {
-        ...InputValue
+        queryType { name }
+        mutationType { name }
+        subscriptionType { name }
+        types {
+          ...FullType
         }
+        directives {
+          name
+          description
+          
+          locations
+          args(includeDeprecated: true) {
+            ...InputValue
+          }
+        }
+      }
     }
-    }
-}
-fragment FullType on __Type {
-    kind
-    name
-    
-    fields(includeDeprecated: true) {
-    name
-    
-    args {
+
+    fragment FullType on __Type {
+      kind
+      name
+      description
+      
+      fields(includeDeprecated: true) {
+        name
+        description
+        args(includeDeprecated: true) {
+          ...InputValue
+        }
+        type {
+          ...TypeRef
+        }
+        isDeprecated
+        deprecationReason
+      }
+      inputFields(includeDeprecated: true) {
         ...InputValue
-    }
-    type {
+      }
+      interfaces {
         ...TypeRef
+      }
+      enumValues(includeDeprecated: true) {
+        name
+        description
+        isDeprecated
+        deprecationReason
+      }
+      possibleTypes {
+        ...TypeRef
+      }
     }
-    isDeprecated
-    deprecationReason
+
+    fragment InputValue on __InputValue {
+      name
+      description
+      type { ...TypeRef }
+      defaultValue
+      isDeprecated
+      deprecationReason
     }
-    inputFields {
-    ...InputValue
-    }
-    interfaces {
-    ...TypeRef
-    }
-    enumValues(includeDeprecated: true) {
-    name
-    
-    isDeprecated
-    deprecationReason
-    }
-    possibleTypes {
-    ...TypeRef
-    }
-}
-fragment InputValue on __InputValue {
-    name
-    
-    type { ...TypeRef }
-    defaultValue
-}
-fragment TypeRef on __Type {
-    kind
-    name
-    ofType {
-    kind
-    name
-    ofType {
+
+    fragment TypeRef on __Type {
+      kind
+      name
+      ofType {
         kind
         name
         ofType {
-        kind
-        name
-        ofType {
+          kind
+          name
+          ofType {
             kind
             name
             ofType {
-            kind
-            name
-            ofType {
+              kind
+              name
+              ofType {
                 kind
                 name
                 ofType {
-                kind
-                name
+                  kind
+                  name
+                  ofType {
+                    kind
+                    name
+                  }
                 }
+              }
             }
-            }
+          }
         }
-        }
+      }
     }
-    }
-}
+  


### PR DESCRIPTION
Closes #531 

It turns out the Introspection query changed a little bit, which caused us to miss the Introspection cache.
The next studio release and this fix solve this.
