### PR TITLE
Remove typed builder. All builders use buildstructor.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,6 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tracing-test",
- "typed-builder 0.10.0",
  "uname",
  "url",
  "urlencoding",
@@ -577,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "buildstructor"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40602615b158f55f9b0d70ec0e83a98f99c206b1725b095e793f111f7f8d56e"
+checksum = "366e31800cdecf1b0438b21e2d2c9a66e922a26b93fde60bdf6bc16e25f33cc7"
 dependencies = [
  "lazy_static",
  "proc-macro2",
@@ -3545,7 +3544,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
- "typed-builder 0.9.1",
+ "typed-builder",
 ]
 
 [[package]]
@@ -5763,17 +5762,6 @@ name = "typed-builder"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a46ee5bd706ff79131be9c94e7edcb82b703c487766a114434e5790361cf08c5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "typed-builder"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89851716b67b937e393b3daa8423e67ddfc4bbbf1654bcf05488e95e0828db0c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -144,6 +144,9 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1185
 
 ### Update buildstructor to 0.3 ([PR #1207](https://github.com/apollographql/router/pull/1207))
-
 Update buildstructor to 0.3.
 By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/1207
+
+### Remove typed-builder ([PR #1218](https://github.com/apollographql/router/pull/1218))
+Migrate all typed-builders code to buildstructor
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/1218

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -25,7 +25,7 @@ async-trait = "0.1.53"
 atty = "0.2.14"
 axum = { version = "0.5.4", features = ["headers", "json", "original-uri"] }
 backtrace = "0.3.65"
