### PR TITLE
rename subgraph request.sub_headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4284,6 +4284,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rhai-subgraph-request-log"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "apollo-router",
+ "futures",
+ "http",
+ "serde_json",
+ "tokio",
+ "tower",
+]
+
+[[package]]
 name = "rhai-surrogate-cache-key"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "examples/rhai-logging",
     "examples/rhai-data-response-mutate",
     "examples/rhai-error-response-mutate",
+    "examples/rhai-subgraph-request-log",
     "examples/rhai-surrogate-cache-key",
     "examples/jwt-auth",
     "fuzz",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -26,6 +26,24 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 
 # [0.9.5] (unreleased) - 2022-mm-dd
 ## ❗ BREAKING ❗
+
+### Rhai plugin `request.sub_headers` renamed to `request.sub.headers` [PR #XXXX](https://github.com/apollographql/router/pull/XXXX)
+
+Rhai scripts previously supported the `request.sub_headers` attribute so that subgraph request headers could be
+accessed. This is now replaced with an extended interface for subgraph requests:
+
+```
+request.sub.headers
+request.sub.body.query
+request.sub.body.operation_name
+request.sub.body.variables
+request.sub.body.extensions
+request.sub.uri.host
+request.sub.uri.path
+```
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/XXXX
+
 ## 🚀 Features ( :rocket: )
 
 ### Add support of multiple uplink URLs [PR #1210](https://github.com/apollographql/router/pull/1210)

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -27,19 +27,19 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 # [0.9.5] (unreleased) - 2022-mm-dd
 ## ❗ BREAKING ❗
 
-### Rhai plugin `request.sub_headers` renamed to `request.sub.headers` [PR #1261](https://github.com/apollographql/router/pull/1261)
+### Rhai plugin `request.sub_headers` renamed to `request.subgraph.headers` [PR #1261](https://github.com/apollographql/router/pull/1261)
 
 Rhai scripts previously supported the `request.sub_headers` attribute so that subgraph request headers could be
 accessed. This is now replaced with an extended interface for subgraph requests:
 
 ```
-request.sub.headers
-request.sub.body.query
-request.sub.body.operation_name
-request.sub.body.variables
-request.sub.body.extensions
-request.sub.uri.host
-request.sub.uri.path
+request.subgraph.headers
+request.subgraph.body.query
+request.subgraph.body.operation_name
+request.subgraph.body.variables
+request.subgraph.body.extensions
+request.subgraph.uri.host
+request.subgraph.uri.path
 ```
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1261

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -27,7 +27,7 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 # [0.9.5] (unreleased) - 2022-mm-dd
 ## ❗ BREAKING ❗
 
-### Rhai plugin `request.sub_headers` renamed to `request.sub.headers` [PR #XXXX](https://github.com/apollographql/router/pull/XXXX)
+### Rhai plugin `request.sub_headers` renamed to `request.sub.headers` [PR #1261](https://github.com/apollographql/router/pull/1261)
 
 Rhai scripts previously supported the `request.sub_headers` attribute so that subgraph request headers could be
 accessed. This is now replaced with an extended interface for subgraph requests:
