### PR TITLE
relax variables selection for subgraph queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ server:
   ```
   In addition, other existing uplink env variables are now also configurable via arg. 
 
+- Relax variables selection for subgraph queries ([PR #755](https://github.com/apollographql/router/pull/755))
+
+  federated subgraph queries relying on partial or invalid data from previous subgraph queries could result in response failures or empty subgraph queries. The router is now more flexible when selecting data from previous queries, while still keeping a correct form for the final response
+
 ## 🛠 Maintenance
 ## 📚 Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ server:
   ```
   In addition, other existing uplink env variables are now also configurable via arg. 
 
-- Relax variables selection for subgraph queries ([PR #755](https://github.com/apollographql/router/pull/755))
+- **Relax variables selection for subgraph queries** ([PR #755](https://github.com/apollographql/router/pull/755))
 
   federated subgraph queries relying on partial or invalid data from previous subgraph queries could result in response failures or empty subgraph queries. The router is now more flexible when selecting data from previous queries, while still keeping a correct form for the final response
 

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -307,11 +307,9 @@ pub(crate) mod fetch {
                 let mut values = Vec::new();
                 data.select_values_and_paths(current_dir, |path, value| {
                     if let Value::Object(content) = value {
-                        if let Ok(object) = select_object(content, requires, schema) {
-                            if let Some(value) = object {
-                                paths.push(path);
-                                values.push(value);
-                            }
+                        if let Ok(Some(value)) = select_object(content, requires, schema) {
+                            paths.push(path);
+                            values.push(value);
                         }
                     }
                 });

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -292,7 +292,7 @@ pub(crate) mod fetch {
             current_dir: &Path,
             context: &Context,
             schema: &Schema,
-        ) -> Result<Variables, FetchError> {
+        ) -> Option<Variables> {
             let body = context.request.body();
             if !requires.is_empty() {
                 let mut variables = Object::with_capacity(1 + variable_usages.len());
@@ -306,29 +306,25 @@ pub(crate) mod fetch {
                 let mut paths = Vec::new();
                 let mut values = Vec::new();
                 data.select_values_and_paths(current_dir, |path, value| {
-                    match value {
-                        Value::Object(content) => {
-                            let object = select_object(content, requires, schema)?;
+                    if let Value::Object(content) = value {
+                        if let Ok(object) = select_object(content, requires, schema) {
                             if let Some(value) = object {
                                 paths.push(path);
-                                values.push(value)
+                                values.push(value);
                             }
                         }
-                        _ => {
-                            return Err(FetchError::ExecutionInvalidContent {
-                                reason: "not an object".to_string(),
-                            })
-                        }
                     }
-                    Ok(())
-                })?;
-                let representations = Value::Array(values);
+                });
 
-                variables.insert("representations", representations);
+                if values.is_empty() {
+                    return None;
+                }
 
-                Ok(Variables { variables, paths })
+                variables.insert("representations", Value::Array(values));
+
+                Some(Variables { variables, paths })
             } else {
-                Ok(Variables {
+                Some(Variables {
                     variables: variable_usages
                         .iter()
                         .filter_map(|key| {
@@ -359,7 +355,7 @@ pub(crate) mod fetch {
                 ..
             } = self;
 
-            let Variables { variables, paths } = Variables::new(
+            let Variables { variables, paths } = match Variables::new(
                 &self.requires,
                 self.variable_usages.as_ref(),
                 data,
@@ -367,7 +363,13 @@ pub(crate) mod fetch {
                 context,
                 schema,
             )
-            .await?;
+            .await
+            {
+                Some(variables) => variables,
+                None => {
+                    return Ok((Value::from_path(current_dir, Value::Null), Vec::new()));
+                }
+            };
 
             let subgraph_request = SubgraphRequest {
                 http_request: http_compat::RequestBuilder::new(

--- a/apollo-router-core/src/query_planner/selection.rs
+++ b/apollo-router-core/src/query_planner/selection.rs
@@ -125,12 +125,9 @@ mod tests {
         schema: &Schema,
     ) -> Result<Value, FetchError> {
         let mut values = Vec::new();
-        response
-            .data
-            .select_values_and_paths(path, |_path, value| {
-                values.push(value);
-                Ok(())
-            })?;
+        response.data.select_values_and_paths(path, |_path, value| {
+            values.push(value);
+        });
 
         Ok(Value::Array(
             values


### PR DESCRIPTION
Fix #298 
Fix #744

for federated subgraph queries, we encountered multiple issues:
- if we got a null entity from a previous call, selecting data from it
  would return an error and fail the subgraph request. This is invalid,
because for a request like `query { topProducts { reviews { body } } }`
and a products subgraph returning `[ {"upc": 0}, null, { "upc": 2} ]`,
we should do a query to the reviews subgraph for the products 0 and 2
- if the list of representations to query a subgraph is empty, we were
  still doing a HTTP request expecting an empty result

this PR fixes those issues by ignoring selection errors when
creating variables, then canceling the subgraph request if the
representations array is empty
