### PR TITLE
use rover-client to download the uplink schema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,9 +67,6 @@ commands:
       - run:
           name: Assert npm version
           command: test "$(npm --version)" = "${NPM_VERSION}"
-      - run:
-          name: Install rover
-          command:  npm i -g @apollo/rover
   linux_prepare_node_env:
     steps:
       #TODO[igni]: check for node version before we try to install it
@@ -90,9 +87,6 @@ commands:
       - run:
           name: Assert npm version
           command: test "$(npm --version)" = "${NPM_VERSION}"
-      - run:
-          name: Install rover
-          command:  npm i -g @apollo/rover
 
   windows_prepare_node_env:
     #TODO[igni]: check for node version before we try to install it
@@ -127,9 +121,6 @@ commands:
           name: Assert npm version
           command: |
             if ((npm --version) -Ne "${Env:NPM_VERSION}") { exit 1 }
-      - run:
-          name: Install rover
-          command: iwr 'https://rover.apollo.dev/win/latest' | iex
 
   windows_prepare_test_env:
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.4",
  "once_cell",
  "version_check",
 ]
@@ -66,6 +66,21 @@ name = "anyhow"
 version = "1.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "159bb86af3a200e19a068f4224eae4c8bb2d0fa054c7e5d1cacd5cef95e684cd"
