### PR TITLE
feat: add configuration to declare your own graphql endpoint

### DIFF
--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -57,6 +57,8 @@ pub enum ConfigurationError {
         message: &'static str,
         error: String,
     },
+    /// could not deserialize configuration: {0}
+    DeserializeConfigError(serde_yaml::Error),
 }
 
 /// The configuration for the router.
@@ -248,6 +250,12 @@ pub struct Server {
     #[serde(default = "default_landing_page")]
     #[builder(default_code = "default_landing_page()", setter(into))]
     pub landing_page: bool,
+
+    /// GraphQL endpoint
+    /// default: "/"
+    #[serde(default = "default_endpoint")]
+    #[builder(default_code = "default_endpoint()", setter(into))]
+    pub endpoint: String,
 }
 
 /// Listening address.
@@ -360,6 +368,10 @@ fn default_landing_page() -> bool {
     true
 }
 
+fn default_endpoint() -> String {
+    String::from("/")
+}
+
 impl Default for Server {
     fn default() -> Self {
         Server::builder().build()
@@ -431,7 +443,7 @@ pub fn generate_config_schema() -> RootSchema {
 ///
 /// If at any point something doesn't work out it lets the config pass and it'll get re-validated by serde later.
 ///
-pub fn validate_configuration(raw_yaml: &str) -> Result<(), ConfigurationError> {
+pub fn validate_configuration(raw_yaml: &str) -> Result<Configuration, ConfigurationError> {
     let yaml =
         &serde_yaml::from_str(raw_yaml).map_err(|e| ConfigurationError::InvalidConfiguration {
             message: "failed to parse yaml",
@@ -561,15 +573,12 @@ pub fn validate_configuration(raw_yaml: &str) -> Result<(), ConfigurationError> 
                         })
                         .join("\n\n");
 
-                // There were no remaining errors after expansion.
-                if errors.is_empty() {
-                    return Ok(());
+                if !errors.is_empty() {
+                    return Err(ConfigurationError::InvalidConfiguration {
+                        message: "configuration had errors",
+                        error: format!("\n{}", errors),
+                    });
                 }
-
-                return Err(ConfigurationError::InvalidConfiguration {
-                    message: "configuration had errors",
-                    error: format!("\n{}", errors),
-                });
             }
             Err(e) => {
                 // the yaml failed to parse. Just let serde do it's thing.
@@ -577,11 +586,46 @@ pub fn validate_configuration(raw_yaml: &str) -> Result<(), ConfigurationError> 
                     "failed to parse yaml using marked parser: {}. Falling back to serde validation",
                     e
                 );
-                return Ok(());
             }
         }
     }
-    Ok(())
+
+    let config: Configuration =
+        serde_yaml::from_str(raw_yaml).map_err(ConfigurationError::DeserializeConfigError)?;
+
+    // Custom validations
+    if !config.server.endpoint.starts_with('/') {
+        return Err(ConfigurationError::InvalidConfiguration {
+            message: "invalid 'server.endpoint' configuration",
+            error: format!(
+                "'{}' is invalid, it must be an absolute path and start with '/', you should try with '/{}'",
+                config.server.endpoint,
+                config.server.endpoint
+            ),
+        });
+    }
+    if config.server.endpoint.ends_with('*') && !config.server.endpoint.ends_with("/*") {
+        return Err(ConfigurationError::InvalidConfiguration {
+            message: "invalid 'server.endpoint' configuration",
+            error: format!(
+                "'{}' is invalid, you can only set a wildcard after a '/'",
+                config.server.endpoint
+            ),
+        });
+    }
+    if config.server.endpoint.contains("/*/") {
+        return Err(
+                ConfigurationError::InvalidConfiguration {
+                    message: "invalid 'server.endpoint' configuration",
+                    error: format!(
+                        "'{}' is invalid, if you need to set a path like '/*/graphql' it won't work you need to specify it as a path parameter with a name, for example '/:my_project_key/graphql'",
+                        config.server.endpoint
+                    ),
+                },
+            );
+    }
+
+    Ok(config)
 }
 
 #[cfg(test)]
@@ -713,6 +757,42 @@ mod tests {
             !cors.allow_any_origin.unwrap_or_default(),
             "Allow any origin should be disabled by default"
         );
+    }
+
+    #[test]
+    fn bad_endpoint_configuration_without_slash() {
+        let error = validate_configuration(
+            r#"
+server:
+  endpoint: test
+  "#,
+        )
+        .expect_err("should have resulted in an error");
+        assert_eq!(error.to_string(), String::from("invalid 'server.endpoint' configuration: 'test' is invalid, it must be an absolute path and start with '/', you should try with '/test'"));
+    }
+
+    #[test]
+    fn bad_endpoint_configuration_with_wildcard_as_prefix() {
+        let error = validate_configuration(
+            r#"
+server:
+  endpoint: /*/test
+  "#,
+        )
+        .expect_err("should have resulted in an error");
+        assert_eq!(error.to_string(), String::from("invalid 'server.endpoint' configuration: '/*/test' is invalid, if you need to set a path like '/*/graphql' it won't work you need to specify it as a path parameter with a name, for example '/:my_project_key/graphql'"));
+    }
+
+    #[test]
+    fn bad_endpoint_configuration_with_bad_ending_wildcard() {
+        let error = validate_configuration(
+            r#"
+server:
+  endpoint: /test*
+  "#,
+        )
+        .expect_err("should have resulted in an error");
+        assert_eq!(error.to_string(), String::from("invalid 'server.endpoint' configuration: '/test*' is invalid, you can only set a wildcard after a '/'"));
     }
 
     #[test]

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 562
+assertion_line: 621
 expression: "&schema"
 ---
 {
@@ -325,7 +325,8 @@ expression: "&schema"
         "listen": "127.0.0.1:4000",
         "cors": null,
         "introspection": true,
-        "landing_page": true
+        "landing_page": true,
+        "endpoint": "/"
       },
       "type": "object",
       "properties": {
@@ -390,6 +391,11 @@ expression: "&schema"
           },
           "additionalProperties": false,
           "nullable": true
+        },
+        "endpoint": {
+          "description": "GraphQL endpoint default: \"/\"",
+          "default": "/",
+          "type": "string"
         },
         "introspection": {
           "description": "introspection queries enabled by default",

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -288,9 +288,7 @@ impl ConfigurationKind {
 
     fn read_config(path: &Path) -> Result<Configuration, FederatedServerError> {
         let config = fs::read_to_string(path).map_err(FederatedServerError::ReadConfigError)?;
-        validate_configuration(&config).map_err(FederatedServerError::ConfigError)?;
-        let config =
-            serde_yaml::from_str(&config).map_err(FederatedServerError::DeserializeConfigError)?;
+        let config = validate_configuration(&config).map_err(FederatedServerError::ConfigError)?;
 
         Ok(config)
     }
@@ -579,9 +577,7 @@ impl FederatedServerHandle {
                     State::Startup => {
                         tracing::info!("starting Apollo Router")
                     }
-                    State::Running { address, .. } => {
-                        tracing::info!("listening on {} 🚀", address)
-                    }
+                    State::Running { .. } => {}
                     State::Stopped => {
                         tracing::info!("stopped")
                     }
@@ -710,7 +706,7 @@ mod tests {
         request: &graphql::Request,
     ) -> Result<graphql::Response, graphql::FetchError> {
         Ok(reqwest::Client::new()
-            .post(format!("{}/graphql", listen_addr))
+            .post(format!("{}/", listen_addr))
             .json(request)
             .send()
             .await


### PR DESCRIPTION
close #933 

1. We should reduce from 2 to 1 paths
1. Path should default to `/`
1. The default should be strict, meaning `/jjjj` should not just work because `/` is configured.
1. You can configure it to be something else with path e.g. `/graphql`.
1. You can allow `/graphql/*` by specifying path: `/graphql/*`
1. The thing printed to the console at startup uses path.

Configuration would be in the server section for the yaml.

Let's do the documentation in a follow-up PR.