### PR TITLE
fix: OTLP default service.name and service.namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
  -->
 
-
 # [v0.1.0-preview.1] (unreleased) - 2022-mm-dd
 ## ❗ BREAKING ❗
 ## 🚀 Features
@@ -28,8 +27,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Log and error message formatting** ([PR #721](https://github.com/apollographql/router/pull/721))
 
   Logs and error messages in Rust begin with lower case and do not have trailing punctuation. The codebase is now consistent with this scheme. 
-## 🛠 Maintenance
-## 📚 Documentation
+
+- **OTLP default service.name and service.namespace** ([#719](https://github.com/apollographql/router/issues/719))
+
+  While the Jaeger yaml configuration would default to the "router" service.name and "apollo" service.namespace, it was not the case when using an OTLP configuration. This lead to UNKNOWN_SERVICE name in zipking traces, and hard to find Jaeger traces.
 
 # [v0.1.0-preview.0] - 2022-03-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   Logs and error messages in Rust begin with lower case and do not have trailing punctuation. The codebase is now consistent with this scheme. 
 
-- **OTLP default service.name and service.namespace** ([#719](https://github.com/apollographql/router/issues/719))
+- **OTLP default service.name and service.namespace** ([PR #722](https://github.com/apollographql/router/pull/722))
 
   While the Jaeger yaml configuration would default to the "router" service.name and "apollo" service.namespace, it was not the case when using an OTLP configuration. This lead to UNKNOWN_SERVICE name in zipking traces, and hard to find Jaeger traces.
 

--- a/apollo-router/src/plugins/telemetry.rs
+++ b/apollo-router/src/plugins/telemetry.rs
@@ -364,9 +364,14 @@ impl Telemetry {
         .build();
 
         let mut builder = opentelemetry::sdk::trace::TracerProvider::builder();
-        if let Some(trace_config) = &config.trace_config {
-            builder = builder.with_config(trace_config.trace_config());
-        }
+        builder = builder.with_config(
+            config
+                .trace_config
+                .clone()
+                .unwrap_or_default()
+                .trace_config(),
+        );
+
         // If we have apollo graph configuration, then we can export statistics
         // to the apollo ingress. If we don't, we can't and so no point configuring the
         // exporter.


### PR DESCRIPTION
fixes #719

service.name and service.namespace did default correctly in jaeger configuration, but not in OTLP.
This PR fixes this.

