### PR TITLE
Fix trace propagation across processes

### DIFF
--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -1,8 +1,9 @@
 //! Main entry point for CLI command to start server.
 
 use crate::{
-    configuration::Configuration, set_global_subscriber, ApolloRouterBuilder, ConfigurationKind,
-    RouterSubscriber, SchemaKind, ShutdownKind,
+    configuration::Configuration,
+    subscriber::{set_global_subscriber, RouterSubscriber},
+    ApolloRouterBuilder, ConfigurationKind, SchemaKind, ShutdownKind,
 };
 use anyhow::{anyhow, Context, Result};
 use directories::ProjectDirs;

--- a/apollo-router/src/plugins/reporting.rs
+++ b/apollo-router/src/plugins/reporting.rs
@@ -7,7 +7,7 @@ use crate::apollo_telemetry::StudioGraph;
 use crate::configuration::{default_service_name, default_service_namespace};
 use crate::layers::opentracing::OpenTracingConfig;
 use crate::layers::opentracing::OpenTracingLayer;
-use crate::{replace_layer, BaseLayer, BoxedLayer};
+use crate::subscriber::{replace_layer, BaseLayer, BoxedLayer};
 use apollo_router_core::SubgraphRequest;
 use apollo_router_core::SubgraphResponse;
 use apollo_router_core::{register_plugin, Plugin};

--- a/apollo-router/src/plugins/reporting.rs
+++ b/apollo-router/src/plugins/reporting.rs
@@ -390,8 +390,7 @@ impl Reporting {
                 });
                 futures::executor::block_on(jh)?;
 
-                // let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
-                let telemetry = tracing_opentelemetry::OpenTelemetryLayer::new(tracer);
+                let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
 
                 opentelemetry::global::set_error_handler(handle_error)?;
 

--- a/apollo-router/src/reload.rs
+++ b/apollo-router/src/reload.rs
@@ -146,6 +146,7 @@ where
     //
     // This is not true in the "general case", which I imagine is
     // why this is not implemented in the tracing_subscriber crate.
+    #[inline]
     unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
         self.inner.read().unwrap().downcast_raw(id)
     }

