### PR TITLE
Remove router.yaml.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ crates/*/Cargo.lock
 # Docs
 /docs/node_modules/
 /docs/.cache/
+
+# Prevent accidental commits of router.yaml in the root
+/router.yaml

--- a/router.yaml
+++ b/router.yaml
@@ -1,7 +1,0 @@
-plugins:
-  experimental.traffic_shaping:
-    all:
-      dedup: true
-    subgraphs:
-      products:
-        dedup: true


### PR DESCRIPTION
Prevent accidental commits of router.yaml in the root directory by adding to .gitignore.