@@ -42,7 +42,7 @@ request.sub.uri.host
 request.sub.uri.path
 ```
 
-By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/XXXX
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1261
 
 ## 🚀 Features ( :rocket: )
 

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -9,7 +9,7 @@ use futures::future::ready;
 use futures::stream::{once, BoxStream};
 use futures::StreamExt;
 use http::header::{HeaderName, HeaderValue, InvalidHeaderName};
-use http::uri::{Parts, PathAndQuery};
+use http::uri::{Authority, Parts, PathAndQuery};
 use http::{HeaderMap, StatusCode, Uri};
 use rhai::serde::{from_dynamic, to_dynamic};
 use rhai::{plugin::*, Dynamic, Engine, EvalAltResult, FnPtr, Instant, Map, Scope, Shared, AST};
@@ -149,23 +149,74 @@ mod router_plugin_mod {
         };
     }
 
-    #[rhai_fn(get = "sub_headers", pure, return_raw)]
-    pub(crate) fn get_subgraph_headers(
+    // The next group of functions are specifically for interacting
+    // with the subgraph_request on a SubgraphRequest.
+    #[rhai_fn(get = "sub", pure, return_raw)]
+    pub(crate) fn get_subgraph(
         obj: &mut SharedSubgraphRequest,
-    ) -> Result<HeaderMap, Box<EvalAltResult>> {
-        obj.with_mut(|request| Ok(request.subgraph_request.headers().clone()))
+    ) -> Result<http_compat::Request<Request>, Box<EvalAltResult>> {
+        obj.with_mut(|request| Ok(request.subgraph_request.clone()))
     }
 
-    #[rhai_fn(set = "sub_headers", return_raw)]
-    pub(crate) fn set_subgraph_headers(
+    #[rhai_fn(set = "sub", return_raw)]
+    pub(crate) fn set_subgraph(
         obj: &mut SharedSubgraphRequest,
-        headers: HeaderMap,
+        sub: http_compat::Request<Request>,
     ) -> Result<(), Box<EvalAltResult>> {
         obj.with_mut(|request| {
-            *request.subgraph_request.headers_mut() = headers;
+            request.subgraph_request = sub;
             Ok(())
         })
     }
+
+    #[rhai_fn(get = "headers", pure, return_raw)]
+    pub(crate) fn get_subgraph_headers(
+        obj: &mut http_compat::Request<Request>,
+    ) -> Result<HeaderMap, Box<EvalAltResult>> {
+        Ok(obj.headers().clone())
+    }
+
+    #[rhai_fn(set = "headers", return_raw)]
+    pub(crate) fn set_subgraph_headers(
+        obj: &mut http_compat::Request<Request>,
+        headers: HeaderMap,
+    ) -> Result<(), Box<EvalAltResult>> {
+        *obj.headers_mut() = headers;
+        Ok(())
+    }
+
+    #[rhai_fn(get = "body", pure, return_raw)]
+    pub(crate) fn get_subgraph_body(
+        obj: &mut http_compat::Request<Request>,
+    ) -> Result<Request, Box<EvalAltResult>> {
+        Ok(obj.body().clone())
+    }
+
+    #[rhai_fn(set = "body", return_raw)]
+    pub(crate) fn set_subgraph_body(
+        obj: &mut http_compat::Request<Request>,
+        body: Request,
+    ) -> Result<(), Box<EvalAltResult>> {
+        *obj.body_mut() = body;
+        Ok(())
+    }
+
+    #[rhai_fn(get = "uri", pure, return_raw)]
+    pub(crate) fn get_subgraph_uri(
+        obj: &mut http_compat::Request<Request>,
+    ) -> Result<Uri, Box<EvalAltResult>> {
+        Ok(obj.uri().clone())
+    }
+
+    #[rhai_fn(set = "uri", return_raw)]
+    pub(crate) fn set_subgraph_uri(
+        obj: &mut http_compat::Request<Request>,
+        uri: Uri,
+    ) -> Result<(), Box<EvalAltResult>> {
+        *obj.uri_mut() = uri;
+        Ok(())
+    }
+    // End of SubgraphRequest specific section
 
     #[rhai_fn(get = "headers", pure, return_raw)]
     pub(crate) fn get_originating_headers_router_response(
@@ -1428,6 +1479,29 @@ impl Rhai {
                         Some(PathAndQuery::from_maybe_shared(value).map_err(|e| e.to_string())?)
                     }
                 };
+                *x = Uri::from_parts(parts).map_err(|e| e.to_string())?;
+                Ok(())
+            })
+            // Request.uri.host
+            .register_get_result("host", |x: &mut Uri| to_dynamic(x.host()))
+            .register_set_result("host", |x: &mut Uri, value: &str| {
+                // Because there is no simple way to update parts on an existing
+                // Uri (no parts_mut()), then we need to create a new Uri from our
+                // existing parts, preserving any port, and update our existing
+                // Uri.
+                let mut parts: Parts = x.clone().into_parts();
+                let new_authority = match parts.authority {
+                    Some(old_authority) => {
+                        if let Some(port) = old_authority.port() {
+                            Authority::from_maybe_shared(format!("{}:{}", value, port))
+                                .map_err(|e| e.to_string())?
+                        } else {
+                            Authority::from_maybe_shared(value).map_err(|e| e.to_string())?
+                        }
+                    }
+                    None => Authority::from_maybe_shared(value).map_err(|e| e.to_string())?,
+                };
+                parts.authority = Some(new_authority);
                 *x = Uri::from_parts(parts).map_err(|e| e.to_string())?;
                 Ok(())
             })

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -151,14 +151,14 @@ mod router_plugin_mod {
 
     // The next group of functions are specifically for interacting
     // with the subgraph_request on a SubgraphRequest.
-    #[rhai_fn(get = "sub", pure, return_raw)]
+    #[rhai_fn(get = "subgraph", pure, return_raw)]
     pub(crate) fn get_subgraph(
         obj: &mut SharedSubgraphRequest,
     ) -> Result<http_compat::Request<Request>, Box<EvalAltResult>> {
         obj.with_mut(|request| Ok(request.subgraph_request.clone()))
     }
 
-    #[rhai_fn(set = "sub", return_raw)]
+    #[rhai_fn(set = "subgraph", return_raw)]
     pub(crate) fn set_subgraph(
         obj: &mut SharedSubgraphRequest,
         sub: http_compat::Request<Request>,

--- a/docs/source/customizations/rhai.mdx
+++ b/docs/source/customizations/rhai.mdx
@@ -156,13 +156,13 @@ request.uri.path
 In addition, SubgraphRequest, exposes the additional ability to interact with requests sent to subgraphs:
 
 ```
