### PR TITLE
fix: Correctly flag incoming POST requests. 

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -28,7 +28,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🚀 Features
 
 ## 🐛 Fixes
-
+### Correctly flag incoming POST requests [#865](https://github.com/apollographql/router/issues/865)
+A regression happened during our recent switch to axum that would propagate incoming POST requests as GET requests. This has been fixed and we now have several regression tests, pending more integration tests.
 ## 🛠 Maintenance
 
 ## 📚 Documentation

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -99,15 +99,10 @@ impl HttpServerFactory for AxumHttpServerFactory {
                         move |host: Host,
                               service: Extension<BufferedService>,
                               http_request: Request<Body>| {
-                            redirect_or_run_graphql_operation(
-                                host,
-                                service,
-                                http_request,
-                                display_landing_page,
-                            )
+                            handle_get(host, service, http_request, display_landing_page)
                         }
                     })
-                    .post(run_graphql_operation),
+                    .post(handle_post),
                 )
                 .route(
                     "/graphql",
@@ -116,15 +111,10 @@ impl HttpServerFactory for AxumHttpServerFactory {
                         move |host: Host,
                               service: Extension<BufferedService>,
                               http_request: Request<Body>| {
-                            redirect_or_run_graphql_operation(
-                                host,
-                                service,
-                                http_request,
-                                display_landing_page,
-                            )
+                            handle_get(host, service, http_request, display_landing_page)
                         }
                     })
-                    .post(run_graphql_operation),
+                    .post(handle_post),
                 )
                 .route("/.well-known", get(health_check))
                 .route("/apollo", get(health_check))
@@ -407,7 +397,7 @@ async fn custom_plugin_handler(
     Ok::<_, String>(res)
 }
 
-async fn redirect_or_run_graphql_operation(
+async fn handle_get(
     Host(host): Host,
     Extension(service): Extension<BufferedService>,
     http_request: Request<Body>,
@@ -439,7 +429,7 @@ async fn redirect_or_run_graphql_operation(
     (StatusCode::BAD_REQUEST, "Invalid Graphql request").into_response()
 }
 
-async fn run_graphql_operation(
+async fn handle_post(
     Host(host): Host,
     OriginalUri(uri): OriginalUri,
     Json(request): Json<graphql::Request>,

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -446,13 +446,12 @@ async fn run_graphql_operation(
     Extension(service): Extension<BufferedService>,
     header_map: HeaderMap,
 ) -> impl IntoResponse {
-    let mut http_request = Request::builder()
-        .uri(
-            Uri::from_str(&format!("http://{}{}", host, uri))
-                .expect("the URL is already valid because it comes from axum; qed"),
-        )
-        .body(request)
-        .expect("body has already been parsed; qed");
+    let mut http_request = Request::post(
+        Uri::from_str(&format!("http://{}{}", host, uri))
+            .expect("the URL is already valid because it comes from axum; qed"),
+    )
+    .body(request)
+    .expect("body has already been parsed; qed");
     *http_request.headers_mut() = header_map;
 
     run_graphql_request(service, http_request)

--- a/apollo-router/src/plugins/override_url.rs
+++ b/apollo-router/src/plugins/override_url.rs
@@ -63,13 +63,7 @@ mod tests {
         let mut mock_service = MockSubgraphService::new();
         mock_service
             .expect_call()
-            .withf(|req| {
-                assert_eq!(
-                    req.http_request.url(),
-                    &Uri::from_str("http://localhost:8001").unwrap()
-                );
-                true
-            })
+            .withf(|req| req.http_request.url() == &Uri::from_str("http://localhost:8001").unwrap())
             .times(1)
             .returning(move |req: SubgraphRequest| {
                 Ok(plugin_utils::SubgraphResponse::builder()


### PR DESCRIPTION
fixes #865

A regression happened during our switch to Axum which would mark incoming POST requests as GET, thus triggering our forbid_http_mutations layer, and preventing mutations on the router.
This PR fixes this, and introduces some tests. More integration or axum oriented tests should follow.

When writing a unit test to assert subgraph requests are POST, I noticed the test would never fail. this is because withf only acts as a request router, and panicking (or in our case asserting) within wouldnt cause the router to fail.

This commit rewrites a couple of subgraph tests so they properly notify whether they completed successfully or failed.