### PR TITLE
chore(deps): Update `router-bridge` to latest revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3607,7 +3607,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation-rs.git?rev=ce38b4d7ba8ebba43a713e4b5b2a617249d05db4#ce38b4d7ba8ebba43a713e4b5b2a617249d05db4"
+source = "git+https://github.com/apollographql/federation-rs.git?rev=e30bb7240e34be9490ad323ff755330bdd3d2ba0#e30bb7240e34be9490ad323ff755330bdd3d2ba0"
 dependencies = [
  "anyhow",
  "deno_core",

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -36,7 +36,7 @@ regex = "1.5.5"
 reqwest = { version = "0.11.10" }
 reqwest-middleware = "0.1.5"
 reqwest-tracing = { version = "0.2.1", features = ["opentelemetry_0_17"] }
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "ce38b4d7ba8ebba43a713e4b5b2a617249d05db4" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "e30bb7240e34be9490ad323ff755330bdd3d2ba0" }
 schemars = { version = "0.8.8", features = ["url"] }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }


### PR DESCRIPTION
This brings in `@apollo/query-planner@preview.5` via a corresponding bump to
the packages in `federation-rs`:

  https://github.com/apollographql/federation-rs/pull/73

Closes: https://github.com/apollographql/router/issues/642