### PR TITLE
Ensure that Reporting plugin is processed ahead of other plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## :bug: Fixes
 
 - **Fix plugin ordering** ([PR #559](https://github.com/apollographql/router/issues/559))
-  Plugins need to execute in sequence of declaration *except* for certain "core" plugins (for instance, Reporting) which must execute prior early in the plugin sequence to make sure they are in place as soon as possible in the router lifecycle. This change now ensures that Reporting plugin executes first and that all other plugins are executed in the order of declaration in configuration. 
+  Plugins need to execute in sequence of declaration *except* for certain "core" plugins (for instance, Reporting) which must execute early in the plugin sequence to make sure they are in place as soon as possible in the router lifecycle. This change now ensures that Reporting plugin executes first and that all other plugins are executed in the order of declaration in configuration. 
 
 # [v0.1.0-alpha.7] 2022-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
  -->
  
+# [v0.1.0-alpha.8] Not yet released
+
+## :bug: Fixes
+
+- **Fix plugin ordering** ([PR #559](https://github.com/apollographql/router/issues/559))
+  Plugins need to execute in sequence of declaration *except* for certain "core" plugins (for instance, Reporting) which must execute prior early in the plugin sequence to make sure they are in place as soon as possible in the router lifecycle. This change now ensures that Reporting plugin executes first and that all other plugins are executed in the order of declaration in configuration. 
+
 # [v0.1.0-alpha.7] 2022-02-25
 
 ## :sparkles: Features

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -55,7 +55,7 @@ reqwest-middleware = "0.1.5"
 reqwest-tracing = { version = "0.2.1", features = ["opentelemetry_0_17"] }
 schemars = { version="0.8.8", features = ["url"] }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
-serde_json = "1.0.79"
+serde_json = { version = "1.0.79", features = ["preserve_order"] }
 serde_yaml = "0.8.23"
 startup = "0.1.1"
 static_assertions = "1.1.0"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 645
+assertion_line: 474
 expression: "&schema"
 
 ---
@@ -135,27 +135,27 @@ expression: "&schema"
       "anyOf": [
         {
           "required": [
-            "com.apollo.test.always_fails_to_start"
-          ]
-        },
-        {
-          "required": [
-            "com.apollo.test.always_fails_to_start_and_stop"
-          ]
-        },
-        {
-          "required": [
-            "com.apollo.test.always_fails_to_stop"
-          ]
-        },
-        {
-          "required": [
-            "com.apollo.test.always_starts_and_stops"
-          ]
-        },
-        {
-          "required": [
             "com.apollographql.reporting"
+          ]
+        },
+        {
+          "required": [
+            "com.apollographql.test.always_fails_to_start"
+          ]
+        },
+        {
+          "required": [
+            "com.apollographql.test.always_fails_to_start_and_stop"
+          ]
+        },
+        {
+          "required": [
+            "com.apollographql.test.always_fails_to_stop"
+          ]
+        },
+        {
+          "required": [
+            "com.apollographql.test.always_starts_and_stops"
           ]
         },
         {
@@ -165,19 +165,19 @@ expression: "&schema"
         }
       ],
       "properties": {
-        "com.apollo.test.always_fails_to_start": {
-          "$ref": "#/definitions/Conf"
-        },
-        "com.apollo.test.always_fails_to_start_and_stop": {
-          "$ref": "#/definitions/Conf"
-        },
-        "com.apollo.test.always_fails_to_stop": {
-          "$ref": "#/definitions/Conf"
-        },
-        "com.apollo.test.always_starts_and_stops": {
-          "$ref": "#/definitions/Conf"
-        },
         "com.apollographql.reporting": {
+          "$ref": "#/definitions/Conf"
+        },
+        "com.apollographql.test.always_fails_to_start": {
+          "$ref": "#/definitions/Conf"
+        },
+        "com.apollographql.test.always_fails_to_start_and_stop": {
+          "$ref": "#/definitions/Conf"
+        },
+        "com.apollographql.test.always_fails_to_stop": {
+          "$ref": "#/definitions/Conf"
+        },
+        "com.apollographql.test.always_starts_and_stops": {
           "$ref": "#/definitions/Conf"
         },
         "com.example.hello": {

--- a/apollo-router/src/plugins/reporting.rs
+++ b/apollo-router/src/plugins/reporting.rs
@@ -5,7 +5,7 @@ use crate::apollo_telemetry::new_pipeline;
 use crate::apollo_telemetry::SpaceportConfig;
 use crate::apollo_telemetry::StudioGraph;
 use crate::configuration::{default_service_name, default_service_namespace};
-use crate::set_subscriber;
+use crate::set_dispatcher;
 use crate::GLOBAL_ENV_FILTER;
 use apollo_router_core::{register_plugin, Plugin};
 use apollo_spaceport::server::ReportSpaceport;
@@ -191,7 +191,7 @@ impl Plugin for Reporting {
 
     async fn startup(&mut self) -> Result<(), BoxError> {
         tracing::debug!("starting: {}: {}", stringify!(Reporting), self.name());
-        set_subscriber(self.try_initialize_subscriber()?);
+        set_dispatcher(self.try_initialize_subscriber()?);
 
         // Only check for notify if we have graph configuration
         if self.config.graph.is_some() {

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -170,35 +170,27 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
             // If it was required, we ensured that the Reporting plugin was in the
             // list of plugins above. Now make sure that we process that plugin
             // before any other plugins.
-            let already_processed_plugins = if configuration
-                .plugins
-                .plugins
-                .contains_key(REPORTING_MODULE_NAME)
-            {
-                let reporting_configuration = configuration
-                    .plugins
-                    .plugins
-                    .get(REPORTING_MODULE_NAME)
-                    .expect("reporting plugin must be present");
-                builder = process_plugin(
-                    builder,
-                    &mut errors,
-                    REPORTING_MODULE_NAME.to_string(),
-                    reporting_configuration,
-                )
-                .await;
-                vec![REPORTING_MODULE_NAME]
-            } else {
-                vec![]
+            let already_processed = match configuration.plugins.plugins.get(REPORTING_MODULE_NAME) {
+                Some(reporting_configuration) => {
+                    builder = process_plugin(
+                        builder,
+                        &mut errors,
+                        REPORTING_MODULE_NAME.to_string(),
+                        reporting_configuration,
+                    )
+                    .await;
+                    vec![REPORTING_MODULE_NAME]
+                }
+                None => vec![],
             };
 
-            // Process the remaining plugins. We use already_processed_plugins to skip
+            // Process the remaining plugins. We use already_processed to skip
             // those plugins we already processed.
             for (name, configuration) in configuration
                 .plugins
                 .plugins
                 .iter()
-                .filter(|(name, _)| !already_processed_plugins.contains(&name.as_str()))
+                .filter(|(name, _)| !already_processed.contains(&name.as_str()))
             {
                 let name = name.clone();
                 builder = process_plugin(builder, &mut errors, name, configuration).await;

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -15,6 +15,8 @@ use tower::{BoxError, Layer, ServiceBuilder, ServiceExt};
 use tower_service::Service;
 use tracing::instrument::WithSubscriber;
 
+const REPORTING_MODULE_NAME: &str = "com.apollographql.reporting";
+
 /// Factory for creating a RouterService
 ///
 /// Instances of this traits are used by the StateMachine to generate a new
@@ -78,20 +80,20 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
             errors.append(&mut e);
         }
 
-        // Because studio usage reporting requires the OTEL plugin,
-        // we must force the addition of the OTEL plugin if APOLLO_KEY
+        // Because studio usage reporting requires the Reporting plugin,
+        // we must force the addition of the Reporting plugin if APOLLO_KEY
         // is set.
         if std::env::var("APOLLO_KEY").is_ok() {
-            // If the user has not specified OTEL configuration, then
+            // If the user has not specified Reporting configuration, then
             // insert a valid "minimal" configuration which allows
             // studio usage reporting to function
             if !configuration
                 .plugins
                 .plugins
-                .contains_key("com.apollographql.reporting")
+                .contains_key(REPORTING_MODULE_NAME)
             {
                 configuration.plugins.plugins.insert(
-                    "com.apollographql.reporting".to_string(),
+                    REPORTING_MODULE_NAME.to_string(),
                     serde_json::json!({ "opentelemetry": null }),
                 );
             }
@@ -130,9 +132,13 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
             builder = builder.with_subgraph_service(name, subgraph_service);
         }
         {
-            let plugin_registry = apollo_router_core::plugins();
-            for (name, configuration) in &configuration.plugins.plugins {
-                let name = name.as_str().to_string();
+            async fn process_plugin(
+                mut builder: PluggableRouterServiceBuilder,
+                errors: &mut Vec<ConfigurationError>,
+                name: String,
+                configuration: &serde_json::Value,
+            ) -> PluggableRouterServiceBuilder {
+                let plugin_registry = apollo_router_core::plugins();
                 match plugin_registry.get(name.as_str()) {
                     Some(factory) => match factory.create_instance(configuration) {
                         Ok(mut plugin) => match plugin.startup().await {
@@ -141,23 +147,52 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
                             }
                             Err(err) => {
                                 tracing::error!("starting plugin: {}, error: {}", name, err);
-                                errors.push(ConfigurationError::PluginStartup {
+                                (*errors).push(ConfigurationError::PluginStartup {
                                     plugin: name,
                                     error: err.to_string(),
                                 });
                             }
                         },
                         Err(err) => {
-                            errors.push(ConfigurationError::PluginConfiguration {
+                            (*errors).push(ConfigurationError::PluginConfiguration {
                                 plugin: name,
                                 error: err.to_string(),
                             });
                         }
                     },
                     None => {
-                        errors.push(ConfigurationError::PluginUnknown(name));
+                        (*errors).push(ConfigurationError::PluginUnknown(name));
                     }
                 }
+                builder
+            }
+
+            // We ensured that the Reporting plugin was in the list of plugins
+            // above. Now make sure that we process that plugin before any
+            // other plugins.
+            let reporting_configuration = configuration
+                .plugins
+                .plugins
+                .get(REPORTING_MODULE_NAME)
+                .expect("reporting plugin must be present");
+            builder = process_plugin(
+                builder,
+                &mut errors,
+                REPORTING_MODULE_NAME.to_string(),
+                reporting_configuration,
+            )
+            .await;
+
+            // Process the remaining plugins. Filter out the reporting module so that
+            // we don't process it twice
+            for (name, configuration) in configuration
+                .plugins
+                .plugins
+                .iter()
+                .filter(|(name, _)| *name != REPORTING_MODULE_NAME)
+            {
+                let name = name.clone();
+                builder = process_plugin(builder, &mut errors, name, configuration).await;
             }
         }
         if !errors.is_empty() {
@@ -178,12 +213,12 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
         }
 
         // This **must** run after:
-        //  - the OTEL plugin is initialized.
+        //  - the Reporting plugin is initialized.
         //  - all configuration errors are checked
         // and **before** build() is called.
         //
         // This is because our global SUBSCRIBER is initialized by
-        // the startup() method of our OTEL plugin.
+        // the startup() method of our Reporting plugin.
         let dispatcher = get_dispatcher();
         builder = builder.with_dispatcher(dispatcher.clone());
         let (pluggable_router_service, plugins) = builder.build().await;


### PR DESCRIPTION
Also:

 - Cleanup the SUBSCRIBER/DISPATCHER to store a Dispatch and clone
   as required.
 - Enable preserve_order in apollo-router to ensure that plugins
   are processed in order (after Reporting)

fixes: #557 