### PR TITLE
Bump router-bridge dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3546,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation-rs.git?rev=a1846dd1780989cbad767249c9c4f59a649523ad#a1846dd1780989cbad767249c9c4f59a649523ad"
+source = "git+https://github.com/apollographql/federation-rs.git?rev=85043c931d82a52a9af777b21f0795a15c425b0e#85043c931d82a52a9af777b21f0795a15c425b0e"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3546,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation-rs.git?rev=3d446589837b5e9d17df4ca4be9c3add4ca6e59b#3d446589837b5e9d17df4ca4be9c3add4ca6e59b"
+source = "git+https://github.com/apollographql/federation-rs.git?rev=59b38f09522b100c052ecf842c50870ec56cc1a4#59b38f09522b100c052ecf842c50870ec56cc1a4"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3546,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation-rs.git?rev=85043c931d82a52a9af777b21f0795a15c425b0e#85043c931d82a52a9af777b21f0795a15c425b0e"
+source = "git+https://github.com/apollographql/federation-rs.git?rev=258717a888b5406ac228cdbbe22ef7ae8e1b9b7c#258717a888b5406ac228cdbbe22ef7ae8e1b9b7c"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3546,7 +3546,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation-rs.git?rev=258717a888b5406ac228cdbbe22ef7ae8e1b9b7c#258717a888b5406ac228cdbbe22ef7ae8e1b9b7c"
+source = "git+https://github.com/apollographql/federation-rs.git?rev=3d446589837b5e9d17df4ca4be9c3add4ca6e59b#3d446589837b5e9d17df4ca4be9c3add4ca6e59b"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -83,4 +83,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   ```
 ## 🐛 Fixes
 ## 🛠 Maintenance
+- **Apollo federation 2.0.0 compatible query planning** [PR#828](https://github.com/apollographql/router/pull/828)
+
+  Now that Federation 2.0 is available, we have updated the query planner to use the latest release (@apollo/query-planner v2.0.0).
 ## 📚 Documentation

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -93,6 +93,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   When selecting data for a federated query, if there is no data the router will not perform the subgraph query and will instead return a default value. This value had the wrong shape and was generating an object where the query would expect an array.
 
 ## 🛠 Maintenance
+
 - **Apollo federation 2.0.0 compatible query planning** [PR#828](https://github.com/apollographql/router/pull/828)
 
   Now that Federation 2.0 is available, we have updated the query planner to use the latest release (@apollo/query-planner v2.0.0).

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -37,7 +37,7 @@ opentelemetry = "0.17.0"
 opentelemetry-http = "0.6.0"
 paste = "1.0.6"
 regex = "1.5.5"
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "3d446589837b5e9d17df4ca4be9c3add4ca6e59b" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "59b38f09522b100c052ecf842c50870ec56cc1a4" }
 schemars = { version = "0.8.8", features = ["url"] }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -37,7 +37,7 @@ opentelemetry = "0.17.0"
 opentelemetry-http = "0.6.0"
 paste = "1.0.6"
 regex = "1.5.5"
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "258717a888b5406ac228cdbbe22ef7ae8e1b9b7c" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "3d446589837b5e9d17df4ca4be9c3add4ca6e59b" }
 schemars = { version = "0.8.8", features = ["url"] }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -37,7 +37,7 @@ opentelemetry = "0.17.0"
 opentelemetry-http = "0.6.0"
 paste = "1.0.6"
 regex = "1.5.5"
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "a1846dd1780989cbad767249c9c4f59a649523ad" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "85043c931d82a52a9af777b21f0795a15c425b0e" }
 schemars = { version = "0.8.8", features = ["url"] }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -37,7 +37,7 @@ opentelemetry = "0.17.0"
 opentelemetry-http = "0.6.0"
 paste = "1.0.6"
 regex = "1.5.5"
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "85043c931d82a52a9af777b21f0795a15c425b0e" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "258717a888b5406ac228cdbbe22ef7ae8e1b9b7c" }
 schemars = { version = "0.8.8", features = ["url"] }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }


### PR DESCRIPTION
chore: update router-bridge

Now that Federation 2.0 is available, we have updated the query planner to use the latest release (@apollo/query-planner v2.0.0).