### PR TITLE
chore: CORS default Configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
  -->
 
-<!--# [v0.1.0-preview.2] (unreleased) - 2022-mm-dd
+# [v0.1.0-preview.2] (unreleased) - 2022-mm-dd
 ## ❗ BREAKING ❗
+
+- **CORS default Configuration** ([#40](https://github.com/apollographql/router/issues/40))
+
+  The Router will allow only the https://studio.apollographql.com origin by default, instead of any origin.
+  This behavior can still be tweaked in the [YAML configuration](https://www.apollographql.com/docs/router/configuration/cors)
+
 ## 🚀 Features
 
 - **Skip and Include directives in post processing** ([PR #626](https://github.com/apollographql/router/pull/626))
@@ -69,7 +75,7 @@ server:
 ## 🛠 Maintenance
 ## 📚 Documentation
 
-# [v0.1.0-preview.1] - 2022-03-23
+<!--# [v0.1.0-preview.1] - 2022-03-23
 
 ## 🎉 **The Apollo Router has graduated to its Preview phase!** 🎉
 ## ❗ BREAKING ❗

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/src/configuration/mod.rs
+assertion_line: 443
 expression: "&schema"
 ---
 {
@@ -316,7 +317,7 @@ expression: "&schema"
           "type": "object",
           "properties": {
             "allow_any_origin": {
-              "description": "Set to false to disallow any origin and rely exclusively on `origins`.\n\n/!\\ Defaults to true Having this set to true is the only way to allow Origin: null.",
+              "description": "Set to true to allow any origin.\n\nDefaults to false Having this set to true is the only way to allow Origin: null.",
               "default": null,
               "type": "boolean",
               "nullable": true
@@ -359,7 +360,7 @@ expression: "&schema"
               }
             },
             "origins": {
-              "description": "The origin(s) to allow requests from. Use `https://studio.apollographql.com/` to allow Apollo Studio to function.",
+              "description": "The origin(s) to allow requests from. Defaults to `https://studio.apollographql.com/` for Apollo Studio.",
               "default": [],
               "type": "array",
               "items": {

--- a/docs/source/configuration/cors.mdx
+++ b/docs/source/configuration/cors.mdx
@@ -5,7 +5,7 @@ sidebar_title: CORS
 
 import { Link } from 'gatsby';
 
-The Apollo Router supports [Cross-Origin Resource Sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) (CORS) to indicate which origins it accepts requests from. **By default, the router accepts requests from all origins**.
+The Apollo Router supports [Cross-Origin Resource Sharing](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) (CORS) to indicate which origins it accepts requests from. **By default, the router accepts requests from the Apollo studio**.
 
 If your environment has security requirements around CORS, you can specify them in the router's [configuration file](./overview/#configuration-file):
 
@@ -16,14 +16,15 @@ server:
   #
   cors:
 
-    # Set to false to disallow any origin and rely exclusively on `origins`
-    # (Defaults to true)
-    allow_any_origin: false
+    # Set to true to allow any origin
+    # (Defaults to false)
+    allow_any_origin: true
 
     # List of accepted origins
     # (Ignored if allow_any_origin is true)
+    # (Defaults to the Apollo Studio url: `https://studio.apollographql.com`)
     origins:
-      - https://studio.apollographql.com
+      - https://www.my-frontend.com
 
     # Set to true to add the `Access-Control-Allow-Credentials` header
     # (Defaults to false)

--- a/examples/async-auth/router.yaml
+++ b/examples/async-auth/router.yaml
@@ -1,7 +1,3 @@
-server:
-  cors:
-    origins:
-      - "https://studio.apollographql.com/"
 plugins:
   # this plugin takes a path
   # and will read from it everytime a request comes in

--- a/examples/context/router.yaml
+++ b/examples/context/router.yaml
@@ -1,8 +1,4 @@
 version: 4.0.0
-server:
-  cors:
-    origins:
-      - "https://studio.apollographql.com/"
 telemetry:
   opentelemetry:
     jaeger:
@@ -13,5 +9,3 @@ plugins:
   # this plugin doesn't have any configuration
   # mention it here and you're set!
   example.context_data:
-
-

--- a/examples/embedded/router.yaml
+++ b/examples/embedded/router.yaml
@@ -1,6 +1,2 @@
-server:
-  cors:
-    origins:
-      - "https://studio.apollographql.com/"
 plugins:
   example.forbid_anonymous_operations:

--- a/examples/forbid-anonymous-operations/router.yaml
+++ b/examples/forbid-anonymous-operations/router.yaml
@@ -1,7 +1,3 @@
-server:
-  cors:
-    origins:
-      - "https://studio.apollographql.com/"
 plugins:
   # this plugin doesn't have any configuration
   # mention it here and you're set!

--- a/examples/forbid_mutations/router.yaml
+++ b/examples/forbid_mutations/router.yaml
@@ -2,8 +2,4 @@
 # ./router -c ./examples/forbid_mutations/router.yaml -s ./examples/graphql/supergraph.graphql
 # You can then open http://localhost:4000 on your browser,
 # and try to run a Query and a Mutation in apollo studio.
-server:
-  cors:
-    origins:
-      - "https://studio.apollographql.com/"
 forbid_mutations: true

--- a/examples/hello-world/router.yaml
+++ b/examples/hello-world/router.yaml
@@ -1,7 +1,3 @@
-server:
-  cors:
-    origins:
-      - "https://studio.apollographql.com/"
 plugins:
   # this plugin doesn't have any configuration
   # mention it here and you're set!

--- a/examples/jwt-auth/router.yaml
+++ b/examples/jwt-auth/router.yaml
@@ -1,13 +1,9 @@
-server:
-  cors:
-    origins:
-      - "https://studio.apollographql.com/"
 plugins:
   # Authentication Mechanism
   # plugin name: example.jwt
   #
   # Mandatory Configuration:
-  #   - algorithm: HS256 | HS384 | HS512 
+  #   - algorithm: HS256 | HS384 | HS512
   #   - key: valid base64 encoded key
   #
   # Optional Configuration:
@@ -27,5 +23,3 @@ plugins:
     key: 629709bdc3bd794312ccc3a1c47beb03ac7310bc02d32d4587e59b5ad81c99ba
     time_tolerance: 60
     max_token_life: 600
-
-


### PR DESCRIPTION
Fixes :#40

The Router now allows only the `https://studio.apollographql.com` origin by default, instead of any origin.