-request.sub.headers
-request.sub.body.query
-request.sub.body.operation_name
-request.sub.body.variables
-request.sub.body.extensions
-request.sub.uri.host
-request.sub.uri.path
+request.subgraph.headers
+request.subgraph.body.query
+request.subgraph.body.operation_name
+request.subgraph.body.variables
+request.subgraph.body.extensions
+request.subgraph.uri.host
+request.subgraph.uri.path
 ```
 
 All of the above are read/write *apart* from `request.body.variables` which is read-only.
@@ -213,16 +213,16 @@ print(`${request.headers["x-my-new-header"]}`); // writes "42" into the router l
 request.headers.x-my-new-header = 42.to_string();
 ```
 
-#### request.sub.*
+#### request.subgraph.*
 
 Only present when processing subgraph requests. The interface is exactly the same as for request.*.
 
 ```javascript
-// You can interact with request.sub.headers as an indexed variable
-request.sub.headers["x-my-new-header"] = 42.to_string(); // inserts a new header "x-my-new-header" with value "42"
-print(`${request.sub.headers["x-my-new-header"]}`); // writes "42" into the router log at info level
+// You can interact with request.subgraph.headers as an indexed variable
+request.subgraph.headers["x-my-new-header"] = 42.to_string(); // inserts a new header "x-my-new-header" with value "42"
+print(`${request.subgraph.headers["x-my-new-header"]}`); // writes "42" into the router log at info level
 // Rhai also supports extended dot notation for indexed variables so, this is equivalent
-request.sub.headers.x-my-new-header = 42.to_string();
+request.subgraph.headers.x-my-new-header = 42.to_string();
 ```
 
 #### request.body.query