--- a/apollo-router/src/reload.rs
+++ b/apollo-router/src/reload.rs
@@ -1,0 +1,273 @@
+//! THIS IS PORTED FROM THE tracing_subscriber CRATE. SLIGHTLY MODIFIED
+//! TO ADD SUPPORT FOR `downcast_raw`. THE FIX IS TEMPORARY
+//! WHILST WE FIGURE OUT HOW TO PROGRESS THIS WITH THE CRATE OWNERS.
+//!
+//! SEE THE COMMENT ON THE `downcast_raw` FN FOR MORE DETAILS.
+//!
+//! Wrapper for a `Layer` to allow it to be dynamically reloaded.
+//!
+//! This module provides a [`Layer` type] which wraps another type implementing
+//! the [`Layer` trait], allowing the wrapped type to be replaced with another
+//! instance of that type at runtime.
+//!
+//! This can be used in cases where a subset of `Subscriber` functionality
+//! should be dynamically reconfigured, such as when filtering directives may
+//! change at runtime. Note that this layer introduces a (relatively small)
+//! amount of overhead, and should thus only be used as needed.
+//!
+//! [`Layer` type]: struct.Layer.html
+//! [`Layer` trait]: ../layer/trait.Layer.html
+use tracing_subscriber::layer;
+
+use std::{
+    any::TypeId,
+    error, fmt,
+    marker::PhantomData,
+    sync::{Arc, RwLock, Weak},
+};
+use tracing_core::{
+    callsite, span,
+    subscriber::{Interest, Subscriber},
+    Event, Metadata,
+};
+
+// #[cfg(feature = "std")]
+macro_rules! try_lock {
+    ($lock:expr) => {
+        try_lock!($lock, else return)
+    };
+    ($lock:expr, else $els:expr) => {
+        if let Ok(l) = $lock {
+            l
+        } else if std::thread::panicking() {
+            $els
+        } else {
+            panic!("lock poisoned")
+        }
+    };
+}
+
+/// Wraps a `Layer`, allowing it to be reloaded dynamically at runtime.
+#[derive(Debug)]
+pub struct Layer<L, S> {
+    // TODO(eliza): this once used a `crossbeam_util::ShardedRwLock`. We may
+    // eventually wish to replace it with a sharded lock implementation on top
+    // of our internal `RwLock` wrapper type. If possible, we should profile
+    // this first to determine if it's necessary.
+    inner: Arc<RwLock<L>>,
+    _s: PhantomData<fn(S)>,
+}
+
+/// Allows reloading the state of an associated `Layer`.
+#[derive(Debug)]
+pub struct Handle<L, S> {
+    inner: Weak<RwLock<L>>,
+    _s: PhantomData<fn(S)>,
+}
+
+/// Indicates that an error occurred when reloading a layer.
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+}
+
+#[derive(Debug)]
+enum ErrorKind {
+    SubscriberGone,
+    Poisoned,
+}
+
+// ===== impl Layer =====
+
+impl<L, S> crate::Layer<S> for Layer<L, S>
+where
+    L: crate::Layer<S> + 'static,
+    S: Subscriber,
+{
+    fn on_layer(&mut self, subscriber: &mut S) {
+        try_lock!(self.inner.write(), else return).on_layer(subscriber);
+    }
+
+    #[inline]
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+        try_lock!(self.inner.read(), else return Interest::sometimes()).register_callsite(metadata)
+    }
+
+    #[inline]
+    fn enabled(&self, metadata: &Metadata<'_>, ctx: layer::Context<'_, S>) -> bool {
+        try_lock!(self.inner.read(), else return false).enabled(metadata, ctx)
+    }
+
+    #[inline]
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: layer::Context<'_, S>) {
+        try_lock!(self.inner.read()).on_new_span(attrs, id, ctx)
+    }
+
+    #[inline]
+    fn on_record(&self, span: &span::Id, values: &span::Record<'_>, ctx: layer::Context<'_, S>) {
+        try_lock!(self.inner.read()).on_record(span, values, ctx)
+    }
+
+    #[inline]
+    fn on_follows_from(&self, span: &span::Id, follows: &span::Id, ctx: layer::Context<'_, S>) {
+        try_lock!(self.inner.read()).on_follows_from(span, follows, ctx)
+    }
+
+    #[inline]
+    fn on_event(&self, event: &Event<'_>, ctx: layer::Context<'_, S>) {
+        try_lock!(self.inner.read()).on_event(event, ctx)
+    }
+
+    #[inline]
+    fn on_enter(&self, id: &span::Id, ctx: layer::Context<'_, S>) {
+        try_lock!(self.inner.read()).on_enter(id, ctx)
+    }
+
+    #[inline]
+    fn on_exit(&self, id: &span::Id, ctx: layer::Context<'_, S>) {
+        try_lock!(self.inner.read()).on_exit(id, ctx)
+    }
+
+    #[inline]
+    fn on_close(&self, id: span::Id, ctx: layer::Context<'_, S>) {
+        try_lock!(self.inner.read()).on_close(id, ctx)
+    }
+
+    #[inline]
+    fn on_id_change(&self, old: &span::Id, new: &span::Id, ctx: layer::Context<'_, S>) {
+        try_lock!(self.inner.read()).on_id_change(old, new, ctx)
+    }
+
+    // In the context in which we use this code, it is deemed to
+    // be safe to return a pointer for the downcast since we "know"
+    // that the function which we are ultimately pointing at is
+    // statically defined in the code and will not change over the
+    // lifetime of the process.
+    //
+    // This is not true in the "general case", which I imagine is
+    // why this is not implemented in the tracing_subscriber crate.
+    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
+        self.inner.read().unwrap().downcast_raw(id)
+    }
+}
+
+impl<L, S> Layer<L, S>
+where
+    L: crate::Layer<S> + 'static,
+    S: Subscriber,
+{
+    /// Wraps the given `Layer`, returning a `Layer` and a `Handle` that allows
+    /// the inner type to be modified at runtime.
+    pub fn new(inner: L) -> (Self, Handle<L, S>) {
+        let this = Self {
+            inner: Arc::new(RwLock::new(inner)),
+            _s: PhantomData,
+        };
+        let handle = this.handle();
+        (this, handle)
+    }
+
+    /// Returns a `Handle` that can be used to reload the wrapped `Layer`.
+    pub fn handle(&self) -> Handle<L, S> {
+        Handle {
+            inner: Arc::downgrade(&self.inner),
+            _s: PhantomData,
+        }
+    }
+}
+
+// ===== impl Handle =====
+
+impl<L, S> Handle<L, S>
+where
+    L: crate::Layer<S> + 'static,
+    S: Subscriber,
+{
+    /// Replace the current layer with the provided `new_layer`.
+    pub fn reload(&self, new_layer: impl Into<L>) -> Result<(), Error> {
+        self.modify(|layer| {
+            *layer = new_layer.into();
+        })
+    }
+
+    /// Invokes a closure with a mutable reference to the current layer,
+    /// allowing it to be modified in place.
+    pub fn modify(&self, f: impl FnOnce(&mut L)) -> Result<(), Error> {
+        let inner = self.inner.upgrade().ok_or(Error {
+            kind: ErrorKind::SubscriberGone,
+        })?;
+
+        let mut lock = try_lock!(inner.write(), else return Err(Error::poisoned()));
+        f(&mut *lock);
+        // Release the lock before rebuilding the interest cache, as that
+        // function will lock the new layer.
+        drop(lock);
+
+        callsite::rebuild_interest_cache();
+        Ok(())
+    }
+
+    /// Returns a clone of the layer's current value if it still exists.
+    /// Otherwise, if the subscriber has been dropped, returns `None`.
+    #[allow(dead_code)]
+    pub fn clone_current(&self) -> Option<L>
+    where
+        L: Clone,
+    {
+        self.with_current(L::clone).ok()
+    }
+
+    /// Invokes a closure with a borrowed reference to the current layer,
+    /// returning the result (or an error if the subscriber no longer exists).
+    #[allow(dead_code)]
+    pub fn with_current<T>(&self, f: impl FnOnce(&L) -> T) -> Result<T, Error> {
+        let inner = self.inner.upgrade().ok_or(Error {
+            kind: ErrorKind::SubscriberGone,
+        })?;
+        let inner = try_lock!(inner.read(), else return Err(Error::poisoned()));
+        Ok(f(&*inner))
+    }
+}
+
+impl<L, S> Clone for Handle<L, S> {
+    fn clone(&self) -> Self {
+        Handle {
+            inner: self.inner.clone(),
+            _s: PhantomData,
+        }
+    }
+}
+
+// ===== impl Error =====
+
+impl Error {
+    fn poisoned() -> Self {
+        Self {
+            kind: ErrorKind::Poisoned,
+        }
+    }
+
+    /// Returns `true` if this error occurred because the layer was poisoned by
+    /// a panic on another thread.
+    pub fn is_poisoned(&self) -> bool {
+        matches!(self.kind, ErrorKind::Poisoned)
+    }
+
+    /// Returns `true` if this error occurred because the `Subscriber`
+    /// containing the reloadable layer was dropped.
+    pub fn is_dropped(&self) -> bool {
+        matches!(self.kind, ErrorKind::SubscriberGone)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = match self.kind {
+            ErrorKind::SubscriberGone => "subscriber no longer exists",
+            ErrorKind::Poisoned => "lock poisoned",
+        };
+        f.pad(msg)
+    }
+}
+
+impl error::Error for Error {}

