### PR TITLE
 aggregate usage reports as they come and flush every 5 seconds to spaceport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,6 @@ dependencies = [
  "displaydoc",
  "envmnt",
  "futures",
- "futures-batch",
  "hotwatch",
  "http",
  "humantime",
@@ -1565,17 +1564,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-batch"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f5c372b0c5d1023cce2a0ff7667b589ba88dae751b5f65c400b5d0803b30cbf"
-dependencies = [
- "futures",
- "futures-timer",
- "pin-utils",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1646,12 +1634,6 @@ name = "futures-task"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
-
-[[package]]
-name = "futures-timer"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1de7508b218029b0f01662ed8f61b1c964b3ae99d6f25462d0f55a595109df6"
 
 [[package]]
 name = "futures-util"

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -32,6 +32,11 @@ In addition these setting have also been removed from the telemetry configuratio
 
 ## 🚀 Features
 ## 🐛 Fixes
+
+
+### Aggregate usage reports in streaming and set the timeout to 5 seconds [PR #1066](https://github.com/apollographql/router/pull/1066)
+The metrics plugin was allocating chunks of usagen reports to aggregate them right after, this was replaced by a streaming loop. The interval for sending the reports to spaceport was reduced from 10s to 5s.
+
 ## 🛠 Maintenance
 ## 📚 Documentation
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -35,7 +35,7 @@ In addition these setting have also been removed from the telemetry configuratio
 
 
 ### Aggregate usage reports in streaming and set the timeout to 5 seconds [PR #1066](https://github.com/apollographql/router/pull/1066)
-The metrics plugin was allocating chunks of usagen reports to aggregate them right after, this was replaced by a streaming loop. The interval for sending the reports to spaceport was reduced from 10s to 5s.
+The metrics plugin was allocating chunks of usage reports to aggregate them right after, this was replaced by a streaming loop. The interval for sending the reports to spaceport was reduced from 10s to 5s.
 
 ## 🛠 Maintenance
 ## 📚 Documentation

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -27,7 +27,6 @@ directories = "4.0.1"
 displaydoc = "0.2"
 envmnt = "0.9.1"
 futures = { version = "0.3.21", features = ["thread-pool"] }
-futures-batch = "0.6.0"
 hotwatch = "0.4.6"
 http = "0.2.7"
 humantime = "2.1.0"

--- a/apollo-router/src/plugins/telemetry/metrics/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo.rs
@@ -20,7 +20,7 @@ use url::Url;
 mod duration_histogram;
 pub(crate) mod studio;
 
-const DEFAULT_BATCH_SIZE: usize = 65_536;
+const DEFAULT_BATCH_SIZE: usize = 50;
 const DEFAULT_QUEUE_SIZE: usize = 65_536;
 
 #[derive(Clone)]
@@ -156,7 +156,7 @@ impl ApolloMetricsExporter {
             // We want to collect stats into batches, but also send periodically if a batch is not filled.
             // This implementation is not ideal as we do have to store all the data when really it could be folded as it is generated.
             // But in the interested of getting something over the line quickly let's go with this as it is simple to understand.
-            rx.chunks_timeout(DEFAULT_BATCH_SIZE, Duration::from_secs(10))
+            rx.chunks_timeout(DEFAULT_BATCH_SIZE, Duration::from_secs(1))
                 .for_each(|reports| async {
                     let aggregated_report = Report::new(reports);
 

--- a/apollo-router/src/plugins/telemetry/metrics/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo.rs
@@ -4,11 +4,11 @@ use crate::plugins::telemetry::apollo::Config;
 use crate::plugins::telemetry::config::MetricsCommon;
 use crate::plugins::telemetry::metrics::{MetricsBuilder, MetricsConfigurator};
 use crate::stream::StreamExt;
-use apollo_spaceport::{Reporter, ReporterError};
+use apollo_spaceport::{ReportHeader, Reporter, ReporterError};
 use async_trait::async_trait;
+use deadpool::managed::Pool;
 use deadpool::{managed, Runtime};
 use futures::channel::mpsc;
-use futures_batch::ChunksTimeoutStreamExt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 use studio::Report;
@@ -20,7 +20,6 @@ use url::Url;
 mod duration_histogram;
 pub(crate) mod studio;
 
-const DEFAULT_BATCH_SIZE: usize = 50;
 const DEFAULT_QUEUE_SIZE: usize = 65_536;
 
 #[derive(Clone)]
@@ -124,7 +123,7 @@ impl ApolloMetricsExporter {
         // * If we cannot connect to spaceport metrics are discarded and a warning raised.
         // * When the stream of metrics finishes we terminate the thread.
         // * If the exporter is dropped the remaining records are flushed.
-        let (tx, rx) = mpsc::channel::<SingleReport>(DEFAULT_QUEUE_SIZE);
+        let (tx, mut rx) = mpsc::channel::<SingleReport>(DEFAULT_QUEUE_SIZE);
 
         let header = apollo_spaceport::ReportHeader {
             graph_ref: apollo_graph_ref.to_string(),
@@ -153,44 +152,65 @@ impl ApolloMetricsExporter {
 
         // This is the thread that actually sends metrics
         tokio::spawn(async move {
-            // We want to collect stats into batches, but also send periodically if a batch is not filled.
-            // This implementation is not ideal as we do have to store all the data when really it could be folded as it is generated.
-            // But in the interested of getting something over the line quickly let's go with this as it is simple to understand.
-            rx.chunks_timeout(DEFAULT_BATCH_SIZE, Duration::from_secs(1))
-                .for_each(|reports| async {
-                    let aggregated_report = Report::new(reports);
+            let timeout = tokio::time::interval(Duration::from_secs(5));
+            let mut report = Report::default();
+            tokio::pin!(timeout);
 
-                    match pool.get().await {
-                        Ok(mut reporter) => {
-                            let report = aggregated_report.into_report(header.clone());
-                            match reporter
-                                .submit(apollo_spaceport::ReporterRequest {
-                                    apollo_key: apollo_key.clone(),
-                                    report: Some(report),
-                                })
-                                .await
-                            {
-                                Ok(_) => {}
-                                Err(e) => {
-                                    tracing::warn!("failed to submit stats to spaceport: {}", e);
-                                }
-                            };
+            loop {
+                tokio::select! {
+                    single_report = rx.next() => {
+                        if let Some(r) = single_report {
+                            report += r;
+                        } else {
+                            break;
                         }
-                        Err(err) => {
-                            tracing::warn!(
-                                "stats discarded as unable to get connection to spaceport: {}",
-                                err
-                            );
+                       },
+                    _ = timeout.tick() => {
+                        if report.operation_count != 0 {
+                            Self::send_report(&pool, &apollo_key, &header, std::mem::take(&mut report)).await;
                         }
-                    };
-                })
-                .await;
+                    }
+                };
+            }
+
+            Self::send_report(&pool, &apollo_key, &header, report).await;
         });
         Ok(ApolloMetricsExporter { tx })
     }
 
     pub(crate) fn provider(&self) -> Sender {
         Sender::Spaceport(self.tx.clone())
+    }
+
+    async fn send_report(
+        pool: &Pool<ReporterManager>,
+        apollo_key: &str,
+        header: &ReportHeader,
+        report: Report,
+    ) {
+        match pool.get().await {
+            Ok(mut reporter) => {
+                let report = report.into_report(header.clone());
+                match reporter
+                    .submit(apollo_spaceport::ReporterRequest {
+                        apollo_key: apollo_key.to_string(),
+                        report: Some(report),
+                    })
+                    .await
+                {
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!("failed to submit stats to spaceport: {}", e);
+                    }
+                };
+            }
+            Err(err) => {
+                tracing::warn!(
+                    "stats discarded as unable to get connection to spaceport: {}",
+                    err
+                );
+            }
+        };
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/metrics/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo.rs
@@ -166,9 +166,7 @@ impl ApolloMetricsExporter {
                         }
                        },
                     _ = timeout.tick() => {
-                        if report.operation_count != 0 {
-                            Self::send_report(&pool, &apollo_key, &header, std::mem::take(&mut report)).await;
-                        }
+                        Self::send_report(&pool, &apollo_key, &header, std::mem::take(&mut report)).await;
                     }
                 };
             }
@@ -188,6 +186,10 @@ impl ApolloMetricsExporter {
         header: &ReportHeader,
         report: Report,
     ) {
+        if report.operation_count == 0 {
+            return;
+        }
+
         match pool.get().await {
             Ok(mut reporter) => {
                 let report = report.into_report(header.clone());

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/studio.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/studio.rs
@@ -7,7 +7,8 @@ use std::ops::AddAssign;
 use std::time::{Duration, SystemTime};
 
 impl Report {
-    pub(crate) fn new(reports: Vec<SingleReport>) -> Report {
+    #[cfg(test)]
+    fn new(reports: Vec<SingleReport>) -> Report {
         let mut aggregated_report = Report::default();
         for report in reports {
             aggregated_report += report;
@@ -89,7 +90,7 @@ pub(crate) struct SingleFieldStat {
 #[derive(Default, Serialize)]
 pub(crate) struct Report {
     traces_per_query: HashMap<String, TracesAndStats>,
-    operation_count: u64,
+    pub(crate) operation_count: u64,
 }
 
 impl AddAssign<SingleReport> for Report {

--- a/licenses.html
+++ b/licenses.html
@@ -2761,7 +2761,6 @@
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/llogiq/bytecount ">bytecount</a></li>
-                    <li><a href=" https://github.com/mre/futures-batch ">futures-batch</a></li>
                     <li><a href=" https://github.com/derekdreery/normalize-line-endings ">normalize-line-endings</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi</a></li>
                 </ul>
@@ -6122,7 +6121,6 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/dnsl48/fraction.git ">fraction</a></li>
                     <li><a href=" https://github.com/sagiegurari/fsio.git ">fsio</a></li>
                     <li><a href=" https://github.com/smol-rs/futures-lite ">futures-lite</a></li>
-                    <li><a href=" https://github.com/async-rs/futures-timer ">futures-timer</a></li>
                     <li><a href=" https://github.com/gimli-rs/gimli ">gimli</a></li>
                     <li><a href=" https://github.com/rust-lang/glob ">glob</a></li>
                     <li><a href=" https://github.com/zkcrypto/group ">group</a></li>


### PR DESCRIPTION
65536 is not a useful batch size because we will rarely reach it, and
with a 10s timeout, we need to wait for at least 10s to have a first
message sent to studio, which does not make a great local development
experience