### PR TITLE
count persisted cache hits

### DIFF
--- a/apollo-router-core/src/services/layers/apq.rs
+++ b/apollo-router-core/src/services/layers/apq.rs
@@ -79,10 +79,12 @@ where
                     }
                     (Some(apq_hash), _) => {
                         if let Some(cached_query) = cache.get(&apq_hash) {
+                            let _ = req.context.insert("persisted_query_hit", true);
                             tracing::trace!("apq: cache hit");
                             req.originating_request.body_mut().query = Some(cached_query);
                             Ok(ControlFlow::Continue(req))
                         } else {
+                            let _ = req.context.insert("persisted_query_hit", false);
                             tracing::trace!("apq: cache miss");
                             let errors = vec![crate::Error {
                                 message: "PersistedQueryNotFound".to_string(),

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/studio.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/studio.rs
@@ -55,7 +55,7 @@ pub(crate) struct SingleContextualizedStats {
 pub(crate) struct SingleQueryLatencyStats {
     pub(crate) latency: Duration,
     pub(crate) cache_hit: bool,
-    pub(crate) persisted_query_hit: bool,
+    pub(crate) persisted_query_hit: Option<bool>,
     pub(crate) cache_latency: Option<Duration>,
     pub(crate) root_error_stats: SinglePathErrorStats,
     pub(crate) has_errors: bool,
@@ -158,8 +158,11 @@ impl AddAssign<SingleQueryLatencyStats> for QueryLatencyStats {
     fn add_assign(&mut self, stats: SingleQueryLatencyStats) {
         self.request_latencies
             .increment_duration(Some(stats.latency), 1);
-        self.persisted_query_hits += stats.persisted_query_hit as u64;
-        self.persisted_query_misses += !stats.persisted_query_hit as u64;
+        match stats.persisted_query_hit {
+            Some(true) => self.persisted_query_hits += 1,
+            Some(false) => self.persisted_query_misses += 1,
+            None => {}
+        }
         self.cache_hits.increment_duration(stats.cache_latency, 1);
         self.root_error_stats += stats.root_error_stats;
         self.requests_with_errors_count += stats.has_errors as u64;

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -479,6 +479,9 @@ impl Telemetry {
             .unwrap_or_default()
         {
             let operation_count = operation_count(&usage_reporting.stats_report_key);
+            let persisted_query_hit = context
+                .get::<_, bool>("persisted_query_hit")
+                .unwrap_or_default();
 
             if context
                 .get(STUDIO_EXCLUDE)
@@ -520,6 +523,7 @@ impl Telemetry {
                                         }
                                         Err(_) => true,
                                     },
+                                    persisted_query_hit,
                                     ..Default::default()
                                 },
                                 ..Default::default()


### PR DESCRIPTION
Fix #1014

This counts properly `persisted_cache_hits`, but not `persisted_cache_misses`. Apparently, in that case we do not even get into the `update_apollo_metrics` function, so I suspect the error returned by APQ skips the reporting phase. I also do not know yet under which `stats_report_key` I should record APQ cache misses, because if we get a cache miss, we do not know which query it was linked to.

Looking at this code it's not clear to me which stats report key I should use: https://github.com/apollographql/apollo-server/blob/main/packages/apollo-server-core/src/plugin/usageReporting/plugin.ts#L644-L682