### PR TITLE
chore: add rust-toolchain.toml to have the same rust version everywhere

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ parameters:
   cache_version:
     type: string
     # increment that one to invalidate all the caches
-    default: v6
+    default: v6-{{ checksum "rust-toolchain.toml" }}
 
 commands:
   initialize_submodules:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.59.0"
+components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Create `rust-toolchain.toml` with the rust version we want.
Add a better cache key to automatically invalidate the cache when upgrading rust version from rust-toolchain.