### PR TITLE
Improve caching layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,7 @@ dependencies = [
  "futures",
  "hex",
  "http",
+ "humantime",
  "include_dir",
  "insta",
  "lru",

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -22,6 +22,7 @@ displaydoc = "0.2"
 futures = "0.3.21"
 hex = "0.4.3"
 http = "0.2.6"
+humantime = "2.1.0"
 include_dir = "0.7.2"
 lru = "0.7.3"
 miette = { version = "3.3.0", features = ["fancy"] }

--- a/apollo-router-core/src/layer.rs
+++ b/apollo-router-core/src/layer.rs
@@ -92,7 +92,7 @@ macro_rules! register_layer {
             };
 
             $crate::register_layer(qualified_name, $crate::LayerFactory::new(|configuration| {
-                let layer = $value::new(serde_json::from_value(configuration.clone())?)?;
+                let layer = <$value as $crate::ConfigurableLayer>::new(serde_json::from_value(configuration.clone())?)?;
                 Ok(tower::util::BoxLayer::new(layer))
             }, |gen| gen.subschema_for::<<$value as $crate::ConfigurableLayer>::Config>()));
         }

--- a/apollo-router-core/src/layers/cache.rs
+++ b/apollo-router-core/src/layers/cache.rs
@@ -1,10 +1,15 @@
 use futures::future::BoxFuture;
+use futures::FutureExt;
 use futures::TryFutureExt;
 use moka::sync::Cache;
 use std::hash::Hash;
 use std::marker::PhantomData;
+use std::sync::Arc;
 use std::task::Poll;
+use tokio::sync::RwLock;
 use tower::{BoxError, Layer, Service};
+
+pub type Sentinel<Value> = Arc<RwLock<Option<Value>>>;
 
 pub struct CachingService<S, Request, Key, Value>
 where
@@ -14,23 +19,23 @@ where
     <S as Service<Request>>::Response: Send + 'static,
     <S as Service<Request>>::Future: Send + 'static,
 {
-    key_fn: fn(&Request) -> Key,
-    value_fn: fn(&S::Response) -> Value,
+    key_fn: fn(&Request) -> Option<&Key>,
+    value_fn: fn(&S::Response) -> &Value,
     response_fn: fn(Request, Value) -> S::Response,
     inner: S,
-    cache: Cache<Key, Result<Value, String>>,
+    cache: Cache<Key, Sentinel<Result<Value, String>>>,
     phantom: PhantomData<Request>,
 }
 
 impl<S, Request, Key, Value> Service<Request> for CachingService<S, Request, Key, Value>
 where
-    Request: Send,
-    S: Service<Request> + Send,
+    Request: Send + 'static,
+    S: Service<Request> + Send + 'static,
     Key: Send + Sync + Eq + Hash + Clone + 'static,
     Value: Send + Sync + Clone + 'static,
