### PR TITLE
improve async cancellation handling in the router

### DIFF
--- a/apollo-router-core/src/cache.rs
+++ b/apollo-router-core/src/cache.rs
@@ -6,6 +6,7 @@ use std::cmp::Eq;
 use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
+use std::sync::{Arc, Weak};
 use tokio::sync::broadcast::{self, Sender};
 
 /// A caching map optimised for slow value resolution.
@@ -21,7 +22,7 @@ pub struct CachingMap<K, V> {
     cached: Mutex<LruCache<K, Result<V, CacheResolverError>>>,
     #[allow(clippy::type_complexity)]
     #[derivative(Debug = "ignore")]
-    wait_map: Mutex<HashMap<K, Sender<(K, Result<V, CacheResolverError>)>>>,
+    wait_map: Mutex<HashMap<K, Weak<Sender<(K, Result<V, CacheResolverError>)>>>>,
     cache_limit: usize,
     #[derivative(Debug = "ignore")]
     resolver: Box<dyn CacheResolver<K, V> + Send + Sync>,
@@ -76,50 +77,62 @@ where
         // miss a broadcast.
         drop(locked_cache);
 
-        match locked_wait_map.get_mut(&key) {
-            Some(waiter) => {
-                // Register interest in key
-                let mut receiver = waiter.subscribe();
-                drop(locked_wait_map);
-                // Our use case is very specific, so we are sure
-                // that we won't get any errors here.
-                let (recv_key, recv_value) = receiver.recv().await.expect(
-                    "the sender won't ever be dropped before all the receivers finish; qed",
-                );
-                debug_assert_eq!(recv_key, key);
-                recv_value
-            }
-            None => {
-                let (tx, _rx) = broadcast::channel(1);
-                locked_wait_map.insert(key.clone(), tx.clone());
-                drop(locked_wait_map);
-                // This is the potentially high duration operation where we ask our resolver to
-                // resolve the key (retrieve a value) for us
-                // No cache locks are held here
-                let value = self.resolver.retrieve(key.clone()).await;
-
-                // this is a separate block used to release the locks after editing the cache and wait map,
-                // but before broadcasting the value
-                {
-                    // Update our cache
-                    let mut locked_cache = self.cached.lock().await;
-                    locked_cache.put(key.clone(), value.clone());
-                    // Update our wait list
-                    let mut locked_wait_map = self.wait_map.lock().await;
-                    locked_wait_map.remove(&key);
+        loop {
+            match locked_wait_map.get_mut(&key) {
+                Some(weak_waiter) => {
+                    // Try to upgrade our weak Arc. If we can't, the sender must have
+                    // been cancelled, so remove the entry from the map and try again.
+                    let waiter = match Weak::upgrade(weak_waiter) {
+                        Some(waiter) => waiter,
+                        None => {
+                            locked_wait_map.remove(&key);
+                            continue;
+                        }
+                    };
+                    // Register interest in key
+                    let mut receiver = waiter.subscribe();
+                    drop(locked_wait_map);
+                    // Our use case is very specific, so we are sure
+                    // that we won't get any errors here.
+                    let (recv_key, recv_value) = receiver
+                        .recv()
+                        .await
+                        .expect("we ensured our receiver was valid before receiving; qed");
+                    debug_assert_eq!(recv_key, key);
+                    return recv_value;
                 }
+                None => {
+                    let (tx, _rx) = broadcast::channel(1);
+                    let tx = Arc::new(tx);
+                    locked_wait_map.insert(key.clone(), Arc::downgrade(&tx));
+                    drop(locked_wait_map);
+                    // This is the potentially high duration operation where we ask our resolver to
+                    // resolve the key (retrieve a value) for us
+                    // No cache locks are held here
+                    let value = self.resolver.retrieve(key.clone()).await;
 
-                // Let our waiters know
-                let broadcast_value = value.clone();
-                // Our use case is very specific, so we are sure that
-                // we won't get any errors here.
-                tokio::task::spawn_blocking(move || {
-                    tx.send((key, broadcast_value))
-                        .expect("there is always at least one receiver alive, the _rx guard; qed")
-                })
-                .await
-                .expect("can only fail if the task is aborted or if the internal code panics, neither is possible here; qed");
-                value
+                    // this is a separate block used to release the locks after editing the cache and wait map,
+                    // but before broadcasting the value
+                    {
+                        // Update our cache
+                        let mut locked_cache = self.cached.lock().await;
+                        locked_cache.put(key.clone(), value.clone());
+                        // Update our wait list
+                        let mut locked_wait_map = self.wait_map.lock().await;
+                        locked_wait_map.remove(&key);
+                    }
+
+                    // Let our waiters know
+                    let broadcast_value = value.clone();
+                    // We may get errors here, for instance if a task is cancelled,
+                    // so just ignore the result of send
+                    let _ = tokio::task::spawn_blocking(move || {
+                        tx.send((key, broadcast_value))
+                    })
+                    .await
+                    .expect("can only fail if the task is aborted or if the internal code panics, neither is possible here; qed");
+                    return value;
+                }
             }
         }
     }

--- a/apollo-router-core/src/layers/deduplication.rs
+++ b/apollo-router-core/src/layers/deduplication.rs
@@ -1,6 +1,10 @@
 use crate::{fetch::OperationKind, http_compat, Request, SubgraphRequest, SubgraphResponse};
 use futures::{future::BoxFuture, lock::Mutex};
-use std::{collections::HashMap, sync::Arc, task::Poll};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Weak},
+    task::Poll,
+};
 use tokio::sync::broadcast::{self, Sender};
 use tower::{BoxError, Layer, ServiceExt};
 
@@ -17,8 +21,9 @@ where
     }
 }
 
