### PR TITLE
release: v0.1.0-alpha.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - **Move Apollo plugins to top-level configuration** ([PR #623](https://github.com/apollographql/router/pull/623))
 
-  Previously plugins were all under the `plugins:` section of the YAML config.  However, these "core" plugins are now promoted to the top-level of the config. This reflects the fact that these plugins provide core functionality even though they are implemented as plugins under the hood and further reflects the fact that they receive special treatment in terms of initialization order (they are initialize first before members of `plugins`).
+  Previously plugins were all under the `plugins:` section of the YAML config.  However, these "core" plugins are now promoted to the top-level of the config. This reflects the fact that these plugins provide core functionality even though they are implemented as plugins under the hood and further reflects the fact that they receive special treatment in terms of initialization order (they are initialized first before members of `plugins`).
 
 - **Remove configurable layers** ([PR #603](https://github.com/apollographql/router/pull/603))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,11 +56,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   Having `plugins` _and_ `layers` as configurable items in YAML was creating confusion as to when it was appropriate to use a `layer` vs a `plugin`.  As the layer API is a subset of the plugin API, `plugins` has been kept, however the `layer` option has been dropped.
 
--  **Plugin names have dropped the `com.apollographql` prefix** ([PR #602](https://github.com/apollographql/router/pull/600))
+- **Plugin names have dropped the `com.apollographql` prefix** ([PR #602](https://github.com/apollographql/router/pull/600))
 
   Previously, core plugins were prefixed with `com.apollographql.`.  This is no longer the case and, when coupled with the above moving of the core plugins to the top-level, the prefixing is no longer present.  This means that, for example, `com.apollographql.telemetry` would now be just `telemetry`.
 
--  **Use `ControlFlow` in checkpoints** ([PR #602](https://github.com/apollographql/router/pull/602))
+- **Use `ControlFlow` in checkpoints** ([PR #602](https://github.com/apollographql/router/pull/602))
 
   Both `checkpoint` and `async_checkpoint` now `use std::ops::ControlFlow` instead of the `Step` enum.  `ControlFlow` has two variants, `Continue` and `Break`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- # [x.x.x] (unreleased) - 2021-mm-dd
+<!-- # [x.x.x] (unreleased) - 2022-mm-dd
 > Important: X breaking changes below, indicated by **❗ BREAKING ❗**
 ## ❗ BREAKING ❗
 ## 🚀 Features
@@ -20,98 +20,106 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
  -->
 
-# [x.x.x] (unreleased) - 2021-mm-dd
-
- - **❗ BREAKING ❗**
- -  **Rename plugins with the prefix `apollo` instead of `com.apollographql`** ([PR #602](https://github.com/apollographql/router/pull/600))
-    Instead of using `com.apollographql.reporting` in the configuration file you have to use `apollo.reporting`.
-
- - **❗ BREAKING ❗**
- -  **use ControlFlow in checkpoints** ([PR #602](https://github.com/apollographql/router/pull/602))
-   `checkpoint` and `async_checkpoint` now `use std::ops::ControlFlow instead` of the `Step` enum. ControlFlow has two variants, `Continue` and `Break`.
- 
+# [v0.1.0-alpha.9] 2022-03-16
 ## ❗ BREAKING ❗
-- **Header propagation plugin** ([PR #599](https://github.com/apollographql/router/pull/599))
 
-  Header manipulation has been shifted to a plugin rather than service level layers. It now supports rules for all 
-  subgraphs as wel as individual subgraphs.
+- **Header propagation configuration changes** ([PR #599](https://github.com/apollographql/router/pull/599))
+
+  Header manipulation configuration is now a core-plugin and configured at the _top-level_ of the Router's configuration file, rather than its previous location within service-level layers.  Some keys have also been renamed.  For example:
+
+  **Previous configuration**
 
   ```yaml
-    headers:
-      all:
-      - propagate:
-        matching: "aaa.*"
-      - propagate:
-        named: "bbb"
-        default: "def"
-        rename: "ccc"
-      - insert:
-        name: "ddd"
-        value: "eee"
-      - remove:
-        matching: "fff.*"
-      - remove:
-        name: "ggg"
-      subgraphs:
-        products:
+  subgraphs:
+    products:
+      layers:
+        - headers_propagate:
+            matching:
+              regex: .*
+  ```
+
+  **New configuration**
+
+  ```yaml
+  headers:
+    subgraphs:
+      products:
         - propagate:
           matching: ".*"
-    ```
+  ```
+
+- **Move Apollo plugins to top-level configuration** ([PR #623](https://github.com/apollographql/router/pull/623))
+
+  Previously plugins were all under the `plugins:` section of the YAML config.  However, these "core" plugins are now promoted to the top-level of the config. This reflects the fact that these plugins provide core functionality even though they are implemented as plugins under the hood and further reflects the fact that they receive special treatment in terms of initialization order (they are initialize first before members of `plugins`).
+
 - **Remove configurable layers** ([PR #603](https://github.com/apollographql/router/pull/603))
 
-  Having plugins and layers as configurable items in yaml was creating confusion as to when it was appropriate to
-use a layer vs a plugin. As the layer API is a subset of the plugin API the layer option has been removed.
+  Having `plugins` _and_ `layers` as configurable items in YAML was creating confusion as to when it was appropriate to use a `layer` vs a `plugin`.  As the layer API is a subset of the plugin API, `plugins` has been kept, however the `layer` option has been dropped.
 
-- **Move Apollo plugins to top level configuration** ([PR #623](https://github.com/apollographql/router/pull/623))
-Previously plugins were all under the `plugins:` section of the yaml config. However, now apollo plugins are promoted 
-to the top level of the config. This reflects the fact that these plugins provide core functionality even though they 
-are implemented as plugins under the hood.
+-  **Plugin names have dropped the `com.apollographql` prefix** ([PR #602](https://github.com/apollographql/router/pull/600))
 
-- **Reporting config name changed to telemetry** ([PR #651](https://github.com/apollographql/router/pull/651))
-All configuration that was previously under the `reporting` header is now under `telemetry`
+  Previously, core plugins were prefixed with `com.apollographql.`.  This is no longer the case and, when coupled with the above moving of the core plugins to the top-level, the prefixing is no longer present.  This means that, for example, `com.apollographql.telemetry` would now be just `telemetry`.
 
-## 🚀 Features
+-  **Use `ControlFlow` in checkpoints** ([PR #602](https://github.com/apollographql/router/pull/602))
 
-- **Add Rhai plugin** ([PR #548](https://github.com/apollographql/router/pull/484))
+  Both `checkpoint` and `async_checkpoint` now `use std::ops::ControlFlow` instead of the `Step` enum.  `ControlFlow` has two variants, `Continue` and `Break`.
 
-  Add a plugin to be able to write plugins in [Rhai script](https://rhai.rs/). You are now able to write your own `*_service` function you can have on a Rust plugin. You have access to the context and headers directly from the RHAI script.
+- **The `reporting` configuration changes to `telemetry`** ([PR #651](https://github.com/apollographql/router/pull/651))
+
+  All configuration that was previously under the `reporting` header is now under a `telemetry` key.
+## :sparkles: Features
+
+- **Header propagation now supports "all" subgraphs** ([PR #599](https://github.com/apollographql/router/pull/599))
+
+  It is now possible to configure header propagation rules for *all* subgraphs without needing to explicitly name each subgraph.  You can accomplish this by using the `all` key, under the (now relocated; see above _breaking changes_) `headers` section.
+
+  ```yaml
+  headers:
+    all:
+    - propagate:
+      matching: "aaa.*"
+    - propagate:
+      named: "bbb"
+      default: "def"
+      rename: "ccc"
+    - insert:
+      name: "ddd"
+      value: "eee"
+    - remove:
+      matching: "fff.*"
+    - remove:
+      name: "ggg"
+  ```
 
 ## 🐛 Fixes
 
-- **Content-Type is application/json** ([639](https://github.com/apollographql/router/issues/639)) 
-  The router was not setting a content-type on results. This fix ensures that a content-type
-  of application/json is added to the route response if not present.
+- **`Content-Type` of HTTP responses is now set to `application/json`** ([Issue #639](https://github.com/apollographql/router/issues/639))
 
-- **Enums in query parameters** ([612](https://github.com/apollographql/router/issues/612)) 
-  Enums in query parameters were handled correctly in the response formatting, but not in query validation.
-  We now have a new test and a fix.
+  Previously, we were not setting a `content-type` on HTTP responses.  While plugins can still set a different `content-type` if they'd like, we now ensure that a `content-type` of `application/json` is set when one was not already provided.
 
-- **OTEL trace propagation** ([PR #620](https://github.com/apollographql/router/pull/620))
-  When we re-worked our OTEL implementation to be a plugin, the ability to trace across processes (into subgraphs) was
-  lost. This fix restores this capability.
+- **GraphQL Enums in query parameters** ([Issue #612](https://github.com/apollographql/router/issues/612))
+
+  Enums in query parameters were handled correctly in the response formatting, but not in query validation.  We now have a new test and a fix.
+
+- **OTel trace propagation works again** ([PR #620](https://github.com/apollographql/router/pull/620))
+
+  When we re-worked our OTel implementation to be a plugin, the ability to trace across processes (into subgraphs) was lost. This fix restores this capability.  We are working to improve our end-to-end testing of this to prevent further regressions.
 
 - **Reporting plugin schema generation** ([PR #607](https://github.com/apollographql/router/pull/607))
-  Previously our reporting plugin configuration did not participate in json schema generation. This is now broadly correct
-  and make writing schema much easier.
 
-  To generate a schema use the following command.
+  Previously our `reporting` plugin configuration was not able to participate in JSON Schema generation. This is now broadly correct and makes writing a syntactically-correct schema much easier.
+
+  To generate a schema, you can still run the same command as before:
+
   ```
   router --schema > apollo_configuration_schema.json
   ```
-  and follow the instructions for associating it with your particular text editor/IDE. 
+
+  Then, follow the instructions for associating it with your development environment.
 
 - **Input object validation** ([PR #658](https://github.com/apollographql/router/pull/658))
-  variable validation was incorrectly using output object instead of input objects
 
-## 🛠 Maintenance
-## 📚 Documentation
-
-## Example section entry format
-
-- **Headline** via [#PR_NUMBER](https://github.com/apollographql/router/pull/PR_NUMBER)
-
-  Description! And a link to a [reference](http://url)
-
+  Variable validation was incorrectly using output objects instead of input objects
 
 # [v0.1.0-alpha.8] 2022-03-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "anyhow",
  "apollo-parser 0.2.4 (git+https://github.com/apollographql/apollo-rs.git?rev=e707e0f78f41ace1c3ecfe69bc10f4144ffbf7ac)",
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "apollo-router",
  "apollo-router-core",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-core"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "apollo-parser 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-trait",
@@ -256,7 +256,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-spaceport"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "bytes",
  "clap 3.1.6",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 The **Apollo Router** is a configurable, high-performance **graph router** for a [federated graph](https://www.apollographql.com/docs/federation/) written in Rust that uses [Apollo Federation 2](https://www.apollographql.com/docs/federation/v2/federation-2/new-in-federation-2).
 
-Apollo Router is well-tested, regularly benchmarked, includes most major features of Apollo Gateway and is able to serve production-scale workloads.  Please note that the (pre-1.0) version is not yet "semver stable" and we may still make breaking changes.  Generally speaking, we expect most breaking changes to be mostly on the plugin API and the configuration file format.  We will clearly convey such changes in the release notes.
+Apollo Router is well-tested, regularly benchmarked, includes most major features of Apollo Gateway and is able to serve production-scale workloads.  Please note that the (pre-1.0) version is not yet "semver stable" and we may still make breaking changes.  Generally speaking, we expect most breaking changes to be on the plugin API and the configuration file format.  We will clearly convey such changes in the release notes.
 
 New releases and their release notes (along with notes about any breaking changes) can be found on the [Releases](https://github.com/apollographql/router/releases) page, and the latest release can always be found [on the latest page](https://github.com/apollographql/router/releases/latest).  The `CHANGELOG.md` at the root of this repository also contains _unreleased_ changes in addition to the full history of changes.
 

--- a/README.md
+++ b/README.md
@@ -5,21 +5,19 @@
 
 # Apollo Router
 
-The **Apollo Router** is a configurable, high-performance **graph router** for a [federated graph](https://www.apollographql.com/docs/federation/).
+The **Apollo Router** is a configurable, high-performance **graph router** for a [federated graph](https://www.apollographql.com/docs/federation/) written in Rust that uses [Apollo Federation 2](https://www.apollographql.com/docs/federation/v2/federation-2/new-in-federation-2).
+
+Apollo Router is well-tested, regularly benchmarked, includes most major features of Apollo Gateway and is able to serve production-scale workloads.  Please note that the (pre-1.0) version is not yet "semver stable" and we may still make breaking changes.  Generally speaking, we expect most breaking changes to be mostly on the plugin API and the configuration file format.  We will clearly convey such changes in the release notes.
+
+New releases and their release notes (along with notes about any breaking changes) can be found on the [Releases](https://github.com/apollographql/router/releases) page, and the latest release can always be found [on the latest page](https://github.com/apollographql/router/releases/latest).  The `CHANGELOG.md` at the root of this repository also contains _unreleased_ changes in addition to the full history of changes.
+
+Currently, we're publishing new releases every 1-2 weeks.
 
 ## Getting started
 
 Follow the [quickstart tutorial](https://www.apollographql.com/docs/router/quickstart/) to get up and running with the Apollo Router.
 
 See [the documentation](https://www.apollographql.com/docs/router) for more details.
-
-## Status
-
-🚧 Apollo Router is experimental software.  We're working on it!  See our [release stages](https://www.apollographql.com/docs/resources/release-stages/) for more information.
-
-The Apollo Router can serve queries but is not yet feature complete nor fully compliant with the GraphQL specification.
-
-We'd encourage you to experiment with it, report troubles and offer your feedback on it!
 
 ## Usage
 

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-core"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license-file = "./LICENSE"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license-file = "./LICENSE"

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-spaceport"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license-file = "./LICENSE"

--- a/deny.toml
+++ b/deny.toml
@@ -64,13 +64,13 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 [[licenses.clarify]]
 name = "apollo-router"
 expression = "LicenseRef-ELv2"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
 
 [[licenses.clarify]]
 name = "apollo-router-core"
 expression = "LicenseRef-ELv2"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
 
 [[licenses.clarify]]
@@ -81,7 +81,7 @@ license-files = [{ path = "router-bridge/LICENSE", hash = 0xaceadac9 }]
 [[licenses.clarify]]
 name = "apollo-spaceport"
 expression = "LicenseRef-ELv2"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
 
 [[licenses.clarify]]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"


### PR DESCRIPTION
## ❗ BREAKING ❗

- **Header propagation configuration changes** ([PR #599](https://github.com/apollographql/router/pull/599))

  Header manipulation configuration is now a core-plugin and configured at the _top-level_ of the Router's configuration file, rather than its previous location within service-level layers.  Some keys have also been renamed.  For example:

  **Previous configuration**

  ```yaml
  subgraphs:
    products:
      layers:
        - headers_propagate:
            matching:
              regex: .*
  ```

  **New configuration**

  ```yaml
  headers:
    subgraphs:
      products:
        - propagate:
          matching: ".*"
  ```

- **Move Apollo plugins to top-level configuration** ([PR #623](https://github.com/apollographql/router/pull/623))

  Previously plugins were all under the `plugins:` section of the YAML config.  However, these "core" plugins are now promoted to the top-level of the config. This reflects the fact that these plugins provide core functionality even though they are implemented as plugins under the hood and further reflects the fact that they receive special treatment in terms of initialization order (they are initialize first before members of `plugins`).

- **Remove configurable layers** ([PR #603](https://github.com/apollographql/router/pull/603))

  Having `plugins` _and_ `layers` as configurable items in YAML was creating confusion as to when it was appropriate to use a `layer` vs a `plugin`.  As the layer API is a subset of the plugin API, `plugins` has been kept, however the `layer` option has been dropped.

- **Plugin names have dropped the `com.apollographql` prefix** ([PR #602](https://github.com/apollographql/router/pull/600))

  Previously, core plugins were prefixed with `com.apollographql.`.  This is no longer the case and, when coupled with the above moving of the core plugins to the top-level, the prefixing is no longer present.  This means that, for example, `com.apollographql.telemetry` would now be just `telemetry`.

- **Use `ControlFlow` in checkpoints** ([PR #602](https://github.com/apollographql/router/pull/602))

  Both `checkpoint` and `async_checkpoint` now `use std::ops::ControlFlow` instead of the `Step` enum.  `ControlFlow` has two variants, `Continue` and `Break`.

- **The `reporting` configuration changes to `telemetry`** ([PR #651](https://github.com/apollographql/router/pull/651))

  All configuration that was previously under the `reporting` header is now under a `telemetry` key.
## :sparkles: Features

- **Header propagation now supports "all" subgraphs** ([PR #599](https://github.com/apollographql/router/pull/599))

  It is now possible to configure header propagation rules for *all* subgraphs without needing to explicitly name each subgraph.  You can accomplish this by using the `all` key, under the (now relocated; see above _breaking changes_) `headers` section.

  ```yaml
  headers:
    all:
    - propagate:
      matching: "aaa.*"
    - propagate:
      named: "bbb"
      default: "def"
      rename: "ccc"
    - insert:
      name: "ddd"
      value: "eee"
    - remove:
      matching: "fff.*"
    - remove:
      name: "ggg"
  ```

- **Update to latest query planner from Federation 2** ([PR #653](https://github.com/apollographql/router/pull/653))

  The Router now uses the `@apollo/query-planner@2.0.0-preview.5` query planner, bringing the most recent version of Federation 2.

## 🐛 Fixes

- **`Content-Type` of HTTP responses is now set to `application/json`** ([Issue #639](https://github.com/apollographql/router/issues/639))

  Previously, we were not setting a `content-type` on HTTP responses.  While plugins can still set a different `content-type` if they'd like, we now ensure that a `content-type` of `application/json` is set when one was not already provided.

- **GraphQL Enums in query parameters** ([Issue #612](https://github.com/apollographql/router/issues/612))

  Enums in query parameters were handled correctly in the response formatting, but not in query validation.  We now have a new test and a fix.

- **OTel trace propagation works again** ([PR #620](https://github.com/apollographql/router/pull/620))

  When we re-worked our OTel implementation to be a plugin, the ability to trace across processes (into subgraphs) was lost. This fix restores this capability.  We are working to improve our end-to-end testing of this to prevent further regressions.

- **Reporting plugin schema generation** ([PR #607](https://github.com/apollographql/router/pull/607))

  Previously our `reporting` plugin configuration was not able to participate in JSON Schema generation. This is now broadly correct and makes writing a syntactically-correct schema much easier.

  To generate a schema, you can still run the same command as before:

  ```
  router --schema > apollo_configuration_schema.json
  ```

  Then, follow the instructions for associating it with your development environment.

- **Input object validation** ([PR #658](https://github.com/apollographql/router/pull/658))

  Variable validation was incorrectly using output objects instead of input objects