### PR TITLE
fix: Use QueryPlan::fake_new.

### DIFF
--- a/apollo-router-core/src/services/mod.rs
+++ b/apollo-router-core/src/services/mod.rs
@@ -375,7 +375,7 @@ impl QueryPlannerResponse {
     ) -> Result<QueryPlannerResponse, BoxError> {
         tracing::warn!("no way to propagate error response from QueryPlanner");
         Ok(QueryPlannerResponse::new(
-            Arc::new(QueryPlan::fake_new(None, None)),
+            Arc::new(QueryPlan::fake_builder().build()),
             context,
         ))
     }

--- a/apollo-router-core/src/services/mod.rs
+++ b/apollo-router-core/src/services/mod.rs
@@ -375,7 +375,7 @@ impl QueryPlannerResponse {
     ) -> Result<QueryPlannerResponse, BoxError> {
         tracing::warn!("no way to propagate error response from QueryPlanner");
         Ok(QueryPlannerResponse::new(
-            Arc::new(Default::default()),
+            Arc::new(QueryPlan::fake_new(None, None)),
             context,
         ))
     }


### PR DESCRIPTION
QueryPlan doesn't have a default implementation anymore, since any query plan will at least have an optional root and usage reporting.

This commit fixes the compile issue.