### PR TITLE
release: v0.1.0-preview.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,68 @@ All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+# [v0.1.0-preview.5] - 2022-04-20
+## ❗ BREAKING ❗
+## 🚀 Features
+### Helm chart for the router [PR #861](https://github.com/apollographql/router/pull/861)
+
+[Helm](https://helm.sh) support provided by @damienpontifex.
+
+### Line precise error reporting [PR #830](https://github.com/apollographql/router/pull/782)
+The router will make a best effort to give line precise error reporting if the configuration was invalid.
+```yaml
+1. /telemetry/tracing/trace_config/sampler
+
+telemetry:
+  tracing:
+    trace_config:
+      service_name: router3
+      sampler: "0.3"
+               ^----- "0.3" is not valid under any of the given schemas
+```
+### Install experience [PR #820](https://github.com/apollographql/router/pull/820)
+
+Added an install script that will automatically download and unzip the router into the local directory.
+For more info see the quickstart documentation.
+
+## 🐛 Fixes
+
+### Fix concurrent query planning [#846](https://github.com/apollographql/router/issues/846)
+The query planner has been reworked to make sure concurrent plan requests will be dispatched to the relevant requester.
+
+### Do not hang when tracing provider was not set as global [#849](https://github.com/apollographql/router/issues/847)
+The telemetry plugin will now Drop cleanly when the Router service stack fails to build.
+
+### Propagate error extensions originating from subgraphs [PR #839](https://github.com/apollographql/router/pull/839)
+Extensions are now propagated following the configuration of the `include_subgraph_error` plugin.
+
+### Telemetry configuration [PR #830](https://github.com/apollographql/router/pull/830)
+Jaeger and Zipkin telemetry config produced JSON schema that was invalid.
+
+### Return a better error when introspection is disabled [PR #751](https://github.com/apollographql/router/pull/751)
+Instead of returning an error coming from the query planner, we are now returning a proper error explaining that the introspection has been disabled.
+
+### Add operation name to subquery fetches [PR #840](https://github.com/apollographql/router/pull/840)
+If present in the query plan fetch node, the operation name will be added to sub-fetches.
+
+### Remove trailing slash from Datadog agent endpoint URL [PR #863](https://github.com/apollographql/router/pull/863)
+due to the way the endpoint URL is constructed in opentelemetry-datadog, we
+cannot set the agent endpoint to a URL with a trailing slash
+
+## 🛠 Maintenance
+### Configuration files validated [PR #830](https://github.com/apollographql/router/pull/830)
+Router configuration files within the project are now largely validated via unit test.
+
+### Switch web server framework from `warp` to `axum` [PR #751](https://github.com/apollographql/router/pull/751)
+The router is now running by default with an [axum](https://github.com/tokio-rs/axum/) web server instead of `warp`.
+
+### Improve the way we handle Request with axum [PR #845](https://github.com/apollographql/router/pull/845) [PR #877](https://github.com/apollographql/router/pull/877)
+Take advantages of new extractors given by `axum`
+
+## 📚 Documentation
+
+
 # [v0.1.0-preview.4] - 2022-04-11
 ## ❗ BREAKING ❗
 - **Telemetry simplification** [PR #782](https://github.com/apollographql/router/pull/782)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,7 @@ Instead of returning an error coming from the query planner, we are now returnin
 If present in the query plan fetch node, the operation name will be added to sub-fetches.
 
 ### Remove trailing slash from Datadog agent endpoint URL [PR #863](https://github.com/apollographql/router/pull/863)
-due to the way the endpoint URL is constructed in opentelemetry-datadog, we
-cannot set the agent endpoint to a URL with a trailing slash
+Due to the way the endpoint URL is constructed in opentelemetry-datadog, we cannot set the agent endpoint to a URL with a trailing slash.
 
 ## 🛠 Maintenance
 ### Configuration files validated [PR #830](https://github.com/apollographql/router/pull/830)
@@ -61,7 +60,7 @@ Router configuration files within the project are now largely validated via unit
 The router is now running by default with an [axum](https://github.com/tokio-rs/axum/) web server instead of `warp`.
 
 ### Improve the way we handle Request with axum [PR #845](https://github.com/apollographql/router/pull/845) [PR #877](https://github.com/apollographql/router/pull/877)
-Take advantages of new extractors given by `axum`
+Take advantages of new extractors given by `axum`.
 
 ## 📚 Documentation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,7 +93,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "0.1.0-preview.4"
+version = "0.1.0-preview.5"
 dependencies = [
  "anyhow",
  "apollo-parser 0.2.4",
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "0.1.0-preview.4"
+version = "0.1.0-preview.5"
 dependencies = [
  "apollo-router",
  "apollo-router-core",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-core"
-version = "0.1.0-preview.4"
+version = "0.1.0-preview.5"
 dependencies = [
  "apollo-parser 0.2.5",
  "async-trait",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-spaceport"
-version = "0.1.0-preview.4"
+version = "0.1.0-preview.5"
 dependencies = [
  "bytes",
  "clap 3.1.8",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-uplink"
-version = "0.1.0-preview.4"
+version = "0.1.0-preview.5"
 dependencies = [
  "futures",
  "graphql_client",
@@ -5545,7 +5545,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.1.0-preview.4"
+version = "0.1.0-preview.5"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -22,65 +22,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Description! And a link to a [reference](http://url)
 -->
 
-# [v0.1.0-preview.5] - (unreleased)
+# [v0.1.0-preview.6] - (unreleased)
 ## ❗ BREAKING ❗
+
 ## 🚀 Features
-### Helm chart for the router [PR #861](https://github.com/apollographql/router/pull/861)
-
-  [Helm](https://helm.sh) support provided by @damienpontifex.
-
-### Line precise error reporting [PR #830](https://github.com/apollographql/router/pull/782)
-The router will make a best effort to give line precise error reporting if the configuration was invalid.
-```yaml
-1. /telemetry/tracing/trace_config/sampler
-
-telemetry:
-  tracing:
-    trace_config:
-      service_name: router3
-      sampler: "0.3"
-               ^----- "0.3" is not valid under any of the given schemas
-```
-### Install experience [PR #820](https://github.com/apollographql/router/pull/820)
-
-  Added an install script that will automatically download and unzip the router into the local directory.
-  For more info see the quickstart documentation.
 
 ## 🐛 Fixes
 
-### Export the right operation name in Studio [#866](https://github.com/apollographql/router/issues/866)
-Due to the switch to axum, when the query was coming from a POST request, we didn't take the `operation_name` from the body.
-
-### Make sure concurrent query plan are not mixed up [#846](https://github.com/apollographql/router/issues/846)
-The query planner has been reworked to make sure concurrent plan requests will be dispatched to the relevant requester.
-
-### Do not hang when tracing provider was not set as global [#849](https://github.com/apollographql/router/issues/847)
-The telemetry plugin will now Drop cleanly when the Router service stack fails to build.
-
-### Propagate error extensions originating from subgraphs [PR #839](https://github.com/apollographql/router/pull/839)
-Extensions are now propagated following the configuration of the `include_subgraph_error` plugin.
-
-### Telemetry configuration [PR #830](https://github.com/apollographql/router/pull/830)
-Jaeger and Zipkin telemetry config produced JSON schema that was invalid.
-
-### Early return a better error when introspection is disabled [PR #751](https://github.com/apollographql/router/pull/751)
-Instead of returning an error coming from the query planner, we are now returning a proper error explaining that the introspection has been disabled.
-
-### Add operation name to subquery fetches [PR #840](https://github.com/apollographql/router/pull/840)
-If present in the query plan fetch noede, the operation name will be added to sub-fetches.
-
-### Remove trailing slash from Datadog agent endpoint URL [PR #863](https://github.com/apollographql/router/pull/863)
-due to the way the endpoint URL is constructed in opentelemetry-datadog, we
-cannot set the agent endpoint to a URL with a trailing slash
-
 ## 🛠 Maintenance
-### Configuration files validated [PR #830](https://github.com/apollographql/router/pull/830)
-Router configuration files within the project are now largely validated via unit test.
 
-### Switch web server framework from `warp` to `axum` [PR #751](https://github.com/apollographql/router/pull/751)
-The router is now running by default with an [axum](https://github.com/tokio-rs/axum/) web server instead of `warp`.
-
-### Improve the way we handle Request with axum [PR #845](https://github.com/apollographql/router/pull/845)
-Take advantages of new extractors given by `axum`
-  
 ## 📚 Documentation

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -12,34 +12,35 @@ If you are releasing a beta or a release candidate, no official changelog is
 needed, but you're not off the hook! You'll need to write testing instructions
 in lieu of an official changelog.
 
-1.  Open the associated milestone. All issues and PRs should be closed. If
+1. Open the associated milestone. All issues and PRs should be closed. If
     they are not you should reassign all open issues and PRs to future
     milestones.
-2.  Go through the commit history since the last release. Ensure that all PRs
+2. Go through the commit history since the last release. Ensure that all PRs
     that have landed are marked with the milestone. You can use this to
     show all the PRs that are merged on or after YYYY-MM-DD:
     `https://github.com/issues?utf8=%E2%9C%93&q=repo%3Aapollographql%2Frouter+merged%3A%3E%3DYYYY-MM-DD`
-3.  Go through the closed PRs in the milestone. Each should have a changelog
+3. Go through the closed PRs in the milestone. Each should have a changelog
     label indicating if the change is documentation, feature, fix, or
     maintenance. If there is a missing label, please add one. If it is a
     breaking change, also add a BREAKING label.
-4.  Set the release date in `NEXT_CHANGELOG.md`. Add this release to the
+4. Set the release date in `NEXT_CHANGELOG.md`. Add this release to the
     `CHANGELOG.md`. Use the structure of previous entries.
 
 ### Start a release PR
 
-1.  Make sure you have `cargo` installed on your machine and in your `PATH`.
-2.  Create a new branch "#.#.#" where "#.#.#" is this release's version
+1. Make sure you have `cargo` installed on your machine and in your `PATH`.
+2. Create a new branch "#.#.#" where "#.#.#" is this release's version
     (release) or "#.#.#-rc.#" (release candidate)
-3.  Update the version in `*/Cargo.toml`.
-4.  Update the date in `NEXT_CHANGELOG.md`.
-5.  Update the version in `deny.toml` in the `[[licenses.clarify]]` sections for `apollo-router-core`, `apollo-router` and `apollo-spaceport`.
-6.  Run `cargo check` so the lock file gets updated.
-7.  Run `cargo xtask check-compliance`.
-8.  Push up a commit with the `*/Cargo.toml`, `Cargo.lock`, `CHANGELOG.md` and
+3. Update the version in `*/Cargo.toml`.
+4. Update the version in `NEXT_CHANGELOG.md`.
+5. Clear `NEXT_CHANGELOG.md` leaving only the template.
+6. Update the version in `deny.toml` in the `[[licenses.clarify]]` sections for `apollo-router-core`, `apollo-router` and `apollo-spaceport`.
+7. Run `cargo check` so the lock file gets updated.
+8. Run `cargo xtask check-compliance`.
+9. Push up a commit with the `*/Cargo.toml`, `Cargo.lock`, `CHANGELOG.md` and
     `NEXT_CHANGELOG.md` changes. The commit message should be "release: v#.#.#" or
     "release: v#.#.#-rc.#"
-9.  Request review from the Router team.
+10. Request review from the Router team.
 
 ### Review
 

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "0.1.0-preview.4"
+version = "0.1.0-preview.5"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-core"
-version = "0.1.0-preview.4"
+version = "0.1.0-preview.5"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license-file = "./LICENSE"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -37,7 +37,7 @@ humantime-serde = "1.0.1"
 hyper = { version = "0.14.18", features = ["server"] }
 itertools = "0.10.3"
 indexmap = "1.8.1"
-jsonschema = { version = "0.15.1", default-features = false }
+jsonschema = { version = "=0.15.1", default-features = false }
 once_cell = "1.9.0"
 opentelemetry = { version = "0.17.0", features = [
     "rt-tokio",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "0.1.0-preview.4"
+version = "0.1.0-preview.5"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license-file = "./LICENSE"

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-spaceport"
-version = "0.1.0-preview.4"
+version = "0.1.0-preview.5"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license-file = "./LICENSE"

--- a/deny.toml
+++ b/deny.toml
@@ -64,13 +64,13 @@ license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 [[licenses.clarify]]
 name = "apollo-router"
 expression = "LicenseRef-ELv2"
-version = "0.1.0-preview.4"
+version = "0.1.0-preview.5"
 license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
 
 [[licenses.clarify]]
 name = "apollo-router-core"
 expression = "LicenseRef-ELv2"
-version = "0.1.0-preview.4"
+version = "0.1.0-preview.5"
 license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
 
 [[licenses.clarify]]
@@ -81,7 +81,7 @@ license-files = [{ path = "router-bridge/LICENSE", hash = 0xaceadac9 }]
 [[licenses.clarify]]
 name = "apollo-spaceport"
 expression = "LicenseRef-ELv2"
-version = "0.1.0-preview.4"
+version = "0.1.0-preview.5"
 license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
 
 [[licenses.clarify]]

--- a/docs/source/containerization/docker.mdx
+++ b/docs/source/containerization/docker.mdx
@@ -9,7 +9,7 @@ The default behaviour of the router images is suitable for a quickstart or devel
 
 Note: The [docker documentation](https://docs.docker.com/engine/reference/run/) for the run command may be helpful when reading through the examples.
 
-Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v0.1.0-preview.4`
+Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v0.1.0-preview.5`
 
 ## Override the configuration
 

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-uplink"
-version = "0.1.0-preview.4"
+version = "0.1.0-preview.5"
 edition = "2021"
 build = "build.rs"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.1.0-preview.4"
+version = "0.1.0-preview.5"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"


### PR DESCRIPTION
# [v0.1.0-preview.5] - 2022-04-20
## ❗ BREAKING ❗
## 🚀 Features
### Helm chart for the router [PR #861](https://github.com/apollographql/router/pull/861)

[Helm](https://helm.sh) support provided by @damienpontifex.

### Line precise error reporting [PR #830](https://github.com/apollographql/router/pull/782)
The router will make a best effort to give line precise error reporting if the configuration was invalid.
```yaml
1. /telemetry/tracing/trace_config/sampler

telemetry:
  tracing:
    trace_config:
      service_name: router3
      sampler: "0.3"
               ^----- "0.3" is not valid under any of the given schemas
```
### Install experience [PR #820](https://github.com/apollographql/router/pull/820)

Added an install script that will automatically download and unzip the router into the local directory.
For more info see the quickstart documentation.

## 🐛 Fixes

### Fix concurrent query planning [#846](https://github.com/apollographql/router/issues/846)
The query planner has been reworked to make sure concurrent plan requests will be dispatched to the relevant requester.

### Do not hang when tracing provider was not set as global [#849](https://github.com/apollographql/router/issues/847)
The telemetry plugin will now Drop cleanly when the Router service stack fails to build.

### Propagate error extensions originating from subgraphs [PR #839](https://github.com/apollographql/router/pull/839)
Extensions are now propagated following the configuration of the `include_subgraph_error` plugin.

### Telemetry configuration [PR #830](https://github.com/apollographql/router/pull/830)
Jaeger and Zipkin telemetry config produced JSON schema that was invalid.

### Return a better error when introspection is disabled [PR #751](https://github.com/apollographql/router/pull/751)
Instead of returning an error coming from the query planner, we are now returning a proper error explaining that the introspection has been disabled.

### Add operation name to subquery fetches [PR #840](https://github.com/apollographql/router/pull/840)
If present in the query plan fetch node, the operation name will be added to sub-fetches.

### Remove trailing slash from Datadog agent endpoint URL [PR #863](https://github.com/apollographql/router/pull/863)
due to the way the endpoint URL is constructed in opentelemetry-datadog, we
cannot set the agent endpoint to a URL with a trailing slash

## 🛠 Maintenance
### Configuration files validated [PR #830](https://github.com/apollographql/router/pull/830)
Router configuration files within the project are now largely validated via unit test.

### Switch web server framework from `warp` to `axum` [PR #751](https://github.com/apollographql/router/pull/751)
The router is now running by default with an [axum](https://github.com/tokio-rs/axum/) web server instead of `warp`.

### Improve the way we handle Request with axum [PR #845](https://github.com/apollographql/router/pull/845) [PR #877](https://github.com/apollographql/router/pull/877)
Take advantages of new extractors given by `axum`

## 📚 Documentation