### PR TITLE
create the ExecutionResponse after the primary response was generated

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -47,6 +47,14 @@ resulting in some introspection queries not working.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1240
 
+### Create the ExecutionResponse after the primary response was generated ([PR #1259](https://github.com/apollographql/router/pull/1259))
+
+The `@defer` preliminary work has a surprising side effect: when using methods like `RouterResponse::map_response`, they are
+executed before the subgraph responses are received, because they work on the stream of responses.
+This PR goes back to the previous behaviour by awaiting the primary response before creating the ExecutionResponse.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1259
+
 ## 🛠 Maintenance
 ## 📚 Documentation
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -47,13 +47,13 @@ resulting in some introspection queries not working.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1240
 
-### Create the ExecutionResponse after the primary response was generated ([PR #1259](https://github.com/apollographql/router/pull/1259))
+### Create the ExecutionResponse after the primary response was generated ([PR #1260](https://github.com/apollographql/router/pull/1260))
 
 The `@defer` preliminary work has a surprising side effect: when using methods like `RouterResponse::map_response`, they are
 executed before the subgraph responses are received, because they work on the stream of responses.
 This PR goes back to the previous behaviour by awaiting the primary response before creating the ExecutionResponse.
 
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1259
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1260
 
 ## 🛠 Maintenance
 ## 📚 Documentation

--- a/apollo-router/src/services/execution_service.rs
+++ b/apollo-router/src/services/execution_service.rs
@@ -2,8 +2,10 @@
 
 use crate::{ExecutionRequest, ExecutionResponse, Response, SubgraphRequest, SubgraphResponse};
 use crate::{Schema, ServiceRegistry};
-use futures::future::BoxFuture;
-use futures::stream::BoxStream;
+use futures::future::{ready, BoxFuture};
+use futures::stream::{once, BoxStream};
+use futures::StreamExt;
+use http::StatusCode;
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -76,10 +78,27 @@ impl Service<ExecutionRequest> for ExecutionService {
                 .in_current_span(),
             );
 
-            Ok(ExecutionResponse::new_from_response(
-                http::Response::new(Box::pin(receiver) as BoxStream<'static, Response>).into(),
-                ctx,
-            ))
+            let (first, rest) = receiver.into_future().await;
+            match first {
+                None => Ok(ExecutionResponse::error_builder()
+                    .errors(vec![crate::Error {
+                        message: "empty response".to_string(),
+                        ..Default::default()
+                    }])
+                    .status_code(StatusCode::INTERNAL_SERVER_ERROR)
+                    .context(ctx)
+                    .build()
+                    .expect("can't fail to build our error message")
+                    .boxed()),
+                Some(response) => {
+                    let stream = once(ready(response)).chain(rest).boxed();
+
+                    Ok(ExecutionResponse::new_from_response(
+                        http::Response::new(stream as BoxStream<'static, Response>).into(),
+                        ctx,
+                    ))
+                }
+            }
         }
         .in_current_span();
         Box::pin(fut)


### PR DESCRIPTION
The `@defer` preliminary work has a surprising side effect: when using
methods like `RouterResponse::map_response`, they are
executed before the subgraph responses are received, because they work
on the stream of responses.
This commit goes back to the previous behaviour by awaiting the primary
response before creating the ExecutionResponse.

this will address issues like https://github.com/apollographql/router/discussions/1252#discussioncomment-2955415