### PR TITLE
set the default log level to info for reqwest_tracing

### DIFF
--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -24,7 +24,7 @@ pub struct Opt {
     /// Log level (off|error|warn|info|debug|trace).
     #[structopt(
         long = "log",
-        default_value = "apollo_router=info,router=info,apollo_router_core=info,apollo_spaceport=info,tower_http=info",
+        default_value = "apollo_router=info,router=info,apollo_router_core=info,apollo_spaceport=info,tower_http=info,reqwest_tracing=info",
         alias = "loglevel"
     )]
     env_filter: String,


### PR DESCRIPTION
reqwest_tracing creates a span in which the HTTP query is executed. That
span is used as parent for opentelemetry. If it is disabled (example:
log level filter remove reqwest_tracing), no tracing header will be sent
to the subgraphs
