### PR TITLE
add otel.kind and otel.status_code to follow otel spec

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -54,6 +54,9 @@ In addition, the `activate` lifecycle hook is now not marked as deprecated, and 
 
 ## 🚀 Features
 
+### Add SpanKind and SpanStatusCode to follow the opentelemetry spec [PR #925](https://github.com/apollographql/router/pull/925)
+Spans now contains [`otel.kind`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#spankind) and [`otel.status_code`](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/api.md#set-status) attributes when needed to follow the opentelemtry spec .
+
 ###  Configurable client identification headers [PR #850](https://github.com/apollographql/router/pull/850)
 The router uses the HTTP headers `apollographql-client-name` and `apollographql-client-version` to identify clients in Studio telemetry. Those headers can now be overriden in the configuration:
 ```yaml title="router.yaml"

--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -6,6 +6,7 @@ pub use bridge_query_planner::*;
 pub use caching_query_planner::*;
 use fetch::OperationKind;
 use futures::prelude::*;
+use opentelemetry::trace::SpanKind;
 use serde::Deserialize;
 use std::collections::HashSet;
 use tracing::Instrument;
@@ -205,7 +206,10 @@ impl PlanNode {
                             originating_request,
                             schema,
                         )
-                        .instrument(tracing::info_span!("fetch"))
+                        .instrument(tracing::info_span!(
+                            "fetch",
+                            "otel.kind" = %SpanKind::Internal
+                        ))
                         .await
                     {
                         Ok((v, e)) => {

--- a/apollo-router-core/src/spec/query.rs
+++ b/apollo-router-core/src/spec/query.rs
@@ -5,7 +5,6 @@
 use crate::{fetch::OperationKind, prelude::graphql::*};
 use apollo_parser::ast;
 use derivative::Derivative;
-use opentelemetry::trace::SpanKind;
 use serde_json_bytes::ByteString;
 use std::collections::{HashMap, HashSet};
 use tracing::level_filters::LevelFilter;

--- a/apollo-router-core/src/spec/query.rs
+++ b/apollo-router-core/src/spec/query.rs
@@ -84,8 +84,6 @@ impl Query {
             failfast_debug!("invalid type for data in response.");
         }
     }
-
-    #[tracing::instrument(skip_all, level = "info" name = "parse_query", fields(otel.kind=%SpanKind::Internal) )]
     pub fn parse(query: impl Into<String>, schema: &Schema) -> Option<Self> {
         let string = query.into();
 

--- a/apollo-router-core/src/spec/query.rs
+++ b/apollo-router-core/src/spec/query.rs
@@ -5,6 +5,7 @@
 use crate::{fetch::OperationKind, prelude::graphql::*};
 use apollo_parser::ast;
 use derivative::Derivative;
+use opentelemetry::trace::SpanKind;
 use serde_json_bytes::ByteString;
 use std::collections::{HashMap, HashSet};
 use tracing::level_filters::LevelFilter;
@@ -84,7 +85,7 @@ impl Query {
         }
     }
 
-    #[tracing::instrument(skip_all, level = "info" name = "parse_query")]
+    #[tracing::instrument(skip_all, level = "info" name = "parse_query", fields(otel.kind=%SpanKind::Internal) )]
     pub fn parse(query: impl Into<String>, schema: &Schema) -> Option<Self> {
         let string = query.into();
 

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -120,7 +120,7 @@ impl HttpServerFactory for AxumHttpServerFactory {
                 .route("/.well-known/apollo/server-health", get(health_check))
                 .layer(
                     TraceLayer::new_for_http()
-                        .make_span_with(PropagatingMakeSpan::new(Level::INFO))
+                        .make_span_with(PropagatingMakeSpan::new())
                         .on_response(|resp: &Response<_>, _duration: Duration, span: &Span| {
                             if resp.status() >= StatusCode::BAD_REQUEST {
                                 span.record(
@@ -528,8 +528,8 @@ struct PropagatingMakeSpan {
 }
 
 impl PropagatingMakeSpan {
-    fn new(level: Level) -> Self {
-        Self { level }
+    fn new() -> Self {
+        Self { level: Level::INFO }
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -33,7 +33,7 @@ use tower::{service_fn, BoxError, ServiceBuilder, ServiceExt};
 use url::Url;
 
 mod apollo;
-mod config;
+pub mod config;
 mod metrics;
 mod otlp;
 mod tracing;

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -1,6 +1,8 @@
+use apollo_router::plugins::telemetry::config::Tracing;
+use apollo_router::plugins::telemetry::{self, Telemetry};
 use apollo_router_core::{
-    http_compat, prelude::*, Object, PluggableRouterServiceBuilder, ResponseBody, RouterRequest,
-    RouterResponse, Schema, SubgraphRequest, TowerSubgraphService, ValueExt,
+    http_compat, prelude::*, Object, PluggableRouterServiceBuilder, Plugin, ResponseBody,
+    RouterRequest, RouterResponse, Schema, SubgraphRequest, TowerSubgraphService, ValueExt,
 };
 use http::Method;
 use maplit::hashmap;
@@ -533,6 +535,14 @@ async fn setup_router_and_registry() -> (
     let counting_registry = CountingServiceRegistry::new();
     let subgraphs = schema.subgraphs();
     let mut builder = PluggableRouterServiceBuilder::new(schema.clone());
+    let telemetry_plugin = Telemetry::new(telemetry::config::Conf {
+        metrics: Option::default(),
+        tracing: Some(Tracing::default()),
+        apollo: Option::default(),
+    })
+    .await
+    .unwrap();
+    builder = builder.with_dyn_plugin("apollo.telemetry".to_string(), Box::new(telemetry_plugin));
     for (name, _url) in subgraphs {
         let cloned_counter = counting_registry.clone();
         let cloned_name = name.clone();

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/tests/integration_tests.rs
-assertion_line: 140
+assertion_line: 132
 expression: get_spans()
 ---
 {
@@ -18,6 +18,29 @@ expression: get_spans()
     }
   },
   "children": {
+    "apollo_router_core::query_cache::parse_query": {
+      "name": "apollo_router_core::query_cache::parse_query",
+      "record": {
+        "entries": [
+          [
+            "otel.kind",
+            "internal"
+          ]
+        ],
+        "metadata": {
+          "name": "parse_query",
+          "target": "apollo_router_core::query_cache",
+          "level": "INFO",
+          "module_path": "apollo_router_core::query_cache",
+          "fields": {
+            "names": [
+              "otel.kind"
+            ]
+          }
+        }
+      },
+      "children": {}
+    },
     "apollo_router_core::query_planner::sequence": {
       "name": "apollo_router_core::query_planner::sequence",
       "record": {

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
@@ -146,14 +146,21 @@ expression: get_spans()
                 "apollo_router_core::query_planner::fetch": {
                   "name": "apollo_router_core::query_planner::fetch",
                   "record": {
-                    "entries": [],
+                    "entries": [
+                      [
+                        "otel.kind",
+                        "internal"
+                      ]
+                    ],
                     "metadata": {
                       "name": "fetch",
                       "target": "apollo_router_core::query_planner",
                       "level": "INFO",
                       "module_path": "apollo_router_core::query_planner",
                       "fields": {
-                        "names": []
+                        "names": [
+                          "otel.kind"
+                        ]
                       }
                     }
                   },

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/tests/integration_tests.rs
-assertion_line: 132
+assertion_line: 134
 expression: get_spans()
 ---
 {
@@ -18,102 +18,209 @@ expression: get_spans()
     }
   },
   "children": {
-    "apollo_router_core::query_cache::parse_query": {
-      "name": "apollo_router_core::query_cache::parse_query",
+    "apollo_router::plugins::telemetry::router": {
+      "name": "apollo_router::plugins::telemetry::router",
       "record": {
         "entries": [
+          [
+            "query",
+            "{ topProducts { upc name reviews {id product { name } author { id name } } } }"
+          ],
+          [
+            "operation_name",
+            ""
+          ],
+          [
+            "client_name",
+            ""
+          ],
+          [
+            "client_version",
+            ""
+          ],
           [
             "otel.kind",
             "internal"
           ]
         ],
         "metadata": {
-          "name": "parse_query",
-          "target": "apollo_router_core::query_cache",
+          "name": "router",
+          "target": "apollo_router::plugins::telemetry",
           "level": "INFO",
-          "module_path": "apollo_router_core::query_cache",
+          "module_path": "apollo_router::plugins::telemetry",
           "fields": {
             "names": [
+              "query",
+              "operation_name",
+              "client_name",
+              "client_version",
               "otel.kind"
             ]
           }
         }
       },
-      "children": {}
-    },
-    "apollo_router_core::query_planner::sequence": {
-      "name": "apollo_router_core::query_planner::sequence",
-      "record": {
-        "entries": [],
-        "metadata": {
-          "name": "sequence",
-          "target": "apollo_router_core::query_planner",
-          "level": "INFO",
-          "module_path": "apollo_router_core::query_planner",
-          "fields": {
-            "names": []
-          }
-        }
-      },
       "children": {
-        "apollo_router_core::query_planner::fetch": {
-          "name": "apollo_router_core::query_planner::fetch",
+        "apollo_router_core::query_cache::parse_query": {
+          "name": "apollo_router_core::query_cache::parse_query",
           "record": {
-            "entries": [],
+            "entries": [
+              [
+                "otel.kind",
+                "internal"
+              ]
+            ],
             "metadata": {
-              "name": "fetch",
-              "target": "apollo_router_core::query_planner",
+              "name": "parse_query",
+              "target": "apollo_router_core::query_cache",
               "level": "INFO",
-              "module_path": "apollo_router_core::query_planner",
+              "module_path": "apollo_router_core::query_cache",
               "fields": {
-                "names": []
+                "names": [
+                  "otel.kind"
+                ]
+              }
+            }
+          },
+          "children": {}
+        },
+        "apollo_router::plugins::telemetry::query_planning": {
+          "name": "apollo_router::plugins::telemetry::query_planning",
+          "record": {
+            "entries": [
+              [
+                "otel.kind",
+                "internal"
+              ]
+            ],
+            "metadata": {
+              "name": "query_planning",
+              "target": "apollo_router::plugins::telemetry",
+              "level": "INFO",
+              "module_path": "apollo_router::plugins::telemetry",
+              "fields": {
+                "names": [
+                  "otel.kind"
+                ]
+              }
+            }
+          },
+          "children": {}
+        },
+        "apollo_router::plugins::telemetry::execution": {
+          "name": "apollo_router::plugins::telemetry::execution",
+          "record": {
+            "entries": [
+              [
+                "otel.kind",
+                "internal"
+              ]
+            ],
+            "metadata": {
+              "name": "execution",
+              "target": "apollo_router::plugins::telemetry",
+              "level": "INFO",
+              "module_path": "apollo_router::plugins::telemetry",
+              "fields": {
+                "names": [
+                  "otel.kind"
+                ]
               }
             }
           },
           "children": {
-            "apollo_router_core::query_planner::fetch::make_variables": {
-              "name": "apollo_router_core::query_planner::fetch::make_variables",
+            "apollo_router_core::query_planner::sequence": {
+              "name": "apollo_router_core::query_planner::sequence",
               "record": {
                 "entries": [],
                 "metadata": {
-                  "name": "make_variables",
-                  "target": "apollo_router_core::query_planner::fetch",
-                  "level": "DEBUG",
-                  "module_path": "apollo_router_core::query_planner::fetch",
+                  "name": "sequence",
+                  "target": "apollo_router_core::query_planner",
+                  "level": "INFO",
+                  "module_path": "apollo_router_core::query_planner",
                   "fields": {
                     "names": []
                   }
                 }
               },
-              "children": {}
-            },
-            "apollo_router_core::query_planner::fetch::response_insert": {
-              "name": "apollo_router_core::query_planner::fetch::response_insert",
-              "record": {
-                "entries": [],
-                "metadata": {
-                  "name": "response_insert",
-                  "target": "apollo_router_core::query_planner::fetch",
-                  "level": "DEBUG",
-                  "module_path": "apollo_router_core::query_planner::fetch",
-                  "fields": {
-                    "names": []
+              "children": {
+                "apollo_router_core::query_planner::fetch": {
+                  "name": "apollo_router_core::query_planner::fetch",
+                  "record": {
+                    "entries": [],
+                    "metadata": {
+                      "name": "fetch",
+                      "target": "apollo_router_core::query_planner",
+                      "level": "INFO",
+                      "module_path": "apollo_router_core::query_planner",
+                      "fields": {
+                        "names": []
+                      }
+                    }
+                  },
+                  "children": {
+                    "apollo_router_core::query_planner::fetch::make_variables": {
+                      "name": "apollo_router_core::query_planner::fetch::make_variables",
+                      "record": {
+                        "entries": [],
+                        "metadata": {
+                          "name": "make_variables",
+                          "target": "apollo_router_core::query_planner::fetch",
+                          "level": "DEBUG",
+                          "module_path": "apollo_router_core::query_planner::fetch",
+                          "fields": {
+                            "names": []
+                          }
+                        }
+                      },
+                      "children": {}
+                    },
+                    "apollo_router_core::query_planner::fetch::response_insert": {
+                      "name": "apollo_router_core::query_planner::fetch::response_insert",
+                      "record": {
+                        "entries": [],
+                        "metadata": {
+                          "name": "response_insert",
+                          "target": "apollo_router_core::query_planner::fetch",
+                          "level": "DEBUG",
+                          "module_path": "apollo_router_core::query_planner::fetch",
+                          "fields": {
+                            "names": []
+                          }
+                        }
+                      },
+                      "children": {}
+                    }
                   }
+                },
+                "apollo_router_core::query_planner::parallel": {
+                  "name": "apollo_router_core::query_planner::parallel",
+                  "record": {
+                    "entries": [],
+                    "metadata": {
+                      "name": "parallel",
+                      "target": "apollo_router_core::query_planner",
+                      "level": "INFO",
+                      "module_path": "apollo_router_core::query_planner",
+                      "fields": {
+                        "names": []
+                      }
+                    }
+                  },
+                  "children": {}
                 }
-              },
-              "children": {}
+              }
             }
           }
         },
-        "apollo_router_core::query_planner::parallel": {
-          "name": "apollo_router_core::query_planner::parallel",
+        "apollo_router_core::services::router_service::format_response": {
+          "name": "apollo_router_core::services::router_service::format_response",
           "record": {
             "entries": [],
             "metadata": {
-              "name": "parallel",
-              "target": "apollo_router_core::query_planner",
-              "level": "INFO",
-              "module_path": "apollo_router_core::query_planner",
+              "name": "format_response",
+              "target": "apollo_router_core::services::router_service",
+              "level": "DEBUG",
+              "module_path": "apollo_router_core::services::router_service",
               "fields": {
                 "names": []
               }
@@ -122,22 +229,6 @@ expression: get_spans()
           "children": {}
         }
       }
-    },
-    "apollo_router_core::services::router_service::format_response": {
-      "name": "apollo_router_core::services::router_service::format_response",
-      "record": {
-        "entries": [],
-        "metadata": {
-          "name": "format_response",
-          "target": "apollo_router_core::services::router_service",
-          "level": "DEBUG",
-          "module_path": "apollo_router_core::services::router_service",
-          "fields": {
-            "names": []
-          }
-        }
-      },
-      "children": {}
     }
   }
 }

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
@@ -131,14 +131,21 @@ expression: get_spans()
             "apollo_router_core::query_planner::fetch": {
               "name": "apollo_router_core::query_planner::fetch",
               "record": {
-                "entries": [],
+                "entries": [
+                  [
+                    "otel.kind",
+                    "internal"
+                  ]
+                ],
                 "metadata": {
                   "name": "fetch",
                   "target": "apollo_router_core::query_planner",
                   "level": "INFO",
                   "module_path": "apollo_router_core::query_planner",
                   "fields": {
-                    "names": []
+                    "names": [
+                      "otel.kind"
+                    ]
                   }
                 }
               },

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/tests/integration_tests.rs
-assertion_line: 125
+assertion_line: 117
 expression: get_spans()
 ---
 {
@@ -18,6 +18,29 @@ expression: get_spans()
     }
   },
   "children": {
+    "apollo_router_core::query_cache::parse_query": {
+      "name": "apollo_router_core::query_cache::parse_query",
+      "record": {
+        "entries": [
+          [
+            "otel.kind",
+            "internal"
+          ]
+        ],
+        "metadata": {
+          "name": "parse_query",
+          "target": "apollo_router_core::query_cache",
+          "level": "INFO",
+          "module_path": "apollo_router_core::query_cache",
+          "fields": {
+            "names": [
+              "otel.kind"
+            ]
+          }
+        }
+      },
+      "children": {}
+    },
     "apollo_router_core::query_planner::fetch": {
       "name": "apollo_router_core::query_planner::fetch",
       "record": {

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/tests/integration_tests.rs
-assertion_line: 117
+assertion_line: 119
 expression: get_spans()
 ---
 {
@@ -18,69 +18,176 @@ expression: get_spans()
     }
   },
   "children": {
-    "apollo_router_core::query_cache::parse_query": {
-      "name": "apollo_router_core::query_cache::parse_query",
+    "apollo_router::plugins::telemetry::router": {
+      "name": "apollo_router::plugins::telemetry::router",
       "record": {
         "entries": [
+          [
+            "query",
+            "{ topProducts { name name2:name } }"
+          ],
+          [
+            "operation_name",
+            ""
+          ],
+          [
+            "client_name",
+            ""
+          ],
+          [
+            "client_version",
+            ""
+          ],
           [
             "otel.kind",
             "internal"
           ]
         ],
         "metadata": {
-          "name": "parse_query",
-          "target": "apollo_router_core::query_cache",
+          "name": "router",
+          "target": "apollo_router::plugins::telemetry",
           "level": "INFO",
-          "module_path": "apollo_router_core::query_cache",
+          "module_path": "apollo_router::plugins::telemetry",
           "fields": {
             "names": [
+              "query",
+              "operation_name",
+              "client_name",
+              "client_version",
               "otel.kind"
             ]
           }
         }
       },
-      "children": {}
-    },
-    "apollo_router_core::query_planner::fetch": {
-      "name": "apollo_router_core::query_planner::fetch",
-      "record": {
-        "entries": [],
-        "metadata": {
-          "name": "fetch",
-          "target": "apollo_router_core::query_planner",
-          "level": "INFO",
-          "module_path": "apollo_router_core::query_planner",
-          "fields": {
-            "names": []
-          }
-        }
-      },
       "children": {
-        "apollo_router_core::query_planner::fetch::make_variables": {
-          "name": "apollo_router_core::query_planner::fetch::make_variables",
+        "apollo_router_core::query_cache::parse_query": {
+          "name": "apollo_router_core::query_cache::parse_query",
           "record": {
-            "entries": [],
+            "entries": [
+              [
+                "otel.kind",
+                "internal"
+              ]
+            ],
             "metadata": {
-              "name": "make_variables",
-              "target": "apollo_router_core::query_planner::fetch",
-              "level": "DEBUG",
-              "module_path": "apollo_router_core::query_planner::fetch",
+              "name": "parse_query",
+              "target": "apollo_router_core::query_cache",
+              "level": "INFO",
+              "module_path": "apollo_router_core::query_cache",
               "fields": {
-                "names": []
+                "names": [
+                  "otel.kind"
+                ]
               }
             }
           },
           "children": {}
         },
-        "apollo_router_core::query_planner::fetch::response_insert": {
-          "name": "apollo_router_core::query_planner::fetch::response_insert",
+        "apollo_router::plugins::telemetry::query_planning": {
+          "name": "apollo_router::plugins::telemetry::query_planning",
+          "record": {
+            "entries": [
+              [
+                "otel.kind",
+                "internal"
+              ]
+            ],
+            "metadata": {
+              "name": "query_planning",
+              "target": "apollo_router::plugins::telemetry",
+              "level": "INFO",
+              "module_path": "apollo_router::plugins::telemetry",
+              "fields": {
+                "names": [
+                  "otel.kind"
+                ]
+              }
+            }
+          },
+          "children": {}
+        },
+        "apollo_router::plugins::telemetry::execution": {
+          "name": "apollo_router::plugins::telemetry::execution",
+          "record": {
+            "entries": [
+              [
+                "otel.kind",
+                "internal"
+              ]
+            ],
+            "metadata": {
+              "name": "execution",
+              "target": "apollo_router::plugins::telemetry",
+              "level": "INFO",
+              "module_path": "apollo_router::plugins::telemetry",
+              "fields": {
+                "names": [
+                  "otel.kind"
+                ]
+              }
+            }
+          },
+          "children": {
+            "apollo_router_core::query_planner::fetch": {
+              "name": "apollo_router_core::query_planner::fetch",
+              "record": {
+                "entries": [],
+                "metadata": {
+                  "name": "fetch",
+                  "target": "apollo_router_core::query_planner",
+                  "level": "INFO",
+                  "module_path": "apollo_router_core::query_planner",
+                  "fields": {
+                    "names": []
+                  }
+                }
+              },
+              "children": {
+                "apollo_router_core::query_planner::fetch::make_variables": {
+                  "name": "apollo_router_core::query_planner::fetch::make_variables",
+                  "record": {
+                    "entries": [],
+                    "metadata": {
+                      "name": "make_variables",
+                      "target": "apollo_router_core::query_planner::fetch",
+                      "level": "DEBUG",
+                      "module_path": "apollo_router_core::query_planner::fetch",
+                      "fields": {
+                        "names": []
+                      }
+                    }
+                  },
+                  "children": {}
+                },
+                "apollo_router_core::query_planner::fetch::response_insert": {
+                  "name": "apollo_router_core::query_planner::fetch::response_insert",
+                  "record": {
+                    "entries": [],
+                    "metadata": {
+                      "name": "response_insert",
+                      "target": "apollo_router_core::query_planner::fetch",
+                      "level": "DEBUG",
+                      "module_path": "apollo_router_core::query_planner::fetch",
+                      "fields": {
+                        "names": []
+                      }
+                    }
+                  },
+                  "children": {}
+                }
+              }
+            }
+          }
+        },
+        "apollo_router_core::services::router_service::format_response": {
+          "name": "apollo_router_core::services::router_service::format_response",
           "record": {
             "entries": [],
             "metadata": {
-              "name": "response_insert",
-              "target": "apollo_router_core::query_planner::fetch",
+              "name": "format_response",
+              "target": "apollo_router_core::services::router_service",
               "level": "DEBUG",
-              "module_path": "apollo_router_core::query_planner::fetch",
+              "module_path": "apollo_router_core::services::router_service",
               "fields": {
                 "names": []
               }
@@ -89,22 +196,6 @@ expression: get_spans()
           "children": {}
         }
       }
-    },
-    "apollo_router_core::services::router_service::format_response": {
-      "name": "apollo_router_core::services::router_service::format_response",
-      "record": {
-        "entries": [],
-        "metadata": {
-          "name": "format_response",
-          "target": "apollo_router_core::services::router_service",
-          "level": "DEBUG",
-          "module_path": "apollo_router_core::services::router_service",
-          "fields": {
-            "names": []
-          }
-        }
-      },
-      "children": {}
     }
   }
 }


### PR DESCRIPTION
close #909 

I added `SpanKind` and `SpanStatusCode` to be compliant with the otel spec and also follow the same rules than the Gateway. 
I also added a `.instrument(...)` to be able to see the parsing of the query in our main trace, before it was considered as a standalone span because it's spawned with a `spawn_blocking`