### PR TITLE
no need to keep jsonschema pinned at 0.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba9278850dcb3a55938dfc2843701c5e26746d1679310bf5480c01d1a1cefe37"
+checksum = "4ebd40599e7f1230ce296f73b88c022b98ed66689f97eaa54bbeadc337a2ffa6"
 dependencies = [
  "ahash",
  "anyhow",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -37,9 +37,7 @@ humantime-serde = "1.0.1"
 hyper = { version = "0.14.18", features = ["server"] }
 itertools = "0.10.3"
 indexmap = "1.8.1"
-# Pinning to 0.15.1 until various issues around jsonschema mis-compilation with features are fixed
-# https://github.com/Stranger6667/jsonschema-rs/issues/356 (for example)
-jsonschema = { version = "=0.15.1", default-features = false }
+jsonschema = { version = "0.16.0", default-features = false }
 once_cell = "1.9.0"
 opentelemetry = { version = "0.17.0", features = [
     "rt-tokio",


### PR DESCRIPTION
The author has released a new version (0.16.0) which fixes the issues in
0.15.2. Time to update.

fixes: #874