### PR TITLE
maintenance: Bump Moka to fix panics on AMD hardware.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2606,9 +2606,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.7.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e1a0803406a47496169480f26cab92e78936c1180ad439ee18d36478c1509c"
+checksum = "e924a2158752c5e2358a3a230e01a532cd9948a0eee35de848e094a9eb8ec294"
 dependencies = [
  "async-io",
  "async-lock",
@@ -3463,9 +3463,9 @@ dependencies = [
 
 [[package]]
 name = "quanta"
-version = "0.9.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20afe714292d5e879d8b12740aa223c6a88f118af41870e8b6196e39a02238a8"
+checksum = "bafd74c340a0a7e79415981ede3460df16b530fd071541901a57416eea950b17"
 dependencies = [
  "crossbeam-utils 0.8.8",
  "libc",
@@ -4306,12 +4306,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
-
-[[package]]
 name = "startup"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5044,8 +5038,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c45e322b26410d7260e00f64234810c2f17d7ece356182af4df8f7ff07890f09"
 dependencies = [
  "memoffset 0.6.5",
- "serde",
- "stable_deref_trait",
 ]
 
 [[package]]

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -44,6 +44,9 @@ The Schemars 0.8.9 caused compile errors due to it validating default types.
 This change has however been rolled back upstream.
 We can now safely depend on schemars 0.8.10.
 
+### Update Moka to fix occasional panics on AMD hardware [#1137](https://github.com/apollographql/router/issues/1137)
+Moka has a dependency on Quanta which had an issue with AMD hardware. This is now fixed via [Moka-#119](https://github.com/moka-rs/moka/issues/119).
+
 ## 📚 Documentation
 
 ## 🐛 Fixes

--- a/apollo-router-core/Cargo.toml
+++ b/apollo-router-core/Cargo.toml
@@ -36,7 +36,7 @@ lru = "0.7.5"
 miette = { version = "4.7.1", features = ["fancy"] }
 mockall = "0.11.0"
 multimap = "0.8.3"
-moka = { version = "0.7.2", features = ["future", "futures-util"] }
+moka = { version = "0.8.4", features = ["future", "futures-util"] }
 once_cell = "1.9.0"
 opentelemetry = "0.17.0"
 opentelemetry-http = "0.6.0"

--- a/licenses.html
+++ b/licenses.html
@@ -6207,7 +6207,6 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/budziq/rust-skeptic ">skeptic</a></li>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec</a></li>
                     <li><a href=" https://github.com/rust-lang/socket2 ">socket2</a></li>
-                    <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait</a></li>
                     <li><a href=" https://github.com/dtolnay/syn ">syn</a></li>
                     <li><a href=" https://github.com/alexcrichton/tar-rs ">tar</a></li>
                     <li><a href=" https://github.com/Stebalien/tempfile ">tempfile</a></li>


### PR DESCRIPTION
Moka has a dependency on Quanta which had an issue with AMD hardware. This is now fixed via [Moka-#119](https://github.com/moka-rs/moka/issues/119).
