### PR TITLE
Move apollo plugins to top level

### DIFF
--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -61,7 +61,7 @@ pub struct Configuration {
     /// Plugin configuration
     #[serde(default)]
     #[builder(default)]
-    pub plugins: UserPlugins,
+    pub user_plugins: UserPlugins,
 
     #[serde(default)]
     #[builder(default)]

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-2.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-2.snap
@@ -1,9 +1,9 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 366
+assertion_line: 443
 expression: config
-
 ---
+plugins: {}
 server:
   listen: "1.2.3.4:5"
   cors:
@@ -19,5 +19,4 @@ server:
     methods:
       - foo
       - bar
-plugins: {}
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-3.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-3.snap
@@ -1,11 +1,10 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 367
+assertion_line: 444
 expression: config
-
 ---
+plugins: {}
 server:
   listen: "1.2.3.4:5"
   cors: ~
-plugins: {}
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-4.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-4.snap
@@ -1,11 +1,10 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 368
+assertion_line: 445
 expression: config
-
 ---
+plugins: {}
 server:
   listen: "1.2.3.4:5"
   cors: ~
-plugins: {}
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change.snap
@@ -1,11 +1,10 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 365
+assertion_line: 442
 expression: config
-
 ---
+plugins: {}
 server:
   listen: "1.2.3.4:5"
   cors: ~
-plugins: {}
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_grpc-2.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_grpc-2.snap
@@ -1,11 +1,10 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 394
+assertion_line: 471
 expression: config
-
 ---
+plugins: {}
 server:
   listen: "1.2.3.4:5"
   cors: ~
-plugins: {}
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_grpc.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_grpc.snap
@@ -1,11 +1,10 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 393
+assertion_line: 470
 expression: config
-
 ---
+plugins: {}
 server:
   listen: "1.2.3.4:5"
   cors: ~
-plugins: {}
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_tls_config.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_tls_config.snap
@@ -1,11 +1,10 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 407
+assertion_line: 484
 expression: config
-
 ---
+plugins: {}
 server:
   listen: "1.2.3.4:5"
   cors: ~
-plugins: {}
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 360
+assertion_line: 432
 expression: "&schema"
 ---
 {
@@ -8,11 +8,69 @@ expression: "&schema"
   "title": "Configuration",
   "description": "The configuration for the router. Currently maintains a mapping of subgraphs.",
   "type": "object",
+  "anyOf": [
+    {
+      "required": [
+        "headers"
+      ]
+    },
+    {
+      "required": [
+        "override_subgraph_url"
+      ]
+    },
+    {
+      "required": [
+        "reporting"
+      ]
+    },
+    {
+      "required": [
+        "rhai"
+      ]
+    },
+    {
+      "required": [
+        "test.always_fails_to_start"
+      ]
+    },
+    {
+      "required": [
+        "test.always_fails_to_start_and_stop"
+      ]
+    },
+    {
+      "required": [
+        "test.always_fails_to_stop"
+      ]
+    },
+    {
+      "required": [
+        "test.always_starts_and_stops"
+      ]
+    }
+  ],
   "properties": {
+    "headers": {
+      "$ref": "#/definitions/Config"
+    },
+    "override_subgraph_url": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string",
+        "format": "uri"
+      }
+    },
     "plugins": {
       "description": "Plugin configuration",
       "default": {},
       "$ref": "#/definitions/Plugins"
+    },
+    "reporting": {
+      "$ref": "#/definitions/Conf"
+    },
+    "rhai": {
+      "$ref": "#/definitions/Conf"
     },
     "server": {
       "description": "Configuration options pertaining to the http server component.",
@@ -21,17 +79,24 @@ expression: "&schema"
         "cors": null
       },
       "$ref": "#/definitions/Server"
+    },
+    "test.always_fails_to_start": {
+      "$ref": "#/definitions/Conf"
+    },
+    "test.always_fails_to_start_and_stop": {
+      "$ref": "#/definitions/Conf"
+    },
+    "test.always_fails_to_stop": {
+      "$ref": "#/definitions/Conf"
+    },
+    "test.always_starts_and_stops": {
+      "$ref": "#/definitions/Conf"
     }
   },
