### PR TITLE
opensslectomy (follow-up)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
  "hex",
  "http",
  "hyper",
+ "hyper-rustls",
  "include_dir",
  "insta",
  "itertools",
@@ -1921,7 +1922,9 @@ checksum = "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac"
 dependencies = [
  "http",
  "hyper",
+ "log",
  "rustls 0.20.4",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.23.3",
 ]
@@ -3393,7 +3396,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.20.4",
- "rustls-pemfile",
+ "rustls-pemfile 0.3.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3557,6 +3560,27 @@ dependencies = [
  "ring",
  "sct 0.7.0",
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca9ebdfa27d3fc180e42879037b5338ab1c040c06affd00d8338598e7800943"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 0.2.1",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64",
 ]
 
 [[package]]

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -24,6 +24,7 @@ futures = "0.3.21"
 hex = "0.4.3"
 http = "0.2.6"
 hyper = { version = "0.14.18", features = ["client"] }
+hyper-rustls = "0.23.0"
 include_dir = "0.7.2"
 itertools = "0.10.3"
 lazy_static = "1.4.0"

--- a/examples/telemetry/README.md
+++ b/examples/telemetry/README.md
@@ -18,6 +18,6 @@ cargo run -- -s ../graphql/supergraph.graphql -c ./oltp.router.yaml
 ```
 ## Spaceport
 ```bash
-cargo run -- -s ../graphql/supergraph.graphql -c ./sapceport.router.yaml
+cargo run -- -s ../graphql/supergraph.graphql -c ./spaceport.router.yaml
 ```
 

--- a/licenses.html
+++ b/licenses.html
@@ -5339,6 +5339,8 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/rust-lang-nursery/rustc-hash ">rustc-hash</a></li>
                     <li><a href=" https://github.com/Kimundi/rustc-version-rs ">rustc_version</a></li>
                     <li><a href=" https://github.com/rustls/rustls ">rustls</a></li>
+                    <li><a href=" https://github.com/ctz/rustls-native-certs ">rustls-native-certs</a></li>
+                    <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile</a></li>
                     <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile</a></li>
                     <li><a href=" https://github.com/dtolnay/rustversion ">rustversion</a></li>
                     <li><a href=" https://github.com/alexcrichton/scoped-tls ">scoped-tls</a></li>


### PR DESCRIPTION
hyper clients don't support TLS by default. We need TLS support to talk
to subgraphs securely. Use hyper-rustls crate and create a hyper client
capable of talking https or http.

(I have manually tested against https and http subgraphs.)