-    <S as Service<Request>>::Error: Into<BoxError>,
-    <S as Service<Request>>::Response: Send,
-    <S as Service<Request>>::Future: Send,
+    <S as Service<Request>>::Error: Into<BoxError> + 'static,
+    <S as Service<Request>>::Response: Send + 'static,
+    <S as Service<Request>>::Future: Send + 'static,
 {
     type Response = S::Response;
     type Error = BoxError;
@@ -41,80 +46,99 @@ where
     }
 
     fn call(&mut self, request: Request) -> Self::Future {
-        let cache = self.cache.clone();
-        let value_fn = self.value_fn;
         let key = (self.key_fn)(&request);
-        let value = self.cache.get(&key);
-        match value {
-            Some(Ok(value)) => Box::pin(futures::future::ready(Ok((self.response_fn)(
-                request, value,
-            )))),
-            Some(Err(err)) => Box::pin(futures::future::ready(Err(BoxError::from(err)))),
+        match key {
             None => {
-                let delegate = self.inner.call(request).err_into();
-                Box::pin(async move {
-                    let response = delegate.await;
+                // The key function returned none, so the request was uncachable.
+                self.inner.call(request).err_into().boxed()
+            }
+            Some(key) => {
+                let value = self.cache.get(key);
+                match value {
+                    None => {
+                        // This is a new value. Create a sentinel and lock it.
+                        // The sentinel is an RWLock over an initially empty option.
+                        // Once the sentinel is created it is locked it so that readers must wait to read.
+                        // The sentinel is then put into the cache so that any subsequent read
+                        // will pick this up and have to wait.
+                        let sentinel = Arc::new(RwLock::new(None));
+                        let mut guard = sentinel
+                            .clone()
+                            .try_write_owned()
+                            .expect("This will never fail as we have just created the lock.");
 
-                    match &response {
-                        Ok(result) => {
-                            let value = value_fn(result);
-                            cache.insert(key, Ok(value));
-                        }
-                        Err(err) => {
-                            cache.insert(key, Err(err.to_string()));
-                        }
+                        self.cache.insert(key.clone(), sentinel);
+
+                        let value_fn = self.value_fn;
+                        self.inner
+                            .call(request)
+                            .err_into()
+                            .then(move |response| async move {
+                                // We got the response now. Update the sentinel and release the guard.
+                                let sentinel_value = match &response {
+                                    Ok(response) => Ok((value_fn)(response).clone()),
+                                    Err(e) => Err(e.to_string()),
+                                };
+                                let _ = guard.insert(sentinel_value);
+                                // Here we could also add functionality to immediately invalidate the key
+                                // This would have the effect of only caching for the duration of the
+                                // downstream call.
+                                response
+                            })
+                            .boxed()
                     }
-                    response
-                })
+                    Some(value) => {
+                        // The value has been populated, we need to await on the sentinel.
+                        // The read lock on the sentinel is released when it is populated allowing the
+                        // current read to proceed.
+                        let response_fn = self.response_fn;
+                        value
+                            .read_owned()
+                            .map(move |value| {
+                                let value = value.clone().expect("Value will always have been set");
+                                match value {
+                                    Ok(value) => Ok((response_fn)(request, value)),
+                                    Err(err) => Err(err.into()),
+                                }
+                            })
+                            .boxed()
+                    }
+                }
             }
         }
     }
 }
 
-pub struct CachingLayer<S, Request, Key, Value>
+pub struct CachingLayer<Request, Response, Key, Value>
 where
     Request: Send,
-    S: Service<Request> + Send,
-    <S as Service<Request>>::Error: Into<BoxError>,
-    <S as Service<Request>>::Response: Send + 'static,
-    <S as Service<Request>>::Future: Send + 'static,
 {
-    key_fn: fn(&Request) -> Key,
-    value_fn: fn(&S::Response) -> Value,
-    response_fn: fn(Request, Value) -> S::Response,
-    cache: Cache<Key, Result<Value, String>>,
-    phantom1: PhantomData<Request>,
-    phantom2: PhantomData<Value>,
-    phantom3: PhantomData<S>,
+    key_fn: fn(&Request) -> Option<&Key>,
+    value_fn: fn(&Response) -> &Value,
+    response_fn: fn(Request, Value) -> Response,
+    cache: Cache<Key, crate::layers::cache::Sentinel<Result<Value, String>>>,
 }
 
-impl<S, Request, Key, Value> CachingLayer<S, Request, Key, Value>
+impl<Request, Response, Key, Value> CachingLayer<Request, Response, Key, Value>
 where
     Request: Send,
-    S: Service<Request> + Send,
-    <S as Service<Request>>::Error: Into<BoxError>,
-    <S as Service<Request>>::Response: Send + 'static,
-    <S as Service<Request>>::Future: Send + 'static,
 {
     pub fn new(
-        cache: Cache<Key, Result<Value, String>>,
-        key_fn: fn(&Request) -> Key,
-        value_fn: fn(&S::Response) -> Value,
-        response_fn: fn(Request, Value) -> S::Response,
+        cache: Cache<Key, Sentinel<Result<Value, String>>>,
+        key_fn: fn(&Request) -> Option<&Key>,
+        value_fn: fn(&Response) -> &Value,
+        response_fn: fn(Request, Value) -> Response,
     ) -> Self {
         Self {
             key_fn,
             value_fn,
             response_fn,
             cache,
-            phantom1: Default::default(),
-            phantom2: Default::default(),
-            phantom3: Default::default(),
         }
     }
 }
 
-impl<S, Request, Key, Value> Layer<S> for CachingLayer<S, Request, Key, Value>
+impl<S, Request, Key, Value> Layer<S> for CachingLayer<Request, S::Response, Key, Value>
 where
     Request: Send,
     S: Service<Request> + Send,
@@ -142,12 +166,31 @@ where
 mod test {
     use super::*;
     use crate::mock_service;
+    use mockall::predicate::eq;
     use moka::sync::CacheBuilder;
+    use std::time::Duration;
+    use tower::filter::AsyncPredicate;
     use tower::{BoxError, ServiceBuilder, ServiceExt};
+
+    #[derive(Default, Clone)]
+    struct Slow;
+
+    impl AsyncPredicate<A> for Slow {
+        type Future = BoxFuture<'static, Result<A, BoxError>>;
+        type Request = A;
+
+        fn check(&mut self, request: A) -> Self::Future {
+            Box::pin(async move {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                Ok(request)
+            })
+        }
+    }
 
     #[derive(Clone, Eq, PartialEq, Debug)]
     pub struct A {
         key: String,
+        value: String,
     }
 
     #[derive(Clone, Eq, PartialEq, Debug)]
@@ -159,7 +202,7 @@ mod test {
     mock_service!(AB, A, B);
 
     #[tokio::test]
-    async fn cache_ok() {
+    async fn is_should_cache_ok() {
         let mut mock_service = MockABService::new();
 
         mock_service.expect_call().times(1).returning(move |a| {
@@ -172,7 +215,7 @@ mod test {
         let mut service = create_service(mock_service);
 
         let expected = Ok(B {
-            key: "hi".to_string(),
+            key: "Cacheable hi".to_string(),
             value: "there".to_string(),
         });
 
@@ -180,20 +223,26 @@ mod test {
             .ready()
             .await
             .unwrap()
-            .call(A { key: "hi".into() })
+            .call(A {
+                key: "Cacheable hi".into(),
+                value: "there".into(),
+            })
             .await;
         assert_eq!(b, expected);
         let b = service
             .ready()
             .await
             .unwrap()
-            .call(A { key: "hi".into() })
+            .call(A {
+                key: "Cacheable hi".into(),
+                value: "there".into(),
+            })
             .await;
         assert_eq!(b, expected);
     }
 
     #[tokio::test]
-    async fn cache_err() {
+    async fn is_should_cache_err() {
         let mut mock_service = MockABService::new();
 
         mock_service
@@ -203,22 +252,105 @@ mod test {
 
         let mut service = create_service(mock_service);
 
-        let expected = Err("hi err".to_string());
+        let expected = Err("Cacheable hi err".to_string());
 
         let b = service
             .ready()
             .await
             .unwrap()
-            .call(A { key: "hi".into() })
+            .call(A {
+                key: "Cacheable hi".into(),
+                value: "there".into(),
+            })
             .await;
         assert_eq!(b, expected);
         let b = service
             .ready()
             .await
             .unwrap()
-            .call(A { key: "hi".into() })
+            .call(A {
+                key: "Cacheable hi".into(),
+                value: "there".into(),
+            })
             .await;
         assert_eq!(b, expected);
+    }
+
+    #[tokio::test]
+    async fn it_should_not_cache_non_cachable() {
+        let mut mock_service = MockABService::new();
+
+        mock_service
+            .expect_call()
+            .times(2)
+            .with(eq(A {
+                key: "Not cacheable".into(),
+                value: "Needed".into(),
+            }))
+            .returning(move |a| {
+                Ok(B {
+                    key: a.key,
+                    value: "there".into(),
+                })
+            });
+
+        let mut service = create_service(mock_service);
+
+        for _ in 0..2 {
+            service
+                .ready()
+                .await
+                .unwrap()
+                .call(A {
+                    key: "Not cacheable".into(),
+                    value: "Needed".into(),
+                })
+                .await
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn it_should_dedupe_in_flight_calls() {
+        let mut mock_service = MockABService::new();
+
+        mock_service
+            .expect_call()
+            .times(1)
+            .with(eq(A {
+                key: "Cacheable A".into(),
+                value: "Not needed".into(),
+            }))
+            .returning(move |a| {
+                Ok(B {
+                    key: a.key,
+                    value: "there".into(),
+                })
+            });
+
+        let mut service = create_service(mock_service);
+
+        let mut tasks = Vec::default();
+        // Our service is a little slow. It will pause for 10ms.
+        // This is enough time for our other requests to back up and enter the dedup logic.
+        // Once the first request returns the rest will all return.
+        for _ in 0..10 {
+            tasks.push(service.ready().await.unwrap().call(A {
+                key: "Cacheable A".into(),
+                value: "Not needed".into(),
+            }));
+        }
+
+        let results = futures::future::join_all(tasks).await;
+        for result in results {
+            assert_eq!(
+                result,
+                Ok(B {
+                    key: "Cacheable A".into(),
+                    value: "there".into()
+                })
+            );
+        }
     }
 
     fn create_service(
@@ -228,13 +360,20 @@ mod test {
         ServiceBuilder::new()
             .layer(CachingLayer::new(
                 cache,
-                |r: &A| r.key.clone(),
-                |r: &B| r.value.clone(),
-                |r: A, c: String| B {
-                    key: r.key,
-                    value: c,
+                |request: &A| {
+                    if request.key.starts_with("Cacheable") {
+                        Some(&request.key)
+                    } else {
+                        None
+                    }
+                },
+                |request: &B| &request.value,
+                |request: A, value: String| B {
+                    key: request.key,
+                    value,
                 },
             ))
+            .filter_async(Slow::default())
             .service(mock_service.build())
             .map_err(|e: BoxError| e.to_string())
     }

--- a/apollo-router-core/src/services/mod.rs
+++ b/apollo-router-core/src/services/mod.rs
@@ -10,6 +10,7 @@ use static_assertions::assert_impl_all;
 use std::convert::Infallible;
 use std::str::FromStr;
 use std::sync::Arc;
+use tokio::sync::RwLock;
 use tower::layer::util::Stack;
 use tower::{BoxError, ServiceBuilder};
 use tower_service::Service;
@@ -127,103 +128,18 @@ impl AsRef<Request> for Arc<http_compat::Request<Request>> {
 }
 
 #[allow(clippy::type_complexity)]
-pub trait ServiceBuilderExt<L> {
-    fn cache<S, Request, Key, Value>(
+pub trait ServiceBuilderExt<L>: Sized {
+    fn cache<Request, Response, Key, Value>(
         self,
-        cache: Cache<Key, Result<Value, String>>,
-        key_fn: fn(&Request) -> Key,
-        value_fn: fn(&S::Response) -> Value,
-        response_fn: fn(Request, Value) -> S::Response,
-    ) -> ServiceBuilder<Stack<CachingLayer<S, Request, Key, Value>, L>>
+        cache: Cache<Key, Arc<RwLock<Option<Result<Value, String>>>>>,
+        key_fn: fn(&Request) -> Option<&Key>,
+        value_fn: fn(&Response) -> &Value,
+        response_fn: fn(Request, Value) -> Response,
+    ) -> ServiceBuilder<Stack<CachingLayer<Request, Response, Key, Value>, L>>
     where
         Request: Send,
-        S: Service<Request> + Send,
-        <S as Service<Request>>::Error: Into<BoxError> + Send + Sync,
-        <S as Service<Request>>::Response: Send,
-        <S as Service<Request>>::Future: Send;
-
-    fn cache_query_plan<S>(
-        self,
-    ) -> ServiceBuilder<
-        Stack<
-            CachingLayer<S, QueryPlannerRequest, (Option<String>, Option<String>), Arc<QueryPlan>>,
-            L,
-        >,
-    >
-    where
-        S: Service<QueryPlannerRequest, Response = QueryPlannerResponse> + Send,
-        <S as Service<QueryPlannerRequest>>::Error: Into<BoxError> + Send + Sync,
-        <S as Service<QueryPlannerRequest>>::Response: Send,
-        <S as Service<QueryPlannerRequest>>::Future: Send;
-
-    fn with_checkpoint<S, Request>(
-        self,
-        checkpoint_fn: fn(
-            Request,
-        ) -> Result<
-            Step<Request, <S as Service<Request>>::Response>,
-            <S as Service<Request>>::Error,
-        >,
-    ) -> ServiceBuilder<Stack<CheckpointLayer<S, Request>, L>>
-    where
-        S: Service<Request> + Send + 'static,
-        Request: Send + 'static,
-        S::Future: Send,
-        S::Response: Send + 'static,
-        S::Error: Into<BoxError> + Send + 'static;
-}
-
-#[allow(clippy::type_complexity)]
-impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
-    fn cache<S, Request, Key, Value>(
-        self,
-        cache: Cache<Key, Result<Value, String>>,
-        key_fn: fn(&Request) -> Key,
-        value_fn: fn(&S::Response) -> Value,
-        response_fn: fn(Request, Value) -> S::Response,
-    ) -> ServiceBuilder<Stack<CachingLayer<S, Request, Key, Value>, L>>
-    where
-        Request: Send,
-        S: Service<Request> + Send,
-        <S as Service<Request>>::Error: Into<BoxError> + Send + Sync,
-        <S as Service<Request>>::Response: Send,
-        <S as Service<Request>>::Future: Send,
     {
         self.layer(CachingLayer::new(cache, key_fn, value_fn, response_fn))
-    }
-
-    fn cache_query_plan<S>(
-        self,
-    ) -> ServiceBuilder<
-        Stack<
-            CachingLayer<S, QueryPlannerRequest, (Option<String>, Option<String>), Arc<QueryPlan>>,
-            L,
-        >,
-    >
-    where
-        S: Service<QueryPlannerRequest, Response = QueryPlannerResponse> + Send,
-        <S as Service<QueryPlannerRequest>>::Error: Into<BoxError> + Send + Sync,
-        <S as Service<QueryPlannerRequest>>::Response: Send,
-        <S as Service<QueryPlannerRequest>>::Future: Send,
-    {
-        let plan_cache_limit = std::env::var("ROUTER_PLAN_CACHE_LIMIT")
-            .ok()
-            .and_then(|x| x.parse().ok())
-            .unwrap_or(100);
-        self.cache(
-            moka::sync::CacheBuilder::new(plan_cache_limit).build(),
-            |r: &QueryPlannerRequest| {
-                (
-                    r.context.request.body().query.clone(),
-                    r.context.request.body().operation_name.clone(),
-                )
-            },
-            |r: &QueryPlannerResponse| r.query_plan.clone(),
-            |r: QueryPlannerRequest, v: Arc<QueryPlan>| QueryPlannerResponse {
-                query_plan: v,
-                context: r.context,
-            },
-        )
     }
 
     fn with_checkpoint<S, Request>(
@@ -243,5 +159,14 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
         S::Error: Into<BoxError> + Send + 'static,
     {
         self.layer(CheckpointLayer::new(checkpoint_fn))
+    }
+
+    fn layer<T>(self, layer: T) -> ServiceBuilder<Stack<T, L>>;
+}
+
+#[allow(clippy::type_complexity)]
+impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
+    fn layer<T>(self, layer: T) -> ServiceBuilder<Stack<T, L>> {
+        ServiceBuilder::layer(self, layer)
     }
 }

--- a/uplink/uplink.graphql
+++ b/uplink/uplink.graphql
@@ -3,6 +3,8 @@ directive @specifiedBy("The URL that specifies the behaviour of this scalar." ur
 type FetchError {
   code: FetchErrorCode!
   message: String!
+  "Minimum delay before the next fetch should occur, in seconds."
+  minDelaySeconds: Float!
 }
 enum FetchErrorCode {
   "This token provided is not a valid graph token. Do not retry"
@@ -25,16 +27,23 @@ enum MessageLevel {
 }
 type Query {
   "Fetch the configuration for a router. If a valid configuration is available, it will be readable as cSDL."
-  routerConfig("The reference to a graph variant, like `engine@prod` or `engine` (i.e. `engine@current`)." ref: String!, apiKey: String!, "If specified and the ID of the result is lower than or equal to it, Unchanged will be returned rather RouterConfigResult" ifAfterId: ID): RouterConfigResponse!
+  routerConfig("The reference to a graph variant, like `engine@prod` or `engine` (i.e. `engine@current`)." ref: String!, apiKey: String!, "When specified and the result is not newer, `Unchanged` is returned rather `RouterConfigResult`." ifAfterId: ID): RouterConfigResponse!
 }
 union RouterConfigResponse = RouterConfigResult | Unchanged | FetchError
 type RouterConfigResult {
+  "Variant-unique identifier."
   id: ID!
-  "The configuration as core schema"
+  "The configuration as core schema."
   supergraphSDL: String!
   "Messages that should be reported back to the operators of this router, eg through logs and/or monitoring."
   messages: [Message!]!
+  "Minimum delay before the next fetch should occur, in seconds."
+  minDelaySeconds: Float!
 }
+"Response indicating the router configuration available is not newer than the one passed in `ifAfterId`."
 type Unchanged {
+  "Variant-unique identifier for the configuration that remains in place."
   id: ID!
+  "Minimum delay before the next fetch should occur, in seconds."
+  minDelaySeconds: Float!
 }


### PR DESCRIPTION
Previously concurrent cache calls would not dedup for downstream requests, this was a major downside compared to
the other cache implementations we have. Here we use a sentinel to avoid clone while also allowing dedup of
ongoing requests.

This could in future be used for subgraph response caching or even query planner caching, but for now it is a proof of concept.