### PR TITLE
fix: improve the configuration error report

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -27,8 +27,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🚀 Features ( :rocket: )
 ## 🐛 Fixes ( :bug: )
 
-### Fix incorrectly omitting content of interface's fragment [PR #949](https://github.com/apollographql/router/pull/949)
+### Improve the configuration error report [PR #963](https://github.com/apollographql/router/pull/963)
+In case you have unknown properties on your configuration it will highlight the entity with unknown properties. Before we always pointed on the first field of this entity even if it wasn't the bad one, it's now fixed.
 
+### Fix incorrectly omitting content of interface's fragment [PR #949](https://github.com/apollographql/router/pull/949)
 Router now distinguish between fragment on concrete type and interface.
 If interface is encountered and  `__typename` is queried, additionally checks that returned type implements interface.
 

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -461,7 +461,7 @@ pub fn validate_configuration(raw_yaml: &str) -> Result<(), ConfigurationError> 
                     .enumerate()
                     .filter_map(|(idx, e)| {
                         if let Some(element) = yaml.get_element(&e.instance_path) {
-                            const NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY: isize = 5;
+                            const NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY: usize = 5;
                             match element {
                                 yaml::Value::String(value, marker) => {
                                     // Dirty hack.
@@ -477,11 +477,8 @@ pub fn validate_configuration(raw_yaml: &str) -> Result<(), ConfigurationError> 
                                         return None;
                                     }
 
-                                    let lines = yaml_split_by_lines[0.max(
-                                        marker.line() as isize
-                                            - NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY,
-                                    )
-                                        as usize
+                                    let lines = yaml_split_by_lines[0
+                                        .max(marker.line() - NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY)
                                         ..marker.line()]
                                         .iter()
                                         .join("\n");
@@ -499,9 +496,8 @@ pub fn validate_configuration(raw_yaml: &str) -> Result<(), ConfigurationError> 
                                     let (start_marker, end_marker) = (m, seq_element.end_marker());
 
                                     let offset = 0.max(
-                                        start_marker.line() as isize
-                                            - NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY,
-                                    ) as usize;
+                                        start_marker.line() - NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY,
+                                    );
                                     let lines = yaml_split_by_lines[offset..end_marker.line()]
                                         .iter()
                                         .enumerate()
@@ -529,9 +525,8 @@ pub fn validate_configuration(raw_yaml: &str) -> Result<(), ConfigurationError> 
                                         map_value.end_marker(),
                                     );
                                     let offset = 0.max(
-                                        start_marker.line() as isize
-                                            - NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY,
-                                    ) as usize;
+                                        start_marker.line() - NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY,
+                                    );
                                     let lines = yaml_split_by_lines[offset..end_marker.line()]
                                         .iter()
                                         .enumerate()

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -461,6 +461,7 @@ pub fn validate_configuration(raw_yaml: &str) -> Result<(), ConfigurationError> 
                     .enumerate()
                     .filter_map(|(idx, e)| {
                         if let Some(element) = yaml.get_element(&e.instance_path) {
+                            const NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY: isize = 5;
                             match element {
                                 yaml::Value::String(value, marker) => {
                                     // Dirty hack.
@@ -476,8 +477,12 @@ pub fn validate_configuration(raw_yaml: &str) -> Result<(), ConfigurationError> 
                                         return None;
                                     }
 
-                                    let lines = yaml_split_by_lines
-                                        [0.max(marker.line() as isize - 5) as usize..marker.line()]
+                                    let lines = yaml_split_by_lines[0.max(
+                                        marker.line() as isize
+                                            - NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY,
+                                    )
+                                        as usize
+                                        ..marker.line()]
                                         .iter()
                                         .join("\n");
 
@@ -493,7 +498,10 @@ pub fn validate_configuration(raw_yaml: &str) -> Result<(), ConfigurationError> 
                                 seq_element @ yaml::Value::Sequence(_, m) => {
                                     let (start_marker, end_marker) = (m, seq_element.end_marker());
 
-                                    let offset = 0.max(start_marker.line() as isize - 5) as usize;
+                                    let offset = 0.max(
+                                        start_marker.line() as isize
+                                            - NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY,
+                                    ) as usize;
                                     let lines = yaml_split_by_lines[offset..end_marker.line()]
                                         .iter()
                                         .enumerate()
@@ -520,7 +528,10 @@ pub fn validate_configuration(raw_yaml: &str) -> Result<(), ConfigurationError> 
                                         current_label.as_ref()?.marker.as_ref()?,
                                         map_value.end_marker(),
                                     );
-                                    let offset = 0.max(start_marker.line() as isize - 5) as usize;
+                                    let offset = 0.max(
+                                        start_marker.line() as isize
+                                            - NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY,
+                                    ) as usize;
                                     let lines = yaml_split_by_lines[offset..end_marker.line()]
                                         .iter()
                                         .enumerate()

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -15,6 +15,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Map;
 use serde_json::Value;
+use std::cmp::Ordering;
 use std::fmt;
 use std::net::SocketAddr;
 use std::str::FromStr;
@@ -460,35 +461,88 @@ pub fn validate_configuration(raw_yaml: &str) -> Result<(), ConfigurationError> 
                     .enumerate()
                     .filter_map(|(idx, e)| {
                         if let Some(element) = yaml.get_element(&e.instance_path) {
-                            // Dirty hack.
-                            // If the element is a string and it has env variable expansion then we can't validate
-                            // Leave it up to serde to catch these.
-                            if let yaml::Value::String(value, _) = element {
-                                if &envmnt::expand(
-                                    value,
-                                    Some(ExpandOptions::new().clone_with_expansion_type(
-                                        ExpansionType::UnixBracketsWithDefaults,
-                                    )),
-                                ) != value
-                                {
-                                    return None;
+                            match element {
+                                yaml::Value::String(value, marker) => {
+                                    // Dirty hack.
+                                    // If the element is a string and it has env variable expansion then we can't validate
+                                    // Leave it up to serde to catch these.
+                                    if &envmnt::expand(
+                                        value,
+                                        Some(ExpandOptions::new().clone_with_expansion_type(
+                                            ExpansionType::UnixBracketsWithDefaults,
+                                        )),
+                                    ) != value
+                                    {
+                                        return None;
+                                    }
+
+                                    let lines = yaml_split_by_lines
+                                        [0.max(marker.line() as isize - 5) as usize..marker.line()]
+                                        .iter()
+                                        .join("\n");
+
+                                    Some(format!(
+                                        "{}. {}\n\n{}\n{}^----- {}",
+                                        idx + 1,
+                                        e.instance_path,
+                                        lines,
+                                        " ".repeat(0.max(marker.col())),
+                                        e
+                                    ))
+                                }
+                                seq_element @ yaml::Value::Sequence(_, m) => {
+                                    let (start_marker, end_marker) = (m, seq_element.end_marker());
+
+                                    let offset = 0.max(start_marker.line() as isize - 5) as usize;
+                                    let lines = yaml_split_by_lines[offset..end_marker.line()]
+                                        .iter()
+                                        .enumerate()
+                                        .map(|(idx, line)| {
+                                            let real_line = idx + offset;
+                                            match real_line.cmp(&start_marker.line()) {
+                                                Ordering::Equal => format!("┌ {line}"),
+                                                Ordering::Greater => format!("| {line}"),
+                                                Ordering::Less => line.to_string(),
+                                            }
+                                        })
+                                        .join("\n");
+
+                                    Some(format!(
+                                        "{}. {}\n\n{}\n└-----> {}",
+                                        idx + 1,
+                                        e.instance_path,
+                                        lines,
+                                        e
+                                    ))
+                                }
+                                map_value @ yaml::Value::Mapping(current_label, _, _marker) => {
+                                    let (start_marker, end_marker) = (
+                                        current_label.as_ref()?.marker.as_ref()?,
+                                        map_value.end_marker(),
+                                    );
+                                    let offset = 0.max(start_marker.line() as isize - 5) as usize;
+                                    let lines = yaml_split_by_lines[offset..end_marker.line()]
+                                        .iter()
+                                        .enumerate()
+                                        .map(|(idx, line)| {
+                                            let real_line = idx + offset;
+                                            match real_line.cmp(&start_marker.line()) {
+                                                Ordering::Equal => format!("┌ {line}"),
+                                                Ordering::Greater => format!("| {line}"),
+                                                Ordering::Less => line.to_string(),
+                                            }
+                                        })
+                                        .join("\n");
+
+                                    Some(format!(
+                                        "{}. {}\n\n{}\n└-----> {}",
+                                        idx + 1,
+                                        e.instance_path,
+                                        lines,
+                                        e
+                                    ))
                                 }
                             }
-
-                            let marker = element.marker();
-                            let lines = yaml_split_by_lines
-                                [0.max(marker.line() as isize - 5) as usize..marker.line()]
-                                .iter()
-                                .join("\n");
-
-                            Some(format!(
-                                "{}. {}\n\n{}\n{}^----- {}",
-                                idx + 1,
-                                e.instance_path,
-                                lines,
-                                " ".repeat(marker.col()),
-                                e
-                            ))
                         } else {
                             None
                         }
@@ -659,6 +713,70 @@ plugins:
 
 telemetry:  
   another_non_existant: 3
+  "#,
+        )
+        .expect_err("should have resulted in an error");
+        insta::assert_snapshot!(error.to_string());
+    }
+
+    #[test]
+    fn line_precise_config_errors_with_errors_after_first_field() {
+        let error = validate_configuration(
+            r#"
+server:
+  # The socket address and port to listen on
+  # Defaults to 127.0.0.1:4000
+  listen: 127.0.0.1:4000
+  bad: "donotwork"
+  another_one: true
+        "#,
+        )
+        .expect_err("should have resulted in an error");
+        insta::assert_snapshot!(error.to_string());
+    }
+
+    #[test]
+    fn line_precise_config_errors_bad_type() {
+        let error = validate_configuration(
+            r#"
+server:
+  # The socket address and port to listen on
+  # Defaults to 127.0.0.1:4000
+  listen: true
+        "#,
+        )
+        .expect_err("should have resulted in an error");
+        insta::assert_snapshot!(error.to_string());
+    }
+
+    #[test]
+    fn line_precise_config_errors_with_inline_sequence() {
+        let error = validate_configuration(
+            r#"
+server:
+  # The socket address and port to listen on
+  # Defaults to 127.0.0.1:4000
+  listen: 127.0.0.1:4000
+  cors:
+    allow_headers: [ Content-Type, 5 ]
+        "#,
+        )
+        .expect_err("should have resulted in an error");
+        insta::assert_snapshot!(error.to_string());
+    }
+
+    #[test]
+    fn line_precise_config_errors_with_sequence() {
+        let error = validate_configuration(
+            r#"
+server:
+  # The socket address and port to listen on
+  # Defaults to 127.0.0.1:4000
+  listen: 127.0.0.1:4000
+  cors:
+    allow_headers:
+      - Content-Type
+      - 5
         "#,
         )
         .expect_err("should have resulted in an error");

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 698
+assertion_line: 748
 expression: error.to_string()
 ---
 configuration had errors: 
@@ -8,14 +8,16 @@ configuration had errors:
 
 
 plugins:
-  non_existant:
-              ^----- Additional properties are not allowed ('non_existant' was unexpected)
+┌   non_existant:
+|     foo: "bar"
+└-----> Additional properties are not allowed ('non_existant' was unexpected)
 
 2. /telemetry
 
+plugins:
   non_existant:
     foo: "bar"
 
 telemetry:  
-  another_non_existant: 3
-                      ^----- Additional properties are not allowed ('another_non_existant' was unexpected)
+┌   another_non_existant: 3
+└-----> Additional properties are not allowed ('another_non_existant' was unexpected)

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_bad_type.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_bad_type.snap
@@ -1,0 +1,14 @@
+---
+source: apollo-router/src/configuration/mod.rs
+assertion_line: 751
+expression: error.to_string()
+---
+configuration had errors: 
+1. /server/listen
+
+
+server:
+  # The socket address and port to listen on
+  # Defaults to 127.0.0.1:4000
+  listen: true
+          ^----- true is not valid under any of the given schemas

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field.snap
@@ -1,0 +1,16 @@
+---
+source: apollo-router/src/configuration/mod.rs
+assertion_line: 737
+expression: error.to_string()
+---
+configuration had errors: 
+1. /server
+
+
+server:
+┌   # The socket address and port to listen on
+|   # Defaults to 127.0.0.1:4000
+|   listen: 127.0.0.1:4000
+|   bad: "donotwork"
+|   another_one: true
+└-----> Additional properties are not allowed ('bad', 'another_one' were unexpected)

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_inline_sequence.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_inline_sequence.snap
@@ -1,0 +1,14 @@
+---
+source: apollo-router/src/configuration/mod.rs
+assertion_line: 766
+expression: error.to_string()
+---
+configuration had errors: 
+1. /server/cors/allow_headers/1
+
+  # The socket address and port to listen on
+  # Defaults to 127.0.0.1:4000
+  listen: 127.0.0.1:4000
+  cors:
+    allow_headers: [ Content-Type, 5 ]
+                                   ^----- 5 is not of type "string"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_sequence.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_sequence.snap
@@ -1,0 +1,14 @@
+---
+source: apollo-router/src/configuration/mod.rs
+assertion_line: 784
+expression: error.to_string()
+---
+configuration had errors: 
+1. /server/cors/allow_headers/1
+
+  listen: 127.0.0.1:4000
+  cors:
+    allow_headers:
+      - Content-Type
+      - 5
+        ^----- 5 is not of type "string"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__yaml__test__test.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__yaml__test__test.snap
@@ -1,9 +1,10 @@
 ---
 source: apollo-router/src/configuration/yaml.rs
-assertion_line: 178
+assertion_line: 214
 expression: "format!(\"{:#?}\", root)"
 ---
 Mapping(
+    None,
     {
         Label {
             name: "test",
@@ -15,6 +16,18 @@ Mapping(
                 },
             ),
         }: Mapping(
+            Some(
+                Label {
+                    name: "test",
+                    marker: Some(
+                        Marker {
+                            index: 0,
+                            line: 1,
+                            col: 0,
+                        },
+                    ),
+                },
+            ),
             {
                 Label {
                     name: "a",
@@ -78,6 +91,7 @@ Mapping(
                             },
                         ),
                         Mapping(
+                            None,
                             {
                                 Label {
                                     name: "f",
@@ -99,6 +113,7 @@ Mapping(
                                             },
                                         ),
                                         Mapping(
+                                            None,
                                             {
                                                 Label {
                                                     name: "h",
@@ -110,6 +125,18 @@ Mapping(
                                                         },
                                                     ),
                                                 }: Mapping(
+                                                    Some(
+                                                        Label {
+                                                            name: "h",
+                                                            marker: Some(
+                                                                Marker {
+                                                                    index: 74,
+                                                                    line: 9,
+                                                                    col: 7,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
                                                     {
                                                         Label {
                                                             name: "i",
@@ -191,6 +218,7 @@ Mapping(
                             },
                         ),
                         Mapping(
+                            None,
                             {
                                 Label {
                                     name: "f",
@@ -212,6 +240,7 @@ Mapping(
                                             },
                                         ),
                                         Mapping(
+                                            None,
                                             {
                                                 Label {
                                                     name: "h",
@@ -223,6 +252,18 @@ Mapping(
                                                         },
                                                     ),
                                                 }: Mapping(
+                                                    Some(
+                                                        Label {
+                                                            name: "h",
+                                                            marker: Some(
+                                                                Marker {
+                                                                    index: 74,
+                                                                    line: 9,
+                                                                    col: 7,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ),
                                                     {
                                                         Label {
                                                             name: "i",


### PR DESCRIPTION
close #921 

What we had before for this kind of bad configuration:

```yaml
server:
  # The socket address and port to listen on
  # Defaults to 127.0.0.1:4000
  listen: 127.0.0.1:4000
  bad: "donotwork"
  another_one: true
```

+ Previous report:

```
configuration had errors: 
1. /server


server:
   # The socket address and port to listen on
   # Defaults to 127.0.0.1:4000
   listen: 127.0.0.1:4000
          ^-----> Additional properties are not allowed ('bad', 'another_one' were unexpected)
```

+ Here is the new report:

```
configuration had errors: 
1. /server


server:
┌   # The socket address and port to listen on
|   # Defaults to 127.0.0.1:4000
|   listen: 127.0.0.1:4000
|   bad: "donotwork"
|   another_one: true
└-----> Additional properties are not allowed ('bad', 'another_one' were unexpected)
```

We had a bug previously that only highlighted the first field of the map with unknown properties.