### PR TITLE
remove the batching and timeout from spaceport

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -35,7 +35,14 @@ In addition these setting have also been removed from the telemetry configuratio
 ### Pin schemars version to 0.8.8 [PR #1075](https://github.com/apollographql/router/pull/1075)
 The Schemars 0.8.9 causes compile errors due to it validating default types. Pin the version to 0.8.8.
 See issue [#1074](https://github.com/apollographql/router/issues/1074)
+
 ## 🛠 Maintenance
+
+### Remove the batching and timeout from spaceport  [PR #1080](https://github.com/apollographql/router/pull/1080)
+apollo-router is already handling report aggregation and sends the
+report every 5s. Now spaceport will put the incoming reports in a
+bounded queue and send them in order, with backpressure.
+
 ## 📚 Documentation
 
 ### Document available metrics in Prometheus [PR #1067](https://github.com/apollographql/router/pull/1067)

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 bytes = "1.1.0"
-clap = { version = "3.1.3", default-features = false, features = ["derive"] }
+clap = { version = "3.1.3", default-features = false, features = ["std", "derive"] }
 flate2 = "1.0.22"
 prost = "0.9.0"
 prost-types = "0.9.0"
@@ -18,7 +18,7 @@ reqwest = { version = "0.11.10", default_features = false, features = [
     "rustls-tls",
     "json",
 ] }
-serde = "1.0.136"
+serde = {version = "1.0.136", features = ["derive"] }
 sys-info = "0.9.1"
 tonic = "0.6.2"
 tokio = { version = "1.17.0", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
follow up on #1066 

apollo-router is already handling report aggregation and sends the
report every 5s. Now spaceport will put the incoming reports in a
bounded queue and send them in order, with backpressure