### PR TITLE
Add api schema to schema.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3312,7 +3312,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation-rs.git?rev=f0a4e4519040df86f5a830e519c3c9b872dbe3a1#f0a4e4519040df86f5a830e519c3c9b872dbe3a1"
+source = "git+https://github.com/apollographql/federation-rs.git?rev=ce38b4d7ba8ebba43a713e4b5b2a617249d05db4#ce38b4d7ba8ebba43a713e4b5b2a617249d05db4"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,7 @@ dependencies = [
  "http",
  "include_dir",
  "insta",
+ "itertools",
  "lru",
  "miette",
  "mockall",
@@ -3311,7 +3312,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation-rs.git?rev=cf87257b9d58701cd9e09e8b5992f809147a2165#cf87257b9d58701cd9e09e8b5992f809147a2165"
+source = "git+https://github.com/apollographql/federation-rs.git?rev=f0a4e4519040df86f5a830e519c3c9b872dbe3a1#f0a4e4519040df86f5a830e519c3c9b872dbe3a1"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -23,6 +23,7 @@ futures = "0.3.21"
 hex = "0.4.3"
 http = "0.2.6"
 include_dir = "0.7.2"
+itertools = "0.10.3"
 lru = "0.7.3"
 miette = { version = "3.3.0", features = ["fancy"] }
 mockall = "0.11.0"
@@ -30,7 +31,7 @@ moka = { version = "0.6.4", features = ["future", "futures-util"] }
 once_cell = "1.9.0"
 paste = "1.0.6"
 regex = "1.5.4"
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "cf87257b9d58701cd9e09e8b5992f809147a2165" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "f0a4e4519040df86f5a830e519c3c9b872dbe3a1" }
 schemars = { version = "0.8.8", features = ["url"] }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -31,7 +31,7 @@ moka = { version = "0.6.4", features = ["future", "futures-util"] }
 once_cell = "1.9.0"
 paste = "1.0.6"
 regex = "1.5.4"
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "f0a4e4519040df86f5a830e519c3c9b872dbe3a1" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "ce38b4d7ba8ebba43a713e4b5b2a617249d05db4" }
 schemars = { version = "0.8.8", features = ["url"] }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }

