### PR TITLE
Split queries for defer directive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
  "typed-builder 0.10.0",
  "uname",
  "url",
- "uuid 1.0.0",
+ "uuid 1.1.0",
  "walkdir",
  "yaml-rust",
 ]
@@ -5947,9 +5947,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cfcd319456c4d6ea10087ed423473267e1a071f3bc0aa89f80d60997843c6f0"
+checksum = "93bbc61e655a4833cf400d0d15bf3649313422fa7572886ad6dab16d79886365"
 dependencies = [
  "getrandom",
  "serde",

--- a/apollo-router-core/src/json_ext.rs
+++ b/apollo-router-core/src/json_ext.rs
@@ -365,7 +365,7 @@ where
 /// A GraphQL path element that is composes of strings or numbers.
 /// e.g `/book/3/name`
 #[doc(hidden)]
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(untagged)]
 pub enum PathElement {
     /// A path element that given an array will flatmap the content.
@@ -424,7 +424,7 @@ where
 ///
 /// This can be composed of strings and numbers
 #[doc(hidden)]
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default, Hash)]
 #[serde(transparent)]
 pub struct Path(pub Vec<PathElement>);
 

--- a/apollo-router-core/src/spec/query.rs
+++ b/apollo-router-core/src/spec/query.rs
@@ -329,21 +329,14 @@ impl Query {
                     ..
                 } => {
                     let field_name = alias.as_ref().unwrap_or(name);
-                    if skip
-                        .should_skip(variables)
-                        // validate_variables should have already checked that
-                        // the variable is present and it is of the correct type
-                        .unwrap_or(false)
-                    {
+                    // Using .unwrap_or is legit here because
+                    // validate_variables should have already checked that
+                    // the variable is present and it is of the correct type
+                    if skip.should_skip(variables).unwrap_or(false) {
                         continue;
                     }
 
-                    if !include
-                        .should_include(variables)
-                        // validate_variables should have already checked that
-                        // the variable is present and it is of the correct type
-                        .unwrap_or(true)
-                    {
+                    if !include.should_include(variables).unwrap_or(true) {
                         continue;
                     }
 
@@ -390,22 +383,24 @@ impl Query {
                     skip,
                     include,
                     known_type,
+                    defer,
                     ..
                 } => {
-                    if skip
-                        .should_skip(variables)
-                        // validate_variables should have already checked that
-                        // the variable is present and it is of the correct type
-                        .unwrap_or(false)
-                    {
+                    // Using .unwrap_or is legit here because
+                    // validate_variables should have already checked that
+                    // the variable is present and it is of the correct type
+                    if skip.should_skip(variables).unwrap_or(false) {
                         continue;
                     }
 
-                    if !include
-                        .should_include(variables)
-                        // validate_variables should have already checked that
-                        // the variable is present and it is of the correct type
-                        .unwrap_or(true)
+                    if !include.should_include(variables).unwrap_or(true) {
+                        continue;
+                    }
+
+                    if defer
+                        .as_ref()
+                        .map(|d| d.should_defer(variables).unwrap_or(true))
+                        .unwrap_or(false)
                     {
                         continue;
                     }
@@ -438,21 +433,22 @@ impl Query {
                     known_type,
                     skip,
                     include,
-                    ..
+                    defer,
                 } => {
-                    if skip
-                        .should_skip(variables)
-                        // validate_variables should have already checked that
-                        // the variable is present and it is of the correct type
-                        .unwrap_or(false)
-                    {
+                    // Using .unwrap_or is legit here because
+                    // validate_variables should have already checked that
+                    // the variable is present and it is of the correct type
+                    if skip.should_skip(variables).unwrap_or(false) {
                         continue;
                     }
-                    if !include
-                        .should_include(variables)
-                        // validate_variables should have already checked that
-                        // the variable is present and it is of the correct type
-                        .unwrap_or(true)
+                    if !include.should_include(variables).unwrap_or(true) {
+                        continue;
+                    }
+
+                    if defer
+                        .as_ref()
+                        .map(|d| d.should_defer(variables).unwrap_or(true))
+                        .unwrap_or(false)
                     {
                         continue;
                     }
@@ -522,21 +518,14 @@ impl Query {
                     include,
                     ..
                 } => {
-                    if skip
-                        .should_skip(variables)
-                        // validate_variables should have already checked that
-                        // the variable is present and it is of the correct type
-                        .unwrap_or_default()
-                    {
+                    // Using .unwrap_or is legit here because
+                    // validate_variables should have already checked that
+                    // the variable is present and it is of the correct type
+                    if skip.should_skip(variables).unwrap_or_default() {
                         continue;
                     }
 
-                    if !include
-                        .should_include(variables)
-                        // validate_variables should have already checked that
-                        // the variable is present and it is of the correct type
-                        .unwrap_or(true)
-                    {
+                    if !include.should_include(variables).unwrap_or(true) {
                         continue;
                     }
 

--- a/apollo-router-core/src/spec/selection.rs
+++ b/apollo-router-core/src/spec/selection.rs
@@ -521,6 +521,16 @@ pub struct Defer {
 }
 
 impl Defer {
+    pub(crate) fn should_defer(&self, variables: &Object) -> Option<bool> {
+        match &self.condition {
+            Some(ValueOrVariable::Value(val)) => Some(*val),
+            Some(ValueOrVariable::Variable(variable_name)) => variables
+                .get(variable_name.as_str())
+                .and_then(|v| v.as_bool()),
+            None => Some(true),
+        }
+    }
+
     pub(crate) fn statically_deferred(&self) -> bool {
         // If we don't have any condition then it's true by default
         self.condition


### PR DESCRIPTION
Related to #80 

+ Split main query into primary and deferred queries
+ Rewrite the `InlineFragment` implementation
+ Add support of static check for `@include` and `@skip` directives

The query is split regarding the `@defer` directive. If we could statically detect that the selection will be deferred then we just skip it from the primary selection. If not we will clone the selection into deferred_queries and also keep it in the primary query to be able to detect at the execution stage if it's a deferred selection or not.

TODO:

- [ ] To link a deferred node with a deferred query the main idea would be to specify a `label` on defer if not already provided, then in format response we just skip this `label` parameter if we detect that's one of our custom label