### PR TITLE
proper behaviour for the response data field

### DIFF
--- a/apollo-router-core/src/query_planner/mod.rs
+++ b/apollo-router-core/src/query_planner/mod.rs
@@ -467,7 +467,7 @@ pub(crate) mod fetch {
                 })
                 .collect();
 
-            self.response_at_path(current_dir, paths, response.data)
+            self.response_at_path(current_dir, paths, response.data.unwrap_or_default())
                 .map(|value| (value, errors))
         }
 

--- a/apollo-router-core/src/query_planner/selection.rs
+++ b/apollo-router-core/src/query_planner/selection.rs
@@ -140,9 +140,13 @@ mod tests {
         schema: &Schema,
     ) -> Result<Value, FetchError> {
         let mut values = Vec::new();
-        response.data.select_values_and_paths(path, |_path, value| {
-            values.push(value);
-        });
+        response
+            .data
+            .as_ref()
+            .unwrap()
+            .select_values_and_paths(path, |_path, value| {
+                values.push(value);
+            });
 
         Ok(Value::Array(
             values

--- a/apollo-router-core/src/response.rs
+++ b/apollo-router-core/src/response.rs
@@ -15,9 +15,9 @@ pub struct Response {
     pub label: Option<String>,
 
     /// The response data.
-    #[serde(skip_serializing_if = "skip_data_if", default)]
-    #[builder(default = Value::Object(Default::default()))]
-    pub data: Value,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    #[builder(default, setter(strip_option))]
+    pub data: Option<Value>,
 
     /// The path that the data should be merged at.
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -33,14 +33,6 @@ pub struct Response {
     #[serde(skip_serializing_if = "Object::is_empty", default)]
     #[builder(default)]
     pub extensions: Object,
-}
-
-fn skip_data_if(value: &Value) -> bool {
-    match value {
-        Value::Object(o) => o.is_empty(),
-        Value::Null => true,
-        _ => false,
-    }
 }
 
 impl Response {
@@ -65,7 +57,7 @@ impl Response {
                 reason: error.to_string(),
             })?;
 
-        let data = extract_key_value_from_object!(object, "data").unwrap_or_default();
+        let data = extract_key_value_from_object!(object, "data");
         let errors = extract_key_value_from_object!(object, "errors", Value::Array(v) => v)
             .map_err(|err| FetchError::SubrequestMalformedResponse {
                 service: service_name.to_string(),

--- a/apollo-router-core/src/services/mod.rs
+++ b/apollo-router-core/src/services/mod.rs
@@ -230,7 +230,7 @@ impl RouterResponse {
     /// Required parameters are required in non-testing code to create a RouterResponse..
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        data: Value,
+        data: Option<Value>,
         path: Option<Path>,
         errors: Vec<crate::Error>,
         extensions: HashMap<String, Value>,
@@ -243,12 +243,14 @@ impl RouterResponse {
             .map(|(name, value)| (ByteString::from(name), value))
             .collect();
         // Build a response
-        let res = Response::builder()
-            .data(data)
+        let b = Response::builder()
             .path(path)
             .errors(errors)
-            .extensions(extensions)
-            .build();
+            .extensions(extensions);
+        let res = match data {
+            Some(data) => b.data(data).build(),
+            None => b.build(),
+        };
 
         // Build an http Response
         let mut builder = http::Response::builder().status(status_code.unwrap_or(StatusCode::OK));
@@ -291,7 +293,7 @@ impl RouterResponse {
         context: Option<Context>,
     ) -> Result<RouterResponse, BoxError> {
         RouterResponse::new(
-            data.unwrap_or_default(),
+            data,
             path,
             errors,
             extensions,

--- a/apollo-router-core/src/services/router_service.rs
+++ b/apollo-router-core/src/services/router_service.rs
@@ -13,7 +13,6 @@ use crate::{
 use futures::{future::BoxFuture, TryFutureExt};
 use http::StatusCode;
 use indexmap::IndexMap;
-use serde_json_bytes::Value;
 use std::sync::Arc;
 use std::task::Poll;
 use tower::buffer::Buffer;
@@ -204,7 +203,6 @@ where
                     ..Default::default()
                 }];
                 RouterResponse::builder()
-                    .data(Value::default())
                     .errors(errors)
                     .status_code(StatusCode::INTERNAL_SERVER_ERROR)
                     .context(context_cloned)

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -42,14 +42,15 @@ macro_rules! assert_federated_response {
         tracing::debug!("query:\n{}\n", $query);
 
         assert!(
-            expected.data.is_object(),
+            expected.data.as_ref().unwrap().is_object(),
             "nodejs: no response's data: please check that the gateway and the subgraphs are running",
         );
 
         tracing::debug!("expected: {}", to_string_pretty(&expected).unwrap());
         tracing::debug!("actual: {}", to_string_pretty(&actual).unwrap());
 
-        assert!(expected.data.eq_and_ordered(&actual.data));
+        assert!(expected.data.as_ref().expect("expected data should not be none")
+        .eq_and_ordered(&actual.data.as_ref().expect("received data should not be none")));
         assert_eq!(registry.totals(), $service_requests);
     };
 }


### PR DESCRIPTION
fix #859

According to the GraphQL specification (
https://spec.graphql.org/October2021/#sec-Response ), the `data` field
in the response can have varying behaviours:

> If an error was raised before execution begins, the data entry should
not be present in the result.

> If an error was raised during the execution that prevented a valid
response, the data entry in the response should be null.

Following this, we make the data field optional, and set it to
Some(Value::Null) on errors in query execution.

Looking at this also means we should handle that format from subgraphs
