### PR TITLE
Fix schema generation for optional custom fields.

### DIFF
--- a/apollo-router-core/src/plugins/headers.rs
+++ b/apollo-router-core/src/plugins/headers.rs
@@ -65,10 +65,10 @@ enum Propagate {
         #[schemars(schema_with = "string_schema")]
         #[serde(deserialize_with = "deserialize_header_name")]
         named: HeaderName,
-        #[schemars(schema_with = "option_string_schema")]
+        #[schemars(schema_with = "option_string_schema", default)]
         #[serde(deserialize_with = "deserialize_option_header_name")]
         rename: Option<HeaderName>,
-        #[schemars(schema_with = "option_string_schema")]
+        #[schemars(schema_with = "option_string_schema", default)]
         #[serde(deserialize_with = "deserialize_option_header_value")]
         default: Option<HeaderValue>,
     },

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -101,9 +101,7 @@ expression: "&schema"
                       {
                         "type": "object",
                         "required": [
-                          "default",
-                          "named",
-                          "rename"
+                          "named"
                         ],
                         "properties": {
                           "default": {
@@ -219,9 +217,7 @@ expression: "&schema"
                         {
                           "type": "object",
                           "required": [
-                            "default",
-                            "named",
-                            "rename"
+                            "named"
                           ],
                           "properties": {
                             "default": {
@@ -397,10 +393,6 @@ expression: "&schema"
                     },
                     "trace_config": {
                       "type": "object",
-                      "required": [
-                        "resource",
-                        "sampler"
-                      ],
                       "properties": {
                         "max_attributes_per_event": {
                           "type": "integer",
@@ -433,11 +425,13 @@ expression: "&schema"
                           "nullable": true
                         },
                         "resource": {
+                          "default": null,
                           "type": "object",
                           "additionalProperties": true,
                           "nullable": true
                         },
                         "sampler": {
+                          "default": null,
                           "oneOf": [
                             {
                               "type": "string",
@@ -504,9 +498,6 @@ expression: "&schema"
                                   "properties": {
                                     "grpc": {
                                       "type": "object",
-                                      "required": [
-                                        "protocol"
-                                      ],
                                       "properties": {
                                         "endpoint": {
                                           "default": null,
@@ -521,6 +512,7 @@ expression: "&schema"
                                           "nullable": true
                                         },
                                         "protocol": {
+                                          "default": null,
                                           "type": "string",
                                           "enum": [
                                             "Grpc",
@@ -643,10 +635,6 @@ expression: "&schema"
                             },
                             "trace_config": {
                               "type": "object",
-                              "required": [
-                                "resource",
-                                "sampler"
-                              ],
                               "properties": {
                                 "max_attributes_per_event": {
                                   "type": "integer",
@@ -679,11 +667,13 @@ expression: "&schema"
                                   "nullable": true
                                 },
                                 "resource": {
+                                  "default": null,
                                   "type": "object",
                                   "additionalProperties": true,
                                   "nullable": true
                                 },
                                 "sampler": {
+                                  "default": null,
                                   "oneOf": [
                                     {
                                       "type": "string",

--- a/apollo-router/src/plugins/telemetry.rs
+++ b/apollo-router/src/plugins/telemetry.rs
@@ -80,14 +80,14 @@ fn default_jaeger_password() -> Option<String> {
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct TraceConfig {
-    #[schemars(schema_with = "option_sampler_schema")]
+    #[schemars(schema_with = "option_sampler_schema", default)]
     pub sampler: Option<Sampler>,
     pub max_events_per_span: Option<u32>,
     pub max_attributes_per_span: Option<u32>,
     pub max_links_per_span: Option<u32>,
     pub max_attributes_per_event: Option<u32>,
     pub max_attributes_per_link: Option<u32>,
-    #[schemars(schema_with = "option_resource_schema")]
+    #[schemars(schema_with = "option_resource_schema", default)]
     pub resource: Option<Resource>,
 }
 

--- a/apollo-router/src/plugins/telemetry/otlp/grpc.rs
+++ b/apollo-router/src/plugins/telemetry/otlp/grpc.rs
@@ -18,7 +18,7 @@ pub struct GrpcExporter {
         serialize_with = "header_map_serde::serialize",
         default
     )]
-    #[schemars(schema_with = "option_metadata_map")]
+    #[schemars(schema_with = "option_metadata_map", default)]
     metadata: Option<MetadataMap>,
 }
 

--- a/apollo-router/src/plugins/telemetry/otlp/mod.rs
+++ b/apollo-router/src/plugins/telemetry/otlp/mod.rs
@@ -105,7 +105,7 @@ pub struct ExportConfig {
     #[serde(deserialize_with = "endpoint_url", default)]
     pub endpoint: Option<Url>,
 
-    #[schemars(schema_with = "option_protocol_schema")]
+    #[schemars(schema_with = "option_protocol_schema", default)]
     pub protocol: Option<Protocol>,
     pub timeout: Option<u64>,
 }


### PR DESCRIPTION
Optional fields that use custom schema generation need to be explicitly marked as `default` in the `schemars` annotation, otherwise they show up as being required.

<!--
First, 🌠 thank you 🌠 for considering a contribution to Apollo!

Some of this information is also included in the /CONTRIBUTING.md file at the
root of this repository.  We suggest you read it!

  https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md

Here are some important details to keep in mind:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!  Documentation in the docs/ directory should be updated
        as necessary.  Finally, a /CHANGELOG.md entry should be added.

We hope you will find this to be a positive experience! Contribution can be
intimidating and we hope to alleviate that pain as much as possible. Without
following these guidelines, you may be missing context that can help you succeed
with your contribution, which is why we encourage discussion first. Ultimately,
there is no guarantee that we will be able to merge your pull-request, but by
following these guidelines we can try to avoid disappointment.

-->
