### PR TITLE
tests(axum): create SocketAddr to fix flappy test

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -36,3 +36,10 @@ server:
 ```
 
 By [@jcaromiq](https://github.com/jcaromiq) in https://github.com/apollographql/router/pull/1164
+
+## 🛠 Maintenance ( :hammer_and_wrench: )
+
+### Fix a flappy test to test custom health check path ([PR #1176](https://github.com/apollographql/router/pull/1176))
+Force the creation of `SocketAddr` to use a new unused port.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1176

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -1457,6 +1457,7 @@ Content-Type: application/json\r
         let conf = Configuration::builder()
             .server(
                 crate::configuration::Server::builder()
+                    .listen(SocketAddr::from_str("127.0.0.1:0").unwrap())
                     .health_check_path("/health")
                     .build(),
             )


### PR DESCRIPTION
If we do not create this `SocketAddr` it will use the default one and then listen on the same port than another test. Which means sometimes it will work, sometimes not because the port has already been used.