### PR TITLE
add support for http2 to subgraph requests

### DIFF
--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -27,7 +27,7 @@ hex = "0.4.3"
 http = "0.2.6"
 http-body = "0.4.4"
 hyper = { version = "0.14.18", features = ["client"] }
-hyper-rustls = "0.23.0"
+hyper-rustls = { version = "0.23.0", features = ["http1", "http2"] }
 include_dir = "0.7.2"
 indexmap = "1.8.1"
 itertools = "0.10.3"

--- a/apollo-router-core/src/services/tower_subgraph_service.rs
+++ b/apollo-router-core/src/services/tower_subgraph_service.rs
@@ -25,14 +25,15 @@ pub struct TowerSubgraphService {
 
 impl TowerSubgraphService {
     pub fn new(service: impl Into<String>) -> Self {
-        let https = hyper_rustls::HttpsConnectorBuilder::new()
+        let connector = hyper_rustls::HttpsConnectorBuilder::new()
             .with_native_roots()
             .https_or_http()
             .enable_http1()
+            .enable_http2()
             .build();
 
         Self {
-            client: ServiceBuilder::new().service(hyper::Client::builder().build(https)),
+            client: ServiceBuilder::new().service(hyper::Client::builder().build(connector)),
             service: Arc::new(service.into()),
         }
     }


### PR DESCRIPTION
Configure the hyper-rustls crate to support both http1 and http2. Modify
the creation of the connector to enable both http1 and http2.

fixes: #952 

Note: It would be nice to add some tests to support this, but I can't think of a good way to do this right now.