### PR TITLE
Fix Header propagation by `name` only fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
  -->
 
+# [v0.1.0-alpha.11] (unreleased) - 2022-mm-dd
+## ❗ BREAKING ❗
+## 🚀 Features
+## 🐛 Fixes
+- **Header propagation by `name` only fixed** ([PR #709](https://github.com/apollographql/router/pull/709))
+  Previously `rename` and `default` values were required (even though they were correctly not flagged as required in the json schema).
+  The following will now work:
+  ```yaml
+  headers:
+    all:
+    - propagate:
+        named: test
+  ```
+## 🛠 Maintenance
+## 📚 Documentation
+
 # [v0.1.0-alpha.10] 2022-03-21
 
 ## ❗ BREAKING ❗

--- a/apollo-router-core/src/plugins/headers.rs
+++ b/apollo-router-core/src/plugins/headers.rs
@@ -55,22 +55,21 @@ struct Insert {
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 #[serde(untagged)]
 enum Propagate {
-    Matching {
-        #[schemars(schema_with = "string_schema")]
-        #[serde(deserialize_with = "deserialize_regex")]
-        matching: Regex,
-    },
-
     Named {
         #[schemars(schema_with = "string_schema")]
         #[serde(deserialize_with = "deserialize_header_name")]
         named: HeaderName,
         #[schemars(schema_with = "option_string_schema", default)]
-        #[serde(deserialize_with = "deserialize_option_header_name")]
+        #[serde(deserialize_with = "deserialize_option_header_name", default)]
         rename: Option<HeaderName>,
         #[schemars(schema_with = "option_string_schema", default)]
-        #[serde(deserialize_with = "deserialize_option_header_value")]
+        #[serde(deserialize_with = "deserialize_option_header_value", default)]
         default: Option<HeaderValue>,
+    },
+    Matching {
+        #[schemars(schema_with = "string_schema")]
+        #[serde(deserialize_with = "deserialize_regex")]
+        matching: Regex,
     },
 }
 
@@ -437,6 +436,25 @@ mod test {
 
     #[test]
     fn test_propagate_config() {
+        serde_yaml::from_str::<Config>(
+            r#"
+        all:
+            - propagate:
+                named: "test"
+        "#,
+        )
+        .unwrap();
+
+        serde_yaml::from_str::<Config>(
+            r#"
+        all:
+            - propagate:
+                named: "test"
+                rename: "bif"
+        "#,
+        )
+        .unwrap();
+
         serde_yaml::from_str::<Config>(
             r#"
         all:

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -92,18 +92,6 @@ expression: "&schema"
                       {
                         "type": "object",
                         "required": [
-                          "matching"
-                        ],
-                        "properties": {
-                          "matching": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false
-                      },
-                      {
-                        "type": "object",
-                        "required": [
                           "named"
                         ],
                         "properties": {
@@ -117,6 +105,18 @@ expression: "&schema"
                           "rename": {
                             "type": "string",
                             "nullable": true
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "matching"
+                        ],
+                        "properties": {
+                          "matching": {
+                            "type": "string"
                           }
                         },
                         "additionalProperties": false
@@ -208,18 +208,6 @@ expression: "&schema"
                         {
                           "type": "object",
                           "required": [
-                            "matching"
-                          ],
-                          "properties": {
-                            "matching": {
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "required": [
                             "named"
                           ],
                           "properties": {
@@ -233,6 +221,18 @@ expression: "&schema"
                             "rename": {
                               "type": "string",
                               "nullable": true
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "required": [
+                            "matching"
+                          ],
+                          "properties": {
+                            "matching": {
+                              "type": "string"
                             }
                           },
                           "additionalProperties": false


### PR DESCRIPTION
  Previously `rename` and `default` values were required (even though they were correctly not flagged as required un the json schema).
  The following will now work:
  ```yaml
  headers:
    all:
    - propagate:
        named: test
  ```

The fix is to mark the fields as defaulted.

<!--
First, 🌠 thank you 🌠 for considering a contribution to Apollo!

Some of this information is also included in the /CONTRIBUTING.md file at the
root of this repository.  We suggest you read it!

  https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md

Here are some important details to keep in mind:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!  Documentation in the docs/ directory should be updated
        as necessary.  Finally, a /CHANGELOG.md entry should be added.

We hope you will find this to be a positive experience! Contribution can be
intimidating and we hope to alleviate that pain as much as possible. Without
following these guidelines, you may be missing context that can help you succeed
with your contribution, which is why we encourage discussion first. Ultimately,
there is no guarantee that we will be able to merge your pull-request, but by
following these guidelines we can try to avoid disappointment.

-->
