### PR TITLE
dockerfile example and publish on release to github (#764) (follow-up)

### DIFF
--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -15,7 +15,8 @@ RUN tar xvzf router.tar.gz -C /
 # Make directories for config and schema
 RUN mkdir /dist/config && mkdir /dist/schema
 
-COPY router.yaml /dist/config
+# Copy configuration for docker image
+COPY dockerfiles/router.yaml /dist/config
 
 # Final image uses distroless
 FROM --platform=linux/amd64 gcr.io/distroless/cc-debian11${DEBUG_IMAGE}


### PR DESCRIPTION
Found bug in dockerfile during release process. The dockerfile copied
the default configuration from the wrong directory. By bad luck, it
found a configuration in the specified location, which meant the build
succeeded, but that config didn't work in docker (wrong listen address
for router).

This fix ensures that the correct config file is included in the docker
image.

We've re-issued the fixed docker files manually.