+
+[[package]]
+name = "apollo-encoder"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da9c412262c1dd533a84c9b867dcb4e68ab852a0936e235d75242585dda631"
+
+[[package]]
+name = "apollo-federation-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a9c68b5f69d903740cdfda32b6dcdac1ce6944448fa4d5439d938bb21dc68d"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "apollo-parser"
@@ -138,7 +153,7 @@ dependencies = [
  "tower-test",
  "tracing",
  "tracing-opentelemetry",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.9",
  "typed-builder",
  "url",
  "uuid",
@@ -158,7 +173,7 @@ dependencies = [
  "serde_json",
  "serde_json_bytes",
  "tokio",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.9",
 ]
 
 [[package]]
@@ -199,7 +214,7 @@ dependencies = [
  "tower-service",
  "tower-test",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.9",
  "typed-builder",
  "url",
  "urlencoding",
@@ -222,7 +237,7 @@ dependencies = [
  "tonic",
  "tonic-build",
  "tracing",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.9",
  "uname",
 ]
 
@@ -233,12 +248,24 @@ dependencies = [
  "futures",
  "graphql_client",
  "reqwest",
+ "rover-client",
  "serde",
  "tokio",
  "tokio-stream",
  "tracing",
- "which",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "ascii"
@@ -252,7 +279,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
 dependencies = [
- "term",
+ "term 0.7.0",
 ]
 
 [[package]]
@@ -487,6 +514,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "getrandom 0.2.4",
+ "instant",
+ "rand",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +576,17 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block-buffer"
@@ -685,6 +734,9 @@ name = "cc"
 version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -697,6 +749,20 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "clap"
@@ -744,6 +810,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "color-eyre"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f1885697ee8a177096d42f158922251a41973117f6d8a234cee94b9509157b7"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors 1.3.0",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
+dependencies = [
+ "once_cell",
+ "owo-colors 1.3.0",
+ "tracing-core",
+ "tracing-error",
+]
+
+[[package]]
 name = "combine"
 version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -777,6 +870,12 @@ dependencies = [
  "terminal_size",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "convert_case"
@@ -1107,6 +1206,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+dependencies = [
+ "libc",
+ "redox_users 0.3.5",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1123,7 +1243,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.0",
  "winapi 0.3.9",
 ]
 
@@ -1134,7 +1254,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
- "redox_users",
+ "redox_users 0.4.0",
  "winapi 0.3.9",
 ]
 
@@ -1213,6 +1333,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77f3309417938f28bf8228fcff79a4a37103981e3e186d2ccd19c74b38f4eb71"
 
 [[package]]
+name = "eyre"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9289ed2c0440a6536e65119725cf91fc2c6b5e513bfd2e36e1134d7cca6ca12f"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,7 +1381,7 @@ checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.10",
  "winapi 0.3.9",
 ]
 
@@ -1487,13 +1617,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "418d37c8b1d42553c93648be529cb70f920d3baf8ef469b74b9638df426e0b4c"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1501,6 +1642,34 @@ name = "gimli"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
+
+[[package]]
+name = "git-url-parse"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b223a4c4957b1b46e7bd24cb361bef01dbedff634463e57dfb1b1863dff704c"
+dependencies = [
+ "color-eyre",
+ "log",
+ "regex",
+ "strum",
+ "strum_macros",
+ "url",
+]
+
+[[package]]
+name = "git2"
+version = "0.13.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-sys",
+ "url",
+]
 
 [[package]]
 name = "glob"
@@ -1717,6 +1886,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "houston"
+version = "0.0.0"
+source = "git+https://github.com/apollographql/rover/?rev=c650649682ab891a3b718b5277c3b2e9a5fc5224#c650649682ab891a3b718b5277c3b2e9a5fc5224"
+dependencies = [
+ "camino",
+ "directories-next",
+ "serde",
+ "thiserror",
+ "toml",
+ "tracing",
+]
+
+[[package]]
 name = "http"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,6 +1965,12 @@ dependencies = [
  "tokio",
  "url",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1880,6 +2068,12 @@ dependencies = [
  "proc-macro2",
  "quote",
 ]
+
+[[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
@@ -2010,6 +2204,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2055,7 +2258,7 @@ dependencies = [
  "regex",
  "regex-syntax",
  "string_cache",
- "term",
+ "term 0.7.0",
  "tiny-keccak",
  "unicode-xid",
 ]
@@ -2092,6 +2295,19 @@ name = "libc"
 version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.12.26+1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
 
 [[package]]
 name = "libnghttp2-sys"
@@ -2223,7 +2439,7 @@ dependencies = [
  "backtrace",
  "miette-derive",
  "once_cell",
- "owo-colors",
+ "owo-colors 3.2.0",
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
@@ -2484,6 +2700,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,6 +2744,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
+name = "online"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7680985bd550795c0161707f51f9abada87c63a5409114ed818a8618d18ec5e5"
+
+[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,6 +2782,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.17.0+1.1.1m"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d6a336abd10814198f66e2a91ccd7336611f30334119ca8ce300536666fcf4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,6 +2799,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -2665,6 +2907,12 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
+
+[[package]]
+name = "owo-colors"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20448fd678ec04e6ea15bbe0476874af65e98a01515d667aa49f1434dc44ebf4"
@@ -2705,7 +2953,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.10",
  "smallvec",
  "winapi 0.3.9",
 ]
@@ -2718,7 +2966,7 @@ checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.10",
  "smallvec",
  "windows-sys",
 ]
@@ -2900,6 +3148,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettytable-rs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
+dependencies = [
+ "atty",
+ "csv",
+ "encode_unicode",
+ "lazy_static",
+ "term 0.5.2",
+ "unicode-width",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3007,7 +3269,7 @@ dependencies = [
  "mach",
  "once_cell",
  "raw-cpuid",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
  "web-sys",
  "winapi 0.3.9",
 ]
@@ -3049,7 +3311,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.4",
 ]
 
 [[package]]
@@ -3097,6 +3359,12 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_syscall"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
@@ -3106,12 +3374,23 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom 0.1.16",
+ "redox_syscall 0.1.57",
+ "rust-argon2",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom",
- "redox_syscall",
+ "getrandom 0.2.4",
+ "redox_syscall 0.2.10",
 ]
 
 [[package]]
@@ -3155,6 +3434,7 @@ version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
 dependencies = [
+ "async-compression",
  "base64",
  "bytes",
  "encoding_rs",
@@ -3179,6 +3459,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-socks",
  "tokio-util 0.6.9",
  "url",
  "wasm-bindgen",
@@ -3248,6 +3529,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "rover-client"
+version = "0.0.0"
+source = "git+https://github.com/apollographql/rover/?rev=c650649682ab891a3b718b5277c3b2e9a5fc5224#c650649682ab891a3b718b5277c3b2e9a5fc5224"
+dependencies = [
+ "apollo-encoder",
+ "apollo-federation-types",
+ "backoff",
+ "camino",
+ "chrono",
+ "git-url-parse",
+ "git2",
+ "graphql_client",
+ "houston",
+ "http",
+ "humantime",
+ "online",
+ "prettytable-rs",
+ "regex",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "rowan"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3258,6 +3567,18 @@ dependencies = [
  "memoffset 0.6.5",
  "rustc-hash",
  "text-size",
+]
+
+[[package]]
+name = "rust-argon2"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
+dependencies = [
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils 0.8.6",
 ]
 
 [[package]]
@@ -3733,6 +4054,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7ac893c7d471c8a21f31cfe213ec4f6d9afeed25537c772e08ef3f005f8729e"
+
+[[package]]
+name = "strum_macros"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339f799d8b549e3744c7ac7feb216383e4005d94bdb22561b3ab8f3b808ae9fb"
+dependencies = [
+ "heck 0.3.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "supports-color"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3822,8 +4161,19 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.10",
  "remove_dir_all",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "term"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
+dependencies = [
+ "byteorder",
+ "dirs",
  "winapi 0.3.9",
 ]
 
@@ -3892,7 +4242,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-futures",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.9",
 ]
 
 [[package]]
@@ -3981,6 +4331,16 @@ dependencies = [
  "log",
  "ordered-float",
  "threadpool",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -4080,6 +4440,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-socks"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51165dfa029d2a65969413a6cc96f354b86b464498702f174a4efa13608fd8c0"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4129,6 +4501,15 @@ dependencies = [
  "log",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -4276,6 +4657,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
+dependencies = [
+ "tracing",
+ "tracing-subscriber 0.2.25",
+]
+
+[[package]]
 name = "tracing-futures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4306,7 +4697,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-subscriber",
+ "tracing-subscriber 0.3.9",
 ]
 
 [[package]]
@@ -4316,6 +4707,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
 dependencies = [
  "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
  "tracing-core",
 ]
 
@@ -4463,7 +4865,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.4",
  "serde",
 ]
 
@@ -4575,6 +4977,12 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/licenses.html
+++ b/licenses.html
@@ -44,8 +44,8 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#MIT">MIT License</a> (68)</li>
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (37)</li>
+            <li><a href="#MIT">MIT License</a> (76)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (36)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (2)</li>
             <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a> (1)</li>
             <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a> (1)</li>
@@ -246,6 +246,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/tormol/encode_unicode ">encode_unicode</a></li>
                     <li><a href=" https://github.com/hsivonen/encoding_rs ">encoding_rs</a></li>
                     <li><a href=" https://github.com/nvzqz/static-assertions-rs ">static_assertions</a></li>
                 </ul>
@@ -855,7 +856,6 @@
                     <li><a href=" https://github.com/clap-rs/clap/tree/master/clap_derive ">clap_derive</a></li>
                     <li><a href=" https://github.com/open-telemetry/opentelemetry-rust ">opentelemetry</a></li>
                     <li><a href=" https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-jaeger ">opentelemetry-jaeger</a></li>
-                    <li><a href=" https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-semantic-conventions ">opentelemetry-semantic-conventions</a></li>
                     <li><a href=" https://github.com/dylni/os_str_bytes ">os_str_bytes</a></li>
                     <li><a href=" https://github.com/cecton/serde_json_traversal ">serde_json_traversal</a></li>
                     <li><a href=" https://github.com/TeXitoi/structopt ">structopt</a></li>
@@ -1699,6 +1699,7 @@
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast</a></li>
+                    <li><a href=" https://github.com/tailhook/humantime ">humantime</a></li>
                     <li><a href=" https://github.com/sfackler/scheduled-thread-pool ">scheduled-thread-pool</a></li>
                     <li><a href=" https://github.com/reem/rust-unreachable.git ">unreachable</a></li>
                 </ul>
@@ -1910,7 +1911,9 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys</a></li>
+                    <li><a href=" https://github.com/soc/directories-rs ">directories</a></li>
+                    <li><a href=" https://github.com/xdg-rs/dirs/tree/master/directories ">directories-next</a></li>
+                    <li><a href=" https://github.com/xdg-rs/dirs/tree/master/dirs-sys ">dirs-sys-next</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -2092,7 +2095,9 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/rust-lang/libc ">libc</a></li>
                     <li><a href=" https://github.com/nox/serde_urlencoded ">serde_urlencoded</a></li>
+                    <li><a href=" https://github.com/TrueLayer/task-local-extensions ">task-local-extensions</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -3746,215 +3751,6 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/cryptocorrosion/cryptocorrosion ">ppv-lite86</a></li>
-                </ul>
-                <pre class="license-text">                              Apache License
-                        Version 2.0, January 2004
-                     http://www.apache.org/licenses/
-
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-1. Definitions.
-
-   &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-   and distribution as defined by Sections 1 through 9 of this document.
-
-   &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-   the copyright owner that is granting the License.
-
-   &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-   other entities that control, are controlled by, or are under common
-   control with that entity. For the purposes of this definition,
-   &quot;control&quot; means (i) the power, direct or indirect, to cause the
-   direction or management of such entity, whether by contract or
-   otherwise, or (ii) ownership of fifty percent (50%) or more of the
-   outstanding shares, or (iii) beneficial ownership of such entity.
-
-   &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-   exercising permissions granted by this License.
-
-   &quot;Source&quot; form shall mean the preferred form for making modifications,
-   including but not limited to software source code, documentation
-   source, and configuration files.
-
-   &quot;Object&quot; form shall mean any form resulting from mechanical
-   transformation or translation of a Source form, including but
-   not limited to compiled object code, generated documentation,
-   and conversions to other media types.
-
-   &quot;Work&quot; shall mean the work of authorship, whether in Source or
-   Object form, made available under the License, as indicated by a
-   copyright notice that is included in or attached to the work
-   (an example is provided in the Appendix below).
-
-   &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-   form, that is based on (or derived from) the Work and for which the
-   editorial revisions, annotations, elaborations, or other modifications
-   represent, as a whole, an original work of authorship. For the purposes
-   of this License, Derivative Works shall not include works that remain
-   separable from, or merely link (or bind by name) to the interfaces of,
-   the Work and Derivative Works thereof.
-
-   &quot;Contribution&quot; shall mean any work of authorship, including
-   the original version of the Work and any modifications or additions
-   to that Work or Derivative Works thereof, that is intentionally
-   submitted to Licensor for inclusion in the Work by the copyright owner
-   or by an individual or Legal Entity authorized to submit on behalf of
-   the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-   means any form of electronic, verbal, or written communication sent
-   to the Licensor or its representatives, including but not limited to
-   communication on electronic mailing lists, source code control systems,
-   and issue tracking systems that are managed by, or on behalf of, the
-   Licensor for the purpose of discussing and improving the Work, but
-   excluding communication that is conspicuously marked or otherwise
-   designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-   &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-   on behalf of whom a Contribution has been received by Licensor and
-   subsequently incorporated within the Work.
-
-2. Grant of Copyright License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   copyright license to reproduce, prepare Derivative Works of,
-   publicly display, publicly perform, sublicense, and distribute the
-   Work and such Derivative Works in Source or Object form.
-
-3. Grant of Patent License. Subject to the terms and conditions of
-   this License, each Contributor hereby grants to You a perpetual,
-   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-   (except as stated in this section) patent license to make, have made,
-   use, offer to sell, sell, import, and otherwise transfer the Work,
-   where such license applies only to those patent claims licensable
-   by such Contributor that are necessarily infringed by their
-   Contribution(s) alone or by combination of their Contribution(s)
-   with the Work to which such Contribution(s) was submitted. If You
-   institute patent litigation against any entity (including a
-   cross-claim or counterclaim in a lawsuit) alleging that the Work
-   or a Contribution incorporated within the Work constitutes direct
-   or contributory patent infringement, then any patent licenses
-   granted to You under this License for that Work shall terminate
-   as of the date such litigation is filed.
-
-4. Redistribution. You may reproduce and distribute copies of the
-   Work or Derivative Works thereof in any medium, with or without
-   modifications, and in Source or Object form, provided that You
-   meet the following conditions:
-
-   (a) You must give any other recipients of the Work or
-       Derivative Works a copy of this License; and
-
-   (b) You must cause any modified files to carry prominent notices
-       stating that You changed the files; and
-
-   (c) You must retain, in the Source form of any Derivative Works
-       that You distribute, all copyright, patent, trademark, and
-       attribution notices from the Source form of the Work,
-       excluding those notices that do not pertain to any part of
-       the Derivative Works; and
-
-   (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-       distribution, then any Derivative Works that You distribute must
-       include a readable copy of the attribution notices contained
-       within such NOTICE file, excluding those notices that do not
-       pertain to any part of the Derivative Works, in at least one
-       of the following places: within a NOTICE text file distributed
-       as part of the Derivative Works; within the Source form or
-       documentation, if provided along with the Derivative Works; or,
-       within a display generated by the Derivative Works, if and
-       wherever such third-party notices normally appear. The contents
-       of the NOTICE file are for informational purposes only and
-       do not modify the License. You may add Your own attribution
-       notices within Derivative Works that You distribute, alongside
-       or as an addendum to the NOTICE text from the Work, provided
-       that such additional attribution notices cannot be construed
-       as modifying the License.
-
-   You may add Your own copyright statement to Your modifications and
-   may provide additional or different license terms and conditions
-   for use, reproduction, or distribution of Your modifications, or
-   for any such Derivative Works as a whole, provided Your use,
-   reproduction, and distribution of the Work otherwise complies with
-   the conditions stated in this License.
-
-5. Submission of Contributions. Unless You explicitly state otherwise,
-   any Contribution intentionally submitted for inclusion in the Work
-   by You to the Licensor shall be under the terms and conditions of
-   this License, without any additional terms or conditions.
-   Notwithstanding the above, nothing herein shall supersede or modify
-   the terms of any separate license agreement you may have executed
-   with Licensor regarding such Contributions.
-
-6. Trademarks. This License does not grant permission to use the trade
-   names, trademarks, service marks, or product names of the Licensor,
-   except as required for reasonable and customary use in describing the
-   origin of the Work and reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty. Unless required by applicable law or
-   agreed to in writing, Licensor provides the Work (and each
-   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-   implied, including, without limitation, any warranties or conditions
-   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-   PARTICULAR PURPOSE. You are solely responsible for determining the
-   appropriateness of using or redistributing the Work and assume any
-   risks associated with Your exercise of permissions under this License.
-
-8. Limitation of Liability. In no event and under no legal theory,
-   whether in tort (including negligence), contract, or otherwise,
-   unless required by applicable law (such as deliberate and grossly
-   negligent acts) or agreed to in writing, shall any Contributor be
-   liable to You for damages, including any direct, indirect, special,
-   incidental, or consequential damages of any character arising as a
-   result of this License or out of the use or inability to use the
-   Work (including but not limited to damages for loss of goodwill,
-   work stoppage, computer failure or malfunction, or any and all
-   other commercial damages or losses), even if such Contributor
-   has been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability. While redistributing
-   the Work or Derivative Works thereof, You may choose to offer,
-   and charge a fee for, acceptance of support, warranty, indemnity,
-   or other liability obligations and/or rights consistent with this
-   License. However, in accepting such obligations, You may act only
-   on Your own behalf and on Your sole responsibility, not on behalf
-   of any other Contributor, and only if You agree to indemnify,
-   defend, and hold each Contributor harmless for any liability
-   incurred by, or claims asserted against, such Contributor by reason
-   of your accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-APPENDIX: How to apply the Apache License to your work.
-
-   To apply the Apache License to your work, attach the following
-   boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
-   replaced with your own identifying information. (Don&#x27;t include
-   the brackets!)  The text should be enclosed in the appropriate
-   comment syntax for the file format. We also recommend that a
-   file or class name and description of purpose be included on the
-   same &quot;printed page&quot; as the copyright notice for easier
-   identification within third-party archives.
-
-Copyright 2019 The CryptoCorrosion Contributors
-
-Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-   http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://gitlab.com/CreepySkeleton/proc-macro-error ">proc-macro-error-attr</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -4376,21 +4172,22 @@ limitations under the License.
                     <li><a href=" https://github.com/gimli-rs/addr2line ">addr2line</a></li>
                     <li><a href=" https://github.com/tkaitchuck/ahash ">ahash</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow</a></li>
+                    <li><a href=" https://github.com/bluss/arrayvec ">arrayvec</a></li>
                     <li><a href=" https://github.com/smol-rs/async-io ">async-io</a></li>
                     <li><a href=" https://github.com/dtolnay/async-trait ">async-trait</a></li>
                     <li><a href=" https://github.com/cuviper/autocfg ">autocfg</a></li>
                     <li><a href=" https://github.com/rust-lang/backtrace-rs ">backtrace</a></li>
+                    <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64</a></li>
                     <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo</a></li>
                     <li><a href=" https://github.com/smol-rs/cache-padded ">cache-padded</a></li>
                     <li><a href=" https://github.com/camino-rs/camino ">camino</a></li>
-                    <li><a href=" https://github.com/alexcrichton/cc-rs ">cc</a></li>
+                    <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if</a></li>
                     <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if</a></li>
                     <li><a href=" https://github.com/stjepang/concurrent-queue ">concurrent-queue</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation</a></li>
                     <li><a href=" https://github.com/servo/core-foundation-rs ">core-foundation-sys</a></li>
                     <li><a href=" https://github.com/matklad/countme ">countme</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-channel</a></li>
-                    <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-epoch</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-utils</a></li>
                     <li><a href=" https://github.com/mcarton/rust-derivative ">derivative</a></li>
                     <li><a href=" https://github.com/yaahc/displaydoc ">displaydoc</a></li>
@@ -4398,26 +4195,28 @@ limitations under the License.
                     <li><a href=" https://github.com/bluss/either ">either</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/error-chain ">error-chain</a></li>
                     <li><a href=" https://github.com/smol-rs/event-listener ">event-listener</a></li>
+                    <li><a href=" https://github.com/yaahc/eyre ">eyre</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/failure ">failure</a></li>
                     <li><a href=" https://github.com/alexcrichton/filetime ">filetime</a></li>
                     <li><a href=" https://github.com/petgraph/fixedbitset ">fixedbitset</a></li>
                     <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv</a></li>
                     <li><a href=" https://github.com/smol-rs/futures-lite ">futures-lite</a></li>
-                    <li><a href=" https://github.com/gimli-rs/gimli ">gimli</a></li>
+                    <li><a href=" https://github.com/rust-lang/git2-rs ">git2</a></li>
                     <li><a href=" https://github.com/rust-lang/glob ">glob</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown</a></li>
                     <li><a href=" https://github.com/HdrHistogram/HdrHistogram_rust.git ">hdrhistogram</a></li>
                     <li><a href=" https://github.com/withoutboats/heck ">heck</a></li>
-                    <li><a href=" https://github.com/withoutboats/heck ">heck</a></li>
-                    <li><a href=" https://github.com/francesca64/hotwatch ">hotwatch</a></li>
+                    <li><a href=" https://github.com/hermitcore/libhermit-rs ">hermit-abi</a></li>
                     <li><a href=" https://github.com/seanmonstar/httparse ">httparse</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">idna</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools</a></li>
                     <li><a href=" https://github.com/dtolnay/itoa ">itoa</a></li>
+                    <li><a href=" https://github.com/alexcrichton/jobserver-rs ">jobserver</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys ">js-sys</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static</a></li>
                     <li><a href=" https://github.com/indiv0/lazycell ">lazycell</a></li>
+                    <li><a href=" https://github.com/rust-lang/git2-rs ">libgit2-sys</a></li>
                     <li><a href=" https://github.com/est31/maybe-uninit ">maybe-uninit</a></li>
                     <li><a href=" https://github.com/alexcrichton/miow ">miow</a></li>
                     <li><a href=" https://github.com/yoshuawuyts/miow ">miow</a></li>
@@ -4425,10 +4224,12 @@ limitations under the License.
                     <li><a href=" https://github.com/asomers/mockall ">mockall_derive</a></li>
                     <li><a href=" https://github.com/havarnov/multimap ">multimap</a></li>
                     <li><a href=" https://github.com/deprecrated/net2-rs ">net2</a></li>
-                    <li><a href=" https://github.com/rust-num/num-traits ">num-traits</a></li>
+                    <li><a href=" https://github.com/rust-num/num-integer ">num-integer</a></li>
                     <li><a href=" https://github.com/seanmonstar/num_cpus ">num_cpus</a></li>
                     <li><a href=" https://github.com/gimli-rs/object ">object</a></li>
+                    <li><a href=" https://github.com/matklad/once_cell ">once_cell</a></li>
                     <li><a href=" https://github.com/alexcrichton/openssl-probe ">openssl-probe</a></li>
+                    <li><a href=" https://github.com/alexcrichton/openssl-src-rs ">openssl-src</a></li>
                     <li><a href=" https://github.com/stjepang/parking ">parking</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot</a></li>
@@ -4445,6 +4246,7 @@ limitations under the License.
                     <li><a href=" https://github.com/rust-lang/regex ">regex</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-syntax</a></li>
                     <li><a href=" https://github.com/rust-analyzer/rowan ">rowan</a></li>
+                    <li><a href=" https://github.com/sru-systems/rust-argon2 ">rust-argon2</a></li>
                     <li><a href=" https://github.com/alexcrichton/rustc-demangle ">rustc-demangle</a></li>
                     <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls</a></li>
                     <li><a href=" https://github.com/bluss/scopeguard ">scopeguard</a></li>
@@ -4462,18 +4264,20 @@ limitations under the License.
                     <li><a href=" https://github.com/budziq/rust-skeptic ">skeptic</a></li>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec</a></li>
                     <li><a href=" https://github.com/dtolnay/syn ">syn</a></li>
-                    <li><a href=" https://github.com/alexcrichton/tar-rs ">tar</a></li>
-                    <li><a href=" https://github.com/Stebalien/tempfile ">tempfile</a></li>
+                    <li><a href=" https://github.com/Stebalien/term ">term</a></li>
                     <li><a href=" https://github.com/rust-analyzer/text-size ">text-size</a></li>
                     <li><a href=" https://github.com/dtolnay/thiserror ">thiserror</a></li>
                     <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl</a></li>
                     <li><a href=" https://github.com/Amanieu/thread_local-rs ">thread_local</a></li>
+                    <li><a href=" https://github.com/rust-threadpool/rust-threadpool ">threadpool</a></li>
+                    <li><a href=" https://github.com/time-rs/time ">time</a></li>
                     <li><a href=" https://github.com/idanarye/rust-typed-builder ">typed-builder</a></li>
                     <li><a href=" https://github.com/seanmonstar/unicase ">unicase</a></li>
                     <li><a href=" https://github.com/servo/unicode-bidi ">unicode-bidi</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-normalization ">unicode-normalization</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width</a></li>
                     <li><a href=" https://github.com/stjepang/waker-fn ">waker-fn</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/wasi ">wasi</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasi ">wasi</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen ">wasm-bindgen</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/backend ">wasm-bindgen-backend</a></li>
@@ -4900,7 +4704,7 @@ limitations under the License.
                     <li><a href=" https://github.com/RustCrypto/utils ">block-buffer</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">digest</a></li>
-                    <li><a href=" https://github.com/RustCrypto/utils ">opaque-debug</a></li>
+                    <li><a href=" https://github.com/RustCrypto/traits ">digest</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">sha-1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -5110,7 +4914,8 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-random/rand ">rand_hc</a></li>
+                    <li><a href=" https://github.com/rust-random/getrandom ">getrandom</a></li>
+                    <li><a href=" https://github.com/rust-random/getrandom ">getrandom</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -6596,19 +6401,24 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-encoder</a></li>
                     <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
-                    <li><a href=" https://crates.io/crates/apollo-router-benchmarks ">apollo-router-benchmarks</a></li>
                     <li><a href=" https://crates.io/crates/apollo-router-core ">apollo-router-core</a></li>
                     <li><a href=" https://crates.io/crates/apollo-spaceport ">apollo-spaceport</a></li>
                     <li><a href=" https://crates.io/crates/apollo-uplink ">apollo-uplink</a></li>
+                    <li><a href=" https://github.com/droundy/arrayref ">arrayref</a></li>
                     <li><a href=" https://github.com/tokio-rs/async-stream ">async-stream</a></li>
                     <li><a href=" https://github.com/tokio-rs/async-stream ">async-stream-impl</a></li>
                     <li><a href=" https://github.com/softprops/atty ">atty</a></li>
                     <li><a href=" https://github.com/dropbox/rust-brotli ">brotli</a></li>
                     <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder</a></li>
+                    <li><a href=" https://github.com/oli-obk/cargo_metadata ">cargo_metadata</a></li>
+                    <li><a href=" https://github.com/chronotope/chrono ">chrono</a></li>
                     <li><a href=" https://github.com/clap-rs/clap ">clap</a></li>
                     <li><a href=" https://github.com/Marwes/combine ">combine</a></li>
+                    <li><a href=" https://github.com/cesarb/constant_time_eq ">constant_time_eq</a></li>
                     <li><a href=" https://github.com/rutrum/convert-case ">convert_case</a></li>
+                    <li><a href=" https://github.com/BurntSushi/rust-csv ">csv</a></li>
                     <li><a href=" https://github.com/denoland/deno ">deno_core</a></li>
                     <li><a href=" https://github.com/JelteF/derive_more ">derive_more</a></li>
                     <li><a href=" https://github.com/DimaKudosh/difflib ">difflib</a></li>
@@ -6627,10 +6437,13 @@ limitations under the License.
                     <li><a href=" https://github.com/graphql-rust/graphql-client ">graphql_client_codegen</a></li>
                     <li><a href=" https://github.com/hyperium/headers ">headers</a></li>
                     <li><a href=" https://github.com/hyperium/headers ">headers-core</a></li>
-                    <li><a href=" https://github.com/MarcusGrass/parse-range-headers ">http-range-header</a></li>
+                    <li><a href=" https://crates.io/crates/houston ">houston</a></li>
+                    <li><a href=" https://github.com/hyperium/http-body ">http-body</a></li>
+                    <li><a href=" https://github.com/BurntSushi/ripgrep/tree/master/crates/ignore ">ignore</a></li>
                     <li><a href=" https://github.com/inotify-rs/inotify ">inotify</a></li>
                     <li><a href=" https://github.com/hannobraun/inotify-sys ">inotify-sys</a></li>
                     <li><a href=" https://github.com/dermesser/integer-encoding-rs ">integer-encoding</a></li>
+                    <li><a href=" https://github.com/zkat/is_ci ">is_ci</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">kernel32-sys</a></li>
                     <li><a href=" https://github.com/jeromefroe/lru-rs.git ">lru</a></li>
                     <li><a href=" https://github.com/BurntSushi/memchr ">memchr</a></li>
@@ -6639,36 +6452,41 @@ limitations under the License.
                     <li><a href=" https://github.com/tokio-rs/mio ">mio</a></li>
                     <li><a href=" https://github.com/Geal/nom ">nom</a></li>
                     <li><a href=" https://github.com/notify-rs/notify.git ">notify</a></li>
+                    <li><a href=" https://github.com/jesusprubio/online.git ">online</a></li>
                     <li><a href=" https://github.com/sfackler/rust-openssl ">openssl-sys</a></li>
                     <li><a href=" https://github.com/reem/rust-ordered-float ">ordered-float</a></li>
                     <li><a href=" https://github.com/jam1garner/owo-colors ">owo-colors</a></li>
+                    <li><a href=" https://github.com/jam1garner/owo-colors ">owo-colors</a></li>
+                    <li><a href=" https://github.com/phsym/prettytable-rs ">prettytable-rs</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-derive</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-types</a></li>
                     <li><a href=" https://github.com/raphlinus/pulldown-cmark ">pulldown-cmark</a></li>
                     <li><a href=" https://github.com/metrics-rs/quanta ">quanta</a></li>
                     <li><a href=" https://gitlab.redox-os.org/redox-os/syscall ">redox_syscall</a></li>
                     <li><a href=" https://gitlab.redox-os.org/redox-os/users ">redox_users</a></li>
+                    <li><a href=" https://gitlab.redox-os.org/redox-os/users ">redox_users</a></li>
                     <li><a href=" https://github.com/BurntSushi/regex-automata ">regex-automata</a></li>
-                    <li><a href=" https://github.com/TrueLayer/reqwest-middleware ">reqwest-middleware</a></li>
                     <li><a href=" https://github.com/TrueLayer/reqwest-middleware ">reqwest-tracing</a></li>
                     <li><a href=" https://github.com/briansmith/ring ">ring</a></li>
                     <li><a href=" https://github.com/apollographql/federation/ ">router-bridge</a></li>
+                    <li><a href=" https://crates.io/crates/rover-client ">rover-client</a></li>
                     <li><a href=" https://github.com/ctz/rustls ">rustls</a></li>
                     <li><a href=" https://github.com/steffengy/schannel-rs ">schannel</a></li>
                     <li><a href=" https://github.com/GREsau/schemars ">schemars</a></li>
                     <li><a href=" https://github.com/GREsau/schemars ">schemars_derive</a></li>
                     <li><a href=" https://github.com/hawkw/sharded-slab ">sharded-slab</a></li>
                     <li><a href=" https://github.com/mgeisler/smawk ">smawk</a></li>
-                    <li><a href=" https://github.com/dguo/strsim-rs ">strsim</a></li>
-                    <li><a href=" https://github.com/dguo/strsim-rs ">strsim</a></li>
+                    <li><a href=" https://github.com/Peternator7/strum ">strum</a></li>
+                    <li><a href=" https://github.com/Peternator7/strum ">strum_macros</a></li>
                     <li><a href=" https://github.com/mystor/synstructure ">synstructure</a></li>
+                    <li><a href=" https://github.com/FillZpp/sys-info-rs ">sys-info</a></li>
                     <li><a href=" https://github.com/rust-cli/termtree ">termtree</a></li>
                     <li><a href=" https://github.com/mgeisler/textwrap ">textwrap</a></li>
                     <li><a href=" https://github.com/mgeisler/textwrap ">textwrap</a></li>
-                    <li><a href=" https://github.com/apache/thrift/tree/master/lib/rs ">thrift</a></li>
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-opentelemetry</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-serde</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-subscriber</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-subscriber</a></li>
                     <li><a href=" https://github.com/seanmonstar/try-lock ">try-lock</a></li>
                     <li><a href=" https://github.com/kornelski/rust_urlencoding ">urlencoding</a></li>
@@ -7044,6 +6862,7 @@ according to those terms.
                 <h3 id="BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://crates.io/crates/apollo-router-benchmarks ">apollo-router-benchmarks</a></li>
                     <li><a href=" https://github.com/contain-rs/linked-hash-map ">linked-hash-map</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) &lt;year&gt; &lt;owner&gt; All rights reserved.
@@ -7082,12 +6901,13 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/dropbox/rust-alloc-no-stdlib ">alloc-stdlib</a></li>
-                    <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64</a></li>
                     <li><a href=" https://github.com/bitflags/bitflags ">bitflags</a></li>
-                    <li><a href=" https://github.com/GuillaumeGomez/doc-comment ">doc-comment</a></li>
+                    <li><a href=" https://github.com/oconnor663/blake2_simd ">blake2b_simd</a></li>
+                    <li><a href=" https://github.com/fkoep/downcast-rs ">downcast</a></li>
                     <li><a href=" https://github.com/mitsuhiko/fragile ">fragile</a></li>
                     <li><a href=" https://github.com/octplane/fsevent-rust ">fsevent</a></li>
-                    <li><a href=" https://github.com/Michael-F-Bryan/include_dir ">include_dir_macros</a></li>
+                    <li><a href=" https://github.com/yaahc/indenter ">indenter</a></li>
+                    <li><a href=" https://github.com/cryptocorrosion/cryptocorrosion ">ppv-lite86</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) &lt;year&gt; &lt;owner&gt;. All rights reserved.
@@ -7107,6 +6927,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&
                 <h3 id="CC0-1.0">Creative Commons Zero v1.0 Universal</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/yaahc/color-eyre ">color-eyre</a></li>
                     <li><a href=" https://github.com/sfackler/rust-native-tls ">native-tls</a></li>
                 </ul>
                 <pre class="license-text">Creative Commons Legal Code
@@ -7236,8 +7057,8 @@ express Statement of Purpose.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/BurntSushi/ripgrep/tree/master/crates/ignore ">ignore</a></li>
                     <li><a href=" https://github.com/Michael-F-Bryan/include_dir ">include_dir</a></li>
+                    <li><a href=" https://github.com/Michael-F-Bryan/include_dir ">include_dir_macros</a></li>
                     <li><a href=" https://github.com/sebcrozet/instant ">instant</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro</a></li>
@@ -7387,12 +7208,48 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if</a></li>
+                    <li><a href=" https://github.com/alexcrichton/cc-rs ">cc</a></li>
                     <li><a href=" https://github.com/rust-lang/socket2 ">socket2</a></li>
+                    <li><a href=" https://github.com/alexcrichton/tar-rs ">tar</a></li>
+                    <li><a href=" https://github.com/alexcrichton/toml-rs ">toml</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys ">web-sys</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Alex Crichton
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the &quot;Software&quot;), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2014 Alex Crichton
+Copyright (c) 2020 Josh Triplett
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -7451,7 +7308,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-threadpool/rust-threadpool ">threadpool</a></li>
+                    <li><a href=" https://github.com/rust-num/num-traits ">num-traits</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 The Rust Project Developers
 
@@ -7550,39 +7407,6 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-lang/libc ">libc</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2014-2020 The Rust Project Developers
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the &quot;Software&quot;), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/hyperium/hyper ">hyper</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014-2021 Sean McArthur
@@ -7637,6 +7461,40 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/Stebalien/tempfile ">tempfile</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2015 Steven Allen
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the &quot;Software&quot;), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/gimli-rs/gimli ">gimli</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-xid ">unicode-xid</a></li>
                     <li><a href=" https://github.com/contain-rs/vec-map ">vec_map</a></li>
                 </ul>
@@ -7793,9 +7651,9 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/bluss/indexmap ">indexmap</a></li>
+                    <li><a href=" https://github.com/ihrwein/backoff ">backoff</a></li>
                 </ul>
-                <pre class="license-text">Copyright (c) 2016--2017
+                <pre class="license-text">Copyright (c) 2016 Tibor Benke &lt;ihrwein@gmail.com&gt;
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -7826,9 +7684,9 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/RustCrypto/traits ">digest</a></li>
+                    <li><a href=" https://github.com/bluss/indexmap ">indexmap</a></li>
                 </ul>
-                <pre class="license-text">Copyright (c) 2017 Artyom Pavlov
+                <pre class="license-text">Copyright (c) 2016--2017
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated
@@ -7880,6 +7738,36 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://gitlab.redox-os.org/redox-os/syscall ">redox_syscall</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2017 Redox OS Developers
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+&quot;Software&quot;), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
             </li>
             <li class="license">
                 <h3 id="MIT">MIT License</h3>
@@ -8127,9 +8015,69 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/soc/directories-rs ">directories</a></li>
+                    <li><a href=" https://github.com/soc/dirs-rs ">dirs</a></li>
                 </ul>
-                <pre class="license-text">Copyright (c) 2018 directories-rs contributors
+                <pre class="license-text">Copyright (c) 2018 dirs-rs contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/RustCrypto/utils ">opaque-debug</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2018-2019 The RustCrypto Project Developers
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the &quot;Software&quot;), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2018-2019 dirs-rs contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -8214,45 +8162,13 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/http-body ">http-body</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2019 Hyper Contributors
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the &quot;Software&quot;), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/tokio-rs/tls ">tokio-native-tls</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-attributes</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-futures</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-log</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-opentelemetry</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019 Tokio Contributors
 