-  "additionalProperties": false,
   "definitions": {
     "Conf": {
       "type": "object",
       "properties": {
-        "graph": {
-          "$ref": "#/definitions/StudioGraph",
-          "nullable": true
-        },
         "opentelemetry": {
           "$ref": "#/definitions/OpenTelemetry",
           "nullable": true
@@ -351,78 +416,7 @@ expression: "&schema"
       ]
     },
     "Plugins": {
-      "anyOf": [
-        {
-          "required": [
-            "apollo.headers"
-          ]
-        },
-        {
-          "required": [
-            "apollo.override_subgraph_url"
-          ]
-        },
-        {
-          "required": [
-            "apollo.reporting"
-          ]
-        },
-        {
-          "required": [
-            "apollo.rhai"
-          ]
-        },
-        {
-          "required": [
-            "apollo.test.always_fails_to_start"
-          ]
-        },
-        {
-          "required": [
-            "apollo.test.always_fails_to_start_and_stop"
-          ]
-        },
-        {
-          "required": [
-            "apollo.test.always_fails_to_stop"
-          ]
-        },
-        {
-          "required": [
-            "apollo.test.always_starts_and_stops"
-          ]
-        }
-      ],
-      "properties": {
-        "apollo.headers": {
-          "$ref": "#/definitions/Config"
-        },
-        "apollo.override_subgraph_url": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string",
-            "format": "uri"
-          }
-        },
-        "apollo.reporting": {
-          "$ref": "#/definitions/Conf"
-        },
-        "apollo.rhai": {
-          "$ref": "#/definitions/Conf"
-        },
-        "apollo.test.always_fails_to_start": {
-          "$ref": "#/definitions/Conf"
-        },
-        "apollo.test.always_fails_to_start_and_stop": {
-          "$ref": "#/definitions/Conf"
-        },
-        "apollo.test.always_fails_to_stop": {
-          "$ref": "#/definitions/Conf"
-        },
-        "apollo.test.always_starts_and_stops": {
-          "$ref": "#/definitions/Conf"
-        }
-      }
+      "anyOf": []
     },
     "Propagate": {
       "anyOf": [
@@ -594,9 +588,6 @@ expression: "&schema"
         }
       },
       "additionalProperties": false
