### PR TITLE
Pin clap dependency in Cargo.toml

### DIFF
--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.56"
-clap = { version = "3.1.8", features = ["derive"] }
+clap = { version = "=3.1.8", features = ["derive"] }
 cargo-scaffold = { version = "0.8.3", default-features = false }
 regex = "1"
 str_inflector = "0.12.0"

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -16,5 +16,5 @@ apollo-router-scaffold = { git="https://github.com/apollographql/router.git", br
 apollo-router-scaffold = { git="https://github.com/apollographql/router.git", tag="v0.9.3"}
 {{/if}}
 {{/if}}
-anyhow = "1.0.56"
-clap = "3.1.8"
+anyhow = "=1.0.56"
+clap = "=3.1.8"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -27,7 +27,7 @@ axum = { version = "0.5.4", features = ["headers", "json", "original-uri"] }
 backtrace = "0.3.65"
 buildstructor = "0.3.2"
 bytes = "1.1.0"
-clap = { version = "3.1.18", default-features = false, features = [
+clap = { version = "=3.1.18", default-features = false, features = [
     "env",
     "derive",
     "std",

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 bytes = "1.1.0"
-clap = { version = "3.1.18", default-features = false, features = ["std", "derive"] }
+clap = { version = "=3.1.18", default-features = false, features = ["std", "derive"] }
 flate2 = "1.0.23"
 prost = "0.9.0"
 prost-types = "0.9.0"


### PR DESCRIPTION
Workaround against #1231

A minor release of Clap occured yesterday; which introduced a breaking change.

This might lead cargo scaffold users to hit a panic a runtime when the router tries to parse env variables and arguments.

This patch Pins the clap dependency to the version that was available before the release, until the root cause is found and fixed.
