### PR TITLE
Remove apollo_router::prelude::graphql reexports

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -38,6 +38,17 @@ To upgrade, remove any dependency on the former in `Cargo.toml` files (keeping o
 
 By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/1189
 
+### The `prelude::graphql` has been removed
+
+After the previous change, it only re-exported the crate root. Use that directly instead:
+
+```diff
+- use apollo_router::prelude::graphql;
+-
+- fn example(schema: Arc<graphql::Schema>) {
++ fn example(schema: Arc<apollo_router::Schema>) {
+```
+
 ## 🚀 Features
 ### Helm chart now has the option to use an existing Secret for API Key [PR #1196](https://github.com/apollographql/router/pull/1196)
 This change allows the use an already existing Secret for the graph API Key.

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -713,7 +713,6 @@ pub fn validate_configuration(raw_yaml: &str) -> Result<Configuration, Configura
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prelude::*;
     use crate::SchemaError;
     use http::Uri;
     #[cfg(unix)]
@@ -741,7 +740,7 @@ mod tests {
 
     #[test]
     fn routing_url_in_schema() {
-        let schema: graphql::Schema = r#"
+        let schema: crate::Schema = r#"
         schema
           @core(feature: "https://specs.apollo.dev/core/v0.1"),
           @core(feature: "https://specs.apollo.dev/join/v0.1")
@@ -815,7 +814,7 @@ mod tests {
           PRODUCTS @join__graph(name: "products" url: "http://localhost:4003/graphql")
           REVIEWS @join__graph(name: "reviews" url: "")
         }"#
-        .parse::<graphql::Schema>()
+        .parse::<crate::Schema>()
         .expect_err("Must have an error because we have one missing subgraph routing url");
 
         if let SchemaError::MissingSubgraphUrl(subgraph) = schema_error {

--- a/apollo-router/src/context.rs
+++ b/apollo-router/src/context.rs
@@ -3,7 +3,7 @@
 //! Router plugins accept a mutable [`Context`] when invoked and this contains a DashMap which
 //! allows additional data to be passed back and forth along the request invocation pipeline.
 
-use crate::prelude::graphql::*;
+use crate::*;
 use dashmap::mapref::multiple::{RefMulti, RefMutMulti};
 use dashmap::DashMap;
 use serde::Serialize;

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -1,4 +1,4 @@
-use crate::prelude::graphql::*;
+use crate::*;
 use displaydoc::Display;
 use miette::{Diagnostic, NamedSource, Report, SourceSpan};
 pub use router_bridge::planner::{PlanError, PlannerError};

--- a/apollo-router/src/http_server_factory.rs
+++ b/apollo-router/src/http_server_factory.rs
@@ -1,9 +1,6 @@
 use super::FederatedServerError;
 use crate::configuration::{Configuration, ListenAddr};
-use crate::{
-    http_compat::{Request, Response},
-    prelude::*,
-};
+use crate::http_compat::{Request, Response};
 use crate::{Handler, ResponseBody};
 use derivative::Derivative;
 use futures::prelude::*;
@@ -29,7 +26,7 @@ pub(crate) trait HttpServerFactory {
     ) -> Self::Future
     where
         RS: Service<
-                Request<graphql::Request>,
+                Request<crate::Request>,
                 Response = BoxStream<'static, Response<ResponseBody>>,
                 Error = BoxError,
             > + Send
@@ -95,7 +92,7 @@ impl HttpServerHandle {
     where
         SF: HttpServerFactory,
         RS: Service<
-                Request<graphql::Request>,
+                Request<crate::Request>,
                 Response = BoxStream<'static, Response<ResponseBody>>,
                 Error = BoxError,
             > + Send

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -1,4 +1,4 @@
-use crate::prelude::graphql::*;
+use crate::*;
 use include_dir::include_dir;
 use once_cell::sync::Lazy;
 use router_bridge::introspect::{self, IntrospectionError};

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -1,4 +1,4 @@
-use crate::prelude::graphql::*;
+use crate::*;
 use serde::{Deserialize, Serialize};
 pub use serde_json_bytes::Value;
 use serde_json_bytes::{ByteString, Entry, Map};

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -71,20 +71,7 @@ pub use traits::*;
 
 /// Useful traits.
 pub mod prelude {
-    // NOTE: only traits can be added here! Everything else should be scoped under the module
-    //       graphql so the user can use, for example:
-    //        -  graphql::Schema to get a GraphQL Schema
-    //        -  graphql::Request to get a GraphQL Request
-    //        -  graphql::Response to get a GraphQL Response
-    //        -  ...
-    //
-    //      This is because the user might work with HTTP requests alongside GraphQL requests so we
-    //      thought it might be handy to have everything under the namespace "graphql" and let
-    //      the user imports things explicitly if they prefer to.
     pub use crate::traits::*;
-    pub mod graphql {
-        pub use crate::*;
-    }
 }
 
 /// Useful reexports.

--- a/apollo-router/src/query_cache.rs
+++ b/apollo-router/src/query_cache.rs
@@ -2,8 +2,8 @@
 use opentelemetry::trace::SpanKind;
 use tracing::{info_span, Instrument};
 
-use crate::prelude::graphql::*;
 use crate::CacheResolver;
+use crate::*;
 use std::sync::Arc;
 
 /// A cache for parsed GraphQL queries.

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -1,6 +1,6 @@
 //! Calls out to nodejs query planner
 
-use crate::prelude::graphql::*;
+use crate::*;
 use async_trait::async_trait;
 use futures::future::BoxFuture;
 use router_bridge::planner::PlanSuccess;

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -1,5 +1,5 @@
-use crate::prelude::graphql::*;
 use crate::CacheResolver;
+use crate::*;
 use async_trait::async_trait;
 use futures::future::BoxFuture;
 use std::marker::PhantomData;

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -1,7 +1,7 @@
 mod bridge_query_planner;
 mod caching_query_planner;
 mod selection;
-use crate::prelude::graphql::*;
+use crate::*;
 pub use bridge_query_planner::*;
 pub use caching_query_planner::*;
 use fetch::OperationKind;
@@ -300,7 +300,7 @@ impl PlanNode {
 
 pub(crate) mod fetch {
     use super::selection::{select_object, Selection};
-    use crate::prelude::graphql::*;
+    use crate::*;
     use indexmap::IndexSet;
     use serde::Deserialize;
     use std::{collections::HashMap, fmt::Display, sync::Arc};
@@ -629,7 +629,7 @@ mod log {
         service_name: &str,
         operation: &str,
         variables: &Map<ByteString, Value>,
-        response: &crate::prelude::graphql::Response,
+        response: &crate::Response,
     ) {
         tracing::trace!(
             "subgraph fetch to {}: operation = '{}', variables = {:?}, response:\n{}",

--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -1,4 +1,4 @@
-use crate::prelude::graphql::*;
+use crate::*;
 use serde::Deserialize;
 use serde_json_bytes::Entry;
 

--- a/apollo-router/src/request.rs
+++ b/apollo-router/src/request.rs
@@ -1,4 +1,4 @@
-use crate::prelude::graphql::*;
+use crate::*;
 use bytes::Bytes;
 use derivative::Derivative;
 use serde::{de::Error, Deserialize, Serialize};

--- a/apollo-router/src/response.rs
+++ b/apollo-router/src/response.rs
@@ -1,4 +1,4 @@
-use crate::prelude::graphql::*;
+use crate::*;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -1,7 +1,6 @@
 use crate::axum_http_server_factory::AxumHttpServerFactory;
 use crate::configuration::validate_configuration;
 use crate::configuration::{Configuration, ListenAddr};
-use crate::prelude::*;
 use crate::reload::Error as ReloadError;
 use crate::router_factory::{RouterServiceFactory, YamlRouterServiceFactory};
 use crate::state_machine::StateMachine;
@@ -24,7 +23,7 @@ use url::Url;
 use Event::{NoMoreConfiguration, NoMoreSchema};
 use Event::{Shutdown, UpdateConfiguration, UpdateSchema};
 
-type SchemaStream = Pin<Box<dyn Stream<Item = graphql::Schema> + Send>>;
+type SchemaStream = Pin<Box<dyn Stream<Item = crate::Schema> + Send>>;
 
 /// Error types for FederatedServer.
 #[derive(Error, Debug, DisplayDoc)]
@@ -51,7 +50,7 @@ pub enum FederatedServerError {
     ConfigError(crate::configuration::ConfigurationError),
 
     /// could not read schema: {0}
-    ReadSchemaError(graphql::SchemaError),
+    ReadSchemaError(crate::SchemaError),
 
     /// could not create the HTTP pipeline: {0}
     ServiceCreationError(tower::BoxError),
@@ -78,7 +77,7 @@ pub enum FederatedServerError {
 pub enum SchemaKind {
     /// A static schema.
     #[display(fmt = "Instance")]
-    Instance(Box<graphql::Schema>),
+    Instance(Box<crate::Schema>),
 
     /// A stream of schema.
     #[display(fmt = "Stream")]
@@ -114,8 +113,8 @@ pub enum SchemaKind {
     },
 }
 
-impl From<graphql::Schema> for SchemaKind {
-    fn from(schema: graphql::Schema) -> Self {
+impl From<crate::Schema> for SchemaKind {
+    fn from(schema: crate::Schema) -> Self {
         Self::Instance(Box::new(schema))
     }
 }
@@ -277,8 +276,8 @@ impl ConfigurationKind {
         Ok(config)
     }
 
-    fn read_schema(path: &Path) -> Result<graphql::Schema, FederatedServerError> {
-        graphql::Schema::read(path).map_err(FederatedServerError::ReadSchemaError)
+    fn read_schema(path: &Path) -> Result<crate::Schema, FederatedServerError> {
+        crate::Schema::read(path).map_err(FederatedServerError::ReadSchemaError)
     }
 }
 
@@ -331,7 +330,7 @@ impl ShutdownKind {
 ///
 /// async {
 ///     let configuration = serde_yaml::from_str::<Configuration>("Config").unwrap();
-///     let schema: graphql::Schema = "schema".parse().unwrap();
+///     let schema: crate::Schema = "schema".parse().unwrap();
 ///     let server = ApolloRouterBuilder::default()
 ///             .configuration(ConfigurationKind::Instance(Box::new(configuration)))
 ///             .schema(SchemaKind::Instance(Box::new(schema)))
@@ -350,7 +349,7 @@ impl ShutdownKind {
 ///
 /// async {
 ///     let configuration = serde_yaml::from_str::<Configuration>("Config").unwrap();
-///     let schema: graphql::Schema = "schema".parse().unwrap();
+///     let schema: crate::Schema = "schema".parse().unwrap();
 ///     let server = ApolloRouterBuilder::default()
 ///             .configuration(ConfigurationKind::Instance(Box::new(configuration)))
 ///             .schema(SchemaKind::Instance(Box::new(schema)))
@@ -456,7 +455,7 @@ pub(crate) enum Event {
     NoMoreConfiguration,
 
     /// The schema was updated.
-    UpdateSchema(Box<graphql::Schema>),
+    UpdateSchema(Box<crate::Schema>),
 
     /// There are no more updates to the schema
     NoMoreSchema,
@@ -659,7 +658,7 @@ mod tests {
         let configuration =
             serde_yaml::from_str::<Configuration>(include_str!("testdata/supergraph_config.yaml"))
                 .unwrap();
-        let schema: graphql::Schema = include_str!("testdata/supergraph.graphql").parse().unwrap();
+        let schema: crate::Schema = include_str!("testdata/supergraph.graphql").parse().unwrap();
         ApolloRouterBuilder::default()
             .configuration(ConfigurationKind::Instance(Box::new(configuration)))
             .schema(SchemaKind::Instance(Box::new(schema)))
@@ -676,7 +675,7 @@ mod tests {
     }
 
     async fn assert_federated_response(listen_addr: &ListenAddr, request: &str) {
-        let request = graphql::Request::builder()
+        let request = crate::Request::builder()
             .query(Some(request.to_string()))
             .build();
         let expected = query(listen_addr, &request).await.unwrap();
@@ -687,8 +686,8 @@ mod tests {
 
     async fn query(
         listen_addr: &ListenAddr,
-        request: &graphql::Request,
-    ) -> Result<graphql::Response, graphql::FetchError> {
+        request: &crate::Request,
+    ) -> Result<crate::Response, crate::FetchError> {
         Ok(reqwest::Client::new()
             .post(format!("{}/", listen_addr))
             .json(request)

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -1,6 +1,5 @@
 // This entire file is license key functionality
 use crate::configuration::{Configuration, ConfigurationError};
-use crate::prelude::*;
 use crate::{
     http_compat::{Request, Response},
     PluggableRouterServiceBuilder, Plugins, ResponseBody, Schema, ServiceBuilderExt,
@@ -25,7 +24,7 @@ use tower_service::Service;
 #[async_trait::async_trait]
 pub trait RouterServiceFactory: Send + Sync + 'static {
     type RouterService: Service<
-            Request<graphql::Request>,
+            Request<crate::Request>,
             Response = BoxStream<'static, Response<ResponseBody>>,
             Error = BoxError,
             Future = Self::Future,
@@ -38,7 +37,7 @@ pub trait RouterServiceFactory: Send + Sync + 'static {
     async fn create<'a>(
         &'a mut self,
         configuration: Arc<Configuration>,
-        schema: Arc<graphql::Schema>,
+        schema: Arc<crate::Schema>,
         previous_router: Option<&'a Self::RouterService>,
     ) -> Result<(Self::RouterService, Plugins), BoxError>;
 }
@@ -51,13 +50,13 @@ pub struct YamlRouterServiceFactory;
 impl RouterServiceFactory for YamlRouterServiceFactory {
     type RouterService = Buffer<
         BoxCloneService<
-            Request<graphql::Request>,
+            Request<crate::Request>,
             BoxStream<'static, Response<ResponseBody>>,
             BoxError,
         >,
-        Request<graphql::Request>,
+        Request<crate::Request>,
     >;
-    type Future = <Self::RouterService as Service<Request<graphql::Request>>>::Future;
+    type Future = <Self::RouterService as Service<Request<crate::Request>>>::Future;
 
     async fn create<'a>(
         &'a mut self,

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -3,7 +3,7 @@
 pub use self::execution_service::*;
 pub use self::router_service::*;
 use crate::fetch::OperationKind;
-use crate::prelude::graphql::*;
+use crate::*;
 use http::{header::HeaderName, HeaderValue, StatusCode};
 use http::{method::Method, Uri};
 use http_compat::IntoHeaderName;
@@ -734,7 +734,6 @@ impl AsRef<Request> for Arc<http_compat::Request<Request>> {
 
 #[cfg(test)]
 mod test {
-    use crate::prelude::graphql;
     use crate::{Context, ResponseBody, RouterRequest, RouterResponse};
     use http::{HeaderValue, Method, Uri};
     use serde_json::json;
@@ -789,7 +788,7 @@ mod test {
             .clone();
         assert_eq!(
             request.originating_request.body(),
-            &graphql::Request::builder()
+            &crate::Request::builder()
                 .variables(variables)
                 .extensions(extensions)
                 .operation_name(Some("Default".to_string()))
@@ -825,7 +824,7 @@ mod test {
         assert_eq!(
             response.response.body(),
             &ResponseBody::GraphQL(
-                graphql::Response::builder()
+                crate::Response::builder()
                     .extensions(extensions)
                     .data(json!({}))
                     .build()

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -418,7 +418,7 @@ impl PluggableRouterServiceBuilder {
             None
         };
 
-        // Router service takes a graphql::Request and outputs a graphql::Response
+        // Router service takes a crate::Request and outputs a crate::Response
         // NB: Cannot use .buffer() here or the code won't compile...
         let router_service = Buffer::new(
             ServiceBuilder::new()

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -2,7 +2,8 @@
 //!
 //! Parsing, formatting and manipulation of queries.
 
-use crate::{fetch::OperationKind, prelude::graphql::*};
+use crate::fetch::OperationKind;
+use crate::*;
 use apollo_parser::ast;
 use derivative::Derivative;
 use serde_json_bytes::ByteString;

--- a/apollo-router/src/traits.rs
+++ b/apollo-router/src/traits.rs
@@ -1,4 +1,4 @@
-use crate::prelude::graphql::*;
+use crate::*;
 use async_trait::async_trait;
 use std::fmt::Debug;
 use std::sync::Arc;

--- a/apollo-router/tests/infrastructure_tests.rs
+++ b/apollo-router/tests/infrastructure_tests.rs
@@ -1,9 +1,7 @@
-use apollo_router::prelude::*;
-
 #[test]
 fn test_starstuff_supergraph_is_valid() {
     include_str!("../../examples/graphql/supergraph.graphql")
-        .parse::<graphql::Schema>()
+        .parse::<apollo_router::Schema>()
         .expect(
             r#"Couldn't parse the supergraph example.
 This file is being used in the router documentation, as a quickstart example.


### PR DESCRIPTION
It had become the same as the crate root.

Fixes https://github.com/apollographql/router/issues/1214