-    },
-    "StudioGraph": {
-      "type": "object"
     },
     "TlsConfig": {
       "type": "object",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__supergraph_config_serde.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__supergraph_config_serde.snap
@@ -1,9 +1,9 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 360
+assertion_line: 437
 expression: config
-
 ---
+plugins: {}
 server:
   listen: "127.0.0.1:4001"
   cors:
@@ -17,5 +17,4 @@ server:
     methods:
       - GET
       - PUT
-plugins: {}
 

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -116,6 +116,7 @@ pub async fn rt_main() -> Result<()> {
         let settings = SchemaSettings::draft2019_09().with(|s| {
             s.option_nullable = true;
             s.option_add_null_type = false;
+            s.inline_subschemas = true;
         });
         let gen = settings.into_generator();
         let schema = gen.into_root_schema_for::<Configuration>();

--- a/apollo-router/src/plugins/reporting.rs
+++ b/apollo-router/src/plugins/reporting.rs
@@ -184,6 +184,7 @@ struct Reporting {
 struct Conf {
     pub spaceport: Option<SpaceportConfig>,
 
+    #[serde(skip)]
     pub graph: Option<StudioGraph>,
 
     pub opentelemetry: Option<OpenTelemetry>,
@@ -230,7 +231,8 @@ impl Plugin for Reporting {
 
     fn new(mut configuration: Self::Config) -> Result<Self, BoxError> {
         tracing::debug!("Reporting configuration {:?}!", configuration);
-        // Create graph configuration based on environment variables
+
+        // Graph can only be set via env variables.
         configuration.graph = studio_graph();
 
         // Studio Agent Spaceport listener

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -124,7 +124,11 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
             // If it was required, we ensured that the Reporting plugin was in the
             // list of plugins above. Now make sure that we process that plugin
             // before any other plugins.
-            let already_processed = match configuration.plugins.plugins.get(REPORTING_MODULE_NAME) {
+            let already_processed = match configuration
+                .user_plugins
+                .plugins
+                .get(REPORTING_MODULE_NAME)
+            {
                 Some(reporting_configuration) => {
                     builder = process_plugin(
                         builder,
@@ -141,7 +145,7 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
             // Process the remaining plugins. We use already_processed to skip
             // those plugins we already processed.
             for (name, configuration) in configuration
-                .plugins
+                .user_plugins
                 .plugins
                 .iter()
                 .filter(|(name, _)| !already_processed.contains(&name.as_str()))
@@ -209,11 +213,11 @@ fn add_default_plugins(mut configuration: Configuration) -> Configuration {
         // insert a valid "minimal" configuration which allows
         // studio usage reporting to function
         if !configuration
-            .plugins
+            .user_plugins
             .plugins
             .contains_key(REPORTING_MODULE_NAME)
         {
-            configuration.plugins.plugins.insert(
+            configuration.user_plugins.plugins.insert(
                 REPORTING_MODULE_NAME.to_string(),
                 serde_json::json!({ "opentelemetry": null }),
             );

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -12,8 +12,6 @@ use tower::util::{BoxCloneService, BoxService};
 use tower::{BoxError, Layer, ServiceBuilder, ServiceExt};
 use tower_service::Service;
 
-const REPORTING_MODULE_NAME: &str = "apollo.reporting";
-
 /// Factory for creating a RouterService
 ///
 /// Instances of this traits are used by the StateMachine to generate a new
@@ -74,8 +72,6 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
         let mut errors: Vec<ConfigurationError> = Vec::default();
         let configuration = (*configuration).clone();
 
-        let configuration = add_default_plugins(configuration);
-
         let mut builder = PluggableRouterServiceBuilder::new(schema.clone());
 
         for (name, _) in schema.subgraphs() {
@@ -121,35 +117,8 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
                 builder
             }
 
-            // If it was required, we ensured that the Reporting plugin was in the
-            // list of plugins above. Now make sure that we process that plugin
-            // before any other plugins.
-            let already_processed = match configuration
-                .user_plugins
-                .plugins
-                .get(REPORTING_MODULE_NAME)
-            {
-                Some(reporting_configuration) => {
-                    builder = process_plugin(
-                        builder,
-                        &mut errors,
-                        REPORTING_MODULE_NAME.to_string(),
-                        reporting_configuration,
-                    )
-                    .await;
-                    vec![REPORTING_MODULE_NAME]
-                }
-                None => vec![],
-            };
-
-            // Process the remaining plugins. We use already_processed to skip
-            // those plugins we already processed.
-            for (name, configuration) in configuration
-                .user_plugins
-                .plugins
-                .iter()
-                .filter(|(name, _)| !already_processed.contains(&name.as_str()))
-            {
+            // Process the plugins.
+            for (name, configuration) in configuration.plugins().iter() {
                 let name = name.clone();
                 builder = process_plugin(builder, &mut errors, name, configuration).await;
             }
@@ -202,29 +171,6 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
         }
         Ok(service)
     }
-}
-
-fn add_default_plugins(mut configuration: Configuration) -> Configuration {
-    // Because studio usage reporting requires the Reporting plugin,
-    // we must force the addition of the Reporting plugin if APOLLO_KEY
-    // is set.
-    if std::env::var("APOLLO_KEY").is_ok() {
-        // If the user has not specified Reporting configuration, then
-        // insert a valid "minimal" configuration which allows
-        // studio usage reporting to function
-        if !configuration
-            .user_plugins
-            .plugins
-            .contains_key(REPORTING_MODULE_NAME)
-        {
-            configuration.user_plugins.plugins.insert(
-                REPORTING_MODULE_NAME.to_string(),
-                serde_json::json!({ "opentelemetry": null }),
-            );
-        }
-    }
-
-    configuration
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Any plugins that are prefixed with `apollo.` are pushed to the top level of configuration.

This means that whereas we previously had:

```yaml
plugins:
 apollo.headers:
  - propagate: ....
```
It now looks like:
```yaml
headers:
  - propagate: ...
```  
The reason for this is that it gives the user a clearer idea of what is core to the router and what is an external plugin.


<!--
First, 🌠 thank you 🌠 for considering a contribution to Apollo!

Some of this information is also included in the /CONTRIBUTING.md file at the
root of this repository.  We suggest you read it!

  https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md

Here are some important details to keep in mind:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!  Documentation in the docs/ directory should be updated
        as necessary.  Finally, a /CHANGELOG.md entry should be added.

We hope you will find this to be a positive experience! Contribution can be
intimidating and we hope to alleviate that pain as much as possible. Without
following these guidelines, you may be missing context that can help you succeed
with your contribution, which is why we encourage discussion first. Ultimately,
there is no guarantee that we will be able to merge your pull-request, but by
following these guidelines we can try to avoid disappointment.

-->
