### PR TITLE
Bump cache version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ parameters:
   cache_version:
     type: string
     # increment that one to invalidate all the caches
-    default: v3.{{ checksum "rust-toolchain.toml" }}
+    default: v6.{{ checksum "rust-toolchain.toml" }}
 
 commands:
   initialize_submodules:


### PR DESCRIPTION
Bump the  cache version because OSX builds are currently failing.
Skipped v4 and v5 because we also used them in other branches recently