### PR TITLE
Prevent spans from being created for healthcheck requests.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -69,8 +69,11 @@ telemetry:
 ### Fields in the root selection set of a query are now correctly skipped and included [PR #931](https://github.com/apollographql/router/pull/931)
 The `@skip` and `@include` directives are now executed for the fields in the root selection set.
 
-###  Configuration errors on hot-reload are output [PR #850](https://github.com/apollographql/router/pull/850)
+### Configuration errors on hot-reload are output [PR #850](https://github.com/apollographql/router/pull/850)
 If a configuration file had errors on reload these were silently swallowed. These are now added to the logs.
+
+### Telemetry spans are no longer created for healthcheck requests [PR #938](https://github.com/apollographql/router/pull/938)
+Telemetry spans where previously being created for the healthcheck requests which was creating noisy telemetry for users.
 
 ## 🛠 Maintenance
 ### End to end integration tests for Jaeger [PR #850](https://github.com/apollographql/router/pull/850)

--- a/apollo-router/src/snapshots/apollo_router__axum_http_server_factory__tests__display_home_page.snap
+++ b/apollo-router/src/snapshots/apollo_router__axum_http_server_factory__tests__display_home_page.snap
@@ -1,0 +1,88 @@
+---
+source: apollo-router/src/axum_http_server_factory.rs
+assertion_line: 727
+expression: "test_span::get_spans_for_root(&root_span.id().unwrap(),\n    &test_span::Filter::new(Level::INFO))"
+---
+{
+  "name": "apollo_router::axum_http_server_factory::tests::root",
+  "record": {
+    "entries": [],
+    "metadata": {
+      "name": "root",
+      "target": "apollo_router::axum_http_server_factory::tests",
+      "level": "INFO",
+      "module_path": "apollo_router::axum_http_server_factory::tests",
+      "fields": {
+        "names": []
+      }
+    }
+  },
+  "children": {
+    "tower_http::trace::make_span::request": {
+      "name": "tower_http::trace::make_span::request",
+      "record": {
+        "entries": [
+          [
+            "method",
+            "GET"
+          ],
+          [
+            "uri",
+            "/"
+          ],
+          [
+            "version",
+            "HTTP/1.1"
+          ]
+        ],
+        "metadata": {
+          "name": "request",
+          "target": "tower_http::trace::make_span",
+          "level": "INFO",
+          "module_path": "tower_http::trace::make_span",
+          "fields": {
+            "names": [
+              "method",
+              "uri",
+              "version"
+            ]
+          }
+        }
+      },
+      "children": {}
+    },
+    "tower_http::trace::make_span::request": {
+      "name": "tower_http::trace::make_span::request",
+      "record": {
+        "entries": [
+          [
+            "method",
+            "GET"
+          ],
+          [
+            "uri",
+            "/graphql"
+          ],
+          [
+            "version",
+            "HTTP/1.1"
+          ]
+        ],
+        "metadata": {
+          "name": "request",
+          "target": "tower_http::trace::make_span",
+          "level": "INFO",
+          "module_path": "tower_http::trace::make_span",
+          "fields": {
+            "names": [
+              "method",
+              "uri",
+              "version"
+            ]
+          }
+        }
+      },
+      "children": {}
+    }
+  }
+}

--- a/apollo-router/src/snapshots/apollo_router__axum_http_server_factory__tests__health_check.snap
+++ b/apollo-router/src/snapshots/apollo_router__axum_http_server_factory__tests__health_check.snap
@@ -1,0 +1,21 @@
+---
+source: apollo-router/src/axum_http_server_factory.rs
+assertion_line: 1123
+expression: "test_span::get_spans_for_root(&root_span.id().unwrap(),\n    &test_span::Filter::new(Level::INFO))"
+---
+{
+  "name": "apollo_router::axum_http_server_factory::tests::root",
+  "record": {
+    "entries": [],
+    "metadata": {
+      "name": "root",
+      "target": "apollo_router::axum_http_server_factory::tests",
+      "level": "INFO",
+      "module_path": "apollo_router::axum_http_server_factory::tests",
+      "fields": {
+        "names": []
+      }
+    }
+  },
+  "children": {}
+}

