### PR TITLE
chore: Update to use new CircleCI Gen2 Mac resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ executors:
   rust_macos: &rust_macos_executor
     macos:
       xcode: 11.4
+    resource_class: macos.x86.medium.gen2
   rust_windows: &rust_windows_executor
     machine:
       image: "windows-server-2019-vs2019:stable"


### PR DESCRIPTION
The new resource class for macOS instances introduced in November offer faster CPU options and could are expected to reduce our build times.

Ref: https://discuss.circleci.com/t/coming-soon-gen2-macos-resources/41886
Ref: https://circleci.com/docs/2.0/configuration-reference/#macos-executor

Fixes: https://github.com/apollographql/router/issues/903