### PR TITLE
use vanity URL for download instructions

### DIFF
--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -11,7 +11,7 @@ Hello! This tutorial walks you through installing the Apollo Router and running 
 
 If you have a bash compatible terminal you can download the latest version of the Apollo Router directly to your current directory.
 ```bash
-https://router.apollo.dev/download/nix/latest | sh
+curl -sSL https://router.apollo.dev/download/nix/latest | sh
 ```
 
 ### Manual download

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -11,7 +11,7 @@ Hello! This tutorial walks you through installing the Apollo Router and running 
 
 If you have a bash compatible terminal you can download the latest version of the Apollo Router directly to your current directory.
 ```bash
-bash <(curl -fsSL https://raw.githubusercontent.com/apollographql/router/main/scripts/install.sh)  
+https://router.apollo.dev/download/nix/latest | bash
 ```
 
 ### Manual download

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -11,7 +11,7 @@ Hello! This tutorial walks you through installing the Apollo Router and running 
 
 If you have a bash compatible terminal you can download the latest version of the Apollo Router directly to your current directory.
 ```bash
-https://router.apollo.dev/download/nix/latest | bash
+https://router.apollo.dev/download/nix/latest | sh
 ```
 
 ### Manual download


### PR DESCRIPTION
This allows us to own the host that is used for installing the router and
mitigate outages if GitHub goes down.  For now, the URL just redirects to
the previous URL, but in the future we could have it try other locations in
the event of an outage.

It also looks much nicer!

Closes #962