### PR TITLE
Allows to set a custom health check path

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -33,4 +33,3 @@ Added the possibility to set a custom health check path
 server:
   # Default is /.well-known/apollo/server-health
   health_check_path: /health
-```

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -42,6 +42,14 @@ Description! And a link to a [reference](http://url)
 
   Add a new span only for the subgraph request, with all HTTP and net information needed for the opentelemetry specs
 
+### Allow to set a custom health check path ([PR #1164](https://github.com/apollographql/router/pull/1164))
+  Added the possibility to set a custom health check path
+  ```yaml
+server:
+  # Default is /.well-known/apollo/server-health
+  health_check_path: /health
+```
+
 ## 🐛 Fixes
 
 ### Content-Type is application/json ([1154](https://github.com/apollographql/router/issues/1154)) 

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -1463,14 +1463,10 @@ Content-Type: application/json\r
             .build();
         let expectations = MockRouterService::new();
         let (server, client) = init_with_config(expectations, conf, HashMap::new()).await;
-        let url = format!(
-            "{}/health",
-            server.listen_address()
-        );
+        let url = format!("{}/health", server.listen_address());
 
         let response = client.get(url).send().await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-
     }
 
     #[test(tokio::test)]

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -275,6 +275,12 @@ pub struct Server {
     #[serde(default = "default_endpoint")]
     #[builder(default_code = "default_endpoint()", setter(into))]
     pub endpoint: String,
+
+    /// healthCheck path
+    /// default: "/.well-known/apollo/server-health"
+    #[serde(default = "default_health_check_path")]
+    #[builder(default_code = "default_health_check_path()", setter(into))]
+    pub health_check_path: String,
 }
 
 /// Listening address.
@@ -390,6 +396,10 @@ fn default_landing_page() -> bool {
 
 fn default_endpoint() -> String {
     String::from("/")
+}
+
+fn default_health_check_path() -> String {
+    String::from("/.well-known/apollo/server-health")
 }
 
 impl Default for Server {
@@ -696,13 +706,13 @@ mod tests {
         {
           query: Query
         }
-        
+
         type Query {
           me: String
         }
-        
+
         directive @core(feature: String!) repeatable on SCHEMA
-        
+
         directive @join__graph(name: String!, url: String!) on ENUM_VALUE
         enum join__Graph {
           ACCOUNTS @join__graph(name: "accounts" url: "http://localhost:4001/graphql")
@@ -748,15 +758,15 @@ mod tests {
         {
           query: Query
         }
-        
+
         type Query {
           me: String
         }
-        
+
         directive @core(feature: String!) repeatable on SCHEMA
-        
+
         directive @join__graph(name: String!, url: String!) on ENUM_VALUE
-        
+
         enum join__Graph {
           ACCOUNTS @join__graph(name: "accounts" url: "http://localhost:4001/graphql")
           INVENTORY @join__graph(name: "inventory" url: "http://localhost:4002/graphql")
@@ -839,7 +849,7 @@ plugins:
   non_existant:
     foo: "bar"
 
-telemetry:  
+telemetry:
   another_non_existant: 3
   "#,
         )

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 748
+assertion_line: 857
 expression: error.to_string()
 ---
 configuration had errors: 
@@ -18,6 +18,6 @@ plugins:
   non_existant:
     foo: "bar"
 
-telemetry:  
+telemetry:
 ┌   another_non_existant: 3
 └-----> Additional properties are not allowed ('another_non_existant' was unexpected)

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 687
+assertion_line: 697
 expression: "&schema"
 ---
 {
@@ -349,7 +349,8 @@ expression: "&schema"
         "cors": null,
         "introspection": true,
         "landing_page": true,
-        "endpoint": "/"
+        "endpoint": "/",
+        "health_check_path": "/.well-known/apollo/server-health"
       },
       "type": "object",
       "properties": {
@@ -415,6 +416,11 @@ expression: "&schema"
         "endpoint": {
           "description": "GraphQL endpoint default: \"/\"",
           "default": "/",
+          "type": "string"
+        },
+        "health_check_path": {
+          "description": "healthCheck path default: \"/.well-known/apollo/server-health\"",
+          "default": "/.well-known/apollo/server-health",
           "type": "string"
         },
         "introspection": {

--- a/docs/source/configuration/health-checks.mdx
+++ b/docs/source/configuration/health-checks.mdx
@@ -7,7 +7,7 @@ Health checks are often used by load balancers to determine whether a server is 
 
 The Apollo Router supports a basic HTTP-level health check. This is enabled by default and is served at the URL path `/.well-known/apollo/server-health`. This returns a `200` status code if the HTTP server is successfully serving. It does not invoke any GraphQL execution machinery.
 You can change this path by setting `server.health_check_path`:
-```yml
+```yaml title="router.yaml"
 server:
   health_check_path: /health
 ```

--- a/docs/source/configuration/health-checks.mdx
+++ b/docs/source/configuration/health-checks.mdx
@@ -6,3 +6,8 @@ description: Determining the router's status
 Health checks are often used by load balancers to determine whether a server is available and ready to start serving traffic.
 
 The Apollo Router supports a basic HTTP-level health check. This is enabled by default and is served at the URL path `/.well-known/apollo/server-health`. This returns a `200` status code if the HTTP server is successfully serving. It does not invoke any GraphQL execution machinery.
+You can change this path by setting `server.health_check_path`:
+```yml
+server:
+  health_check_path: /health
+```


### PR DESCRIPTION
With this change, we can customize the health check path, 
By default is working as now, with the /.well-known/apollo/server-health