### PR TITLE
APOLLO_KEY and APOLLO_GRAPH_REF can only be set via env variable.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -25,6 +25,11 @@ Description! And a link to a [reference](http://url)
 # [0.9.1] (unreleased) - 2022-mm-dd
 
 ## ❗ BREAKING ❗
+
+### Remove command line options `--apollo-graph-key` and `--apollo-graph-ref` [PR #1069](https://github.com/apollographql/router/pull/1069)
+Using these command lime options exposes sensitive data in the process list. Setting via environment variables is now the only way that these can be set.   
+In addition these setting have also been removed from the telemetry configuration in yaml.
+
 ## 🚀 Features
 ## 🐛 Fixes
 ## 🛠 Maintenance

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -449,16 +449,6 @@ expression: "&schema"
         "apollo": {
           "type": "object",
           "properties": {
-            "apollo_graph_ref": {
-              "default": "${APOLLO_GRAPH_REF}",
-              "type": "string",
-              "nullable": true
-            },
-            "apollo_key": {
-              "default": "${APOLLO_KEY}",
-              "type": "string",
-              "nullable": true
-            },
             "client_name_header": {
               "default": "apollographql-client-name",
               "type": "string",

--- a/apollo-router/src/configuration/testdata/tracing_apollo.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_apollo.router.yaml
@@ -5,6 +5,4 @@ telemetry:
     endpoint: "http://example.com"
     client_version_header: apollographql-client-version
     client_name_header: apollographql-client-name
-    apollo_graph_ref: ""
-    apollo_key: ""
 

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -21,8 +21,11 @@ static GLOBAL_ENV_FILTER: OnceCell<String> = OnceCell::new();
 
 /// Options for the router
 #[derive(Parser, Debug)]
-#[clap(global_setting(AppSettings::NoAutoVersion))]
-#[structopt(name = "router", about = "Apollo federation router")]
+#[clap(
+    name = "router",
+    about = "Apollo federation router",
+    global_setting(AppSettings::NoAutoVersion)
+)]
 pub struct Opt {
     /// Log level (off|error|warn|info|debug|trace).
     #[clap(
@@ -59,12 +62,12 @@ pub struct Opt {
     #[clap(long)]
     schema: bool,
 
-    /// Your Apollo key
-    #[clap(long, env)]
+    /// Your Apollo key.
+    #[clap(skip = std::env::var("APOLLO_KEY").ok())]
     apollo_key: Option<String>,
 
-    /// Your Apollo graph reference
-    #[clap(long, env)]
+    /// Your Apollo graph reference.
+    #[clap(skip = std::env::var("APOLLO_GRAPH_REF").ok())]
     apollo_graph_ref: Option<String>,
 
     /// The endpoint polled to fetch the latest supergraph schema.
@@ -75,7 +78,7 @@ pub struct Opt {
     #[clap(long, default_value = "10s", parse(try_from_str = humantime::parse_duration), env)]
     apollo_uplink_poll_interval: Duration,
 
-    /// Display version and exit
+    /// Display version and exit.
     #[clap(parse(from_flag), long, short = 'V')]
     pub version: bool,
 }

--- a/apollo-router/src/plugins/telemetry/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/apollo.rs
@@ -11,12 +11,12 @@ use url::Url;
 pub struct Config {
     pub endpoint: Option<Url>,
 
-    #[schemars(with = "Option<String>", default = "apollo_key_env_str")]
-    #[serde(default = "apollo_key")]
+    #[schemars(skip)]
+    #[serde(skip, default = "apollo_key")]
     pub apollo_key: Option<String>,
 
-    #[schemars(with = "Option<String>", default = "apollo_graph_ref_env_str")]
-    #[serde(default = "apollo_graph_reference")]
+    #[schemars(skip)]
+    #[serde(skip, default = "apollo_graph_reference")]
     pub apollo_graph_ref: Option<String>,
 
     #[schemars(with = "Option<String>", default = "client_name_header_default_str")]
@@ -37,14 +37,6 @@ pub struct Config {
     // The purpose is to allow is to pass this in to the plugin.
     #[schemars(skip)]
     pub(crate) schema_id: String,
-}
-
-fn apollo_key_env_str() -> Option<String> {
-    Some("${APOLLO_KEY}".to_string())
-}
-
-fn apollo_graph_ref_env_str() -> Option<String> {
-    Some("${APOLLO_GRAPH_REF}".to_string())
 }
 
 fn apollo_key() -> Option<String> {

--- a/docs/source/configuration/apollo-telemetry.mdx
+++ b/docs/source/configuration/apollo-telemetry.mdx
@@ -32,12 +32,6 @@ telemetry:
     # If not specified an in-process spaceport is used.
     endpoint: "https://my-spaceport"
 
-    # Optional Apollo key. If not specified the env variable APOLLO_KEY will be used.
-    apollo_key: "${APOLLO_KEY}"
-
-    # Optional graphs reference. If not specified the env variable APOLLO_GRAPH_REF will be used.
-    apollo_graph_ref: "${APOLLO_GRAPH_REF}"
-
 ```
 
 ## Running Spaceport externally (not recommended)

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -100,6 +100,7 @@ One of this or env [`APOLLO_GRAPH_REF`](#APOLLO_GRAPH_REF) is **required**.
 </td>
 </tr>
 
+<tr>
 <td style="min-width: 150px;">
 
 ##### `-c` / `--config`

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -13,6 +13,60 @@ You run the Apollo Router with the following command (assuming you're in the sam
 
 Arguments for this command are described below.
 
+## Environment variables
+
+
+To use [managed federation](https://www.apollographql.com/docs/federation/managed-federation/overview/)
+set these environment variables when running the router:
+```bash
+APOLLO_KEY="..." APOLLO_GRAPH_REF="..." ./router
+```
+
+<table class="field-table api-ref">
+  <thead>
+    <tr>
+      <th>Argument / Environment Variable</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+
+<tbody>
+<tr class="required">
+<td style="min-width: 150px;">
+
+##### `APOLLO_GRAPH_REF`
+
+</td>
+<td>
+
+The graph ref of the registered Apollo graph and variant that the router fetches its supergraph schema from.
+
+One of this or [`-s` / `--supergraph`](#-s----supergraph) is **required**.
+
+If you provide this argument, you must also provide [`APOLLO_KEY`](#APOLLO_KEY).
+
+</td>
+</tr>
+<tr class="required">
+<td style="min-width: 150px;">
+
+##### `APOLLO_KEY`
+
+</td>
+<td>
+
+The [graph API key](/studio/api-keys/#graph-api-keys) that the Apollo Router should use to authenticate with Apollo Studio when fetching its supergraph schema.
+
+If you provide the [`APOLLO_GRAPH_REF`](#APOLLO_GRAPH_REF) env variable, this argument is **required**.
+
+</td>
+</tr>
+
+<tr>
+</tr>
+</tbody>
+</table>
+
 ## Command arguments
 
 Where indicated, some of these arguments can also be set via an environment variable. Command-line arguments always take precedence over environment variables if an option is provided both ways.
@@ -41,47 +95,11 @@ The absolute or relative path to the Apollo Router's [supergraph schema](/federa
 
 To learn how to compose your supergraph schema with the Rover CLI, see the [Federation quickstart](https://www.apollographql.com/docs/federation/quickstart/#3-compose-the-supergraph-schema).
 
-One of this or [`--apollo-graph-ref`](#--apollo-graph-ref) is **required**.
+One of this or env [`APOLLO_GRAPH_REF`](#APOLLO_GRAPH_REF) is **required**.
 
 </td>
 </tr>
 
-<tr class="required">
-<td style="min-width: 150px;">
-
-##### `--apollo-graph-ref`
-
-`APOLLO_GRAPH_REF`
-
-</td>
-<td>
-
-The graph ref of the registered Apollo graph and variant that the router fetches its supergraph schema from.
-
-One of this or [`-s` / `--supergraph`](#-s----supergraph) is **required**.
-
-If you provide this argument, you must also provide [`--apollo-key`](#--apollo-key).
-
-</td>
-</tr>
-<tr class="required">
-<td style="min-width: 150px;">
-
-##### `--apollo-key`
-
-`APOLLO_KEY`
-
-</td>
-<td>
-
-The [graph API key](/studio/api-keys/#graph-api-keys) that the Apollo Router should use to authenticate with Apollo Studio when fetching its supergraph schema.
-
-If you provide the [`--apollo-graph-ref`](#--apollo-graph-ref) argument, this argument is **required**.
-
-</td>
-</tr>
-
-<tr>
 <td style="min-width: 150px;">
 
 ##### `-c` / `--config`


### PR DESCRIPTION
Remove command line args `--apollo-key` and `--apollo-graph-ref`
Remove setting from telemetry.
