### PR TITLE
release: v0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,50 @@
 All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+# [0.9.2] - 2022-05-20
+
+## ❗ BREAKING ❗
+
+### Simplify Context::upsert() [PR #1073](https://github.com/apollographql/router/pull/1073)
+Removes the `default` parameter and requires inserted values to implement `Default`.
+
+## 🚀 Features
+
+### DIY docker images [PR #1106](https://github.com/apollographql/router/pull/1106)
+The build_docker_image.sh script is now provided as a working example of how to build docker images from our GH release tarballs or from a commit hash/tag against the router repo.
+
+## 🐛 Fixes
+
+### Return top `__typename` field when it's not an introspection query [PR #1102](https://github.com/apollographql/router/pull/1102)
+When `__typename` is used at the top of the query in combination with other fields it was not returned in the output.
+
+### Fix the installation and releasing script for Windows [PR #1098](https://github.com/apollographql/router/pull/1098)
+Do not put .exe for Windows in the name of the tarball when releasing new version
+
+### Aggregate usage reports in streaming and set the timeout to 5 seconds [PR #1066](https://github.com/apollographql/router/pull/1066)
+The metrics plugin was allocating chunks of usage reports to aggregate them right after, this was replaced by a streaming loop. The interval for sending the reports to spaceport was reduced from 10s to 5s.
+
+### Put back the ability to use environment variable expansion for telemetry endpoints [PR #1092](https://github.com/apollographql/router/pull/1092)
+Adds the ability to use environment variable expansion for the configuration of agent/collector endpoint for Jaeger, OTLP, Datadog.
+
+### Fix the introspection query detection [PR #1100](https://github.com/apollographql/router/pull/1100)
+Fix the introspection query detection, for example if you only have `__typename` in the query then it's an introspection query, if it's used with other fields (not prefixed by `__`) then it's not an introspection query.
+
+## 🛠 Maintenance
+
+### Add well known query to `PluginTestHarness` [PR #1114](https://github.com/apollographql/router/pull/1114)
+Add `call_canned` on `PluginTestHarness`. It performs a well known query that will generate a valid response.
+
+
+### Remove the batching and timeout from spaceport  [PR #1080](https://github.com/apollographql/router/pull/1080)
+apollo-router is already handling report aggregation and sends the
+report every 5s. Now spaceport will put the incoming reports in a
+bounded queue and send them in order, with backpressure.
+
+## 📚 Documentation
+### Add CORS documentation ([PR #1044](https://github.com/apollographql/router/pull/1044))
+We've updated the CORS documentation to reflect the recent [CORS and CSRF](https://github.com/apollographql/router/pull/1006) updates.
+
 
 # [0.9.1] - 2022-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ Removes the `default` parameter and requires inserted values to implement `Defau
 
 ## 🚀 Features
 
-### DIY docker images [PR #1106](https://github.com/apollographql/router/pull/1106)
-The build_docker_image.sh script is now provided as a working example of how to build docker images from our GH release tarballs or from a commit hash/tag against the router repo.
+### DIY docker images script [PR #1106](https://github.com/apollographql/router/pull/1106)
+The `build_docker_image.sh` script shows how to build docker images from our GH release tarballs or from a commit hash/tag against the router repo.
 
 ## 🐛 Fixes
 
@@ -26,7 +26,7 @@ Do not put .exe for Windows in the name of the tarball when releasing new versio
 ### Aggregate usage reports in streaming and set the timeout to 5 seconds [PR #1066](https://github.com/apollographql/router/pull/1066)
 The metrics plugin was allocating chunks of usage reports to aggregate them right after, this was replaced by a streaming loop. The interval for sending the reports to spaceport was reduced from 10s to 5s.
 
-### Put back the ability to use environment variable expansion for telemetry endpoints [PR #1092](https://github.com/apollographql/router/pull/1092)
+### Fix the environment variable expansion for telemetry endpoints [PR #1092](https://github.com/apollographql/router/pull/1092)
 Adds the ability to use environment variable expansion for the configuration of agent/collector endpoint for Jaeger, OTLP, Datadog.
 
 ### Fix the introspection query detection [PR #1100](https://github.com/apollographql/router/pull/1100)
@@ -37,15 +37,13 @@ Fix the introspection query detection, for example if you only have `__typename`
 ### Add well known query to `PluginTestHarness` [PR #1114](https://github.com/apollographql/router/pull/1114)
 Add `call_canned` on `PluginTestHarness`. It performs a well known query that will generate a valid response.
 
-
 ### Remove the batching and timeout from spaceport  [PR #1080](https://github.com/apollographql/router/pull/1080)
-apollo-router is already handling report aggregation and sends the
-report every 5s. Now spaceport will put the incoming reports in a
-bounded queue and send them in order, with backpressure.
+Apollo Router is already handling report aggregation and sends the report every 5s. Now spaceport will put the incoming reports in a bounded queue and send them in order, with backpressure.
 
 ## 📚 Documentation