@@ -434,9 +434,9 @@ fn process_request(request) {
             k_v[0].trim();
             k_v[1].trim();
             // update our headers
-            // Note: we must update sub.headers, since we are
-            // setting a header in our sub graph request
-            request.sub.headers[k_v[0]] = k_v[1];
+            // Note: we must update subgraph.headers, since we are
+            // setting a header in our subgraph request
+            request.subgraph.headers[k_v[0]] = k_v[1];
         }
     }
 }

--- a/docs/source/customizations/rhai.mdx
+++ b/docs/source/customizations/rhai.mdx
@@ -149,13 +149,20 @@ request.body.query
 request.body.operation_name
 request.body.variables
 request.body.extensions
+request.uri.host
 request.uri.path
 ```
 
-In addition, SubgraphRequest, exposes the additional ability to interact with headers sent to subgraphs:
+In addition, SubgraphRequest, exposes the additional ability to interact with requests sent to subgraphs:
 
 ```
-request.sub_headers
+request.sub.headers
+request.sub.body.query
+request.sub.body.operation_name
+request.sub.body.variables
+request.sub.body.extensions
+request.sub.uri.host
+request.sub.uri.path
 ```
 
 All of the above are read/write *apart* from `request.body.variables` which is read-only.
@@ -206,16 +213,16 @@ print(`${request.headers["x-my-new-header"]}`); // writes "42" into the router l
 request.headers.x-my-new-header = 42.to_string();
 ```
 
-#### request.sub_headers
+#### request.sub.*
 
-Only present when processing subgraph requests. The interface is exactly the same as for request.header.
+Only present when processing subgraph requests. The interface is exactly the same as for request.*.
 
 ```javascript
-// You can interact with request.sub_headers as an indexed variable
-request.sub_headers["x-my-new-header"] = 42.to_string(); // inserts a new header "x-my-new-header" with value "42"
-print(`${request.sub_headers["x-my-new-header"]}`); // writes "42" into the router log at info level
+// You can interact with request.sub.headers as an indexed variable
+request.sub.headers["x-my-new-header"] = 42.to_string(); // inserts a new header "x-my-new-header" with value "42"
+print(`${request.sub.headers["x-my-new-header"]}`); // writes "42" into the router log at info level
 // Rhai also supports extended dot notation for indexed variables so, this is equivalent
-request.sub_headers.x-my-new-header = 42.to_string();
+request.sub.headers.x-my-new-header = 42.to_string();
 ```
 
 #### request.body.query
