### PR TITLE
docs: use true path of "apollo telemetry" in sidebar config

### DIFF
--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -18,7 +18,7 @@
       "Tracing": "/configuration/tracing",
       "Traffic shaping": "/configuration/traffic-shaping",
       "Subgraph Error Inclusion": "/configuration/subgraph-error-inclusion",
-      "Usage reporting": "/configuration/spaceport"
+      "Usage reporting": "/configuration/apollo-telemetry"
     },
     "Containerization": {
       "Overview": "/containerization/overview",

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -17,7 +17,7 @@
       "Metrics": "/configuration/metrics",
       "Tracing": "/configuration/tracing",
       "Traffic shaping": "/configuration/traffic-shaping",
-      "Subgraph Error Inclusion": "/configuration/subgraph-error-inclusion",
+      "Subgraph Error Inclusion": "/configuration/subgraph-error-inclusion"
     },
     "Containerization": {
       "Overview": "/containerization/overview",

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -18,7 +18,6 @@
       "Tracing": "/configuration/tracing",
       "Traffic shaping": "/configuration/traffic-shaping",
       "Subgraph Error Inclusion": "/configuration/subgraph-error-inclusion",
-      "Usage reporting": "/configuration/apollo-telemetry"
     },
     "Containerization": {
       "Overview": "/containerization/overview",


### PR DESCRIPTION
This updates the sidebar docs URL to use the real path for the new location of these docs, rather than continuing to rely on a redirect — as supplied by #881. 

This follows-up on #782, which probably should have updated this originally when the page itself was moved to `apollo-telemetry` from `spaceport`.