### PR TITLE
Fix regression caused by plugin name change

### DIFF
--- a/examples/async-allow-client-id/src/allow_client_id_from_file.rs
+++ b/examples/async-allow-client-id/src/allow_client_id_from_file.rs
@@ -176,7 +176,7 @@ mod tests {
     #[tokio::test]
     async fn plugin_registered() {
         apollo_router_core::plugins()
-            .get("example.allow-client-id-from-file")
+            .get("example.allow_client_id_from_file")
             .expect("Plugin not found")
             .create_instance(&json!({"header": "x-client-id","path": "allowedClientIds.json"}))
             .unwrap();


### PR DESCRIPTION
The change in: 1f8ee7af2df49aebd1b355844a232c45bf077520 re-named the example plugin and broke the
test.

This fixes the test.