### PR TITLE
Use `.gitattributes` to exclude licenses from "linguist" language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+licenses.html linguist-vendored


### PR DESCRIPTION
Without this, our repository shows that it's 45% HTML in the language stats
because our licenses.html file is 600kB+.

Ref: https://github.com/github/linguist/blob/master/docs/overrides.md#using-gitattributes