### PR TITLE
chore: add RUST_BACKTRACE=full to ci steps.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,7 @@ parameters:
 # additional configuration.
 common_job_environment: &common_job_environment
   CARGO_NET_GIT_FETCH_WITH_CLI: true
+  RUST_BACKTRACE: full
   NODE_VERSION: 14.17.5
   NPM_VERSION: 7.10.0
 


### PR DESCRIPTION
This commit adds a backtrace to all rust CI steps, which will give us more verbose logs whenever a test is flaky.
