### PR TITLE
fix: Show a helpful error message when a subgraph does not return JSON or bad status code

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -80,6 +80,11 @@ By [@jcaromiq](https://github.com/jcaromiq) in https://github.com/apollographql/
 
 ## 🐛 Fixes ( :bug: )
 
+### Display better error message when on subgraph fetch errors ([PR #1201](https://github.com/apollographql/router/pull/1201))
+Show a helpful error message when a subgraph does not return JSON or bad status code
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1201
+
 ### Fix CORS configuration to eliminate runtime panic on mis-configuration ([PR #1197](https://github.com/apollographql/router/pull/1197))
 Previously, it was possible to specify a CORS configuration which was syntactically valid, but which could not be enforced at runtime:
 Example:

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -5,7 +5,7 @@ use crate::{
     http_compat::{Request, Response},
     PluggableRouterServiceBuilder, Plugins, ResponseBody, Schema, ServiceBuilderExt,
 };
-use crate::{DynPlugin, TowerSubgraphService};
+use crate::{DynPlugin, SubgraphService};
 use envmnt::types::ExpandOptions;
 use envmnt::ExpansionType;
 use futures::stream::BoxStream;
@@ -71,7 +71,7 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
         }
 
         for (name, _) in schema.subgraphs() {
-            let subgraph_service = BoxService::new(TowerSubgraphService::new(name.to_string()));
+            let subgraph_service = BoxService::new(SubgraphService::new(name.to_string()));
 
             builder = builder.with_subgraph_service(name, subgraph_service);
         }

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -16,14 +16,14 @@ use std::collections::HashMap;
 use std::convert::Infallible;
 use std::str::FromStr;
 use std::sync::Arc;
+pub use subgraph_service::SubgraphService;
 use tower::BoxError;
-pub use tower_subgraph_service::TowerSubgraphService;
 
 mod execution_service;
 pub mod http_compat;
 pub(crate) mod layers;
 mod router_service;
