### PR TITLE
more precision in 'http_requests_duration' metrics

### DIFF
--- a/apollo-router/src/plugins/telemetry/metrics/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/mod.rs
@@ -7,6 +7,7 @@ use opentelemetry::KeyValue;
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tower::util::BoxService;
 use tower::BoxError;
 
@@ -81,6 +82,10 @@ pub(crate) struct BasicMetrics {
     pub http_requests_total: AggregateCounter<u64>,
     pub http_requests_error_total: AggregateCounter<u64>,
     pub http_requests_duration: AggregateValueRecorder<f64>,
+}
+
+pub fn duration_to_observation(duration: &Duration) -> f64 {
+    (duration.as_secs() as f64) + f64::from(duration.subsec_nanos()) / 1_000_000_000_f64
 }
 
 impl BasicMetrics {

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -5,10 +5,7 @@ use crate::plugins::telemetry::config::{MetricsCommon, Trace};
 use crate::plugins::telemetry::metrics::apollo::studio::{
     SingleContextualizedStats, SingleQueryLatencyStats, SingleReport, SingleTracesAndStats,
 };
-use crate::plugins::telemetry::metrics::{
-    AggregateMeterProvider, BasicMetrics, MetricsBuilder, MetricsConfigurator,
-    MetricsExporterHandle,
-};
+use crate::plugins::telemetry::metrics::{AggregateMeterProvider, BasicMetrics, duration_to_observation, MetricsBuilder, MetricsConfigurator, MetricsExporterHandle};
 use crate::plugins::telemetry::tracing::TracingConfigurator;
 use crate::subscriber::replace_layer;
 use ::tracing::{info_span, Span};
@@ -312,7 +309,7 @@ impl Plugin for Telemetry {
                     }
                     metrics
                         .http_requests_duration
-                        .record(now.elapsed().as_secs_f64(), &[subgraph_attribute.clone()]);
+                        .record(duration_to_observation(&now.elapsed()), &[subgraph_attribute.clone()]);
                     r
                 })
             })
@@ -562,7 +559,7 @@ impl Telemetry {
         }
         metrics
             .http_requests_duration
-            .record(now.elapsed().as_secs_f64(), &[]);
+            .record(duration_to_observation(&now.elapsed()), &[]);
     }
 
     fn populate_context(config: &Config, req: &RouterRequest) {


### PR DESCRIPTION
Report a more precise duration.
This code is a copy/paste from https://github.com/nlopes/actix-web-prom/blob/master/src/lib.rs#L372-L373