### PR TITLE
Add additional example to header propagation docs

### DIFF
--- a/docs/source/configuration/header-propagation.mdx
+++ b/docs/source/configuration/header-propagation.mdx
@@ -75,6 +75,32 @@ Enables you to add custom headers to requests going to a specific subgraph. Thes
     value: "indeed"
 ```
 
+## Rules Ordering
+
+Rules are applied in the order in which they are declared. For example:
+
+```yaml title="bad_configuration.yaml"
+headers:
+all:
+  - remove:
+    named: "test"
+  - propagate:
+    matching: .*
+```
+
+In this example, the header named test would be removed from the propagation list, but then immediately the propagate rule would match and ensure it was added back to the list. This is clearly undesirable. To do this correctly, ensure that the propagate rule is specified first in your configuration:
+
+```yaml title="good_configuration.yaml"
+headers:
+all:
+  - propagate:
+    matching: .*
+  - remove:
+    named: "test"
+```
+
+This would result in adding all headers to the propagation list, then removing the header named "test", which is the desired outcome.
+
 ## Example
 
 Here's a complete example showing all the possible configuration options in use:


### PR DESCRIPTION
Along with a bit of explanatory text about rule ordering.

fixes: #1055 