### PR TITLE
use the operation name in apollo_router_core spans

### DIFF
--- a/apollo-router-core/src/plugin_utils/structures/execution_request.rs
+++ b/apollo-router-core/src/plugin_utils/structures/execution_request.rs
@@ -8,6 +8,7 @@ use typed_builder::TypedBuilder;
 pub struct ExecutionRequest {
     query_plan: Option<Arc<QueryPlan>>,
     context: Option<Context<CompatRequest>>,
+    operation_name: Option<String>,
 }
 
 impl From<ExecutionRequest> for crate::ExecutionRequest {
@@ -17,6 +18,7 @@ impl From<ExecutionRequest> for crate::ExecutionRequest {
             context: execution_request
                 .context
                 .unwrap_or_else(|| Context::new().with_request(Arc::new(Request::mock()))),
+            operation_name: execution_request.operation_name,
         }
     }
 }

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -81,6 +81,7 @@ impl QueryPlan {
     /// Execute the plan and return a [`Response`].
     pub async fn execute<'a>(
         &'a self,
+        operation: Option<&'a str>,
         context: &'a Context,
         service_registry: &'a ServiceRegistry,
         schema: &'a Schema,
@@ -92,6 +93,11 @@ impl QueryPlan {
         let (value, errors) = self
             .root
             .execute_recursively(&root, context, service_registry, schema, &Value::default())
+            .instrument(tracing::span!(
+                tracing::Level::TRACE,
+                "executing plan",
+                operation_name = &operation
+            ))
             .await;
 
         Response::builder().data(value).errors(errors).build()

--- a/apollo-router-core/src/services/execution_service.rs
+++ b/apollo-router-core/src/services/execution_service.rs
@@ -42,7 +42,12 @@ impl Service<ExecutionRequest> for ExecutionService {
             let context = req.context;
             let response = req
                 .query_plan
-                .execute(&context, &this.subgraph_services, &this.schema)
+                .execute(
+                    req.operation_name.as_deref(),
+                    &context,
+                    &this.subgraph_services,
+                    &this.schema,
+                )
                 .await;
 
             // Note that request context is not propagated from downstream.

--- a/apollo-router-core/src/services/mod.rs
+++ b/apollo-router-core/src/services/mod.rs
@@ -167,6 +167,8 @@ pub struct ExecutionRequest {
     pub query_plan: Arc<QueryPlan>,
 
     pub context: Context,
+
+    pub operation_name: Option<String>,
 }
 
 assert_impl_all!(ExecutionResponse: Send);

--- a/apollo-router-core/src/services/router_service.rs
+++ b/apollo-router-core/src/services/router_service.rs
@@ -148,6 +148,7 @@ where
                     .call(ExecutionRequest {
                         query_plan: planned_query.query_plan,
                         context: planned_query.context,
+                        operation_name: operation_name.clone(),
                     })
                     .await?;
 


### PR DESCRIPTION
this adds the operation_name as a field on a span in the query planner execution, to let us filter logs on the operation name. This way, we could show the log only for a specific operation. Right now it works with this command:

```
RUST_LOG=info,apollo_router_core::query_planner[{operation_name=MyQuery}]=trace router -s supergraph.graphql
```

Currently it cannot filter on `apollo_router_core::query_planner::log` so all of the query planner's log will be evaluated in the trace level

Maybe there's a way to make it work?