### PR TITLE
Environment variables have been renamed for consistency:

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -25,6 +25,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 # [v0.1.0-preview.8] - (unreleased)
 ## ❗ BREAKING ❗
 
+### Env variables naming [PR #990](https://github.com/apollographql/router/pull/990)
+Environment variables have been renamed for consistency:
+* `RUST_LOG` -> `APOLLO_ROUTER_LOG`
+* `CONFIGURATION_PATH` -> `APOLLO_ROUTER_CONFIG_PATH`
+* `SUPERGRAPH_PATH` -> `APOLLO_ROUTER_SUPERGRAPH_PATH`
+* `ROUTER_HOT_RELOAD` -> `APOLLO_ROUTER_HOT_RELOAD`
+
+
+### Rhai scripts should be able to do more things (like rust plugins) [PR #971](https://github.com/apollographql/router/pull/971)
 ### Add configuration to declare your own GraphQL endpoint [PR #976](https://github.com/apollographql/router/pull/976)
 You are now able to declare your own GraphQL endpoint in the config like this:
 ```yaml

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -31,7 +31,12 @@ Environment variables have been renamed for consistency:
 * `CONFIGURATION_PATH` -> `APOLLO_ROUTER_CONFIG_PATH`
 * `SUPERGRAPH_PATH` -> `APOLLO_ROUTER_SUPERGRAPH_PATH`
 * `ROUTER_HOT_RELOAD` -> `APOLLO_ROUTER_HOT_RELOAD`
+* `APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT` -> `APOLLO_UPLINK_URL`
+* `APOLLO_SCHEMA_POLL_INTERVAL`-> `APOLLO_UPLINK_INTERVAL`
 
+In addition, the following command line flags have changed:
+* `--apollo-schema-config-delivery-endpoint` -> `--apollo-uplink-url`
+* `--apollo-schema-poll-interval` -> `--apollo-uplink-poll-interval`
 
 ### Rhai scripts should be able to do more things (like rust plugins) [PR #971](https://github.com/apollographql/router/pull/971)
 ### Add configuration to declare your own GraphQL endpoint [PR #976](https://github.com/apollographql/router/pull/976)

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -69,11 +69,11 @@ pub struct Opt {
 
     /// The endpoint polled to fetch the latest supergraph schema.
     #[clap(long, env)]
-    apollo_schema_config_delivery_endpoint: Option<Url>,
+    apollo_uplink_url: Option<Url>,
 
     /// The time between polls to Apollo uplink. Minimum 10s.
     #[clap(long, default_value = "10s", parse(try_from_str = humantime::parse_duration), env)]
-    apollo_schema_poll_interval: Duration,
+    apollo_uplink_poll_interval: Duration,
 
     /// Display version and exit
     #[clap(parse(from_flag), long, short = 'V')]
@@ -222,15 +222,15 @@ pub async fn rt_main() -> Result<()> {
                 std::env!("CARGO_PKG_VERSION")
             );
             let apollo_graph_ref = opt.apollo_graph_ref.ok_or_else(||anyhow!("cannot fetch the supergraph from Apollo Studio without setting the APOLLO_GRAPH_REF environment variable"))?;
-            if opt.apollo_schema_poll_interval < Duration::from_secs(10) {
+            if opt.apollo_uplink_poll_interval < Duration::from_secs(10) {
                 return Err(anyhow!("Apollo poll interval must be at least 10s"));
             }
 
             SchemaKind::Registry {
                 apollo_key,
                 apollo_graph_ref,
-                url: opt.apollo_schema_config_delivery_endpoint,
-                poll_interval: opt.apollo_schema_poll_interval,
+                url: opt.apollo_uplink_url,
+                poll_interval: opt.apollo_uplink_poll_interval,
             }
         }
         _ => {

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -28,7 +28,7 @@ COPY --from=build --chown=root:root /dist /dist
 
 WORKDIR /dist
 
-ENV CONFIGURATION_PATH="/dist/config/router.yaml"
+ENV APOLLO_ROUTER_CONFIGURATION_PATH="/dist/config/router.yaml"
 
 # Default executable is the router
 ENTRYPOINT ["./router"]

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -135,7 +135,7 @@ Your Apollo key.
 <tr>
 <td style="min-width: 150px;">
 
-##### `--apollo-schema-config-delivery-endpoint` <br/><br/> `APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT`
+##### `--apollo-uplink-url` <br/><br/> `APOLLO_UPLINK_URL`
 
 </td>
 <td>
@@ -147,7 +147,7 @@ The endpoint polled to fetch the latest supergraph schema.
 <tr>
 <td style="min-width: 150px;">
 
-##### `--apollo-schema-poll-interval` <br/><br/> `APOLLO_SCHEMA_POLL_INTERVAL`
+##### `--apollo-uplink-poll-interval` <br/><br/> `APOLLO_UPLINK_POLL_INTERVAL`
 
 </td>
 <td>

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -30,7 +30,7 @@ Options are described below. Some may also be configured via env variable, howev
 <tr class="required">
 <td>
 
-##### `-s` / `--supergraph` <br/><br/> `SUPERGRAPH_PATH`
+##### `-s` / `--supergraph` <br/><br/> `APOLLO_ROUTER_SUPERGRAPH_PATH`
 
 </td>
 <td>
@@ -45,7 +45,7 @@ To learn how to compose your supergraph schema with the Rover CLI, see the [Fede
 <tr>
 <td style="min-width: 150px;">
 
-##### `-c` / `--config` <br/><br/> `CONFIGURATION_PATH`
+##### `-c` / `--config` <br/><br/> `APOLLO_ROUTER_CONFIG_PATH`
 
 </td>
 <td>
@@ -58,7 +58,7 @@ The absolute or relative path to the router's optional [YAML configuration file]
 <tr>
 <td style="min-width: 150px;">
 
-##### `--log` <br/><br/> `RUST_LOG`
+##### `--log` <br/><br/> `APOLLO_ROUTER_LOG`
 
 </td>
 <td>
@@ -86,7 +86,7 @@ Prints out a JSON schema of the configuration file, including plugin configurati
 <tr>
 <td style="min-width: 150px;">
 
-##### `--hr` / `--hot-reload`
+##### `--hr` / `--hot-reload` <br/><br/> `APOLLO_ROUTER_HOT_RELOAD`
 
 </td>
 <td>
@@ -162,7 +162,7 @@ The time between polls to Apollo uplink. Minimum 10s.
 
 ## Configuration file
 
-The Apollo Router takes an optional YAML configuration file as input via the `--config` option. If the `--hot-reload` flag is also passed (or the `ROUTER_HOT_RELOAD` environment variable is set to `true`), the router will automatically restart when changes to the configuration file are made.
+The Apollo Router takes an optional YAML configuration file as input via the `--config` option. If the `--hot-reload` flag is also passed (or the `APOLLO_ROUTER_HOT_RELOAD` environment variable is set to `true`), the router will automatically restart when changes to the configuration file are made.
 
 This file enables you to customize the router's behavior in many ways:
 

--- a/docs/source/migrating-from-gateway.mdx
+++ b/docs/source/migrating-from-gateway.mdx
@@ -8,7 +8,7 @@ If you're currently using the `@apollo/gateway` library in your federated graph,
 
 ## What's different?
 
-Unlike `@apollo/gateway`, the Apollo Router is usually packaged as a _static, standalone binary_. You can pass this binary a [YAML configuration file](./configuration/overview/#configuration-file) at startup to customize its behavior.  Additionally, if you start your router with the `--hot-reload` flag, or set the `ROUTER_HOT_RELOAD` environment variable to `true` you can even _modify_ that configuration and have changes picked up without restarting the router.
+Unlike `@apollo/gateway`, the Apollo Router is usually packaged as a _static, standalone binary_. You can pass this binary a [YAML configuration file](./configuration/overview/#configuration-file) at startup to customize its behavior.  Additionally, if you start your router with the `--hot-reload` flag, or set the `APOLLO_ROUTER_HOT_RELOAD` environment variable to `true` you can even _modify_ that configuration and have changes picked up without restarting the router.
 
 You _can_ use the Apollo Router as a library in a larger project, but our goal is to remove the need to write custom code in your graph router (as is necessary with `@apollo/gateway`). Instead, the Apollo Router exposes the most common critical features via declarative configuration.
 


### PR DESCRIPTION
* `RUST_LOG` -> `APOLLO_ROUTER_LOG`
* `CONFIGURATION_PATH` -> `APOLLO_ROUTER_CONFIG_PATH`
* `SUPERGRAPH_PATH` -> `APOLLO_ROUTER_SUPERGRAPH_PATH`
* `ROUTER_HOT_RELOAD` -> `APOLLO_ROUTER_HOT_RELOAD`
* `APOLLO_SCHEMA_CONFIG_DELIVERY_ENDPOINT` -> `APOLLO_UPLINK_URL`
* `APOLLO_SCHEMA_POLL_INTERVAL`-> `APOLLO_UPLINK_POLL_INTERVAL`

Cmd line flag changes:
* `--apollo-schema-config-delivery-endpoint` -> `--apollo-uplink-url`
* `--apollo-schema-poll-interval` -> `--apollo-uplink-poll-interval`

Notes:
I checked the logic of tracing subscriber with respect to https://github.com/tokio-rs/tracing/issues/735#issuecomment-948076439 and I believe we are safe.

The issue is around `tracing_subscriber::fmt::init()` which has some logic that deals with `RUST_LOG`.
However, we are not currently using this, and  the logic within `tracing_subscriber::fmt::fmt().with_env_filter(EnvFilter::try_new(&opt.log_level)` seems sound.
