### PR TITLE
fix: Cleanly shutdown the Telemetry plugin.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -43,6 +43,9 @@ telemetry:
   For more info see the quickstart documentation.
 
 ## 🐛 Fixes
+
+### Do not hang at startup when ServiceBuilder::build() fails [#847](https://github.com/apollographql/router/issues/847)
+The telemetry plugin will now Drop cleanly when the Router service stack fails to build.
 ### Propagate error extensions originating from subgraphs [PR #839](https://github.com/apollographql/router/pull/839)
 Extensions are now propagated following the configuration of the `include_subgraph_error` plugin.
 

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -438,6 +438,41 @@ mod test {
         assert!(service.is_err())
     }
 
+    #[tokio::test]
+    async fn test_telemetry_doesnt_hang_with_invalid_schema() {
+        use crate::subscriber::{set_global_subscriber, RouterSubscriber};
+        use tracing_subscriber::EnvFilter;
+
+        // A global subscriber must be set before we start up the telemetry plugin
+        let _ = set_global_subscriber(RouterSubscriber::JsonSubscriber(
+            tracing_subscriber::fmt::fmt()
+                .with_env_filter(EnvFilter::from_default_env())
+                .json()
+                .finish(),
+        ));
+
+        let config: Configuration = serde_yaml::from_str(
+            r#"
+            telemetry:
+              tracing:
+                trace_config:
+                  service_name: router
+                otlp:
+                  endpoint: default
+        "#,
+        )
+        .unwrap();
+
+        let schema: Schema = include_str!("testdata/invalid_supergraph.graphql")
+            .parse()
+            .unwrap();
+
+        let service = YamlRouterServiceFactory::default()
+            .create(Arc::new(config), Arc::new(schema), None)
+            .await;
+        service.map(|_| ()).unwrap_err();
+    }
+
     async fn create_service(config: Configuration) -> Result<(), BoxError> {
         let schema: Schema = include_str!("testdata/supergraph.graphql").parse().unwrap();
 

--- a/apollo-router/src/testdata/invalid_supergraph.graphql
+++ b/apollo-router/src/testdata/invalid_supergraph.graphql
@@ -1,0 +1,66 @@
+# This supergraph is almost valid. the only difference is that the reviews field in the Product type joins on REVIEWS which is incorrect
+
+schema @core(feature: "https://specs.apollo.dev/core/v0.1") @core(feature: "https://specs.apollo.dev/join/v0.1") @core(feature: "https://specs.apollo.dev/tag/v0.1") @apollo_studio_metadata(launchId: "2396d4fb-a1e4-457d-8da4-347479b852f1", buildId: "2396d4fb-a1e4-457d-8da4-347479b852f1", checkId: null) @core(feature: "https://specs.apollo.dev/inaccessible/v0.1") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @core(feature: String!) repeatable on SCHEMA
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet) repeatable on OBJECT | INTERFACE
+
+directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+
+directive @apollo_studio_metadata(launchId: String, buildId: String, checkId: String) on SCHEMA
+
+directive @inaccessible on OBJECT | FIELD_DEFINITION | INTERFACE | UNION
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "http://localhost:4001/graphql")
+  INVENTORY @join__graph(name: "inventory", url: "http://localhost:4004/graphql")
+  PRODUCTS @join__graph(name: "products", url: "http://localhost:4003/graphql")
+  REVIEWS @join__graph(name: "reviews", url: "http://localhost:4002/graphql")
+}
+
+type Mutation {
+  createProduct(name: String, upc: ID!): Product @join__field(graph: PRODUCTS)
+  createReview(body: String, id: ID!, upc: ID!): Review @join__field(graph: REVIEWS)
+}
+
+type Product @join__owner(graph: PRODUCTS) @join__type(graph: PRODUCTS, key: "upc") @join__type(graph: REVIEWS, key: "upc") @join__type(graph: INVENTORY, key: "upc") {
+  inStock: Boolean @join__field(graph: INVENTORY) @tag(name: "private") @inaccessible
+  name: String @join__field(graph: PRODUCTS)
+  price: Int @join__field(graph: PRODUCTS)
+  reviews: [Review] @join__field(graph: PRODUCTS)
+  reviewsForAuthor(authorID: ID!): [Review] @join__field(graph: REVIEWS)
+  shippingEstimate: Int @join__field(graph: INVENTORY, requires: "price weight")
+  upc: String! @join__field(graph: PRODUCTS)
+  weight: Int @join__field(graph: PRODUCTS)
+}
+
+type Query {
+  me: User @join__field(graph: ACCOUNTS)
+  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCTS)
+}
+
+type Review @join__owner(graph: REVIEWS) @join__type(graph: REVIEWS, key: "id") {
+  author: User @join__field(graph: REVIEWS, provides: "username")
+  body: String @join__field(graph: REVIEWS)
+  id: ID! @join__field(graph: REVIEWS)
+  product: Product @join__field(graph: REVIEWS)
+}
+
+type User @join__owner(graph: ACCOUNTS) @join__type(graph: ACCOUNTS, key: "id") @join__type(graph: REVIEWS, key: "id") {
+  id: ID! @join__field(graph: ACCOUNTS)
+  name: String @join__field(graph: ACCOUNTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  username: String @join__field(graph: ACCOUNTS)
+}


### PR DESCRIPTION
fixes #847

The telemetry plugin would cause the router to hang if ServiceBuilder::build() failed.
This commit makes sure the Telemetry plugin is cleanly shutdown when it's the case, thus correctly erroring out instead of hanging.
