### PR TITLE
CORS mis-configuration shouldn't cause a router panic

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -64,7 +64,6 @@ telemetry:
             rename: "payload_type"
             default: "application/json"
           - named: "x-custom-header-to-add"
->>>>>>> ecb875a36b2fdf88025a1fb571dcd2fb5e009778
 ```
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1159

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -67,7 +67,7 @@ By [@jcaromiq](https://github.com/jcaromiq) in https://github.com/apollographql/
 
 ## 🐛 Fixes ( :bug: )
 
-### Fix CORS configuration to eliminate runtime panic on mis-configuration ([PR #XXXX](https://github.com/apollographql/router/pull/XXXX))
+### Fix CORS configuration to eliminate runtime panic on mis-configuration ([PR #1197](https://github.com/apollographql/router/pull/1197))
 Previously, it was possible to specify a CORS configuration which was syntactically valid, but which could not be enforced at runtime:
 Example:
 ```yaml
@@ -79,7 +79,7 @@ server:
 Such a configuration would result in a runtime panic. The router will now detect this kind of mis-configuration and report the error
 without panick-ing.
 
-By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/XXXX
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1197
 
 ## 🛠 Maintenance ( :hammer_and_wrench: )
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -65,6 +65,22 @@ server:
 
 By [@jcaromiq](https://github.com/jcaromiq) in https://github.com/apollographql/router/pull/1164
 
+## 🐛 Fixes ( :bug: )
+
+### Fix CORS configuration to eliminate runtime panic on mis-configuration ([PR #XXXX](https://github.com/apollographql/router/pull/XXXX))
+Previously, it was possible to specify a CORS configuration which was syntactically valid, but which could not be enforced at runtime:
+Example:
+```yaml
+server:
+  cors:
+    allow_any_origin: true
+    allow_credentials: true
+```
+Such a configuration would result in a runtime panic. The router will now detect this kind of mis-configuration and report the error
+without panick-ing.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/XXXX
+
 ## 🛠 Maintenance ( :hammer_and_wrench: )
 
 ### Fix a flappy test to test custom health check path ([PR #1176](https://github.com/apollographql/router/pull/1176))

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -37,7 +37,6 @@ To upgrade, remove any dependency on the former in `Cargo.toml` files (keeping o
 ```
 
 ## 🚀 Features
-<<<<<<< HEAD
 ### Add an experimental optimization to deduplicate variables in query planner [PR #872](https://github.com/apollographql/router/pull/872)
 Get rid of duplicated variables in requests and responses of the query planner. This optimization is disabled by default, if you want to enable it you just need override your configuration:
 
@@ -45,7 +44,10 @@ Get rid of duplicated variables in requests and responses of the query planner. 
 plugins:
   experimental.traffic_shaping:
     variables_deduplication: true # Enable the variables deduplication optimization
-=======
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/872
+
 ### Add more customizable metrics ([PR #1159](https://github.com/apollographql/router/pull/1159))
 Added the ability to add custom attributes/labels on metrics via the configuration file.
 Example:
@@ -64,6 +66,8 @@ telemetry:
           - named: "x-custom-header-to-add"
 >>>>>>> ecb875a36b2fdf88025a1fb571dcd2fb5e009778
 ```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1159
 
 ### Allow to set a custom health check path ([PR #1164](https://github.com/apollographql/router/pull/1164))
 Added the possibility to set a custom health check path

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -90,7 +90,15 @@ impl HttpServerFactory for AxumHttpServerFactory {
                 .cors
                 .clone()
                 .map(|cors_configuration| cors_configuration.into_layer())
-                .unwrap_or_else(|| Cors::builder().build().into_layer());
+                .unwrap_or_else(|| Cors::builder().build().into_layer())
+                .map_err(|e| {
+                    FederatedServerError::ConfigError(
+                        crate::configuration::ConfigurationError::LayerConfiguration {
+                            layer: "Cors".to_string(),
+                            error: e,
+                        },
+                    )
+                })?;
             let graphql_endpoint = if configuration.server.endpoint.ends_with("/*") {
                 // Needed for axum (check the axum docs for more information about wildcards https://docs.rs/axum/latest/axum/struct.Router.html#wildcards)
                 format!("{}router_extra_path", configuration.server.endpoint)

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -461,10 +461,10 @@ impl Cors {
         }
     }
 
-    // This is cribbed from the similarly named function in tower. The version there asserts
-    // that CORS rules are useable, which results in a panic if they aren't. We don't want
-    // the router to panic in such cases, so this function returns an error with a message
-    // describing what the problem is.
+    // This is cribbed from the similarly named function in tower-http. The version there
+    // asserts that CORS rules are useable, which results in a panic if they aren't. We
+    // don't want the router to panic in such cases, so this function returns an error
+    // with a message describing what the problem is.
     fn ensure_usable_cors_rules(&self) -> Result<(), &'static str> {
         if self.allow_credentials.unwrap_or_default() {
             if let Some(headers) = &self.allow_headers {

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -409,7 +409,11 @@ impl Default for Server {
 }
 
 impl Cors {
-    pub fn into_layer(self) -> CorsLayer {
+    pub fn into_layer(self) -> Result<CorsLayer, String> {
+        // Ensure configuration is valid before creating CorsLayer
+
+        self.ensure_usable_cors_rules()?;
+
         let allow_headers = if let Some(headers_to_allow) = self.allow_headers {
             cors::AllowHeaders::list(headers_to_allow.iter().filter_map(|header| {
                 header
@@ -444,17 +448,55 @@ impl Cors {
             )));
 
         if self.allow_any_origin.unwrap_or_default() {
-            cors.allow_origin(cors::Any)
+            Ok(cors.allow_origin(cors::Any))
         } else {
-            cors.allow_origin(cors::AllowOrigin::list(
+            Ok(cors.allow_origin(cors::AllowOrigin::list(
                 self.origins.into_iter().filter_map(|origin| {
                     origin
                         .parse()
                         .map_err(|_| tracing::error!("origin '{origin}' is not valid"))
                         .ok()
                 }),
-            ))
+            )))
         }
+    }
+
+    // This is cribbed from the similarly named function in tower. The version there asserts
+    // that CORS rules are useable, which results in a panic if they aren't. We don't want
+    // the router to panic in such cases, so this function returns an error with a message
+    // describing what the problem is.
+    fn ensure_usable_cors_rules(&self) -> Result<(), &'static str> {
+        if self.allow_credentials.unwrap_or_default() {
+            if let Some(headers) = &self.allow_headers {
+                if headers.iter().any(|x| x == "*") {
+                    return Err("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` \
+                        with `Access-Control-Allow-Headers: *`");
+                }
+            }
+
+            if self.methods.iter().any(|x| x == "*") {
+                return Err("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` \
+                    with `Access-Control-Allow-Methods: *`");
+            }
+
+            if self.origins.iter().any(|x| x == "*") {
+                return Err("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` \
+                    with `Access-Control-Allow-Origin: *`");
+            }
+
+            if self.allow_any_origin.unwrap_or_default() {
+                return Err("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` \
+                    with `Access-Control-Allow-Origin: *`");
+            }
+
+            if let Some(headers) = &self.expose_headers {
+                if headers.iter().any(|x| x == "*") {
+                    return Err("Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` \
+                        with `Access-Control-Expose-Headers: *`");
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -919,6 +961,66 @@ server:
         )
         .expect_err("should have resulted in an error");
         insta::assert_snapshot!(error.to_string());
+    }
+
+    #[test]
+    fn it_does_not_allow_invalid_cors_headers() {
+        let cfg = validate_configuration(
+            r#"
+server:
+  cors:
+    allow_credentials: true
+    allow_headers: [ "*" ]
+        "#,
+        )
+        .expect("should not have resulted in an error");
+        let error = cfg
+            .server
+            .cors
+            .expect("should not have resulted in an error")
+            .into_layer()
+            .expect_err("should have resulted in an error");
+        assert_eq!(error, "Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Headers: *`");
+    }
+
+    #[test]
+    fn it_does_not_allow_invalid_cors_methods() {
+        let cfg = validate_configuration(
+            r#"
+server:
+  cors:
+    allow_credentials: true
+    methods: [ GET, "*" ]
+        "#,
+        )
+        .expect("should not have resulted in an error");
+        let error = cfg
+            .server
+            .cors
+            .expect("should not have resulted in an error")
+            .into_layer()
+            .expect_err("should have resulted in an error");
+        assert_eq!(error, "Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Methods: *`");
+    }
+
+    #[test]
+    fn it_does_not_allow_invalid_cors_origins() {
+        let cfg = validate_configuration(
+            r#"
+server:
+  cors:
+    allow_credentials: true
+    allow_any_origin: true
+        "#,
+        )
+        .expect("should not have resulted in an error");
+        let error = cfg
+            .server
+            .cors
+            .expect("should not have resulted in an error")
+            .into_layer()
+            .expect_err("should have resulted in an error");
+        assert_eq!(error, "Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Origin: *`");
     }
 
     #[test]


### PR DESCRIPTION
Tower validates supplied router configuration and `asserts` that it is
valid to use. If it isn't, this results in a runtime panic which is not
a nice user experience.
    
This set of changes checks the CORS parameters before passing them to
tower and results in a manageable error if mis-configuration is
detected. It would be better if this was fixed in tower, but I imagine
there is a good reason to have the asserts. I'll file a ticket there
anyway, but in the meantime we can just have this function in our code.
