### PR TITLE
Default SocketAddr be 0.0.0.0 and port configurable by environment variable

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -25,6 +25,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 # [v0.1.0-preview.8] - (unreleased)
 ## ❗ BREAKING ❗
 ## 🚀 Features ( :rocket: )
+
+### Default server listen on 0.0.0.0 and port configurable by `PORT` environment variable [PR #970](https://github.com/apollographql/router/pull/970)
+Updates the default server listen address to be "unspecified" or 0.0.0.0 IP. Also allows setting the server listening port via the `PORT` environment variable while retaining the default of 4000 as it was previously.
+
 ## 🐛 Fixes ( :bug: )
 
 ### Improve the configuration error report [PR #963](https://github.com/apollographql/router/pull/963)

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -84,7 +84,10 @@ pub struct Configuration {
 const APOLLO_PLUGIN_PREFIX: &str = "apollo.";
 
 fn default_listen() -> ListenAddr {
-    SocketAddr::from_str("127.0.0.1:4000").unwrap().into()
+    let port: u16 = std::env::var("PORT").ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(4000);
+    SocketAddr::from((std::net::Ipv4Addr::UNSPECIFIED, port)).into()
 }
 
 impl Configuration {


### PR DESCRIPTION
Proposed change that would resolve #969

- Default listen on 0.0.0.0 to bind to "unspecified" IP
  - I don't think will be a breaking change, but allows more operating models without a need to override the server listen configuration
- Allow port configuration by `PORT` environment variable and retain default of port 4000
  - Allows running/configuring without need to override server listen configuration in config file