### PR TITLE
introduce new experimental plugin to allow subgraph error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   See the docs for more examples.
 
 ## 🐛 Fixes
+- **Eliminate memory leaks when tasks are cancelled** [PR #758](https://github.com/apollographql/router/pull/758)
+
+  The deduplication layer could leak memory when queries were cancelled and never retried: leaks were previously cleaned up on the next similar query. Now the leaking data will be deleted right when the query is cancelled
+
 - **Trim the query to better detect an empty query** ([PR #738](https://github.com/apollographql/router/pull/738))
 
   Before this fix, if you wrote a query with only whitespaces inside, it wasn't detected as an empty query.
@@ -78,10 +82,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 
 ## 🛠 Maintenance
-- **Eliminate memory leaks when tasks are cancelled** [PR #758](https://github.com/apollographql/router/pull/758)
-
-  The deduplication layer could leak memory when queries were cancelled and never retried: leaks were previously cleaned up on the next similar query. Now the leaking data will be deleted right when the query is cancelled
-
 - **A faster Query planner** ([PR #768](https://github.com/apollographql/router/pull/768))
 
   We reworked the way query plans are generated before being cached, which lead to a great performance improvement. Moreover, the router is able to make sure the schema is valid at startup and on schema update, before you query it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,30 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🐛 Fixes
 ## 🛠 Maintenance
 ## 📚 Documentation
+-->
+
+# [x.x.x] (unreleased) - 2022-mm-dd
+## ❗ BREAKING ❗
+## 🚀 Features
+
+- **configurable subgraph error redaction** ([797](https://github.com/apollographql/router/issues/797))
+  By default, subgraph errors are not propagated to the user. This experimental plugin allows messages to be propagated either for all subgraphs or on
+  an individual subgraph basis. Individual subgraph configuration overrides the default (all) configuration. The configuration mechanism is similar
+  to that used in the `headers` plugin:
+  ```yaml
+  plugins:
+    experimental.include_subgraph_errors:
+      all: true
+  ```
+  See the docs for more examples.
+
 ## 🐛 Fixes
+## 🛠 Maintenance
 
 - **Eliminate memory leaks when tasks are cancelled** [PR #758](https://github.com/apollographql/router/pull/758)
 
   The deduplication layer could leak memory when queries were cancelled and never retried: leaks were previously cleaned up on the next similar query. Now the leaking data will be deleted right when the query is cancelled
 
-
-## 🛠 Maintenance
 
 - **Xtask improvements** ([PR #604](https://github.com/apollographql/router/pull/604))
 
@@ -47,7 +63,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   It results in better performance due to less URL parsing, and now header propagation falls under the apollo_router_core log filter, making it harder to disable accidentally
 
- -->
+## 📚 Documentation
 
 # [v0.1.0-preview.2] - 2022-04-01
 ## ❗ BREAKING ❗

--- a/apollo-router-benchmarks/benches/basic_composition.rs
+++ b/apollo-router-benchmarks/benches/basic_composition.rs
@@ -1,59 +1,13 @@
+use apollo_router_core::plugin_utils::mock::subgraph::MockSubgraph;
 use apollo_router_core::{
-    plugin_utils, PluggableRouterServiceBuilder, Request, Response, ResponseBody, RouterRequest,
-    RouterResponse, Schema, SubgraphRequest, SubgraphResponse, Value,
+    plugin_utils, PluggableRouterServiceBuilder, ResponseBody, RouterRequest, RouterResponse,
+    Schema,
 };
 use criterion::{criterion_group, criterion_main, Criterion};
-use futures::future;
 use once_cell::sync::Lazy;
-use serde_json_bytes::ByteString;
-use std::{collections::HashMap, sync::Arc, task::Poll};
+use serde_json_bytes::{ByteString, Value};
+use std::sync::Arc;
 use tower::{util::BoxCloneService, BoxError, Service, ServiceExt};
-
-type MockResponses = HashMap<Request, Response>;
-
-#[derive(Default, Clone)]
-struct MockSubgraph {
-    // using an arc here because benchmarks will clone a lot of services
-    mocks: Arc<MockResponses>,
-}
-
-impl MockSubgraph {
-    pub fn new(mocks: MockResponses) -> Self {
-        Self {
-            mocks: Arc::new(mocks),
-        }
-    }
-}
-
-impl Service<SubgraphRequest> for MockSubgraph {
-    type Response = SubgraphResponse;
-
-    type Error = BoxError;
-
-    type Future = future::Ready<Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn call(&mut self, req: SubgraphRequest) -> Self::Future {
-        let builder = plugin_utils::SubgraphResponse::builder().context(req.context);
-        let response = if let Some(response) = self.mocks.get(req.http_request.body()) {
-            builder.data(response.data.clone()).build().into()
-        } else {
-            builder
-                .errors(vec![apollo_router_core::Error {
-                    message: "couldn't find mock for query".to_string(),
-                    locations: Default::default(),
-                    path: Default::default(),
-                    extensions: Default::default(),
-                }])
-                .build()
-                .into()
-        };
-        future::ok(response)
-    }
-}
 
 static EXPECTED_RESPONSE: Lazy<ResponseBody> = Lazy::new(|| {
     ResponseBody::GraphQL(serde_json::from_str(r#"{"data":{"topProducts":[{"upc":"1","name":"Table","reviews":[{"id":"1","product":{"name":"Table"},"author":{"id":"1","name":"Ada Lovelace"}},{"id":"4","product":{"name":"Table"},"author":{"id":"2","name":"Alan Turing"}}]},{"upc":"2","name":"Couch","reviews":[{"id":"2","product":{"name":"Couch"},"author":{"id":"1","name":"Ada Lovelace"}}]}]}}"#).unwrap())
@@ -87,7 +41,7 @@ async fn basic_composition_benchmark(
 fn from_elem(c: &mut Criterion) {
     let account_mocks = vec![
         (
-            r#"{"query":"query($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}","variables":{"representations":[{"__typename":"User","id":"1"},{"__typename":"User","id":"2"},{"__typename":"User","id":"1"}]}}"#,
+            r#"{"query":"query TopProducts__accounts__3($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}","variables":{"representations":[{"__typename":"User","id":"1"},{"__typename":"User","id":"2"},{"__typename":"User","id":"1"}]}}"#,
             r#"{"data":{"_entities":[{"name":"Ada Lovelace"},{"name":"Alan Turing"},{"name":"Ada Lovelace"}]}}"#
         )
     ].into_iter().map(|(query, response)| (serde_json::from_str(query).unwrap(), serde_json::from_str(response).unwrap())).collect();
@@ -95,19 +49,19 @@ fn from_elem(c: &mut Criterion) {
 
     let review_mocks = vec![
         (
-            r#"{"query":"query($representations:[_Any!]!){_entities(representations:$representations){...on Product{reviews{id product{__typename upc}author{__typename id}}}}}","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}"#,
+            r#"{"query":"query TopProducts__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on Product{reviews{id product{__typename upc}author{__typename id}}}}}","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}"#,
             r#"{"data":{"_entities":[{"reviews":[{"id":"1","product":{"__typename":"Product","upc":"1"},"author":{"__typename":"User","id":"1"}},{"id":"4","product":{"__typename":"Product","upc":"1"},"author":{"__typename":"User","id":"2"}}]},{"reviews":[{"id":"2","product":{"__typename":"Product","upc":"2"},"author":{"__typename":"User","id":"1"}}]}]}}"#
-        ),
+        )
         ].into_iter().map(|(query, response)| (serde_json::from_str(query).unwrap(), serde_json::from_str(response).unwrap())).collect();
     let review_service = MockSubgraph::new(review_mocks);
 
     let product_mocks = vec![
         (
-            r#"{"query":"query($first:Int){topProducts(first:$first){__typename upc name}}","variables":{"first":2}}"#,
+            r#"{"query":"query TopProducts__products__0($first:Int){topProducts(first:$first){__typename upc name}}","variables":{"first":2}}"#,
             r#"{"data":{"topProducts":[{"__typename":"Product","upc":"1","name":"Table"},{"__typename":"Product","upc":"2","name":"Couch"}]}}"#
         ),
         (
-            r#"{"query":"query($representations:[_Any!]!){_entities(representations:$representations){...on Product{name}}}","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}"#,
+            r#"{"query":"query TopProducts__products__2($representations:[_Any!]!){_entities(representations:$representations){...on Product{name}}}","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}"#,
             r#"{"data":{"_entities":[{"name":"Table"},{"name":"Table"},{"name":"Couch"}]}}"#
         )
         ].into_iter().map(|(query, response)| (serde_json::from_str(query).unwrap(), serde_json::from_str(response).unwrap())).collect();

--- a/apollo-router-core/src/error.rs
+++ b/apollo-router-core/src/error.rs
@@ -146,7 +146,7 @@ impl Error {
                     reason: err.to_string(),
                 })?
                 .unwrap_or_default();
-        let message = extract_key_value_from_object!(object, "label", Value::String(s) => s)
+        let message = extract_key_value_from_object!(object, "message", Value::String(s) => s)
             .map_err(|err| FetchError::SubrequestMalformedResponse {
                 service: service_name.to_string(),
                 reason: err.to_string(),

--- a/apollo-router-core/src/plugin_utils/mock/mod.rs
+++ b/apollo-router-core/src/plugin_utils/mock/mod.rs
@@ -1,0 +1,1 @@
+pub mod subgraph;

--- a/apollo-router-core/src/plugin_utils/mock/subgraph.rs
+++ b/apollo-router-core/src/plugin_utils/mock/subgraph.rs
@@ -1,0 +1,50 @@
+use crate::{plugin_utils, Request, Response, SubgraphRequest, SubgraphResponse};
+use futures::future;
+use std::{collections::HashMap, sync::Arc, task::Poll};
+use tower::{BoxError, Service};
+
+type MockResponses = HashMap<Request, Response>;
+
+#[derive(Clone, Default)]
+pub struct MockSubgraph {
+    // using an arc to improve efficiency when service is cloned
+    mocks: Arc<MockResponses>,
+}
+
+impl MockSubgraph {
+    pub fn new(mocks: MockResponses) -> Self {
+        Self {
+            mocks: Arc::new(mocks),
+        }
+    }
+}
+
+impl Service<SubgraphRequest> for MockSubgraph {
+    type Response = SubgraphResponse;
+
+    type Error = BoxError;
+
+    type Future = future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: SubgraphRequest) -> Self::Future {
+        let builder = plugin_utils::SubgraphResponse::builder().context(req.context);
+        let response = if let Some(response) = self.mocks.get(req.http_request.body()) {
+            builder.data(response.data.clone()).build().into()
+        } else {
+            builder
+                .errors(vec![crate::Error {
+                    message: "couldn't find mock for query".to_string(),
+                    locations: Default::default(),
+                    path: Default::default(),
+                    extensions: Default::default(),
+                }])
+                .build()
+                .into()
+        };
+        future::ok(response)
+    }
+}

--- a/apollo-router-core/src/plugin_utils/mod.rs
+++ b/apollo-router-core/src/plugin_utils/mod.rs
@@ -1,3 +1,4 @@
+pub mod mock;
 pub mod service;
 pub mod structures;
 

--- a/apollo-router-core/src/plugins/include_subgraph_errors.rs
+++ b/apollo-router-core/src/plugins/include_subgraph_errors.rs
@@ -1,0 +1,273 @@
+use crate::error::Error as SubgraphError;
+use crate::plugin::Plugin;
+use crate::{register_plugin, SubgraphRequest, SubgraphResponse};
+use once_cell::sync::Lazy;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use std::collections::HashMap;
+use tower::util::BoxService;
+use tower::{BoxError, ServiceExt};
+
+#[allow(clippy::field_reassign_with_default)]
+static REDACTED_ERROR_MESSAGE: Lazy<Vec<SubgraphError>> = Lazy::new(|| {
+    let mut error: SubgraphError = Default::default();
+
+    error.message = "Subgraph errors redacted".to_string();
+
+    vec![error]
+});
+
+register_plugin!(
+    "experimental",
+    "include_subgraph_errors",
+    IncludeSubgraphErrors
+);
+
+#[derive(Clone, Debug, JsonSchema, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+struct Config {
+    #[serde(default)]
+    all: bool,
+    #[serde(default)]
+    subgraphs: HashMap<String, bool>,
+}
+
+struct IncludeSubgraphErrors {
+    config: Config,
+}
+
+impl Plugin for IncludeSubgraphErrors {
+    type Config = Config;
+
+    fn new(config: Self::Config) -> Result<Self, BoxError> {
+        Ok(IncludeSubgraphErrors { config })
+    }
+
+    fn subgraph_service(
+        &mut self,
+        name: &str,
+        service: BoxService<SubgraphRequest, SubgraphResponse, BoxError>,
+    ) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError> {
+        // Search for subgraph in our configured subgraph map.
+        // If we can't find it, use the "all" value
+        if !*self.config.subgraphs.get(name).unwrap_or(&self.config.all) {
+            return service
+                .map_response(move |mut response: SubgraphResponse| {
+                    if !response.response.body().errors.is_empty() {
+                        response.response.body_mut().errors = REDACTED_ERROR_MESSAGE.clone();
+                    }
+                    response
+                })
+                .boxed();
+        }
+        service
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::plugin_utils::mock::subgraph::MockSubgraph;
+    use crate::{
+        plugin_utils, DynPlugin, PluggableRouterServiceBuilder, ResponseBody, RouterRequest,
+        RouterResponse, Schema,
+    };
+    use serde_json::Value as jValue;
+    use serde_json_bytes::{ByteString, Value};
+    use std::sync::Arc;
+    use tower::{util::BoxCloneService, Service};
+
+    static UNREDACTED_PRODUCT_RESPONSE: Lazy<ResponseBody> = Lazy::new(|| {
+        ResponseBody::GraphQL(serde_json::from_str(r#"{"data": {"topProducts":null}, "errors":[{"message": "couldn't find mock for query", "locations": [], "path": null, "extensions": {}}]}"#).unwrap())
+    });
+
+    static REDACTED_PRODUCT_RESPONSE: Lazy<ResponseBody> = Lazy::new(|| {
+        ResponseBody::GraphQL(serde_json::from_str(r#"{"data": {"topProducts":null}, "errors":[{"message": "Subgraph errors redacted", "locations": [], "path": null, "extensions": {}}]}"#).unwrap())
+    });
+
+    static REDACTED_ACCOUNT_RESPONSE: Lazy<ResponseBody> = Lazy::new(|| {
+        ResponseBody::GraphQL(serde_json::from_str(r#"{"data": null , "errors":[{"message": "Subgraph errors redacted", "locations": [], "path": null, "extensions": {}}]}"#).unwrap())
+    });
+
+    static EXPECTED_RESPONSE: Lazy<ResponseBody> = Lazy::new(|| {
+        ResponseBody::GraphQL(serde_json::from_str(r#"{"data":{"topProducts":[{"upc":"1","name":"Table","reviews":[{"id":"1","product":{"name":"Table"},"author":{"id":"1","name":"Ada Lovelace"}},{"id":"4","product":{"name":"Table"},"author":{"id":"2","name":"Alan Turing"}}]},{"upc":"2","name":"Couch","reviews":[{"id":"2","product":{"name":"Couch"},"author":{"id":"1","name":"Ada Lovelace"}}]}]}}"#).unwrap())
+    });
+
+    static VALID_QUERY: &str = r#"query TopProducts($first: Int) { topProducts(first: $first) { upc name reviews { id product { name } author { id name } } } }"#;
+
+    static ERROR_PRODUCT_QUERY: &str = r#"query ErrorTopProducts($first: Int) { topProducts(first: $first) { upc name reviews { id product { name } author { id name } } } }"#;
+
+    static ERROR_ACCOUNT_QUERY: &str = r#"query Query { me { name }}"#;
+
+    async fn execute_router_test(
+        query: &str,
+        body: &ResponseBody,
+        mut router_service: BoxCloneService<RouterRequest, RouterResponse, BoxError>,
+    ) {
+        let request = plugin_utils::RouterRequest::builder()
+            .query(query.to_string())
+            .variables(Arc::new(
+                vec![(ByteString::from("first"), Value::Number(2usize.into()))]
+                    .into_iter()
+                    .collect(),
+            ))
+            .build()
+            .into();
+
+        let response = router_service
+            .ready()
+            .await
+            .unwrap()
+            .call(request)
+            .await
+            .unwrap();
+        assert_eq!(response.response.body(), body);
+    }
+
+    async fn build_mock_router(
+        plugin: Box<dyn DynPlugin>,
+    ) -> BoxCloneService<RouterRequest, RouterResponse, BoxError> {
+        let account_mocks = vec![
+            (
+                r#"{"query":"query TopProducts__accounts__3($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}","variables":{"representations":[{"__typename":"User","id":"1"},{"__typename":"User","id":"2"},{"__typename":"User","id":"1"}]}}"#,
+                r#"{"data":{"_entities":[{"name":"Ada Lovelace"},{"name":"Alan Turing"},{"name":"Ada Lovelace"}]}}"#
+            )
+        ].into_iter().map(|(query, response)| (serde_json::from_str(query).unwrap(), serde_json::from_str(response).unwrap())).collect();
+        let account_service = MockSubgraph::new(account_mocks);
+
+        let review_mocks = vec![
+            (
+                r#"{"query":"query TopProducts__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on Product{reviews{id product{__typename upc}author{__typename id}}}}}","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}"#,
+                r#"{"data":{"_entities":[{"reviews":[{"id":"1","product":{"__typename":"Product","upc":"1"},"author":{"__typename":"User","id":"1"}},{"id":"4","product":{"__typename":"Product","upc":"1"},"author":{"__typename":"User","id":"2"}}]},{"reviews":[{"id":"2","product":{"__typename":"Product","upc":"2"},"author":{"__typename":"User","id":"1"}}]}]}}"#
+            )
+            ].into_iter().map(|(query, response)| (serde_json::from_str(query).unwrap(), serde_json::from_str(response).unwrap())).collect();
+        let review_service = MockSubgraph::new(review_mocks);
+
+        let product_mocks = vec![
+            (
+                r#"{"query":"query TopProducts__products__0($first:Int){topProducts(first:$first){__typename upc name}}","variables":{"first":2}}"#,
+                r#"{"data":{"topProducts":[{"__typename":"Product","upc":"1","name":"Table"},{"__typename":"Product","upc":"2","name":"Couch"}]}}"#
+            ),
+            (
+                r#"{"query":"query TopProducts__products__2($representations:[_Any!]!){_entities(representations:$representations){...on Product{name}}}","variables":{"representations":[{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"1"},{"__typename":"Product","upc":"2"}]}}"#,
+                r#"{"data":{"_entities":[{"name":"Table"},{"name":"Table"},{"name":"Couch"}]}}"#
+            )
+            ].into_iter().map(|(query, response)| (serde_json::from_str(query).unwrap(), serde_json::from_str(response).unwrap())).collect();
+        let product_service = MockSubgraph::new(product_mocks);
+
+        let schema: Arc<Schema> = Arc::new(
+            include_str!("../../../apollo-router-benchmarks/benches/fixtures/supergraph.graphql")
+                .parse()
+                .unwrap(),
+        );
+
+        let builder = PluggableRouterServiceBuilder::new(schema.clone());
+
+        let builder = builder
+            .with_dyn_plugin(plugin)
+            .with_subgraph_service("accounts", account_service.clone())
+            .with_subgraph_service("reviews", review_service.clone())
+            .with_subgraph_service("products", product_service.clone());
+
+        let (router, _) = builder.build().await;
+
+        router
+    }
+
+    fn get_redacting_plugin(config: &jValue) -> Box<dyn DynPlugin> {
+        // Build a redacting plugin
+        crate::plugins()
+            .get("experimental.include_subgraph_errors")
+            .expect("Plugin not found")
+            .create_instance(config)
+            .expect("Plugin not created")
+    }
+
+    #[tokio::test]
+    async fn it_returns_valid_response() {
+        // Build a redacting plugin
+        let plugin = get_redacting_plugin(&serde_json::json!({ "all": false }));
+        let router = build_mock_router(plugin).await;
+        execute_router_test(VALID_QUERY, &*EXPECTED_RESPONSE, router).await;
+    }
+
+    #[tokio::test]
+    async fn it_redacts_all_subgraphs_explicit_withold() {
+        // Build a redacting plugin
+        let plugin = get_redacting_plugin(&serde_json::json!({ "all": false }));
+        let router = build_mock_router(plugin).await;
+        execute_router_test(ERROR_PRODUCT_QUERY, &*REDACTED_PRODUCT_RESPONSE, router).await;
+    }
+
+    #[tokio::test]
+    async fn it_redacts_all_subgraphs_implicit_withold() {
+        // Build a redacting plugin
+        let plugin = get_redacting_plugin(&serde_json::json!({}));
+        let router = build_mock_router(plugin).await;
+        execute_router_test(ERROR_PRODUCT_QUERY, &*REDACTED_PRODUCT_RESPONSE, router).await;
+    }
+
+    #[tokio::test]
+    async fn it_does_not_redact_all_subgraphs_explicit_allow() {
+        // Build a redacting plugin
+        let plugin = get_redacting_plugin(&serde_json::json!({ "all": true }));
+        let router = build_mock_router(plugin).await;
+        execute_router_test(ERROR_PRODUCT_QUERY, &*UNREDACTED_PRODUCT_RESPONSE, router).await;
+    }
+
+    #[tokio::test]
+    async fn it_does_not_redact_all_implicit_withold_product_explict_allow_for_product_query() {
+        // Build a redacting plugin
+        let plugin = get_redacting_plugin(&serde_json::json!({ "subgraphs": {"products": true }}));
+        let router = build_mock_router(plugin).await;
+        execute_router_test(ERROR_PRODUCT_QUERY, &*UNREDACTED_PRODUCT_RESPONSE, router).await;
+    }
+
+    #[tokio::test]
+    async fn it_does_redact_all_implicit_withold_product_explict_allow_for_review_query() {
+        // Build a redacting plugin
+        let plugin = get_redacting_plugin(&serde_json::json!({ "subgraphs": {"reviews": true }}));
+        let router = build_mock_router(plugin).await;
+        execute_router_test(ERROR_PRODUCT_QUERY, &*REDACTED_PRODUCT_RESPONSE, router).await;
+    }
+
+    #[tokio::test]
+    async fn it_does_not_redact_all_explicit_allow_review_explict_withold_for_product_query() {
+        // Build a redacting plugin
+        let plugin = get_redacting_plugin(
+            &serde_json::json!({ "all": true, "subgraphs": {"reviews": false }}),
+        );
+        let router = build_mock_router(plugin).await;
+        execute_router_test(ERROR_PRODUCT_QUERY, &*UNREDACTED_PRODUCT_RESPONSE, router).await;
+    }
+
+    #[tokio::test]
+    async fn it_does_redact_all_explicit_allow_product_explict_withold_for_product_query() {
+        // Build a redacting plugin
+        let plugin = get_redacting_plugin(
+            &serde_json::json!({ "all": true, "subgraphs": {"products": false }}),
+        );
+        let router = build_mock_router(plugin).await;
+        execute_router_test(ERROR_PRODUCT_QUERY, &*REDACTED_PRODUCT_RESPONSE, router).await;
+    }
+
+    #[tokio::test]
+    async fn it_does_not_redact_all_explicit_allow_account_explict_withold_for_product_query() {
+        // Build a redacting plugin
+        let plugin = get_redacting_plugin(
+            &serde_json::json!({ "all": true, "subgraphs": {"accounts": false }}),
+        );
+        let router = build_mock_router(plugin).await;
+        execute_router_test(ERROR_PRODUCT_QUERY, &*UNREDACTED_PRODUCT_RESPONSE, router).await;
+    }
+
+    #[tokio::test]
+    async fn it_does_redact_all_explicit_allow_account_explict_withold_for_account_query() {
+        // Build a redacting plugin
+        let plugin = get_redacting_plugin(
+            &serde_json::json!({ "all": true, "subgraphs": {"accounts": false }}),
+        );
+        let router = build_mock_router(plugin).await;
+        execute_router_test(ERROR_ACCOUNT_QUERY, &*REDACTED_ACCOUNT_RESPONSE, router).await;
+    }
+}

--- a/apollo-router-core/src/plugins/include_subgraph_errors.rs
+++ b/apollo-router-core/src/plugins/include_subgraph_errors.rs
@@ -192,7 +192,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn it_redacts_all_subgraphs_explicit_withold() {
+    async fn it_redacts_all_subgraphs_explicit_redact() {
         // Build a redacting plugin
         let plugin = get_redacting_plugin(&serde_json::json!({ "all": false }));
         let router = build_mock_router(plugin).await;
@@ -200,7 +200,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn it_redacts_all_subgraphs_implicit_withold() {
+    async fn it_redacts_all_subgraphs_implicit_redact() {
         // Build a redacting plugin
         let plugin = get_redacting_plugin(&serde_json::json!({}));
         let router = build_mock_router(plugin).await;
@@ -216,7 +216,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn it_does_not_redact_all_implicit_withold_product_explict_allow_for_product_query() {
+    async fn it_does_not_redact_all_implicit_redact_product_explict_allow_for_product_query() {
         // Build a redacting plugin
         let plugin = get_redacting_plugin(&serde_json::json!({ "subgraphs": {"products": true }}));
         let router = build_mock_router(plugin).await;
@@ -224,7 +224,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn it_does_redact_all_implicit_withold_product_explict_allow_for_review_query() {
+    async fn it_does_redact_all_implicit_redact_product_explict_allow_for_review_query() {
         // Build a redacting plugin
         let plugin = get_redacting_plugin(&serde_json::json!({ "subgraphs": {"reviews": true }}));
         let router = build_mock_router(plugin).await;
@@ -232,7 +232,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn it_does_not_redact_all_explicit_allow_review_explict_withold_for_product_query() {
+    async fn it_does_not_redact_all_explicit_allow_review_explict_redact_for_product_query() {
         // Build a redacting plugin
         let plugin = get_redacting_plugin(
             &serde_json::json!({ "all": true, "subgraphs": {"reviews": false }}),
@@ -242,7 +242,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn it_does_redact_all_explicit_allow_product_explict_withold_for_product_query() {
+    async fn it_does_redact_all_explicit_allow_product_explict_redact_for_product_query() {
         // Build a redacting plugin
         let plugin = get_redacting_plugin(
             &serde_json::json!({ "all": true, "subgraphs": {"products": false }}),
@@ -252,7 +252,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn it_does_not_redact_all_explicit_allow_account_explict_withold_for_product_query() {
+    async fn it_does_not_redact_all_explicit_allow_account_explict_redact_for_product_query() {
         // Build a redacting plugin
         let plugin = get_redacting_plugin(
             &serde_json::json!({ "all": true, "subgraphs": {"accounts": false }}),
@@ -262,7 +262,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn it_does_redact_all_explicit_allow_account_explict_withold_for_account_query() {
+    async fn it_does_redact_all_explicit_allow_account_explict_redact_for_account_query() {
         // Build a redacting plugin
         let plugin = get_redacting_plugin(
             &serde_json::json!({ "all": true, "subgraphs": {"accounts": false }}),

--- a/apollo-router-core/src/plugins/mod.rs
+++ b/apollo-router-core/src/plugins/mod.rs
@@ -1,3 +1,4 @@
 mod forbid_mutations;
 mod headers;
+mod include_subgraph_errors;
 mod traffic_shaping;

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -419,7 +419,7 @@ pub(crate) mod fetch {
                 .map(|error| Error {
                     locations: error.locations,
                     path: error.path.map(|path| current_dir.join(path)),
-                    message: String::new(),
+                    message: error.message,
                     extensions: Object::default(),
                 })
                 .collect();

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,5 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 443
 expression: "&schema"
 ---
 {
@@ -260,6 +259,23 @@ expression: "&schema"
       "description": "Plugin configuration",
       "default": null,
       "properties": {
+        "experimental.include_subgraph_errors": {
+          "type": "object",
+          "properties": {
+            "all": {
+              "default": false,
+              "type": "boolean"
+            },
+            "subgraphs": {
+              "default": {},
+              "type": "object",
+              "additionalProperties": {
+                "type": "boolean"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
         "experimental.rhai": {
           "type": "object",
           "required": [

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -14,6 +14,7 @@
       "Logging": "/configuration/logging",
       "Header propagation": "/configuration/header-propagation",
       "OpenTelemetry": "/configuration/opentelemetry",
+      "Subgraph Error Inclusion": "/configuration/subgraph-error-inclusion",
       "Traffic shaping": "/configuration/traffic-shaping",
       "Usage reporting": "/configuration/spaceport"
     },

--- a/docs/source/configuration/subgraph-error-inclusion.mdx
+++ b/docs/source/configuration/subgraph-error-inclusion.mdx
@@ -1,0 +1,33 @@
+---
+title: Subgraph error inclusion
+description: Configuring subgraph error inclusion
+---
+
+import { Link } from "gatsby";
+
+> ⚠️ Apollo Router support for subgraph error inclusion is currently experimental.
+
+The Apollo Router provides experimental support for subgraph error inclusion.
+
+By default, the router will redact subgraph errors from clients. This is to prevent potential
+leaks of information to the client. This plugin makes it possible to configure your router so
+that subgraph errors are propagated to the client. This may be done for all subgraphs or on a
+per subgraph basis.
+
+## Configuration
+To configure subgraph error inclusion add the `include_subgraph_errors` plugin to `your router.yaml`:
+
+```yaml title="router.yaml"
+plugins:
+  experimental.include_subgraph_errors:
+    all: true # Propagate errors for all subraphs
+    subgraphs: 
+      products: false # Do not propagate errors from the products subgraph
+```
+
+Note that configuration in the `subgraphs` section will take precedence over that in the `all` section.
+
+### Subgraph error reporting
+
+If a subgraph error is not included (default behaviour) then errors in subgraphs will be replaced with a default error containing this message: "Subgraph errors redacted"
+


### PR DESCRIPTION
This works in a similar fashion to the headers plugin. You can configure
all to apply to all subgraphs and/or a subgraphs hashmap which overrides
the all specification on a per subgraph basis.

I've also migrated some of the benchmark mock code into
apollo-router-core since it's helpful for testing this kind of thing and
fixed the benchmarks (with help from geoffroy and jeremy).

fixes: #743 