### PR TITLE
add client awareness headers to CORS default configuration

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -81,6 +81,10 @@ All windows processes are spawned via xtask rather than a separate CircleCI stag
 ### Enable default feature in graphql_client [PR #905](https://github.com/apollographql/router/pull/905)
 removing the default feature can cause build issues in plugins.
 
+## Add client awareness headers to CORS allowed headers [PR #917](https://github.com/apollographql/router/pull/917)
+
+The client awareness headers are now added by default to the list of CORS allowed headers, for easier integration of brower based applications. We also document how to override them and update the CORS configuration accordingly.
+
 ## 📚 Documentation
 ### Enhanced rust docs ([PR #819](https://github.com/apollographql/router/pull/819))
 Many more rust docs have been added.

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -341,7 +341,11 @@ fn default_origins() -> Vec<String> {
 }
 
 fn default_cors_headers() -> Vec<String> {
-    vec!["Content-Type".into()]
+    vec![
+        "Content-Type".into(),
+        "apollographql-client-name".into(),
+        "apollographql-client-version".into(),
+    ]
 }
 
 fn default_cors_methods() -> Vec<String> {

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 567
+assertion_line: 562
 expression: "&schema"
 ---
 {
@@ -349,7 +349,9 @@ expression: "&schema"
             "allow_headers": {
               "description": "The headers to allow. Defaults to the required request header for Apollo Studio",
               "default": [
-                "Content-Type"
+                "Content-Type",
+                "apollographql-client-name",
+                "apollographql-client-version"
               ],
               "type": "array",
               "items": {

--- a/docs/source/managed-federation/client awareness.mdx
+++ b/docs/source/managed-federation/client awareness.mdx
@@ -1,0 +1,28 @@
+---
+title: Client awareness
+---
+
+import { Link } from "gatsby";
+
+The router supports [client awareness](https://www.apollographql.com/docs/kotlin/advanced/client-awareness/) by default:
+if the client sets the headers `apollographql-client-name` and `apollographql-client-version` in its HTTP requests,
+Apollo Studio will be able to separate the metrics and queries per client.
+
+## Overriding client awareness headers
+
+Different header names can be used by updating the configuration file. If those headers will be sent by
+a browser, they must be allowed in the [CORS (Cross Origin Resource Sharing) configuration](../configuration/cors), as follows:
+
+```yaml title="router.yaml"
+telemetry:
+  apollo:
+    # defaults to apollographql-client-name
+    client_name_header: MyClientHeaderName
+    # defaults to apollographql-client-version
+    client_version_header: MyClientHeaderVersion
+server:
+  cors:
+    # The headers to allow.
+    # (Defaults to [ Content-Type ], which is required for Apollo Studio)
+    allow_headers: [ Content-Type, MyClientHeaderName, MyClientHeaderVersion]
+```


### PR DESCRIPTION
Fix #127

The client awareness headers can be used by browser based applications,
and as such should be part of the headers allowed by CORS configuration.

This PR also adds a doc page about client awareness and indicates how to override the headers