### PR TITLE
Geal/clean up dedup on cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ server:
   ```
   In addition, other existing uplink env variables are now also configurable via arg. 
 
-- **Make deduplication and caching more robust against cancellation** [PR #752](https://github.com/apollographql/router/pull/752)
+- **Make deduplication and caching more robust against cancellation** [PR #752](https://github.com/apollographql/router/pull/752) [PR #758](https://github.com/apollographql/router/pull/758)
 
   Cancelling a request could put the router in an unresponsive state where the deduplication layer or cache would make subgraph requests hang.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## ❗ BREAKING ❗
 ## 🚀 Features
 ## 🐛 Fixes
+
+- **Eliminate memory leaks when tasks are cancelled** [PR #758](https://github.com/apollographql/router/pull/758)
+
+  The deduplication layer could leak memory when queries were cancelled and never retried: leaks were previously cleaned up on the next similar query. Now the leaking data will be deleted right when the query is cancelled
+
+
 ## 🛠 Maintenance
 ## 📚 Documentation
 
@@ -84,7 +90,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   ```
   In addition, other existing uplink env variables are now also configurable via arg. 
 
-- **Make deduplication and caching more robust against cancellation** [PR #752](https://github.com/apollographql/router/pull/752) [PR #758](https://github.com/apollographql/router/pull/758)
+- **Make deduplication and caching more robust against cancellation** [PR #752](https://github.com/apollographql/router/pull/752)
 
   Cancelling a request could put the router in an unresponsive state where the deduplication layer or cache would make subgraph requests hang.
 

--- a/apollo-router-core/src/layers/deduplication.rs
+++ b/apollo-router-core/src/layers/deduplication.rs
@@ -1,11 +1,10 @@
 use crate::{fetch::OperationKind, http_compat, Request, SubgraphRequest, SubgraphResponse};
 use futures::{future::BoxFuture, lock::Mutex};
-use std::{
-    collections::HashMap,
-    sync::{Arc, Weak},
-    task::Poll,
+use std::{collections::HashMap, sync::Arc, task::Poll};
+use tokio::sync::{
+    broadcast::{self, Sender},
+    oneshot,
 };
-use tokio::sync::broadcast::{self, Sender};
 use tower::{BoxError, Layer, ServiceExt};
 
 pub struct QueryDeduplicationLayer;
@@ -21,9 +20,8 @@ where
     }
 }
 
-type WaitMap = Arc<
-    Mutex<HashMap<http_compat::Request<Request>, Weak<Sender<Result<SubgraphResponse, String>>>>>,
->;
+type WaitMap =
+    Arc<Mutex<HashMap<http_compat::Request<Request>, Sender<Result<SubgraphResponse, String>>>>>;
 
 pub struct QueryDeduplicationService<S> {
     service: S,
@@ -49,16 +47,7 @@ where
         loop {
             let mut locked_wait_map = wait_map.lock().await;
             match locked_wait_map.get_mut(&request.http_request) {
-                Some(weak_waiter) => {
-                    // Try to upgrade our weak Arc. If we can't, the sender must have
-                    // been cancelled, so remove the entry from the map and try again.
-                    let waiter = match Weak::upgrade(weak_waiter) {
-                        Some(waiter) => waiter,
-                        None => {
-                            locked_wait_map.remove(&request.http_request);
-                            continue;
-                        }
-                    };
+                Some(waiter) => {
                     // Register interest in key
                     let mut receiver = waiter.subscribe();
                     drop(locked_wait_map);
@@ -78,29 +67,25 @@ where
                 }
                 None => {
                     let (tx, _rx) = broadcast::channel(1);
-                    let tx = Arc::new(tx);
-                    // Store a Weak reference to our Sender. If we are cancelled, then the
-                    // client will be unable to upgrade their Weak reference and will know
-                    // to clean up the wait_map and try again.
-                    locked_wait_map.insert(request.http_request.clone(), Arc::downgrade(&tx));
+
+                    locked_wait_map.insert(request.http_request.clone(), tx.clone());
                     drop(locked_wait_map);
 
                     let context = request.context.clone();
                     let http_request = request.http_request.clone();
-                    let res = match service.ready_oneshot().await {
-                        Ok(mut s) => s.call(request).await,
-                        Err(e) => {
-                            // Clean up wait map if ready_oneshot failed
+                    let res = {
+                        // when _drop_signal is dropped, either by getting out of the block, returning
+                        // the error from ready_oneshot or by cancellation, the drop_sentinel future will
+                        // return with Err(), then we remove the entry from the wait map
+                        let (_drop_signal, drop_sentinel) = oneshot::channel::<()>();
+                        tokio::task::spawn(async move {
+                            let _ = drop_sentinel.await;
                             let mut locked_wait_map = wait_map.lock().await;
                             locked_wait_map.remove(&http_request);
-                            return Err(e);
-                        }
-                    };
+                        });
 
-                    {
-                        let mut locked_wait_map = wait_map.lock().await;
-                        locked_wait_map.remove(&http_request);
-                    }
+                        service.ready_oneshot().await?.call(request).await
+                    };
 
                     // Let our waiters know
                     let broadcast_value = res


### PR DESCRIPTION
Fix #754

This takes care of cleaning up the wait map by using a oneshot channel as drop signal. This is a pattern that I used a lot in [pulsar-rs](https://github.com/wyyerd/pulsar-rs) to perform async tasks on drop