### PR TITLE
release: v0.1.0-preview.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## ❗ BREAKING ❗
 - **Telemetry simplification** [PR #782](https://github.com/apollographql/router/pull/782)
 
-  Telemetry configuration has been reworked to focus exporters rather than OpenTelemetry. Users can focus on what they are tying to integrate with rather than the fact that OpenTelemetry is used in the Apollo Router under the hood.
+  Telemetry configuration has been reworked to focus exporters rather than OpenTelemetry. Users can focus on what they are trying to integrate with rather than the fact that OpenTelemetry is used in the Apollo Router under the hood.
 
   ```yaml
   telemetry:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,83 @@ All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [v0.1.0-preview.4] - 2022-04-11
+## ❗ BREAKING ❗
+- **Telemetry simplification** [PR #782](https://github.com/apollographql/router/pull/782)
+
+  Telemetry configuration has been reworked to focus exporters rather than OpenTelemetry. Users can focus on what they are tying to integrate with rather than the fact that OpenTelemetry is used in the Apollo Router under the hood.
+
+  ```yaml
+  telemetry:
+    apollo:
+      endpoint:
+      apollo_graph_ref:
+      apollo_key:
+    metrics:
+      prometheus:
+        enabled: true
+    tracing:
+      propagation:
+        # Propagation is automatically enabled for any exporters that are enabled,
+        # but you can enable extras. This is mostly to support otlp and opentracing.
+        zipkin: true
+        datadog: false
+        trace_context: false
+        jaeger: false
+        baggage: false
+  
+      otlp:
+        endpoint: default
+        protocol: grpc
+        http:
+          ..
+        grpc:
+          ..
+      zipkin:
+        agent:
+          endpoint: default
+      jaeger:
+        agent:
+          endpoint: default
+      datadog:
+        endpoint: default
+  ```
+## 🚀 Features
+- **Datadog support** [PR #782](https://github.com/apollographql/router/pull/782)
+
+  Datadog support has been added via `telemetry` yaml configuration.
+
+- **Yaml env variable expansion** [PR #782](https://github.com/apollographql/router/pull/782)
+
+  All values in the router configuration outside the `server` section may use environment variable expansion.
+  Unix style expansion is used. Either:
+
+  * `${ENV_VAR_NAME}`- Expands to the environment variable `ENV_VAR_NAME`.
+  * `${ENV_VAR_NAME:some_default}` - Expands to `ENV_VAR_NAME` or `some_default` if the environment variable did not exist.
+
+  Only values may be expanded (not keys):
+  ```yaml {4,8} title="router.yaml"
+  example:
+    passord: "${MY_PASSWORD}" 
+  ```
+## 🐛 Fixes
+
+- **Accept arrays in keys for subgraph joins** [PR #822](https://github.com/apollographql/router/pull/822)
+
+  The router is now accepting arrays as part of the key joining between subgraphs.
+
+
+- **Fix value shape on empty subgraph queries** [PR #827](https://github.com/apollographql/router/pull/827)
+
+  When selecting data for a federated query, if there is no data the router will not perform the subgraph query and will instead return a default value. This value had the wrong shape and was generating an object where the query would expect an array.
+
+## 🛠 Maintenance
+
+- **Apollo federation 2.0.0 compatible query planning** [PR#828](https://github.com/apollographql/router/pull/828)
+
+  Now that Federation 2.0 is available, we have updated the query planner to use the latest release (@apollo/query-planner v2.0.0).
+
+
 # [v0.1.0-preview.3] - 2022-04-08
 ## 🚀 Features
 - **Add version flag to router** ([PR #805](https://github.com/apollographql/router/pull/805))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "0.1.0-preview.3"
+version = "0.1.0-preview.4"
 dependencies = [
  "anyhow",
  "apollo-parser 0.2.4",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "0.1.0-preview.3"
+version = "0.1.0-preview.4"
 dependencies = [
  "apollo-router",
  "apollo-router-core",
@@ -180,7 +180,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-core"
-version = "0.1.0-preview.3"
+version = "0.1.0-preview.4"
 dependencies = [
  "apollo-parser 0.2.5",
  "async-trait",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-spaceport"
-version = "0.1.0-preview.3"
+version = "0.1.0-preview.4"
 dependencies = [
  "bytes",
  "clap 3.1.6",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-uplink"
-version = "0.1.0-preview.3"
+version = "0.1.0-preview.4"
 dependencies = [
  "futures",
  "graphql_client",
@@ -5250,7 +5250,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.0-preview.3"
+version = "0.1.0-preview.4"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -26,7 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## ❗ BREAKING ❗
 - **Telemetry simplification** [PR #782](https://github.com/apollographql/router/pull/782)
 
-  Telemetry configuration has been reworked to focus exporters rather than OpenTelemetry. Users can focus on what they are tying to integrate with rather than the fact that OpenTelemetry is used in the Apollo Router under the hood.
+  Telemetry configuration has been reworked to focus exporters rather than OpenTelemetry. Users can focus on what they are trying to integrate with rather than the fact that OpenTelemetry is used in the Apollo Router under the hood.
 
   ```yaml
   telemetry:
@@ -97,4 +97,3 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - **Apollo federation 2.0.0 compatible query planning** [PR#828](https://github.com/apollographql/router/pull/828)
 
   Now that Federation 2.0 is available, we have updated the query planner to use the latest release (@apollo/query-planner v2.0.0).
-## 📚 Documentation

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Description! And a link to a [reference](http://url)
 -->
 
-# [v0.1.0-preview.4] - Unreleased
+# [v0.1.0-preview.4] - 2022-04-11
 ## ❗ BREAKING ❗
 - **Telemetry simplification** [PR #782](https://github.com/apollographql/router/pull/782)
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -32,13 +32,14 @@ in lieu of an official changelog.
 2.  Create a new branch "#.#.#" where "#.#.#" is this release's version
     (release) or "#.#.#-rc.#" (release candidate)
 3.  Update the version in `*/Cargo.toml`.
-3.  Update the version in `deny.toml` in the `[[licenses.clarify]]` sections for `apollo-router-core` and `apollo-router`.
-4.  Run `cargo check` so the lock file gets updated.
-5.  Run `cargo xtask check-compliance` so the lock file gets updated.
-6.  Push up a commit with the `*/Cargo.toml`, `Cargo.lock`, `CHANGELOG.md` and
+4.  Update the date in `NEXT_CHANGELOG.md`.
+5.  Update the version in `deny.toml` in the `[[licenses.clarify]]` sections for `apollo-router-core`, `apollo-router` and `apollo-spaceport`.
+6.  Run `cargo check` so the lock file gets updated.
+7.  Run `cargo xtask check-compliance`.
+8.  Push up a commit with the `*/Cargo.toml`, `Cargo.lock`, `CHANGELOG.md` and
     `NEXT_CHANGELOG.md` changes. The commit message should be "release: v#.#.#" or
     "release: v#.#.#-rc.#"
-7.  Request review from the Router team.
+9.  Request review from the Router team.
 
 ### Review
 

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "0.1.0-preview.3"
+version = "0.1.0-preview.4"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"
@@ -15,7 +15,7 @@ criterion = { version = "0.3", features = ["async_tokio", "async_futures"] }
 futures = "0.3.21"
 once_cell = "1"
 serde_json = { version = "1.0.79", features = ["preserve_order"] }
-serde_json_bytes = { version = "0.2.0", features = ["preserve_order"]}
+serde_json_bytes = { version = "0.2.0", features = ["preserve_order"] }
 tokio = { version = "1", features = ["full"] }
 tracing-subscriber = { version = "0.3.11", features = ["json", "env-filter"] }
 

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-core"
-version = "0.1.0-preview.3"
+version = "0.1.0-preview.4"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license-file = "./LICENSE"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "0.1.0-preview.3"
+version = "0.1.0-preview.4"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license-file = "./LICENSE"
@@ -31,8 +31,12 @@ humantime-serde = "1.0.1"
 hyper = { version = "0.14.18", features = ["server"] }
 itertools = "0.10.3"
 once_cell = "1.9.0"
-opentelemetry = { version = "0.17.0", features = ["rt-tokio", "serialize", "metrics"] }
-opentelemetry-datadog = {version="0.5.0", features=["reqwest-client"]}
+opentelemetry = { version = "0.17.0", features = [
+    "rt-tokio",
+    "serialize",
+    "metrics",
+] }
+opentelemetry-datadog = { version = "0.5.0", features = ["reqwest-client"] }
 opentelemetry-http = "0.6.0"
 opentelemetry-jaeger = { version = "0.16.0", features = [
     "collector_client",
@@ -53,7 +57,11 @@ opentelemetry-prometheus = "0.10.0"
 prometheus = "0.13"
 prost-types = "0.9.0"
 regex = "1.5.4"
-reqwest = { version = "0.11.10", default-features = false, features = ["rustls-tls", "json", "stream"] }
+reqwest = { version = "0.11.10", default-features = false, features = [
+    "rustls-tls",
+    "json",
+    "stream",
+] }
 schemars = { version = "0.8.8", features = ["url"] }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json_bytes = { version = "0.2.0", features = ["preserve_order"] }
@@ -86,7 +94,10 @@ libc = "0.2.122"
 insta = "1.12.0"
 maplit = "1.0.2"
 mockall = "0.11.0"
-reqwest = { version = "0.11.10", default-features = false, features = ["json", "stream"] }
+reqwest = { version = "0.11.10", default-features = false, features = [
+    "json",
+    "stream",
+] }
 tempfile = "3.3.0"
 test-log = { version = "0.2.10", default-features = false, features = [
     "trace",

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-spaceport"
-version = "0.1.0-preview.3"
+version = "0.1.0-preview.4"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license-file = "./LICENSE"
@@ -14,13 +14,16 @@ clap = { version = "3.1.3", features = ["derive"] }
 flate2 = "1.0.22"
 prost = "0.9.0"
 prost-types = "0.9.0"
-reqwest = { version = "0.11.10", default_features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default_features = false, features = [
+    "rustls-tls",
+    "json",
+] }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.79" }
 sys-info = "0.9.1"
 tonic = "0.6.2"
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }
-tokio-stream = {version="0.1.8", features=["net"]}
+tokio-stream = { version = "0.1.8", features = ["net"] }
 tracing = "0.1.33"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
 
@@ -31,7 +34,10 @@ uname = "0.1.1"
 uname = "0.1.1"
 
 [build-dependencies]
-reqwest = { version = "0.11.10", default-features = false, features = ["rustls-tls", "blocking"] }
+reqwest = { version = "0.11.10", default-features = false, features = [
+    "rustls-tls",
+    "blocking",
+] }
 tonic-build = "0.6.2"
 
 [lib]

--- a/deny.toml
+++ b/deny.toml
@@ -44,7 +44,7 @@ allow = [
     "LicenseRef-ELv2",
     "LicenseRef-ring",
     "MIT",
-    "MPL-2.0"
+    "MPL-2.0",
 ]
 copyleft = "warn"
 allow-osi-fsf-free = "neither"
@@ -64,13 +64,13 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 [[licenses.clarify]]
 name = "apollo-router"
 expression = "LicenseRef-ELv2"
-version = "0.1.0-preview.3"
+version = "0.1.0-preview.4"
 license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
 
 [[licenses.clarify]]
 name = "apollo-router-core"
 expression = "LicenseRef-ELv2"
-version = "0.1.0-preview.3"
+version = "0.1.0-preview.4"
 license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
 
 [[licenses.clarify]]
@@ -81,7 +81,7 @@ license-files = [{ path = "router-bridge/LICENSE", hash = 0xaceadac9 }]
 [[licenses.clarify]]
 name = "apollo-spaceport"
 expression = "LicenseRef-ELv2"
-version = "0.1.0-preview.3"
+version = "0.1.0-preview.4"
 license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
 
 [[licenses.clarify]]

--- a/licenses.html
+++ b/licenses.html
@@ -8113,6 +8113,7 @@ limitations under the License.</pre>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-encoder</a></li>
                     <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
+                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-smith</a></li>
                 </ul>
                 <pre class="license-text">../../LICENSE-APACHE</pre>
             </li>
@@ -8554,7 +8555,6 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
-                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-smith</a></li>
                     <li><a href=" https://github.com/RustCrypto/signatures ">ecdsa</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/failure ">failure_derive</a></li>
                     <li><a href=" https://github.com/graphql-rust/graphql-client ">graphql-introspection-query</a></li>

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-uplink"
-version = "0.1.0-preview.3"
+version = "0.1.0-preview.4"
 edition = "2021"
 build = "build.rs"
 
@@ -9,7 +9,10 @@ build = "build.rs"
 [dependencies]
 futures = "0.3.21"
 graphql_client = "0.10.0"
-reqwest = { version = "0.11.10", default_features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.11.10", default_features = false, features = [
+    "rustls-tls",
+    "json",
+] }
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 tokio = "1.17.0"
 tokio-stream = "0.1.8"
@@ -17,8 +20,13 @@ tracing = "0.1.33"
 url = "2.2.2"
 
 [build-dependencies]
-launchpad = { git = "https://github.com/apollographql/rover.git", rev="94141242ba34cf00cde9630fc4a6dcd05d4fa5da" }
-reqwest = { version = "0.11.10", default_features = false, features = ["rustls-tls"] }
+launchpad = { git = "https://github.com/apollographql/rover.git", rev = "94141242ba34cf00cde9630fc4a6dcd05d4fa5da" }
+reqwest = { version = "0.11.10", default_features = false, features = [
+    "rustls-tls",
+] }
 
 [dev-dependencies]
-tokio = { version = "1.17.0", default-features = false, features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.17.0", default-features = false, features = [
+    "macros",
+    "rt-multi-thread",
+] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.1.0-preview.3"
+version = "0.1.0-preview.4"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"


### PR DESCRIPTION
# [v0.1.0-preview.4] - 2022-04-11
## ❗ BREAKING ❗
- **Telemetry simplification** [PR #782](https://github.com/apollographql/router/pull/782)

  Telemetry configuration has been reworked to focus exporters rather than OpenTelemetry. Users can focus on what they are trying to integrate with rather than the fact that OpenTelemetry is used in the Apollo Router under the hood.

  ```yaml
  telemetry:
    apollo:
      endpoint:
      apollo_graph_ref:
      apollo_key:
    metrics:
      prometheus:
        enabled: true
    tracing:
      propagation:
        # Propagation is automatically enabled for any exporters that are enabled,
        # but you can enable extras. This is mostly to support otlp and opentracing.
        zipkin: true
        datadog: false
        trace_context: false
        jaeger: false
        baggage: false
  
      otlp:
        endpoint: default
        protocol: grpc
        http:
          ..
        grpc:
          ..
      zipkin:
        agent:
          endpoint: default
      jaeger:
        agent:
          endpoint: default
      datadog:
        endpoint: default
  ```
## 🚀 Features
- **Datadog support** [PR #782](https://github.com/apollographql/router/pull/782)

  Datadog support has been added via `telemetry` yaml configuration.

- **Yaml env variable expansion** [PR #782](https://github.com/apollographql/router/pull/782)

  All values in the router configuration outside the `server` section may use environment variable expansion.
  Unix style expansion is used. Either:

  * `${ENV_VAR_NAME}`- Expands to the environment variable `ENV_VAR_NAME`.
  * `${ENV_VAR_NAME:some_default}` - Expands to `ENV_VAR_NAME` or `some_default` if the environment variable did not exist.

  Only values may be expanded (not keys):
  ```yaml {4,8} title="router.yaml"
  example:
    passord: "${MY_PASSWORD}" 
  ```
## 🐛 Fixes

- **Accept arrays in keys for subgraph joins** [PR #822](https://github.com/apollographql/router/pull/822)

  The router is now accepting arrays as part of the key joining between subgraphs.


- **Fix value shape on empty subgraph queries** [PR #827](https://github.com/apollographql/router/pull/827)

  When selecting data for a federated query, if there is no data the router will not perform the subgraph query and will instead return a default value. This value had the wrong shape and was generating an object where the query would expect an array.

## 🛠 Maintenance

- **Apollo federation 2.0.0 compatible query planning** [PR#828](https://github.com/apollographql/router/pull/828)

  Now that Federation 2.0 is available, we have updated the query planner to use the latest release (@apollo/query-planner v2.0.0).
