### PR TITLE
release: v0.1.0-alpha.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,30 +20,44 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
  -->
  
-# [v0.1.0-alpha.8] Not yet released
+# [v0.1.0-alpha.8] 2022-03-08
 
 ## :sparkles: Features
 
-- **Add opentracing support** ([PR #548](https://github.com/apollographql/router/pull/548))
-  Opentracing support has been added into the reporting plugin. You're know able to have span propagation via headers with 2 different formats supported by opentracing (`zipkin_b3` and `jaeger`).
-
 - **Sync and async checkpoints** ([PR #558](https://github.com/apollographql/router/pull/548) and [PR #580](https://github.com/apollographql/router/pull/548))
-  You can now write plugins that can act as check points in the services! Checkpoints allow you to make checks, and either return early with a Response, or forward a Request down the query pipeline.
+
+  You can now write plugins that can act as check points in services! Checkpoints allow you to make checks, and either return early with a `Response`, or forward a `Request` down the query pipeline.
+
+- **Contracts support** ([PR #573](https://github.com/apollographql/router/pull/573))
+
+  The Apollo Router now supports [Apollo Studio Contracts](https://www.apollographql.com/docs/studio/contracts/)!
+
+- **Add OpenTracing support** ([PR #548](https://github.com/apollographql/router/pull/548))
+
+  OpenTracing support has been added into the reporting plugin.  You're now able to have span propagation (via headers) via two common formats supported by the `opentracing` crate: `zipkin_b3` and `jaeger`.
+
 
 ## :bug: Fixes
 
-- **Fix plugin ordering** ([PR #559](https://github.com/apollographql/router/issues/559))
-  Plugins need to execute in sequence of declaration *except* for certain "core" plugins (for instance, Reporting) which must execute early in the plugin sequence to make sure they are in place as soon as possible in the router lifecycle. This change now ensures that Reporting plugin executes first and that all other plugins are executed in the order of declaration in configuration. 
+- **Managed Federation no longer requires `router_url`** ([PR #553](https://github.com/apollographql/router/pull/553))
 
-- **Propagate router query lifecycle errors**([PR #537](https://github.com/apollographql/router/issues/537))
-  Our recent extension rework was missing a key part: Error propagation and handling! This change makes sure errors that occured during query planning and query execution will be displayed as graphql errors, instead of an empty payload.
+  When using Managed Federation, it is no longer necessary to provide a `routing_url` value.  Instead, the values provided by Studio will be used and the `routing_url` can be used only to override those URLs.
+
+- **Fix plugin ordering** ([PR #559](https://github.com/apollographql/router/issues/559))
+
+  Plugins need to execute in sequence of declaration *except* for certain "core" plugins (e.g., reporting) which must execute early in the plugin sequence to make sure they are in place as soon as possible in the Router lifecycle. This change now ensures that the reporting plugin executes first and that all other plugins are executed in the order of declaration in configuration.
+
+- **Propagate Router operation lifecycle errors** ([PR #537](https://github.com/apollographql/router/issues/537))
+
+  Our recent extension rework was missing a key part: Error propagation and handling! This change makes sure errors that occurred during query planning and query execution will be displayed as GraphQL errors instead of an empty payload.
 
 ## :nail_care: Improvements
 
 - **Introduce Checkpoint and Step** ([PR #558](https://github.com/apollographql/router/pull/558))
-  Layers and Extensions writers (which includes us!) now have a mechanism that allows them to let the service orchestrator know whether a service call should be propagated further down the service stack, or it has been fullfilled already and it can bail out. A caching layer for example could return Step::Return(response) if the cache hit was successful, and Step::Continue(request) if the cache missed.
 
-# [v0.1.0-alpha.7] 2022-02-25
+  Layers and extensions writers (which includes us!) now have a mechanism that allows them to let the service orchestrator know whether a service call should be propagated further down the service stack, or it has been fulfilled already and it can bail out. A caching layer, for example, could return `Step::Return(response)` if a cache "hit" occurred and `Step::Continue(request)` in the event of a cache "miss".
+
+# [v0.1.0-alpha.8] 2022-02-25
 
 ## :sparkles: Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,9 +46,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## :bug: Fixes
 
-- **Managed Federation no longer requires `router_url`** ([PR #553](https://github.com/apollographql/router/pull/553))
+- **Configuration no longer requires `router_url`** ([PR #553](https://github.com/apollographql/router/pull/553))
 
-  When using Managed Federation, it is no longer necessary to provide a `routing_url` value.  Instead, the values provided by Studio will be used and the `routing_url` can be used only to override those URLs.
+  When using Managed Federation or directly providing a Supergraph file, it is no longer necessary to provide a `routing_url` value.  Instead, the values provided by the Supergraph or Studio will be used and the `routing_url` can be used only to override specific URLs for specific subgraphs.
 
 - **Fix plugin ordering** ([PR #559](https://github.com/apollographql/router/issues/559))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   Our recent extension rework was missing a key part: Error propagation and handling! This change makes sure errors that occurred during query planning and query execution will be displayed as GraphQL errors instead of an empty payload.
 
-## :nail_care: Improvements
-
 
 # [v0.1.0-alpha.7] 2022-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## :sparkles: Features
 
-- **Sync and async checkpoints** ([PR #558](https://github.com/apollographql/router/pull/548) and [PR #580](https://github.com/apollographql/router/pull/548))
+- **Request lifecycle checkpoints** ([PR #558](https://github.com/apollographql/router/pull/548) and [PR #580](https://github.com/apollographql/router/pull/548))
 
-  You can now write plugins that can act as check points in services! Checkpoints allow you to make checks, and either return early with a `Response`, or forward a `Request` down the query pipeline.
+    Checkpoints in the request pipeline now allow plugin authors (which includes us!) to check conditions during a request's lifecycle and circumvent further execution if desired.
+    
+    Using `Step` return types within the checkpoint it's possible to influence what happens (including changing things like the HTTP status code, etc.).  A caching layer, for example, could return `Step::Return(response)` if a cache "hit" occurred and `Step::Continue(request)` (to allow normal processing to continue) in the event of a cache "miss".
+    
+    These can be either synchronous or asynchronous.  To see examples, see:
+    
+    - A [synchronous example](https://github.com/apollographql/router/tree/190afe181bf2c50be1761b522fcbdcc82b81d6ca/examples/forbid-anonymous-operations)
+    - An [asynchronous example](https://github.com/apollographql/router/tree/190afe181bf2c50be1761b522fcbdcc82b81d6ca/examples/async-allow-client-id)
 
 - **Contracts support** ([PR #573](https://github.com/apollographql/router/pull/573))
 
@@ -53,9 +60,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## :nail_care: Improvements
 
-- **Introduce Checkpoint and Step** ([PR #558](https://github.com/apollographql/router/pull/558))
-
-  Layers and extensions writers (which includes us!) now have a mechanism that allows them to let the service orchestrator know whether a service call should be propagated further down the service stack, or it has been fulfilled already and it can bail out. A caching layer, for example, could return `Step::Return(response)` if a cache "hit" occurred and `Step::Continue(request)` in the event of a cache "miss".
 
 # [v0.1.0-alpha.7] 2022-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   Layers and extensions writers (which includes us!) now have a mechanism that allows them to let the service orchestrator know whether a service call should be propagated further down the service stack, or it has been fulfilled already and it can bail out. A caching layer, for example, could return `Step::Return(response)` if a cache "hit" occurred and `Step::Continue(request)` in the event of a cache "miss".
 
-# [v0.1.0-alpha.8] 2022-02-25
+# [v0.1.0-alpha.7] 2022-02-25
 
 ## :sparkles: Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 dependencies = [
  "anyhow",
  "apollo-parser 0.2.2",
@@ -172,7 +172,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 dependencies = [
  "apollo-router",
  "apollo-router-core",
@@ -189,7 +189,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-core"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 dependencies = [
  "apollo-parser 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-spaceport"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 dependencies = [
  "bytes",
  "clap 3.1.3",
@@ -4899,7 +4899,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-core"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license-file = "./LICENSE"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license-file = "./LICENSE"

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-spaceport"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license-file = "./LICENSE"

--- a/deny.toml
+++ b/deny.toml
@@ -63,13 +63,13 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 [[licenses.clarify]]
 name = "apollo-router"
 expression = "LicenseRef-ELv2"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
 
 [[licenses.clarify]]
 name = "apollo-router-core"
 expression = "LicenseRef-ELv2"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
 
 [[licenses.clarify]]
@@ -80,7 +80,7 @@ license-files = [{ path = "router-bridge/LICENSE", hash = 0xaceadac9 }]
 [[licenses.clarify]]
 name = "apollo-spaceport"
 expression = "LicenseRef-ELv2"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
 
 [[licenses.clarify]]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.1.0-alpha.7"
+version = "0.1.0-alpha.8"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"


### PR DESCRIPTION
## :sparkles: Features

- **Request lifecycle checkpoints** ([PR #558](https://github.com/apollographql/router/pull/548) and [PR #580](https://github.com/apollographql/router/pull/548))

    Checkpoints in the request pipeline now allow plugin authors (which includes us!) to check conditions during a request's lifecycle and circumvent further execution if desired.
    
    Using `Step` return types within the checkpoint it's possible to influence what happens (including changing things like the HTTP status code, etc.).  A caching layer, for example, could return `Step::Return(response)` if a cache "hit" occurred and `Step::Continue(request)` (to allow normal processing to continue) in the event of a cache "miss".
    
    These can be either synchronous or asynchronous.  To see examples, see:
    
    - A [synchronous example](https://github.com/apollographql/router/tree/190afe181bf2c50be1761b522fcbdcc82b81d6ca/examples/forbid-anonymous-operations)
    - An [asynchronous example](https://github.com/apollographql/router/tree/190afe181bf2c50be1761b522fcbdcc82b81d6ca/examples/async-allow-client-id)

- **Contracts support** ([PR #573](https://github.com/apollographql/router/pull/573))

  The Apollo Router now supports [Apollo Studio Contracts](https://www.apollographql.com/docs/studio/contracts/)!

- **Add OpenTracing support** ([PR #548](https://github.com/apollographql/router/pull/548))

  OpenTracing support has been added into the reporting plugin.  You're now able to have span propagation (via headers) via two common formats supported by the `opentracing` crate: `zipkin_b3` and `jaeger`.


## :bug: Fixes

- **Managed Federation no longer requires `router_url`** ([PR #553](https://github.com/apollographql/router/pull/553))

  When using Managed Federation, it is no longer necessary to provide a `routing_url` value.  Instead, the values provided by Studio will be used and the `routing_url` can be used only to override those URLs.

- **Fix plugin ordering** ([PR #559](https://github.com/apollographql/router/issues/559))

  Plugins need to execute in sequence of declaration *except* for certain "core" plugins (e.g., reporting) which must execute early in the plugin sequence to make sure they are in place as soon as possible in the Router lifecycle. This change now ensures that the reporting plugin executes first and that all other plugins are executed in the order of declaration in configuration.

- **Propagate Router operation lifecycle errors** ([PR #537](https://github.com/apollographql/router/issues/537))

  Our recent extension rework was missing a key part: Error propagation and handling! This change makes sure errors that occurred during query planning and query execution will be displayed as GraphQL errors instead of an empty payload.