--- a/apollo-router/src/snapshots/apollo_router__axum_http_server_factory__tests__it_extracts_query_and_operation_name_on_get_requests.snap
+++ b/apollo-router/src/snapshots/apollo_router__axum_http_server_factory__tests__it_extracts_query_and_operation_name_on_get_requests.snap
@@ -1,0 +1,54 @@
+---
+source: apollo-router/src/axum_http_server_factory.rs
+expression: "test_span::get_spans_for_root(&root_span.id().unwrap(),\n    &test_span::Filter::new(Level::INFO))"
+---
+{
+  "name": "apollo_router::axum_http_server_factory::tests::root",
+  "record": {
+    "entries": [],
+    "metadata": {
+      "name": "root",
+      "target": "apollo_router::axum_http_server_factory::tests",
+      "level": "INFO",
+      "module_path": "apollo_router::axum_http_server_factory::tests",
+      "fields": {
+        "names": []
+      }
+    }
+  },
+  "children": {
+    "tower_http::trace::make_span::request": {
+      "name": "tower_http::trace::make_span::request",
+      "record": {
+        "entries": [
+          [
+            "method",
+            "GET"
+          ],
+          [
+            "uri",
+            "/graphql?query=query&operationName=operationName"
+          ],
+          [
+            "version",
+            "HTTP/1.1"
+          ]
+        ],
+        "metadata": {
+          "name": "request",
+          "target": "tower_http::trace::make_span",
+          "level": "INFO",
+          "module_path": "tower_http::trace::make_span",
+          "fields": {
+            "names": [
+              "method",
+              "uri",
+              "version"
+            ]
+          }
+        }
+      },
+      "children": {}
+    }
+  }
+}

--- a/apollo-router/src/snapshots/apollo_router__axum_http_server_factory__tests__response.snap
+++ b/apollo-router/src/snapshots/apollo_router__axum_http_server_factory__tests__response.snap
@@ -1,0 +1,87 @@
+---
+source: apollo-router/src/axum_http_server_factory.rs
+expression: "test_span::get_spans_for_root(&root_span.id().unwrap(),\n    &test_span::Filter::new(Level::INFO))"
+---
+{
+  "name": "apollo_router::axum_http_server_factory::tests::root",
+  "record": {
+    "entries": [],
+    "metadata": {
+      "name": "root",
+      "target": "apollo_router::axum_http_server_factory::tests",
+      "level": "INFO",
+      "module_path": "apollo_router::axum_http_server_factory::tests",
+      "fields": {
+        "names": []
+      }
+    }
+  },
+  "children": {
+    "tower_http::trace::make_span::request": {
+      "name": "tower_http::trace::make_span::request",
+      "record": {
+        "entries": [
+          [
+            "method",
+            "POST"
+          ],
+          [
+            "uri",
+            "/graphql"
+          ],
+          [
+            "version",
+            "HTTP/1.1"
+          ]
+        ],
+        "metadata": {
+          "name": "request",
+          "target": "tower_http::trace::make_span",
+          "level": "INFO",
+          "module_path": "tower_http::trace::make_span",
+          "fields": {
+            "names": [
+              "method",
+              "uri",
+              "version"
+            ]
+          }
+        }
+      },
+      "children": {}
+    },
+    "tower_http::trace::make_span::request": {
+      "name": "tower_http::trace::make_span::request",
+      "record": {
+        "entries": [
+          [
+            "method",
+            "GET"
+          ],
+          [
+            "uri",
+            "/graphql?query=query"
+          ],
+          [
+            "version",
+            "HTTP/1.1"
+          ]
+        ],
+        "metadata": {
+          "name": "request",
+          "target": "tower_http::trace::make_span",
+          "level": "INFO",
+          "module_path": "tower_http::trace::make_span",
+          "fields": {
+            "names": [
+              "method",
+              "uri",
+              "version"
+            ]
+          }
+        }
+      },
+      "children": {}
+    }
+  }
+}


### PR DESCRIPTION
Telemetry spans where previously being created for the healthcheck requests which was creating noisy telemetry for users.
