### PR TITLE
Fix some links in doc-comments.

### DIFF
--- a/apollo-router/src/context.rs
+++ b/apollo-router/src/context.rs
@@ -13,14 +13,14 @@ use tower::BoxError;
 /// Holds [`Context`] entries.
 pub type Entries = Arc<DashMap<String, Value>>;
 
-/// Context for a [`http_compat::Request`]
+/// Context for a [`crate::http_compat::Request`]
 ///
 /// Context makes use of [`DashMap`] under the hood which tries to handle concurrency
 /// by allowing concurrency across threads without requiring locking. This is great
 /// for usability but could lead to surprises when updates are highly contested.
 ///
 /// Within the router, contention is likely to be highest within plugins which
-/// provide [`SubgraphRequest`] or [`SubgraphResponse`] processing. At such times,
+/// provide [`crate::SubgraphRequest`] or [`crate::SubgraphResponse`] processing. At such times,
 /// plugins should restrict themselves to the [`Context::get`] and [`Context::upsert`]
 /// functions to minimise the possibility of mis-sequenced updates.
 #[derive(Clone, Debug)]

--- a/apollo-router/src/plugins/csrf.rs
+++ b/apollo-router/src/plugins/csrf.rs
@@ -15,7 +15,8 @@ use tower::{BoxError, ServiceBuilder, ServiceExt};
 pub struct CSRFConfig {
     /// The CSRF plugin is enabled by default;
     /// set unsafe_disabled = true to disable the plugin behavior
-    /// Note that setting this to true is deemed unsafe https://developer.mozilla.org/en-US/docs/Glossary/CSRF
+    /// Note that setting this to true is deemed unsafe.
+    /// See <https://developer.mozilla.org/en-US/docs/Glossary/CSRF>.
     #[serde(default)]
     unsafe_disabled: bool,
     /// Override the headers to check for by setting
@@ -54,8 +55,8 @@ static NON_PREFLIGHTED_CONTENT_TYPES: &[&str] = &[
 
 /// The Csrf plugin makes sure any request received would have been preflighted if it was sent by a browser.
 ///
-/// Quoting the great apollo server comment:
-/// https://github.com/apollographql/apollo-server/blob/12bf5fc8ef305caa6a8848e37f862d32dae5957f/packages/server/src/preventCsrf.ts#L26
+/// Quoting the [great apollo server comment](
+/// https://github.com/apollographql/apollo-server/blob/12bf5fc8ef305caa6a8848e37f862d32dae5957f/packages/server/src/preventCsrf.ts#L26):
 ///
 /// We don't want random websites to be able to execute actual GraphQL operations
 /// from a user's browser unless our CORS policy supports it. It's not good


### PR DESCRIPTION
This fixes some of the warnings emitted by `cargo doc`.

Remaining warnings involve either making some types public, or removing mentions of them in public docs and in some cases making fields private. See: https://github.com/apollographql/router/issues/1150#issuecomment-1157692784