### PR TITLE
Add support for building "diy" docker images on demand

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -30,6 +30,10 @@ Description! And a link to a [reference](http://url)
 Removes the `default` parameter and requires inserted values to implement `Default`.
 
 ## 🚀 Features
+
+### DIY docker images [PR #1106](https://github.com/apollographql/router/pull/1106)
+The build_docker_image.sh script is now provided as a working example of how to build docker images from our GH release tarballs or from a commit hash/tag against the router repo.
+
 ## 🐛 Fixes
 
 ### Fix the installation and releasing script for Windows [PR #1098](https://github.com/apollographql/router/pull/1098)

--- a/dockerfiles/diy/build_docker_image.sh
+++ b/dockerfiles/diy/build_docker_image.sh
@@ -7,11 +7,14 @@
 # docker_build_image.sh -h
 #
 # Requirements: To run successfully, you need quite a few utilities installed.
-# Most of them are likely to be installed on your OS. Some will require installation,
-# such as: docker, git, curl, mktemp, getopt
+# Most of them are likely to be installed on your OS. Some will require
+# installation, such as: docker, git, curl, mktemp, getopt
 #
 # Note: git is only required if you are building an image from source with the
 #       -b flag.
+# Note: This utility makes assumptions about the existence of files relative
+#       to the directory where it is executed. To work correctly you must
+#       execute in the "repo"/dockerfiles/diy directory.
 ###
 
 ###

--- a/dockerfiles/diy/build_docker_image.sh
+++ b/dockerfiles/diy/build_docker_image.sh
@@ -1,0 +1,146 @@
+#! /bin/sh
+
+###
+# Build docker images from git commit hash or tag or from released tarballs.
+#
+# See the usage message for more help
+# docker_build_image.sh -h
+#
+# Requirements: To run successfully, you need quite a few utilities installed.
+# Most of them are likely to be installed on your OS. Some will require installation,
+# such as: docker, git, curl, mktemp, getopt
+#
+# Note: git is only required if you are building an image from source with the
+#       -b flag.
+###
+
+###
+# Terminate with a nice usage message
+###
+usage () {
+   printf "Usage: build_docker_image.sh [-b] [<release>]\n"
+   printf "\t-b build docker image from a repo, if not present build from a released tarball\n"
+   printf "\t<release> a valid release. If [-b] is specified, this is optional\n"
+   printf "\tExample 1: Building HEAD from the repo\n"
+   printf "\t\tbuild_docker_image.sh -b\n"
+   printf "\tExample 2: Building tag from the repo\n"
+   printf "\t\tbuild_docker_image.sh -b v0.9.1\n"
+   printf "\tExample 3: Building commit hash from the repo\n"
+   printf "\t\tbuild_docker_image.sh -b 7f7d223f42af34fad35b898d976bc07d0f5440c5\n"
+   printf "\tExample 4: Building tag v0.9.1 from the released tarball\n"
+   printf "\t\tbuild_docker_image.sh v0.9.1\n"
+   exit 2
+}
+
+###
+# Terminate the build and clean up the build directory
+###
+terminate () {
+    echo "${1}, terminating..."
+    # let's be defensive...
+    if [ -n "${BUILD_DIR}" ]; then
+        rm -rf "${BUILD_DIR}"
+    fi
+    exit 1
+}
+
+###
+# Globals
+###
+# If no ROUTER_VERSION specified, we are building HEAD from a repo
+ROUTER_VERSION=
+BUILD_IMAGE=false
+
+###
+# Process Command Line
+###
+if ! args=$(getopt bh "$@"); then
+    usage
+fi
+
+# Note: We want word splitting, disable shellcheck warning
+# shellcheck disable=SC2086
+set -- $args
+
+# You cannot use the set command with a backquoted getopt directly,
+# since the exit code from getopt would be shadowed by those of set,
+# which is zero by definition.
+while :; do
+       case "$1" in
+       -b)
+               BUILD_IMAGE=true
+               shift
+               ;;
+       -h)
+               usage
+               ;;
+       --)
+               shift; break
+               ;;
+       esac
+done
+
+# We only expect 0 or 1 arguments
+if [ $# -gt 1 ]; then
+    usage
+fi
+
+# If we aren't building, we need a ROUTER_VERSION
+if [ $# -gt 0 ]; then
+    ROUTER_VERSION="${1}"
+else
+    if [ "${BUILD_IMAGE}" = false ]; then
+        usage
+    fi
+fi
+
+# We need a place to build
+if ! BUILD_DIR=$(mktemp -d -t "router-build.XXXXXXXXXX"); then
+    echo "Couldn't make build directory, terminating..."
+    exit 1
+fi
+
+echo "Building in: ${BUILD_DIR}"
+
+# Copy in our dockerfiles, we'll need them later
+cp dockerfiles/* "${BUILD_DIR}" || terminate "Couldn't copy dockerfiles to ${BUILD_DIR}"
+cp ../router.yaml "${BUILD_DIR}" || terminate "Couldn't copy ../router.yaml to ${BUILD_DIR}"
+
+# Change to our build directory
+cd "${BUILD_DIR}" || terminate "Couldn't cd to ${BUILD_DIR}";
+ 
+# If we are building, clone our repo
+if [ "${BUILD_IMAGE}" = true ]; then
+    git clone https://github.com/apollographql/router.git > /dev/null 2>&1 || terminate "Couldn't clone repository"
+    cd router || terminate "Couldn't cd to router"
+    # Either unset or blank (equivalent for our purposes)
+    if [ -z "${ROUTER_VERSION}" ]; then
+        ROUTER_VERSION=$(git rev-parse HEAD)
+    fi
+    # Let the user know what we are going to do
+    echo "Building image: ${ROUTER_VERSION}" from repo""
+    git checkout "${ROUTER_VERSION}" > /dev/null 2>&1 || terminate "Couldn't checkout ${ROUTER_VERSION}"
+    # Build our docker images
+    docker build -q -t "router:${ROUTER_VERSION}" \
+        --build-arg ROUTER_VERSION="${ROUTER_VERSION}" \
+        --no-cache -f ../Dockerfile.repo . \
+        || terminate "Couldn't build router image"
+else
+    # Let the user know what we are going to do
+    echo "Building image: ${ROUTER_VERSION}" from released tarballs""
+    ROUTER_RELEASE="$(echo "${ROUTER_VERSION}" | cut -c2-)"
+    docker build -q -t "router:${ROUTER_VERSION}" \
+        --build-arg ROUTER_RELEASE="${ROUTER_RELEASE}" \
+        --no-cache -f Dockerfile.release . \
+        || terminate "Couldn't build router image"
+fi
+
+echo "Image built!"
+
+echo "Cleaning up build directory: ${BUILD_DIR}"
+
+# Finally cleanup our BUILD_DIR
+# let's be defensive...
+if [ -n "${BUILD_DIR}" ]; then
+    rm -rf "${BUILD_DIR}"
+fi

--- a/dockerfiles/diy/dockerfiles/Dockerfile.release
+++ b/dockerfiles/diy/dockerfiles/Dockerfile.release
@@ -1,0 +1,37 @@
+# Note: We require linux/amd64 images here, because we are definitely
+# downloading linux/amd64 images from github and would like our image
+# builds to work on platforms such as Mac OS X/M1 (with some help from
+# rosetta)
+# Build is required to extract the release files
+FROM --platform=linux/amd64 alpine:latest AS build
+
+ARG ROUTER_RELEASE
+
+# Pull release from GH
+ADD https://github.com/apollographql/router/releases/download/v${ROUTER_RELEASE}/router-${ROUTER_RELEASE}-x86_64-linux.tar.gz /tmp/router.tar.gz
+
+WORKDIR /tmp
+
+# router.tar.gz extracts to "dist"
+RUN tar xvzf router.tar.gz -C /
+
+# Make directories for config and schema
+RUN mkdir /dist/config && mkdir /dist/schema
+
+# Copy configuration for docker image
+COPY router.yaml /dist/config
+
+# Final image uses distroless. Feel free to change this to an image that suits your needs.
+FROM --platform=linux/amd64 gcr.io/distroless/cc-debian11
+
+LABEL org.opencontainers.image.authors="ApolloGraphQL https://github.com/apollographql/router"
+
+# Copy in the extracted/created files
+COPY --from=build --chown=root:root /dist /dist
+
+WORKDIR /dist
+
+ENV APOLLO_ROUTER_CONFIG_PATH="/dist/config/router.yaml"
+
+# Default executable is the router
+ENTRYPOINT ["./router"]

--- a/dockerfiles/diy/dockerfiles/Dockerfile.repo
+++ b/dockerfiles/diy/dockerfiles/Dockerfile.repo
@@ -1,0 +1,44 @@
+# Use the rust build image from docker as our base
+FROM rust:1.60.0 as build
+
+# Set our working directory for the build
+WORKDIR /usr/src/router
+
+# Update our build image and install required packages
+RUN apt-get update
+RUN apt-get -y install \
+    npm \
+    nodejs
+
+# Add rustfmt since build requires it
+RUN rustup component add rustfmt
+
+# Copy the router source to our build environment
+COPY . .
+
+# Build and install the router
+RUN cargo install --path apollo-router
+
+# Make directories for config and schema
+RUN mkdir -p /dist/config && \
+    mkdir /dist/schema && \
+    mv /usr/local/cargo/bin/router /dist
+
+# Copy configuration for docker image
+COPY dockerfiles/router.yaml /dist/config
+
+# Final image uses distroless. Feel free to change this to an image that suits your needs.
+FROM gcr.io/distroless/cc-debian11
+
+# Set a label for our image
+LABEL org.opencontainers.image.authors="ApolloGraphQL https://github.com/apollographql/router"
+
+# Copy in the required files from our build image
+COPY --from=build --chown=root:root /dist /dist
+
+WORKDIR /dist
+
+ENV APOLLO_ROUTER_CONFIG_PATH="/dist/config/router.yaml"
+
+# Default executable is the router
+ENTRYPOINT ["./router"]

--- a/docs/source/containerization/docker.mdx
+++ b/docs/source/containerization/docker.mdx
@@ -78,3 +78,24 @@ docker run -p 4000:4000 \
 
 Note: In this example we have to mount the local definition of the supergraph into our image AND specify the location of the file. It doesn't have to be mounted in the /dist/schema directory, but it's a reasonable location to use. We must specify the configuration file location as well, since overriding the default params will override our default config file location. In this case, since we don't want to change our router configuration but want to make sure it's used, we just specify the default location of the default configuration.
 
+## Building your own container
+
+> This section is aimed at developers familiar with tooling such as `docker` and `git` who wish to make their own DIY container images. The script documented here is not a part of the router product, but an illustrative example of what's involved in making your own images.
+
+In the `dockerfiles/diy` directory, we now provide a script, `build_docker_image.sh` which illustrates how to build your own docker images from either our released tarballs or from a git commit hash or tag. Here's how to use it:
+
+```bash
+% ./build_docker_image.sh -h
+Usage: build_docker_image.sh [-b] [<release>]
+	-b build docker image from a repo, if not present build from a released tarball
+	<release> a valid release. If [-b] is specified, this is optional
+	Example 1: Building HEAD from the repo
+		build_docker_image.sh -b
+	Example 2: Building tag from the repo
+		build_docker_image.sh -b v0.9.1
+	Example 3: Building commit hash from the repo
+		build_docker_image.sh -b 7f7d223f42af34fad35b898d976bc07d0f5440c5
+	Example 4: Building tag v0.9.1 from the released tarball
+		build_docker_image.sh v0.9.1
+```
+Note: The script has to be run from the `dockerfiles/diy` directory because it makes assumptions about the relative availability of various files. The example uses [distroless images](https://github.com/GoogleContainerTools/distroless) for the final image build. Feel free to modify the script to use images which better suit your own needs.


### PR DESCRIPTION
We build docker images when we release the router, but it would be nice
to have a mechanism which supported:

 - building from source to arbitrary commit or tag
 - building from released tarballs

This is now provided by build_docker_image.sh. If you don't like the
final image used (distroless), then change that image to whichever image
you prefer.

Note: You can only pull from GH branches which are known in the GH router repo. We could probably add some code to make the clone happen from local (checked out) repos if that's required.
