### PR TITLE
fix the test in rhai surrogate cache key example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4368,6 +4368,7 @@ dependencies = [
  "anyhow",
  "apollo-router",
  "apollo-router-core",
+ "futures",
  "http",
  "serde_json",
  "tokio",

--- a/examples/rhai-surrogate-cache-key/Cargo.toml
+++ b/examples/rhai-surrogate-cache-key/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 anyhow = "1.0.55"
 apollo-router = { path = "../../apollo-router" }
 apollo-router-core = { path = "../../apollo-router-core" }
+futures = "0.3.21"
 http = "0.2.6"
 serde_json = "1.0.79"
 tokio = { version = "1.17.0", features = ["full"] }

--- a/examples/rhai-surrogate-cache-key/src/main.rs
+++ b/examples/rhai-surrogate-cache-key/src/main.rs
@@ -16,6 +16,7 @@ mod tests {
     use apollo_router_core::utils::test::IntoSchema::Canned;
     use apollo_router_core::utils::test::PluginTestHarness;
     use apollo_router_core::{Context, Plugin, RouterRequest};
+    use futures::StreamExt;
     use http::StatusCode;
 
     #[tokio::test]
@@ -55,6 +56,9 @@ mod tests {
                     .build()
                     .expect("a valid RouterRequest"),
             )
+            .await
+            .expect("a router response")
+            .next()
             .await
             .expect("a router response");
 


### PR DESCRIPTION
somehow the CI failed on https://github.com/apollographql/router/commit/8e0aedaf415b7a87f5e76bc33384f665fe346ca5 while it was ok on the PR :thinking: 