### PR TITLE
Fix: Update the scaffold template so it works with streams.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-scaffold"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc14c70a4bb3d18ee69eafc7afc8a3c39e51fcd31e2add965a8f9fba8b8a5450"
+checksum = "2f6232669ff969fc9827d8a47dbc9e128a8eb1c7dffc9bcf1cf71be34dee5ef9"
 dependencies = [
  "anyhow",
  "buildstructor",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid 1.0.0",
- "walkdir",
+ "walkdir 2.3.2",
  "yaml-rust",
 ]
 
@@ -207,6 +207,7 @@ dependencies = [
  "anyhow",
  "cargo-scaffold",
  "clap 3.1.18",
+ "copy_dir",
  "regex",
  "str_inflector",
  "tempfile",
@@ -688,7 +689,7 @@ dependencies = [
  "unicode-width",
  "unicode-xid",
  "url",
- "walkdir",
+ "walkdir 2.3.2",
  "winapi 0.3.9",
 ]
 
@@ -722,7 +723,7 @@ dependencies = [
  "shell-words",
  "structopt",
  "toml",
- "walkdir",
+ "walkdir 2.3.2",
 ]
 
 [[package]]
@@ -743,7 +744,7 @@ dependencies = [
  "same-file",
  "shell-escape",
  "tempfile",
- "walkdir",
+ "walkdir 2.3.2",
  "winapi 0.3.9",
 ]
 
@@ -1006,6 +1007,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "copy_dir"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4281031634644843bd2f5aa9c48cf98fc48d6b083bd90bb11becf10deaf8b0"
+dependencies = [
+ "walkdir 0.1.8",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,7 +1094,7 @@ dependencies = [
  "serde_json",
  "tinytemplate",
  "tokio",
- "walkdir",
+ "walkdir 2.3.2",
 ]
 
 [[package]]
@@ -2433,7 +2443,7 @@ dependencies = [
  "regex",
  "same-file",
  "thread_local",
- "walkdir",
+ "walkdir 2.3.2",
  "winapi-util",
 ]
 
@@ -3177,7 +3187,7 @@ dependencies = [
  "libc",
  "mio 0.6.23",
  "mio-extras",
- "walkdir",
+ "walkdir 2.3.2",
  "winapi 0.3.9",
 ]
 
@@ -4875,7 +4885,7 @@ dependencies = [
  "glob",
  "pulldown-cmark",
  "tempfile",
- "walkdir",
+ "walkdir 2.3.2",
 ]
 
 [[package]]
@@ -5973,6 +5983,16 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "walkdir"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66c0b9792f0a765345452775f3adbd28dde9d33f30d13e5dcc5ae17cf6f3780"
+dependencies = [
+ "kernel32-sys",
+ "winapi 0.2.8",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-default-members = ["apollo-router"]
+default-members = ["apollo-router", "apollo-router-scaffold"]
 members = [
     "apollo-spaceport",
     "apollo-router",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -42,6 +42,15 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 
 ### Support introspection object types ([PR #1240](https://github.com/apollographql/router/pull/1240))
 
+
+### Update the scaffold template so it works with Streams ([#1247](https://github.com/apollographql/router/issues/1247))
+
+Release v0.9.4 changed the way we deal with Response objects, which can now be streams.
+This Pull request updates the scaffold template so it generates plugins that are compatible with the new Plugin API.
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1248
+
+
 Introspection queries can use a set of object types defined in the specification. The query parsing code was not recognizing them,
 resulting in some introspection queries not working.
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -43,7 +43,7 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 ### Support introspection object types ([PR #1240](https://github.com/apollographql/router/pull/1240))
 
 
-### Update the scaffold template so it works with Streams ([#1247](https://github.com/apollographql/router/issues/1247))
+### Update the scaffold template so it works with streams ([#1247](https://github.com/apollographql/router/issues/1247))
 
 Release v0.9.4 changed the way we deal with Response objects, which can now be streams.
 This Pull request updates the scaffold template so it generates plugins that are compatible with the new Plugin API.

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.57"
 clap = { version = "=3.1.18", features = ["derive"] }
-cargo-scaffold = { version = "0.8.3", default-features = false }
+cargo-scaffold = { version = "0.8.4", default-features = false }
 regex = "1"
 str_inflector = "0.12.0"
 toml = "0.5.8"

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -7,7 +7,7 @@ license = "Elastic-2.0"
 publish = false
 
 [dependencies]
-anyhow = "1.0.56"
+anyhow = "1.0.57"
 clap = { version = "=3.1.18", features = ["derive"] }
 cargo-scaffold = { version = "0.8.3", default-features = false }
 regex = "1"

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -15,3 +15,4 @@ str_inflector = "0.12.0"
 toml = "0.5.8"
 [dev-dependencies]
 tempfile = "3.3.0"
+copy_dir = "0.1.2"

--- a/apollo-router-scaffold/src/lib.rs
+++ b/apollo-router-scaffold/src/lib.rs
@@ -36,7 +36,7 @@ mod test {
     fn the_next_test_takes_a_while_to_pass_do_not_worry() {}
 
     #[test]
-    // this test takes a while, I hope the function name
+    // this test takes a while, I hope the above test name
     // let users know they should not worry and wait a bit.
     // Hang in there!
     fn test_scaffold() -> Result<()> {

--- a/apollo-router-scaffold/src/lib.rs
+++ b/apollo-router-scaffold/src/lib.rs
@@ -28,7 +28,7 @@ mod test {
     use inflector::Inflector;
     use std::collections::BTreeMap;
     use std::env;
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
     use std::process::Command;
     use tempfile::TempDir;
 
@@ -48,7 +48,7 @@ mod test {
         let opts = Opts::builder()
             .project_name("temp")
             .target_dir(temp_dir.path())
-            .template_path("templates/base")
+            .template_path(PathBuf::from("templates").join("base"))
             .force(true)
             .build();
         ScaffoldDescription::new(opts)?.scaffold_with_parameters(BTreeMap::from([(
@@ -69,12 +69,12 @@ mod test {
         scaffold_plugin(&current_dir, &temp_dir, "auth")?;
         scaffold_plugin(&current_dir, &temp_dir, "tracing")?;
         std::fs::write(
-            temp_dir.path().join("src/plugins/mod.rs"),
+            temp_dir.path().join("src").join("plugins").join("mod.rs"),
             "mod auth;\nmod basic;\nmod tracing;\n",
         )?;
         test_build(&temp_dir)?;
 
-        // drop(temp_dir);
+        drop(temp_dir);
         Ok(())
     }
 
@@ -83,7 +83,7 @@ mod test {
             .project_name(plugin_type)
             .target_dir(dir.path())
             .append(true)
-            .template_path("templates/plugin")
+            .template_path(PathBuf::from("templates").join("plugin"))
             .build();
         ScaffoldDescription::new(opts)?.scaffold_with_parameters(BTreeMap::from([
             (

--- a/apollo-router-scaffold/src/lib.rs
+++ b/apollo-router-scaffold/src/lib.rs
@@ -134,7 +134,7 @@ mod test {
     }
 
     fn test_build_with_backup_folder(temp_dir: &TempDir) -> Result<()> {
-        test_build(&temp_dir).map_err(|e| {
+        test_build(temp_dir).map_err(|e| {
             let mut output_dir = std::env::temp_dir();
             output_dir.push("test_scaffold_output");
 

--- a/apollo-router-scaffold/src/lib.rs
+++ b/apollo-router-scaffold/src/lib.rs
@@ -58,7 +58,8 @@ mod test {
                     .to_str()
                     .expect("current dir must be convertable to string")
                     .to_string()
-                    .replace('\\', "/"),
+                    // windows paths use \
+                    .replace('\\', "\\\\"),
             ),
         )]))?;
         test_build(&temp_dir)?;
@@ -108,7 +109,8 @@ mod test {
                         .to_str()
                         .expect("current dir must be convertable to string")
                         .to_string()
-                        .replace('\\', "/"),
+                        // windows paths use \
+                        .replace('\\', "\\\\"),
                 ),
             ),
         ]))?;

--- a/apollo-router-scaffold/src/lib.rs
+++ b/apollo-router-scaffold/src/lib.rs
@@ -74,7 +74,7 @@ mod test {
         )?;
         test_build(&temp_dir)?;
 
-        drop(temp_dir);
+        // drop(temp_dir);
         Ok(())
     }
 

--- a/apollo-router-scaffold/src/lib.rs
+++ b/apollo-router-scaffold/src/lib.rs
@@ -28,7 +28,7 @@ mod test {
     use inflector::Inflector;
     use std::collections::BTreeMap;
     use std::env;
-    use std::path::{Path, PathBuf};
+    use std::path::{Path, PathBuf, MAIN_SEPARATOR};
     use std::process::Command;
     use tempfile::TempDir;
 
@@ -58,12 +58,18 @@ mod test {
             .scaffold_with_parameters(BTreeMap::from([(
                 "integration_test".to_string(),
                 toml::Value::String(
-                    current_dir
-                        .to_str()
-                        .expect("current dir must be convertable to string")
-                        .to_string()
-                        // windows paths use \
-                        .replace('\\', "\\\\"),
+                    format!(
+                        "{}{}",
+                        current_dir
+                            .parent()
+                            .expect("current dir cannot be the root")
+                            .to_str()
+                            .expect("current dir must be convertable to string"),
+                        // add / or \ depending on windows or unix
+                        MAIN_SEPARATOR,
+                    )
+                    // we need to double \ so they don't get interpreted as escape characters in TOML
+                    .replace('\\', "\\\\"),
                 ),
             )]))
             .unwrap();
@@ -109,12 +115,18 @@ mod test {
             (
                 "integration_test".to_string(),
                 toml::Value::String(
-                    current_dir
-                        .to_str()
-                        .expect("current dir must be convertable to string")
-                        .to_string()
-                        // windows paths use \
-                        .replace('\\', "\\\\"),
+                    format!(
+                        "{}{}",
+                        current_dir
+                            .parent()
+                            .expect("current dir cannot be the root")
+                            .to_str()
+                            .expect("current dir must be convertable to string"),
+                        // add / or \ depending on windows or unix
+                        MAIN_SEPARATOR,
+                    )
+                    // we need to double \ so they don't get interpreted as escape characters in TOML
+                    .replace('\\', "\\\\"),
                 ),
             ),
         ]))?;
@@ -131,7 +143,7 @@ mod test {
             copy_dir::copy_dir(&temp_dir, &output_dir)
                 .expect("couldn't copy test_scaffold_output directory");
             anyhow::anyhow!(
-                "scaffold test failed: {e}\nYou can find the scaffolded project at\n{}",
+                "scaffold test failed: {e}\nYou can find the scaffolded project at '{}'",
                 output_dir.display()
             )
         })

--- a/apollo-router-scaffold/src/lib.rs
+++ b/apollo-router-scaffold/src/lib.rs
@@ -51,7 +51,8 @@ mod test {
                 current_dir
                     .to_str()
                     .expect("current dir must be convertable to string")
-                    .to_string(),
+                    .to_string()
+                    .replace("\\", "/"),
             ),
         )]))?;
         test_build(&temp_dir)?;
@@ -100,7 +101,8 @@ mod test {
                     current_dir
                         .to_str()
                         .expect("current dir must be convertable to string")
-                        .to_string(),
+                        .to_string()
+                        .replace("\\", "/"),
                 ),
             ),
         ]))?;

--- a/apollo-router-scaffold/src/lib.rs
+++ b/apollo-router-scaffold/src/lib.rs
@@ -43,6 +43,7 @@ mod test {
         let temp_dir = tempfile::Builder::new()
             .prefix("router_scaffold")
             .tempdir()?;
+
         let current_dir = env::current_dir()?;
         // Scaffold the main project
         let opts = Opts::builder()
@@ -72,7 +73,14 @@ mod test {
             temp_dir.path().join("src").join("plugins").join("mod.rs"),
             "mod auth;\nmod basic;\nmod tracing;\n",
         )?;
-        test_build(&temp_dir)?;
+
+        test_build(&temp_dir).map_err(|e| {
+            let mut output_dir = std::env::temp_dir();
+            output_dir.push("test_scaffold_output");
+            copy_dir::copy_dir(&temp_dir, output_dir)
+                .expect("couldn't copy test_scaffold_output directory");
+            e
+        })?;
 
         drop(temp_dir);
         Ok(())

--- a/apollo-router-scaffold/src/lib.rs
+++ b/apollo-router-scaffold/src/lib.rs
@@ -33,6 +33,12 @@ mod test {
     use tempfile::TempDir;
 
     #[test]
+    fn the_next_test_takes_a_while_to_pass_do_not_worry() {}
+
+    #[test]
+    // this test takes a while, I hope the function name
+    // let users know they should not worry and wait a bit.
+    // Hang in there!
     fn test_scaffold() -> Result<()> {
         let temp_dir = tempfile::Builder::new()
             .prefix("router_scaffold")

--- a/apollo-router-scaffold/src/lib.rs
+++ b/apollo-router-scaffold/src/lib.rs
@@ -126,22 +126,14 @@ mod test {
             let mut output_dir = std::env::temp_dir();
             output_dir.push("test_scaffold_output");
 
-            match std::fs::remove_dir_all(&output_dir) {
-                Ok(_) => {
-                    copy_dir::copy_dir(&temp_dir, &output_dir)
-                        .expect("couldn't copy test_scaffold_output directory");
-                    anyhow::anyhow!(
-                        "scaffold test failed: {e} \nYou can find the scaffolded project at {}",
-                        output_dir.display()
-                    )
-                }
-                Err(rmdir_error) => {
-                    anyhow::anyhow!(
-                        "scaffold test failed: {e} \nWe couldn't prepare an output {}",
-                        rmdir_error
-                    )
-                }
-            }
+            // best effort to prepare the output directory
+            let _ = std::fs::remove_dir_all(&output_dir);
+            copy_dir::copy_dir(&temp_dir, &output_dir)
+                .expect("couldn't copy test_scaffold_output directory");
+            anyhow::anyhow!(
+                "scaffold test failed: {e}\nYou can find the scaffolded project at\n{}",
+                output_dir.display()
+            )
         })
     }
 

--- a/apollo-router-scaffold/src/lib.rs
+++ b/apollo-router-scaffold/src/lib.rs
@@ -52,7 +52,7 @@ mod test {
                     .to_str()
                     .expect("current dir must be convertable to string")
                     .to_string()
-                    .replace("\\", "/"),
+                    .replace('\\', "/"),
             ),
         )]))?;
         test_build(&temp_dir)?;
@@ -102,7 +102,7 @@ mod test {
                         .to_str()
                         .expect("current dir must be convertable to string")
                         .to_string()
-                        .replace("\\", "/"),
+                        .replace('\\', "/"),
                 ),
             ),
         ]))?;