+
 ### Add CORS documentation ([PR #1044](https://github.com/apollographql/router/pull/1044))
-We've updated the CORS documentation to reflect the recent [CORS and CSRF](https://github.com/apollographql/router/pull/1006) updates.
+Updated the CORS documentation to reflect the recent [CORS and CSRF](https://github.com/apollographql/router/pull/1006) updates.
 
 
 # [0.9.1] - 2022-05-17

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "apollo-router",
  "apollo-router-core",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-core"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "apollo-parser 0.2.5 (git+https://github.com/apollographql/apollo-rs.git?tag=hotfix_227)",
  "async-trait",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-spaceport"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "bytes",
  "clap 3.1.9",
@@ -284,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-uplink"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "futures",
  "graphql_client",
@@ -5540,7 +5540,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -22,48 +22,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 Description! And a link to a [reference](http://url)
 -->
 
-# [0.9.2] (unreleased) - 2022-mm-dd
+# [0.9.3] (unreleased) - 2022-mm-dd
 
 ## ❗ BREAKING ❗
 
-### Simplify Context::upsert() [PR #1073](https://github.com/apollographql/router/pull/1073)
-Removes the `default` parameter and requires inserted values to implement `Default`.
-
 ## 🚀 Features
-
-### DIY docker images [PR #1106](https://github.com/apollographql/router/pull/1106)
-The build_docker_image.sh script is now provided as a working example of how to build docker images from our GH release tarballs or from a commit hash/tag against the router repo.
 
 ## 🐛 Fixes
 
-### Return top `__typename` field when it's not an introspection query [PR #1102](https://github.com/apollographql/router/pull/1102)
-When `__typename` is used at the top of the query in combination with other fields it was not returned in the output.
-
-### Fix the installation and releasing script for Windows [PR #1098](https://github.com/apollographql/router/pull/1098)
-Do not put .exe for Windows in the name of the tarball when releasing new version
-
-### Aggregate usage reports in streaming and set the timeout to 5 seconds [PR #1066](https://github.com/apollographql/router/pull/1066)
-The metrics plugin was allocating chunks of usage reports to aggregate them right after, this was replaced by a streaming loop. The interval for sending the reports to spaceport was reduced from 10s to 5s.
-
-### Put back the ability to use environment variable expansion for telemetry endpoints [PR #1092](https://github.com/apollographql/router/pull/1092)
-Adds the ability to use environment variable expansion for the configuration of agent/collector endpoint for Jaeger, OTLP, Datadog.
-
-### Fix the introspection query detection [PR #1100](https://github.com/apollographql/router/pull/1100)
-Fix the introspection query detection, for example if you only have `__typename` in the query then it's an introspection query, if it's used with other fields (not prefixed by `__`) then it's not an introspection query.
-
 ## 🛠 Maintenance
 
-### Add well known query to `PluginTestHarness` [PR #1114](https://github.com/apollographql/router/pull/1114)
-Add `call_canned` on `PluginTestHarness`. It performs a well known query that will generate a valid response.
-
-
-### Remove the batching and timeout from spaceport  [PR #1080](https://github.com/apollographql/router/pull/1080)
-apollo-router is already handling report aggregation and sends the
-report every 5s. Now spaceport will put the incoming reports in a
-bounded queue and send them in order, with backpressure.
-
 ## 📚 Documentation
-### Add CORS documentation ([PR #1044](https://github.com/apollographql/router/pull/1044))
-We've updated the CORS documentation to reflect the recent [CORS and CSRF](https://github.com/apollographql/router/pull/1006) updates.
 
 ## 🐛 Fixes

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-core"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-spaceport"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/docs/source/containerization/docker.mdx
+++ b/docs/source/containerization/docker.mdx
@@ -11,7 +11,7 @@ The default behaviour of the router images is suitable for a quickstart or devel
 
 Note: The [docker documentation](https://docs.docker.com/engine/reference/run/) for the run command may be helpful when reading through the examples.
 
-Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v0.9.1`
+Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v0.9.2`
 
 ## Override the configuration
 
@@ -92,10 +92,10 @@ Usage: build_docker_image.sh [-b] [<release>]
 	Example 1: Building HEAD from the repo
 		build_docker_image.sh -b
 	Example 2: Building tag from the repo
-		build_docker_image.sh -b v0.9.1
+		build_docker_image.sh -b v0.9.2
 	Example 3: Building commit hash from the repo
 		build_docker_image.sh -b 7f7d223f42af34fad35b898d976bc07d0f5440c5
-	Example 4: Building tag v0.9.1 from the released tarball
-		build_docker_image.sh v0.9.1
+	Example 4: Building tag v0.9.2 from the released tarball
+		build_docker_image.sh v0.9.2
 ```
 Note: The script has to be run from the `dockerfiles/diy` directory because it makes assumptions about the relative availability of various files. The example uses [distroless images](https://github.com/GoogleContainerTools/distroless) for the final image build. Feel free to modify the script to use images which better suit your own needs.

--- a/docs/source/containerization/kubernetes.mdx
+++ b/docs/source/containerization/kubernetes.mdx
@@ -50,7 +50,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.9.1"
+    app.kubernetes.io/version: "v0.9.2"
 ---
 # Source: router/templates/secret.yaml
 apiVersion: v1
@@ -60,7 +60,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.9.1"
+    app.kubernetes.io/version: "v0.9.2"
 data:
   managedFederationApiKey: "REDACTED"
 ---
@@ -72,7 +72,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.9.1"
+    app.kubernetes.io/version: "v0.9.2"
 data:
   configuration.yaml: |
     server:
@@ -90,7 +90,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.9.1"
+    app.kubernetes.io/version: "v0.9.2"
 spec:
   type: ClusterIP
   ports:
@@ -110,7 +110,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.9.1"
+    app.kubernetes.io/version: "v0.9.2"
   annotations:
     prometheus.io/path: /plugins/apollo.telemetry/prometheus
     prometheus.io/port: "80"
@@ -134,7 +134,7 @@ spec:
         - name: router
           securityContext:
             {}
-          image: "ghcr.io/apollographql/router:v0.9.1"
+          image: "ghcr.io/apollographql/router:v0.9.2"
           imagePullPolicy: IfNotPresent
           args:
             - --hot-reload

--- a/docs/source/federation-version-support.mdx
+++ b/docs/source/federation-version-support.mdx
@@ -21,6 +21,16 @@ Apollo Federation is an evolving project, and it will receive new features and b
     </thead>
     <tbody>
     <tr>
+        <td>v0.9.2
+        </td>
+        <td>
+            2.0.2
+        </td>
+        <td>
+            2022-05-20
+        </td>
+    </tr>
+    <tr>
         <td>v0.9.1
         </td>
         <td>

--- a/helm/chart/router/Chart.yaml
+++ b/helm/chart/router/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.9.1"
+appVersion: "v0.9.2"

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-uplink"
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 build = "build.rs"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"


### PR DESCRIPTION
# [0.9.2] - 2022-05-20

## ❗ BREAKING ❗

### Simplify Context::upsert() [PR #1073](https://github.com/apollographql/router/pull/1073)
Removes the `default` parameter and requires inserted values to implement `Default`.

## 🚀 Features

### DIY docker images [PR #1106](https://github.com/apollographql/router/pull/1106)
The build_docker_image.sh script is now provided as a working example of how to build docker images from our GH release tarballs or from a commit hash/tag against the router repo.

## 🐛 Fixes

### Return top `__typename` field when it's not an introspection query [PR #1102](https://github.com/apollographql/router/pull/1102)
When `__typename` is used at the top of the query in combination with other fields it was not returned in the output.

### Fix the installation and releasing script for Windows [PR #1098](https://github.com/apollographql/router/pull/1098)
Do not put .exe for Windows in the name of the tarball when releasing new version

### Aggregate usage reports in streaming and set the timeout to 5 seconds [PR #1066](https://github.com/apollographql/router/pull/1066)
The metrics plugin was allocating chunks of usage reports to aggregate them right after, this was replaced by a streaming loop. The interval for sending the reports to spaceport was reduced from 10s to 5s.

### Put back the ability to use environment variable expansion for telemetry endpoints [PR #1092](https://github.com/apollographql/router/pull/1092)
Adds the ability to use environment variable expansion for the configuration of agent/collector endpoint for Jaeger, OTLP, Datadog.

### Fix the introspection query detection [PR #1100](https://github.com/apollographql/router/pull/1100)
Fix the introspection query detection, for example if you only have `__typename` in the query then it's an introspection query, if it's used with other fields (not prefixed by `__`) then it's not an introspection query.

## 🛠 Maintenance

### Add well known query to `PluginTestHarness` [PR #1114](https://github.com/apollographql/router/pull/1114)
Add `call_canned` on `PluginTestHarness`. It performs a well known query that will generate a valid response.


### Remove the batching and timeout from spaceport  [PR #1080](https://github.com/apollographql/router/pull/1080)
apollo-router is already handling report aggregation and sends the
report every 5s. Now spaceport will put the incoming reports in a
bounded queue and send them in order, with backpressure.

## 📚 Documentation
### Add CORS documentation ([PR #1044](https://github.com/apollographql/router/pull/1044))
We've updated the CORS documentation to reflect the recent [CORS and CSRF](https://github.com/apollographql/router/pull/1006) updates.
