### PR TITLE
remove the platforms crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3241,12 +3241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
-name = "platforms"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d0eef3571242013a0d5dc84861c3ae4a652e56e12adf8bdc26ff5f8cb34c94"
-
-[[package]]
 name = "plotters"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5550,7 +5544,6 @@ dependencies = [
  "flate2",
  "libc",
  "once_cell",
- "platforms",
  "reqwest",
  "serde_json",
  "serde_json_traversal",

--- a/licenses.html
+++ b/licenses.html
@@ -6174,7 +6174,6 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding</a></li>
                     <li><a href=" https://github.com/petgraph/petgraph ">petgraph</a></li>
                     <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config</a></li>
-                    <li><a href=" https://github.com/rustsec/rustsec/tree/main/platforms ">platforms</a></li>
                     <li><a href=" https://github.com/smol-rs/polling ">polling</a></li>
                     <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost</a></li>

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,7 +15,6 @@ cargo_metadata = "0.14"
 flate2 = "1"
 libc = "0.2"
 once_cell = "1"
-platforms = "2"
 reqwest = { version = "0.11", default-features = false, features = [
     "blocking",
     "native-tls",

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -43,8 +43,8 @@ impl Package {
                 "router-{}-{}-{}.tar.gz",
                 *PKG_VERSION,
                 // NOTE: same as xtask
-                TARGET_ARCH,
-                TARGET_OS,
+                std::env::consts::ARCH,
+                std::env::consts::OS,
             ))
         } else {
             self.output.to_owned()
@@ -79,43 +79,3 @@ impl Package {
         Ok(())
     }
 }
-
-#[cfg(target_arch = "aarch64")]
-pub const TARGET_ARCH: &str = "x86_64";
-
-#[cfg(target_arch = "arm")]
-pub const TARGET_ARCH: &str = "arm";
-
-#[cfg(target_arch = "x86")]
-pub const TARGET_ARCH: &str = "x86";
-
-#[cfg(target_arch = "x86_64")]
-pub const TARGET_ARCH: &str = "x86_64";
-
-#[cfg(not(any(
-    target_arch = "aarch64",
-    target_arch = "arm",
-    target_arch = "x86",
-    target_arch = "x86_64"
-)))]
-pub const TARGET_ARCH: &str = "unknown";
-
-#[cfg(target_os = "linux")]
-pub const TARGET_OS: &str = "linux";
-
-#[cfg(target_os = "macos")]
-pub const TARGET_OS: &str = "macos";
-
-#[cfg(target_os = "windows")]
-pub const TARGET_OS: &str = "windows";
-
-#[cfg(target_os = "freebsd")]
-pub const TARGET_OS: &str = "freebsd";
-
-#[cfg(not(any(
-    target_os = "freebsd",
-    target_os = "linux",
-    target_os = "macos",
-    target_os = "windows",
-)))]
-pub const TARGET_OS: &str = "unknown";

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -43,8 +43,8 @@ impl Package {
                 "router-{}-{}-{}.tar.gz",
                 *PKG_VERSION,
                 // NOTE: same as xtask
-                platforms::TARGET_ARCH,
-                platforms::TARGET_OS,
+                TARGET_ARCH,
+                TARGET_OS,
             ))
         } else {
             self.output.to_owned()
@@ -79,3 +79,43 @@ impl Package {
         Ok(())
     }
 }
+
+#[cfg(target_arch = "aarch64")]
+pub const TARGET_ARCH: &str = "x86_64";
+
+#[cfg(target_arch = "arm")]
+pub const TARGET_ARCH: &str = "arm";
+
+#[cfg(target_arch = "x86")]
+pub const TARGET_ARCH: &str = "x86";
+
+#[cfg(target_arch = "x86_64")]
+pub const TARGET_ARCH: &str = "x86_64";
+
+#[cfg(not(any(
+    target_arch = "aarch64",
+    target_arch = "arm",
+    target_arch = "x86",
+    target_arch = "x86_64"
+)))]
+pub const TARGET_ARCH: &str = "unknown";
+
+#[cfg(target_os = "linux")]
+pub const TARGET_OS: &str = "linux";
+
+#[cfg(target_os = "macos")]
+pub const TARGET_OS: &str = "macos";
+
+#[cfg(target_os = "windows")]
+pub const TARGET_OS: &str = "windows";
+
+#[cfg(target_os = "freebsd")]
+pub const TARGET_OS: &str = "freebsd";
+
+#[cfg(not(any(
+    target_os = "freebsd",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "windows",
+)))]
+pub const TARGET_OS: &str = "unknown";


### PR DESCRIPTION
we relied on its TARGET_ARCH and TARGET_PLATFORM values that were
removed in version 3

this replaces #900 where renovate tries again and again to update to an incompatible platforms version. We could also migrate to the [sysinfo](https://docs.rs/sysinfo) crate once it supports printing the OS type