@@ -8387,7 +8303,6 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream</a></li>
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-test</a></li>
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util</a></li>
                 </ul>
@@ -8510,7 +8425,39 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-random/getrandom ">getrandom</a></li>
+                    <li><a href=" https://github.com/rust-random/rand ">rand_hc</a></li>
+                </ul>
+                <pre class="license-text">Copyright 2018 Developers of the Rand project
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the &quot;Software&quot;), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/rust-random/rand ">rand</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_core</a></li>
@@ -8562,11 +8509,11 @@ according to those terms.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/GuillaumeGomez/doc-comment ">doc-comment</a></li>
+                    <li><a href=" https://github.com/sticnarf/tokio-socks ">tokio-socks</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
-Copyright (c) 2018 Guillaume Gomez
+Copyright (c) 2018 Yilin Chen
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -8650,11 +8597,11 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/TrueLayer/task-local-extensions ">task-local-extensions</a></li>
+                    <li><a href=" https://github.com/tjtelan/git-url-parse-rs ">git-url-parse</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
-Copyright (c) 2021 TrueLayer
+Copyright (c) 2020 T.J. Telan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -8679,20 +8626,53 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/MarcusGrass/parse-range-headers ">http-range-header</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2021 MarcusGrass
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/apollographql/rover/ ">apollo-federation-types</a></li>
                     <li><a href=" https://github.com/dropbox/rust-brotli-decompressor ">brotli-decompressor</a></li>
