### PR TITLE
Small CONTRIBUTING update to fix help command example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ To run the CLI:
 
 ```bash
 cargo run -- <args>
-# e.g. 'cargo run -- help' will run the Apollo Router's help command
+# e.g. 'cargo run -- --help' will run the Apollo Router's help command
 ```
 
 Refer to [the README file](README.md) or run `cargo run --help` for more information.


### PR DESCRIPTION
Worlds smallest PR incoming 😂 - without the additional `--` the router call returns:

```
error: Found argument 'help' which wasn't expected, or isn't valid in this context

USAGE:
    router [OPTIONS]

For more information try --help
```