### PR TITLE
fix: extract operation name correctly from a get query.

### DIFF
--- a/apollo-router-core/src/request.rs
+++ b/apollo-router-core/src/request.rs
@@ -63,7 +63,14 @@ impl Request {
         let urldecoded: serde_json::Value =
             serde_urlencoded::from_bytes(&decoded_string).map_err(serde_json::Error::custom)?;
 
-        let operation_name = get_from_urldecoded(&urldecoded, "operationName")?;
+        let operation_name = if let Some(serde_json::Value::String(operation_name)) =
+            urldecoded.get("operationName")
+        {
+            Some(operation_name.clone())
+        } else {
+            None
+        };
+
         let query = if let Some(serde_json::Value::String(query)) = urldecoded.get("query") {
             Some(query.as_str())
         } else {


### PR DESCRIPTION
In a get query, the operation name was extracted as if it had been a JSON payload.
We misstook this bug for an instrument related issue (we thought instrumentation had a bug when it wouldnt display the operation name).

this PR adds http get and http post tests to make sure query and operation name will always be extracted correctly from the http server.
