### PR TITLE
Improve the hello world example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1870,6 +1870,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
+ "tracing",
 ]
 
 [[package]]

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -14,3 +14,4 @@ serde = "1.0.136"
 serde_json = "1.0.79"
 tokio = { version = "1.17.0", features = ["full"] }
 tower = { version = "0.4.12", features = ["full"] }
+tracing = "0.1.34"

--- a/examples/hello-world/router.yaml
+++ b/examples/hello-world/router.yaml
@@ -1,4 +1,5 @@
 plugins:
-  # this plugin doesn't have any configuration
-  # mention it here and you're set!
+  # this plugin has one piece of configuration,
+  # the name of the entity you'd like to say hello to
   example.hello_world:
+    name: "Bob"


### PR DESCRIPTION
Log/Print the supplied name configuration when router_service callback is
invoked.

Also: add a test which uses the new PluginTestHarness and prints
a configuration based message to stdout when the router_service callback
is invoked.

fixes: #961 