+                    <li><a href=" https://github.com/yaahc/color-spantrace ">color-spantrace</a></li>
                     <li><a href=" https://github.com/graphql-rust/graphql-client ">graphql_query_derive</a></li>
-                    <li><a href=" https://github.com/zkat/is_ci ">is_ci</a></li>
                     <li><a href=" https://github.com/fitzgen/mach ">mach</a></li>
                     <li><a href=" https://github.com/open-telemetry/opentelemetry-rust ">opentelemetry-http</a></li>
                     <li><a href=" https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-otlp ">opentelemetry-otlp</a></li>
+                    <li><a href=" https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-semantic-conventions ">opentelemetry-semantic-conventions</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-build</a></li>
                     <li><a href=" https://github.com/dtolnay/ryu ">ryu</a></li>
                     <li><a href=" https://github.com/denoland/deno ">serde_v8</a></li>
                     <li><a href=" https://github.com/zkat/supports-color ">supports-color</a></li>
                     <li><a href=" https://github.com/zkat/supports-hyperlinks ">supports-hyperlinks</a></li>
+                    <li><a href=" https://github.com/apache/thrift/tree/master/lib/rs ">thrift</a></li>
                     <li><a href=" https://github.com/hyperium/tonic ">tonic</a></li>
                     <li><a href=" https://github.com/hyperium/tonic ">tonic-build</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-error</a></li>
                     <li><a href=" https://github.com/briansmith/untrusted ">untrusted</a></li>
                     <li><a href=" https://github.com/reem/rust-void.git ">void</a></li>
                     <li><a href=" https://crates.io/crates/windows_i686_gnu ">windows_i686_gnu</a></li>
