### PR TITLE
docs: Remove "(preview)" from docset switcher button

### DIFF
--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -1,5 +1,5 @@
 {
-  "title": "Router (preview)",
+  "title": "Router",
   "algoliaFilters": [
     "docset:router"
   ],


### PR DESCRIPTION
We have graduated to the GA release and are no longer in "preview"!
