### PR TITLE
fix: Restore the health check route

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -28,6 +28,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🚀 Features
 
 ## 🐛 Fixes
+
+### Restore the health check route [#883](https://github.com/apollographql/router/issues/883)
+Our axum rework caused the healthckeck route `/.well-known/apollo/server-health` to change. The route is now restored.
+
 ### Correctly flag incoming POST requests [#865](https://github.com/apollographql/router/issues/865)
 A regression happened during our recent switch to axum that would propagate incoming POST requests as GET requests. This has been fixed and we now have several regression tests, pending more integration tests.
 ## 🛠 Maintenance


### PR DESCRIPTION
fixes #883

Our axum rework caused the healthckeck route `/.well-known/apollo/server-health` to change. The route is now restored.