### PR TITLE
Remove Netlify Badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <a href="#"><img src="https://raw.githubusercontent.com/apollographql/space-kit/main/src/illustrations/svgs/satellite1.svg" width="100%" height="144"></a>
 
 [![CircleCI](https://circleci.com/gh/apollographql/router/tree/main.svg?style=shield)](https://circleci.com/gh/apollographql/router/tree/main)
-[![Netlify Status](https://api.netlify.com/api/v1/badges/29a5691a-77f6-4253-99a4-45027cfa3278/deploy-status)](https://app.netlify.com/sites/apollo-router-docs/deploys)
 
 # Apollo Router
 


### PR DESCRIPTION
This badge is no longer necessary and always showing as failed right now.
