### PR TITLE
Add an option to deactivate introspection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   The Router now understands the [@skip](https://spec.graphql.org/October2021/#sec--skip) and [@include](https://spec.graphql.org/October2021/#sec--include) directives in queries, to add or remove fields depending on variables. It works in post processing, by filtering fields after aggregating the subgraph responses.
 
+- **Add an option to deactivate introspection** ([PR #749](https://github.com/apollographql/router/pull/749))
+
+  While schema introspection is useful in development, we might not want to expose the entire schema in production,
+  so the router can be configured to forbid introspection queries as follows:
+```yaml
+server:
+  introspection: false
+```
+
 ## 🐛 Fixes
 - **Remove `hasNext` from our response objects** ([PR #733](https://github.com/apollographql/router/pull/733))
 

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -214,6 +214,12 @@ pub struct Server {
     #[serde(default)]
     #[builder(default)]
     pub cors: Option<Cors>,
+
+    /// introspection queries
+    /// enabled by default
+    #[serde(default = "default_introspection")]
+    #[builder(default_code = "default_introspection()", setter(into))]
+    pub introspection: bool,
 }
 
 /// Listening address.
@@ -308,6 +314,10 @@ fn default_cors_headers() -> Vec<String> {
 
 fn default_cors_methods() -> Vec<String> {
     vec!["GET".into(), "POST".into(), "OPTIONS".into()]
+}
+
+fn default_introspection() -> bool {
+    true
 }
 
 impl Default for Server {

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-2.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-2.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 439
+assertion_line: 450
 expression: config
 ---
 plugins: ~
@@ -19,4 +19,5 @@ server:
     methods:
       - foo
       - bar
+  introspection: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-3.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-3.snap
@@ -1,10 +1,11 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 440
+assertion_line: 451
 expression: config
 ---
 plugins: ~
 server:
   listen: "1.2.3.4:5"
   cors: ~
+  introspection: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-4.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change-4.snap
@@ -1,10 +1,11 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 441
+assertion_line: 452
 expression: config
 ---
 plugins: ~
 server:
   listen: "1.2.3.4:5"
   cors: ~
+  introspection: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change.snap
@@ -1,10 +1,11 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 438
+assertion_line: 449
 expression: config
 ---
 plugins: ~
 server:
   listen: "1.2.3.4:5"
   cors: ~
+  introspection: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_grpc-2.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_grpc-2.snap
@@ -1,10 +1,11 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 467
+assertion_line: 478
 expression: config
 ---
 plugins: ~
 server:
   listen: "1.2.3.4:5"
   cors: ~
+  introspection: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_grpc.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_grpc.snap
@@ -1,10 +1,11 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 466
+assertion_line: 477
 expression: config
 ---
 plugins: ~
 server:
   listen: "1.2.3.4:5"
   cors: ~
+  introspection: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_http-2.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_http-2.snap
@@ -1,10 +1,11 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 488
+assertion_line: 485
 expression: config
 ---
 plugins: ~
 server:
   listen: "1.2.3.4:5"
   cors: ~
+  introspection: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_http.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_http.snap
@@ -1,10 +1,11 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 473
+assertion_line: 484
 expression: config
 ---
 plugins: ~
 server:
   listen: "1.2.3.4:5"
   cors: ~
+  introspection: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_tls_config.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__ensure_configuration_api_does_not_change_tls_config.snap
@@ -1,10 +1,11 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 480
+assertion_line: 491
 expression: config
 ---
 plugins: ~
 server:
   listen: "1.2.3.4:5"
   cors: ~
+  introspection: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 429
+assertion_line: 439
 expression: "&schema"
 ---
 {
@@ -279,7 +279,8 @@ expression: "&schema"
       "description": "Configuration options pertaining to the http server component.",
       "default": {
         "listen": "127.0.0.1:4000",
-        "cors": null
+        "cors": null,
+        "introspection": true
       },
       "type": "object",
       "properties": {
@@ -342,6 +343,11 @@ expression: "&schema"
           },
           "additionalProperties": false,
           "nullable": true
+        },
+        "introspection": {
+          "description": "introspection queries enabled by default",
+          "default": true,
+          "type": "boolean"
         },
         "listen": {
           "description": "The socket address and port to listen on Defaults to 127.0.0.1:4000",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__supergraph_config_serde.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__supergraph_config_serde.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 433
+assertion_line: 444
 expression: config
 ---
 plugins: ~
@@ -17,4 +17,5 @@ server:
     methods:
       - GET
       - PUT
+  introspection: true
 

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -73,6 +73,9 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
         let configuration = (*configuration).clone();
 
         let mut builder = PluggableRouterServiceBuilder::new(schema.clone());
+        if configuration.server.introspection {
+            builder = builder.with_naive_introspection();
+        }
 
         for (name, _) in schema.subgraphs() {
             let dedup_layer = QueryDeduplicationLayer;


### PR DESCRIPTION
Fix #564 

we might want to disable schema introspection on production systems, so here's an option in the yaml configuration for that