### PR TITLE
Use the new router bridge that generates usage reporting from the apollo_utils package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3783,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation-rs.git?rev=2837a6ce1afc1342f0817bc270b27b07b3f000b3#2837a6ce1afc1342f0817bc270b27b07b3f000b3"
+source = "git+https://github.com/apollographql/federation-rs.git?rev=46fdeb35aa3d3f3289ff0dbbccf63c1234da92a8#46fdeb35aa3d3f3289ff0dbbccf63c1234da92a8"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3783,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation-rs.git?rev=ef47767e80ef7e362105f73e88288a3acca7ea37#ef47767e80ef7e362105f73e88288a3acca7ea37"
+source = "git+https://github.com/apollographql/federation-rs.git?rev=2837a6ce1afc1342f0817bc270b27b07b3f000b3#2837a6ce1afc1342f0817bc270b27b07b3f000b3"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3783,7 +3783,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation-rs.git?rev=572120fdbf957a0640cb946958b9fe52207584ac#572120fdbf957a0640cb946958b9fe52207584ac"
+source = "git+https://github.com/apollographql/federation-rs.git?rev=ef47767e80ef7e362105f73e88288a3acca7ea37#ef47767e80ef7e362105f73e88288a3acca7ea37"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -42,7 +42,7 @@ opentelemetry = "0.17.0"
 opentelemetry-http = "0.6.0"
 paste = "1.0.6"
 regex = "1.5.5"
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "ef47767e80ef7e362105f73e88288a3acca7ea37" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "2837a6ce1afc1342f0817bc270b27b07b3f000b3" }
 schemars = { version = "=0.8.8", features = ["url"] } # https://github.com/apollographql/router/issues/1074
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -42,7 +42,7 @@ opentelemetry = "0.17.0"
 opentelemetry-http = "0.6.0"
 paste = "1.0.6"
 regex = "1.5.5"
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "2837a6ce1afc1342f0817bc270b27b07b3f000b3" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "46fdeb35aa3d3f3289ff0dbbccf63c1234da92a8" }
 schemars = { version = "=0.8.8", features = ["url"] } # https://github.com/apollographql/router/issues/1074
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -42,7 +42,7 @@ opentelemetry = "0.17.0"
 opentelemetry-http = "0.6.0"
 paste = "1.0.6"
 regex = "1.5.5"
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "572120fdbf957a0640cb946958b9fe52207584ac" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "ef47767e80ef7e362105f73e88288a3acca7ea37" }
 schemars = { version = "=0.8.8", features = ["url"] } # https://github.com/apollographql/router/issues/1074
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }


### PR DESCRIPTION
fixes #1096

The usage reporting functions have been refactored into the apollo-utils repository.