### PR TITLE
Change unreachable `pub` items to be private to the create

### DIFF
--- a/apollo-router/src/context.rs
+++ b/apollo-router/src/context.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use tower::BoxError;
 
 /// Holds [`Context`] entries.
-pub type Entries = Arc<DashMap<String, Value>>;
+pub(crate) type Entries = Arc<DashMap<String, Value>>;
 
 /// Context for a [`http_compat::Request`]
 ///

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -29,7 +29,7 @@ static GLOBAL_ENV_FILTER: OnceCell<String> = OnceCell::new();
     about = "Apollo federation router",
     global_setting(AppSettings::NoAutoVersion)
 )]
-pub struct Opt {
+pub(crate) struct Opt {
     /// Log level (off|error|warn|info|debug|trace).
     #[clap(
         long = "log",
@@ -84,7 +84,7 @@ pub struct Opt {
 
     /// Display version and exit.
     #[clap(parse(from_flag), long, short = 'V')]
-    pub version: bool,
+    pub(crate) version: bool,
 }
 
 /// Wrapper so that structop can display the default config path in the help message.

--- a/apollo-router/src/http_server_factory.rs
+++ b/apollo-router/src/http_server_factory.rs
@@ -145,20 +145,20 @@ impl HttpServerHandle {
     }
 }
 
-pub enum Listener {
+pub(crate) enum Listener {
     Tcp(tokio::net::TcpListener),
     #[cfg(unix)]
     Unix(tokio::net::UnixListener),
 }
 
-pub enum NetworkStream {
+pub(crate) enum NetworkStream {
     Tcp(tokio::net::TcpStream),
     #[cfg(unix)]
     Unix(tokio::net::UnixStream),
 }
 
 impl Listener {
-    pub fn local_addr(&self) -> std::io::Result<ListenAddr> {
+    pub(crate) fn local_addr(&self) -> std::io::Result<ListenAddr> {
         match self {
             Listener::Tcp(listener) => listener.local_addr().map(Into::into),
             #[cfg(unix)]
@@ -172,7 +172,7 @@ impl Listener {
         }
     }
 
-    pub async fn accept(&mut self) -> std::io::Result<NetworkStream> {
+    pub(crate) async fn accept(&mut self) -> std::io::Result<NetworkStream> {
         match self {
             Listener::Tcp(listener) => listener
                 .accept()

--- a/apollo-router/src/layers/cache.rs
+++ b/apollo-router/src/layers/cache.rs
@@ -166,6 +166,7 @@ where
     }
 }
 
+#[allow(unreachable_pub)] // Not worth making mock_service! support both pub and pub(crate)
 #[cfg(test)]
 mod test {
     use super::*;

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -1,6 +1,7 @@
 //! Starts a server that will handle http graphql requests.
 
 #![cfg_attr(feature = "failfast", allow(unreachable_code))]
+#![warn(unreachable_pub)]
 
 macro_rules! failfast_debug {
     ($($tokens:tt)+) => {{

--- a/apollo-router/src/plugin/utils/test/mock/canned.rs
+++ b/apollo-router/src/plugin/utils/test/mock/canned.rs
@@ -4,7 +4,7 @@ use crate::plugin::utils::test::mock::subgraph::MockSubgraph;
 use serde_json::json;
 
 /// Canned responses for accounts_subgraphs.
-pub fn accounts_subgraph() -> MockSubgraph {
+pub(crate) fn accounts_subgraph() -> MockSubgraph {
     let account_mocks = vec![
         (
             json! {{
@@ -48,7 +48,7 @@ pub fn accounts_subgraph() -> MockSubgraph {
 }
 
 /// Canned responses for reviews_subgraphs.
-pub fn reviews_subgraph() -> MockSubgraph {
+pub(crate) fn reviews_subgraph() -> MockSubgraph {
     let review_mocks = vec![
         (
             json! {{
@@ -120,7 +120,7 @@ pub fn reviews_subgraph() -> MockSubgraph {
 }
 
 /// Canned responses for products_subgraphs.
-pub fn products_subgraph() -> MockSubgraph {
+pub(crate) fn products_subgraph() -> MockSubgraph {
     let product_mocks = vec![
         (
             json!{{

--- a/apollo-router/src/plugins/telemetry/metrics/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo.rs
@@ -216,7 +216,7 @@ impl ApolloMetricsExporter {
     }
 }
 
-pub struct ReporterManager {
+pub(crate) struct ReporterManager {
     endpoint: Url,
 }
 

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/studio.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/studio.rs
@@ -308,10 +308,10 @@ impl From<FieldStat> for apollo_spaceport::FieldStat {
     }
 }
 
-pub mod vectorize {
+pub(crate) mod vectorize {
     use serde::{Serialize, Serializer};
 
-    pub fn serialize<'a, T, K, V, S>(target: T, ser: S) -> Result<S::Ok, S::Error>
+    pub(crate) fn serialize<'a, T, K, V, S>(target: T, ser: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
         T: IntoIterator<Item = (&'a K, &'a V)>,

--- a/apollo-router/src/plugins/telemetry/metrics/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/mod.rs
@@ -128,13 +128,13 @@ pub(crate) trait MetricsConfigurator {
 
 #[derive(Clone)]
 pub(crate) struct BasicMetrics {
-    pub http_requests_total: AggregateCounter<u64>,
-    pub http_requests_error_total: AggregateCounter<u64>,
-    pub http_requests_duration: AggregateValueRecorder<f64>,
+    pub(crate) http_requests_total: AggregateCounter<u64>,
+    pub(crate) http_requests_error_total: AggregateCounter<u64>,
+    pub(crate) http_requests_duration: AggregateValueRecorder<f64>,
 }
 
 impl BasicMetrics {
-    pub fn new(meter_provider: &AggregateMeterProvider) -> BasicMetrics {
+    pub(crate) fn new(meter_provider: &AggregateMeterProvider) -> BasicMetrics {
         let meter = meter_provider.meter("apollo/router", None);
         BasicMetrics {
             http_requests_total: meter.build_counter(|m| {
@@ -159,13 +159,13 @@ impl BasicMetrics {
 #[derive(Clone, Default)]
 pub(crate) struct AggregateMeterProvider(Vec<Arc<dyn MeterProvider + Send + Sync + 'static>>);
 impl AggregateMeterProvider {
-    pub fn new(
+    pub(crate) fn new(
         meters: Vec<Arc<dyn MeterProvider + Send + Sync + 'static>>,
     ) -> AggregateMeterProvider {
         AggregateMeterProvider(meters)
     }
 
-    pub fn meter(
+    pub(crate) fn meter(
         &self,
         instrumentation_name: &'static str,
         instrumentation_version: Option<&'static str>,
@@ -180,16 +180,16 @@ impl AggregateMeterProvider {
 }
 
 #[derive(Clone)]
-pub struct AggregateMeter(Vec<Arc<Meter>>);
+pub(crate) struct AggregateMeter(Vec<Arc<Meter>>);
 impl AggregateMeter {
-    pub fn build_counter<T: Into<Number> + Copy>(
+    pub(crate) fn build_counter<T: Into<Number> + Copy>(
         &self,
         build: fn(&Meter) -> Counter<T>,
     ) -> AggregateCounter<T> {
         AggregateCounter(self.0.iter().map(|m| build(m)).collect())
     }
 
-    pub fn build_value_recorder<T: Into<Number> + Copy>(
+    pub(crate) fn build_value_recorder<T: Into<Number> + Copy>(
         &self,
         build: fn(&Meter) -> ValueRecorder<T>,
     ) -> AggregateValueRecorder<T> {
@@ -198,12 +198,12 @@ impl AggregateMeter {
 }
 
 #[derive(Clone)]
-pub struct AggregateCounter<T: Into<Number> + Copy>(Vec<Counter<T>>);
+pub(crate) struct AggregateCounter<T: Into<Number> + Copy>(Vec<Counter<T>>);
 impl<T> AggregateCounter<T>
 where
     T: Into<Number> + Copy,
 {
-    pub fn add(&self, value: T, attributes: &[KeyValue]) {
+    pub(crate) fn add(&self, value: T, attributes: &[KeyValue]) {
         for counter in &self.0 {
             counter.add(value, attributes)
         }
@@ -211,12 +211,12 @@ where
 }
 
 #[derive(Clone)]
-pub struct AggregateValueRecorder<T: Into<Number> + Copy>(Vec<ValueRecorder<T>>);
+pub(crate) struct AggregateValueRecorder<T: Into<Number> + Copy>(Vec<ValueRecorder<T>>);
 impl<T> AggregateValueRecorder<T>
 where
     T: Into<Number> + Copy,
 {
-    pub fn record(&self, value: T, attributes: &[KeyValue]) {
+    pub(crate) fn record(&self, value: T, attributes: &[KeyValue]) {
         for value_recorder in &self.0 {
             value_recorder.record(value, attributes)
         }

--- a/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
@@ -67,7 +67,7 @@ impl MetricsConfigurator for Config {
 }
 
 #[derive(Clone)]
-pub struct PrometheusService {
+pub(crate) struct PrometheusService {
     registry: Registry,
 }
 

--- a/apollo-router/src/plugins/telemetry/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/otlp.rs
@@ -157,13 +157,13 @@ impl TryFrom<&TlsConfig> for tonic::transport::channel::ClientTlsConfig {
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub enum Secret {
+pub(crate) enum Secret {
     Env(String),
     File(PathBuf),
 }
 
 impl Secret {
-    pub fn read(&self) -> Result<String, ConfigurationError> {
+    pub(crate) fn read(&self) -> Result<String, ConfigurationError> {
         match self {
             Secret::Env(s) => std::env::var(s).map_err(ConfigurationError::CannotReadSecretFromEnv),
             Secret::File(path) => {

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -54,7 +54,7 @@ pub(crate) fn default_collector() -> String {
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub struct SpaceportConfig {
+pub(crate) struct SpaceportConfig {
     #[serde(default = "default_collector")]
     pub(crate) collector: String,
 }
@@ -62,7 +62,7 @@ pub struct SpaceportConfig {
 #[allow(dead_code)]
 #[derive(Clone, Derivative, Deserialize, Serialize, JsonSchema)]
 #[derivative(Debug)]
-pub struct StudioGraph {
+pub(crate) struct StudioGraph {
     #[serde(skip, default = "apollo_graph_reference")]
     pub(crate) reference: String,
 
@@ -91,14 +91,14 @@ impl Default for SpaceportConfig {
 }
 /// Pipeline builder
 #[derive(Debug)]
-pub struct PipelineBuilder {
+pub(crate) struct PipelineBuilder {
     graph_config: Option<StudioGraph>,
     spaceport_config: Option<SpaceportConfig>,
     trace_config: Option<sdk::trace::Config>,
 }
 
 /// Create a new apollo telemetry exporter pipeline builder.
-pub fn new_pipeline() -> PipelineBuilder {
+pub(crate) fn new_pipeline() -> PipelineBuilder {
     PipelineBuilder::default()
 }
 
@@ -120,25 +120,25 @@ impl PipelineBuilder {
 
     /// Assign the SDK trace configuration.
     #[allow(dead_code)]
-    pub fn with_trace_config(mut self, config: sdk::trace::Config) -> Self {
+    pub(crate) fn with_trace_config(mut self, config: sdk::trace::Config) -> Self {
         self.trace_config = Some(config);
         self
     }
 
     /// Assign graph identification configuration
-    pub fn with_graph_config(mut self, config: &Option<StudioGraph>) -> Self {
+    pub(crate) fn with_graph_config(mut self, config: &Option<StudioGraph>) -> Self {
         self.graph_config = config.clone();
         self
     }
 
     /// Assign spaceport reporting configuration
-    pub fn with_spaceport_config(mut self, config: &Option<SpaceportConfig>) -> Self {
+    pub(crate) fn with_spaceport_config(mut self, config: &Option<SpaceportConfig>) -> Self {
         self.spaceport_config = config.clone();
         self
     }
 
     /// Install the apollo telemetry exporter pipeline with the recommended defaults.
-    pub fn install_batch(mut self) -> Result<sdk::trace::Tracer, ApolloError> {
+    pub(crate) fn install_batch(mut self) -> Result<sdk::trace::Tracer, ApolloError> {
         let exporter = self.build_exporter()?;
 
         // Users can override the default batch and queue sizes, but they can't
@@ -218,7 +218,7 @@ impl PipelineBuilder {
     // WHEN TRYING TO EXPORT...
     /// Install the apollo telemetry exporter pipeline with the recommended defaults.
     #[allow(dead_code)]
-    pub fn install_simple(mut self) -> Result<sdk::trace::Tracer, ApolloError> {
+    pub(crate) fn install_simple(mut self) -> Result<sdk::trace::Tracer, ApolloError> {
         let exporter = self.build_exporter()?;
 
         let mut provider_builder =
@@ -239,7 +239,7 @@ impl PipelineBuilder {
     }
 
     /// Create a client to talk to our spaceport and return an exporter.
-    pub fn build_exporter(&self) -> Result<Exporter, ApolloError> {
+    pub(crate) fn build_exporter(&self) -> Result<Exporter, ApolloError> {
         let collector = match self.spaceport_config.clone() {
             Some(cfg) => cfg.collector,
             None => DEFAULT_SERVER_URL.to_string(),
@@ -259,7 +259,7 @@ impl PipelineBuilder {
 /// [`Reporter`]: apollo_spaceport::Reporter
 #[derive(Debug)]
 #[allow(dead_code)]
-pub struct Exporter {
+pub(crate) struct Exporter {
     collector: String,
     graph: Option<StudioGraph>,
     reporter: tokio::sync::OnceCell<Reporter>,
@@ -268,7 +268,7 @@ pub struct Exporter {
 
 impl Exporter {
     /// Create a new apollo telemetry `Exporter`.
-    pub fn new(collector: String, graph: Option<StudioGraph>) -> Self {
+    pub(crate) fn new(collector: String, graph: Option<StudioGraph>) -> Self {
         Self {
             collector,
             graph,
@@ -281,7 +281,7 @@ impl Exporter {
 /// Apollo Telemetry exporter's error
 #[derive(thiserror::Error, Debug)]
 #[error(transparent)]
-pub struct ApolloError(#[from] apollo_spaceport::ReporterError);
+pub(crate) struct ApolloError(#[from] apollo_spaceport::ReporterError);
 
 impl From<std::io::Error> for ApolloError {
     fn from(error: std::io::Error) -> Self {

--- a/apollo-router/src/plugins/telemetry/tracing/mod.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/mod.rs
@@ -5,14 +5,14 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Deserializer, Serialize};
 use tower::BoxError;
 
-pub mod apollo;
-pub mod apollo_telemetry;
-pub mod datadog;
-pub mod jaeger;
-pub mod otlp;
-pub mod zipkin;
+pub(crate) mod apollo;
+pub(crate) mod apollo_telemetry;
+pub(crate) mod datadog;
+pub(crate) mod jaeger;
+pub(crate) mod otlp;
+pub(crate) mod zipkin;
 
-pub trait TracingConfigurator {
+pub(crate) trait TracingConfigurator {
     fn apply(&self, builder: Builder, trace_config: &Trace) -> Result<Builder, BoxError>;
 }
 

--- a/apollo-router/src/plugins/traffic_shaping/deduplication.rs
+++ b/apollo-router/src/plugins/traffic_shaping/deduplication.rs
@@ -13,7 +13,7 @@ use tokio::sync::{
 use tower::{BoxError, Layer, ServiceExt};
 
 #[derive(Default)]
-pub struct QueryDeduplicationLayer;
+pub(crate) struct QueryDeduplicationLayer;
 
 impl<S> Layer<S> for QueryDeduplicationLayer
 where
@@ -29,7 +29,7 @@ where
 type WaitMap =
     Arc<Mutex<HashMap<http_compat::Request<Request>, Sender<Result<SubgraphResponse, String>>>>>;
 
-pub struct QueryDeduplicationService<S> {
+pub(crate) struct QueryDeduplicationService<S> {
     service: S,
     wait_map: WaitMap,
 }

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -15,18 +15,18 @@ use std::sync::Arc;
 use tower::BoxError;
 use tower::Service;
 
-pub static USAGE_REPORTING: &str = "apollo_telemetry::usage_reporting";
+pub(crate) static USAGE_REPORTING: &str = "apollo_telemetry::usage_reporting";
 
 #[derive(Debug, Clone)]
 /// A query planner that calls out to the nodejs router-bridge query planner.
 ///
 /// No caching is performed. To cache, wrap in a [`CachingQueryPlanner`].
-pub struct BridgeQueryPlanner {
+pub(crate) struct BridgeQueryPlanner {
     planner: Arc<Planner<QueryPlan>>,
 }
 
 impl BridgeQueryPlanner {
-    pub async fn new(schema: Arc<Schema>) -> Result<Self, QueryPlannerError> {
+    pub(crate) async fn new(schema: Arc<Schema>) -> Result<Self, QueryPlannerError> {
         Ok(Self {
             planner: Arc::new(Planner::new(schema.as_str().to_string()).await?),
         })

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -3,8 +3,8 @@ use crate::error::FetchError;
 use crate::json_ext::{Path, Value, ValueExt};
 use crate::service_registry::ServiceRegistry;
 use crate::*;
-pub use bridge_query_planner::*;
-pub use caching_query_planner::*;
+pub(crate) use bridge_query_planner::*;
+pub(crate) use caching_query_planner::*;
 use fetch::OperationKind;
 use futures::prelude::*;
 use opentelemetry::trace::SpanKind;
@@ -76,7 +76,7 @@ pub(crate) enum PlanNode {
 }
 
 impl PlanNode {
-    pub fn contains_mutations(&self) -> bool {
+    pub(crate) fn contains_mutations(&self) -> bool {
         match self {
             Self::Sequence { nodes } => nodes.iter().any(|n| n.contains_mutations()),
             Self::Parallel { nodes } => nodes.iter().any(|n| n.contains_mutations()),

--- a/apollo-router/src/reload.rs
+++ b/apollo-router/src/reload.rs
@@ -48,7 +48,7 @@ macro_rules! try_lock {
 
 /// Wraps a `Layer`, allowing it to be reloaded dynamically at runtime.
 #[derive(Debug)]
-pub struct Layer<L, S> {
+pub(crate) struct Layer<L, S> {
     // TODO(eliza): this once used a `crossbeam_util::ShardedRwLock`. We may
     // eventually wish to replace it with a sharded lock implementation on top
     // of our internal `RwLock` wrapper type. If possible, we should profile
@@ -59,7 +59,7 @@ pub struct Layer<L, S> {
 
 /// Allows reloading the state of an associated `Layer`.
 #[derive(Debug)]
-pub struct Handle<L, S> {
+pub(crate) struct Handle<L, S> {
     inner: Weak<RwLock<L>>,
     _s: PhantomData<fn(S)>,
 }
@@ -158,7 +158,7 @@ where
 {
     /// Wraps the given `Layer`, returning a `Layer` and a `Handle` that allows
     /// the inner type to be modified at runtime.
-    pub fn new(inner: L) -> (Self, Handle<L, S>) {
+    pub(crate) fn new(inner: L) -> (Self, Handle<L, S>) {
         let this = Self {
             inner: Arc::new(RwLock::new(inner)),
             _s: PhantomData,
@@ -168,7 +168,7 @@ where
     }
 
     /// Returns a `Handle` that can be used to reload the wrapped `Layer`.
-    pub fn handle(&self) -> Handle<L, S> {
+    pub(crate) fn handle(&self) -> Handle<L, S> {
         Handle {
             inner: Arc::downgrade(&self.inner),
             _s: PhantomData,
@@ -184,7 +184,7 @@ where
     S: Subscriber,
 {
     /// Replace the current layer with the provided `new_layer`.
-    pub fn reload(&self, new_layer: impl Into<L>) -> Result<(), Error> {
+    pub(crate) fn reload(&self, new_layer: impl Into<L>) -> Result<(), Error> {
         self.modify(|layer| {
             *layer = new_layer.into();
         })
@@ -192,7 +192,7 @@ where
 
     /// Invokes a closure with a mutable reference to the current layer,
     /// allowing it to be modified in place.
-    pub fn modify(&self, f: impl FnOnce(&mut L)) -> Result<(), Error> {
+    pub(crate) fn modify(&self, f: impl FnOnce(&mut L)) -> Result<(), Error> {
         let inner = self.inner.upgrade().ok_or(Error {
             kind: ErrorKind::SubscriberGone,
         })?;
@@ -210,7 +210,7 @@ where
     /// Returns a clone of the layer's current value if it still exists.
     /// Otherwise, if the subscriber has been dropped, returns `None`.
     #[allow(dead_code)]
-    pub fn clone_current(&self) -> Option<L>
+    pub(crate) fn clone_current(&self) -> Option<L>
     where
         L: Clone,
     {
@@ -220,7 +220,7 @@ where
     /// Invokes a closure with a borrowed reference to the current layer,
     /// returning the result (or an error if the subscriber no longer exists).
     #[allow(dead_code)]
-    pub fn with_current<T>(&self, f: impl FnOnce(&L) -> T) -> Result<T, Error> {
+    pub(crate) fn with_current<T>(&self, f: impl FnOnce(&L) -> T) -> Result<T, Error> {
         let inner = self.inner.upgrade().ok_or(Error {
             kind: ErrorKind::SubscriberGone,
         })?;

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -24,7 +24,7 @@ use tower_service::Service;
 /// Instances of this traits are used by the StateMachine to generate a new
 /// RouterService from configuration when it changes
 #[async_trait::async_trait]
-pub trait RouterServiceFactory: Send + Sync + 'static {
+pub(crate) trait RouterServiceFactory: Send + Sync + 'static {
     type RouterService: Service<
             Request<crate::Request>,
             Response = Response<BoxStream<'static, ResponseBody>>,
@@ -46,7 +46,7 @@ pub trait RouterServiceFactory: Send + Sync + 'static {
 
 /// Main implementation of the RouterService factory, supporting the extensions system
 #[derive(Default)]
-pub struct YamlRouterServiceFactory;
+pub(crate) struct YamlRouterServiceFactory;
 
 #[async_trait::async_trait]
 impl RouterServiceFactory for YamlRouterServiceFactory {

--- a/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
+++ b/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
@@ -12,7 +12,7 @@ use std::ops::ControlFlow;
 use tower::{BoxError, Layer, Service};
 
 #[derive(Default)]
-pub struct AllowOnlyHttpPostMutationsLayer {}
+pub(crate) struct AllowOnlyHttpPostMutationsLayer {}
 
 impl<S> Layer<S> for AllowOnlyHttpPostMutationsLayer
 where

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -17,20 +17,21 @@ use tower::{BoxError, Layer, Service};
 
 /// A persisted query.
 #[derive(Deserialize, Clone, Debug)]
-pub struct PersistedQuery {
-    pub version: u8,
+struct PersistedQuery {
+    #[allow(unused)]
+    version: u8,
     #[serde(rename = "sha256Hash")]
-    pub sha256hash: String,
+    sha256hash: String,
 }
 
 /// [`Layer`] for APQ implementation.
 #[derive(Clone)]
-pub struct APQLayer {
+pub(crate) struct APQLayer {
     cache: Cache<Vec<u8>, String>,
 }
 
 impl APQLayer {
-    pub fn with_cache(cache: Cache<Vec<u8>, String>) -> Self {
+    pub(crate) fn with_cache(cache: Cache<Vec<u8>, String>) -> Self {
         Self { cache }
     }
 }

--- a/apollo-router/src/services/layers/ensure_query_presence.rs
+++ b/apollo-router/src/services/layers/ensure_query_presence.rs
@@ -13,7 +13,7 @@ use std::ops::ControlFlow;
 use tower::{BoxError, Layer, Service};
 
 #[derive(Default)]
-pub struct EnsureQueryPresence {}
+pub(crate) struct EnsureQueryPresence {}
 
 impl<S> Layer<S> for EnsureQueryPresence
 where

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -36,7 +36,7 @@ use tower_service::Service;
 use tracing_futures::Instrument;
 
 /// An [`IndexMap`] of available plugins.
-pub type Plugins = IndexMap<String, Box<dyn DynPlugin>>;
+pub(crate) type Plugins = IndexMap<String, Box<dyn DynPlugin>>;
 
 /// Containing [`Service`] in the request lifecyle.
 #[derive(Clone)]

--- a/apollo-router/src/spec/mod.rs
+++ b/apollo-router/src/spec/mod.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 pub(crate) use field_type::*;
 pub(crate) use fragments::*;
-pub use query::*;
+pub(crate) use query::*;
 pub use schema::*;
 pub(crate) use selection::*;
 


### PR DESCRIPTION
Some reexports where recently removed, making some items unreachable from other crates as they are defined in private modules. This changes such items from `pub` to `pub(crate)` in order to better communicate the situation to human readers, and enables warnings for the `unreachable_pub` lint.

The diff is mostly generated by `cargo fix` with this lint.