### PR TITLE
chore: update github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ['triage']
+labels: ['triage', 'raised by user']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ['triage']
+labels: ['triage', 'raised by user']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -2,7 +2,7 @@
 name: Improvement
 about: Improve the project without adding new features
 title: ''
-labels: ['triage']
+labels: ['triage', 'raised by user']
 assignees: ''
 
 ---


### PR DESCRIPTION
This will cause the `raised by user` label by default, in addition to `triage`.