### PR TITLE
accept endpoint URL without scheme for telemetry

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -34,5 +34,10 @@ If interface is encountered and  `__typename` is queried, additionally checks th
 
 ### Set the service name if not specified in config or environment [PR #960](https://github.com/apollographql/router/pull/960)
 The router now sets "router" as default service name in Opentelemetry traces, that can be replaced using the configuration file or environment variables. It also sets the key "process.executable_name".
+
+### Accept an endpoint URL without scheme for telemetry [PR #964](https://github.com/apollographql/router/pull/964)
+
+Endpoint configuration for Datadog and OTLP take a URL as argument, but was incorrectly recognizing addresses of the format "host:port"
+
 ## 🛠 Maintenance ( :hammer_and_wrench: )
 ## 📚 Documentation ( :books: )

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -3,27 +3,48 @@ use crate::plugins::telemetry::config::{GenericWith, Trace};
 use crate::plugins::telemetry::tracing::TracingConfigurator;
 use opentelemetry::sdk::trace::Builder;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use tower::BoxError;
 use url::Url;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
+    #[serde(deserialize_with = "deser_endpoint")]
     pub endpoint: AgentEndpoint,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "snake_case", untagged)]
 pub enum AgentEndpoint {
     Default(AgentDefault),
     Url(Url),
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub enum AgentDefault {
     Default,
+}
+
+fn deser_endpoint<'de, D>(deserializer: D) -> Result<AgentEndpoint, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut s = String::deserialize(deserializer)?;
+    if s == "default" {
+        return Ok(AgentEndpoint::Default(AgentDefault::Default));
+    }
+    let mut url = Url::parse(&s).map_err(serde::de::Error::custom)?;
+
+    // support the case of 'collector:4317' where url parses 'collector'
+    // as the scheme instead of the host
+    if url.host().is_none() && (url.scheme() != "http" || url.scheme() != "https") {
+        s = format!("http://{}", s);
+
+        url = Url::parse(&s).map_err(serde::de::Error::custom)?;
+    }
+    Ok(AgentEndpoint::Url(url))
 }
 
 impl TracingConfigurator for Config {
@@ -41,5 +62,31 @@ impl TracingConfigurator for Config {
             .with_trace_config(trace_config.into())
             .build_exporter()?;
         Ok(builder.with_batch_exporter(exporter, opentelemetry::runtime::Tokio))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_configuration() {
+        let config: Config = serde_yaml::from_str("endpoint: default").unwrap();
+        assert_eq!(
+            AgentEndpoint::Default(AgentDefault::Default),
+            config.endpoint
+        );
+
+        let config: Config = serde_yaml::from_str("endpoint: collector:1234").unwrap();
+        assert_eq!(
+            AgentEndpoint::Url(Url::parse("http://collector:1234").unwrap()),
+            config.endpoint
+        );
+
+        let config: Config = serde_yaml::from_str("endpoint: https://collector:1234").unwrap();
+        assert_eq!(
+            AgentEndpoint::Url(Url::parse("https://collector:1234").unwrap()),
+            config.endpoint
+        );
     }
 }


### PR DESCRIPTION
endpoint configuration for Datadog and OTLP take a URL as argument, but
it is easy to make the mistake of setting a value of the format
"host:port". In that case, the URL parser will happily understand that
as "host" scheme and "port" path.
This PR instead transforms it to "http://host:port"
