### PR TITLE
chore: Update license identifiers to use `Elastic-2.0` SPDX identifier

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -42,4 +42,8 @@ The router now sets "router" as default service name in Opentelemetry traces, th
 Endpoint configuration for Datadog and OTLP take a URL as argument, but was incorrectly recognizing addresses of the format "host:port"
 
 ## 🛠 Maintenance ( :hammer_and_wrench: )
+
+### Use official SPDX license identifier for Elastic License v2 (ELv2) [Issue #418](https://github.com/apollographql/router/issues/418)
+
+Rather than pointing to our `LICENSE` file, we now use the `Elastic-2.0` SPDX license identifier to indicate that a particular component is governed by the Elastic License 2.0 (ELv2).  This should facilitate automated compatibility with licensing tools which assist with compliance.
 ## 📚 Documentation ( :books: )

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -3,7 +3,7 @@ name = "apollo-router-core"
 version = "0.1.0-preview.7"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
-license-file = "./LICENSE"
+license = "Elastic-2.0"
 publish = false
 
 [features]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -3,7 +3,7 @@ name = "apollo-router"
 version = "0.1.0-preview.7"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
-license-file = "./LICENSE"
+license = "Elastic-2.0"
 publish = false
 
 [[bin]]

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -3,7 +3,7 @@ name = "apollo-spaceport"
 version = "0.1.0-preview.7"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
-license-file = "./LICENSE"
+license = "Elastic-2.0"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/deny.toml
+++ b/deny.toml
@@ -60,30 +60,6 @@ expression = "LicenseRef-ring"
 version = "0.16.20"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
 
-# TODO: remove this if / once there is an SPDX entry for ELv2
-[[licenses.clarify]]
-name = "apollo-router"
-expression = "LicenseRef-ELv2"
-version = "0.1.0-preview.7"
-license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
-
-[[licenses.clarify]]
-name = "apollo-router-core"
-expression = "LicenseRef-ELv2"
-version = "0.1.0-preview.7"
-license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
-
-[[licenses.clarify]]
-name = "router-bridge"
-expression = "LicenseRef-ELv2"
-license-files = [{ path = "router-bridge/LICENSE", hash = 0xaceadac9 }]
-
-[[licenses.clarify]]
-name = "apollo-spaceport"
-expression = "LicenseRef-ELv2"
-version = "0.1.0-preview.7"
-license-files = [{ path = "LICENSE", hash = 0xaceadac9 }]
-
 [[licenses.clarify]]
 name = "encoding_rs"
 version = "*"


### PR DESCRIPTION
Since `Elastic-2.0` SPDX identifiers now exist in the [SPDX License List],
we can use them in place of the `license-file` that we had been using
previously, along with our license clarifications in our `deny.toml`
configuration.

[SPDX License List]: https://spdx.org/licenses/

Closes: https://github.com/apollographql/router/issues/418