### PR TITLE
add a test for #827

### DIFF
--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -671,4 +671,12 @@ mod tests {
         let result = Value::from_path(&path, json);
         assert_eq!(result, json!({"obj":{"arr":[null, {"prop1":1}]}}));
     }
+
+    #[test]
+    fn test_from_path_flatten() {
+        let json = json!({"prop1":1});
+        let path = Path::from("obj/arr/@/obj2");
+        let result = Value::from_path(&path, json);
+        assert_eq!(result, json!({"obj":{"arr":null}}));
+    }
 }


### PR DESCRIPTION
Fix #834 

if we try to create a JSON object from an existing one and a path that
contains a "flatten" node, we should stop at the flatten node because we
have no way of knowing the expected shape past that (number of array
elements, etc)
