### PR TITLE
upgrade test-span and then display more children spans in snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4542,9 +4542,9 @@ dependencies = [
 
 [[package]]
 name = "test-span"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0253fc94d43dcc581fc5a1150683b722d469013ed0b8e79ede0046333f18d243"
+checksum = "b9212327b97823ef8b5ed882b8b28f2b83d7199c7fe5fc607c2e8e88bfe3a2fd"
 dependencies = [
  "daggy",
  "derivative",
@@ -4563,9 +4563,9 @@ dependencies = [
 
 [[package]]
 name = "test-span-macro"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7563c12f5cd1424ed95688dc89b638f96947111d6aacc84610857d1ee2a7a328"
+checksum = "72f4a59cfac686d226a4dffce6613f0aa7ab73f6aea348f8cb48cb4891afc29c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -79,6 +79,9 @@ If a configuration file had errors on reload these were silently swallowed. Thes
 Telemetry spans where previously being created for the healthcheck requests which was creating noisy telemetry for users.
 
 ## 🛠 Maintenance
+### Upgrade `test-span` to display more children spans in our snapshots [PR #942](https://github.com/apollographql/router/pull/942)
+Previously in test-span before the fix [introduced here](https://github.com/apollographql/test-span/pull/13) we were filtering too aggressively. So if we wanted to snapshot all `DEBUG` level if we encountered a `TRACE` span which had `DEBUG` children then these children were not snapshotted. It's now fixed and it's more consistent with what we could have/see in jaeger.
+
 ### Finalize migration from Warp to Axum [PR #920](https://github.com/apollographql/router/pull/920)
 Adding more tests to be more confident to definitely delete the `warp-server` feature and get rid of `warp`
 

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -107,7 +107,7 @@ tempfile = "3.3.0"
 test-log = { version = "0.2.10", default-features = false, features = [
     "trace",
 ] }
-test-span = "0.3"
+test-span = "0.4"
 tower-test = "0.4.0"
 tracing-subscriber = { version = "0.3", default-features = false, features = [
     "env-filter",

--- a/apollo-router/src/snapshots/apollo_router__axum_http_server_factory__tests__it_display_home_page.snap
+++ b/apollo-router/src/snapshots/apollo_router__axum_http_server_factory__tests__it_display_home_page.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/axum_http_server_factory.rs
-assertion_line: 756
+assertion_line: 790
 expression: "test_span::get_spans_for_root(&root_span.id().unwrap(),\n    &test_span::Filter::new(Level::INFO))"
 ---
 {
@@ -18,8 +18,8 @@ expression: "test_span::get_spans_for_root(&root_span.id().unwrap(),\n    &test_
     }
   },
   "children": {
-    "tower_http::trace::make_span::request": {
-      "name": "tower_http::trace::make_span::request",
+    "apollo_router::axum_http_server_factory::request": {
+      "name": "apollo_router::axum_http_server_factory::request",
       "record": {
         "entries": [
           [
@@ -33,26 +33,40 @@ expression: "test_span::get_spans_for_root(&root_span.id().unwrap(),\n    &test_
           [
             "version",
             "HTTP/1.1"
+          ],
+          [
+            "otel.kind",
+            "server"
+          ],
+          [
+            "otel.status_code",
+            ""
+          ],
+          [
+            "otel.status_code",
+            "OK"
           ]
         ],
         "metadata": {
           "name": "request",
-          "target": "tower_http::trace::make_span",
+          "target": "apollo_router::axum_http_server_factory",
           "level": "INFO",
-          "module_path": "tower_http::trace::make_span",
+          "module_path": "apollo_router::axum_http_server_factory",
           "fields": {
             "names": [
               "method",
               "uri",
-              "version"
+              "version",
+              "otel.kind",
+              "otel.status_code"
             ]
           }
         }
       },
       "children": {}
     },
-    "tower_http::trace::make_span::request": {
-      "name": "tower_http::trace::make_span::request",
+    "apollo_router::axum_http_server_factory::request": {
+      "name": "apollo_router::axum_http_server_factory::request",
       "record": {
         "entries": [
           [
@@ -66,18 +80,32 @@ expression: "test_span::get_spans_for_root(&root_span.id().unwrap(),\n    &test_
           [
             "version",
             "HTTP/1.1"
+          ],
+          [
+            "otel.kind",
+            "server"
+          ],
+          [
+            "otel.status_code",
+            ""
+          ],
+          [
+            "otel.status_code",
+            "OK"
           ]
         ],
         "metadata": {
           "name": "request",
-          "target": "tower_http::trace::make_span",
+          "target": "apollo_router::axum_http_server_factory",
           "level": "INFO",
-          "module_path": "tower_http::trace::make_span",
+          "module_path": "apollo_router::axum_http_server_factory",
           "fields": {
             "names": [
               "method",
               "uri",
-              "version"
+              "version",
+              "otel.kind",
+              "otel.status_code"
             ]
           }
         }

--- a/apollo-router/src/snapshots/apollo_router__axum_http_server_factory__tests__it_extracts_query_and_operation_name_on_get_requests.snap
+++ b/apollo-router/src/snapshots/apollo_router__axum_http_server_factory__tests__it_extracts_query_and_operation_name_on_get_requests.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/src/axum_http_server_factory.rs
+assertion_line: 932
 expression: "test_span::get_spans_for_root(&root_span.id().unwrap(),\n    &test_span::Filter::new(Level::INFO))"
 ---
 {
@@ -17,8 +18,8 @@ expression: "test_span::get_spans_for_root(&root_span.id().unwrap(),\n    &test_
     }
   },
   "children": {
-    "tower_http::trace::make_span::request": {
-      "name": "tower_http::trace::make_span::request",
+    "apollo_router::axum_http_server_factory::request": {
+      "name": "apollo_router::axum_http_server_factory::request",
       "record": {
         "entries": [
           [
@@ -32,18 +33,32 @@ expression: "test_span::get_spans_for_root(&root_span.id().unwrap(),\n    &test_
           [
             "version",
             "HTTP/1.1"
+          ],
+          [
+            "otel.kind",
+            "server"
+          ],
+          [
+            "otel.status_code",
+            ""
+          ],
+          [
+            "otel.status_code",
+            "OK"
           ]
         ],
         "metadata": {
           "name": "request",
-          "target": "tower_http::trace::make_span",
+          "target": "apollo_router::axum_http_server_factory",
           "level": "INFO",
-          "module_path": "tower_http::trace::make_span",
+          "module_path": "apollo_router::axum_http_server_factory",
           "fields": {
             "names": [
               "method",
               "uri",
-              "version"
+              "version",
+              "otel.kind",
+              "otel.status_code"
             ]
           }
         }

--- a/apollo-router/src/snapshots/apollo_router__axum_http_server_factory__tests__response.snap
+++ b/apollo-router/src/snapshots/apollo_router__axum_http_server_factory__tests__response.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/src/axum_http_server_factory.rs
+assertion_line: 869
 expression: "test_span::get_spans_for_root(&root_span.id().unwrap(),\n    &test_span::Filter::new(Level::INFO))"
 ---
 {
@@ -17,8 +18,8 @@ expression: "test_span::get_spans_for_root(&root_span.id().unwrap(),\n    &test_
     }
   },
   "children": {
-    "tower_http::trace::make_span::request": {
-      "name": "tower_http::trace::make_span::request",
+    "apollo_router::axum_http_server_factory::request": {
+      "name": "apollo_router::axum_http_server_factory::request",
       "record": {
         "entries": [
           [
@@ -32,26 +33,40 @@ expression: "test_span::get_spans_for_root(&root_span.id().unwrap(),\n    &test_
           [
             "version",
             "HTTP/1.1"
+          ],
+          [
+            "otel.kind",
+            "server"
+          ],
+          [
+            "otel.status_code",
+            ""
+          ],
+          [
+            "otel.status_code",
+            "OK"
           ]
         ],
         "metadata": {
           "name": "request",
-          "target": "tower_http::trace::make_span",
+          "target": "apollo_router::axum_http_server_factory",
           "level": "INFO",
-          "module_path": "tower_http::trace::make_span",
+          "module_path": "apollo_router::axum_http_server_factory",
           "fields": {
             "names": [
               "method",
               "uri",
-              "version"
+              "version",
+              "otel.kind",
+              "otel.status_code"
             ]
           }
         }
       },
       "children": {}
     },
-    "tower_http::trace::make_span::request": {
-      "name": "tower_http::trace::make_span::request",
+    "apollo_router::axum_http_server_factory::request": {
+      "name": "apollo_router::axum_http_server_factory::request",
       "record": {
         "entries": [
           [
@@ -65,18 +80,32 @@ expression: "test_span::get_spans_for_root(&root_span.id().unwrap(),\n    &test_
           [
             "version",
             "HTTP/1.1"
+          ],
+          [
+            "otel.kind",
+            "server"
+          ],
+          [
+            "otel.status_code",
+            ""
+          ],
+          [
+            "otel.status_code",
+            "OK"
           ]
         ],
         "metadata": {
           "name": "request",
-          "target": "tower_http::trace::make_span",
+          "target": "apollo_router::axum_http_server_factory",
           "level": "INFO",
-          "module_path": "tower_http::trace::make_span",
+          "module_path": "apollo_router::axum_http_server_factory",
           "fields": {
             "names": [
               "method",
               "uri",
-              "version"
+              "version",
+              "otel.kind",
+              "otel.status_code"
             ]
           }
         }

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/tests/integration_tests.rs
-assertion_line: 134
+assertion_line: 135
 expression: get_spans()
 ---
 {
@@ -181,6 +181,184 @@ expression: get_spans()
                       },
                       "children": {}
                     },
+                    "apollo_router::plugins::telemetry::subgraph": {
+                      "name": "apollo_router::plugins::telemetry::subgraph",
+                      "record": {
+                        "entries": [
+                          [
+                            "name",
+                            "products"
+                          ],
+                          [
+                            "otel.kind",
+                            "client"
+                          ]
+                        ],
+                        "metadata": {
+                          "name": "subgraph",
+                          "target": "apollo_router::plugins::telemetry",
+                          "level": "INFO",
+                          "module_path": "apollo_router::plugins::telemetry",
+                          "fields": {
+                            "names": [
+                              "name",
+                              "otel.kind"
+                            ]
+                          }
+                        }
+                      },
+                      "children": {
+                        "apollo_router_core::services::tower_subgraph_service::aggregate_response_data": {
+                          "name": "apollo_router_core::services::tower_subgraph_service::aggregate_response_data",
+                          "record": {
+                            "entries": [],
+                            "metadata": {
+                              "name": "aggregate_response_data",
+                              "target": "apollo_router_core::services::tower_subgraph_service",
+                              "level": "DEBUG",
+                              "module_path": "apollo_router_core::services::tower_subgraph_service",
+                              "fields": {
+                                "names": []
+                              }
+                            }
+                          },
+                          "children": {}
+                        },
+                        "apollo_router_core::services::tower_subgraph_service::parse_subgraph_response": {
+                          "name": "apollo_router_core::services::tower_subgraph_service::parse_subgraph_response",
+                          "record": {
+                            "entries": [],
+                            "metadata": {
+                              "name": "parse_subgraph_response",
+                              "target": "apollo_router_core::services::tower_subgraph_service",
+                              "level": "DEBUG",
+                              "module_path": "apollo_router_core::services::tower_subgraph_service",
+                              "fields": {
+                                "names": []
+                              }
+                            }
+                          },
+                          "children": {}
+                        }
+                      }
+                    },
+                    "apollo_router_core::query_planner::fetch::response_insert": {
+                      "name": "apollo_router_core::query_planner::fetch::response_insert",
+                      "record": {
+                        "entries": [],
+                        "metadata": {
+                          "name": "response_insert",
+                          "target": "apollo_router_core::query_planner::fetch",
+                          "level": "DEBUG",
+                          "module_path": "apollo_router_core::query_planner::fetch",
+                          "fields": {
+                            "names": []
+                          }
+                        }
+                      },
+                      "children": {}
+                    }
+                  }
+                },
+                "apollo_router_core::query_planner::fetch": {
+                  "name": "apollo_router_core::query_planner::fetch",
+                  "record": {
+                    "entries": [
+                      [
+                        "otel.kind",
+                        "internal"
+                      ]
+                    ],
+                    "metadata": {
+                      "name": "fetch",
+                      "target": "apollo_router_core::query_planner",
+                      "level": "INFO",
+                      "module_path": "apollo_router_core::query_planner",
+                      "fields": {
+                        "names": [
+                          "otel.kind"
+                        ]
+                      }
+                    }
+                  },
+                  "children": {
+                    "apollo_router_core::query_planner::fetch::make_variables": {
+                      "name": "apollo_router_core::query_planner::fetch::make_variables",
+                      "record": {
+                        "entries": [],
+                        "metadata": {
+                          "name": "make_variables",
+                          "target": "apollo_router_core::query_planner::fetch",
+                          "level": "DEBUG",
+                          "module_path": "apollo_router_core::query_planner::fetch",
+                          "fields": {
+                            "names": []
+                          }
+                        }
+                      },
+                      "children": {}
+                    },
+                    "apollo_router::plugins::telemetry::subgraph": {
+                      "name": "apollo_router::plugins::telemetry::subgraph",
+                      "record": {
+                        "entries": [
+                          [
+                            "name",
+                            "reviews"
+                          ],
+                          [
+                            "otel.kind",
+                            "client"
+                          ]
+                        ],
+                        "metadata": {
+                          "name": "subgraph",
+                          "target": "apollo_router::plugins::telemetry",
+                          "level": "INFO",
+                          "module_path": "apollo_router::plugins::telemetry",
+                          "fields": {
+                            "names": [
+                              "name",
+                              "otel.kind"
+                            ]
+                          }
+                        }
+                      },
+                      "children": {
+                        "apollo_router_core::services::tower_subgraph_service::aggregate_response_data": {
+                          "name": "apollo_router_core::services::tower_subgraph_service::aggregate_response_data",
+                          "record": {
+                            "entries": [],
+                            "metadata": {
+                              "name": "aggregate_response_data",
+                              "target": "apollo_router_core::services::tower_subgraph_service",
+                              "level": "DEBUG",
+                              "module_path": "apollo_router_core::services::tower_subgraph_service",
+                              "fields": {
+                                "names": []
+                              }
+                            }
+                          },
+                          "children": {}
+                        },
+                        "apollo_router_core::services::tower_subgraph_service::parse_subgraph_response": {
+                          "name": "apollo_router_core::services::tower_subgraph_service::parse_subgraph_response",
+                          "record": {
+                            "entries": [],
+                            "metadata": {
+                              "name": "parse_subgraph_response",
+                              "target": "apollo_router_core::services::tower_subgraph_service",
+                              "level": "DEBUG",
+                              "module_path": "apollo_router_core::services::tower_subgraph_service",
+                              "fields": {
+                                "names": []
+                              }
+                            }
+                          },
+                          "children": {}
+                        }
+                      }
+                    },
                     "apollo_router_core::query_planner::fetch::response_insert": {
                       "name": "apollo_router_core::query_planner::fetch::response_insert",
                       "record": {
@@ -213,7 +391,242 @@ expression: get_spans()
                       }
                     }
                   },
-                  "children": {}
+                  "children": {
+                    "apollo_router_core::query_planner::fetch": {
+                      "name": "apollo_router_core::query_planner::fetch",
+                      "record": {
+                        "entries": [
+                          [
+                            "otel.kind",
+                            "internal"
+                          ]
+                        ],
+                        "metadata": {
+                          "name": "fetch",
+                          "target": "apollo_router_core::query_planner",
+                          "level": "INFO",
+                          "module_path": "apollo_router_core::query_planner",
+                          "fields": {
+                            "names": [
+                              "otel.kind"
+                            ]
+                          }
+                        }
+                      },
+                      "children": {
+                        "apollo_router_core::query_planner::fetch::make_variables": {
+                          "name": "apollo_router_core::query_planner::fetch::make_variables",
+                          "record": {
+                            "entries": [],
+                            "metadata": {
+                              "name": "make_variables",
+                              "target": "apollo_router_core::query_planner::fetch",
+                              "level": "DEBUG",
+                              "module_path": "apollo_router_core::query_planner::fetch",
+                              "fields": {
+                                "names": []
+                              }
+                            }
+                          },
+                          "children": {}
+                        },
+                        "apollo_router::plugins::telemetry::subgraph": {
+                          "name": "apollo_router::plugins::telemetry::subgraph",
+                          "record": {
+                            "entries": [
+                              [
+                                "name",
+                                "products"
+                              ],
+                              [
+                                "otel.kind",
+                                "client"
+                              ]
+                            ],
+                            "metadata": {
+                              "name": "subgraph",
+                              "target": "apollo_router::plugins::telemetry",
+                              "level": "INFO",
+                              "module_path": "apollo_router::plugins::telemetry",
+                              "fields": {
+                                "names": [
+                                  "name",
+                                  "otel.kind"
+                                ]
+                              }
+                            }
+                          },
+                          "children": {
+                            "apollo_router_core::services::tower_subgraph_service::aggregate_response_data": {
+                              "name": "apollo_router_core::services::tower_subgraph_service::aggregate_response_data",
+                              "record": {
+                                "entries": [],
+                                "metadata": {
+                                  "name": "aggregate_response_data",
+                                  "target": "apollo_router_core::services::tower_subgraph_service",
+                                  "level": "DEBUG",
+                                  "module_path": "apollo_router_core::services::tower_subgraph_service",
+                                  "fields": {
+                                    "names": []
+                                  }
+                                }
+                              },
+                              "children": {}
+                            },
+                            "apollo_router_core::services::tower_subgraph_service::parse_subgraph_response": {
+                              "name": "apollo_router_core::services::tower_subgraph_service::parse_subgraph_response",
+                              "record": {
+                                "entries": [],
+                                "metadata": {
+                                  "name": "parse_subgraph_response",
+                                  "target": "apollo_router_core::services::tower_subgraph_service",
+                                  "level": "DEBUG",
+                                  "module_path": "apollo_router_core::services::tower_subgraph_service",
+                                  "fields": {
+                                    "names": []
+                                  }
+                                }
+                              },
+                              "children": {}
+                            }
+                          }
+                        },
+                        "apollo_router_core::query_planner::fetch::response_insert": {
+                          "name": "apollo_router_core::query_planner::fetch::response_insert",
+                          "record": {
+                            "entries": [],
+                            "metadata": {
+                              "name": "response_insert",
+                              "target": "apollo_router_core::query_planner::fetch",
+                              "level": "DEBUG",
+                              "module_path": "apollo_router_core::query_planner::fetch",
+                              "fields": {
+                                "names": []
+                              }
+                            }
+                          },
+                          "children": {}
+                        }
+                      }
+                    },
+                    "apollo_router_core::query_planner::fetch": {
+                      "name": "apollo_router_core::query_planner::fetch",
+                      "record": {
+                        "entries": [
+                          [
+                            "otel.kind",
+                            "internal"
+                          ]
+                        ],
+                        "metadata": {
+                          "name": "fetch",
+                          "target": "apollo_router_core::query_planner",
+                          "level": "INFO",
+                          "module_path": "apollo_router_core::query_planner",
+                          "fields": {
+                            "names": [
+                              "otel.kind"
+                            ]
+                          }
+                        }
+                      },
+                      "children": {
+                        "apollo_router_core::query_planner::fetch::make_variables": {
+                          "name": "apollo_router_core::query_planner::fetch::make_variables",
+                          "record": {
+                            "entries": [],
+                            "metadata": {
+                              "name": "make_variables",
+                              "target": "apollo_router_core::query_planner::fetch",
+                              "level": "DEBUG",
+                              "module_path": "apollo_router_core::query_planner::fetch",
+                              "fields": {
+                                "names": []
+                              }
+                            }
+                          },
+                          "children": {}
+                        },
+                        "apollo_router::plugins::telemetry::subgraph": {
+                          "name": "apollo_router::plugins::telemetry::subgraph",
+                          "record": {
+                            "entries": [
+                              [
+                                "name",
+                                "accounts"
+                              ],
+                              [
+                                "otel.kind",
+                                "client"
+                              ]
+                            ],
+                            "metadata": {
+                              "name": "subgraph",
+                              "target": "apollo_router::plugins::telemetry",
+                              "level": "INFO",
+                              "module_path": "apollo_router::plugins::telemetry",
+                              "fields": {
+                                "names": [
+                                  "name",
+                                  "otel.kind"
+                                ]
+                              }
+                            }
+                          },
+                          "children": {
+                            "apollo_router_core::services::tower_subgraph_service::aggregate_response_data": {
+                              "name": "apollo_router_core::services::tower_subgraph_service::aggregate_response_data",
+                              "record": {
+                                "entries": [],
+                                "metadata": {
+                                  "name": "aggregate_response_data",
+                                  "target": "apollo_router_core::services::tower_subgraph_service",
+                                  "level": "DEBUG",
+                                  "module_path": "apollo_router_core::services::tower_subgraph_service",
+                                  "fields": {
+                                    "names": []
+                                  }
+                                }
+                              },
+                              "children": {}
+                            },
+                            "apollo_router_core::services::tower_subgraph_service::parse_subgraph_response": {
+                              "name": "apollo_router_core::services::tower_subgraph_service::parse_subgraph_response",
+                              "record": {
+                                "entries": [],
+                                "metadata": {
+                                  "name": "parse_subgraph_response",
+                                  "target": "apollo_router_core::services::tower_subgraph_service",
+                                  "level": "DEBUG",
+                                  "module_path": "apollo_router_core::services::tower_subgraph_service",
+                                  "fields": {
+                                    "names": []
+                                  }
+                                }
+                              },
+                              "children": {}
+                            }
+                          }
+                        },
+                        "apollo_router_core::query_planner::fetch::response_insert": {
+                          "name": "apollo_router_core::query_planner::fetch::response_insert",
+                          "record": {
+                            "entries": [],
+                            "metadata": {
+                              "name": "response_insert",
+                              "target": "apollo_router_core::query_planner::fetch",
+                              "level": "DEBUG",
+                              "module_path": "apollo_router_core::query_planner::fetch",
+                              "fields": {
+                                "names": []
+                              }
+                            }
+                          },
+                          "children": {}
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/tests/integration_tests.rs
-assertion_line: 119
+assertion_line: 120
 expression: get_spans()
 ---
 {
@@ -165,6 +165,67 @@ expression: get_spans()
                     }
                   },
                   "children": {}
+                },
+                "apollo_router::plugins::telemetry::subgraph": {
+                  "name": "apollo_router::plugins::telemetry::subgraph",
+                  "record": {
+                    "entries": [
+                      [
+                        "name",
+                        "products"
+                      ],
+                      [
+                        "otel.kind",
+                        "client"
+                      ]
+                    ],
+                    "metadata": {
+                      "name": "subgraph",
+                      "target": "apollo_router::plugins::telemetry",
+                      "level": "INFO",
+                      "module_path": "apollo_router::plugins::telemetry",
+                      "fields": {
+                        "names": [
+                          "name",
+                          "otel.kind"
+                        ]
+                      }
+                    }
+                  },
+                  "children": {
+                    "apollo_router_core::services::tower_subgraph_service::aggregate_response_data": {
+                      "name": "apollo_router_core::services::tower_subgraph_service::aggregate_response_data",
+                      "record": {
+                        "entries": [],
+                        "metadata": {
+                          "name": "aggregate_response_data",
+                          "target": "apollo_router_core::services::tower_subgraph_service",
+                          "level": "DEBUG",
+                          "module_path": "apollo_router_core::services::tower_subgraph_service",
+                          "fields": {
+                            "names": []
+                          }
+                        }
+                      },
+                      "children": {}
+                    },
+                    "apollo_router_core::services::tower_subgraph_service::parse_subgraph_response": {
+                      "name": "apollo_router_core::services::tower_subgraph_service::parse_subgraph_response",
+                      "record": {
+                        "entries": [],
+                        "metadata": {
+                          "name": "parse_subgraph_response",
+                          "target": "apollo_router_core::services::tower_subgraph_service",
+                          "level": "DEBUG",
+                          "module_path": "apollo_router_core::services::tower_subgraph_service",
+                          "fields": {
+                            "names": []
+                          }
+                        }
+                      },
+                      "children": {}
+                    }
+                  }
                 },
                 "apollo_router_core::query_planner::fetch::response_insert": {
                   "name": "apollo_router_core::query_planner::fetch::response_insert",


### PR DESCRIPTION
Previously in test-span before the fix introduced here https://github.com/apollographql/test-span/pull/13 we were filtering too aggressively. So if we wanted to snapshot all `DEBUG` level if we encountered a `TRACE` span which had `DEBUG` children then these children were not snapshotted. It's now fixed and it's more consistent with what we could have/see in jaeger. 

close #942 