### PR TITLE
implement input object validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ are implemented as plugins under the hood.
   router --schema > apollo_configuration_schema.json
   ```
   and follow the instructions for associating it with your particular text editor/IDE. 
+
+- **Input object validation** ([PR #658](https://github.com/apollographql/router/pull/658))
+  variable validation was incorrectly using output object instead of input objects
+
 ## 🛠 Maintenance
 ## 📚 Documentation
 

--- a/apollo-router-core/src/spec/field_type.rs
+++ b/apollo-router-core/src/spec/field_type.rs
@@ -75,7 +75,7 @@ impl FieldType {
                 Ok(())
             }
             (FieldType::Named(name), value) if value.is_object() => {
-                if let Some(object_ty) = schema.object_types.get(name) {
+                if let Some(object_ty) = schema.input_types.get(name) {
                     object_ty
                         .validate_object(value.as_object().unwrap(), schema)
                         .map_err(|_| InvalidValue)

--- a/apollo-router-core/src/spec/query.rs
+++ b/apollo-router-core/src/spec/query.rs
@@ -1016,49 +1016,34 @@ mod tests {
         assert_validation_error!(schema, "query($foo:[Int!]){x}", json!({"foo":[1,null,3]}));
         assert_validation!(schema, "query($foo:[Int]){x}", json!({"foo":[1,null,3]}));
         assert_validation!(
-            "type Foo{ y: String } type Query { x: String }",
+            "input Foo{ y: String } type Query { x: String }",
             "query($foo:Foo){x}",
             json!({})
         );
         assert_validation!(
-            "type Foo{ y: String } type Query { x: String }",
+            "input Foo{ y: String } type Query { x: String }",
             "query($foo:Foo){x}",
             json!({"foo":{}})
         );
         assert_validation_error!(
-            "type Foo{ y: String } type Query { x: String }",
+            "input Foo{ y: String } type Query { x: String }",
             "query($foo:Foo){x}",
             json!({"foo":1})
         );
         assert_validation_error!(
-            "type Foo{ y: String } type Query { x: String }",
+            "input Foo{ y: String } type Query { x: String }",
             "query($foo:Foo){x}",
             json!({"foo":"str"})
         );
         assert_validation_error!(
-            "type Foo{x:Int!} type Query { x: String }",
+            "input Foo{x:Int!} type Query { x: String }",
             "query($foo:Foo){x}",
             json!({"foo":{}})
         );
         assert_validation!(
-            "type Foo{x:Int!} type Query { x: String }",
+            "input Foo{x:Int!} type Query { x: String }",
             "query($foo:Foo){x}",
             json!({"foo":{"x":1}})
-        );
-        assert_validation!(
-            "type Foo implements Bar { x: Int! } interface Bar{ x:Int! } type Query { x: String }",
-            "query($foo:Foo){x}",
-            json!({"foo":{"x":1}}),
-        );
-        assert_validation_error!(
-            "type Foo implements Bar { x: Int! } interface Bar{ x:Int! } type Query { x: String }",
-            "query($foo:Foo){x}",
-            json!({"foo":{"x":"str"}}),
-        );
-        assert_validation_error!(
-            "type Foo implements Bar { x: Int! } interface Bar{ x:Int! } type Query { x: String }",
-            "query($foo:Foo){x}",
-            json!({"foo":{}}),
         );
         assert_validation!(
             "scalar Foo type Query { x: String }",
@@ -1074,17 +1059,52 @@ mod tests {
             "scalar Foo type Query { x: String }",
             "query($foo:Foo!){x}",
             json!({})
-        );
-        assert_validation!(
-            "type Foo{bar:Bar!} type Bar{x:Int!} type Query { x: String }",
-            "query($foo:Foo){x}",
-            json!({"foo":{"bar":{"x":1}}})
         );
         assert_validation!(
             "enum Availability{AVAILABLE} type Product{availability:Availability! name:String} type Query{products(availability: Availability!): [Product]!}",
             "query GetProductsByAvailability($availability: Availability!){products(availability: $availability) {name}}",
             json!({"availability": "AVAILABLE"})
-        )
+        );
+
+        assert_validation!(
+            "input MessageInput {
+                content: String
+                author: String
+              }
+              type Receipt {
+                  id: ID!
+              }
+              type Query{
+                  send(message: MessageInput): String}",
+            "query {
+                send(message: {
+                    content: \"Hello\"
+                    author: \"Me\"
+                }) {
+                    id
+                }}",
+            json!({"availability": "AVAILABLE"})
+        );
+
+        assert_validation!(
+            "input MessageInput {
+                content: String
+                author: String
+              }
+              type Receipt {
+                  id: ID!
+              }
+              type Query{
+                  send(message: MessageInput): String}",
+            "query($msg: MessageInput) {
+                send(message: $msg) {
+                    id
+                }}",
+            json!({"msg":  {
+                "content": "Hello",
+                "author": "Me"
+            }})
+        );
     }
 
     #[test]

--- a/apollo-router-core/src/spec/query.rs
+++ b/apollo-router-core/src/spec/query.rs
@@ -1061,6 +1061,11 @@ mod tests {
             json!({})
         );
         assert_validation!(
+            "input Foo{bar:Bar!} input Bar{x:Int!} type Query { x: String }",
+            "query($foo:Foo){x}",
+            json!({"foo":{"bar":{"x":1}}})
+        );
+        assert_validation!(
             "enum Availability{AVAILABLE} type Product{availability:Availability! name:String} type Query{products(availability: Availability!): [Product]!}",
             "query GetProductsByAvailability($availability: Availability!){products(availability: $availability) {name}}",
             json!({"availability": "AVAILABLE"})


### PR DESCRIPTION
Fix #655 

input objects were not parsed in the schema object, and output objects
were used for validation