-type WaitMap =
-    Arc<Mutex<HashMap<http_compat::Request<Request>, Sender<Result<SubgraphResponse, String>>>>>;
+type WaitMap = Arc<
+    Mutex<HashMap<http_compat::Request<Request>, Weak<Sender<Result<SubgraphResponse, String>>>>>,
+>;
 
 pub struct QueryDeduplicationService<S> {
     service: S,
@@ -44,32 +49,50 @@ where
         loop {
             let mut locked_wait_map = wait_map.lock().await;
             match locked_wait_map.get_mut(&request.http_request) {
-                Some(waiter) => {
+                Some(weak_waiter) => {
+                    // Try to upgrade our weak Arc. If we can't, the sender must have
+                    // been cancelled, so remove the entry from the map and try again.
+                    let waiter = match Weak::upgrade(weak_waiter) {
+                        Some(waiter) => waiter,
+                        None => {
+                            locked_wait_map.remove(&request.http_request);
+                            continue;
+                        }
+                    };
                     // Register interest in key
                     let mut receiver = waiter.subscribe();
                     drop(locked_wait_map);
 
-                    match receiver.recv().await {
-                        Ok(value) => {
-                            return value
-                                .map(|response| SubgraphResponse {
-                                    response: response.response,
-                                    context: request.context,
-                                })
-                                .map_err(|e| e.into())
-                        }
-                        // there was an issue with the broadcast channel, retry fetching
-                        Err(_) => continue,
-                    }
+                    return receiver
+                        .recv()
+                        .await
+                        .expect("we ensured our receiver was valid before receiving; qed")
+                        .map(|response| SubgraphResponse {
+                            response: response.response,
+                            context: request.context,
+                        })
+                        .map_err(|e| e.into());
                 }
                 None => {
                     let (tx, _rx) = broadcast::channel(1);
-                    locked_wait_map.insert(request.http_request.clone(), tx.clone());
+                    let tx = Arc::new(tx);
+                    // Store a Weak reference to our Sender. If we are cancelled, then the
+                    // client will be unable to upgrade their Weak reference and will know
+                    // to clean up the wait_map and try again.
+                    locked_wait_map.insert(request.http_request.clone(), Arc::downgrade(&tx));
                     drop(locked_wait_map);
 
                     let context = request.context.clone();
                     let http_request = request.http_request.clone();
-                    let res = service.ready_oneshot().await?.call(request).await;
+                    let res = match service.ready_oneshot().await {
+                        Ok(mut s) => s.call(request).await,
+                        Err(e) => {
+                            // Clean up wait map if ready_oneshot failed
+                            let mut locked_wait_map = wait_map.lock().await;
+                            locked_wait_map.remove(&http_request);
+                            return Err(e);
+                        }
+                    };
 
                     {
                         let mut locked_wait_map = wait_map.lock().await;
@@ -82,11 +105,10 @@ where
                         .map(|response| response.clone())
                         .map_err(|e| e.to_string());
 
-                    // Our use case is very specific, so we are sure that
-                    // we won't get any errors here.
-                    tokio::task::spawn_blocking(move || {
+                    // We may get errors here, for instance if a task is cancelled,
+                    // so just ignore the result of send
+                    let _ = tokio::task::spawn_blocking(move || {
                         tx.send(broadcast_value)
-                            .expect("there is always at least one receiver alive, the _rx guard; qed")
                     }).await
                     .expect("can only fail if the task is aborted or if the internal code panics, neither is possible here; qed");
 


### PR DESCRIPTION
If a client cancelled a request this could cause the router to cancel a
deduplicaton task in the middle of processing. If this happened, the
wait_map would be left in an invalid state and further queries with the
same request would be left waiting for a broadcast which can never
arrive.

This change fixes the dedup handling so that we use a Weak reference to
the broadcast channel which gives us the ability to detect cancellation
events. If a broadcaster has been cancelled, the Weak reference will no
longer be upgradeable and so we know we can clean up and try again.

The problem hasn't manifested in the cache layer yet, as far as we know,
but I've added the fix into the cache layer as well.

There may be other components in the router which are subject to this
problem. We are not aware of any at this time, but we'll need to remain
vigilant against async cancellation issues of this type.

fixes: #550 