--- a/apollo-router/src/reload.rs
+++ b/apollo-router/src/reload.rs
@@ -31,7 +31,6 @@ use tracing_core::{
     Event, Metadata,
 };
 
-// #[cfg(feature = "std")]
 macro_rules! try_lock {
     ($lock:expr) => {
         try_lock!($lock, else return)
@@ -79,9 +78,9 @@ enum ErrorKind {
 
 // ===== impl Layer =====
 
-impl<L, S> crate::Layer<S> for Layer<L, S>
+impl<L, S> tracing_subscriber::Layer<S> for Layer<L, S>
 where
-    L: crate::Layer<S> + 'static,
+    L: tracing_subscriber::Layer<S> + 'static,
     S: Subscriber,
 {
     fn on_layer(&mut self, subscriber: &mut S) {
@@ -154,7 +153,7 @@ where
 
 impl<L, S> Layer<L, S>
 where
-    L: crate::Layer<S> + 'static,
+    L: tracing_subscriber::Layer<S> + 'static,
     S: Subscriber,
 {
     /// Wraps the given `Layer`, returning a `Layer` and a `Handle` that allows
@@ -181,7 +180,7 @@ where
 
 impl<L, S> Handle<L, S>
 where
-    L: crate::Layer<S> + 'static,
+    L: tracing_subscriber::Layer<S> + 'static,
     S: Subscriber,
 {
     /// Replace the current layer with the provided `new_layer`.

--- a/apollo-router/src/subscriber.rs
+++ b/apollo-router/src/subscriber.rs
@@ -1,0 +1,255 @@
+//! The apollo-router Subscriber.
+//!
+//! Here are some constraints:
+//!  - We'd like to use tower to compose our services
+//!  - We'd like to be able to choose between Json or Text logging
+//!  - We'd like to use EnvFilter to specify logging parameters
+//!  - We'd like our configuration to be dynamic/re-loadable
+//!
+//! This set of constraints, in the round, act to substantially limit
+//! our choices in terms of our Subscriber/Layer options with tracing.
+//!
+//! 1. Tower, in particular the use of buffer(), spawns threads in a
+//! separate Tokio runtime. One consequence of this is that we have to
+//! set a single global subscriber in order for the spans to be simply
+//! propagated. The alternative is having multiple subscribers which
+//! must be tracked within our code and then propagated into spawned
+//! threads using the Buffer::pair() mechanism.
+//!
+//! 2. FmtSubscriber is heavily generic. The only viable mechanism for
+//! reloading Layers within Tracing is to use the Reload module. However,
+//! this won't accept a BoxedLayer, but requires a Concrete Layer and
+//! imposes other restrictions on the implementation. RouterSubscriber
+//! acts as the concrete implementation and delegates Json/Text decisions
+//! to particular configurations of FmtSubscriber composed with an
+//! EnvFilter.
+//!
+//! 3. With dynamic logging configuration, we need a way to register that
+//! change. Originally we used multiple subscribers, but see (1) for the
+//! problems associate with that. Now we are using a single, global
+//! subscriber which supports a Reload layer. We can't use the Reload
+//! layer from the tracing-subscriber crate because it doesn't properly
+//! downcast when required by the tracing-opentelemetry crate. We've
+//! copied the implementation of Reload from the tracing-subscriber crate
+//! and added the appropriate downcast support.
+//!
+//! There is another alternative which we haven't examined which is using
+//! Option<Layer> to enable/disable different Layers based on configuration.
+//! That might be a simpler solution than using Reload, but it's not clear
+//! how we would control layer enabling at runtime. That may be worth
+//! exploring at some point.
+//!
+//! Summary:
+//!  - We chose not to use multiple subscribers to make it simpler to write
+//!  plugins and not have to understand why Buffer::pair() is required.
+//!  - With a single, generic subscriber, we needed a way to represent that
+//!  in the code base, hence RouterSubscriber
+//!  - To make reloading work properly, we had to fork the Reload
+//!  implementation from tracing-subscriber to add the downcasting support
+//!  which makes things work.
+//!
+//!  Implementation Notes:
+//!
+//!  In our implemenation of download_raw() in our Reload layer, we rely on
+//!  the fact that the tracing-opentelemetry implementation behaves as
+//!  follows:
+//!   - SpanExt::context() uses a downcast to WithContext which then invokes
+//!     a function which we "know" is statically defined in the code and
+//!     cannot change at runtime. This makes it "safe" to unsafely return
+//!     a pointer and execute through that pointer.
+//!  We will need to validate that this remains true as the various moving
+//!  parts change (upgrade) over time.
+use crate::reload::{Handle, Layer as ReloadLayer};
+use crate::FederatedServerError;
+use once_cell::sync::OnceCell;
+use std::any::TypeId;
+use tracing::span::{Attributes, Record};
+use tracing::subscriber::set_global_default;
+use tracing::{Event as TracingEvent, Id, Metadata, Subscriber};
+use tracing_core::span::Current;
+use tracing_core::{Interest, LevelFilter};
+use tracing_subscriber::fmt::format::{DefaultFields, Format, Json, JsonFields};
+use tracing_subscriber::registry::{Data, LookupSpan};
+use tracing_subscriber::{EnvFilter, FmtSubscriber, Layer};
+
+pub(crate) type BoxedLayer = Box<dyn Layer<RouterSubscriber> + Send + Sync>;
+
+type FmtSubscriberTextEnv = FmtSubscriber<DefaultFields, Format, EnvFilter>;
+type FmtSubscriberJsonEnv = FmtSubscriber<JsonFields, Format<Json>, EnvFilter>;
+
+pub enum RouterSubscriber {
+    JsonSubscriber(FmtSubscriberJsonEnv),
+    TextSubscriber(FmtSubscriberTextEnv),
+}
+
+impl Subscriber for RouterSubscriber {
+    // Required to make the trait work
+
+    fn clone_span(&self, id: &Id) -> Id {
+        match self {
+            RouterSubscriber::JsonSubscriber(sub) => sub.clone_span(id),
+            RouterSubscriber::TextSubscriber(sub) => sub.clone_span(id),
+        }
+    }
+
+    fn try_close(&self, id: Id) -> bool {
+        match self {
+            RouterSubscriber::JsonSubscriber(sub) => sub.try_close(id),
+            RouterSubscriber::TextSubscriber(sub) => sub.try_close(id),
+        }
+    }
+
+    /// The delegated downcasting model is copied from the implementation
+    /// of `Subscriber` for `Layered` in the tracing_subscriber crate.
+    /// The logic appears to be sound, but be wary of problems here.
+    unsafe fn downcast_raw(&self, id: std::any::TypeId) -> Option<*const ()> {
+        // If downcasting to `Self`, return a pointer to `self`.
+        if id == TypeId::of::<Self>() {
+            return Some(self as *const _ as *const ());
+        }
+
+        // If not downcasting to `Self`, then check the encapsulated
+        // subscribers to see if we can downcast one of them.
+        match self {
+            RouterSubscriber::JsonSubscriber(sub) => sub.downcast_raw(id),
+            RouterSubscriber::TextSubscriber(sub) => sub.downcast_raw(id),
+        }
+    }
+
+    // May not be required to work, but better safe than sorry
+
+    fn current_span(&self) -> Current {
+        match self {
+            RouterSubscriber::JsonSubscriber(sub) => sub.current_span(),
+            RouterSubscriber::TextSubscriber(sub) => sub.current_span(),
+        }
+    }
+
+    fn drop_span(&self, id: Id) {
+        // Rather than delegate, call try_close() to avoid deprecation
+        // complaints
+        self.try_close(id);
+    }
+
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        match self {
+            RouterSubscriber::JsonSubscriber(sub) => sub.max_level_hint(),
+            RouterSubscriber::TextSubscriber(sub) => sub.max_level_hint(),
+        }
+    }
+
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+        match self {
+            RouterSubscriber::JsonSubscriber(sub) => sub.register_callsite(metadata),
+            RouterSubscriber::TextSubscriber(sub) => sub.register_callsite(metadata),
+        }
+    }
+
+    // Required by the trait
+
+    fn enabled(&self, meta: &Metadata<'_>) -> bool {
+        match self {
+            RouterSubscriber::JsonSubscriber(sub) => sub.enabled(meta),
+            RouterSubscriber::TextSubscriber(sub) => sub.enabled(meta),
+        }
+    }
+
+    fn new_span(&self, attrs: &Attributes<'_>) -> Id {
+        match self {
+            RouterSubscriber::JsonSubscriber(sub) => sub.new_span(attrs),
+            RouterSubscriber::TextSubscriber(sub) => sub.new_span(attrs),
+        }
+    }
+
+    fn record(&self, span: &Id, values: &Record<'_>) {
+        match self {
+            RouterSubscriber::JsonSubscriber(sub) => sub.record(span, values),
+            RouterSubscriber::TextSubscriber(sub) => sub.record(span, values),
+        }
+    }
+
+    fn record_follows_from(&self, span: &Id, follows: &Id) {
+        match self {
+            RouterSubscriber::JsonSubscriber(sub) => sub.record_follows_from(span, follows),
+            RouterSubscriber::TextSubscriber(sub) => sub.record_follows_from(span, follows),
+        }
+    }
+
+    fn event(&self, event: &TracingEvent<'_>) {
+        match self {
+            RouterSubscriber::JsonSubscriber(sub) => sub.event(event),
+            RouterSubscriber::TextSubscriber(sub) => sub.event(event),
+        }
+    }
+
+    fn enter(&self, id: &Id) {
+        match self {
+            RouterSubscriber::JsonSubscriber(sub) => sub.enter(id),
+            RouterSubscriber::TextSubscriber(sub) => sub.enter(id),
+        }
+    }
+
+    fn exit(&self, id: &Id) {
+        match self {
+            RouterSubscriber::JsonSubscriber(sub) => sub.exit(id),
+            RouterSubscriber::TextSubscriber(sub) => sub.exit(id),
+        }
+    }
+}
+
+impl<'a> LookupSpan<'a> for RouterSubscriber {
+    type Data = Data<'a>;
+
+    fn span_data(&'a self, id: &Id) -> Option<<Self as LookupSpan<'a>>::Data> {
+        match self {
+            RouterSubscriber::JsonSubscriber(sub) => sub.span_data(id),
+            RouterSubscriber::TextSubscriber(sub) => sub.span_data(id),
+        }
+    }
+}
+
+pub(crate) struct BaseLayer;
+
+// We don't actually need our BaseLayer to do anything. It exists as a holder
+// for the layers set by the reporting.rs plugin
+impl<S> Layer<S> for BaseLayer where S: Subscriber + for<'span> LookupSpan<'span> {}
+
+static RELOAD_HANDLE: OnceCell<Handle<BoxedLayer, RouterSubscriber>> = OnceCell::new();
+
+pub fn set_global_subscriber(subscriber: RouterSubscriber) -> Result<(), FederatedServerError> {
+    RELOAD_HANDLE
+        .get_or_try_init(move || {
+            // First create a boxed BaseLayer
+            let cl: BoxedLayer = Box::new(BaseLayer {});
+
+            // Now create a reloading layer from that
+            let (reloading_layer, handle) = ReloadLayer::new(cl);
+
+            // Box up our reloading layer
+            let rl: BoxedLayer = Box::new(reloading_layer);
+
+            // Compose that with our subscriber
+            let composed = rl.with_subscriber(subscriber);
+
+            // Set our subscriber as the global subscriber
+            set_global_default(composed)?;
+
+            // Return our handle to store in OnceCell
+            Ok(handle)
+        })
+        .map_err(FederatedServerError::SetGlobalSubscriberError)?;
+    Ok(())
+}
+
+pub fn replace_layer(new_layer: BoxedLayer) -> Result<(), FederatedServerError> {
+    match RELOAD_HANDLE.get() {
+        Some(hdl) => {
+            hdl.reload(new_layer)
+                .map_err(FederatedServerError::ReloadTracingLayerError)?;
+        }
+        None => {
+            return Err(FederatedServerError::NoReloadTracingHandleError);
+        }
+    }
+    Ok(())
+}

--- a/examples/compose-your-graphql-router/src/main.rs
+++ b/examples/compose-your-graphql-router/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{anyhow, Result};
-use apollo_router::{set_global_subscriber, RouterSubscriber};
+use apollo_router::subscriber::{set_global_subscriber, RouterSubscriber};
 use apollo_router_core::{plugin_utils, PluggableRouterServiceBuilder};
 use std::sync::Arc;
 use tower::{util::BoxService, ServiceExt};


### PR DESCRIPTION
The "reload" layer which we added as part of the work to simplify
logging and tracing and introduce a tracing plugin, breaks the delicate
chain of downcasting which tracing and opentelemetry tracing expect to
exist.

This fix restores that chain by copying the Reload layer implementation
from tracing-subscriber into our codebase and adding support for
delegated downcasting.

I've also modified our RouterSubscriber to perform delegated downcasting
and recognise when it is being asked to downcast to itself.

I've also fixed a small bug which would have meant that tracing was not
disabled when configuration was set to turn off tracing.