@@ -252,6 +259,14 @@ Request extensions may be read or modified. They are exposed to Rhai as an [Obje
 
 ```javascript
 print(`${request.body.extensions}`); // log the extensions
+```
+
+#### request.uri.host
+
+Request host may be read or modified. The host is exposed to Rhai as a string and may be set from a string.
+
+```javascript
+print(`${request.uri.host}`); // log the request host
 ```
 
 #### request.uri.path
@@ -419,12 +434,12 @@ fn process_request(request) {
             k_v[0].trim();
             k_v[1].trim();
             // update our headers
-            // Note: we must update sub_headers, since we are
+            // Note: we must update sub.headers, since we are
             // setting a header in our sub graph request
-            request.sub_headers[k_v[0]] = k_v[1];
+            request.sub.headers[k_v[0]] = k_v[1];
         }
     }
 }
 ```
 
-There are seven complete working examples (with tests) of rhai in the [examples directory](https://github.com/apollographql/router/tree/main/examples). The rhai examples are listed in the README.md.
+There are eight complete working examples (with tests) of rhai in the [examples directory](https://github.com/apollographql/router/tree/main/examples). The rhai examples are listed in the README.md.

--- a/examples/README.md
+++ b/examples/README.md
@@ -23,6 +23,7 @@ Experimental scripting support.
 * [Logging](./rhai-logging)
 * [Response data modification](./rhai-data-response-mutate)
 * [Response errors modification](./rhai-error-response-mutate)
+* [Subgraph request logging](./rhai-subgraph-request-log)
 * [Surrogate cache key creation](./rhai-surrogate-cache-key)
 
 ### Native Rust Plugins

--- a/examples/cookies-to-headers/src/cookies_to_headers.rhai
+++ b/examples/cookies-to-headers/src/cookies_to_headers.rhai
@@ -22,9 +22,9 @@ fn process_request(request) {
             k_v[0].trim();
             k_v[1].trim();
             // update our headers
-            // Note: we must update sub.headers, since we are
+            // Note: we must update subgraph.headers, since we are
             // setting a header in our sub graph request
-            request.sub.headers[k_v[0]] = k_v[1];
+            request.subgraph.headers[k_v[0]] = k_v[1];
         }
     }
 }

--- a/examples/cookies-to-headers/src/cookies_to_headers.rhai
+++ b/examples/cookies-to-headers/src/cookies_to_headers.rhai
@@ -22,9 +22,9 @@ fn process_request(request) {
             k_v[0].trim();
             k_v[1].trim();
             // update our headers
-            // Note: we must update sub_headers, since we are
+            // Note: we must update sub.headers, since we are
             // setting a header in our sub graph request
-            request.sub_headers[k_v[0]] = k_v[1];
+            request.sub.headers[k_v[0]] = k_v[1];
         }
     }
 }

--- a/examples/rhai-subgraph-request-log/Cargo.toml
+++ b/examples/rhai-subgraph-request-log/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "rhai-subgraph-request-log"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+anyhow = "1.0.55"
+apollo-router = { path = "../../apollo-router" }
+futures = "0.3.21"
+http = "0.2.6"
+serde_json = "1.0.79"
+tokio = { version = "1.17.0", features = ["full"] }
+tower = { version = "0.4.12", features = ["full"] }

--- a/examples/rhai-subgraph-request-log/README.md
+++ b/examples/rhai-subgraph-request-log/README.md
@@ -1,0 +1,11 @@
+# Rhai script
+
+Demonstrates logging subgraph request details via Rhai script.
+
+**Note that Rhai script is currently experimental** 
+
+
+Usage:
+```bash
+cargo run -- -s ../graphql/supergraph.graphql -c ./router.yaml
+```

--- a/examples/rhai-subgraph-request-log/router.yaml
+++ b/examples/rhai-subgraph-request-log/router.yaml
@@ -1,0 +1,3 @@
+plugins:
+  experimental.rhai:
+    filename: src/rhai_subgraph_request_log.rhai

--- a/examples/rhai-subgraph-request-log/src/main.rs
+++ b/examples/rhai-subgraph-request-log/src/main.rs
@@ -1,0 +1,79 @@
+//! % curl -v \
+//!    --header 'content-type: application/json' \
+//!    --url 'http://127.0.0.1:4000' \
+//!    --data '{"operationName": "me", "query":"query Query {\n  me {\n    name\n  }\n}"}'
+
+use anyhow::Result;
+
+// `cargo run -- -s ../graphql/supergraph.graphql -c ./router.yaml`
+fn main() -> Result<()> {
+    apollo_router::main()
+}
+
+#[cfg(test)]
+mod tests {
+    use apollo_router::plugins::rhai::{Conf, Rhai};
+    use apollo_router::utils::test::IntoSchema::Canned;
+    use apollo_router::utils::test::PluginTestHarness;
+    use apollo_router::{Context, Plugin, RouterRequest};
+    use http::StatusCode;
+
+    #[tokio::test]
+    async fn test_subgraph_logs_data() {
+        // Define a configuration to use with our plugin
+        let conf: Conf = serde_json::from_value(serde_json::json!({
+            "filename": "src/rhai_subgraph_request_log.rhai",
+        }))
+        .expect("valid conf supplied");
+
+        // Build an instance of our plugin to use in the test harness
+        let plugin = Rhai::new(conf).await.expect("created plugin");
+
+        // Build a test harness.
+        let mut test_harness = PluginTestHarness::builder()
+            .plugin(plugin)
+            .schema(Canned)
+            .build()
+            .await
+            .expect("building harness");
+
+        // The expected reply is going to be JSON returned in the RouterResponse { data } section.
+        let _expected_mock_response_data = "response created within the mock";
+
+        // ... Call our test harness
+        let query = "query {topProducts{name}}";
+        let operation_name: Option<&str> = None;
+        let context: Option<Context> = None;
+        let mut service_response = test_harness
+            .call(
+                RouterRequest::fake_builder()
+                    .header("name_header", "test_client")
+                    .header("version_header", "1.0-test")
+                    .query(query)
+                    .and_operation_name(operation_name)
+                    .and_context(context)
+                    .build()
+                    .expect("a valid RouterRequest"),
+            )
+            .await
+            .expect("a router response");
+
+        assert_eq!(StatusCode::OK, service_response.response.status());
+        let _response_body = service_response.next_response().await.unwrap();
+        /* TBD: Figure out how to run this as a test
+        // Rhai should return a 200...
+        println!("RESPONSE: {:?}", service_response);
+        assert_eq!(StatusCode::OK, service_response.response.status());
+
+        // with the expected message
+        if let apollo_router::ResponseBody::GraphQL(response) =
+            service_response.response.body()
+        {
+            assert!(response.errors.is_empty());
+            assert_eq!(expected_mock_response_data, response.data.as_ref().unwrap());
+        } else {
+            panic!("unexpected response");
+        }
+        */
+    }
+}

--- a/examples/rhai-subgraph-request-log/src/rhai_subgraph_request_log.rhai
+++ b/examples/rhai-subgraph-request-log/src/rhai_subgraph_request_log.rhai
@@ -21,13 +21,13 @@ fn subgraph_service(service, subgraph) {
         print(request.uri.path);
         print(request.uri.host);
         print("subgraph request details");
-        print(request.sub.headers);
-        print(request.sub.body.query);
-        print(request.sub.body.operation_name);
-        print(request.sub.body.variables);
-        print(request.sub.body.extensions);
-        print(request.sub.uri.path);
-        print(request.sub.uri.host);
+        print(request.subgraph.headers);
+        print(request.subgraph.body.query);
+        print(request.subgraph.body.operation_name);
+        print(request.subgraph.body.variables);
+        print(request.subgraph.body.extensions);
+        print(request.subgraph.uri.path);
+        print(request.subgraph.uri.host);
     };
     // Map our request using our closure
     service.map_request(f);

--- a/examples/rhai-subgraph-request-log/src/rhai_subgraph_request_log.rhai
+++ b/examples/rhai-subgraph-request-log/src/rhai_subgraph_request_log.rhai
@@ -1,0 +1,34 @@
+// This example illustrates how to interact with subgraph request
+// to log various details of the request.
+
+// At the subgraph_service stage, we log:
+//  - the subgraph name
+//  - various details from the originating request
+//  - the same details from the subgraph request
+//  Note: There is no context for the subgraph
+//  request.
+fn subgraph_service(service, subgraph) {
+    // Create our logging closure
+    let f = |request| {
+        print(`subgraph: ${subgraph}`);
+        print("originating request details");
+        print(request.context);
+        print(request.headers);
+        print(request.body.query);
+        print(request.body.operation_name);
+        print(request.body.variables);
+        print(request.body.extensions);
+        print(request.uri.path);
+        print(request.uri.host);
+        print("subgraph request details");
+        print(request.sub.headers);
+        print(request.sub.body.query);
+        print(request.sub.body.operation_name);
+        print(request.sub.body.variables);
+        print(request.sub.body.extensions);
+        print(request.sub.uri.path);
+        print(request.sub.uri.host);
+    };
+    // Map our request using our closure
+    service.map_request(f);
+}


### PR DESCRIPTION
to request.sub.headers

also:
 - bring sub request access to same level as originating request
 - add support to both for uri.host
 - create a new example logging various request parameters

fixes: #1258 