### PR TITLE
Allow for more granular error handling + refactor layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Propagate router query lifecycle errors**([PR #537](https://github.com/apollographql/router/issues/537))
   Our recent extension rework was missing a key part: Error propagation and handling! This change makes sure errors that occured during query planning and query execution will be displayed as graphql errors, instead of an empty payload.
 
+## :nail_care: Improvements
+
+- **Introduce Checkpoint and Step** ([PR #558](https://github.com/apollographql/router/pull/558))
+  Layers and Extensions writers (which includes us!) now have a mechanism that allows them to let the service orchestrator know whether a service call should be propagated further down the service stack, or it has been fullfilled already and it can bail out. A caching layer for example could return Step::Return(response) if the cache hit was successful, and Step::Forward(request) if the cache missed.
+
 # [v0.1.0-alpha.7] 2022-02-25
 
 ## :sparkles: Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## :nail_care: Improvements
 
 - **Introduce Checkpoint and Step** ([PR #558](https://github.com/apollographql/router/pull/558))
-  Layers and Extensions writers (which includes us!) now have a mechanism that allows them to let the service orchestrator know whether a service call should be propagated further down the service stack, or it has been fullfilled already and it can bail out. A caching layer for example could return Step::Return(response) if the cache hit was successful, and Step::Forward(request) if the cache missed.
+  Layers and Extensions writers (which includes us!) now have a mechanism that allows them to let the service orchestrator know whether a service call should be propagated further down the service stack, or it has been fullfilled already and it can bail out. A caching layer for example could return Step::Return(response) if the cache hit was successful, and Step::Continue(request) if the cache missed.
 
 # [v0.1.0-alpha.7] 2022-02-25
 

--- a/apollo-router-core/src/layers/apq.rs
+++ b/apollo-router-core/src/layers/apq.rs
@@ -6,7 +6,7 @@ use moka::sync::Cache;
 use serde::Deserialize;
 use serde_json_bytes::json;
 use sha2::{Digest, Sha256};
-use tower::{Layer, Service};
+use tower::{BoxError, Layer, Service};
 
 #[derive(Deserialize, Clone, Debug)]
 pub struct PersistedQuery {
@@ -36,7 +36,7 @@ impl<S> Layer<S> for APQLayer
 where
     S: Service<RouterRequest, Response = RouterResponse> + Send + 'static,
     <S as Service<RouterRequest>>::Future: Send + 'static,
-    <S as Service<RouterRequest>>::Error: Send + 'static,
+    <S as Service<RouterRequest>>::Error: Into<BoxError> + Send + 'static,
 {
     type Service = CheckpointService<S, RouterRequest>;
 

--- a/apollo-router-core/src/layers/apq.rs
+++ b/apollo-router-core/src/layers/apq.rs
@@ -1,10 +1,11 @@
-use crate::{plugin_utils, RouterRequest, RouterResponse};
-use futures::future::BoxFuture;
+use crate::{
+    checkpoint::{CheckpointService, Step},
+    plugin_utils, RouterRequest, RouterResponse,
+};
 use moka::sync::Cache;
 use serde::Deserialize;
 use serde_json_bytes::json;
 use sha2::{Digest, Sha256};
-use std::task::Poll;
 use tower::{Layer, Service};
 
 #[derive(Deserialize, Clone, Debug)]
@@ -15,150 +16,97 @@ pub struct PersistedQuery {
 }
 
 #[derive(Clone)]
-pub struct APQ {
+pub struct APQLayer {
     cache: Cache<Vec<u8>, String>,
 }
 
-impl APQ {
+impl APQLayer {
     pub fn with_cache(cache: Cache<Vec<u8>, String>) -> Self {
         Self { cache }
     }
 }
 
-impl Default for APQ {
+impl Default for APQLayer {
     fn default() -> Self {
         Self::with_cache(Cache::new(512))
     }
 }
 
-pub struct APQService<S>
+impl<S> Layer<S> for APQLayer
 where
-    S: Service<RouterRequest>,
+    S: Service<RouterRequest, Response = RouterResponse> + Send + 'static,
+    <S as Service<RouterRequest>>::Future: Send + 'static,
+    <S as Service<RouterRequest>>::Error: Send + 'static,
 {
-    service: S,
-    apq: APQ,
-}
-
-impl<S> APQService<S>
-where
-    S: Service<RouterRequest>,
-{
-    pub fn new(service: S, cache: Cache<Vec<u8>, String>) -> Self {
-        Self {
-            service,
-            apq: APQ::with_cache(cache),
-        }
-    }
-}
-
-impl<S> Layer<S> for APQ
-where
-    S: Service<RouterRequest, Response = RouterResponse>,
-{
-    type Service = APQService<S>;
+    type Service = CheckpointService<S, RouterRequest>;
 
     fn layer(&self, service: S) -> Self::Service {
-        APQService {
-            apq: self.clone(),
+        let cache = self.cache.clone();
+        CheckpointService::new(
+            move |mut req| {
+                let maybe_query_hash: Option<Vec<u8>> = req
+                    .context
+                    .request
+                    .body()
+                    .extensions
+                    .get("persistedQuery")
+                    .and_then(|value| {
+                        serde_json_bytes::from_value::<PersistedQuery>(value.clone()).ok()
+                    })
+                    .and_then(|persisted_query| {
+                        hex::decode(persisted_query.sha256hash.as_bytes()).ok()
+                    });
+
+                let body_query = req.context.request.body().query.clone();
+
+                match (maybe_query_hash, body_query) {
+                    (Some(query_hash), Some(query)) => {
+                        if query_matches_hash(query.as_str(), query_hash.as_slice()) {
+                            tracing::trace!("apq: cache insert");
+                            cache.insert(query_hash, query);
+                        } else {
+                            tracing::warn!(
+                                "apq: graphql request doesn't match provided sha256Hash"
+                            );
+                        }
+                        Ok(Step::Forward(req))
+                    }
+                    (Some(apq_hash), _) => {
+                        if let Some(cached_query) = cache.get(&apq_hash) {
+                            tracing::trace!("apq: cache hit");
+                            req.context.request.body_mut().query = Some(cached_query);
+                            Ok(Step::Forward(req))
+                        } else {
+                            tracing::trace!("apq: cache miss");
+                            let res = plugin_utils::RouterResponse::builder()
+                                .errors(vec![crate::Error {
+                                    message: "PersistedQueryNotFound".to_string(),
+                                    locations: Default::default(),
+                                    path: Default::default(),
+                                    extensions: serde_json_bytes::from_value(json!({
+                                          "code": "PERSISTED_QUERY_NOT_FOUND",
+                                          "exception": {
+                                          "stacktrace": [
+                                              "PersistedQueryNotFoundError: PersistedQueryNotFound",
+                                          ],
+                                      },
+                                    }))
+                                    .unwrap(),
+                                }])
+                                .context(req.context.into())
+                                .build()
+                                .into();
+
+                            Ok(Step::Return(res))
+                        }
+                    }
+                    _ => Ok(Step::Forward(req)),
+                }
+            },
             service,
-        }
+        )
     }
 }
-
-impl<S> Service<RouterRequest> for APQService<S>
-where
-    S: Service<RouterRequest, Response = RouterResponse>,
-    S::Future: Send + 'static,
-{
-    type Response = <S as Service<RouterRequest>>::Response;
-
-    type Error = <S as Service<RouterRequest>>::Error;
-
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.service.poll_ready(cx)
-    }
-
-    fn call(&mut self, mut req: RouterRequest) -> Self::Future {
-        let apq = self.apq.clone();
-
-        let req = {
-            let maybe_query_hash: Option<Vec<u8>> = req
-                .context
-                .request
-                .body()
-                .extensions
-                .get("persistedQuery")
-                .and_then(|value| {
-                    serde_json_bytes::from_value::<PersistedQuery>(value.clone()).ok()
-                })
-                .and_then(|persisted_query| {
-                    hex::decode(persisted_query.sha256hash.as_bytes()).ok()
-                });
-
-            let body_query = req.context.request.body().query.clone();
-
-            match (maybe_query_hash, body_query) {
-                (Some(query_hash), Some(query)) => {
-                    if query_matches_hash(query.as_str(), query_hash.as_slice()) {
-                        tracing::trace!("apq: cache insert");
-                        apq.cache.insert(query_hash, query);
-                    } else {
-                        tracing::warn!("apq: graphql request doesn't match provided sha256Hash");
-                    }
-                }
-                (Some(apq_hash), _) => {
-                    if let Some(cached_query) = apq.cache.get(&apq_hash) {
-                        tracing::trace!("apq: cache hit");
-                        req.context.request.body_mut().query = Some(cached_query);
-                    } else {
-                        tracing::trace!("apq: cache miss");
-                        let res = plugin_utils::RouterResponse::builder()
-                            .errors(vec![crate::Error {
-                                message: "PersistedQueryNotFound".to_string(),
-                                locations: Default::default(),
-                                path: Default::default(),
-                                extensions: serde_json_bytes::from_value(json!({
-                                      "code": "PERSISTED_QUERY_NOT_FOUND",
-                                      "exception": {
-                                      "stacktrace": [
-                                          "PersistedQueryNotFoundError: PersistedQueryNotFound",
-                                      ],
-                                  },
-                                }))
-                                .unwrap(),
-                            }])
-                            .context(req.context.into())
-                            .build()
-                            .into();
-
-                        return Box::pin(async move { Ok(res) });
-                    }
-                }
-                _ => {}
-            }
-            // A query must be available at this point
-            let query = req.context.request.body().query.as_ref();
-            if query.is_none() || query.unwrap().is_empty() {
-                let res = plugin_utils::RouterResponse::builder()
-                    .errors(vec![crate::Error {
-                        message: "Must provide query string.".to_string(),
-                        locations: Default::default(),
-                        path: Default::default(),
-                        extensions: Default::default(),
-                    }])
-                    .context(req.context.into())
-                    .build()
-                    .into();
-                return Box::pin(async move { Ok(res) });
-            }
-            req
-        };
-        Box::pin(self.service.call(req))
-    }
-}
-
 fn query_matches_hash(query: &str, hash: &[u8]) -> bool {
     let mut digest = Sha256::new();
     digest.update(query.as_bytes());
@@ -245,7 +193,7 @@ mod apq_tests {
 
         let mock = mock_service.build();
 
-        let mut service_stack = APQ::default().layer(mock);
+        let mut service_stack = APQLayer::default().layer(mock);
 
         let request_builder = RouterRequest::builder().extensions(vec![(
             "persistedQuery",
@@ -345,7 +293,7 @@ mod apq_tests {
 
         let mock_service = mock_service_builder.build();
 
-        let mut service_stack = APQ::default().layer(mock_service);
+        let mut service_stack = APQLayer::default().layer(mock_service);
 
         let request_builder = RouterRequest::builder().extensions(vec![(
             "persistedQuery",
@@ -375,28 +323,6 @@ mod apq_tests {
         let second_apq_error = services.call(second_hash_only.into()).await.unwrap();
 
         assert_error_matches(&expected_apq_miss_error, second_apq_error);
-    }
-
-    #[tokio::test]
-    async fn it_will_error_on_empty_query_and_no_apq_header() {
-        let expected_error = crate::Error {
-            message: "Must provide query string.".to_string(),
-            locations: Default::default(),
-            path: Default::default(),
-            extensions: Default::default(),
-        };
-
-        let mock_service = MockRouterService::new().build();
-
-        let mut service_stack = APQ::default().layer(mock_service);
-
-        let empty_request = RouterRequest::builder().build();
-
-        let services = service_stack.ready().await.unwrap();
-
-        let actual_response = services.call(empty_request.into()).await.unwrap();
-
-        assert_error_matches(&expected_error, actual_response);
     }
 
     fn assert_error_matches(expected_error: &crate::Error, res: crate::RouterResponse) {

--- a/apollo-router-core/src/layers/apq.rs
+++ b/apollo-router-core/src/layers/apq.rs
@@ -69,13 +69,13 @@ where
                                 "apq: graphql request doesn't match provided sha256Hash"
                             );
                         }
-                        Ok(Step::Forward(req))
+                        Ok(Step::Continue(req))
                     }
                     (Some(apq_hash), _) => {
                         if let Some(cached_query) = cache.get(&apq_hash) {
                             tracing::trace!("apq: cache hit");
                             req.context.request.body_mut().query = Some(cached_query);
-                            Ok(Step::Forward(req))
+                            Ok(Step::Continue(req))
                         } else {
                             tracing::trace!("apq: cache miss");
                             let res = plugin_utils::RouterResponse::builder()
@@ -100,7 +100,7 @@ where
                             Ok(Step::Return(res))
                         }
                     }
-                    _ => Ok(Step::Forward(req)),
+                    _ => Ok(Step::Continue(req)),
                 }
             },
             service,

--- a/apollo-router-core/src/layers/ensure_query_presence.rs
+++ b/apollo-router-core/src/layers/ensure_query_presence.rs
@@ -1,0 +1,121 @@
+use crate::checkpoint::{CheckpointService, Step};
+use crate::{plugin_utils, RouterRequest, RouterResponse};
+use http::StatusCode;
+use tower::{Layer, Service};
+
+#[derive(Default)]
+pub struct EnsureQueryPresence {}
+
+impl<S> Layer<S> for EnsureQueryPresence
+where
+    S: Service<RouterRequest, Response = RouterResponse> + Send + 'static,
+    <S as Service<RouterRequest>>::Future: Send + 'static,
+    <S as Service<RouterRequest>>::Error: Send + 'static,
+{
+    type Service = CheckpointService<S, RouterRequest>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        CheckpointService::new(
+            |req: RouterRequest| {
+                // A query must be available at this point
+                let query = req.context.request.body().query.as_ref();
+                if query.is_none() || query.unwrap().is_empty() {
+                    let res = plugin_utils::RouterResponse::builder()
+                        .errors(vec![crate::Error {
+                            message: "Must provide query string.".to_string(),
+                            locations: Default::default(),
+                            path: Default::default(),
+                            extensions: Default::default(),
+                        }])
+                        .context(req.context.into())
+                        .build()
+                        .with_status(StatusCode::BAD_REQUEST);
+                    Ok(Step::Return(res))
+                } else {
+                    Ok(Step::Forward(req))
+                }
+            },
+            service,
+        )
+    }
+}
+
+#[cfg(test)]
+mod ensure_query_presence_tests {
+    use super::*;
+    use crate::plugin_utils::MockRouterService;
+    use crate::{plugin_utils, ResponseBody};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn it_works_with_query() {
+        let mut mock_service = MockRouterService::new();
+        mock_service
+            .expect_call()
+            .times(1)
+            .returning(move |_req| Ok(plugin_utils::RouterResponse::builder().build().into()));
+
+        let mock = mock_service.build();
+        let service_stack = EnsureQueryPresence::default().layer(mock);
+
+        let request: crate::RouterRequest = plugin_utils::RouterRequest::builder()
+            .query("{__typename}".to_string())
+            .build()
+            .into();
+
+        let _ = service_stack.oneshot(request).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn it_fails_on_empty_query() {
+        let expected_error = "Must provide query string.";
+
+        let mock_service = MockRouterService::new();
+        let mock = mock_service.build();
+
+        let service_stack = EnsureQueryPresence::default().layer(mock);
+
+        let request: crate::RouterRequest = plugin_utils::RouterRequest::builder()
+            .query("".to_string())
+            .build()
+            .into();
+
+        let response = service_stack
+            .oneshot(request)
+            .await
+            .unwrap()
+            .response
+            .into_body();
+        let actual_error = if let ResponseBody::GraphQL(b) = response {
+            b.errors[0].message.clone()
+        } else {
+            panic!("response body should have been GraphQL");
+        };
+
+        assert_eq!(expected_error, actual_error);
+    }
+
+    #[tokio::test]
+    async fn it_fails_on_no_query() {
+        let expected_error = "Must provide query string.";
+
+        let mock_service = MockRouterService::new();
+        let mock = mock_service.build();
+        let service_stack = EnsureQueryPresence::default().layer(mock);
+
+        let request: crate::RouterRequest = plugin_utils::RouterRequest::builder().build().into();
+
+        let response = service_stack
+            .oneshot(request)
+            .await
+            .unwrap()
+            .response
+            .into_body();
+        let actual_error = if let ResponseBody::GraphQL(b) = response {
+            b.errors[0].message.clone()
+        } else {
+            panic!("response body should have been GraphQL");
+        };
+        assert_eq!(expected_error, actual_error);
+    }
+}

--- a/apollo-router-core/src/layers/ensure_query_presence.rs
+++ b/apollo-router-core/src/layers/ensure_query_presence.rs
@@ -1,7 +1,7 @@
 use crate::checkpoint::{CheckpointService, Step};
 use crate::{plugin_utils, RouterRequest, RouterResponse};
 use http::StatusCode;
-use tower::{Layer, Service};
+use tower::{BoxError, Layer, Service};
 
 #[derive(Default)]
 pub struct EnsureQueryPresence {}
@@ -10,7 +10,7 @@ impl<S> Layer<S> for EnsureQueryPresence
 where
     S: Service<RouterRequest, Response = RouterResponse> + Send + 'static,
     <S as Service<RouterRequest>>::Future: Send + 'static,
-    <S as Service<RouterRequest>>::Error: Send + 'static,
+    <S as Service<RouterRequest>>::Error: Into<BoxError> + Send + 'static,
 {
     type Service = CheckpointService<S, RouterRequest>;
 

--- a/apollo-router-core/src/layers/ensure_query_presence.rs
+++ b/apollo-router-core/src/layers/ensure_query_presence.rs
@@ -32,7 +32,7 @@ where
                         .with_status(StatusCode::BAD_REQUEST);
                     Ok(Step::Return(res))
                 } else {
-                    Ok(Step::Forward(req))
+                    Ok(Step::Continue(req))
                 }
             },
             service,

--- a/apollo-router-core/src/layers/forbid_http_get_mutations.rs
+++ b/apollo-router-core/src/layers/forbid_http_get_mutations.rs
@@ -1,66 +1,46 @@
-use crate::{plugin_utils, ExecutionRequest, ExecutionResponse};
-use futures::future::BoxFuture;
+use crate::{
+    checkpoint::{CheckpointService, Step},
+    plugin_utils, ExecutionRequest, ExecutionResponse,
+};
 use http::{Method, StatusCode};
-use std::task::Poll;
 use tower::{Layer, Service};
-
-pub struct ForbidHttpGetMutations {}
-
-pub struct ForbidHttpGetMutationsService<S>
-where
-    S: Service<ExecutionRequest, Response = ExecutionResponse> + Send,
-    <S as Service<ExecutionRequest>>::Future: Send + 'static,
-{
-    service: S,
-}
 
 #[derive(Default)]
 pub struct ForbidHttpGetMutationsLayer {}
 
 impl<S> Layer<S> for ForbidHttpGetMutationsLayer
 where
-    S: Service<ExecutionRequest, Response = ExecutionResponse> + Send,
+    S: Service<ExecutionRequest, Response = ExecutionResponse> + Send + 'static,
     <S as Service<ExecutionRequest>>::Future: Send + 'static,
+    <S as Service<ExecutionRequest>>::Error: Send + 'static,
 {
-    type Service = ForbidHttpGetMutationsService<S>;
+    type Service = CheckpointService<S, ExecutionRequest>;
 
     fn layer(&self, service: S) -> Self::Service {
-        ForbidHttpGetMutationsService { service }
-    }
-}
-
-impl<S> Service<ExecutionRequest> for ForbidHttpGetMutationsService<S>
-where
-    S: Service<ExecutionRequest, Response = ExecutionResponse> + Send,
-    <S as Service<ExecutionRequest>>::Future: Send,
-{
-    type Response = ExecutionResponse;
-    type Error = S::Error;
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.service.poll_ready(cx)
-    }
-
-    fn call(&mut self, req: ExecutionRequest) -> Self::Future {
-        if req.context.request.method() == Method::GET && req.query_plan.contains_mutations() {
-            let res = plugin_utils::ExecutionResponse::builder()
-                .errors(vec![crate::Error {
-                    message: "GET supports only query operation".to_string(),
-                    locations: Default::default(),
-                    path: Default::default(),
-                    extensions: Default::default(),
-                }])
-                .status(StatusCode::METHOD_NOT_ALLOWED)
-                .headers(vec![("Allow".to_string(), "POST".to_string())])
-                .context(req.context)
-                .build()
-                .into();
-
-            Box::pin(async { Ok(res) })
-        } else {
-            Box::pin(self.service.call(req))
-        }
+        CheckpointService::new(
+            |req: ExecutionRequest| {
+                if req.context.request.method() == Method::GET
+                    && req.query_plan.contains_mutations()
+                {
+                    let res = plugin_utils::ExecutionResponse::builder()
+                        .errors(vec![crate::Error {
+                            message: "GET supports only query operation".to_string(),
+                            locations: Default::default(),
+                            path: Default::default(),
+                            extensions: Default::default(),
+                        }])
+                        .status(StatusCode::METHOD_NOT_ALLOWED)
+                        .headers(vec![("Allow".to_string(), "POST".to_string())])
+                        .context(req.context)
+                        .build()
+                        .into();
+                    Ok(Step::Return(res))
+                } else {
+                    Ok(Step::Forward(req))
+                }
+            },
+            service,
+        )
     }
 }
 
@@ -89,7 +69,7 @@ mod forbid_http_get_mutations_tests {
 
         let mock = mock_service.build();
 
-        let mut service_stack = ForbidHttpGetMutationsLayer {}.layer(mock);
+        let mut service_stack = ForbidHttpGetMutationsLayer::default().layer(mock);
 
         let http_post_query_plan_request = create_request(Method::POST, OperationKind::Query);
 
@@ -108,7 +88,7 @@ mod forbid_http_get_mutations_tests {
 
         let mock = mock_service.build();
 
-        let mut service_stack = ForbidHttpGetMutationsLayer {}.layer(mock);
+        let mut service_stack = ForbidHttpGetMutationsLayer::default().layer(mock);
 
         let http_post_query_plan_request = create_request(Method::POST, OperationKind::Mutation);
 
@@ -127,7 +107,7 @@ mod forbid_http_get_mutations_tests {
 
         let mock = mock_service.build();
 
-        let mut service_stack = ForbidHttpGetMutationsLayer {}.layer(mock);
+        let mut service_stack = ForbidHttpGetMutationsLayer::default().layer(mock);
 
         let http_post_query_plan_request = create_request(Method::GET, OperationKind::Query);
 
@@ -147,7 +127,7 @@ mod forbid_http_get_mutations_tests {
         let expected_allow_header = "POST";
 
         let mock = MockExecutionService::new().build();
-        let mut service_stack = ForbidHttpGetMutationsLayer {}.layer(mock);
+        let mut service_stack = ForbidHttpGetMutationsLayer::default().layer(mock);
 
         let http_post_query_plan_request = create_request(Method::GET, OperationKind::Mutation);
 

--- a/apollo-router-core/src/layers/forbid_http_get_mutations.rs
+++ b/apollo-router-core/src/layers/forbid_http_get_mutations.rs
@@ -36,7 +36,7 @@ where
                         .into();
                     Ok(Step::Return(res))
                 } else {
-                    Ok(Step::Forward(req))
+                    Ok(Step::Continue(req))
                 }
             },
             service,

--- a/apollo-router-core/src/layers/forbid_http_get_mutations.rs
+++ b/apollo-router-core/src/layers/forbid_http_get_mutations.rs
@@ -3,7 +3,7 @@ use crate::{
     plugin_utils, ExecutionRequest, ExecutionResponse,
 };
 use http::{Method, StatusCode};
-use tower::{Layer, Service};
+use tower::{BoxError, Layer, Service};
 
 #[derive(Default)]
 pub struct ForbidHttpGetMutationsLayer {}
@@ -12,7 +12,7 @@ impl<S> Layer<S> for ForbidHttpGetMutationsLayer
 where
     S: Service<ExecutionRequest, Response = ExecutionResponse> + Send + 'static,
     <S as Service<ExecutionRequest>>::Future: Send + 'static,
-    <S as Service<ExecutionRequest>>::Error: Send + 'static,
+    <S as Service<ExecutionRequest>>::Error: Into<BoxError> + Send + 'static,
 {
     type Service = CheckpointService<S, ExecutionRequest>;
 

--- a/apollo-router-core/src/layers/mod.rs
+++ b/apollo-router-core/src/layers/mod.rs
@@ -1,5 +1,6 @@
 pub mod apq;
 pub mod cache;
 pub mod deduplication;
+pub mod ensure_query_presence;
 pub mod forbid_http_get_mutations;
 pub mod headers;

--- a/apollo-router-core/src/services/checkpoint.rs
+++ b/apollo-router-core/src/services/checkpoint.rs
@@ -1,6 +1,6 @@
 use futures::future::BoxFuture;
 use std::sync::Arc;
-use tower::{Layer, Service};
+use tower::{BoxError, Layer, Service};
 
 /// An enum representing the next step
 /// A service should follow
@@ -45,7 +45,7 @@ where
     Request: Send + 'static,
     S::Future: Send,
     S::Response: Send + 'static,
-    <S as Service<Request>>::Error: Send + 'static,
+    <S as Service<Request>>::Error: Into<BoxError> + Send + 'static,
 {
     /// Create a `CheckpointLayer` from a function that takes a Service Request and returns a `Step`
     pub fn new(
@@ -70,7 +70,7 @@ where
     <S as Service<Request>>::Future: Send,
     Request: Send + 'static,
     <S as Service<Request>>::Response: Send + 'static,
-    <S as Service<Request>>::Error: Send + 'static,
+    <S as Service<Request>>::Error: Into<BoxError> + Send + 'static,
 {
     type Service = CheckpointService<S, Request>;
 
@@ -88,7 +88,7 @@ pub struct CheckpointService<S, Request>
 where
     Request: Send + 'static,
     S: Service<Request> + Send + 'static,
-    <S as Service<Request>>::Error: Send + 'static,
+    <S as Service<Request>>::Error: Into<BoxError> + Send + 'static,
     <S as Service<Request>>::Response: Send + 'static,
     <S as Service<Request>>::Future: Send + 'static,
 {
@@ -110,7 +110,7 @@ impl<S, Request> CheckpointService<S, Request>
 where
     Request: Send + 'static,
     S: Service<Request> + Send + 'static,
-    <S as Service<Request>>::Error: Send + 'static,
+    <S as Service<Request>>::Error: Into<BoxError> + Send + 'static,
     <S as Service<Request>>::Response: Send + 'static,
     <S as Service<Request>>::Future: Send + 'static,
 {
@@ -140,7 +140,7 @@ where
     S::Future: Send,
     Request: Send + 'static,
     <S as Service<Request>>::Response: Send + 'static,
-    <S as Service<Request>>::Error: Send + 'static,
+    <S as Service<Request>>::Error: Into<BoxError> + Send + 'static,
 {
     type Response = <S as Service<Request>>::Response;
 

--- a/apollo-router-core/src/services/checkpoint.rs
+++ b/apollo-router-core/src/services/checkpoint.rs
@@ -1,0 +1,299 @@
+use futures::future::BoxFuture;
+use std::sync::Arc;
+use tower::{Layer, Service};
+
+/// An enum representing the next step
+/// A service should follow
+pub enum Step<Request, Response>
+where
+    Request: Send + 'static,
+    Response: Send + 'static,
+{
+    /// `CheckpointService` should
+    /// Forward the call to the next service
+    Forward(Request),
+    /// `CheckpointService` should not call the next service.
+    /// Return the provided Response instead
+    Return(Response),
+}
+
+#[allow(clippy::type_complexity)]
+pub struct CheckpointLayer<S, Request>
+where
+    S: Service<Request> + Send + 'static,
+    Request: Send + 'static,
+    S::Future: Send,
+    S::Response: Send + 'static,
+    S::Error: Send + 'static,
+{
+    checkpoint_fn: Arc<
+        dyn Fn(
+                Request,
+            ) -> Result<
+                Step<Request, <S as Service<Request>>::Response>,
+                <S as Service<Request>>::Error,
+            > + Send
+            + Sync
+            + 'static,
+    >,
+}
+
+#[allow(clippy::type_complexity)]
+impl<S, Request> CheckpointLayer<S, Request>
+where
+    S: Service<Request> + Send + 'static,
+    Request: Send + 'static,
+    S::Future: Send,
+    S::Response: Send + 'static,
+    <S as Service<Request>>::Error: Send + 'static,
+{
+    /// Create a `CheckpointLayer` from a function that takes a Service Request and returns a `Step`
+    pub fn new(
+        checkpoint_fn: impl Fn(
+                Request,
+            ) -> Result<
+                Step<Request, <S as Service<Request>>::Response>,
+                <S as Service<Request>>::Error,
+            > + Send
+            + Sync
+            + 'static,
+    ) -> Self {
+        Self {
+            checkpoint_fn: Arc::new(checkpoint_fn),
+        }
+    }
+}
+
+impl<S, Request> Layer<S> for CheckpointLayer<S, Request>
+where
+    S: Service<Request> + Send + 'static,
+    <S as Service<Request>>::Future: Send,
+    Request: Send + 'static,
+    <S as Service<Request>>::Response: Send + 'static,
+    <S as Service<Request>>::Error: Send + 'static,
+{
+    type Service = CheckpointService<S, Request>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        CheckpointService {
+            checkpoint_fn: Arc::clone(&self.checkpoint_fn),
+            inner: service,
+        }
+    }
+}
+
+#[derive(Clone)]
+#[allow(clippy::type_complexity)]
+pub struct CheckpointService<S, Request>
+where
+    Request: Send + 'static,
+    S: Service<Request> + Send + 'static,
+    <S as Service<Request>>::Error: Send + 'static,
+    <S as Service<Request>>::Response: Send + 'static,
+    <S as Service<Request>>::Future: Send + 'static,
+{
+    inner: S,
+    checkpoint_fn: Arc<
+        dyn Fn(
+                Request,
+            ) -> Result<
+                Step<Request, <S as Service<Request>>::Response>,
+                <S as Service<Request>>::Error,
+            > + Send
+            + Sync
+            + 'static,
+    >,
+}
+
+#[allow(clippy::type_complexity)]
+impl<S, Request> CheckpointService<S, Request>
+where
+    Request: Send + 'static,
+    S: Service<Request> + Send + 'static,
+    <S as Service<Request>>::Error: Send + 'static,
+    <S as Service<Request>>::Response: Send + 'static,
+    <S as Service<Request>>::Future: Send + 'static,
+{
+    /// Create a `CheckpointLayer` from a function that takes a Service Request and returns a `Step`
+    pub fn new(
+        checkpoint_fn: impl Fn(
+                Request,
+            ) -> Result<
+                Step<Request, <S as Service<Request>>::Response>,
+                <S as Service<Request>>::Error,
+            > + Send
+            + Sync
+            + 'static,
+        inner: S,
+    ) -> Self {
+        Self {
+            checkpoint_fn: Arc::new(checkpoint_fn),
+            inner,
+        }
+    }
+}
+
+impl<S, Request> Service<Request> for CheckpointService<S, Request>
+where
+    S: Service<Request>,
+    S: Send + 'static,
+    S::Future: Send,
+    Request: Send + 'static,
+    <S as Service<Request>>::Response: Send + 'static,
+    <S as Service<Request>>::Error: Send + 'static,
+{
+    type Response = <S as Service<Request>>::Response;
+
+    type Error = <S as Service<Request>>::Error;
+
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        match (self.checkpoint_fn)(req) {
+            Ok(Step::Return(response)) => Box::pin(async move { Ok(response) }),
+            Ok(Step::Forward(request)) => Box::pin(self.inner.call(request)),
+            Err(error) => Box::pin(async move { Err(error) }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod checkpoint_tests {
+
+    use tower::{BoxError, Layer, ServiceBuilder, ServiceExt};
+
+    use crate::{
+        checkpoint::{CheckpointLayer, Step},
+        plugin_utils::{ExecutionRequest, ExecutionResponse, MockExecutionService},
+        ServiceBuilderExt,
+    };
+
+    #[tokio::test]
+    async fn test_service_builder() {
+        let expected_label = "from_mock_service";
+
+        let mut execution_service = MockExecutionService::new();
+
+        execution_service
+            .expect_call()
+            .times(1)
+            .returning(move |_req: crate::ExecutionRequest| {
+                Ok(ExecutionResponse::builder()
+                    .label(expected_label.to_string())
+                    .build()
+                    .into())
+            });
+
+        let service = execution_service.build();
+
+        let service_stack = ServiceBuilder::new()
+            .with_checkpoint(|req: crate::ExecutionRequest| Ok(Step::Forward(req)))
+            .service(service);
+
+        let request = ExecutionRequest::builder().build().into();
+
+        let actual_label = service_stack
+            .oneshot(request)
+            .await
+            .unwrap()
+            .response
+            .into_body()
+            .label
+            .unwrap();
+
+        assert_eq!(actual_label, expected_label)
+    }
+
+    #[tokio::test]
+    async fn test_forward() {
+        let expected_label = "from_mock_service";
+        let mut router_service = MockExecutionService::new();
+
+        router_service
+            .expect_call()
+            .times(1)
+            .returning(move |_req| {
+                Ok(ExecutionResponse::builder()
+                    .label(expected_label.to_string())
+                    .build()
+                    .into())
+            });
+
+        let service = router_service.build();
+
+        let service_stack = CheckpointLayer::new(|req| Ok(Step::Forward(req))).layer(service);
+
+        let request = ExecutionRequest::builder().build().into();
+
+        let actual_label = service_stack
+            .oneshot(request)
+            .await
+            .unwrap()
+            .response
+            .into_body()
+            .label
+            .unwrap();
+
+        assert_eq!(actual_label, expected_label)
+    }
+
+    #[tokio::test]
+    async fn test_return() {
+        let expected_label = "returned_before_mock_service";
+        let router_service = MockExecutionService::new();
+
+        let service = router_service.build();
+
+        let service_stack = CheckpointLayer::new(|_req| {
+            Ok(Step::Return(
+                ExecutionResponse::builder()
+                    .label("returned_before_mock_service".to_string())
+                    .build()
+                    .into(),
+            ))
+        })
+        .layer(service);
+
+        let request = ExecutionRequest::builder().build().into();
+
+        let actual_label = service_stack
+            .oneshot(request)
+            .await
+            .unwrap()
+            .response
+            .into_body()
+            .label
+            .unwrap();
+
+        assert_eq!(actual_label, expected_label)
+    }
+
+    #[tokio::test]
+    async fn test_error() {
+        let expected_error = "checkpoint_error";
+        let router_service = MockExecutionService::new();
+
+        let service = router_service.build();
+
+        let service_stack =
+            CheckpointLayer::new(move |_req| Err(BoxError::from(expected_error))).layer(service);
+
+        let request = ExecutionRequest::builder().build().into();
+
+        let actual_error = service_stack
+            .oneshot(request)
+            .await
+            .map(|_| unreachable!())
+            .unwrap_err()
+            .to_string();
+
+        assert_eq!(actual_error, expected_error)
+    }
+}

--- a/apollo-router-core/src/services/mod.rs
+++ b/apollo-router-core/src/services/mod.rs
@@ -1,3 +1,4 @@
+use self::checkpoint::{CheckpointLayer, Step};
 pub use self::execution_service::*;
 pub use self::router_service::*;
 use crate::fetch::OperationKind;
@@ -12,6 +13,7 @@ use std::sync::Arc;
 use tower::layer::util::Stack;
 use tower::{BoxError, ServiceBuilder};
 use tower_service::Service;
+pub mod checkpoint;
 mod execution_service;
 pub mod http_compat;
 mod router_service;
@@ -153,6 +155,22 @@ pub trait ServiceBuilderExt<L> {
         <S as Service<QueryPlannerRequest>>::Error: Into<BoxError> + Send + Sync,
         <S as Service<QueryPlannerRequest>>::Response: Send,
         <S as Service<QueryPlannerRequest>>::Future: Send;
+
+    fn with_checkpoint<S, Request>(
+        self,
+        checkpoint_fn: fn(
+            Request,
+        ) -> Result<
+            Step<Request, <S as Service<Request>>::Response>,
+            <S as Service<Request>>::Error,
+        >,
+    ) -> ServiceBuilder<Stack<CheckpointLayer<S, Request>, L>>
+    where
+        S: Service<Request> + Send + 'static,
+        Request: Send + 'static,
+        S::Future: Send,
+        S::Response: Send + 'static,
+        S::Error: Send + 'static;
 }
 
 #[allow(clippy::type_complexity)]
@@ -206,5 +224,24 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
                 context: r.context,
             },
         )
+    }
+
+    fn with_checkpoint<S, Request>(
+        self,
+        checkpoint_fn: fn(
+            Request,
+        ) -> Result<
+            Step<Request, <S as Service<Request>>::Response>,
+            <S as Service<Request>>::Error,
+        >,
+    ) -> ServiceBuilder<Stack<CheckpointLayer<S, Request>, L>>
+    where
+        S: Service<Request> + Send + 'static,
+        Request: Send + 'static,
+        S::Future: Send,
+        S::Response: Send + 'static,
+        S::Error: Send + 'static,
+    {
+        self.layer(CheckpointLayer::new(checkpoint_fn))
     }
 }

--- a/apollo-router-core/src/services/mod.rs
+++ b/apollo-router-core/src/services/mod.rs
@@ -170,7 +170,7 @@ pub trait ServiceBuilderExt<L> {
         Request: Send + 'static,
         S::Future: Send,
         S::Response: Send + 'static,
-        S::Error: Send + 'static;
+        S::Error: Into<BoxError> + Send + 'static;
 }
 
 #[allow(clippy::type_complexity)]
@@ -240,7 +240,7 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
         Request: Send + 'static,
         S::Future: Send,
         S::Response: Send + 'static,
-        S::Error: Send + 'static,
+        S::Error: Into<BoxError> + Send + 'static,
     {
         self.layer(CheckpointLayer::new(checkpoint_fn))
     }

--- a/apollo-router-core/src/services/router_service.rs
+++ b/apollo-router-core/src/services/router_service.rs
@@ -1,4 +1,5 @@
-use crate::apq::APQ;
+use crate::apq::APQLayer;
+use crate::ensure_query_presence::EnsureQueryPresence;
 use crate::forbid_http_get_mutations::ForbidHttpGetMutationsLayer;
 use crate::services::execution_service::ExecutionService;
 use crate::{
@@ -9,11 +10,12 @@ use crate::{
 };
 use futures::future::BoxFuture;
 use futures::TryFutureExt;
+use http::StatusCode;
 use std::sync::Arc;
 use std::task::Poll;
 use tower::buffer::Buffer;
 use tower::util::{BoxCloneService, BoxService};
-use tower::{BoxError, ServiceBuilder, ServiceExt};
+use tower::{BoxError, Layer, ServiceBuilder, ServiceExt};
 use tower_service::Service;
 use tracing::instrument::WithSubscriber;
 use tracing::{Dispatch, Instrument};
@@ -73,35 +75,19 @@ where
 
     fn call(&mut self, req: RouterRequest) -> Self::Future {
         // Consume our cloned services and allow ownership to be transferred to the async block.
-        let mut planning = self.ready_query_planner_service.take().unwrap();
-        let mut execution = self.ready_query_execution_service.take().unwrap();
+        let planning = self.ready_query_planner_service.take().unwrap();
+        let execution = self.ready_query_execution_service.take().unwrap();
 
         let schema = self.schema.clone();
         let query_cache = self.query_cache.clone();
 
-        let query = &req.context.request.body().query.as_ref();
-
-        if query.is_none() || query.expect("checked before; qed").is_empty() {
-            let res = plugin_utils::RouterResponse::builder()
-                .context(req.context.into())
-                .errors(vec![crate::Error {
-                    message: "Must provide query string.".to_string(),
-                    ..Default::default()
-                }])
-                .build()
-                .into();
-            return Box::pin(async move { Ok(res) });
-        };
-
-        let query = req
-            .context
-            .request
-            .body()
-            .query
-            .clone()
-            .expect("checked above; qed");
-
-        if let Some(response) = self.naive_introspection.get(query.as_str()) {
+        if let Some(response) =
+            self.naive_introspection.get(
+                req.context.request.body().query.as_ref().expect(
+                    "com.apollographql.ensure-query-is-present has checked this already; qed",
+                ),
+            )
+        {
             return Box::pin(async move {
                 Ok(RouterResponse {
                     response: http::Response::new(ResponseBody::GraphQL(response)).into(),
@@ -111,9 +97,10 @@ where
         }
 
         let fut = async move {
-            let body = req.context.request.body();
+            let context = req.context;
+            let body = context.request.body();
             let query = query_cache
-                .get_query(query.as_str())
+                .get_query(body.query.as_ref().expect("com.apollographql.ensure-query-is-present has checked this already; qed").as_str())
                 .instrument(tracing::info_span!("query_parsing"))
                 .await;
 
@@ -123,18 +110,18 @@ where
             {
                 Ok(RouterResponse {
                     response: http::Response::new(ResponseBody::GraphQL(err)).into(),
-                    context: req.context.into(),
+                    context: context.into(),
                 })
             } else {
                 let operation_name = body.operation_name.clone();
                 let planned_query = planning
-                    .call(QueryPlannerRequest {
-                        context: req.context.into(),
+                    .oneshot(QueryPlannerRequest {
+                        context: context.into(),
                     })
                     .await?;
 
                 let mut response = execution
-                    .call(ExecutionRequest {
+                    .oneshot(ExecutionRequest {
                         query_plan: planned_query.query_plan,
                         context: planned_query.context,
                     })
@@ -163,7 +150,7 @@ where
                     ..Default::default()
                 }])
                 .build()
-                .into())
+                .with_status(StatusCode::INTERNAL_SERVER_ERROR))
         });
 
         Box::pin(fut)
@@ -303,18 +290,20 @@ impl PluggableRouterServiceBuilder {
 
         // ExecutionService takes a PlannedRequest and outputs a RouterResponse
         let (execution_service, execution_worker) = Buffer::pair(
-            ServiceBuilder::new()
-                .layer(ForbidHttpGetMutationsLayer::default())
-                .service(
-                    self.plugins.iter_mut().rev().fold(
-                        ExecutionService::builder()
-                            .schema(self.schema.clone())
-                            .subgraph_services(subgraphs)
-                            .build()
-                            .boxed(),
-                        |acc, e| e.execution_service(acc),
+            ForbidHttpGetMutationsLayer::default()
+                .layer(
+                    ServiceBuilder::new().service(
+                        self.plugins.iter_mut().rev().fold(
+                            ExecutionService::builder()
+                                .schema(self.schema.clone())
+                                .subgraph_services(subgraphs)
+                                .build()
+                                .boxed(),
+                            |acc, e| e.execution_service(acc),
+                        ),
                     ),
-                ),
+                )
+                .boxed(),
             self.buffer,
         );
         tokio::spawn(
@@ -361,19 +350,23 @@ impl PluggableRouterServiceBuilder {
 
         // Router service takes a graphql::Request and outputs a graphql::Response
         let (router_service, router_worker) = Buffer::pair(
-            ServiceBuilder::new().layer(APQ::default()).service(
-                self.plugins.iter_mut().rev().fold(
-                    RouterService::builder()
-                        .query_planner_service(query_planner_service)
-                        .query_execution_service(execution_service)
-                        .schema(self.schema)
-                        .query_cache(query_cache)
-                        .naive_introspection(naive_introspection)
-                        .build()
-                        .boxed(),
-                    |acc, e| e.router_service(acc),
-                ),
-            ),
+            ServiceBuilder::new()
+                .layer(APQLayer::default())
+                .layer(EnsureQueryPresence::default())
+                .service(
+                    self.plugins.iter_mut().rev().fold(
+                        RouterService::builder()
+                            .query_planner_service(query_planner_service)
+                            .query_execution_service(execution_service)
+                            .schema(self.schema)
+                            .query_cache(query_cache)
+                            .naive_introspection(naive_introspection)
+                            .build()
+                            .boxed(),
+                        |acc, e| e.router_service(acc),
+                    ),
+                )
+                .boxed(),
             self.buffer,
         );
         tokio::spawn(

--- a/apollo-router-core/src/services/router_service.rs
+++ b/apollo-router-core/src/services/router_service.rs
@@ -75,8 +75,8 @@ where
 
     fn call(&mut self, req: RouterRequest) -> Self::Future {
         // Consume our cloned services and allow ownership to be transferred to the async block.
-        let planning = self.ready_query_planner_service.take().unwrap();
-        let execution = self.ready_query_execution_service.take().unwrap();
+        let mut planning = self.ready_query_planner_service.take().unwrap();
+        let mut execution = self.ready_query_execution_service.take().unwrap();
 
         let schema = self.schema.clone();
         let query_cache = self.query_cache.clone();
@@ -115,13 +115,13 @@ where
             } else {
                 let operation_name = body.operation_name.clone();
                 let planned_query = planning
-                    .oneshot(QueryPlannerRequest {
+                    .call(QueryPlannerRequest {
                         context: context.into(),
                     })
                     .await?;
 
                 let mut response = execution
-                    .oneshot(ExecutionRequest {
+                    .call(ExecutionRequest {
                         query_plan: planned_query.query_plan,
                         context: planned_query.context,
                     })

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -80,24 +80,7 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
             errors.append(&mut e);
         }
 
-        // Because studio usage reporting requires the Reporting plugin,
-        // we must force the addition of the Reporting plugin if APOLLO_KEY
-        // is set.
-        if std::env::var("APOLLO_KEY").is_ok() {
-            // If the user has not specified Reporting configuration, then
-            // insert a valid "minimal" configuration which allows
-            // studio usage reporting to function
-            if !configuration
-                .plugins
-                .plugins
-                .contains_key(REPORTING_MODULE_NAME)
-            {
-                configuration.plugins.plugins.insert(
-                    REPORTING_MODULE_NAME.to_string(),
-                    serde_json::json!({ "opentelemetry": null }),
-                );
-            }
-        }
+        let configuration = add_default_plugins(configuration);
 
         let buffer = 20000;
         let mut builder = PluggableRouterServiceBuilder::new(schema, buffer);
@@ -250,6 +233,29 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
         }
         Ok(service)
     }
+}
+
+fn add_default_plugins(mut configuration: Configuration) -> Configuration {
+    // Because studio usage reporting requires the Reporting plugin,
+    // we must force the addition of the Reporting plugin if APOLLO_KEY
+    // is set.
+    if std::env::var("APOLLO_KEY").is_ok() {
+        // If the user has not specified Reporting configuration, then
+        // insert a valid "minimal" configuration which allows
+        // studio usage reporting to function
+        if !configuration
+            .plugins
+            .plugins
+            .contains_key(REPORTING_MODULE_NAME)
+        {
+            configuration.plugins.plugins.insert(
+                REPORTING_MODULE_NAME.to_string(),
+                serde_json::json!({ "opentelemetry": null }),
+            );
+        }
+    }
+
+    configuration
 }
 
 #[cfg(test)]

--- a/apollo-router/src/warp_http_server_factory.rs
+++ b/apollo-router/src/warp_http_server_factory.rs
@@ -355,7 +355,7 @@ where
 
     async move {
         match service.ready_oneshot().await {
-            Ok(service) => {
+            Ok(mut service) => {
                 let mut http_request = http::Request::builder()
                     .method(method)
                     .body(request)
@@ -365,7 +365,7 @@ where
                 let span = Span::current();
 
                 let response = service
-                    .oneshot(http_request.into())
+                    .call(http_request.into())
                     .await
                     .map(|response| {
                         tracing::trace_span!(parent: &span, "serialize_response")

--- a/apollo-router/src/warp_http_server_factory.rs
+++ b/apollo-router/src/warp_http_server_factory.rs
@@ -5,6 +5,7 @@ use crate::FederatedServerError;
 use apollo_router_core::http_compat::{Request, Response};
 use apollo_router_core::prelude::*;
 use apollo_router_core::ResponseBody;
+use bytes::Bytes;
 use futures::{channel::oneshot, prelude::*};
 use hyper::server::conn::Http;
 use once_cell::sync::Lazy;
@@ -23,7 +24,6 @@ use tracing::{Level, Span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use warp::{
     http::{header::HeaderMap, StatusCode},
-    hyper::Body,
     Filter,
 };
 use warp::{Rejection, Reply};
@@ -326,7 +326,6 @@ where
 fn run_graphql_request<RS>(
     service: RS,
     method: http::Method,
-
     request: graphql::Request,
     header_map: HeaderMap,
 ) -> impl Future<Output = Box<dyn Reply>> + Send
@@ -357,46 +356,46 @@ where
     async move {
         match service.ready_oneshot().await {
             Ok(service) => {
-                let service = service.clone();
                 let mut http_request = http::Request::builder()
                     .method(method)
                     .body(request)
                     .unwrap();
                 *http_request.headers_mut() = header_map;
 
-                let response = stream_request(service, http_request.into()).await;
+                let span = Span::current();
 
-                Box::new(hyper::Response::new(Body::from(response))) as Box<dyn Reply>
+                let response = service
+                    .oneshot(http_request.into())
+                    .await
+                    .map(|response| {
+                        tracing::trace_span!(parent: &span, "serialize_response")
+                            .in_scope(|| {
+                                response.map(|body| {
+                                    Bytes::from(
+                                        serde_json::to_vec(&body)
+                                            .expect("responsebody is serializable; qed"),
+                                    )
+                                })
+                            })
+                            .into()
+                    })
+                    .unwrap_or_else(|e| {
+                        tracing::error!("router serivce call failed: {}", e);
+                        http::Response::builder()
+                            .status(StatusCode::INTERNAL_SERVER_ERROR)
+                            .body(Bytes::from_static(b"router service call failed"))
+                            .expect("static response building cannot fail; qed")
+                    });
+
+                Box::new(response) as Box<dyn Reply>
             }
-            Err(_) => Box::new(warp::reply::with_status(
-                "Invalid host to redirect to",
-                StatusCode::BAD_REQUEST,
-            )),
-        }
-    }
-}
-
-async fn stream_request<RS>(service: RS, request: Request<graphql::Request>) -> String
-where
-    RS: Service<Request<graphql::Request>, Response = Response<ResponseBody>, Error = BoxError>
-        + Send
-        + Clone
-        + 'static,
-{
-    match service.oneshot(request).await {
-        Err(_) => String::new(),
-        Ok(response) => {
-            let span = Span::current();
-            // TODO headers
-            tracing::trace_span!(parent: &span, "serialize_response").in_scope(|| {
-                match response.into_body() {
-                    ResponseBody::GraphQL(graphql) => serde_json::to_string(&graphql)
-                        .expect("serde_json::Value serialization will not fail"),
-                    ResponseBody::RawJSON(json) => serde_json::to_string(&json)
-                        .expect("serde_json::Value serialization will not fail"),
-                    ResponseBody::RawString(string) => string,
-                }
-            })
+            Err(e) => {
+                tracing::error!("router service is not available to process request: {}", e);
+                Box::new(warp::reply::with_status(
+                    "router service is not available to process request",
+                    StatusCode::SERVICE_UNAVAILABLE,
+                ))
+            }
         }
     }
 }

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -1,17 +1,19 @@
 use apollo_router::configuration::Configuration;
 use apollo_router::get_dispatcher;
 use apollo_router::reqwest_subgraph_service::ReqwestSubgraphService;
-use apollo_router_core::prelude::*;
 use apollo_router_core::{
-    Context, PluggableRouterServiceBuilder, ResponseBody, SubgraphRequest, ValueExt,
+    prelude::*, Context, Object, PluggableRouterServiceBuilder, ResponseBody, RouterRequest,
+    RouterResponse, SubgraphRequest, ValueExt,
 };
 use maplit::hashmap;
 use serde_json::to_string_pretty;
+use serde_json_bytes::json;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use test_span::prelude::*;
-use tower::Service;
+use tower::util::BoxCloneService;
+use tower::BoxError;
 use tower::ServiceExt;
 
 macro_rules! assert_federated_response {
@@ -245,6 +247,107 @@ async fn mutation_should_not_work_over_get() {
     assert_eq!(registry.totals(), expected_service_hits);
 }
 
+#[tokio::test]
+async fn automated_persisted_queries() {
+    let (router, registry) = setup_router_and_registry().await;
+
+    let mut extensions: Object = Default::default();
+    extensions.insert("code", "PERSISTED_QUERY_NOT_FOUND".into());
+    extensions.insert(
+        "exception",
+        json!(
+                {"stacktrace":["PersistedQueryNotFoundError: PersistedQueryNotFound"]
+        }),
+    );
+    let expected_apq_miss_error = apollo_router_core::Error {
+        message: "PersistedQueryNotFound".to_string(),
+        extensions,
+        ..Default::default()
+    };
+
+    let mut request_extensions: Object = Default::default();
+    request_extensions.insert(
+        "persistedQuery",
+        json!({
+            "version" : 1u8,
+            "sha256Hash" : "9d1474aa069127ff795d3412b11dfc1f1be0853aed7a54c4a619ee0b1725382e"
+        }),
+    );
+    let request_builder = graphql::Request::builder().extensions(request_extensions.clone());
+    let apq_only_request = request_builder.clone().build();
+
+    // First query, apq hash but no query, it will be a cache miss.
+
+    // No services should be queried
+    let expected_service_hits = hashmap! {};
+
+    let http_request = http::Request::builder()
+        .method("GET")
+        .body(apq_only_request)
+        .unwrap()
+        .into();
+
+    let request = graphql::RouterRequest {
+        context: graphql::Context::new().with_request(http_request),
+    };
+
+    let actual = query_with_router(router.clone(), request).await;
+
+    assert_eq!(expected_apq_miss_error, actual.errors[0]);
+    assert_eq!(1, actual.errors.len());
+    assert_eq!(registry.totals(), expected_service_hits);
+
+    // Second query, apq hash with corresponding query, it will be inserted into the cache.
+
+    let apq_request_with_query = request_builder
+        .clone()
+        .query("query Query { me { name } }")
+        .build();
+
+    // Services should have been queried once
+    let expected_service_hits = hashmap! {
+        "accounts".to_string()=>1,
+    };
+
+    let http_request = http::Request::builder()
+        .method("GET")
+        .body(apq_request_with_query)
+        .unwrap()
+        .into();
+
+    let request = graphql::RouterRequest {
+        context: graphql::Context::new().with_request(http_request),
+    };
+
+    let actual = query_with_router(router.clone(), request).await;
+
+    assert_eq!(0, actual.errors.len());
+    assert_eq!(registry.totals(), expected_service_hits);
+
+    // Third and last query, apq hash without query, it will trigger an apq cache hit.
+    let apq_only_request = request_builder.build();
+
+    // Services should have been queried twice
+    let expected_service_hits = hashmap! {
+        "accounts".to_string()=>2,
+    };
+
+    let http_request = http::Request::builder()
+        .method("GET")
+        .body(apq_only_request)
+        .unwrap()
+        .into();
+
+    let request = graphql::RouterRequest {
+        context: graphql::Context::new().with_request(http_request),
+    };
+
+    let actual = query_with_router(router, request).await;
+
+    assert_eq!(0, actual.errors.len());
+    assert_eq!(registry.totals(), expected_service_hits);
+}
+
 #[test_span(tokio::test)]
 async fn variables() {
     assert_federated_response!(
@@ -334,6 +437,14 @@ async fn query_node(request: &graphql::Request) -> Result<graphql::Response, gra
 async fn query_rust(
     request: graphql::RouterRequest,
 ) -> (graphql::Response, CountingServiceRegistry) {
+    let (router, counting_registry) = setup_router_and_registry().await;
+    (query_with_router(router, request).await, counting_registry)
+}
+
+async fn setup_router_and_registry() -> (
+    BoxCloneService<RouterRequest, RouterResponse, BoxError>,
+    CountingServiceRegistry,
+) {
     let schema = Arc::new(include_str!("fixtures/supergraph.graphql").parse().unwrap());
     let config =
         serde_yaml::from_str::<Configuration>(include_str!("fixtures/supergraph_config.yaml"))
@@ -355,13 +466,20 @@ async fn query_rust(
     }
 
     builder = builder.with_dispatcher(get_dispatcher());
-    let (mut router, _) = builder.build().await;
+    let (router, _) = builder.build().await;
 
-    let stream = router.ready().await.unwrap().call(request).await.unwrap();
+    (router, counting_registry)
+}
+
+async fn query_with_router(
+    router: BoxCloneService<RouterRequest, RouterResponse, BoxError>,
+    request: graphql::RouterRequest,
+) -> graphql::Response {
+    let stream = router.oneshot(request).await.unwrap();
     let (_, response) = stream.response.into_parts();
 
     match response {
-        ResponseBody::GraphQL(response) => (response, counting_registry),
+        ResponseBody::GraphQL(response) => response,
         _ => {
             panic!("Expected graphql response")
         }


### PR DESCRIPTION
improvement: Introduce Checkpoint and Step mechanism.

Followup to our recent #537 investigations, we noticed Service layers were missing a straightforward way to let the service orchestrator know whether it shall make progress or bail out.

This Commit introduces `CheckpointLayer` and `CheckpointService` which take a `fn(Request) -> Step<Request, Response>` callback.

`Step` is an enum that contains two variants.
- `Step::Continue(Request)` notifies the CheckpointLayer it should resume calling downstream services.
- `Step::Return(Response)` notifies the CheckpointLayer it should "early return" the response, and not call downstream services.

Iterating on this concept we can now use this to create Layers:
- `EnsureQueryPresence` will Return with a `BAD_REQUEST` if no query is available after the `Automated Persisted Queries` plugin has been called.
- `ForbidHttpGetMutations` will Return with a `METHOD_NOT_ALLOWED` if a mutation was sent over a GET request.
- `APQ` will Return with a `OK` and a graphql error `PERSISTED_QUERY_NOT_FOUND` if the query couldn't be found in the cache.

This refactoring also outlined a couple of bugs that were fixed:
- Backpressure: warp http server returns `SERVICE_UNAVAILABLE` if the `RouterService` isn't ready.
- Error handling: Returning BoxError in a tower service will result in a graphql error and a `INTERNAL_SERVER_ERROR` status.