### PR TITLE
fix a panic in zipkin telemetry configuration

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -39,3 +39,6 @@ Note: prometheus metrics are not enabled by default in the helm chart.
 ## 🛠 Maintenance ( :hammer_and_wrench: )
 ## 📚 Documentation ( :books: )
 ## 🐛 Fixes ( :bug: )
+
+### Fix a panic in Zipkin telemetry configuration [PR #1019](https://github.com/apollographql/router/pull/1019)
+Using the reqwest blocking client feature was panicking due to incompatible asynchronous runtime usage.

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -59,7 +59,7 @@ opentelemetry-otlp = { version = "0.10.0", default-features = false, features = 
 ] }
 opentelemetry-semantic-conventions = "0.9.0"
 opentelemetry-zipkin = { version = "0.15.0", default-features = false, features = [
-    "reqwest-blocking-client",
+    "reqwest-client",
     "reqwest-rustls",
 ] }
 opentelemetry-prometheus = "0.10.0"


### PR DESCRIPTION
fix #1017 

using the blocking reqwest client feature of opentelemetry-zipkin was
pankicing with this message: "Cannot drop a runtime in a context where
blocking is not allowed. This happens when a runtime is dropped from
within an asynchronous context."
