### PR TITLE
Fix telemetry shutdown in the case of a failed config update.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -43,6 +43,10 @@ telemetry:
   For more info see the quickstart documentation.
 
 ## 🐛 Fixes
+
+### Do not hang when tracing provider was not set as global [#849](https://github.com/apollographql/router/issues/847)
+The telemetry plugin will now Drop cleanly when the Router service stack fails to build.
+
 ### Propagate error extensions originating from subgraphs [PR #839](https://github.com/apollographql/router/pull/839)
 Extensions are now propagated following the configuration of the `include_subgraph_error` plugin.
 

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -89,6 +89,33 @@ fn apollo_graph_reference() -> Option<String> {
     std::env::var("APOLLO_GRAPH_REF").ok()
 }
 
+impl Drop for Telemetry {
+    fn drop(&mut self) {
+        if let Some(tracer_provider) = self.tracer_provider.take() {
+            // Tracer providers must be flushed. This may happen as part of otel if the provider was set
+            // as the global, but may also happen in the case of an failed config reload.
+            // If the tracer prover is present then it was not handed over so we must flush it.
+            // The magic incantation seems to be that the flush MUST happen within a tokio runtime,
+            // and then within a spawn blocking.
+            ::tracing::debug!("flushing telemetry");
+            std::thread::spawn(|| {
+                let runtime = tokio::runtime::Builder::new_multi_thread().build().unwrap();
+                runtime.block_on(async {
+                    let jh = tokio::task::spawn_blocking(move || {
+                        opentelemetry::trace::TracerProvider::force_flush(&tracer_provider);
+                    });
+                    futures::executor::block_on(jh).expect("failed to flush tracer provider");
+                });
+            });
+        }
+
+        if let Some(sender) = self.spaceport_shutdown.take() {
+            ::tracing::debug!("notifying spaceport to shut down");
+            let _ = sender.send(());
+        }
+    }
+}
+
 #[async_trait::async_trait]
 impl Plugin for Telemetry {
     type Config = config::Conf;
@@ -187,9 +214,6 @@ impl Plugin for Telemetry {
     }
 
     async fn shutdown(&mut self) -> Result<(), BoxError> {
-        if let Some(sender) = self.spaceport_shutdown.take() {
-            let _ = sender.send(());
-        }
         Ok(())
     }
 

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -438,6 +438,41 @@ mod test {
         assert!(service.is_err())
     }
 
+    #[tokio::test]
+    async fn test_telemetry_doesnt_hang_with_invalid_schema() {
+        use crate::subscriber::{set_global_subscriber, RouterSubscriber};
+        use tracing_subscriber::EnvFilter;
+
+        // A global subscriber must be set before we start up the telemetry plugin
+        let _ = set_global_subscriber(RouterSubscriber::JsonSubscriber(
+            tracing_subscriber::fmt::fmt()
+                .with_env_filter(EnvFilter::from_default_env())
+                .json()
+                .finish(),
+        ));
+
+        let config: Configuration = serde_yaml::from_str(
+            r#"
+            telemetry:
+              tracing:
+                trace_config:
+                  service_name: router
+                otlp:
+                  endpoint: default
+        "#,
+        )
+        .unwrap();
+
+        let schema: Schema = include_str!("testdata/invalid_supergraph.graphql")
+            .parse()
+            .unwrap();
+
+        let service = YamlRouterServiceFactory::default()
+            .create(Arc::new(config), Arc::new(schema), None)
+            .await;
+        service.map(|_| ()).unwrap_err();
+    }
+
     async fn create_service(config: Configuration) -> Result<(), BoxError> {
         let schema: Schema = include_str!("testdata/supergraph.graphql").parse().unwrap();
 

--- a/apollo-router/src/testdata/invalid_supergraph.graphql
+++ b/apollo-router/src/testdata/invalid_supergraph.graphql
@@ -1,4 +1,4 @@
-# This supergraph is almost valid. the only difference is that the reviews field in the Product type joins on REVIEWS which is incorrect
+# This supergraph is almost valid. the only difference is that the reviews field in the Product type joins on PRODUCTS which is incorrect
 
 schema @core(feature: "https://specs.apollo.dev/core/v0.1") @core(feature: "https://specs.apollo.dev/join/v0.1") @core(feature: "https://specs.apollo.dev/tag/v0.1") @apollo_studio_metadata(launchId: "2396d4fb-a1e4-457d-8da4-347479b852f1", buildId: "2396d4fb-a1e4-457d-8da4-347479b852f1", checkId: null) @core(feature: "https://specs.apollo.dev/inaccessible/v0.1") {
   query: Query

--- a/apollo-router/src/testdata/invalid_supergraph.graphql
+++ b/apollo-router/src/testdata/invalid_supergraph.graphql
@@ -1,0 +1,66 @@
+# This supergraph is almost valid. the only difference is that the reviews field in the Product type joins on REVIEWS which is incorrect
+
+schema @core(feature: "https://specs.apollo.dev/core/v0.1") @core(feature: "https://specs.apollo.dev/join/v0.1") @core(feature: "https://specs.apollo.dev/tag/v0.1") @apollo_studio_metadata(launchId: "2396d4fb-a1e4-457d-8da4-347479b852f1", buildId: "2396d4fb-a1e4-457d-8da4-347479b852f1", checkId: null) @core(feature: "https://specs.apollo.dev/inaccessible/v0.1") {
+  query: Query
+  mutation: Mutation
+}
+
+directive @core(feature: String!) repeatable on SCHEMA
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet) on FIELD_DEFINITION
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet) repeatable on OBJECT | INTERFACE
+
+directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+
+directive @apollo_studio_metadata(launchId: String, buildId: String, checkId: String) on SCHEMA
+
+directive @inaccessible on OBJECT | FIELD_DEFINITION | INTERFACE | UNION
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "http://localhost:4001/graphql")
+  INVENTORY @join__graph(name: "inventory", url: "http://localhost:4004/graphql")
+  PRODUCTS @join__graph(name: "products", url: "http://localhost:4003/graphql")
+  REVIEWS @join__graph(name: "reviews", url: "http://localhost:4002/graphql")
+}
+
+type Mutation {
+  createProduct(name: String, upc: ID!): Product @join__field(graph: PRODUCTS)
+  createReview(body: String, id: ID!, upc: ID!): Review @join__field(graph: REVIEWS)
+}
+
+type Product @join__owner(graph: PRODUCTS) @join__type(graph: PRODUCTS, key: "upc") @join__type(graph: REVIEWS, key: "upc") @join__type(graph: INVENTORY, key: "upc") {
+  inStock: Boolean @join__field(graph: INVENTORY) @tag(name: "private") @inaccessible
+  name: String @join__field(graph: PRODUCTS)
+  price: Int @join__field(graph: PRODUCTS)
+  reviews: [Review] @join__field(graph: PRODUCTS)
+  reviewsForAuthor(authorID: ID!): [Review] @join__field(graph: REVIEWS)
+  shippingEstimate: Int @join__field(graph: INVENTORY, requires: "price weight")
+  upc: String! @join__field(graph: PRODUCTS)
+  weight: Int @join__field(graph: PRODUCTS)
+}
+
+type Query {
+  me: User @join__field(graph: ACCOUNTS)
+  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCTS)
+}
+
+type Review @join__owner(graph: REVIEWS) @join__type(graph: REVIEWS, key: "id") {
+  author: User @join__field(graph: REVIEWS, provides: "username")
+  body: String @join__field(graph: REVIEWS)
+  id: ID! @join__field(graph: REVIEWS)
+  product: Product @join__field(graph: REVIEWS)
+}
+
+type User @join__owner(graph: ACCOUNTS) @join__type(graph: ACCOUNTS, key: "id") @join__type(graph: REVIEWS, key: "id") {
+  id: ID! @join__field(graph: ACCOUNTS)
+  name: String @join__field(graph: ACCOUNTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  username: String @join__field(graph: ACCOUNTS)
+}


### PR DESCRIPTION
The root cause is that tracing providers MUST be flushed before drop. otherwise they hang. This is really nasty, but the fix needs to happen in Otel.

Flushing will happen automagically if a provider is set as the global for otel.

In the case of a plugin after the otel plugin failing to start up correctly, or even one of the subsequent methods inside the otel plugin fails then the provider is not set as the global and we must flush it.

Flushing must occur in a separate thread.

Flush will now happen when a telemetry plugin is dropped.
