### PR TITLE
add support of metrics WIP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,8 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-jaeger",
  "opentelemetry-otlp",
+ "opentelemetry-prometheus",
+ "prometheus",
  "prost-types",
  "regex",
  "reqwest",
@@ -199,7 +201,7 @@ dependencies = [
  "async-trait",
  "atty",
  "bytes",
- "dashmap",
+ "dashmap 5.2.0",
  "derivative",
  "displaydoc",
  "futures",
@@ -1067,6 +1069,16 @@ checksum = "91a9304e55e9d601a39ae4deaba85406d5c0980e106f65afcf0460e9af1e7602"
 dependencies = [
  "petgraph",
  "serde",
+]
+
+[[package]]
+name = "dashmap"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "num_cpus",
 ]
 
 [[package]]
@@ -2885,6 +2897,8 @@ checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
+ "dashmap 4.0.2",
+ "fnv",
  "futures-channel",
  "futures-executor",
  "futures-util",
@@ -2949,6 +2963,17 @@ dependencies = [
  "thiserror",
  "tonic",
  "tonic-build",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9328977e479cebe12ce0d3fcecdaea4721d234895a9440c5b5dfd113f0594ac6"
+dependencies = [
+ "opentelemetry",
+ "prometheus",
+ "protobuf",
 ]
 
 [[package]]
@@ -3281,6 +3306,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f64969ffd5dd8f39bd57a68ac53c163a095ed9d0fb707146da1b27025a3504"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.11.2",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
 name = "propagate-status-code"
 version = "0.1.0"
 dependencies = [
@@ -3288,7 +3328,7 @@ dependencies = [
  "apollo-parser 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "apollo-router",
  "apollo-router-core",
- "dashmap",
+ "dashmap 5.2.0",
  "futures",
  "http",
  "schemars",
@@ -3354,6 +3394,12 @@ dependencies = [
  "bytes",
  "prost",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "pulldown-cmark"

--- a/apollo-router-core/src/layers/ensure_query_presence.rs
+++ b/apollo-router-core/src/layers/ensure_query_presence.rs
@@ -20,7 +20,7 @@ where
             |req: RouterRequest| {
                 // A query must be available at this point
                 let query = req.context.request.body().query.as_ref();
-                if query.is_none() || query.unwrap().is_empty() {
+                if query.is_none() || query.unwrap().trim().is_empty() {
                     let res = plugin_utils::RouterResponse::builder()
                         .errors(vec![crate::Error {
                             message: "Must provide query string.".to_string(),

--- a/apollo-router-core/src/services/router_service.rs
+++ b/apollo-router-core/src/services/router_service.rs
@@ -95,7 +95,7 @@ where
                 })
             });
         }
-
+        let context_cloned = req.context.clone();
         let fut = async move {
             let context = req.context;
             let body = context.request.body();
@@ -152,6 +152,7 @@ where
                     message: error.to_string(),
                     ..Default::default()
                 }])
+                .context(context_cloned.into())
                 .build()
                 .with_status(StatusCode::INTERNAL_SERVER_ERROR))
         });

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -41,7 +41,7 @@ http = "0.2.6"
 hyper = { version = "0.14.18", features = ["server"] }
 itertools = "0.10.3"
 once_cell = "1.9.0"
-opentelemetry = { version = "0.17.0", features = ["rt-tokio", "serialize"] }
+opentelemetry = { version = "0.17.0", features = ["rt-tokio", "serialize", "metrics"] }
 opentelemetry-jaeger = { version = "0.16.0", features = [
     "collector_client",
     "reqwest_collector_client",
@@ -50,6 +50,8 @@ opentelemetry-jaeger = { version = "0.16.0", features = [
 opentelemetry-otlp = { version = "0.10.0", default-features = false, features = [
     "serialize",
 ], optional = true }
+opentelemetry-prometheus = "0.10.0"
+prometheus = "0.13"
 prost-types = "0.9.0"
 regex = "1.5.4"
 reqwest = { version = "0.11.10", features = ["json", "stream"] }

--- a/apollo-router/src/plugins/telemetry/metrics.rs
+++ b/apollo-router/src/plugins/telemetry/metrics.rs
@@ -1,0 +1,91 @@
+use apollo_router_core::{Plugin, ResponseBody, RouterRequest, RouterResponse};
+use http::StatusCode;
+use opentelemetry::{global, metrics::Counter, KeyValue};
+use opentelemetry_prometheus::PrometheusExporter;
+use prometheus::{Encoder, TextEncoder};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tower::{util::BoxService, BoxError, ServiceExt};
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct MetricsConfiguration {
+    exporter: MetricsExporter,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub enum MetricsExporter {
+    Prometheus(PrometheusConfiguration),
+    OLTP(OltpConfiguration),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct PrometheusConfiguration {
+    endpoint: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+pub struct OltpConfiguration {}
+
+#[derive(Debug)]
+pub struct MetricsPlugin {
+    exporter: PrometheusExporter,
+    conf: MetricsConfiguration,
+    http_counter: Counter<u64>,
+}
+
+impl Plugin for MetricsPlugin {
+    type Config = MetricsConfiguration;
+
+    fn new(config: Self::Config) -> Result<Self, BoxError> {
+        let exporter = opentelemetry_prometheus::exporter().init();
+        let meter = global::meter("apollo/router");
+
+        Ok(Self {
+            exporter,
+            conf: config,
+            http_counter: meter
+                .u64_counter("http_requests_total")
+                .with_description("Total number of HTTP requests made")
+                .init(),
+        })
+    }
+
+    fn router_service(
+        &mut self,
+        service: BoxService<RouterRequest, RouterResponse, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse, BoxError> {
+        println!("heeere");
+        let http_counter = self.http_counter.clone();
+        let registry = self.exporter.registry().clone();
+        let prometheus_endpoint = match &self.conf.exporter {
+            MetricsExporter::Prometheus(prom) => Some(format!("/graphql{}", prom.endpoint.clone())),
+            MetricsExporter::OLTP(_) => None,
+        };
+
+        service
+            .map_request(move |req: RouterRequest| {
+                http_counter.add(
+                    1,
+                    &[KeyValue::new("url", req.context.request.url().to_string())],
+                );
+                req
+            })
+            .map_response(move |mut response: RouterResponse| {
+                if let Some(prometheus_endpoint) = prometheus_endpoint {
+                    if response.context.request.url().path() == prometheus_endpoint {
+                        let encoder = TextEncoder::new();
+                        let metric_families = registry.gather();
+                        let mut result = Vec::new();
+                        encoder.encode(&metric_families, &mut result).unwrap();
+                        *response.response.body_mut() =
+                            ResponseBody::RawString(String::from_utf8_lossy(&result).into_owned());
+                        *response.response.status_mut() = StatusCode::OK;
+                    }
+                }
+
+                response
+            })
+            .boxed()
+    }
+}


### PR DESCRIPTION
Work in progress
Currently using an evil trick to export prometheus metrics in a specific endpoint. Don't be mad :smile: 

Also I spotted some bugs I fixed:
+ I now trim the query to check if the query is empty or not, before we could trick the layer by using `query=" "`
+ I put the original context in the `RouterResponse` when it's returning an error