### PR TITLE
remove trailing / in the datadog agent endpoint

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -62,6 +62,10 @@ Instead of returning an error coming from the query planner, we are now returnin
 ### Add operation name to subquery fetches [PR #840](https://github.com/apollographql/router/pull/840)
 If present in the query plan fetch noede, the operation name will be added to sub-fetches.
 
+### Remove trailing slash from Datadog agent endpoint URL [PR #863](https://github.com/apollographql/router/pull/863)
+due to the way the endpoint URL is constructed in opentelemetry-datadog, we
+cannot set the agent endpoint to a URL with a trailing slash
+
 ## 🛠 Maintenance
 ### Configuration files validated [PR #830](https://github.com/apollographql/router/pull/830)
 Router configuration files within the project are now largely validated via unit test.

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -34,7 +34,7 @@ impl TracingConfigurator for Config {
         };
         let exporter = opentelemetry_datadog::new_pipeline()
             .with(&url, |b, e| {
-                b.with_agent_endpoint(e.to_string().trim_end_matches("/"))
+                b.with_agent_endpoint(e.to_string().trim_end_matches('/'))
             })
             .with(&trace_config.service_name, |b, n| b.with_service_name(n))
             .with_trace_config(trace_config.into())

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -33,7 +33,9 @@ impl TracingConfigurator for Config {
             AgentEndpoint::Url(s) => Some(s),
         };
         let exporter = opentelemetry_datadog::new_pipeline()
-            .with(&url, |b, e| b.with_agent_endpoint(e.to_string()))
+            .with(&url, |b, e| {
+                b.with_agent_endpoint(e.to_string().trim_end_matches("/"))
+            })
             .with(&trace_config.service_name, |b, n| b.with_service_name(n))
             .with_trace_config(trace_config.into())
             .build_exporter()?;


### PR DESCRIPTION
Fix #851 

due to the way the endpoint URL is constructed in opentelemetry-datadog
( https://github.com/open-telemetry/opentelemetry-rust/issues/782 ), we
cannot set the agent endpoint to a URL with a trailing slash
