### PR TITLE
docs: configuration file consistency

### DIFF
--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -23,7 +23,7 @@
       "Logging": "/configuration/logging",
       "Header propagation": "/configuration/header-propagation",
       "Subgraph routing URLs": "/configuration/subgraph-routing-urls",
-      "OpenTelemetry": "/configuration/open-telemetry",
+      "OpenTelemetry": "/configuration/opentelemetry",
       "Spaceport": "/configuration/spaceport"
     },
     "Customizations": {

--- a/docs/source/configuration/cors.mdx
+++ b/docs/source/configuration/cors.mdx
@@ -10,7 +10,7 @@ The Apollo Router supports [Cross Origin Resource Sharing](https://developer.moz
 to indicate from which origin it accepts requests. **By default, it accepts requests from all origins**.
 If your environment has specific security requirements around CORS, they can be set up in the configuration file:
 
-```yaml title="config.router.yaml"
+```yaml title="router.yaml"
 server:
   #
   # CORS (Cross Origin Resource Sharing)

--- a/docs/source/configuration/header-propagation.mdx
+++ b/docs/source/configuration/header-propagation.mdx
@@ -5,7 +5,7 @@ description: Configuring the HTTP headers which are sent to subgraphs
 
 You can customize which HTTP headers the Apollo Router includes in its requests to your subgraphs. Transformations can be specified on all or per-subgraph basis in your [YAML configuration file](#configuration-file).
 
-```yaml{3-12}:title=config.router.yaml
+```yaml{3-12}:title=router.yaml
 # ...other configuration...
 
 headers:
@@ -79,7 +79,7 @@ Enables you to add custom headers to requests going to a specific subgraph. Thes
 
 Here's a complete example showing all the possible configuration options in use.
 
-```yaml:title=config.router.yaml
+```yaml:title=router.yaml
 headers:
   # All subgraph configuration.
   all:

--- a/docs/source/configuration/opentelemetry.mdx
+++ b/docs/source/configuration/opentelemetry.mdx
@@ -21,12 +21,12 @@ To get maximum benefit from distributed-tracing, all components in your system s
 
 ## Opentracing support
 Although OpenTelemetry has superseded OpenTracing, you may need to interact with systems that have not yet moved to
-OpenTelemetry. 
+OpenTelemetry.
 
 If you are using OpenTelemetry throughout your systems and just want to view in [Jaeger](https://www.jaegertracing.io/) 
-you don't need to configure this.  
+you don't need to configure this.
 
-```yaml title="config.router.yaml" 
+```yaml title="router.yaml"
 # ...other configuration...
 
 telemetry:
@@ -34,14 +34,14 @@ telemetry:
   opentracing:
     # "zipkin_b3" and "jaeger" formats are supported
     format: "zipkin_b3"
-   
+
   # ...other telemetry configuration...
 ```
 
 ## Using Jaeger
 The Apollo Router can be configured to export tracing data to Jaeger either via an agent or http collector.
 
-```yaml title="config.router.yaml"
+```yaml title="router.yaml"
 telemetry:
   opentelemetry:
     jaeger:
@@ -89,14 +89,12 @@ telemetry:
 ```
 
 ## OpenTelemetry Collector via OTLP
-[OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) is a horizontally scalable collector that can be 
-used to receive, process and export your telemetry data in a pluggable way. 
 
-If you find that the built-in telemetry 
-features of the Apollo Router are missing some desired functionality e.g. [exporting to Kafka](https://opentelemetry.io/docs/collector/configuration/#exporters)
-then it's worth considering this option.
+[OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) is a horizontally scalable collector that can be used to receive, process and export your telemetry data in a pluggable way.
 
-```yaml title="config.router.yaml"
+If you find that the built-in telemetry features of the Apollo Router are missing some desired functionality e.g. [exporting to Kafka](https://opentelemetry.io/docs/collector/configuration/#exporters) then it's worth considering this option.
+
+```yaml title="router.yaml"
 telemetry:
   # Configuration to send traces and metrics to an OpenTelemetry Protocol compatible service
   opentelemetry:

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -9,8 +9,10 @@ import { Link } from "gatsby";
 
 You run Apollo Router with the following command (assuming you're in the same directory as the `router` executable):
 
+TODO We don't explain `--config` or the configuration file first.
+
 ```bash
-./router --config configuration.yaml --supergraph supergraph-schema.graphql
+./router --config router.yaml --supergraph supergraph-schema.graphql
 ```
 
 Options are described below.
@@ -141,7 +143,7 @@ Apollo Router takes an optional YAML configuration file as input via the `--conf
 By default, the Apollo Router starts a HTTP server listening on `127.0.0.1:4000`. This can be
 changed in the configuration file:
 
-```yaml title="configuration.router.yaml"
+```yaml title="router.yaml"
 #
 # server: Configuration of the HTTP server
 #
@@ -153,7 +155,7 @@ server:
 
 It can also listen on a Unix socket (not supported on Windows):
 
-```yaml title="configuration.router.yaml"
+```yaml title="router.yaml"
 server:
   # absolute path to a Unix socket
   listen: /tmp/router.sock
@@ -179,7 +181,7 @@ You can set it up in the configuration file's [OpenTelemetry section](../open-te
 The Apollo Router can be customized through [plugins](../customizations/overview). Any plugin
 can have its specific section in the configuration file:
 
-```yaml title="configuration.router.yaml"
+```yaml title="router.yaml"
 plugins:
   example.plugin:
     var1: "hello"
@@ -190,7 +192,7 @@ plugins:
 
 You can avoid repeating sections of configuration multiple times in your configuration file using standard YAML anchors and aliasing techniques:
 
-```yaml {5,9} title="configuration.yaml"
+```yaml {5,9} title="router.yaml"
 headers:
   subgraphs:
     products:

--- a/docs/source/configuration/spaceport.mdx
+++ b/docs/source/configuration/spaceport.mdx
@@ -21,7 +21,7 @@ More information on usage reporting is available in the [Studio documentation](h
 ## Advanced configuration
 Spaceport can run either as an [internal component](#internal-spaceport) of a single Apollo Router instance, or as an [external resource](#external-spaceport) shared by _multiple_ router instances.
 
-```yaml title="config.router.yaml"
+```yaml title="router.yaml"
 telemetry:
   # Spaceport configuration. These values are the default values if not specified
   spaceport:
@@ -37,7 +37,7 @@ By default, spaceport runs within a single Apollo Router instance. It requires n
 
 You can optionally configure which address the internal spaceport listens on by setting the `listener` property. This should only be necessary if there's a conflict on the default port that Router chooses (e.g., if running multiple routers or other applications using the same port on the same host), or if it's desirable to change the bind address.
 
-```yaml title="config.router.yaml"
+```yaml title="router.yaml"
 telemetry:
   # Spaceport configuration. These values are the default values if not specified
   spaceport:
@@ -54,7 +54,7 @@ To enable the external spaceport, another Router can be run to act as the collec
 
 For help with this feature, please [open a discussion](https://github.com/apollographql/router/discussions).
 
-```yaml title="config.router.yaml"
+```yaml title="router.yaml"
 telemetry:
   # Spaceport configuration. These values are the default values if not specified
   spaceport:

--- a/docs/source/managed-federation/setup.mdx
+++ b/docs/source/managed-federation/setup.mdx
@@ -27,7 +27,7 @@ If you haven't yet, complete the first two steps from the Apollo Studio getting 
 If you've already set up Apollo Federation _without_ Apollo Studio, you're probably passing a `--supergraph` (or `-s`) flag in the command (e.g., in container startup scripts) you use to start the router:
 
 ```sh
-router --config ./config.yaml --supergraph ./your-local-supergraph.graphql
+router --config ./router.yaml --supergraph ./your-local-supergraph.graphql
 ```
 
 Your configuration file may use a different name, but the `--supergraph` option is specific to _non_-managed federation, in which supergraph schema composition is performed via the Rover CLI and provided as a file.
@@ -37,7 +37,7 @@ With managed federation, composition is instead performed by _Apollo_, and the r
 When starting the Apollo Router and retrieving the schema from the Apollo Studio registry, remove the `--supergraph` (or `-s`) argument from your Apollo Router startup command, leaving the `--config` argument if it was already provided:
 
 ```sh
-router --config ./config.yaml
+router --config ./router.yaml
 ```
 
 ## 4. Connect the router to Studio
@@ -49,7 +49,7 @@ Your router uses a graph API key to identify itself to Studio.
 After obtaining your graph API key, you set two environment variables in your environment when starting your router:
 
 ```sh
-APOLLO_KEY=<YOUR_GRAPH_API_KEY> APOLLO_GRAPH_REF=<YOUR_GRAPH_ID>@<VARIANT> router --config ./config.yaml
+APOLLO_KEY=<YOUR_GRAPH_API_KEY> APOLLO_GRAPH_REF=<YOUR_GRAPH_ID>@<VARIANT> router --config ./router.yaml
 ```
 
 The `--config` argument may be present if you were previously passing the operational configuration file to the router and the configuration may use a different name.

--- a/examples/async-auth/src/allow_client_id_from_file.rs
+++ b/examples/async-auth/src/allow_client_id_from_file.rs
@@ -172,7 +172,7 @@ mod tests {
     // This test ensures the router will be able to
     // find our `allow-client-id-from-file` plugin,
     // and deserialize an empty yml configuration containing a path
-    // see config.yml for more information
+    // see router.yaml for more information
     #[tokio::test]
     async fn plugin_registered() {
         apollo_router_core::plugins()

--- a/examples/context/src/main.rs
+++ b/examples/context/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 // adding the module to your main.rs file
 // will automatically register it to the router plugin registry.
 //
-// you can use the plugin by adding it to `config.yml`
+// you can use the plugin by adding it to `router.yaml`
 mod context_data;
 
 // `cargo run -- -s ../graphql/supergraph.graphql -c ./router.yaml`

--- a/examples/forbid-anonymous-operations/src/forbid_anonymous_operations.rs
+++ b/examples/forbid-anonymous-operations/src/forbid_anonymous_operations.rs
@@ -14,7 +14,7 @@ struct ForbidAnonymousOperations {}
 impl Plugin for ForbidAnonymousOperations {
     // We either forbid anonymous operations,
     // Or we don't. This is the reason why we don't need
-    // to deserialize any configuration from a .yml file.
+    // to deserialize any configuration from a .yaml file.
     //
     // Config is a unit, and `ForbidAnonymousOperation` derives default.
     type Config = ();
@@ -96,7 +96,7 @@ mod tests {
     // This test ensures the router will be able to
     // find our `forbid_anonymous_operations` plugin,
     // and deserialize an empty yml configuration into it
-    // see config.yml for more information
+    // see router.yml for more information
     #[tokio::test]
     async fn plugin_registered() {
         apollo_router_core::plugins()

--- a/examples/forbid-anonymous-operations/src/main.rs
+++ b/examples/forbid-anonymous-operations/src/main.rs
@@ -15,7 +15,7 @@ use anyhow::Result;
 // adding the module to your main.rs file
 // will automatically register it to the router plugin registry.
 //
-// you can use the plugin by adding it to `config.yml`
+// you can use the plugin by adding it to `router.yaml`
 mod forbid_anonymous_operations;
 
 // `cargo run -- -s ../graphql/supergraph.graphql -c ./router.yaml`

--- a/examples/hello-world/src/main.rs
+++ b/examples/hello-world/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 // adding the module to your main.rs file
 // will automatically register it to the router plugin registry.
 //
-// you can use the plugin by adding it to `config.yml`
+// you can use the plugin by adding it to `router.yml`
 mod hello_world;
 
 // `cargo run -- -s ../graphql/supergraph.graphql -c ./router.yaml`

--- a/examples/jwt-auth/src/jwt.rs
+++ b/examples/jwt-auth/src/jwt.rs
@@ -12,7 +12,7 @@
 //!
 //! Usage:
 //!
-//! In your config.yaml, specify the following details:
+//! In your router.yaml, specify the following details:
 //! ```yaml
 //! plugins:
 //! Authentication Mechanism
@@ -399,7 +399,7 @@ mod tests {
     // This test ensures the router will be able to
     // find our `JwtAuth` plugin,
     // and deserialize an hmac configured yml configuration into it
-    // see config.yml for more information
+    // see `router.yaml` for more information
     #[test]
     fn plugin_registered() {
         apollo_router_core::plugins()

--- a/examples/jwt-auth/src/main.rs
+++ b/examples/jwt-auth/src/main.rs
@@ -16,7 +16,7 @@ use anyhow::Result;
 // adding the module to your main.rs file
 // will automatically register it to the router plugin registry.
 //
-// you can use the plugin by adding it to `config.yml`
+// you can use the plugin by adding it to `router.yaml`
 mod jwt;
 
 // `cargo run -- -s ../graphql/supergraph.graphql -c ./router.yaml`

--- a/examples/status-code-propagation/src/main.rs
+++ b/examples/status-code-propagation/src/main.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 // adding the module to your main.rs file
 // will automatically register it to the router plugin registry.
 //
-// you can use the plugin by adding it to `config.yml`
+// you can use the plugin by adding it to `router.yaml`
 mod propagate_status_code;
 
 // `cargo run -- -s ../graphql/supergraph.graphql -c ./router.yaml`

--- a/examples/status-code-propagation/src/propagate_status_code.rs
+++ b/examples/status-code-propagation/src/propagate_status_code.rs
@@ -104,7 +104,7 @@ mod tests {
     // This test ensures the router will be able to
     // find our `propagate_status_code` plugin,
     // and deserialize an yml configuration with a list of status_codes into it
-    // see config.router.yaml for more information
+    // see `router.yaml` for more information
     #[tokio::test]
     async fn plugin_registered() {
         apollo_router_core::plugins()


### PR DESCRIPTION
This uses `router.yaml` in all locations, rather than other variations.
This commit also introduces a TODO for something that came to mind while I
was reading the docs (unexplained context for the configuration file itself)
and also renames the `open-telemetry.mdx` to `opentelemetry.mdx` for
consistency with other locations on our site (and arguably, the name of the
product anyhow).