--- a/apollo-router-core/src/error.rs
+++ b/apollo-router-core/src/error.rs
@@ -270,6 +270,8 @@ pub enum SchemaError {
     IoError(#[from] std::io::Error),
     /// Parsing error(s).
     Parse(ParseErrors),
+    /// Api error(s): {0}
+    Api(String),
 }
 
 #[derive(Debug)]

--- a/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
+++ b/apollo-router-core/src/query_planner/router_bridge_query_planner.rs
@@ -121,9 +121,7 @@ mod tests {
 
     #[test(tokio::test)]
     async fn test_plan() {
-        let planner = RouterBridgeQueryPlanner::new(Arc::new(
-            include_str!("testdata/schema.graphql").parse().unwrap(),
-        ));
+        let planner = RouterBridgeQueryPlanner::new(Arc::new(example_schema()));
         let result = planner
             .get(
                 include_str!("testdata/query.graphql").into(),
@@ -133,6 +131,10 @@ mod tests {
             .await
             .unwrap();
         insta::assert_debug_snapshot!("plan", result);
+    }
+
+    fn example_schema() -> Schema {
+        include_str!("testdata/schema.graphql").parse().unwrap()
     }
 
     #[test]
@@ -147,21 +149,19 @@ mod tests {
     async fn empty_query_plan_should_be_a_planner_error() {
         insta::assert_debug_snapshot!(
             "empty_query_plan_should_be_a_planner_error",
-            RouterBridgeQueryPlanner::new(Arc::new(
-                include_str!("testdata/schema.graphql").parse().unwrap(),
-            ))
-            .get(
-                include_str!("testdata/unknown_introspection_query.graphql").into(),
-                None,
-                Default::default(),
-            )
-            .await
+            RouterBridgeQueryPlanner::new(Arc::new(example_schema()))
+                .get(
+                    include_str!("testdata/unknown_introspection_query.graphql").into(),
+                    None,
+                    Default::default(),
+                )
+                .await
         )
     }
 
     #[test(tokio::test)]
     async fn test_plan_error() {
-        let planner = RouterBridgeQueryPlanner::new(Arc::new("".parse().unwrap()));
+        let planner = RouterBridgeQueryPlanner::new(Arc::new(example_schema()));
         let result = planner.get("".into(), None, Default::default()).await;
 
         assert_eq!(

--- a/apollo-router-core/src/query_planner/selection.rs
+++ b/apollo-router-core/src/query_planner/selection.rs
@@ -193,7 +193,7 @@ mod tests {
     fn test_selection() {
         assert_eq!(
             select!(
-                "",
+                include_str!("testdata/schema.graphql"),
                 bjson!({"__typename": "User", "id":2, "name":"Bob", "job":{"name":"astronaut"}}),
             )
             .unwrap(),
@@ -211,7 +211,8 @@ mod tests {
     fn test_selection_subtype() {
         assert_eq!(
             select!(
-                "union User = Author | Reviewer",
+                "type Query { me: String } type Author { name: String } type Reviewer { name: String } \
+                union User = Author | Reviewer",
                 bjson!({"__typename": "Author", "id":2, "name":"Bob", "job":{"name":"astronaut"}}),
             )
             .unwrap(),
@@ -229,7 +230,7 @@ mod tests {
     fn test_selection_missing_field() {
         assert!(matches!(
             select!(
-                "",
+                include_str!("testdata/schema.graphql"),
                 json!({"__typename": "User", "name":"Bob", "job":{"name":"astronaut"}}),
             )
                 .unwrap_err(),

--- a/apollo-router-core/src/services/router_service.rs
+++ b/apollo-router-core/src/services/router_service.rs
@@ -145,7 +145,7 @@ where
                         query.format_response(
                             response.response.body_mut(),
                             operation_name.as_deref(),
-                            &schema,
+                            schema.api_schema(),
                         )
                     });
                 }

--- a/apollo-router-core/src/services/router_service.rs
+++ b/apollo-router-core/src/services/router_service.rs
@@ -333,6 +333,7 @@ impl PluggableRouterServiceBuilder {
         let query_cache = Arc::new(QueryCache::new(query_cache_limit, self.schema.clone()));
 
         // NaiveIntrospection instantiation can potentially block for some time
+        // We don't need to use the api schema here because on the deno side we always convert to API schema
         let naive_introspection = {
             let schema = self.schema.clone();
             tokio::task::spawn_blocking(move || NaiveIntrospection::from_schema(&schema))

--- a/apollo-router-core/src/spec/query.rs
+++ b/apollo-router-core/src/spec/query.rs
@@ -737,10 +737,8 @@ mod tests {
             baz: String
         }
         union Thing = Foo
-        extend union Thing = Bar | Baz
-
-        fragment baz on Baz {baz}";
-        let query = "query { thing {...foo ...bar ...baz} } fragment foo on Foo {foo} fragment bar on Bar {bar}";
+        extend union Thing = Bar | Baz";
+        let query = "query { thing {...foo ...bar ...baz} } fragment foo on Foo {foo} fragment bar on Bar {bar} fragment baz on Baz {baz}";
 
         // should only select fields from Foo
         assert_format_response!(
@@ -802,7 +800,7 @@ mod tests {
                 bar: String
             }
 
-            union Element = Baz | Bar | String
+            union Element = Baz | Bar
             ",
             "{get {foo stuff{bar baz} ...fragment array{bar baz} other{bar}}}",
             json! {{
@@ -956,22 +954,22 @@ mod tests {
         assert_validation_error!(schema, "query($foo:[Int!]){x}", json!({"foo":[1,null,3]}));
         assert_validation!(schema, "query($foo:[Int]){x}", json!({"foo":[1,null,3]}));
         assert_validation!(
-            "type Foo{} type Query { x: String }",
+            "type Foo{ y: String } type Query { x: String }",
             "query($foo:Foo){x}",
             json!({})
         );
         assert_validation!(
-            "type Foo{} type Query { x: String }",
+            "type Foo{ y: String } type Query { x: String }",
             "query($foo:Foo){x}",
             json!({"foo":{}})
         );
         assert_validation_error!(
-            "type Foo{} type Query { x: String }",
+            "type Foo{ y: String } type Query { x: String }",
             "query($foo:Foo){x}",
             json!({"foo":1})
         );
         assert_validation_error!(
-            "type Foo{} type Query { x: String }",
+            "type Foo{ y: String } type Query { x: String }",
             "query($foo:Foo){x}",
             json!({"foo":"str"})
         );
@@ -986,17 +984,17 @@ mod tests {
             json!({"foo":{"x":1}})
         );
         assert_validation!(
-            "type Foo implements Bar interface Bar{x:Int!} type Query { x: String }",
+            "type Foo implements Bar { x: Int! } interface Bar{ x:Int! } type Query { x: String }",
             "query($foo:Foo){x}",
             json!({"foo":{"x":1}}),
         );
         assert_validation_error!(
-            "type Foo implements Bar interface Bar{x:Int!} type Query { x: String }",
+            "type Foo implements Bar { x: Int! } interface Bar{ x:Int! } type Query { x: String }",
             "query($foo:Foo){x}",
             json!({"foo":{"x":"str"}}),
         );
         assert_validation_error!(
-            "type Foo implements Bar interface Bar{x:Int!} type Query { x: String }",
+            "type Foo implements Bar { x: Int! } interface Bar{ x:Int! } type Query { x: String }",
             "query($foo:Foo){x}",
             json!({"foo":{}}),
         );

--- a/apollo-router-core/src/spec/schema.rs
+++ b/apollo-router-core/src/spec/schema.rs
@@ -29,12 +29,7 @@ impl std::str::FromStr for Schema {
             let api_schema = api_schema::api_schema(schema)
                 .map_err(|e| SchemaError::Api(e.to_string()))?
                 .map_err(|e| {
-                    SchemaError::Api(
-                        e.iter()
-                            .filter_map(|e| e.message.as_ref())
-                            .join(", ")
-                            .to_string(),
-                    )
+                    SchemaError::Api(e.iter().filter_map(|e| e.message.as_ref()).join(", "))
                 })?;
 
             parse(&api_schema)

--- a/apollo-router-core/src/testdata/contract_schema.graphql
+++ b/apollo-router-core/src/testdata/contract_schema.graphql
@@ -1,0 +1,64 @@
+schema @core(feature: "https://specs.apollo.dev/core/v0.1") @core(feature: "https://specs.apollo.dev/join/v0.1") @core(feature: "https://specs.apollo.dev/tag/v0.1") @apollo_studio_metadata(launchId: "2396d4fb-a1e4-457d-8da4-347479b852f1", buildId: "2396d4fb-a1e4-457d-8da4-347479b852f1", checkId: null) @core(feature: "https://specs.apollo.dev/inaccessible/v0.1") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @core(feature: String!) repeatable on SCHEMA
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet) repeatable on OBJECT | INTERFACE
+
+directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+
+directive @apollo_studio_metadata(launchId: String, buildId: String, checkId: String) on SCHEMA
+
+directive @inaccessible on OBJECT | FIELD_DEFINITION | INTERFACE | UNION
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "http://accounts.demo.starstuff.dev/graphql")
+  INVENTORY @join__graph(name: "inventory", url: "http://inventory.demo.starstuff.dev/graphql")
+  PRODUCTS @join__graph(name: "products", url: "http://products.demo.starstuff.dev/graphql")
+  REVIEWS @join__graph(name: "reviews", url: "http://reviews.demo.starstuff.dev/graphql")
+}
+
+type Mutation {
+  createProduct(name: String, upc: ID!): Product @join__field(graph: PRODUCTS)
+  createReview(body: String, id: ID!, upc: ID!): Review @join__field(graph: REVIEWS)
+}
+
+type Product @join__owner(graph: PRODUCTS) @join__type(graph: PRODUCTS, key: "upc") @join__type(graph: REVIEWS, key: "upc") @join__type(graph: INVENTORY, key: "upc") {
+  inStock: Boolean @join__field(graph: INVENTORY) @tag(name: "private") @inaccessible
+  name: String @join__field(graph: PRODUCTS)
+  price: Int @join__field(graph: PRODUCTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  reviewsForAuthor(authorID: ID!): [Review] @join__field(graph: REVIEWS)
+  shippingEstimate: Int @join__field(graph: INVENTORY, requires: "price weight")
+  upc: String! @join__field(graph: PRODUCTS)
+  weight: Int @join__field(graph: PRODUCTS)
+}
+
+type Query {
+  me: User @join__field(graph: ACCOUNTS)
+  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCTS)
+}
+
+type Review @join__owner(graph: REVIEWS) @join__type(graph: REVIEWS, key: "id") {
+  author: User @join__field(graph: REVIEWS, provides: "username")
+  body: String @join__field(graph: REVIEWS)
+  id: ID! @join__field(graph: REVIEWS)
+  product: Product @join__field(graph: REVIEWS)
+}
+
+type User @join__owner(graph: ACCOUNTS) @join__type(graph: ACCOUNTS, key: "id") @join__type(graph: REVIEWS, key: "id") {
+  id: ID! @join__field(graph: ACCOUNTS)
+  name: String @join__field(graph: ACCOUNTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  username: String @join__field(graph: ACCOUNTS)
+}

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -553,6 +553,20 @@ mod tests {
             .build();
 
         let schema: graphql::Schema = r#"
+        schema
+          @core(feature: "https://specs.apollo.dev/core/v0.1"),
+          @core(feature: "https://specs.apollo.dev/join/v0.1")
+        {
+          query: Query
+        }
+        
+        type Query {
+          me: String
+        }
+        
+        directive @core(feature: String!) repeatable on SCHEMA
+        
+        directive @join__graph(name: String!, url: String!) on ENUM_VALUE
         enum join__Graph {
           ACCOUNTS @join__graph(name: "accounts" url: "http://localhost:4001/graphql")
           INVENTORY @join__graph(name: "inventory" url: "http://localhost:4002/graphql")

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -492,15 +492,7 @@ mod test {
     }
 
     async fn create_service(config: Configuration) -> Result<(), BoxError> {
-        let schema: Schema = r#"schema
-        @core(feature: "https://specs.apollo.dev/core/v0.1"),
-        @core(feature: "https://specs.apollo.dev/join/v0.1")
-        {
-        query: Query
-        mutation: Mutation
-        }"#
-        .parse()
-        .unwrap();
+        let schema: Schema = include_str!("testdata/supergraph.graphql").parse().unwrap();
 
         let service = YamlRouterServiceFactory::default()
             .create(Arc::new(config), Arc::new(schema), None)

--- a/apollo-router/tests/fixtures/inventory.graphql
+++ b/apollo-router/tests/fixtures/inventory.graphql
@@ -1,7 +1,13 @@
+directive @tag(name: String!) repeatable on
+  | FIELD_DEFINITION
+  | INTERFACE
+  | OBJECT
+  | UNION
+
 extend type Product @key(fields: "upc") {
   upc: String! @external
   weight: Int @external
   price: Int @external
-  inStock: Boolean
+  inStock: Boolean @tag(name: "private")
   shippingEstimate: Int @requires(fields: "price weight")
 }

--- a/apollo-router/tests/fixtures/supergraph.graphql
+++ b/apollo-router/tests/fixtures/supergraph.graphql
@@ -1,7 +1,4 @@
-schema
-  @core(feature: "https://specs.apollo.dev/core/v0.1"),
-  @core(feature: "https://specs.apollo.dev/join/v0.1")
-{
+schema @core(feature: "https://specs.apollo.dev/core/v0.1") @core(feature: "https://specs.apollo.dev/join/v0.1") @core(feature: "https://specs.apollo.dev/tag/v0.1") @apollo_studio_metadata(launchId: "2396d4fb-a1e4-457d-8da4-347479b852f1", buildId: "2396d4fb-a1e4-457d-8da4-347479b852f1", checkId: null) @core(feature: "https://specs.apollo.dev/inaccessible/v0.1") {
   query: Query
   mutation: Mutation
 }
@@ -16,13 +13,19 @@ directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+
+directive @apollo_studio_metadata(launchId: String, buildId: String, checkId: String) on SCHEMA
+
+directive @inaccessible on OBJECT | FIELD_DEFINITION | INTERFACE | UNION
+
 scalar join__FieldSet
 
 enum join__Graph {
-  ACCOUNTS @join__graph(name: "accounts" url: "http://localhost:4001/graphql")
-  INVENTORY @join__graph(name: "inventory" url: "http://localhost:4004/graphql")
-  PRODUCTS @join__graph(name: "products" url: "http://localhost:4003/graphql")
-  REVIEWS @join__graph(name: "reviews" url: "http://localhost:4002/graphql")
+  ACCOUNTS @join__graph(name: "accounts", url: "http://accounts.demo.starstuff.dev/graphql")
+  INVENTORY @join__graph(name: "inventory", url: "http://inventory.demo.starstuff.dev/graphql")
+  PRODUCTS @join__graph(name: "products", url: "http://products.demo.starstuff.dev/graphql")
+  REVIEWS @join__graph(name: "reviews", url: "http://reviews.demo.starstuff.dev/graphql")
 }
 
 type Mutation {
@@ -30,13 +33,8 @@ type Mutation {
   createReview(body: String, id: ID!, upc: ID!): Review @join__field(graph: REVIEWS)
 }
 
-type Product
-  @join__owner(graph: PRODUCTS)
-  @join__type(graph: PRODUCTS, key: "upc")
-  @join__type(graph: INVENTORY, key: "upc")
-  @join__type(graph: REVIEWS, key: "upc")
-{
-  inStock: Boolean @join__field(graph: INVENTORY)
+type Product @join__owner(graph: PRODUCTS) @join__type(graph: PRODUCTS, key: "upc") @join__type(graph: REVIEWS, key: "upc") @join__type(graph: INVENTORY, key: "upc") {
+  inStock: Boolean @join__field(graph: INVENTORY) @tag(name: "private") @inaccessible
   name: String @join__field(graph: PRODUCTS)
   price: Int @join__field(graph: PRODUCTS)
   reviews: [Review] @join__field(graph: REVIEWS)
@@ -51,21 +49,14 @@ type Query {
   topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCTS)
 }
 
-type Review
-  @join__owner(graph: REVIEWS)
-  @join__type(graph: REVIEWS, key: "id")
-{
+type Review @join__owner(graph: REVIEWS) @join__type(graph: REVIEWS, key: "id") {
   author: User @join__field(graph: REVIEWS, provides: "username")
   body: String @join__field(graph: REVIEWS)
   id: ID! @join__field(graph: REVIEWS)
   product: Product @join__field(graph: REVIEWS)
 }
 
-type User
-  @join__owner(graph: ACCOUNTS)
-  @join__type(graph: ACCOUNTS, key: "id")
-  @join__type(graph: REVIEWS, key: "id")
-{
+type User @join__owner(graph: ACCOUNTS) @join__type(graph: ACCOUNTS, key: "id") @join__type(graph: REVIEWS, key: "id") {
   id: ID! @join__field(graph: ACCOUNTS)
   name: String @join__field(graph: ACCOUNTS)
   reviews: [Review] @join__field(graph: REVIEWS)


### PR DESCRIPTION
Creating the api schema is done on parse, and blockingly calls out to deno. It should be OK because we load new schemas in the state machine and won't actually block the main request handlers.

Query shaping now operates against the api schema.

Introspection is performed against API schema on the Node side.

Fixed all the broken tests as we now require valid graphql schemas everywhere.

Related PR https://github.com/apollographql/federation-rs/pull/47

Fixes #573 