### PR TITLE
chore: Ensure successful examples and benchmarks compilation.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,7 +251,7 @@ commands:
       - build_common_permutations
       - rust/build:
           with_cache: false
-          crate: --locked --no-default-features -p apollo-router -p apollo-router-core
+          crate: --locked --no-default-features --all --benches
   build_workspace:
     parameters:
       os:


### PR DESCRIPTION
Fixes #716

Linux and OSx circleci build steps will now compile all of the examples, and the benchmarks as well.