--- a/apollo-router-scaffold/src/plugin.rs
+++ b/apollo-router-scaffold/src/plugin.rs
@@ -59,7 +59,11 @@ fn create_plugin(name: &str, template_path: &Option<PathBuf>) -> Result<()> {
             "https://github.com/apollographql/router.git",
         )))
         .git_ref(version)
-        .repository_template_path("apollo-router-scaffold/templates/plugin")
+        .repository_template_path(
+            PathBuf::from("apollo-router-scaffold")
+                .join("templates")
+                .join("plugin"),
+        )
         .target_dir(".")
         .project_name(name)
         .parameter(format!("name={}", name))
@@ -92,11 +96,12 @@ fn create_plugin(name: &str, template_path: &Option<PathBuf>) -> Result<()> {
         Value::Boolean(true),
     );
 
+    dbg!(&params);
     desc.scaffold_with_parameters(params)?;
 
     let mod_path = mod_path();
     let mut mod_rs = if mod_path.exists() {
-        std::fs::read_to_string(mod_path)?
+        std::fs::read_to_string(&mod_path)?
     } else {
         "".to_string()
     };
@@ -147,8 +152,8 @@ fn remove_plugin(name: &str) -> Result<()> {
 
     // Remove the mod;
     let mod_path = mod_path();
-    if Path::new(mod_path).exists() {
-        let mut mod_rs = std::fs::read_to_string(mod_path)?;
+    if Path::new(&mod_path).exists() {
+        let mut mod_rs = std::fs::read_to_string(&mod_path)?;
         let re = Regex::new(&format!(r"(?m)^mod {};$", snake_name)).unwrap();
         mod_rs = re.replace(&mod_rs, "").to_string();
 
@@ -162,10 +167,12 @@ fn remove_plugin(name: &str) -> Result<()> {
     Ok(())
 }
 
-fn mod_path() -> &'static Path {
-    Path::new("src/plugins/mod.rs")
+fn mod_path() -> PathBuf {
+    PathBuf::from("src").join("plugins").join("mod.rs")
 }
 
 fn plugin_path(name: &str) -> PathBuf {
-    format!("src/plugins/{}.rs", name.to_snake_case()).into()
+    PathBuf::from("src")
+        .join("plugins")
+        .join(format!("{}.rs", name.to_snake_case()))
 }

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.57"
 {{#if integration_test}}
-apollo-router = {path ="{{integration_test}}/../apollo-router" }
+apollo-router = { path ="{{integration_test}}/../apollo-router" }
 {{else}}
 {{#if branch}}
 apollo-router = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -26,6 +26,7 @@ apollo-router = { git="https://github.com/apollographql/router.git", tag="v0.9.4
 {{/if}}
 {{/if}}
 async-trait = "0.1.52"
+futures = "0.3.21"
 schemars = "0.8.10"
 serde = "1.0.136"
 serde_json = "1.0.79"

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -14,7 +14,7 @@ name = "router"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1.0.57"
 {{#if integration_test}}
 apollo-router = {path ="{{integration_test}}/../apollo-router" }
 {{else}}

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow = "1.0.57"
 {{#if integration_test}}
-apollo-router = { path ="{{integration_test}}/../apollo-router" }
+apollo-router = { path ="{{integration_test}}apollo-router" }
 {{else}}
 {{#if branch}}
 apollo-router = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -16,5 +16,5 @@ apollo-router-scaffold = { git="https://github.com/apollographql/router.git", br
 apollo-router-scaffold = { git="https://github.com/apollographql/router.git", tag="v0.9.4"}
 {{/if}}
 {{/if}}
-anyhow = "=1.0.56"
+anyhow = "=1.0.57"
 clap = "=3.1.18"

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 # This dependency should stay in line with your router version
 
 {{#if integration_test}}
-apollo-router-scaffold = { path ="{{integration_test}}/../apollo-router-scaffold" }
+apollo-router-scaffold = { path ="{{integration_test}}apollo-router-scaffold" }
 {{else}}
 {{#if branch}}
 apollo-router-scaffold = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }

--- a/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
+++ b/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
@@ -2,7 +2,7 @@ use apollo_router::plugin::Plugin;
 {{#if type_basic}}
 use apollo_router::{
     register_plugin, ExecutionRequest, ExecutionResponse, QueryPlannerRequest,
-    QueryPlannerResponse, ResponseBody, RouterRequest, RouterResponse, SubgraphRequest, SubgraphResponse,
+    QueryPlannerResponse, ResponseBody, RouterRequest, RouterResponse, Response, SubgraphRequest, SubgraphResponse,
 };
 {{/if}}
 {{#if type_auth}}

--- a/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
+++ b/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
@@ -2,12 +2,12 @@ use apollo_router::plugin::Plugin;
 {{#if type_basic}}
 use apollo_router::{
     register_plugin, ExecutionRequest, ExecutionResponse, QueryPlannerRequest,
-    QueryPlannerResponse, RouterRequest, RouterResponse, SubgraphRequest, SubgraphResponse,
+    QueryPlannerResponse, ResponseBody, RouterRequest, RouterResponse, SubgraphRequest, SubgraphResponse,
 };
 {{/if}}
 {{#if type_auth}}
 use apollo_router::{
-    register_plugin, RouterRequest, RouterResponse,
+    register_plugin, ResponseBody, RouterRequest, RouterResponse,
 };
 use std::ops::ControlFlow;
 use apollo_router::ServiceBuilderExt;
@@ -16,12 +16,13 @@ use tower::ServiceBuilder;
 {{/if}}
 {{#if type_tracing}}
 use apollo_router::{
-    register_plugin, RouterRequest, RouterResponse,
+    register_plugin, ResponseBody, RouterRequest, RouterResponse,
 };
 use apollo_router::ServiceBuilderExt;
 use tower::ServiceExt;
 use tower::ServiceBuilder;
 {{/if}}
+use futures::stream::BoxStream;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::util::BoxService;
@@ -54,8 +55,8 @@ impl Plugin for {{pascal_name}} {
     // Delete this function if you are not customizing it.
     fn router_service(
         &mut self,
-        service: BoxService<RouterRequest, RouterResponse, BoxError>,
-    ) -> BoxService<RouterRequest, RouterResponse, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
         // Always use service builder to compose your plugins.
         // It provides off the shelf building blocks for your plugin.
         //
@@ -78,8 +79,8 @@ impl Plugin for {{pascal_name}} {
     // Delete this function if you are not customizing it.
     fn execution_service(
         &mut self,
-        service: BoxService<ExecutionRequest, ExecutionResponse, BoxError>,
-    ) -> BoxService<ExecutionRequest, ExecutionResponse, BoxError> {
+        service: BoxService<ExecutionRequest, ExecutionResponse<BoxStream<'static, Response>>, BoxError>,
+    ) -> BoxService<ExecutionRequest, ExecutionResponse<BoxStream<'static, Response>>, BoxError> {
         service
     }
 
@@ -106,8 +107,8 @@ impl Plugin for {{pascal_name}} {
 
     fn router_service(
         &mut self,
-        service: BoxService<RouterRequest, RouterResponse, BoxError>,
-    ) -> BoxService<RouterRequest, RouterResponse, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
 
         ServiceBuilder::new()
                     .checkpoint_async(|request : RouterRequest| Box::pin(async {
@@ -133,8 +134,8 @@ impl Plugin for {{pascal_name}} {
 
     fn router_service(
         &mut self,
-        service: BoxService<RouterRequest, RouterResponse, BoxError>,
-    ) -> BoxService<RouterRequest, RouterResponse, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
 
         ServiceBuilder::new()
                     .instrument(|_request| {
@@ -184,7 +185,7 @@ mod tests {
         };
 
         // Build an instance of our plugin to use in the test harness
-        let plugin = {{pascal_name}}::new(conf).await.expect("created plugin");
+        let plugin = ResponseTimings::new(conf).await.expect("created plugin");
 
         // Create the test harness. You can add mocks for individual services, or use prebuilt canned services.
         let mut test_harness = PluginTestHarness::builder()
@@ -194,13 +195,21 @@ mod tests {
             .await?;
 
         // Send a request
-        let result = test_harness.call_canned().await?;
-        if let ResponseBody::GraphQL(graphql) = result.response.body() {
+        let mut result = test_harness.call_canned().await?;
+
+        let first_response = result
+            .next_response()
+            .await
+            .expect("couldn't get primary response");
+
+        if let ResponseBody::GraphQL(graphql) = first_response {
             assert!(graphql.data.is_some());
         } else {
             panic!("expected graphql response")
         }
 
+        // You could keep calling result.next_response() until it yields None if you're expexting more parts.
+        assert!(result.next_response().await.is_none());
         Ok(())
     }
 }

--- a/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
+++ b/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
@@ -185,7 +185,7 @@ mod tests {
         };
 
         // Build an instance of our plugin to use in the test harness
-        let plugin = ResponseTimings::new(conf).await.expect("created plugin");
+        let plugin = {{pascal_name}}::new(conf).await.expect("created plugin");
 
         // Create the test harness. You can add mocks for individual services, or use prebuilt canned services.
         let mut test_harness = PluginTestHarness::builder()


### PR DESCRIPTION
fixes #1247

Release v0.9.4 changed the way we deal with Response objects, which can now be streams.
This Pull request updates the scaffold template so it generates plugins that are compatible with the new Plugin API.
