### PR TITLE
set the service name if not specified in config or environment

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -87,6 +87,9 @@ Telemetry spans where previously being created for the healthcheck requests whic
 ### Dockerfile now allows overriding of `CONFIGURATION_PATH` [PR #948](https://github.com/apollographql/router/pull/948)
 Previously `CONFIGURATION_PATH` could not be used to override the config location as it was being passed by command line arg. 
 
+### Set the service name if not specified in config or environment [PR #960](https://github.com/apollographql/router/pull/960)
+The router now sets "router" as default service name in Opentelemetry traces, that can be replaced using the configuration file or environment variables. It also sets the key "process.executable_name".
+
 ## 🛠 Maintenance
 ### Upgrade `test-span` to display more children spans in our snapshots [PR #942](https://github.com/apollographql/router/pull/942)
 Previously in test-span before the fix [introduced here](https://github.com/apollographql/test-span/pull/13) we were filtering too aggressively. So if we wanted to snapshot all `DEBUG` level if we encountered a `TRACE` span which had `DEBUG` children then these children were not snapshotted. It's now fixed and it's more consistent with what we could have/see in jaeger.

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -213,6 +213,11 @@ impl From<&Trace> for opentelemetry::sdk::trace::Config {
                 opentelemetry_semantic_conventions::resource::SERVICE_NAME,
                 service_name.clone(),
             ));
+        } else if std::env::var("OTEL_SERVICE_NAME").is_err() {
+            resource_defaults.push(KeyValue::new(
+                opentelemetry_semantic_conventions::resource::SERVICE_NAME,
+                "router".to_string(),
+            ));
         }
         if let Some(service_namespace) = &config.service_namespace {
             resource_defaults.push(KeyValue::new(
@@ -220,6 +225,17 @@ impl From<&Trace> for opentelemetry::sdk::trace::Config {
                 service_namespace.clone(),
             ));
         }
+
+        if let Some(executable_name) = std::env::current_exe().ok().and_then(|path| {
+            path.file_name()
+                .and_then(|p| p.to_str().map(|s| s.to_string()))
+        }) {
+            resource_defaults.push(KeyValue::new(
+                opentelemetry_semantic_conventions::resource::PROCESS_EXECUTABLE_NAME,
+                executable_name,
+            ));
+        }
+
         let resource = Resource::new(resource_defaults).merge(&mut Resource::new(
             config
                 .attributes

--- a/docs/source/configuration/tracing.mdx
+++ b/docs/source/configuration/tracing.mdx
@@ -25,7 +25,7 @@ Span data is sent to a collector such as [Jaeger](https://www.jaegertracing.io/)
 ## Common configuration
 
 ### Trace config
-The `trace_config` section contains common configuration that will be used in the for all exporters. It is optional and will fall back on env variables as specified by the [OpenTelemetry spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md) if `service_name` is not set.
+The `trace_config` section contains common configuration that will be used by all exporters. It is optional and will fall back on env variables as specified by the [OpenTelemetry spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md) if `service_name` is not set.
 
 ```yaml title="router.yaml"
 telemetry:
@@ -55,7 +55,7 @@ telemetry:
 
 If `service_name` is set then environment variables are not used. However, it is possible to embed environment variables into your router config using Unix `${key:default}` syntax.
 
-If no environment variable is set and service_name is not present then the default of `service_unknown` will be used as per the OpenTelemetry spec.
+If no environment variable is set and `service_name` is not present then `router` will be used as default service name.
 
 ### Propagation
 


### PR DESCRIPTION
for a better out of the box experience, the router should set a default
service name in opentelemetry, that can be overriden by the
configuration file or the OTEL_SERVICE_NAME environment variable

(otherwise the service name is set to `service_unknown` in jaeger or `OTLPRESOURCENOSERVICENAME` in zipkin)