### PR TITLE
Fix the deployment template to support not specifying prometheus

### DIFF
--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -4,11 +4,20 @@ metadata:
   name: {{ include "router.fullname" . }}
   labels:
     {{- include "router.labels" . | nindent 4 }}
+  {{/* There may not be much configuration so check that there is something */}}
+  {{- if .Values.router.configuration }}
+  {{- if .Values.router.configuration.telemetry }}
+  {{- if .Values.router.configuration.telemetry.metrics }}
+  {{- if .Values.router.configuration.telemetry.metrics.prometheus }}
   {{- if .Values.router.configuration.telemetry.metrics.prometheus.enabled }}
   annotations:
     prometheus.io/path: /plugins/apollo.telemetry/prometheus
     prometheus.io/port: "{{ .Values.containerPorts.http }}"
     prometheus.io/scrape: "true"
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
   {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}


### PR DESCRIPTION
The best practice fix appears to be to ensure that elements are present
in the configuration or to check each element in the extended dot
notation reference individually.

Usually, I would go with ensuring we have false elements defaulted in
the configuration, but since this is a complex configuration file I'm
going with keeping the configuration file default clean and having
separate checks.

fixes: #1084 