### PR TITLE
Bump apollo-parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "apollo-parser"
+version = "0.2.5"
+source = "git+https://github.com/apollographql/apollo-rs.git?tag=hotfix_227#bbfb74c682e86cdefcfcfcd5be9eefafefc796e2"
+dependencies = [
+ "rowan",
+]
+
+[[package]]
 name = "apollo-router"
 version = "0.9.0"
 dependencies = [
@@ -188,7 +196,7 @@ dependencies = [
 name = "apollo-router-core"
 version = "0.9.0"
 dependencies = [
- "apollo-parser",
+ "apollo-parser 0.2.5 (git+https://github.com/apollographql/apollo-rs.git?tag=hotfix_227)",
  "async-trait",
  "atty",
  "axum",
@@ -249,7 +257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec51b82f6dad598b00d48bbe02c4f5b5c0231e5376b22278466701d767bcdd9d"
 dependencies = [
  "apollo-encoder 0.3.1",
- "apollo-parser",
+ "apollo-parser 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "arbitrary",
  "once_cell",
 ]
@@ -3795,7 +3803,7 @@ dependencies = [
 name = "router-fuzz"
 version = "0.0.0"
 dependencies = [
- "apollo-parser",
+ "apollo-parser 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "apollo-smith",
  "env_logger",
  "libfuzzer-sys",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -35,6 +35,10 @@ In addition these setting have also been removed from the telemetry configuratio
 ### Pin schemars version to 0.8.8 [PR #1075](https://github.com/apollographql/router/pull/1075)
 The Schemars 0.8.9 causes compile errors due to it validating default types. Pin the version to 0.8.8.
 See issue [#1074](https://github.com/apollographql/router/issues/1074)
+
+### Fix infinite recursion on during parsing [PR #1078](https://github.com/apollographql/router/pull/1078)
+During parsing of queries the use of `"` in a parameter value caused infinite recursion. This preliminary fix will be revisited shortly.
+
 ## 🛠 Maintenance
 ## 📚 Documentation
 

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 failfast = []
 
 [dependencies]
-apollo-parser = "0.2.5"
+apollo-parser = {git="https://github.com/apollographql/apollo-rs.git", tag="hotfix_227"}
 async-trait = "0.1.53"
 atty = "0.2.14"
 axum = { version = "0.5.4" }


### PR DESCRIPTION
Bump apollo-parser. 
Hotfix for #1065 that would infinitely recurse when `\` is used in a `StringValue` as a first char.