@@ -8770,11 +8750,26 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/fkoep/downcast-rs ">downcast</a></li>
+                </ul>
+                <pre class="license-text">MIT License (MIT)
+
+Copyright (c) 2017 Felix Köpge
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the &quot;Software&quot;), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/smol-rs/async-lock ">async-lock</a></li>
-                    <li><a href=" https://github.com/oli-obk/cargo_metadata ">cargo_metadata</a></li>
                     <li><a href=" https://github.com/smol-rs/fastrand ">fastrand</a></li>
-                    <li><a href=" https://github.com/hermitcore/libhermit-rs ">hermit-abi</a></li>
-                    <li><a href=" https://github.com/matklad/once_cell ">once_cell</a></li>
+                    <li><a href=" https://github.com/dtolnay/itoa ">itoa</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/rustc-hash ">rustc-hash</a></li>
                     <li><a href=" https://github.com/apollographql/serde_json_bytes ">serde_json_bytes</a></li>
                 </ul>
@@ -8919,6 +8914,7 @@ SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/BurntSushi/aho-corasick ">aho-corasick</a></li>
+                    <li><a href=" https://github.com/BurntSushi/rust-csv ">csv-core</a></li>
                     <li><a href=" https://github.com/BurntSushi/termcolor ">termcolor</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
