### PR TITLE
release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.9.1] - 2022-05-17
+
+## ❗ BREAKING ❗
+
+### Remove command line options `--apollo-graph-key` and `--apollo-graph-ref` [PR #1069](https://github.com/apollographql/router/pull/1069)
+Using these command lime options exposes sensitive data in the process list. Setting via environment variables is now the only way that these can be set.
+In addition these setting have also been removed from the telemetry configuration in yaml.
+
+## 🐛 Fixes
+### Pin schemars version to 0.8.8 [PR #1075](https://github.com/apollographql/router/pull/1075)
+The Schemars 0.8.9 causes compile errors due to it validating default types. Pin the version to 0.8.8.
+See issue [#1074](https://github.com/apollographql/router/issues/1074)
+
+### Fix infinite recursion on during parsing [PR #1078](https://github.com/apollographql/router/pull/1078)
+During parsing of queries the use of `"` in a parameter value caused infinite recursion. This preliminary fix will be revisited shortly.
+## 📚 Documentation
+
+### Document available metrics in Prometheus [PR #1067](https://github.com/apollographql/router/pull/1067)
+Add the list of metrics you can have using Prometheus
+
 # [v0.9.0] - 2022-05-13
 
 ## 🎉 **The Apollo Router has graduated from _Preview_ to _General Availability (GA)_!** 🎉

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "apollo-router-core",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "apollo-router",
  "apollo-router-core",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "apollo-parser 0.2.5 (git+https://github.com/apollographql/apollo-rs.git?tag=hotfix_227)",
  "async-trait",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-spaceport"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bytes",
  "clap 3.1.9",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-uplink"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "futures",
  "graphql_client",
@@ -5558,7 +5558,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -22,27 +22,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 Description! And a link to a [reference](http://url)
 -->
 
-# [0.9.1] (unreleased) - 2022-mm-dd
+# [0.9.2] (unreleased) - 2022-mm-dd
 
 ## ❗ BREAKING ❗
 
-### Remove command line options `--apollo-graph-key` and `--apollo-graph-ref` [PR #1069](https://github.com/apollographql/router/pull/1069)
-Using these command lime options exposes sensitive data in the process list. Setting via environment variables is now the only way that these can be set.   
-In addition these setting have also been removed from the telemetry configuration in yaml.
-
 ## 🚀 Features
 ## 🐛 Fixes
-### Pin schemars version to 0.8.8 [PR #1075](https://github.com/apollographql/router/pull/1075)
-The Schemars 0.8.9 causes compile errors due to it validating default types. Pin the version to 0.8.8.
-See issue [#1074](https://github.com/apollographql/router/issues/1074)
-
-### Fix infinite recursion on during parsing [PR #1078](https://github.com/apollographql/router/pull/1078)
-During parsing of queries the use of `"` in a parameter value caused infinite recursion. This preliminary fix will be revisited shortly.
-
 ## 🛠 Maintenance
 ## 📚 Documentation
-
-### Document available metrics in Prometheus [PR #1067](https://github.com/apollographql/router/pull/1067)
-Add the list of metrics you can have using Prometheus
-
 ## 🐛 Fixes

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -37,6 +37,8 @@ in lieu of an official changelog.
 2. Create a new branch "#.#.#" where "#.#.#" is this release's version
     (release) or "#.#.#-rc.#" (release candidate)
 3. Update the version in `*/Cargo.toml`.
+4. Add a new section in `CHANGELOG.md` with the contents of `NEXT_CHANGELOG.md`
+5. Put a Release date and the version number on the new `CHANGELOG.md` section
 4. Update the version in `NEXT_CHANGELOG.md`.
 5. Clear `NEXT_CHANGELOG.md` leaving only the template.
 6. Run `cargo check` so the lock file gets updated.

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-core"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-spaceport"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/dockerfiles/tracing/docker-compose.datadog.yml
+++ b/dockerfiles/tracing/docker-compose.datadog.yml
@@ -3,7 +3,7 @@ services:
 
   apollo-router:
     container_name: apollo-router
-    image: ghcr.io/apollographql/router:v0.9.0
+    image: ghcr.io/apollographql/router:v0.9.1
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/datadog.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.jaeger.yml
+++ b/dockerfiles/tracing/docker-compose.jaeger.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     #build: ./router
-    image: ghcr.io/apollographql/router:v0.9.0
+    image: ghcr.io/apollographql/router:v0.9.1
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/jaeger.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.zipkin.yml
+++ b/dockerfiles/tracing/docker-compose.zipkin.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     build: ./router
-    image: ghcr.io/apollographql/router:v0.9.0
+    image: ghcr.io/apollographql/router:v0.9.1
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/zipkin.router.yaml:/etc/config/configuration.yaml

--- a/docs/source/containerization/docker.mdx
+++ b/docs/source/containerization/docker.mdx
@@ -9,7 +9,7 @@ The default behaviour of the router images is suitable for a quickstart or devel
 
 Note: The [docker documentation](https://docs.docker.com/engine/reference/run/) for the run command may be helpful when reading through the examples.
 
-Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v0.9.0`
+Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v0.9.1`
 
 ## Override the configuration
 

--- a/docs/source/containerization/kubernetes.mdx
+++ b/docs/source/containerization/kubernetes.mdx
@@ -48,7 +48,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.9.0"
+    app.kubernetes.io/version: "v0.9.1"
 ---
 # Source: router/templates/secret.yaml
 apiVersion: v1
@@ -58,7 +58,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.9.0"
+    app.kubernetes.io/version: "v0.9.1"
 data:
   managedFederationApiKey: "REDACTED"
 ---
@@ -70,7 +70,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.9.0"
+    app.kubernetes.io/version: "v0.9.1"
 data:
   configuration.yaml: |
     server:
@@ -88,7 +88,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.9.0"
+    app.kubernetes.io/version: "v0.9.1"
 spec:
   type: ClusterIP
   ports:
@@ -108,7 +108,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.9.0"
+    app.kubernetes.io/version: "v0.9.1"
   annotations:
     prometheus.io/path: /plugins/apollo.telemetry/prometheus
     prometheus.io/port: "80"
@@ -132,7 +132,7 @@ spec:
         - name: router
           securityContext:
             {}
-          image: "ghcr.io/apollographql/router:v0.9.0"
+          image: "ghcr.io/apollographql/router:v0.9.1"
           imagePullPolicy: IfNotPresent
           args:
             - --hot-reload

--- a/docs/source/federation-version-support.mdx
+++ b/docs/source/federation-version-support.mdx
@@ -21,6 +21,16 @@ Apollo Federation is an evolving project, and it will receive new features and b
     </thead>
     <tbody>
     <tr>
+        <td>v0.9.1
+        </td>
+        <td>
+            2.0.2
+        </td>
+        <td>
+            2022-05-17
+        </td>
+    </tr>
+    <tr>
         <td>v0.9.0
         </td>
         <td>

--- a/helm/chart/router/Chart.yaml
+++ b/helm/chart/router/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.9.0"
+appVersion: "v0.9.1"

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-uplink"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 build = "build.rs"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"


### PR DESCRIPTION
# [0.9.1] - 2022-05-17

## ❗ BREAKING ❗

### Remove command line options `--apollo-graph-key` and `--apollo-graph-ref` [PR #1069](https://github.com/apollographql/router/pull/1069)
Using these command lime options exposes sensitive data in the process list. Setting via environment variables is now the only way that these can be set.
In addition these setting have also been removed from the telemetry configuration in yaml.

## 🐛 Fixes
### Pin schemars version to 0.8.8 [PR #1075](https://github.com/apollographql/router/pull/1075)
The Schemars 0.8.9 causes compile errors due to it validating default types. Pin the version to 0.8.8.
See issue [#1074](https://github.com/apollographql/router/issues/1074)

### Fix infinite recursion on during parsing [PR #1078](https://github.com/apollographql/router/pull/1078)
During parsing of queries the use of `"` in a parameter value caused infinite recursion. This preliminary fix will be revisited shortly.
## 📚 Documentation

### Document available metrics in Prometheus [PR #1067](https://github.com/apollographql/router/pull/1067)
Add the list of metrics you can have using Prometheus