### PR TITLE
Remove extra table tags and remove comma from config.json

### DIFF
--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -35,7 +35,7 @@
       "Subgraph specification": "https://www.apollographql.com/docs/federation/v2/federation-spec/"
     },
     "TODO(Not Categorized)": {
-      "Build from source": "/build-from-source",
+      "Build from source": "/build-from-source"
     }
   }
 }

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -5,8 +5,6 @@ description: High-performance graph routing for federated graphs
 
 import { Link } from "gatsby";
 
----
-
 > For installation instructions, see the [quickstart](../quickstart/).
 
 You run Apollo Router with the following command (assuming you're in the same directory as the `router` executable):
@@ -83,9 +81,6 @@ Default: `info`
 <td>
 
 Prints out a JSON schema of the configuration file, including plugin configuration (see below)
-
-</td>
-</tr>
 
 </td>
 </tr>


### PR DESCRIPTION
This branch fixes broken docs builds by correcting table tags in the configuration overview article.