### PR TITLE
do not try to generate a JSON value on a "flatten" path

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -87,5 +87,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
   The router is now accepting arrays as part of the key joining between subgraphs.
 
+
+- **Fix value shape on empty subgraph queries** [PR #827](https://github.com/apollographql/router/pull/827)
+
+  When selecting data for a federated query, if there is no data the router will not perform the subgraph query and will instead return a default value. This value had the wrong shape and was generating an object where the query would expect an array.
+
 ## 🛠 Maintenance
 ## 📚 Documentation

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -189,8 +189,7 @@ impl ValueExt for Value {
         for p in path.iter() {
             match p {
                 PathElement::Flatten => {
-                    let a = Vec::new();
-                    *current_node = Value::Array(a);
+                    return res_value;
                 }
 
                 &PathElement::Index(index) => match current_node {
@@ -660,7 +659,7 @@ mod tests {
     #[test]
     fn test_from_path() {
         let json = json!([{"prop1":1},{"prop1":2}]);
-        let path = Path::from("obj/arr/@");
+        let path = Path::from("obj/arr");
         let result = Value::from_path(&path, json);
         assert_eq!(result, json!({"obj":{"arr":[{"prop1":1},{"prop1":2}]}}));
     }


### PR DESCRIPTION
fix #812 

the Value::from_path method is used to generate a json value by
inserting an object at a specific path, so the value has a certain
shape.
If we have { "c": 1 } and want to generate { "a": { "b": { "c": 1 } } },
we will call from_path with the path "/a/b". If we have a path in an
array element, it will contain the index, as follows: "/a/1/b".

In the case of federated queries, for each of the representations, we
generate a path at which the response will be inserted. But in the case
we could not select any representation, we avoid the subgraph query
(since it would return nothing) and return an empty value. This empty
value cannot be null, it has to match the expected shape (otherwise
we'll run into response formatting issues), so we use Value::from_path
with the current path and the null value.

The bug here is that if the current path contains a @ (flatten), which
means that we try to select from all elements of an array, we were
trying to generate the value shape even after the flatten element, while
we have way of knowing if the array there even has elements. In some
cases the array was even replaced by an object afterwards.
So here the safest solution is to avoid generating anything once we
reach the flatten element, and return the partially generated shape

<!--
First, 🌠 thank you 🌠 for considering a contribution to Apollo!

Some of this information is also included in the /CONTRIBUTING.md file at the
root of this repository.  We suggest you read it!

  https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md

Here are some important details to keep in mind:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!  Documentation in the docs/ directory should be updated
        as necessary.  Finally, a /CHANGELOG.md entry should be added.

We hope you will find this to be a positive experience! Contribution can be
intimidating and we hope to alleviate that pain as much as possible. Without
following these guidelines, you may be missing context that can help you succeed
with your contribution, which is why we encourage discussion first. Ultimately,
there is no guarantee that we will be able to merge your pull-request, but by
following these guidelines we can try to avoid disappointment.

-->
