### PR TITLE
do not require the RUST_BACKTRACE environment variable at compilation time

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -55,7 +55,7 @@ This is a re-working of our rhai scripting support. The intent is to make writin
 
 ## 🚀 Features ( :rocket: )
 
-### Panics now output to logs  [PR #1001](https://github.com/apollographql/router/pull/1001)
+### Panics now output to logs [PR #1001](https://github.com/apollographql/router/pull/1001) [PR #1004](https://github.com/apollographql/router/pull/1004)
 Previously panics would get swallowed. Now they are output to the logs.
 Setting `RUST_BACKTRACE=1` or `RUST_BACKTRACE=full` enables the full backtrace to also be logged.
 

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -280,10 +280,11 @@ pub async fn rt_main() -> Result<()> {
 
 fn setup_panic_handler() {
     // Redirect panics to the logs.
-    let backtrace_env = std::env!("RUST_BACKTRACE");
-    let show_backtraces = backtrace_env == "1" || backtrace_env == "full";
+    let backtrace_env = std::env::var("RUST_BACKTRACE");
+    let show_backtraces =
+        backtrace_env.as_deref() == Ok("1") || backtrace_env.as_deref() == Ok("full");
     if show_backtraces {
-        tracing::warn!("RUST_BACKTRACE={} detected. This use useful for diagnostics but will have a performance impact and may leak sensitive information", backtrace_env);
+        tracing::warn!("RUST_BACKTRACE={} detected. This use useful for diagnostics but will have a performance impact and may leak sensitive information", backtrace_env).as_ref().unwrap();
     }
     std::panic::set_hook(Box::new(move |e| {
         if show_backtraces {

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -284,7 +284,7 @@ fn setup_panic_handler() {
     let show_backtraces =
         backtrace_env.as_deref() == Ok("1") || backtrace_env.as_deref() == Ok("full");
     if show_backtraces {
-        tracing::warn!("RUST_BACKTRACE={} detected. This use useful for diagnostics but will have a performance impact and may leak sensitive information", backtrace_env).as_ref().unwrap();
+        tracing::warn!("RUST_BACKTRACE={} detected. This use useful for diagnostics but will have a performance impact and may leak sensitive information", backtrace_env.as_ref().unwrap());
     }
     std::panic::set_hook(Box::new(move |e| {
         if show_backtraces {


### PR DESCRIPTION
if we use std::env!, the router will not xompile when the environment variable is not present:

error: environment variable `RUST_BACKTRACE` not defined                                                               
   --> apollo-router/src/executable.rs:283:25                                                                          
    |                                                                                                                  
283 |     let backtrace_env = std::env!("RUST_BACKTRACE");                                                              
    |                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                              
    |                                                                                                                  
    = note: this error originates in the macro `std::env` (in Nightly builds, run with -Z macro-backtrace for more info)
