### PR TITLE
Dockerfile now specifies configuration path via env variable. 

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -78,6 +78,9 @@ If a configuration file had errors on reload these were silently swallowed. Thes
 ### Telemetry spans are no longer created for healthcheck requests [PR #938](https://github.com/apollographql/router/pull/938)
 Telemetry spans where previously being created for the healthcheck requests which was creating noisy telemetry for users.
 
+### Dockerfile now allows overriding of `CONFIGURATION_PATH` [PR #948](https://github.com/apollographql/router/pull/948)
+Previously `CONFIGURATION_PATH` could not be used to override the config location as it was being passed by command line arg. 
+
 ## 🛠 Maintenance
 ### Upgrade `test-span` to display more children spans in our snapshots [PR #942](https://github.com/apollographql/router/pull/942)
 Previously in test-span before the fix [introduced here](https://github.com/apollographql/test-span/pull/13) we were filtering too aggressively. So if we wanted to snapshot all `DEBUG` level if we encountered a `TRACE` span which had `DEBUG` children then these children were not snapshotted. It's now fixed and it's more consistent with what we could have/see in jaeger.
@@ -110,7 +113,6 @@ The client awareness headers are now added by default to the list of CORS allowe
 ## Remove unnecessary box in instrumentation layer [PR #940](https://github.com/apollographql/router/pull/940)
 
 Minor simplification of code to remove boxing during instrumentation.
-
 
 ## 📚 Documentation
 ### Enhanced rust docs ([PR #819](https://github.com/apollographql/router/pull/819))

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -28,7 +28,7 @@ COPY --from=build --chown=root:root /dist /dist
 
 WORKDIR /dist
 
+ENV CONFIGURATION_PATH="/dist/config/router.yaml"
+
 # Default executable is the router
 ENTRYPOINT ["./router"]
-
-CMD ["--config", "./config/router.yaml"]


### PR DESCRIPTION
Users can now use `CONFIGURATION_PATH` to override this in docker compose/kubernetes config.

<!--
First, 🌠 thank you 🌠 for considering a contribution to Apollo!

Some of this information is also included in the /CONTRIBUTING.md file at the
root of this repository.  We suggest you read it!

  https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md

Here are some important details to keep in mind:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!  Documentation in the docs/ directory should be updated
        as necessary.  Finally, a /CHANGELOG.md entry should be added.

We hope you will find this to be a positive experience! Contribution can be
intimidating and we hope to alleviate that pain as much as possible. Without
following these guidelines, you may be missing context that can help you succeed
with your contribution, which is why we encourage discussion first. Ultimately,
there is no guarantee that we will be able to merge your pull-request, but by
following these guidelines we can try to avoid disappointment.

-->