-buildstructor = "0.3.0"
+buildstructor = "0.3.2"
 bytes = "1.1.0"
 clap = { version = "3.1.18", default-features = false, features = [
     "env",
@@ -124,7 +124,6 @@ tracing-core = "0.1.26"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 tracing-opentelemetry = "0.17.2"
 tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
-typed-builder = "0.10.0"
 url = { version = "2.2.2", features = ["serde"] }
 urlencoding = "2.1.0"
 yaml-rust = "0.4.5"

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -1,5 +1,5 @@
 //! Axum http server factory. Axum provides routing capability on top of Hyper HTTP.
-use crate::configuration::{Configuration, Cors, ListenAddr};
+use crate::configuration::{Configuration, ListenAddr};
 use crate::http_server_factory::{HttpServerFactory, HttpServerHandle, Listener, NetworkStream};
 use crate::FederatedServerError;
 use crate::ResponseBody;
@@ -89,8 +89,8 @@ impl HttpServerFactory for AxumHttpServerFactory {
                 .server
                 .cors
                 .clone()
-                .map(|cors_configuration| cors_configuration.into_layer())
-                .unwrap_or_else(|| Cors::builder().build().into_layer())
+                .unwrap_or_default()
+                .into_layer()
                 .map_err(|e| {
                     FederatedServerError::ConfigError(
                         crate::configuration::ConfigurationError::LayerConfiguration {
@@ -666,11 +666,11 @@ mod tests {
                         .server(
                             crate::configuration::Server::builder()
                                 .listen(SocketAddr::from_str("127.0.0.1:0").unwrap())
-                                .cors(Some(
+                                .cors(
                                     Cors::builder()
                                         .origins(vec!["http://studio".to_string()])
                                         .build(),
-                                ))
+                                )
                                 .build(),
                         )
                         .build(),
@@ -750,11 +750,11 @@ mod tests {
                         .server(
                             crate::configuration::Server::builder()
                                 .listen(ListenAddr::UnixSocket(temp_dir.as_ref().join("sock")))
-                                .cors(Some(
+                                .cors(
                                     Cors::builder()
                                         .origins(vec!["http://studio".to_string()])
                                         .build(),
-                                ))
+                                )
                                 .build(),
                         )
                         .build(),
@@ -947,11 +947,11 @@ mod tests {
             .server(
                 crate::configuration::Server::builder()
                     .listen(SocketAddr::from_str("127.0.0.1:0").unwrap())
-                    .cors(Some(
+                    .cors(
                         Cors::builder()
                             .origins(vec!["http://studio".to_string()])
                             .build(),
-                    ))
+                    )
                     .endpoint(String::from("/graphql"))
                     .build(),
             )
@@ -1017,11 +1017,11 @@ mod tests {
             .server(
                 crate::configuration::Server::builder()
                     .listen(SocketAddr::from_str("127.0.0.1:0").unwrap())
-                    .cors(Some(
+                    .cors(
                         Cors::builder()
                             .origins(vec!["http://studio".to_string()])
                             .build(),
-                    ))
+                    )
                     .endpoint(String::from("/:my_prefix/graphql"))
                     .build(),
             )
@@ -1087,11 +1087,11 @@ mod tests {
             .server(
                 crate::configuration::Server::builder()
                     .listen(SocketAddr::from_str("127.0.0.1:0").unwrap())
-                    .cors(Some(
+                    .cors(
                         Cors::builder()
                             .origins(vec!["http://studio".to_string()])
                             .build(),
-                    ))
+                    )
                     .endpoint(String::from("/graphql/*"))
                     .build(),
             )
@@ -1529,11 +1529,11 @@ Content-Type: application/json\r
             .server(
                 crate::configuration::Server::builder()
                     .listen(SocketAddr::from_str("127.0.0.1:0").unwrap())
-                    .cors(Some(
+                    .cors(
                         Cors::builder()
                             .origins(vec!["http://studio".to_string()])
                             .build(),
-                    ))
+                    )
                     .landing_page(false)
                     .build(),
             )
@@ -1579,11 +1579,11 @@ Content-Type: application/json\r
             .server(
                 crate::configuration::Server::builder()
                     .listen(SocketAddr::from_str("127.0.0.1:0").unwrap())
-                    .cors(Some(
+                    .cors(
                         Cors::builder()
                             .origins(vec!["http://studio".to_string()])
                             .build(),
-                    ))
+                    )
                     .build(),
             )
             .build();

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,5 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 697
 expression: "&schema"
 ---
 {
@@ -410,7 +409,9 @@ expression: "&schema"
             },
             "origins": {
               "description": "The origin(s) to allow requests from. Defaults to `https://studio.apollographql.com/` for Apollo Studio.",
-              "default": [],
+              "default": [
+                "https://studio.apollographql.com"
+              ],
               "type": "array",
               "items": {
                 "type": "string"

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::task::JoinError;
 use tracing::level_filters::LevelFilter;
-use typed_builder::TypedBuilder;
 
 /// Error types for execution.
 ///
@@ -112,10 +111,9 @@ impl FetchError {
 }
 
 /// Any error.
-#[derive(Error, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default, TypedBuilder)]
+#[derive(Error, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[error("{message}")]
 #[serde(rename_all = "camelCase")]
-#[builder(field_defaults(default))]
 pub struct Error {
     /// The error message.
     pub message: String,
@@ -131,7 +129,23 @@ pub struct Error {
     pub extensions: Object,
 }
 
+#[buildstructor::buildstructor]
 impl Error {
+    #[builder]
+    pub fn new(
+        message: String,
+        locations: Vec<Location>,
+        path: Option<Path>,
+        extensions: Option<Object>,
+    ) -> Self {
+        Self {
+            message,
+            locations,
+            path,
+            extensions: extensions.unwrap_or_default(),
+        }
+    }
+
     pub fn from_value(service_name: &str, value: Value) -> Result<Error, FetchError> {
         let mut object =
             ensure_object!(value).map_err(|error| FetchError::SubrequestMalformedResponse {

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -148,9 +148,7 @@ mod naive_introspection_tests {
     #[tokio::test]
     async fn test_plan() {
         let query_to_test = "this is a test query";
-        let expected_data = Response::builder()
-            .data(serde_json::Value::Number(42.into()))
-            .build();
+        let expected_data = Response::builder().data(42).build();
 
         let cache = [(query_to_test.into(), expected_data.clone())]
             .iter()

--- a/apollo-router/src/plugins/headers.rs
+++ b/apollo-router/src/plugins/headers.rs
@@ -523,7 +523,7 @@ mod test {
                     .header(HOST, "host")
                     .header(CONTENT_LENGTH, "2")
                     .header(CONTENT_TYPE, "graphql")
-                    .body(Request::builder().query(Some("query".to_string())).build())
+                    .body(Request::builder().query("query").build())
                     .build()
                     .expect("expecting valid request"),
             ),
@@ -534,7 +534,7 @@ mod test {
                 .header(HOST, "rhost")
                 .header(CONTENT_LENGTH, "22")
                 .header(CONTENT_TYPE, "graphql")
-                .body(Request::builder().query(Some("query".to_string())).build())
+                .body(Request::builder().query("query").build())
                 .build()
                 .expect("expecting valid request"),
             operation_kind: OperationKind::Query,

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -493,9 +493,9 @@ pub(crate) mod fetch {
                         )
                         .body(
                             Request::builder()
-                                .query(Some(operation.to_string()))
-                                .operation_name(operation_name.clone())
-                                .variables(Arc::new(variables.clone()))
+                                .query(operation)
+                                .and_operation_name(operation_name.clone())
+                                .variables(variables.clone())
                                 .build(),
                         )
                         .build()

--- a/apollo-router/src/request.rs
+++ b/apollo-router/src/request.rs
@@ -3,22 +3,18 @@ use bytes::Bytes;
 use derivative::Derivative;
 use serde::{de::Error, Deserialize, Serialize};
 use std::sync::Arc;
-use typed_builder::TypedBuilder;
 
 /// A graphql request.
 /// Used for federated and subgraph queries.
-#[derive(Clone, Derivative, Serialize, Deserialize, TypedBuilder, Default)]
+#[derive(Clone, Derivative, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
-#[builder(field_defaults(setter(into)))]
 #[derivative(Debug, PartialEq, Eq, Hash)]
 pub struct Request {
     /// The graphql query.
-    #[builder(default)]
     pub query: Option<String>,
 
     /// The optional graphql operation.
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    #[builder(default)]
     pub operation_name: Option<String>,
 
     /// The optional variables in the form of a json object.
@@ -27,12 +23,10 @@ pub struct Request {
         default,
         deserialize_with = "deserialize_null_default"
     )]
-    #[builder(default)]
     pub variables: Arc<Object>,
 
     ///  extensions.
     #[serde(skip_serializing_if = "Object::is_empty", default)]
-    #[builder(default)]
     pub extensions: Object,
 }
 
@@ -46,7 +40,23 @@ where
     <Option<T>>::deserialize(deserializer).map(|x| x.unwrap_or_default())
 }
 
+#[buildstructor::buildstructor]
 impl Request {
+    #[builder]
+    pub fn new(
+        query: Option<String>,
+        operation_name: Option<String>,
+        variables: Option<Object>,
+        extensions: Option<Object>,
+    ) -> Self {
+        Self {
+            query,
+            operation_name,
+            variables: Arc::new(variables.unwrap_or_default()),
+            extensions: extensions.unwrap_or_default(),
+        }
+    }
+
     pub fn from_urlencoded_query(url_encoded_query: String) -> Result<Request, serde_json::Error> {
         // As explained in the form content types specification https://www.w3.org/TR/html4/interact/forms.html#h-17.13.4.1
         // `Forms submitted with this content type must be encoded as follows:`
@@ -76,18 +86,17 @@ impl Request {
         } else {
             None
         };
-        let variables =
-            Arc::new(get_from_urldecoded(&urldecoded, "variables")?.unwrap_or_default());
+        let variables: Object = get_from_urldecoded(&urldecoded, "variables")?.unwrap_or_default();
         let extensions: Object =
             get_from_urldecoded(&urldecoded, "extensions")?.unwrap_or_default();
 
         let request_builder = Self::builder()
             .variables(variables)
-            .operation_name(operation_name)
+            .and_operation_name(operation_name)
             .extensions(extensions);
 
         let request = if let Some(query_str) = query {
-            request_builder.query(Some(query_str.to_string())).build()
+            request_builder.query(query_str).build()
         } else {
             request_builder.build()
         };
@@ -158,10 +167,8 @@ mod tests {
             result.unwrap(),
             Request::builder()
                 .query("query aTest($arg1: String!) { test(who: $arg1) }".to_owned())
-                .operation_name(Some("aTest".to_owned()))
-                .variables(Arc::new(
-                    bjson!({ "arg1": "me" }).as_object().unwrap().clone()
-                ))
+                .operation_name("aTest")
+                .variables(bjson!({ "arg1": "me" }).as_object().unwrap().clone())
                 .extensions(bjson!({"extension": 1}).as_object().cloned().unwrap())
                 .build()
         );
@@ -183,7 +190,7 @@ mod tests {
             result.unwrap(),
             Request::builder()
                 .query("query aTest($arg1: String!) { test(who: $arg1) }".to_owned())
-                .operation_name(Some("aTest".to_owned()))
+                .operation_name("aTest")
                 .extensions(bjson!({"extension": 1}).as_object().cloned().unwrap())
                 .build()
         );
@@ -207,8 +214,8 @@ mod tests {
         assert_eq!(
             result.unwrap(),
             Request::builder()
-                .query("query aTest($arg1: String!) { test(who: $arg1) }".to_owned())
-                .operation_name(Some("aTest".to_owned()))
+                .query("query aTest($arg1: String!) { test(who: $arg1) }")
+                .operation_name("aTest")
                 .extensions(bjson!({"extension": 1}).as_object().cloned().unwrap())
                 .build()
         );

--- a/apollo-router/src/response.rs
+++ b/apollo-router/src/response.rs
@@ -1,41 +1,55 @@
 use crate::*;
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
-use typed_builder::TypedBuilder;
+use serde_json_bytes::ByteString;
+use serde_json_bytes::Map;
 
 /// A graphql primary response.
 /// Used for federated and subgraph queries.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, TypedBuilder)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[builder(field_defaults(setter(into)))]
 pub struct Response {
     /// The label that was passed to the defer or stream directive for this patch.
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    #[builder(default)]
     pub label: Option<String>,
 
     /// The response data.
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    #[builder(default, setter(strip_option))]
     pub data: Option<Value>,
 
     /// The path that the data should be merged at.
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    #[builder(default)]
     pub path: Option<Path>,
 
     /// The optional graphql errors encountered.
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    #[builder(default)]
     pub errors: Vec<Error>,
 
     /// The optional graphql extensions.
     #[serde(skip_serializing_if = "Object::is_empty", default)]
-    #[builder(default)]
     pub extensions: Object,
 }
 
+#[buildstructor::buildstructor]
 impl Response {
+    /// Constructor
+    #[builder]
+    pub fn new(
+        label: Option<String>,
+        data: Option<Value>,
+        path: Option<Path>,
+        errors: Vec<Error>,
+        extensions: Map<ByteString, Value>,
+    ) -> Self {
+        Self {
+            label,
+            data,
+            path,
+            errors,
+            extensions,
+        }
+    }
+
     /// If path is None, this is a primary query.
     pub fn is_primary(&self) -> bool {
         self.path.is_none()

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -650,6 +650,7 @@ where
 mod tests {
     use super::*;
     use crate::files::tests::{create_temp_file, write_and_flush};
+    use crate::Request;
     use serde_json::to_string_pretty;
     use std::env::temp_dir;
     use test_log::test;
@@ -675,9 +676,7 @@ mod tests {
     }
 
     async fn assert_federated_response(listen_addr: &ListenAddr, request: &str) {
-        let request = crate::Request::builder()
-            .query(Some(request.to_string()))
-            .build();
+        let request = Request::builder().query(request).build();
         let expected = query(listen_addr, &request).await.unwrap();
 
         let response = to_string_pretty(&expected).unwrap();

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -154,8 +154,8 @@ impl RouterRequest {
             .collect();
 
         let gql_request = Request::builder()
-            .query(query)
-            .operation_name(operation_name)
+            .and_query(query)
+            .and_operation_name(operation_name)
             .variables(variables)
             .extensions(extensions)
             .build();
@@ -234,7 +234,7 @@ impl RouterResponse {
             .collect();
         // Build a response
         let b = Response::builder()
-            .path(path)
+            .and_path(path)
             .errors(errors)
             .extensions(extensions);
         let res = match data {
@@ -488,9 +488,9 @@ impl SubgraphResponse {
     ) -> SubgraphResponse {
         // Build a response
         let res = Response::builder()
-            .label(label)
+            .and_label(label)
             .data(data.unwrap_or_default())
-            .path(path)
+            .and_path(path)
             .errors(errors)
             .extensions(extensions)
             .build();
@@ -631,10 +631,7 @@ impl ExecutionResponse {
         Self { response, context }
     }
 
-    /// This is the constructor (or builder) to use when constructing a real RouterRequest.
-    ///
-    /// The parameters are not optional, because in a live situation all of these properties must be
-    /// set and be correct to create a RouterRequest.
+    /// This is the constructor (or builder) to use when constructing ExecutionResponse.
     #[builder]
     pub fn new(
         label: Option<String>,
@@ -647,9 +644,9 @@ impl ExecutionResponse {
     ) -> ExecutionResponse {
         // Build a response
         let res = Response::builder()
-            .label(label)
+            .and_label(label)
             .data(data.unwrap_or_default())
-            .path(path)
+            .and_path(path)
             .errors(errors)
             .extensions(extensions)
             .build();
@@ -791,8 +788,8 @@ mod test {
             &crate::Request::builder()
                 .variables(variables)
                 .extensions(extensions)
-                .operation_name(Some("Default".to_string()))
-                .query(Some("query { topProducts }".to_string()))
+                .operation_name("Default")
+                .query("query { topProducts }")
                 .build()
         );
     }

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -234,7 +234,7 @@ mod tests {
                     http_compat::Request::fake_builder()
                         .header(HOST, "host")
                         .header(CONTENT_TYPE, "application/json")
-                        .body(Request::builder().query(Some("query".to_string())).build())
+                        .body(Request::builder().query("query").build())
                         .build()
                         .expect("expecting valid request"),
                 ),
@@ -242,7 +242,7 @@ mod tests {
                     .header(HOST, "rhost")
                     .header(CONTENT_TYPE, "application/json")
                     .uri(url)
-                    .body(Request::builder().query(Some("query".to_string())).build())
+                    .body(Request::builder().query("query").build())
                     .build()
                     .expect("expecting valid request"),
                 operation_kind: OperationKind::Query,
@@ -269,7 +269,7 @@ mod tests {
                     http_compat::Request::fake_builder()
                         .header(HOST, "host")
                         .header(CONTENT_TYPE, "application/json")
-                        .body(Request::builder().query(Some("query".to_string())).build())
+                        .body(Request::builder().query("query").build())
                         .build()
                         .expect("expecting valid request"),
                 ),
@@ -277,7 +277,7 @@ mod tests {
                     .header(HOST, "rhost")
                     .header(CONTENT_TYPE, "application/json")
                     .uri(url)
-                    .body(Request::builder().query(Some("query".to_string())).build())
+                    .body(Request::builder().query("query").build())
                     .build()
                     .expect("expecting valid request"),
                 operation_kind: OperationKind::Query,

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -1236,7 +1236,7 @@ mod tests {
             let schema: Schema = $schema.parse().expect("could not parse schema");
             let request = Request::builder()
                 .variables(variables)
-                .query(Some($query.to_string()))
+                .query($query.to_string())
                 .build();
             let query = Query::parse(
                 request

--- a/licenses.html
+++ b/licenses.html
@@ -6663,7 +6663,6 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/Manishearth/triomphe ">triomphe</a></li>
                     <li><a href=" https://github.com/yvt/try_match-rs ">try_match</a></li>
                     <li><a href=" https://github.com/idanarye/rust-typed-builder ">typed-builder</a></li>
-                    <li><a href=" https://github.com/idanarye/rust-typed-builder ">typed-builder</a></li>
                     <li><a href=" https://github.com/BurntSushi/ucd-generate ">ucd-trie</a></li>
                     <li><a href=" https://github.com/seanmonstar/unicase ">unicase</a></li>
                     <li><a href=" https://github.com/servo/unicode-bidi ">unicode-bidi</a></li>


### PR DESCRIPTION
All use of typed_builder has been removed.
Apart from making our code more consistent, it also give a minor improvement in usability for clients.