### PR TITLE
docs: CSRF prevention is not applied to landing pages & health checks

### DIFF
--- a/docs/source/configuration/csrf.mdx
+++ b/docs/source/configuration/csrf.mdx
@@ -25,6 +25,8 @@ Apollo Router 0.9 introduced a CSRF prevention feature, which is enabled by defa
 
 Note that all HTTP header names are case-insensitive.
 
+> CSRF prevention is only applied to requests that will execute GraphQL operations, not to requests that would load landing pages or run health checks.)
+
 HTTP requests that satisfy none of the conditions above will be rejected with a 400 status code and a message clearly explaining which headers need to be added in order to make the request succeed.
 
 This should have no impact on legitimate use of your graph, *unless* you have clients that send `GET` requests and are not Apollo Client Web, Apollo iOS, or Apollo Kotlin. If you do send `GET` requests with other clients, you should configure them to send a non-empty `Apollo-Require-Preflight` header along with all requests.

--- a/docs/source/configuration/csrf.mdx
+++ b/docs/source/configuration/csrf.mdx
@@ -25,7 +25,7 @@ Apollo Router 0.9 introduced a CSRF prevention feature, which is enabled by defa
 
 Note that all HTTP header names are case-insensitive.
 
-> CSRF prevention is only applied to requests that will execute GraphQL operations, not to requests that would load landing pages or run health checks.)
+> Unlike requests that will execute GraphQL operations, CSRF prevention is not applied to the landing page or to health checks. It does however apply to new endpoints added by plugins.
 
 HTTP requests that satisfy none of the conditions above will be rejected with a 400 status code and a message clearly explaining which headers need to be added in order to make the request succeed.
 


### PR DESCRIPTION
… since plugins are indeed only invoked for GraphQL requests.

Fixes https://github.com/apollographql/router/issues/1081