### PR TITLE
Panics now output to logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,7 @@ dependencies = [
  "async-trait",
  "atty",
  "axum",
+ "backtrace",
  "buildstructor",
  "bytes",
  "clap 3.1.9",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -38,7 +38,6 @@ In addition, the following command line flags have changed:
 * `--apollo-schema-config-delivery-endpoint` -> `--apollo-uplink-url`
 * `--apollo-schema-poll-interval` -> `--apollo-uplink-poll-interval`
 
-### Rhai scripts should be able to do more things (like rust plugins) [PR #971](https://github.com/apollographql/router/pull/971)
 ### Add configuration to declare your own GraphQL endpoint [PR #976](https://github.com/apollographql/router/pull/976)
 You are now able to declare your own GraphQL endpoint in the config like this:
 ```yaml
@@ -55,6 +54,10 @@ But we also deleted the `/graphql` endpoint by default, you will know have only 
 This is a re-working of our rhai scripting support. The intent is to make writing a rhai plugin more like writing a rust plugin, with full participation in the service plugin lifecycle. The work is still some way from complete, but does provide new capabilities (such as logging from rhai) and provides a more solid basis on which we can evolve our implementation. The examples and documentation should make clear how to modify any existing scripts to accomodate the changes.
 
 ## 🚀 Features ( :rocket: )
+
+### Panics now output to logs  [PR #1001](https://github.com/apollographql/router/pull/1001)
+Previously panics would get swallowed. Now they are output to the logs.
+Setting `RUST_BACKTRACE=1` or `RUST_BACKTRACE=full` enables the full backtrace to also be logged.
 
 ### Apollo studio Usage Reporting [PR #898](https://github.com/apollographql/router/pull/898)
 If you have [enabled telemetry](https://www.apollographql.com/docs/router/configuration/apollo-telemetry#enabling-usage-reporting), you can now see field usage reporting for your queries by heading to the Apollo studio fields section.

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -16,6 +16,7 @@ apollo-router-core = { path = "../apollo-router-core" }
 apollo-uplink = { path = "../uplink" }
 async-trait = "0.1.53"
 atty = "0.2.14"
+backtrace = "0.3.65"
 buildstructor = "0.1.12"
 bytes = "1.1.0"
 clap = { version = "3.1.3", default-features = false, features = ["env", "derive", "std"] }

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -541,9 +541,6 @@ async fn setup_router_and_registry() -> (
     BoxCloneService<RouterRequest, RouterResponse, BoxError>,
     CountingServiceRegistry,
 ) {
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
-        .try_init();
     std::panic::set_hook(Box::new(|e| {
         let backtrace = backtrace::Backtrace::new();
         tracing::error!("{}\n{:?}", e, backtrace)

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -541,6 +541,13 @@ async fn setup_router_and_registry() -> (
     BoxCloneService<RouterRequest, RouterResponse, BoxError>,
     CountingServiceRegistry,
 ) {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+    std::panic::set_hook(Box::new(|e| {
+        let backtrace = backtrace::Backtrace::new();
+        tracing::error!("{}\n{:?}", e, backtrace)
+    }));
     let schema: Arc<Schema> =
         Arc::new(include_str!("fixtures/supergraph.graphql").parse().unwrap());
     let counting_registry = CountingServiceRegistry::new();


### PR DESCRIPTION
Previously panics would get swallowed. Now they are output to the logs.
Setting `RUST_BACKTRACE=1` or `RUST_BACKTRACE=full` enables the full backtrace to also be logged.

A warning is output to the logs on startup if `RUST_BACKTRACE` is set.