### PR TITLE
fix docker image

### DIFF
--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -18,10 +18,16 @@ RUN mkdir /dist/config && mkdir /dist/schema
 # Copy configuration for docker image
 COPY dockerfiles/router.yaml /dist/config
 
+# Required so we can copy in libz.so.1
+FROM --platform=linux/amd64 debian:stable-slim as libz-required
+
 # Final image uses distroless
 FROM --platform=linux/amd64 gcr.io/distroless/cc-debian11${DEBUG_IMAGE}
 
 LABEL org.opencontainers.image.authors="ApolloGraphQL https://github.com/apollographql/router"
+
+# Copy in the extracted/created files
+COPY --from=libz-required /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
 
 # Copy in the extracted/created files
 COPY --from=build --chown=root:root /dist /dist

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -19,7 +19,7 @@ RUN mkdir /dist/config && mkdir /dist/schema
 COPY dockerfiles/router.yaml /dist/config
 
 # Required so we can copy in libz.so.1
-FROM --platform=linux/amd64 debian:stable-slim as libz-required
+FROM --platform=linux/amd64 gcr.io/distroless/java17-debian11${DEBUG_IMAGE} as libz-required
 
 # Final image uses distroless
 FROM --platform=linux/amd64 gcr.io/distroless/cc-debian11${DEBUG_IMAGE}


### PR DESCRIPTION
the docker image needs a liz.so.1 now that we support compression in the router. Without one, it fails to execute.

We need a longer term solution, but this "hack" at least provides temporary relief.

Note: I've already updated the dockerfiles on github with images based on this change.