-mod tower_subgraph_service;
+mod subgraph_service;
 
 /// Different kinds of body we could have as the Router's response
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -67,8 +67,11 @@ impl tower::Service<graphql::SubgraphRequest> for SubgraphService {
 
             let mut request = http::request::Request::from_parts(parts, body.into());
             let app_json: HeaderValue = HeaderValue::from_static("application/json");
+            let app_graphql_json: HeaderValue =
+                HeaderValue::from_static("application/graphql+json");
             request.headers_mut().insert(CONTENT_TYPE, app_json.clone());
             request.headers_mut().insert(ACCEPT, app_json);
+            request.headers_mut().append(ACCEPT, app_graphql_json);
 
             get_text_map_propagator(|propagator| {
                 propagator.inject_context(

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -114,10 +114,12 @@ impl tower::Service<graphql::SubgraphRequest> for SubgraphService {
             if let Some(content_type) = parts.headers.get(header::CONTENT_TYPE) {
                 if let Ok(content_type_str) = content_type.to_str() {
                     // Using .contains because sometimes we could have charset included (example: "application/json; charset=utf-8")
-                    if !content_type_str.contains("application/json") {
+                    if !content_type_str.contains("application/json")
+                        && !content_type_str.contains("application/graphql+json")
+                    {
                         return Err(BoxError::from(graphql::FetchError::SubrequestHttpError {
                             service: service_name.clone(),
-                            reason: format!("subgraph didn't return JSON (expected content-type: application/json; found content-type: {content_type:?})"),
+                            reason: format!("subgraph didn't return JSON (expected content-type: application/json or content-type: application/graphql+json; found content-type: {content_type:?})"),
                         }));
                     }
                 }
@@ -283,7 +285,7 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             err.to_string(),
-            "HTTP fetch failed from 'test': subgraph didn't return JSON (expected content-type: application/json; found content-type: \"text/html\")"
+            "HTTP fetch failed from 'test': subgraph didn't return JSON (expected content-type: application/json or content-type: application/graphql+json; found content-type: \"text/html\")"
         );
     }
 }

--- a/apollo-router/src/services/tower_subgraph_service.rs
+++ b/apollo-router/src/services/tower_subgraph_service.rs
@@ -138,7 +138,7 @@ impl tower::Service<graphql::SubgraphRequest> for TowerSubgraphService {
                 return Err(BoxError::from(graphql::FetchError::SubrequestHttpError {
                     service: service_name.clone(),
                     reason: format!(
-                        "subgraph returns status error '{}': {})",
+                        "subgraph HTTP status error '{}': {})",
                         parts.status,
                         String::from_utf8_lossy(&body)
                     ),

--- a/apollo-router/src/services/tower_subgraph_service.rs
+++ b/apollo-router/src/services/tower_subgraph_service.rs
@@ -4,8 +4,8 @@ use crate::prelude::*;
 use futures::future::BoxFuture;
 use global::get_text_map_propagator;
 use http::{
-    header::{ACCEPT, CONTENT_TYPE},
-    HeaderValue,
+    header::{self, ACCEPT, CONTENT_TYPE},
+    HeaderValue, StatusCode,
 };
 use hyper::client::HttpConnector;
 use hyper_rustls::HttpsConnector;
@@ -66,7 +66,7 @@ impl tower::Service<graphql::SubgraphRequest> for TowerSubgraphService {
             let body = serde_json::to_string(&body).expect("JSON serialization should not fail");
 
             let mut request = http::request::Request::from_parts(parts, body.into());
-            let app_json: HeaderValue = "application/json".parse().unwrap();
+            let app_json: HeaderValue = HeaderValue::from_static("application/json");
             request.headers_mut().insert(CONTENT_TYPE, app_json.clone());
             request.headers_mut().insert(ACCEPT, app_json);
 
@@ -111,6 +111,18 @@ impl tower::Service<graphql::SubgraphRequest> for TowerSubgraphService {
 
             // Keep our parts, we'll need them later
             let (parts, body) = response.into_parts();
+            if let Some(content_type) = parts.headers.get(header::CONTENT_TYPE) {
+                if let Ok(content_type_str) = content_type.to_str() {
+                    // Using .contains because sometimes we could have charset included (example: "application/json; charset=utf-8")
+                    if !content_type_str.contains("application/json") {
+                        return Err(BoxError::from(graphql::FetchError::SubrequestHttpError {
+                            service: service_name.clone(),
+                            reason: format!("subgraph doesn't return JSON content (current content-type: {content_type:?})"),
+                        }));
+                    }
+                }
+            }
+
             let body = hyper::body::to_bytes(body)
                 .instrument(tracing::debug_span!("aggregate_response_data"))
                 .await
@@ -122,6 +134,16 @@ impl tower::Service<graphql::SubgraphRequest> for TowerSubgraphService {
                         reason: err.to_string(),
                     }
                 })?;
+            if parts.status != StatusCode::OK {
+                return Err(BoxError::from(graphql::FetchError::SubrequestHttpError {
+                    service: service_name.clone(),
+                    reason: format!(
+                        "subgraph returns status error '{}': {})",
+                        parts.status,
+                        String::from_utf8_lossy(&body)
+                    ),
+                }));
+            }
 
             let graphql: graphql::Response = tracing::debug_span!("parse_subgraph_response")
                 .in_scope(|| {
@@ -140,5 +162,128 @@ impl tower::Service<graphql::SubgraphRequest> for TowerSubgraphService {
                 context,
             ))
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::Infallible;
+    use std::net::SocketAddr;
+    use std::str::FromStr;
+
+    use axum::Server;
+    use http::header::HOST;
+    use http::Uri;
+    use hyper::service::make_service_fn;
+    use hyper::Body;
+    use tower::{service_fn, ServiceExt};
+
+    use crate::fetch::OperationKind;
+    use crate::{http_compat, Context, Request, Response, SubgraphRequest};
+
+    use super::*;
+
+    // starts a local server emulating a subgraph returning status code 400
+    async fn emulate_subgraph_bad_request(socket_addr: SocketAddr) {
+        async fn handle(_request: http::Request<Body>) -> Result<http::Response<Body>, Infallible> {
+            Ok(http::Response::builder()
+                .header("Content-Type", "application/json")
+                .status(StatusCode::BAD_REQUEST)
+                .body(r#"BAD REQUEST"#.into())
+                .unwrap())
+        }
+
+        let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle)) });
+        let server = Server::bind(&socket_addr).serve(make_svc);
+        if let Err(e) = server.await {
+            eprintln!("server error: {}", e);
+        }
+    }
+
+    // starts a local server emulating a subgraph returning bad response format
+    async fn emulate_subgraph_bad_response_format(socket_addr: SocketAddr) {
+        async fn handle(_request: http::Request<Body>) -> Result<http::Response<Body>, Infallible> {
+            Ok(http::Response::builder()
+                .header("Content-Type", "text/html")
+                .status(StatusCode::OK)
+                .body(r#"TEST"#.into())
+                .unwrap())
+        }
+
+        let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle)) });
+        let server = Server::bind(&socket_addr).serve(make_svc);
+        if let Err(e) = server.await {
+            eprintln!("server error: {}", e);
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_bad_status_code() {
+        let socket_addr = SocketAddr::from_str("127.0.0.1:2626").unwrap();
+        tokio::task::spawn(emulate_subgraph_bad_request(socket_addr));
+        let subgraph_service = TowerSubgraphService::new("test");
+
+        let url = Uri::from_str(&format!("http://{}", socket_addr)).unwrap();
+        let err = subgraph_service
+            .oneshot(SubgraphRequest {
+                originating_request: Arc::new(
+                    http_compat::Request::fake_builder()
+                        .header(HOST, "host")
+                        .header(CONTENT_TYPE, "application/json")
+                        .body(Request::builder().query(Some("query".to_string())).build())
+                        .build()
+                        .expect("expecting valid request"),
+                ),
+                subgraph_request: http_compat::Request::fake_builder()
+                    .header(HOST, "rhost")
+                    .header(CONTENT_TYPE, "application/json")
+                    .uri(url)
+                    .body(Request::builder().query(Some("query".to_string())).build())
+                    .build()
+                    .expect("expecting valid request"),
+                operation_kind: OperationKind::Query,
+                context: Context::new(),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "HTTP fetch failed from 'test': subgraph returns status error '400 Bad Request': BAD REQUEST)"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_bad_content_type() {
+        let socket_addr = SocketAddr::from_str("127.0.0.1:2525").unwrap();
+        tokio::task::spawn(emulate_subgraph_bad_response_format(socket_addr));
+        let subgraph_service = TowerSubgraphService::new("test");
+
+        let url = Uri::from_str(&format!("http://{}", socket_addr)).unwrap();
+        let err = subgraph_service
+            .oneshot(SubgraphRequest {
+                originating_request: Arc::new(
+                    http_compat::Request::fake_builder()
+                        .header(HOST, "host")
+                        .header(CONTENT_TYPE, "application/json")
+                        .body(Request::builder().query(Some("query".to_string())).build())
+                        .build()
+                        .expect("expecting valid request"),
+                ),
+                subgraph_request: http_compat::Request::fake_builder()
+                    .header(HOST, "rhost")
+                    .header(CONTENT_TYPE, "application/json")
+                    .uri(url)
+                    .body(Request::builder().query(Some("query".to_string())).build())
+                    .build()
+                    .expect("expecting valid request"),
+                operation_kind: OperationKind::Query,
+                context: Context::new(),
+            })
+            .await
+            .unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "HTTP fetch failed from 'test': subgraph doesn't return JSON content (current content-type: \"text/html\")"
+        );
     }
 }

--- a/apollo-router/src/services/tower_subgraph_service.rs
+++ b/apollo-router/src/services/tower_subgraph_service.rs
@@ -117,7 +117,7 @@ impl tower::Service<graphql::SubgraphRequest> for TowerSubgraphService {
                     if !content_type_str.contains("application/json") {
                         return Err(BoxError::from(graphql::FetchError::SubrequestHttpError {
                             service: service_name.clone(),
-                            reason: format!("subgraph doesn't return JSON content (current content-type: {content_type:?})"),
+                            reason: format!("subgraph didn't return JSON (expected content-type: application/json; found content-type: {content_type:?})"),
                         }));
                     }
                 }

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -6,7 +6,7 @@ use apollo_router::plugins::telemetry::config::Tracing;
 use apollo_router::plugins::telemetry::{self, apollo, Telemetry};
 use apollo_router::{
     http_compat, plugins::csrf, prelude::*, Object, PluggableRouterServiceBuilder, Plugin,
-    ResponseBody, RouterRequest, RouterResponse, Schema, SubgraphRequest, TowerSubgraphService,
+    ResponseBody, RouterRequest, RouterResponse, Schema, SubgraphRequest, SubgraphService,
     ValueExt,
 };
 use futures::stream::{BoxStream, StreamExt};
@@ -629,14 +629,13 @@ async fn setup_router_and_registry() -> (
         let cloned_counter = counting_registry.clone();
         let cloned_name = name.clone();
 
-        let service = TowerSubgraphService::new(name.to_owned()).map_request(
-            move |request: SubgraphRequest| {
+        let service =
+            SubgraphService::new(name.to_owned()).map_request(move |request: SubgraphRequest| {
                 let cloned_counter = cloned_counter.clone();
                 cloned_counter.increment(cloned_name.as_str());
 
                 request
-            },
-        );
+            });
         builder = builder.with_subgraph_service(name, service);
     }
 

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/tests/integration_tests.rs
-assertion_line: 154
+assertion_line: 153
 expression: get_spans()
 ---
 {
@@ -208,8 +208,8 @@ expression: get_spans()
                         }
                       },
                       "children": {
-                        "apollo_router::services::tower_subgraph_service::subgraph_request": {
-                          "name": "apollo_router::services::tower_subgraph_service::subgraph_request",
+                        "apollo_router::services::subgraph_service::subgraph_request": {
+                          "name": "apollo_router::services::subgraph_service::subgraph_request",
                           "record": {
                             "entries": [
                               [
@@ -235,9 +235,9 @@ expression: get_spans()
                             ],
                             "metadata": {
                               "name": "subgraph_request",
-                              "target": "apollo_router::services::tower_subgraph_service",
+                              "target": "apollo_router::services::subgraph_service",
                               "level": "INFO",
-                              "module_path": "apollo_router::services::tower_subgraph_service",
+                              "module_path": "apollo_router::services::subgraph_service",
                               "fields": {
                                 "names": [
                                   "otel.kind",
@@ -251,15 +251,15 @@ expression: get_spans()
                           },
                           "children": {}
                         },
-                        "apollo_router::services::tower_subgraph_service::aggregate_response_data": {
-                          "name": "apollo_router::services::tower_subgraph_service::aggregate_response_data",
+                        "apollo_router::services::subgraph_service::aggregate_response_data": {
+                          "name": "apollo_router::services::subgraph_service::aggregate_response_data",
                           "record": {
                             "entries": [],
                             "metadata": {
                               "name": "aggregate_response_data",
-                              "target": "apollo_router::services::tower_subgraph_service",
+                              "target": "apollo_router::services::subgraph_service",
                               "level": "DEBUG",
-                              "module_path": "apollo_router::services::tower_subgraph_service",
+                              "module_path": "apollo_router::services::subgraph_service",
                               "fields": {
                                 "names": []
                               }
@@ -267,15 +267,15 @@ expression: get_spans()
                           },
                           "children": {}
                         },
-                        "apollo_router::services::tower_subgraph_service::parse_subgraph_response": {
-                          "name": "apollo_router::services::tower_subgraph_service::parse_subgraph_response",
+                        "apollo_router::services::subgraph_service::parse_subgraph_response": {
+                          "name": "apollo_router::services::subgraph_service::parse_subgraph_response",
                           "record": {
                             "entries": [],
                             "metadata": {
                               "name": "parse_subgraph_response",
-                              "target": "apollo_router::services::tower_subgraph_service",
+                              "target": "apollo_router::services::subgraph_service",
                               "level": "DEBUG",
-                              "module_path": "apollo_router::services::tower_subgraph_service",
+                              "module_path": "apollo_router::services::subgraph_service",
                               "fields": {
                                 "names": []
                               }
@@ -368,8 +368,8 @@ expression: get_spans()
                         }
                       },
                       "children": {
-                        "apollo_router::services::tower_subgraph_service::subgraph_request": {
-                          "name": "apollo_router::services::tower_subgraph_service::subgraph_request",
+                        "apollo_router::services::subgraph_service::subgraph_request": {
+                          "name": "apollo_router::services::subgraph_service::subgraph_request",
                           "record": {
                             "entries": [
                               [
@@ -395,9 +395,9 @@ expression: get_spans()
                             ],
                             "metadata": {
                               "name": "subgraph_request",
-                              "target": "apollo_router::services::tower_subgraph_service",
+                              "target": "apollo_router::services::subgraph_service",
                               "level": "INFO",
-                              "module_path": "apollo_router::services::tower_subgraph_service",
+                              "module_path": "apollo_router::services::subgraph_service",
                               "fields": {
                                 "names": [
                                   "otel.kind",
@@ -411,15 +411,15 @@ expression: get_spans()
                           },
                           "children": {}
                         },
-                        "apollo_router::services::tower_subgraph_service::aggregate_response_data": {
-                          "name": "apollo_router::services::tower_subgraph_service::aggregate_response_data",
+                        "apollo_router::services::subgraph_service::aggregate_response_data": {
+                          "name": "apollo_router::services::subgraph_service::aggregate_response_data",
                           "record": {
                             "entries": [],
                             "metadata": {
                               "name": "aggregate_response_data",
-                              "target": "apollo_router::services::tower_subgraph_service",
+                              "target": "apollo_router::services::subgraph_service",
                               "level": "DEBUG",
-                              "module_path": "apollo_router::services::tower_subgraph_service",
+                              "module_path": "apollo_router::services::subgraph_service",
                               "fields": {
                                 "names": []
                               }
@@ -427,15 +427,15 @@ expression: get_spans()
                           },
                           "children": {}
                         },
-                        "apollo_router::services::tower_subgraph_service::parse_subgraph_response": {
-                          "name": "apollo_router::services::tower_subgraph_service::parse_subgraph_response",
+                        "apollo_router::services::subgraph_service::parse_subgraph_response": {
+                          "name": "apollo_router::services::subgraph_service::parse_subgraph_response",
                           "record": {
                             "entries": [],
                             "metadata": {
                               "name": "parse_subgraph_response",
-                              "target": "apollo_router::services::tower_subgraph_service",
+                              "target": "apollo_router::services::subgraph_service",
                               "level": "DEBUG",
-                              "module_path": "apollo_router::services::tower_subgraph_service",
+                              "module_path": "apollo_router::services::subgraph_service",
                               "fields": {
                                 "names": []
                               }
@@ -543,8 +543,8 @@ expression: get_spans()
                             }
                           },
                           "children": {
-                            "apollo_router::services::tower_subgraph_service::subgraph_request": {
-                              "name": "apollo_router::services::tower_subgraph_service::subgraph_request",
+                            "apollo_router::services::subgraph_service::subgraph_request": {
+                              "name": "apollo_router::services::subgraph_service::subgraph_request",
                               "record": {
                                 "entries": [
                                   [
@@ -570,9 +570,9 @@ expression: get_spans()
                                 ],
                                 "metadata": {
                                   "name": "subgraph_request",
-                                  "target": "apollo_router::services::tower_subgraph_service",
+                                  "target": "apollo_router::services::subgraph_service",
                                   "level": "INFO",
-                                  "module_path": "apollo_router::services::tower_subgraph_service",
+                                  "module_path": "apollo_router::services::subgraph_service",
                                   "fields": {
                                     "names": [
                                       "otel.kind",
@@ -586,15 +586,15 @@ expression: get_spans()
                               },
                               "children": {}
                             },
-                            "apollo_router::services::tower_subgraph_service::aggregate_response_data": {
-                              "name": "apollo_router::services::tower_subgraph_service::aggregate_response_data",
+                            "apollo_router::services::subgraph_service::aggregate_response_data": {
+                              "name": "apollo_router::services::subgraph_service::aggregate_response_data",
                               "record": {
                                 "entries": [],
                                 "metadata": {
                                   "name": "aggregate_response_data",
-                                  "target": "apollo_router::services::tower_subgraph_service",
+                                  "target": "apollo_router::services::subgraph_service",
                                   "level": "DEBUG",
-                                  "module_path": "apollo_router::services::tower_subgraph_service",
+                                  "module_path": "apollo_router::services::subgraph_service",
                                   "fields": {
                                     "names": []
                                   }
@@ -602,15 +602,15 @@ expression: get_spans()
                               },
                               "children": {}
                             },
-                            "apollo_router::services::tower_subgraph_service::parse_subgraph_response": {
-                              "name": "apollo_router::services::tower_subgraph_service::parse_subgraph_response",
+                            "apollo_router::services::subgraph_service::parse_subgraph_response": {
+                              "name": "apollo_router::services::subgraph_service::parse_subgraph_response",
                               "record": {
                                 "entries": [],
                                 "metadata": {
                                   "name": "parse_subgraph_response",
-                                  "target": "apollo_router::services::tower_subgraph_service",
+                                  "target": "apollo_router::services::subgraph_service",
                                   "level": "DEBUG",
-                                  "module_path": "apollo_router::services::tower_subgraph_service",
+                                  "module_path": "apollo_router::services::subgraph_service",
                                   "fields": {
                                     "names": []
                                   }
@@ -703,8 +703,8 @@ expression: get_spans()
                             }
                           },
                           "children": {
-                            "apollo_router::services::tower_subgraph_service::subgraph_request": {
-                              "name": "apollo_router::services::tower_subgraph_service::subgraph_request",
+                            "apollo_router::services::subgraph_service::subgraph_request": {
+                              "name": "apollo_router::services::subgraph_service::subgraph_request",
                               "record": {
                                 "entries": [
                                   [
@@ -730,9 +730,9 @@ expression: get_spans()
                                 ],
                                 "metadata": {
                                   "name": "subgraph_request",
-                                  "target": "apollo_router::services::tower_subgraph_service",
+                                  "target": "apollo_router::services::subgraph_service",
                                   "level": "INFO",
-                                  "module_path": "apollo_router::services::tower_subgraph_service",
+                                  "module_path": "apollo_router::services::subgraph_service",
                                   "fields": {
                                     "names": [
                                       "otel.kind",
@@ -746,15 +746,15 @@ expression: get_spans()
                               },
                               "children": {}
                             },
-                            "apollo_router::services::tower_subgraph_service::aggregate_response_data": {
-                              "name": "apollo_router::services::tower_subgraph_service::aggregate_response_data",
+                            "apollo_router::services::subgraph_service::aggregate_response_data": {
+                              "name": "apollo_router::services::subgraph_service::aggregate_response_data",
                               "record": {
                                 "entries": [],
                                 "metadata": {
                                   "name": "aggregate_response_data",
-                                  "target": "apollo_router::services::tower_subgraph_service",
+                                  "target": "apollo_router::services::subgraph_service",
                                   "level": "DEBUG",
-                                  "module_path": "apollo_router::services::tower_subgraph_service",
+                                  "module_path": "apollo_router::services::subgraph_service",
                                   "fields": {
                                     "names": []
                                   }
@@ -762,15 +762,15 @@ expression: get_spans()
                               },
                               "children": {}
                             },
-                            "apollo_router::services::tower_subgraph_service::parse_subgraph_response": {
-                              "name": "apollo_router::services::tower_subgraph_service::parse_subgraph_response",
+                            "apollo_router::services::subgraph_service::parse_subgraph_response": {
+                              "name": "apollo_router::services::subgraph_service::parse_subgraph_response",
                               "record": {
                                 "entries": [],
                                 "metadata": {
                                   "name": "parse_subgraph_response",
-                                  "target": "apollo_router::services::tower_subgraph_service",
+                                  "target": "apollo_router::services::subgraph_service",
                                   "level": "DEBUG",
-                                  "module_path": "apollo_router::services::tower_subgraph_service",
+                                  "module_path": "apollo_router::services::subgraph_service",
                                   "fields": {
                                     "names": []
                                   }

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
@@ -193,8 +193,8 @@ expression: get_spans()
                     }
                   },
                   "children": {
-                    "apollo_router::services::tower_subgraph_service::subgraph_request": {
-                      "name": "apollo_router::services::tower_subgraph_service::subgraph_request",
+                    "apollo_router::services::subgraph_service::subgraph_request": {
+                      "name": "apollo_router::services::subgraph_service::subgraph_request",
                       "record": {
                         "entries": [
                           [
@@ -220,9 +220,9 @@ expression: get_spans()
                         ],
                         "metadata": {
                           "name": "subgraph_request",
-                          "target": "apollo_router::services::tower_subgraph_service",
+                          "target": "apollo_router::services::subgraph_service",
                           "level": "INFO",
-                          "module_path": "apollo_router::services::tower_subgraph_service",
+                          "module_path": "apollo_router::services::subgraph_service",
                           "fields": {
                             "names": [
                               "otel.kind",
@@ -236,15 +236,15 @@ expression: get_spans()
                       },
                       "children": {}
                     },
-                    "apollo_router::services::tower_subgraph_service::aggregate_response_data": {
-                      "name": "apollo_router::services::tower_subgraph_service::aggregate_response_data",
+                    "apollo_router::services::subgraph_service::aggregate_response_data": {
+                      "name": "apollo_router::services::subgraph_service::aggregate_response_data",
                       "record": {
                         "entries": [],
                         "metadata": {
                           "name": "aggregate_response_data",
-                          "target": "apollo_router::services::tower_subgraph_service",
+                          "target": "apollo_router::services::subgraph_service",
                           "level": "DEBUG",
-                          "module_path": "apollo_router::services::tower_subgraph_service",
+                          "module_path": "apollo_router::services::subgraph_service",
                           "fields": {
                             "names": []
                           }
@@ -252,15 +252,15 @@ expression: get_spans()
                       },
                       "children": {}
                     },
-                    "apollo_router::services::tower_subgraph_service::parse_subgraph_response": {
-                      "name": "apollo_router::services::tower_subgraph_service::parse_subgraph_response",
+                    "apollo_router::services::subgraph_service::parse_subgraph_response": {
+                      "name": "apollo_router::services::subgraph_service::parse_subgraph_response",
                       "record": {
                         "entries": [],
                         "metadata": {
                           "name": "parse_subgraph_response",
-                          "target": "apollo_router::services::tower_subgraph_service",
+                          "target": "apollo_router::services::subgraph_service",
                           "level": "DEBUG",
-                          "module_path": "apollo_router::services::tower_subgraph_service",
+                          "module_path": "apollo_router::services::subgraph_service",
                           "fields": {
                             "names": []
                           }

--- a/examples/embedded/src/main.rs
+++ b/examples/embedded/src/main.rs
@@ -23,9 +23,8 @@ async fn main() -> Result<()> {
 
     // ... except the SubgraphServices, so we'll let it know Requests against the `accounts` service
     // can be performed with an http client against the `https://accounts.demo.starstuff.dev` url
-    let subgraph_service = BoxService::new(apollo_router::TowerSubgraphService::new(
-        "accounts".to_string(),
-    ));
+    let subgraph_service =
+        BoxService::new(apollo_router::SubgraphService::new("accounts".to_string()));
     router_builder = router_builder.with_subgraph_service("accounts", subgraph_service);
 
     // We can now build our service stack...


### PR DESCRIPTION
close #1183 

+ Rename the `TowerSubgraphService` to `SubgraphService`