### PR TITLE
maintenance: Unpin schemars version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3945,9 +3945,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b5a3c80cea1ab61f4260238409510e814e38b4b563c06044edf91e7dc070e3"
+checksum = "1847b767a3d62d95cbf3d8a9f0e421cf57a0d8aa4f411d4b16525afb0284d4ed"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -3958,9 +3958,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ae4dce13e8614c46ac3c38ef1c0d668b101df6ac39817aebdaa26642ddae9b"
+checksum = "af4d7e1b012cb3d9129567661a63755ea4b8a7386d339dc945ae187e403c6743"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4080,9 +4080,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -35,6 +35,10 @@ Description! And a link to a [reference](http://url)
   Cancelling a request could put the router in an unresponsive state where the deduplication layer or cache would make subgraph requests hang.
 
 ## 🛠 Maintenance
+### Unpin schemars version [#1074](https://github.com/apollographql/router/issues/1074)
+The Schemars 0.8.9 caused compile errors due to it validating default types.
+This change has however been rolled back upstream.
+We can now safely depend on schemars 0.8.10.
 
 ## 📚 Documentation
 

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 failfast = []
 
 [dependencies]
-apollo-parser = {git="https://github.com/apollographql/apollo-rs.git", tag="hotfix_227"}
+apollo-parser = { git = "https://github.com/apollographql/apollo-rs.git", tag = "hotfix_227" }
 async-trait = "0.1.53"
 atty = "0.2.14"
 axum = { version = "0.5.4" }
@@ -43,7 +43,9 @@ opentelemetry-http = "0.6.0"
 paste = "1.0.6"
 regex = "1.5.5"
 router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "46fdeb35aa3d3f3289ff0dbbccf63c1234da92a8" }
-schemars = { version = "=0.8.8", features = ["url"] } # https://github.com/apollographql/router/issues/1074
+schemars = { version = "0.8.10", features = [
+    "url",
+] } # https://github.com/apollographql/router/issues/1074
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }
 serde_json_bytes = { version = "0.2.0", features = ["preserve_order"] }

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -19,10 +19,17 @@ atty = "0.2.14"
 backtrace = "0.3.65"
 buildstructor = "0.1.12"
 bytes = "1.1.0"
-clap = { version = "3.1.3", default-features = false, features = ["env", "derive", "std"] }
-deadpool = { version = "0.9.4", features = ["rt_tokio_1"]}
+clap = { version = "3.1.3", default-features = false, features = [
+    "env",
+    "derive",
+    "std",
+] }
+deadpool = { version = "0.9.4", features = ["rt_tokio_1"] }
 derivative = "2.2.0"
-derive_more = { version = "0.99.17", default-features = false, features = ["from", "display"] }
+derive_more = { version = "0.99.17", default-features = false, features = [
+    "from",
+    "display",
+] }
 directories = "4.0.1"
 displaydoc = "0.2"
 envmnt = "0.9.1"
@@ -70,7 +77,9 @@ reqwest = { version = "0.11.10", default-features = false, features = [
     "json",
     "stream",
 ] }
-schemars = { version = "=0.8.8", features = ["url"] } # https://github.com/apollographql/router/issues/1074
+schemars = { version = "0.8.10", features = [
+    "url",
+] } # https://github.com/apollographql/router/issues/1074
 serde = { version = "1.0.136", features = ["derive", "rc"] }
 serde_json_bytes = { version = "0.2.0", features = ["preserve_order"] }
 serde_json = { version = "1.0.79", features = ["preserve_order"] }

--- a/examples/async-auth/Cargo.toml
+++ b/examples/async-auth/Cargo.toml
@@ -10,7 +10,9 @@ apollo-router = { path = "../../apollo-router" }
 apollo-router-core = { path = "../../apollo-router-core" }
 async-trait = "0.1.53"
 http = "0.2.6"
-schemars = { version = "=0.8.8", features = ["url"] } # https://github.com/apollographql/router/issues/1074
+schemars = { version = "0.8.10", features = [
+    "url",
+] } # https://github.com/apollographql/router/issues/1074
 serde = "1.0.136"
 serde_json = "1.0.79"
 serde_json_bytes = "0.2.0"

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -9,7 +9,9 @@ anyhow = "1.0.55"
 apollo-router = { path = "../../apollo-router" }
 apollo-router-core = { path = "../../apollo-router-core" }
 async-trait = "0.1.52"
-schemars = { version = "=0.8.8", features = ["url"] } # https://github.com/apollographql/router/issues/1074
+schemars = { version = "0.8.10", features = [
+    "url",
+] } # https://github.com/apollographql/router/issues/1074
 serde = "1.0.136"
 serde_json = "1.0.79"
 tokio = { version = "1.17.0", features = ["full"] }

--- a/examples/jwt-auth/Cargo.toml
+++ b/examples/jwt-auth/Cargo.toml
@@ -12,7 +12,9 @@ async-trait = "0.1.53"
 hex = "0.4.3"
 http = "0.2.6"
 jwt-simple = "0.10.8"
-schemars = { version = "=0.8.8", features = ["url"] } # https://github.com/apollographql/router/issues/1074
+schemars = { version = "0.8.10", features = [
+    "url",
+] } # https://github.com/apollographql/router/issues/1074
 serde = "1.0.136"
 serde_json = "1.0.79"
 strum = { version = "0.24.0", features = ["derive"] }

--- a/examples/status-code-propagation/Cargo.toml
+++ b/examples/status-code-propagation/Cargo.toml
@@ -10,7 +10,9 @@ apollo-router = { path = "../../apollo-router" }
 apollo-router-core = { path = "../../apollo-router-core" }
 async-trait = "0.1.53"
 http = "0.2.6"
-schemars = { version = "=0.8.8", features = ["url"] } # https://github.com/apollographql/router/issues/1074
+schemars = { version = "0.8.10", features = [
+    "url",
+] } # https://github.com/apollographql/router/issues/1074
 serde = "1.0.136"
 serde_json = "1.0.79"
 tokio = { version = "1.17.0", features = ["full"] }

--- a/licenses.html
+++ b/licenses.html
@@ -11637,6 +11637,36 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/GREsau/schemars ">schemars</a></li>
+                    <li><a href=" https://github.com/GREsau/schemars ">schemars_derive</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) 2019 Graham Esau
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/Peternator7/strum ">strum</a></li>
                     <li><a href=" https://github.com/Peternator7/strum ">strum_macros</a></li>
                 </ul>
@@ -11781,36 +11811,6 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/GREsau/schemars ">schemars</a></li>
-                    <li><a href=" https://github.com/GREsau/schemars ">schemars_derive</a></li>
-                </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2019 Graham Esau
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 </pre>
             </li>
             <li class="license">


### PR DESCRIPTION
Fixes #1074

The Schemars 0.8.9 caused compile errors due to it validating default types.
This change has however been rolled back upstream.
We can now safely depend on schemars 0.8.10.