### PR TITLE
checkpoint_async() shouldn't require a boxed argument

### DIFF
--- a/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
+++ b/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
@@ -110,10 +110,10 @@ impl Plugin for {{pascal_name}} {
     ) -> BoxService<RouterRequest, RouterResponse, BoxError> {
 
         ServiceBuilder::new()
-                    .checkpoint_async(|request : RouterRequest| Box::pin(async {
+                    .checkpoint_async(|request : RouterRequest| async {
                         // Do some async call here to auth, and decide if to continue or not.
                         Ok(ControlFlow::Continue(request))
-                    }))
+                    })
                     .buffered()
                     .service(service)
                     .boxed()

--- a/apollo-router/src/layers/async_checkpoint.rs
+++ b/apollo-router/src/layers/async_checkpoint.rs
@@ -8,63 +8,49 @@
 //! back to the invoking service.
 
 use futures::future::BoxFuture;
+use futures::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
 use std::{ops::ControlFlow, sync::Arc};
 use tower::{BoxError, Layer, Service, ServiceExt};
 
 /// [`Layer`] for Asynchronous Checkpoints.
 #[allow(clippy::type_complexity)]
-pub struct AsyncCheckpointLayer<S, Request>
+pub struct AsyncCheckpointLayer<S, Fut, Request>
 where
     S: Service<Request, Error = BoxError> + Clone + Send + 'static,
-    Request: Send + 'static,
-    S::Future: Send,
-    S::Response: Send + 'static,
+    Fut: Future<Output = Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>>,
 {
-    checkpoint_fn: Arc<
-        dyn Fn(
-                Request,
-            ) -> BoxFuture<
-                'static,
-                Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>,
-            > + Send
-            + Sync
-            + 'static,
-    >,
+    checkpoint_fn: Arc<Pin<Box<dyn Fn(Request) -> Fut + Send + Sync + 'static>>>,
+    phantom: PhantomData<S>, // XXX: The compiler can't detect that S is used in the Future...
 }
 
-#[allow(clippy::type_complexity)]
-impl<S, Request> AsyncCheckpointLayer<S, Request>
+impl<S, Fut, Request> AsyncCheckpointLayer<S, Fut, Request>
 where
     S: Service<Request, Error = BoxError> + Clone + Send + 'static,
-    Request: Send + 'static,
-    S::Future: Send,
-    S::Response: Send + 'static,
+    Fut: Future<Output = Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>>,
 {
     /// Create an `AsyncCheckpointLayer` from a function that takes a Service Request and returns a `ControlFlow`
-    pub fn new(
-        checkpoint_fn: impl Fn(
-                Request,
-            ) -> BoxFuture<
-                'static,
-                Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>,
-            > + Send
-            + Sync
-            + 'static,
-    ) -> Self {
+    pub fn new<F>(checkpoint_fn: F) -> Self
+    where
+        F: Fn(Request) -> Fut + Send + Sync + 'static,
+    {
         Self {
-            checkpoint_fn: Arc::new(checkpoint_fn),
+            checkpoint_fn: Arc::new(Box::pin(checkpoint_fn)),
+            phantom: PhantomData,
         }
     }
 }
 
-impl<S, Request> Layer<S> for AsyncCheckpointLayer<S, Request>
+impl<S, Fut, Request> Layer<S> for AsyncCheckpointLayer<S, Fut, Request>
 where
     S: Service<Request, Error = BoxError> + Clone + Send + 'static,
     <S as Service<Request>>::Future: Send,
     Request: Send + 'static,
     <S as Service<Request>>::Response: Send + 'static,
+    Fut: Future<Output = Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>>,
 {
-    type Service = AsyncCheckpointService<S, Request>;
+    type Service = AsyncCheckpointService<S, Fut, Request>;
 
     fn layer(&self, service: S) -> Self::Service {
         AsyncCheckpointService {
@@ -75,61 +61,48 @@ where
 }
 
 /// [`Service`] for Asynchronous Checkpoints.
-#[derive(Clone)]
 #[allow(clippy::type_complexity)]
-pub struct AsyncCheckpointService<S, Request>
+pub struct AsyncCheckpointService<S, Fut, Request>
 where
     Request: Send + 'static,
     S: Service<Request, Error = BoxError> + Clone + Send + 'static,
     <S as Service<Request>>::Response: Send + 'static,
     <S as Service<Request>>::Future: Send + 'static,
+    Fut: Future<Output = Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>>,
 {
     inner: S,
-    checkpoint_fn: Arc<
-        dyn Fn(
-                Request,
-            ) -> BoxFuture<
-                'static,
-                Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>,
-            > + Send
-            + Sync
-            + 'static,
-    >,
+    checkpoint_fn: Arc<Pin<Box<dyn Fn(Request) -> Fut + Send + Sync + 'static>>>,
 }
 
-#[allow(clippy::type_complexity)]
-impl<S, Request> AsyncCheckpointService<S, Request>
+impl<S, Fut, Request> AsyncCheckpointService<S, Fut, Request>
 where
     Request: Send + 'static,
     S: Service<Request, Error = BoxError> + Clone + Send + 'static,
     <S as Service<Request>>::Response: Send + 'static,
     <S as Service<Request>>::Future: Send + 'static,
+    Fut: Future<Output = Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>>,
 {
     /// Create an `AsyncCheckpointLayer` from a function that takes a Service Request and returns a `ControlFlow`
-    pub fn new(
-        checkpoint_fn: impl Fn(
-                Request,
-            ) -> BoxFuture<
-                'static,
-                Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>,
-            > + Send
-            + Sync
-            + 'static,
-        service: S,
-    ) -> Self {
+    pub fn new<F>(checkpoint_fn: F, service: S) -> Self
+    where
+        F: Fn(Request) -> Fut + Send + Sync + 'static,
+    {
         Self {
-            checkpoint_fn: Arc::new(checkpoint_fn),
+            checkpoint_fn: Arc::new(Box::pin(checkpoint_fn)),
             inner: service,
         }
     }
 }
 
-impl<S, Request> Service<Request> for AsyncCheckpointService<S, Request>
+impl<S, Fut, Request> Service<Request> for AsyncCheckpointService<S, Fut, Request>
 where
     Request: Send + 'static,
     S: Service<Request, Error = BoxError> + Clone + Send + 'static,
     <S as Service<Request>>::Response: Send + 'static,
     <S as Service<Request>>::Future: Send + 'static,
+    Fut: Future<Output = Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>>
+        + Send
+        + 'static,
 {
     type Response = <S as Service<Request>>::Response;
 
@@ -187,8 +160,8 @@ mod async_checkpoint_tests {
         let service = execution_service.build();
 
         let service_stack = ServiceBuilder::new()
-            .checkpoint_async(|req: crate::ExecutionRequest| {
-                Box::pin(async { Ok(ControlFlow::Continue(req)) })
+            .checkpoint_async(|req: crate::ExecutionRequest| async {
+                Ok(ControlFlow::Continue(req))
             })
             .service(service);
 
@@ -228,7 +201,7 @@ mod async_checkpoint_tests {
         let service = router_service.build();
 
         let service_stack =
-            AsyncCheckpointLayer::new(|req| Box::pin(async { Ok(ControlFlow::Continue(req)) }))
+            AsyncCheckpointLayer::new(|req| async { Ok(ControlFlow::Continue(req)) })
                 .layer(service);
 
         let request = ExecutionRequest::fake_builder().build();
@@ -255,15 +228,13 @@ mod async_checkpoint_tests {
 
         let service = router_service.build();
 
-        let service_stack = AsyncCheckpointLayer::new(|_req| {
-            Box::pin(async {
-                Ok(ControlFlow::Break(Box::pin(once(async {
-                    ExecutionResponse::fake_builder()
-                        .label("returned_before_mock_service".to_string())
-                        .build()
-                }))
-                    as BoxStream<ExecutionResponse>))
-            })
+        let service_stack = AsyncCheckpointLayer::new(|_req| async {
+            Ok(ControlFlow::Break(Box::pin(once(async {
+                ExecutionResponse::fake_builder()
+                    .label("returned_before_mock_service".to_string())
+                    .build()
+            }))
+                as BoxStream<ExecutionResponse>))
         })
         .layer(service);
 
@@ -291,10 +262,11 @@ mod async_checkpoint_tests {
 
         let service = router_service.build();
 
-        let service_stack = AsyncCheckpointLayer::new(move |_req| {
-            Box::pin(async move { Err(BoxError::from(expected_error)) })
-        })
-        .layer(service);
+        let service_stack =
+            AsyncCheckpointLayer::new(
+                move |_req| async move { Err(BoxError::from(expected_error)) },
+            )
+            .layer(service);
 
         let request = ExecutionRequest::fake_builder().build();
 


### PR DESCRIPTION
This change removes the requirement to `Box::pin()` arguments to the `ServiceBuilder::checkpoint_async()` fn.

The major impact is in the example module where I had to perform some substantial re-working of the code to avoid trying to return multiple closures from the handler function.

fixes: #1151 