@@ -8972,6 +8968,68 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/dguo/strsim-rs ">strsim</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2015 Danny Guo
+Copyright (c) 2016 Titus Wormer &lt;tituswormer@gmail.com&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/dguo/strsim-rs ">strsim</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2015 Danny Guo
+Copyright (c) 2016 Titus Wormer &lt;tituswormer@gmail.com&gt;
+Copyright (c) 2018 Akash Kurdekar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -9035,36 +9093,6 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/FillZpp/sys-info-rs ">sys-info</a></li>
-                </ul>
-                <pre class="license-text">The MIT License (MIT)
-
-Copyright (c) 2015 Siyu Wang
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/clap-rs/clap ">clap</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
@@ -9118,6 +9146,35 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/francesca64/hotwatch ">hotwatch</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2016-2020 Francesca Lovebloom
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -9211,6 +9268,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-epoch</a></li>
                     <li><a href=" https://github.com/crossbeam-rs/crossbeam ">crossbeam-utils</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
@@ -9302,6 +9360,7 @@ SOFTWARE.</pre>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/BurntSushi/aho-corasick ">aho-corasick</a></li>
+                    <li><a href=" https://github.com/BurntSushi/rust-csv ">csv-core</a></li>
                     <li><a href=" https://github.com/BurntSushi/same-file ">same-file</a></li>
                     <li><a href=" https://github.com/BurntSushi/termcolor ">termcolor</a></li>
                 </ul>

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -16,7 +16,8 @@ tokio-stream = "0.1.8"
 tracing = "0.1.31"
 
 [build-dependencies]
-which = "4.2.4"
+rover-client = {git = "https://github.com/apollographql/rover/", rev="c650649682ab891a3b718b5277c3b2e9a5fc5224"}
+reqwest = { version = "0.11.9" }
 
 [dev-dependencies]
 tokio = { version = "1.17.0", default-features = false, features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
Fix #562 

this removes the requirement for an installed rover cli when building in
debug mode
