### PR TITLE
impose recursion limits on selection processing

### DIFF
--- a/apollo-router-core/src/spec/fragments.rs
+++ b/apollo-router-core/src/spec/fragments.rs
@@ -41,6 +41,7 @@ impl Fragments {
                                 selection,
                                 &FieldType::Named(type_condition.clone()),
                                 schema,
+                                0,
                             )
                         })
                         .collect::<Option<_>>()?;

--- a/apollo-router-core/src/spec/query.rs
+++ b/apollo-router-core/src/spec/query.rs
@@ -700,7 +700,7 @@ impl Operation {
             .selection_set()
             .expect("the node SelectionSet is not optional in the spec; qed")
             .selections()
-            .map(|selection| Selection::from_ast(selection, &current_field_type, schema))
+            .map(|selection| Selection::from_ast(selection, &current_field_type, schema, 0))
             .collect::<Option<_>>()?;
 
         let variables = operation


### PR DESCRIPTION
Impose a restriction on the amount of recursion that can be performed
during selection processing.

