### PR TITLE
feat: Remove warp from precompiled deps

### DIFF
--- a/precompile.sh
+++ b/precompile.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-for PACKAGE in router-bridge opentelemetry opentelemetry-otlp opentelemetry-jaeger opentelemetry-prometheus tracing tokio moka mockall tower-http tonic hyper-rustls warp rhai hotwatch miette
+for PACKAGE in router-bridge opentelemetry opentelemetry-otlp opentelemetry-jaeger opentelemetry-prometheus tracing tokio moka mockall tower-http tonic hyper-rustls rhai hotwatch miette
 do
   cargo build -p $PACKAGE
 done


### PR DESCRIPTION
The current pipeline for master fails on `precompile large dependencies` step, but somehow exits with 0 so nobody noticed: https://app.circleci.com/pipelines/github/apollographql/router/3148/workflows/38144c6f-62fa-424e-bda7-3b7ee2dbb2ca/jobs/23393/parallel-runs/0/steps/0-111

It happened after [the switch](https://github.com/apollographql/router/pull/751) from `warp` to `axum`. This PR removes the unused dependency from the script.

I was wondering if this file is still maintained. Should then `axum` be added to `precompile.sh` as well instead of just removing `warp`? Is there anything else missing? Thank you