### PR TITLE
http_compat re-examined

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -26,6 +26,13 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 # [0.9.6] (unreleased) - 2022-mm-dd
 ## ❗ BREAKING ❗
 
+### Rename http_compat to http_ext ([PR #1291](https://github.com/apollographql/router/pull/1291)
+
+The module provides extensions to the `http` crate which are specific to the way we use that crate in the router. This change also cleans up the provided extensions and fixes a few potential sources of error (by removing them)
+such as the Request::mock() fn.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1257
+
 ### Rework the entire public API structure ([PR #1216](https://github.com/apollographql/router/pull/1216),  [PR #1242](https://github.com/apollographql/router/pull/1242),  [PR #1267](https://github.com/apollographql/router/pull/1267),  [PR #1277](https://github.com/apollographql/router/pull/1277))
 
 * Many items have been removed from the public API and made private.
@@ -179,12 +186,12 @@ use apollo_router::services::RouterService;
 use apollo_router::services::SubgraphRequest;
 use apollo_router::services::SubgraphResponse;
 use apollo_router::services::SubgraphService;
-use apollo_router::services::http_compat::FakeNewRequestBuilder;
-use apollo_router::services::http_compat::IntoHeaderName;
-use apollo_router::services::http_compat::IntoHeaderValue;
-use apollo_router::services::http_compat::NewRequestBuilder;
-use apollo_router::services::http_compat::Request;
-use apollo_router::services::http_compat::Response;
+use apollo_router::services::http_ext::FakeNewRequestBuilder;
+use apollo_router::services::http_ext::IntoHeaderName;
+use apollo_router::services::http_ext::IntoHeaderValue;
+use apollo_router::services::http_ext::NewRequestBuilder;
+use apollo_router::services::http_ext::Request;
+use apollo_router::services::http_ext::Response;
 use apollo_router::subscriber::RouterSubscriber;
 use apollo_router::subscriber::is_global_subscriber_set;
 use apollo_router::subscriber::replace_layer;

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -1,6 +1,6 @@
 //! Axum http server factory. Axum provides routing capability on top of Hyper HTTP.
 use crate::configuration::{Configuration, ListenAddr};
-use crate::http_compat;
+use crate::http_ext;
 use crate::http_server_factory::{HttpServerFactory, HttpServerHandle, Listener, NetworkStream};
 use crate::layers::DEFAULT_BUFFER_SIZE;
 use crate::plugin::Handler;
@@ -56,11 +56,11 @@ impl AxumHttpServerFactory {
 
 type BufferedService = Buffer<
     BoxService<
-        http_compat::Request<crate::Request>,
-        http_compat::Response<BoxStream<'static, ResponseBody>>,
+        http_ext::Request<crate::Request>,
+        http_ext::Response<BoxStream<'static, ResponseBody>>,
         BoxError,
     >,
-    http_compat::Request<crate::Request>,
+    http_ext::Request<crate::Request>,
 >;
 
 impl HttpServerFactory for AxumHttpServerFactory {
@@ -75,15 +75,15 @@ impl HttpServerFactory for AxumHttpServerFactory {
     ) -> Self::Future
     where
         RS: Service<
-                http_compat::Request<crate::Request>,
-                Response = http_compat::Response<BoxStream<'static, ResponseBody>>,
+                http_ext::Request<crate::Request>,
+                Response = http_ext::Response<BoxStream<'static, ResponseBody>>,
                 Error = BoxError,
             > + Send
             + Sync
             + Clone
             + 'static,
 
-        <RS as Service<http_compat::Request<crate::Request>>>::Future: std::marker::Send,
+        <RS as Service<http_ext::Request<crate::Request>>>::Future: std::marker::Send,
     {
         let boxed_service = Buffer::new(service.boxed(), DEFAULT_BUFFER_SIZE);
         Box::pin(async move {
@@ -511,7 +511,7 @@ async fn run_graphql_request(
                         }
                         Some(response) => {
                             tracing::trace_span!("serialize_response").in_scope(|| {
-                                http_compat::Response::from(http::Response::from_parts(
+                                http_ext::Response::from(http::Response::from_parts(
                                     parts, response,
                                 ))
                                 .into_response()
@@ -659,7 +659,7 @@ impl<B> MakeSpan<B> for PropagatingMakeSpan {
 mod tests {
     use super::*;
     use crate::configuration::Cors;
-    use crate::http_compat::Request;
+    use crate::http_ext::Request;
     use async_compression::tokio::write::GzipEncoder;
     use http::header::{self, ACCEPT_ENCODING, CONTENT_TYPE};
     use mockall::mock;
@@ -718,7 +718,7 @@ mod tests {
     mock! {
         #[derive(Debug)]
         RouterService {
-            fn service_call(&mut self, req: Request<crate::Request>) -> Result<http_compat::Response<BoxStream<'static, ResponseBody>>, BoxError>;
+            fn service_call(&mut self, req: Request<crate::Request>) -> Result<http_ext::Response<BoxStream<'static, ResponseBody>>, BoxError>;
         }
     }
 
@@ -890,7 +890,7 @@ mod tests {
             .times(2)
             .returning(move |_req| {
                 let example_response = example_response.clone();
-                Ok(http_compat::Response::from_response_to_stream(
+                Ok(http_ext::Response::from_response_to_stream(
                     http::Response::builder()
                         .status(200)
                         .body(ResponseBody::GraphQL(example_response))
@@ -981,7 +981,7 @@ mod tests {
             })
             .returning(move |_req| {
                 let example_response = example_response.clone();
-                Ok(http_compat::Response::from_response_to_stream(
+                Ok(http_ext::Response::from_response_to_stream(
                     http::Response::builder()
                         .status(200)
                         .body(ResponseBody::GraphQL(example_response))
@@ -1043,7 +1043,7 @@ mod tests {
             .times(2)
             .returning(move |_| {
                 let example_response = example_response.clone();
-                Ok(http_compat::Response::from_response_to_stream(
+                Ok(http_ext::Response::from_response_to_stream(
                     http::Response::builder()
                         .status(200)
                         .body(ResponseBody::GraphQL(example_response))
@@ -1145,7 +1145,7 @@ mod tests {
             .times(2)
             .returning(move |_| {
                 let example_response = example_response.clone();
-                Ok(http_compat::Response::from_response_to_stream(
+                Ok(http_ext::Response::from_response_to_stream(
                     http::Response::builder()
                         .status(200)
                         .body(ResponseBody::GraphQL(example_response))
@@ -1214,7 +1214,7 @@ mod tests {
             .times(2)
             .returning(move |_| {
                 let example_response = example_response.clone();
-                Ok(http_compat::Response::from_response_to_stream(
+                Ok(http_ext::Response::from_response_to_stream(
                     http::Response::builder()
                         .status(200)
                         .body(ResponseBody::GraphQL(example_response))
@@ -1283,7 +1283,7 @@ mod tests {
             .times(4)
             .returning(move |_| {
                 let example_response = example_response.clone();
-                Ok(http_compat::Response::from_response_to_stream(
+                Ok(http_ext::Response::from_response_to_stream(
                     http::Response::builder()
                         .status(200)
                         .body(ResponseBody::GraphQL(example_response))
@@ -1375,7 +1375,7 @@ mod tests {
             })
             .returning(move |_| {
                 let example_response = example_response.clone();
-                Ok(http_compat::Response::from_response_to_stream(
+                Ok(http_ext::Response::from_response_to_stream(
                     http::Response::builder()
                         .status(200)
                         .body(ResponseBody::GraphQL(example_response))
@@ -1435,7 +1435,7 @@ mod tests {
             })
             .returning(move |_| {
                 let example_response = example_response.clone();
-                Ok(http_compat::Response::from_response_to_stream(
+                Ok(http_ext::Response::from_response_to_stream(
                     http::Response::builder()
                         .status(200)
                         .body(ResponseBody::GraphQL(example_response))
@@ -1474,7 +1474,7 @@ mod tests {
                     reason: "Mock error".to_string(),
                 }
                 .to_response();
-                Ok(http_compat::Response::from_response_to_stream(
+                Ok(http_ext::Response::from_response_to_stream(
                     http::Response::builder()
                         .status(200)
                         .body(ResponseBody::GraphQL(example_response))
@@ -1569,7 +1569,7 @@ mod tests {
             .returning(move |_| {
                 let example_response = example_response.clone();
 
-                Ok(http_compat::Response::from_response_to_stream(
+                Ok(http_ext::Response::from_response_to_stream(
                     http::Response::builder()
                         .status(200)
                         .body(ResponseBody::GraphQL(example_response))
@@ -1758,8 +1758,8 @@ Content-Type: application/json\r
     async fn it_answers_to_custom_endpoint() -> Result<(), ApolloRouterError> {
         let expectations = MockRouterService::new();
         let plugin_handler = Handler::new(
-            service_fn(|req: http_compat::Request<Bytes>| async move {
-                Ok::<_, BoxError>(http_compat::Response {
+            service_fn(|req: http_ext::Request<Bytes>| async move {
+                Ok::<_, BoxError>(http_ext::Response {
                     inner: http::Response::builder()
                         .status(StatusCode::OK)
                         .body(ResponseBody::Text(format!(
@@ -1843,7 +1843,7 @@ Content-Type: application/json\r
             .expect_service_call()
             .times(2)
             .returning(move |req| {
-                Ok(http_compat::Response::from_response_to_stream(
+                Ok(http_ext::Response::from_response_to_stream(
                     http::Response::builder()
                         .status(200)
                         .body(ResponseBody::Text(format!(

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -499,7 +499,7 @@ async fn run_graphql_request(
                         .into_response()
                 }
                 Ok(response) => {
-                    let (parts, mut stream) = response.into_parts();
+                    let (parts, mut stream) = http::Response::from(response).into_parts();
                     match stream.next().await {
                         None => {
                             tracing::error!("router service is not available to process request",);

--- a/apollo-router/src/context.rs
+++ b/apollo-router/src/context.rs
@@ -13,7 +13,7 @@ use tower::BoxError;
 /// Holds [`Context`] entries.
 pub(crate) type Entries = Arc<DashMap<String, Value>>;
 
-/// Context for a [`crate::http_compat::Request`]
+/// Context for a [`crate::http_ext::Request`]
 ///
 /// Context makes use of [`DashMap`] under the hood which tries to handle concurrency
 /// by allowing concurrency across threads without requiring locking. This is great

--- a/apollo-router/src/http_server_factory.rs
+++ b/apollo-router/src/http_server_factory.rs
@@ -1,6 +1,6 @@
 use super::router::ApolloRouterError;
 use crate::configuration::{Configuration, ListenAddr};
-use crate::http_compat::{Request, Response};
+use crate::http_ext::{Request, Response};
 use crate::plugin::Handler;
 use crate::ResponseBody;
 use derivative::Derivative;

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -59,7 +59,7 @@ pub use executable::{main, Executable};
 pub use request::Request;
 pub use response::Response;
 pub use router::{ApolloRouter, ConfigurationKind, SchemaKind, ShutdownKind};
-pub use services::http_compat;
+pub use services::http_ext;
 pub use spec::Schema;
 
 // TODO: clean these up and import from relevant modules instead

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -19,7 +19,7 @@ pub mod test;
 
 use crate::layers::ServiceBuilderExt;
 use crate::{
-    http_compat, ExecutionRequest, ExecutionResponse, QueryPlannerRequest, QueryPlannerResponse,
+    http_ext, ExecutionRequest, ExecutionResponse, QueryPlannerRequest, QueryPlannerResponse,
     Response, ResponseBody, RouterRequest, RouterResponse, SubgraphRequest, SubgraphResponse,
 };
 use ::serde::{de::DeserializeOwned, Deserialize};
@@ -318,18 +318,14 @@ macro_rules! register_plugin {
 #[derive(Clone)]
 pub struct Handler {
     service: Buffer<
-        BoxService<http_compat::Request<Bytes>, http_compat::Response<ResponseBody>, BoxError>,
-        http_compat::Request<Bytes>,
+        BoxService<http_ext::Request<Bytes>, http_ext::Response<ResponseBody>, BoxError>,
+        http_ext::Request<Bytes>,
     >,
 }
 
 impl Handler {
     pub fn new(
-        service: BoxService<
-            http_compat::Request<Bytes>,
-            http_compat::Response<ResponseBody>,
-            BoxError,
-        >,
+        service: BoxService<http_ext::Request<Bytes>, http_ext::Response<ResponseBody>, BoxError>,
     ) -> Self {
         Self {
             service: ServiceBuilder::new().buffered().service(service),
@@ -337,8 +333,8 @@ impl Handler {
     }
 }
 
-impl Service<http_compat::Request<Bytes>> for Handler {
-    type Response = http_compat::Response<ResponseBody>;
+impl Service<http_ext::Request<Bytes>> for Handler {
+    type Response = http_ext::Response<ResponseBody>;
     type Error = BoxError;
     type Future = ResponseFuture<BoxFuture<'static, Result<Self::Response, Self::Error>>>;
 
@@ -346,20 +342,16 @@ impl Service<http_compat::Request<Bytes>> for Handler {
         self.service.poll_ready(cx)
     }
 
-    fn call(&mut self, req: http_compat::Request<Bytes>) -> Self::Future {
+    fn call(&mut self, req: http_ext::Request<Bytes>) -> Self::Future {
         self.service.call(req)
     }
 }
 
-impl From<BoxService<http_compat::Request<Bytes>, http_compat::Response<ResponseBody>, BoxError>>
+impl From<BoxService<http_ext::Request<Bytes>, http_ext::Response<ResponseBody>, BoxError>>
     for Handler
 {
     fn from(
-        original: BoxService<
-            http_compat::Request<Bytes>,
-            http_compat::Response<ResponseBody>,
-            BoxError,
-        >,
+        original: BoxService<http_ext::Request<Bytes>, http_ext::Response<ResponseBody>, BoxError>,
     ) -> Self {
         Self::new(original)
     }

--- a/apollo-router/src/plugin/test/mock/subgraph.rs
+++ b/apollo-router/src/plugin/test/mock/subgraph.rs
@@ -50,7 +50,7 @@ impl Service<SubgraphRequest> for MockSubgraph {
                 .expect("Response is serializable; qed");
 
             // Create a compatible Response
-            let compat_response = crate::http_compat::Response {
+            let compat_response = crate::http_ext::Response {
                 inner: http_response,
             };
 

--- a/apollo-router/src/plugins/forbid_mutations.rs
+++ b/apollo-router/src/plugins/forbid_mutations.rs
@@ -62,7 +62,7 @@ impl Plugin for ForbidMutations {
 #[cfg(test)]
 mod forbid_http_get_mutations_tests {
     use super::*;
-    use crate::http_compat::Request;
+    use crate::http_ext::Request;
     use crate::plugin::test::MockExecutionService;
     use crate::query_planner::fetch::OperationKind;
     use crate::query_planner::{PlanNode, QueryPlan};

--- a/apollo-router/src/plugins/headers.rs
+++ b/apollo-router/src/plugins/headers.rs
@@ -233,7 +233,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::http_compat;
+    use crate::http_ext;
     use crate::plugin::test::MockSubgraphService;
     use crate::plugins::headers::{Config, HeadersLayer};
     use crate::query_planner::fetch::OperationKind;
@@ -516,7 +516,7 @@ mod test {
     fn example_request() -> SubgraphRequest {
         SubgraphRequest {
             originating_request: Arc::new(
-                http_compat::Request::fake_builder()
+                http_ext::Request::fake_builder()
                     .header("da", "vda")
                     .header("db", "vdb")
                     .header("db", "vdb")
@@ -527,7 +527,7 @@ mod test {
                     .build()
                     .expect("expecting valid request"),
             ),
-            subgraph_request: http_compat::Request::fake_builder()
+            subgraph_request: http_ext::Request::fake_builder()
                 .header("aa", "vaa")
                 .header("ab", "vab")
                 .header("ac", "vac")

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -1120,7 +1120,7 @@ impl ServiceStep {
                                 // we split the response stream into headers+first response, then a stream of deferred responses
                                 // for which we will implement mapping later
                                 let RouterResponse { response, context } = router_response;
-                                let (parts, stream) = response.into_parts();
+                                let (parts, stream) = http::Response::from(response).into_parts();
                                 let (first, rest) = stream.into_future().await;
 
                                 if first.is_none() {
@@ -1172,7 +1172,7 @@ impl ServiceStep {
                                 let mut guard = shared_response.lock().unwrap();
                                 let response_opt = guard.take();
                                 let RhaiRouterResponse { context, response } = response_opt.unwrap();
-                                let (parts, body)  = response.into_parts();
+                                let (parts, body)  = http::Response::from(response).into_parts();
 
                                 //FIXME we should also map over the stream of future responses
                                 let response = http::Response::from_parts(parts,once(ready(body)).chain(rest).boxed()).into();
@@ -1219,7 +1219,7 @@ impl ServiceStep {
                                 // we split the response stream into headers+first response, then a stream of deferred responses
                                 // for which we will implement mapping later
                                 let ExecutionResponse { response, context } = execution_response;
-                                let (parts, stream) = response.into_parts();
+                                let (parts, stream) = http::Response::from(response).into_parts();
                                 let (first, rest) = stream.into_future().await;
 
                                 if first.is_none() {
@@ -1274,7 +1274,7 @@ impl ServiceStep {
                                 let response_opt = guard.take();
                                 let RhaiExecutionResponse { context, response } =
                                     response_opt.unwrap();
-                                let (parts, body) = response.into_parts();
+                                let (parts, body) = http::Response::from(response).into_parts();
 
                                 //FIXME we should also map over the stream of future responses
                                 let response = http::Response::from_parts(

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     error::Error,
-    http_compat,
+    http_ext,
     json_ext::{Object, Value},
     layers::ServiceBuilderExt,
     plugin::Plugin,
@@ -159,14 +159,14 @@ mod router_plugin_mod {
     #[rhai_fn(get = "subgraph", pure, return_raw)]
     pub(crate) fn get_subgraph(
         obj: &mut SharedSubgraphRequest,
-    ) -> Result<http_compat::Request<Request>, Box<EvalAltResult>> {
+    ) -> Result<http_ext::Request<Request>, Box<EvalAltResult>> {
         obj.with_mut(|request| Ok(request.subgraph_request.clone()))
     }
 
     #[rhai_fn(set = "subgraph", return_raw)]
     pub(crate) fn set_subgraph(
         obj: &mut SharedSubgraphRequest,
-        sub: http_compat::Request<Request>,
+        sub: http_ext::Request<Request>,
     ) -> Result<(), Box<EvalAltResult>> {
         obj.with_mut(|request| {
             request.subgraph_request = sub;
@@ -176,14 +176,14 @@ mod router_plugin_mod {
 
     #[rhai_fn(get = "headers", pure, return_raw)]
     pub(crate) fn get_subgraph_headers(
-        obj: &mut http_compat::Request<Request>,
+        obj: &mut http_ext::Request<Request>,
     ) -> Result<HeaderMap, Box<EvalAltResult>> {
         Ok(obj.headers().clone())
     }
 
     #[rhai_fn(set = "headers", return_raw)]
     pub(crate) fn set_subgraph_headers(
-        obj: &mut http_compat::Request<Request>,
+        obj: &mut http_ext::Request<Request>,
         headers: HeaderMap,
     ) -> Result<(), Box<EvalAltResult>> {
         *obj.headers_mut() = headers;
@@ -192,14 +192,14 @@ mod router_plugin_mod {
 
     #[rhai_fn(get = "body", pure, return_raw)]
     pub(crate) fn get_subgraph_body(
-        obj: &mut http_compat::Request<Request>,
+        obj: &mut http_ext::Request<Request>,
     ) -> Result<Request, Box<EvalAltResult>> {
         Ok(obj.body().clone())
     }
 
     #[rhai_fn(set = "body", return_raw)]
     pub(crate) fn set_subgraph_body(
-        obj: &mut http_compat::Request<Request>,
+        obj: &mut http_ext::Request<Request>,
         body: Request,
     ) -> Result<(), Box<EvalAltResult>> {
         *obj.body_mut() = body;
@@ -208,14 +208,14 @@ mod router_plugin_mod {
 
     #[rhai_fn(get = "uri", pure, return_raw)]
     pub(crate) fn get_subgraph_uri(
-        obj: &mut http_compat::Request<Request>,
+        obj: &mut http_ext::Request<Request>,
     ) -> Result<Uri, Box<EvalAltResult>> {
         Ok(obj.uri().clone())
     }
 
     #[rhai_fn(set = "uri", return_raw)]
     pub(crate) fn set_subgraph_uri(
-        obj: &mut http_compat::Request<Request>,
+        obj: &mut http_ext::Request<Request>,
         uri: Uri,
     ) -> Result<(), Box<EvalAltResult>> {
         *obj.uri_mut() = uri;
@@ -327,26 +327,26 @@ mod router_plugin_mod {
         Ok(())
     }
 
-    fn get_originating_headers<T: Accessor<http_compat::Request<Request>>>(
+    fn get_originating_headers<T: Accessor<http_ext::Request<Request>>>(
         obj: &mut T,
     ) -> Result<HeaderMap, Box<EvalAltResult>> {
         Ok(obj.accessor().headers().clone())
     }
 
-    fn get_originating_body<T: Accessor<http_compat::Request<Request>>>(
+    fn get_originating_body<T: Accessor<http_ext::Request<Request>>>(
         obj: &mut T,
     ) -> Result<Request, Box<EvalAltResult>> {
         Ok(obj.accessor().body().clone())
     }
 
-    fn get_originating_uri<T: Accessor<http_compat::Request<Request>>>(
+    fn get_originating_uri<T: Accessor<http_ext::Request<Request>>>(
         obj: &mut T,
     ) -> Result<Uri, Box<EvalAltResult>> {
         Ok(obj.accessor().uri().clone())
     }
 
     fn get_originating_headers_response_response_body<
-        T: Accessor<http_compat::Response<ResponseBody>>,
+        T: Accessor<http_ext::Response<ResponseBody>>,
     >(
         obj: &mut T,
     ) -> Result<HeaderMap, Box<EvalAltResult>> {
@@ -354,26 +354,26 @@ mod router_plugin_mod {
     }
 
     fn get_originating_body_response_response_body<
-        T: Accessor<http_compat::Response<ResponseBody>>,
+        T: Accessor<http_ext::Response<ResponseBody>>,
     >(
         obj: &mut T,
     ) -> Result<ResponseBody, Box<EvalAltResult>> {
         Ok(obj.accessor().body().clone())
     }
 
-    fn get_originating_headers_response_response<T: Accessor<http_compat::Response<Response>>>(
+    fn get_originating_headers_response_response<T: Accessor<http_ext::Response<Response>>>(
         obj: &mut T,
     ) -> Result<HeaderMap, Box<EvalAltResult>> {
         Ok(obj.accessor().headers().clone())
     }
 
-    fn get_originating_body_response_response<T: Accessor<http_compat::Response<Response>>>(
+    fn get_originating_body_response_response<T: Accessor<http_ext::Response<Response>>>(
         obj: &mut T,
     ) -> Result<Response, Box<EvalAltResult>> {
         Ok(obj.accessor().body().clone())
     }
 
-    fn set_originating_headers<T: Accessor<http_compat::Request<Request>>>(
+    fn set_originating_headers<T: Accessor<http_ext::Request<Request>>>(
         obj: &mut T,
         headers: HeaderMap,
     ) -> Result<(), Box<EvalAltResult>> {
@@ -381,7 +381,7 @@ mod router_plugin_mod {
         Ok(())
     }
 
-    fn set_originating_body<T: Accessor<http_compat::Request<Request>>>(
+    fn set_originating_body<T: Accessor<http_ext::Request<Request>>>(
         obj: &mut T,
         body: Request,
     ) -> Result<(), Box<EvalAltResult>> {
@@ -389,7 +389,7 @@ mod router_plugin_mod {
         Ok(())
     }
 
-    fn set_originating_uri<T: Accessor<http_compat::Request<Request>>>(
+    fn set_originating_uri<T: Accessor<http_ext::Request<Request>>>(
         obj: &mut T,
         uri: Uri,
     ) -> Result<(), Box<EvalAltResult>> {
@@ -398,7 +398,7 @@ mod router_plugin_mod {
     }
 
     fn set_originating_headers_response_response_body<
-        T: Accessor<http_compat::Response<ResponseBody>>,
+        T: Accessor<http_ext::Response<ResponseBody>>,
     >(
         obj: &mut T,
         headers: HeaderMap,
@@ -408,7 +408,7 @@ mod router_plugin_mod {
     }
 
     fn set_originating_body_response_response_body<
-        T: Accessor<http_compat::Response<ResponseBody>>,
+        T: Accessor<http_ext::Response<ResponseBody>>,
     >(
         obj: &mut T,
         body: ResponseBody,
@@ -417,7 +417,7 @@ mod router_plugin_mod {
         Ok(())
     }
 
-    fn set_originating_headers_response_response<T: Accessor<http_compat::Response<Response>>>(
+    fn set_originating_headers_response_response<T: Accessor<http_ext::Response<Response>>>(
         obj: &mut T,
         headers: HeaderMap,
     ) -> Result<(), Box<EvalAltResult>> {
@@ -425,7 +425,7 @@ mod router_plugin_mod {
         Ok(())
     }
 
-    fn set_originating_body_response_response<T: Accessor<http_compat::Response<Response>>>(
+    fn set_originating_body_response_response<T: Accessor<http_ext::Response<Response>>>(
         obj: &mut T,
         body: Response,
     ) -> Result<(), Box<EvalAltResult>> {
@@ -574,12 +574,12 @@ pub(crate) enum ServiceStep {
 macro_rules! accessor_mut_for_shared_types {
     (subgraph) => {
         // XXX CAN'T DO THIS FOR SUBGRAPH
-        fn accessor_mut(&mut self) -> &mut http_compat::Request<Request> {
+        fn accessor_mut(&mut self) -> &mut http_ext::Request<Request> {
             panic!("cannot mutate originating request on a subgraph");
         }
     };
     ($_base: ident) => {
-        fn accessor_mut(&mut self) -> &mut http_compat::Request<Request> {
+        fn accessor_mut(&mut self) -> &mut http_ext::Request<Request> {
             &mut self.originating_request
         }
     };
@@ -620,9 +620,9 @@ macro_rules! gen_shared_types {
                 }
             }
 
-            impl Accessor<http_compat::Request<Request>> for [<$base:camel Request >] {
+            impl Accessor<http_ext::Request<Request>> for [<$base:camel Request >] {
 
-                fn accessor(&self) -> &http_compat::Request<Request> {
+                fn accessor(&self) -> &http_ext::Request<Request> {
                     &self.originating_request
                 }
 
@@ -755,7 +755,7 @@ type SharedExecutionService = Arc<
 type SharedExecutionRequest = Arc<Mutex<Option<ExecutionRequest>>>;
 pub(crate) struct RhaiExecutionResponse {
     context: Context,
-    response: http_compat::Response<Response>,
+    response: http_ext::Response<Response>,
 }
 #[allow(dead_code)]
 type SharedExecutionResponse = Arc<Mutex<Option<RhaiExecutionResponse>>>;
@@ -775,11 +775,11 @@ impl Accessor<Context> for ExecutionResponse<BoxStream<'static, Response>> {
         &mut self.context
     }
 }
-impl Accessor<http_compat::Request<Request>> for ExecutionRequest {
-    fn accessor(&self) -> &http_compat::Request<Request> {
+impl Accessor<http_ext::Request<Request>> for ExecutionRequest {
+    fn accessor(&self) -> &http_ext::Request<Request> {
         &self.originating_request
     }
-    fn accessor_mut(&mut self) -> &mut http_compat::Request<Request> {
+    fn accessor_mut(&mut self) -> &mut http_ext::Request<Request> {
         &mut self.originating_request
     }
 }
@@ -794,44 +794,44 @@ impl Accessor<Context> for RhaiExecutionResponse {
     }
 }
 
-impl Accessor<http_compat::Response<Response>> for RhaiExecutionResponse {
-    fn accessor(&self) -> &http_compat::Response<Response> {
+impl Accessor<http_ext::Response<Response>> for RhaiExecutionResponse {
+    fn accessor(&self) -> &http_ext::Response<Response> {
         &self.response
     }
 
-    fn accessor_mut(&mut self) -> &mut http_compat::Response<Response> {
+    fn accessor_mut(&mut self) -> &mut http_ext::Response<Response> {
         &mut self.response
     }
 }
 
-impl Accessor<http_compat::Response<ResponseBody>> for RhaiRouterResponse {
-    fn accessor(&self) -> &http_compat::Response<ResponseBody> {
+impl Accessor<http_ext::Response<ResponseBody>> for RhaiRouterResponse {
+    fn accessor(&self) -> &http_ext::Response<ResponseBody> {
         &self.response
     }
 
-    fn accessor_mut(&mut self) -> &mut http_compat::Response<ResponseBody> {
+    fn accessor_mut(&mut self) -> &mut http_ext::Response<ResponseBody> {
         &mut self.response
     }
 }
 
-impl Accessor<http_compat::Response<BoxStream<'static, Response>>>
+impl Accessor<http_ext::Response<BoxStream<'static, Response>>>
     for ExecutionResponse<BoxStream<'static, Response>>
 {
-    fn accessor(&self) -> &http_compat::Response<BoxStream<'static, Response>> {
+    fn accessor(&self) -> &http_ext::Response<BoxStream<'static, Response>> {
         &self.response
     }
 
-    fn accessor_mut(&mut self) -> &mut http_compat::Response<BoxStream<'static, Response>> {
+    fn accessor_mut(&mut self) -> &mut http_ext::Response<BoxStream<'static, Response>> {
         &mut self.response
     }
 }
 
-impl Accessor<http_compat::Response<Response>> for SubgraphResponse {
-    fn accessor(&self) -> &http_compat::Response<Response> {
+impl Accessor<http_ext::Response<Response>> for SubgraphResponse {
+    fn accessor(&self) -> &http_ext::Response<Response> {
         &self.response
     }
 
-    fn accessor_mut(&mut self) -> &mut http_compat::Response<Response> {
+    fn accessor_mut(&mut self) -> &mut http_ext::Response<Response> {
         &mut self.response
     }
 }
@@ -849,7 +849,7 @@ type SharedRouterRequest = Arc<Mutex<Option<RouterRequest>>>;
 
 pub(crate) struct RhaiRouterResponse {
     context: Context,
-    response: http_compat::Response<ResponseBody>,
+    response: http_ext::Response<ResponseBody>,
 }
 
 #[allow(dead_code)]
@@ -870,11 +870,11 @@ impl Accessor<Context> for RhaiRouterResponse {
         &mut self.context
     }
 }
-impl Accessor<http_compat::Request<Request>> for RouterRequest {
-    fn accessor(&self) -> &http_compat::Request<Request> {
+impl Accessor<http_ext::Request<Request>> for RouterRequest {
+    fn accessor(&self) -> &http_ext::Request<Request> {
         &self.originating_request
     }
-    fn accessor_mut(&mut self) -> &mut http_compat::Request<Request> {
+    fn accessor_mut(&mut self) -> &mut http_ext::Request<Request> {
         &mut self.originating_request
     }
 }
@@ -1742,7 +1742,7 @@ mod tests {
 
     use crate::plugin::DynPlugin;
     use crate::{
-        http_compat,
+        http_ext,
         plugin::test::{MockExecutionService, MockRouterService},
         Context, ResponseBody, RouterRequest, RouterResponse,
     };
@@ -1834,7 +1834,7 @@ mod tests {
             .unwrap();
         let mut router_service =
             dyn_plugin.execution_service(BoxService::new(mock_service.build()));
-        let fake_req = http_compat::Request::fake_builder()
+        let fake_req = http_ext::Request::fake_builder()
             .header("x-custom-header", "CUSTOM_VALUE")
             .body(crate::Request::builder().query(String::new()).build())
             .build()?;

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -1133,7 +1133,7 @@ impl ServiceStep {
 
                                 let response = RhaiRouterResponse {
                                     context,
-                                    response: http_compat::Response::from_parts(parts, first.expect("already checked")),
+                                    response: http::Response::from_parts(parts, first.expect("already checked")).into(),
                                 };
                                 let shared_response =
                                 Shared::new(Mutex::new(Some(response)));
@@ -1175,7 +1175,7 @@ impl ServiceStep {
                                 let (parts, body)  = response.into_parts();
 
                                 //FIXME we should also map over the stream of future responses
-                                let response = http_compat::Response::from_parts(parts,once(ready(body)).chain(rest).boxed());
+                                let response = http::Response::from_parts(parts,once(ready(body)).chain(rest).boxed()).into();
                                 Ok(RouterResponse {context, response})
                             },
                         ))
@@ -1232,10 +1232,11 @@ impl ServiceStep {
 
                                 let response = RhaiExecutionResponse {
                                     context,
-                                    response: http_compat::Response::from_parts(
+                                    response: http::Response::from_parts(
                                         parts,
                                         first.expect("already checked"),
-                                    ),
+                                    )
+                                    .into(),
                                 };
                                 let shared_response = Shared::new(Mutex::new(Some(response)));
                                 let result: Result<Dynamic, String> = if callback.is_curried() {
@@ -1276,10 +1277,11 @@ impl ServiceStep {
                                 let (parts, body) = response.into_parts();
 
                                 //FIXME we should also map over the stream of future responses
-                                let response = http_compat::Response::from_parts(
+                                let response = http::Response::from_parts(
                                     parts,
                                     once(ready(body)).chain(rest).boxed(),
-                                );
+                                )
+                                .into();
                                 Ok(ExecutionResponse { context, response })
                             },
                         )

--- a/apollo-router/src/plugins/telemetry/metrics/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/mod.rs
@@ -2,7 +2,7 @@ use crate::plugin::serde::{deserialize_header_name, deserialize_regex};
 use crate::plugin::Handler;
 use crate::plugins::telemetry::config::MetricsCommon;
 use crate::plugins::telemetry::metrics::apollo::Sender;
-use crate::{http_compat, ResponseBody};
+use crate::{http_ext, ResponseBody};
 use ::serde::Deserialize;
 use bytes::Bytes;
 use http::header::HeaderName;
@@ -22,7 +22,7 @@ pub(crate) mod prometheus;
 
 pub(crate) type MetricsExporterHandle = Box<dyn Any + Send + Sync + 'static>;
 pub(crate) type CustomEndpoint =
-    BoxService<http_compat::Request<Bytes>, http_compat::Response<ResponseBody>, BoxError>;
+    BoxService<http_ext::Request<Bytes>, http_ext::Response<ResponseBody>, BoxError>;
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
@@ -1,6 +1,6 @@
 use crate::plugins::telemetry::config::MetricsCommon;
 use crate::plugins::telemetry::metrics::{MetricsBuilder, MetricsConfigurator};
-use crate::{http_compat, ResponseBody};
+use crate::{http_ext, ResponseBody};
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use http::StatusCode;
@@ -71,8 +71,8 @@ pub(crate) struct PrometheusService {
     registry: Registry,
 }
 
-impl Service<http_compat::Request<Bytes>> for PrometheusService {
-    type Response = http_compat::Response<ResponseBody>;
+impl Service<http_ext::Request<Bytes>> for PrometheusService {
+    type Response = http_ext::Response<ResponseBody>;
     type Error = BoxError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
@@ -80,13 +80,13 @@ impl Service<http_compat::Request<Bytes>> for PrometheusService {
         Ok(()).into()
     }
 
-    fn call(&mut self, _req: http_compat::Request<Bytes>) -> Self::Future {
+    fn call(&mut self, _req: http_ext::Request<Bytes>) -> Self::Future {
         let metric_families = self.registry.gather();
         Box::pin(async move {
             let encoder = TextEncoder::new();
             let mut result = Vec::new();
             encoder.encode(&metric_families, &mut result)?;
-            Ok(http_compat::Response {
+            Ok(http_ext::Response {
                 inner: http::Response::builder()
                     .status(StatusCode::OK)
                     .body(ResponseBody::Text(

--- a/apollo-router/src/plugins/traffic_shaping/deduplication.rs
+++ b/apollo-router/src/plugins/traffic_shaping/deduplication.rs
@@ -3,7 +3,7 @@
 //! See [`Layer`] and [`tower::Service`] for more details.
 
 use crate::query_planner::fetch::OperationKind;
-use crate::{http_compat, Request, SubgraphRequest, SubgraphResponse};
+use crate::{http_ext, Request, SubgraphRequest, SubgraphResponse};
 use futures::{future::BoxFuture, lock::Mutex};
 use std::{collections::HashMap, sync::Arc, task::Poll};
 use tokio::sync::{
@@ -27,7 +27,7 @@ where
 }
 
 type WaitMap =
-    Arc<Mutex<HashMap<http_compat::Request<Request>, Sender<Result<SubgraphResponse, String>>>>>;
+    Arc<Mutex<HashMap<http_ext::Request<Request>, Sender<Result<SubgraphResponse, String>>>>>;
 
 pub(crate) struct QueryDeduplicationService<S> {
     service: S,

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -522,16 +522,18 @@ pub(crate) mod fetch {
                 .expect("we already checked that the service exists during planning; qed");
 
             // TODO not sure if we need a RouterReponse here as we don't do anything with it
-            let (_parts, response) = service
-                .oneshot(subgraph_request)
-                .instrument(tracing::trace_span!("subfetch_stream"))
-                .await
-                .map_err(|e| FetchError::SubrequestHttpError {
-                    service: service_name.to_string(),
-                    reason: e.to_string(),
-                })?
-                .response
-                .into_parts();
+            let (_parts, response) = http::Response::from(
+                service
+                    .oneshot(subgraph_request)
+                    .instrument(tracing::trace_span!("subfetch_stream"))
+                    .await
+                    .map_err(|e| FetchError::SubrequestHttpError {
+                        service: service_name.to_string(),
+                        reason: e.to_string(),
+                    })?
+                    .response,
+            )
+            .into_parts();
 
             super::log::trace_subfetch(service_name, operation, &variables, &response);
 
@@ -724,7 +726,11 @@ mod tests {
                         .buffer(1)
                         .service(mock_products_service.build().boxed()),
                 )])),
-                http_compat::Request::mock(),
+                http_compat::Request::fake_builder()
+                    .headers(Default::default())
+                    .body(Default::default())
+                    .build()
+                    .expect("fake builds should always work; qed"),
                 &Schema::from_str(test_schema!()).unwrap(),
                 sender,
             )
@@ -775,7 +781,11 @@ mod tests {
                         .buffer(1)
                         .service(mock_products_service.build().boxed()),
                 )])),
-                http_compat::Request::mock(),
+                http_compat::Request::fake_builder()
+                    .headers(Default::default())
+                    .body(Default::default())
+                    .build()
+                    .expect("fake builds should always work; qed"),
                 &Schema::from_str(test_schema!()).unwrap(),
                 sender,
             )
@@ -820,7 +830,11 @@ mod tests {
                         .buffer(1)
                         .service(mock_products_service.build().boxed()),
                 )])),
-                http_compat::Request::mock(),
+                http_compat::Request::fake_builder()
+                    .headers(Default::default())
+                    .body(Default::default())
+                    .build()
+                    .expect("fake builds should always work; qed"),
                 &Schema::from_str(test_schema!()).unwrap(),
                 sender,
             )

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -113,7 +113,7 @@ impl QueryPlan {
         &self,
         context: &'a Context,
         service_registry: &'a ServiceRegistry,
-        originating_request: http_compat::Request<Request>,
+        originating_request: http_ext::Request<Request>,
         schema: &'a Schema,
         mut sender: futures::channel::mpsc::Sender<Response>,
     ) {
@@ -152,7 +152,7 @@ impl PlanNode {
         context: &'a Context,
         service_registry: &'a ServiceRegistry,
         schema: &'a Schema,
-        originating_request: http_compat::Request<Request>,
+        originating_request: http_ext::Request<Request>,
         parent_value: &'a Value,
         options: &'a QueryPlanOptions,
     ) -> future::BoxFuture<(Value, Vec<Error>)> {
@@ -372,7 +372,7 @@ pub(crate) mod fetch {
             variable_usages: &[String],
             data: &Value,
             current_dir: &Path,
-            request: http_compat::Request<crate::Request>,
+            request: http_ext::Request<crate::Request>,
             schema: &Schema,
             enable_variable_deduplication: bool,
         ) -> Option<Variables> {
@@ -454,7 +454,7 @@ pub(crate) mod fetch {
             current_dir: &'a Path,
             context: &'a Context,
             service_registry: &'a ServiceRegistry,
-            originating_request: http_compat::Request<Request>,
+            originating_request: http_ext::Request<Request>,
             schema: &'a Schema,
             options: &QueryPlanOptions,
         ) -> Result<(Value, Vec<Error>), FetchError> {
@@ -487,7 +487,7 @@ pub(crate) mod fetch {
             let subgraph_request = SubgraphRequest::builder()
                 .originating_request(Arc::new(originating_request))
                 .subgraph_request(
-                    http_compat::Request::builder()
+                    http_ext::Request::builder()
                         .method(http::Method::POST)
                         .uri(
                             schema
@@ -726,7 +726,7 @@ mod tests {
                         .buffer(1)
                         .service(mock_products_service.build().boxed()),
                 )])),
-                http_compat::Request::fake_builder()
+                http_ext::Request::fake_builder()
                     .headers(Default::default())
                     .body(Default::default())
                     .build()
@@ -781,7 +781,7 @@ mod tests {
                         .buffer(1)
                         .service(mock_products_service.build().boxed()),
                 )])),
-                http_compat::Request::fake_builder()
+                http_ext::Request::fake_builder()
                     .headers(Default::default())
                     .body(Default::default())
                     .build()
@@ -830,7 +830,7 @@ mod tests {
                         .buffer(1)
                         .service(mock_products_service.build().boxed()),
                 )])),
-                http_compat::Request::fake_builder()
+                http_ext::Request::fake_builder()
                     .headers(Default::default())
                     .body(Default::default())
                     .build()

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -5,7 +5,7 @@ use crate::plugin::DynPlugin;
 use crate::services::Plugins;
 use crate::SubgraphService;
 use crate::{
-    http_compat::{Request, Response},
+    http_ext::{Request, Response},
     PluggableRouterServiceBuilder, ResponseBody, Schema,
 };
 use envmnt::types::ExpandOptions;

--- a/apollo-router/src/services/http_ext.rs
+++ b/apollo-router/src/services/http_ext.rs
@@ -323,7 +323,7 @@ impl IntoResponse for Response<Bytes> {
 
 #[cfg(test)]
 mod test {
-    use crate::http_compat::Request;
+    use crate::http_ext::Request;
     use http::{HeaderValue, Method, Uri};
 
     #[test]

--- a/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
+++ b/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
@@ -60,7 +60,7 @@ where
 mod forbid_http_get_mutations_tests {
     use super::*;
     use crate::error::Error;
-    use crate::http_compat;
+    use crate::http_ext;
     use crate::plugin::test::MockExecutionService;
     use crate::query_planner::{fetch::OperationKind, PlanNode, QueryPlan};
 
@@ -218,7 +218,7 @@ mod forbid_http_get_mutations_tests {
             .unwrap()
         };
 
-        let request = http_compat::Request::fake_builder()
+        let request = http_ext::Request::fake_builder()
             .method(method)
             .body(crate::Request::default())
             .build()

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -486,8 +486,22 @@ impl SubgraphRequest {
         context: Option<Context>,
     ) -> SubgraphRequest {
         SubgraphRequest::new(
-            originating_request.unwrap_or_else(|| Arc::new(http_compat::Request::mock())),
-            subgraph_request.unwrap_or_else(http_compat::Request::mock),
+            originating_request.unwrap_or_else(|| {
+                Arc::new(
+                    http_compat::Request::fake_builder()
+                        .headers(Default::default())
+                        .body(Default::default())
+                        .build()
+                        .expect("fake builds should always work; qed"),
+                )
+            }),
+            subgraph_request.unwrap_or_else(|| {
+                http_compat::Request::fake_builder()
+                    .headers(Default::default())
+                    .body(Default::default())
+                    .build()
+                    .expect("fake builds should always work; qed")
+            }),
             operation_kind.unwrap_or(OperationKind::Query),
             context.unwrap_or_default(),
         )
@@ -647,7 +661,13 @@ impl ExecutionRequest {
         context: Option<Context>,
     ) -> ExecutionRequest {
         ExecutionRequest::new(
-            originating_request.unwrap_or_else(http_compat::Request::mock),
+            originating_request.unwrap_or_else(|| {
+                http_compat::Request::fake_builder()
+                    .headers(Default::default())
+                    .body(Default::default())
+                    .build()
+                    .expect("fake builds should always work; qed")
+            }),
             Arc::new(query_plan.unwrap_or_else(|| QueryPlan::fake_builder().build())),
             context.unwrap_or_default(),
         )

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -15,8 +15,8 @@ use futures::{
 };
 use http::{header::HeaderName, HeaderValue, StatusCode};
 use http::{method::Method, Uri};
-use http_compat::IntoHeaderName;
-use http_compat::IntoHeaderValue;
+use http_ext::IntoHeaderName;
+use http_ext::IntoHeaderValue;
 use multimap::MultiMap;
 use serde::{Deserialize, Serialize};
 use serde_json_bytes::ByteString;
@@ -29,7 +29,7 @@ pub use subgraph_service::SubgraphService;
 use tower::BoxError;
 
 mod execution_service;
-pub mod http_compat;
+pub mod http_ext;
 pub(crate) mod layers;
 mod router_service;
 pub(crate) mod subgraph_service;
@@ -120,14 +120,14 @@ assert_impl_all!(RouterRequest: Send);
 /// This consists of the parsed graphql Request, HTTP headers and contextual data for extensions.
 pub struct RouterRequest {
     /// Original request to the Router.
-    pub originating_request: http_compat::Request<Request>,
+    pub originating_request: http_ext::Request<Request>,
 
     /// Context for extension
     pub context: Context,
 }
 
-impl From<http_compat::Request<Request>> for RouterRequest {
-    fn from(originating_request: http_compat::Request<Request>) -> Self {
+impl From<http_ext::Request<Request>> for RouterRequest {
+    fn from(originating_request: http_ext::Request<Request>) -> Self {
         Self {
             originating_request,
             context: Context::new(),
@@ -169,7 +169,7 @@ impl RouterRequest {
             .extensions(extensions)
             .build();
 
-        let originating_request = http_compat::Request::builder()
+        let originating_request = http_ext::Request::builder()
             .headers(headers)
             .uri(uri)
             .method(method)
@@ -212,12 +212,12 @@ impl RouterRequest {
 }
 
 assert_impl_all!(RouterResponse<BoxStream<'static, ResponseBody>>: Send);
-/// [`Context`] and [`http_compat::Response<ResponseBody>`] for the response.
+/// [`Context`] and [`http_ext::Response<ResponseBody>`] for the response.
 ///
 /// This consists of the response body and the context.
 #[derive(Clone, Debug)]
 pub struct RouterResponse<T: Stream<Item = ResponseBody>> {
-    pub response: http_compat::Response<T>,
+    pub response: http_ext::Response<T>,
     pub context: Context,
 }
 
@@ -264,7 +264,7 @@ impl RouterResponse<Once<Ready<ResponseBody>>> {
         let http_response = builder.body(once(ready(ResponseBody::GraphQL(res))))?;
 
         // Create a compatible Response
-        let compat_response = http_compat::Response {
+        let compat_response = http_ext::Response {
             inner: http_response,
         };
 
@@ -339,7 +339,7 @@ impl<T: Stream<Item = ResponseBody> + Send + Unpin + 'static> RouterResponse<T> 
 }
 
 impl<T: Stream<Item = ResponseBody> + Send + 'static> RouterResponse<T> {
-    pub fn new_from_response(response: http_compat::Response<T>, context: Context) -> Self {
+    pub fn new_from_response(response: http_ext::Response<T>, context: Context) -> Self {
         Self { response, context }
     }
 
@@ -363,7 +363,7 @@ assert_impl_all!(QueryPlannerRequest: Send);
 #[derive(Clone, Debug)]
 pub struct QueryPlannerRequest {
     /// Original request to the Router.
-    pub originating_request: http_compat::Request<Request>,
+    pub originating_request: http_ext::Request<Request>,
     /// Query plan options
     pub query_plan_options: QueryPlanOptions,
 
@@ -377,7 +377,7 @@ impl QueryPlannerRequest {
     /// Required parameters are required in non-testing code to create a QueryPlannerRequest.
     #[builder]
     pub fn new(
-        originating_request: http_compat::Request<Request>,
+        originating_request: http_ext::Request<Request>,
         query_plan_options: QueryPlanOptions,
         context: Context,
     ) -> QueryPlannerRequest {
@@ -441,12 +441,12 @@ impl QueryPlannerResponse {
 }
 
 assert_impl_all!(SubgraphRequest: Send);
-/// [`Context`], [`OperationKind`] and [`http_compat::Request<Request>`] for the request.
+/// [`Context`], [`OperationKind`] and [`http_ext::Request<Request>`] for the request.
 pub struct SubgraphRequest {
     /// Original request to the Router.
-    pub originating_request: Arc<http_compat::Request<Request>>,
+    pub originating_request: Arc<http_ext::Request<Request>>,
 
-    pub subgraph_request: http_compat::Request<Request>,
+    pub subgraph_request: http_ext::Request<Request>,
 
     pub operation_kind: OperationKind,
 
@@ -460,8 +460,8 @@ impl SubgraphRequest {
     /// Required parameters are required in non-testing code to create a SubgraphRequest.
     #[builder]
     pub fn new(
-        originating_request: Arc<http_compat::Request<Request>>,
-        subgraph_request: http_compat::Request<Request>,
+        originating_request: Arc<http_ext::Request<Request>>,
+        subgraph_request: http_ext::Request<Request>,
         operation_kind: OperationKind,
         context: Context,
     ) -> SubgraphRequest {
@@ -480,15 +480,15 @@ impl SubgraphRequest {
     /// difficult to construct and not required for the pusposes of the test.
     #[builder]
     pub fn fake_new(
-        originating_request: Option<Arc<http_compat::Request<Request>>>,
-        subgraph_request: Option<http_compat::Request<Request>>,
+        originating_request: Option<Arc<http_ext::Request<Request>>>,
+        subgraph_request: Option<http_ext::Request<Request>>,
         operation_kind: Option<OperationKind>,
         context: Option<Context>,
     ) -> SubgraphRequest {
         SubgraphRequest::new(
             originating_request.unwrap_or_else(|| {
                 Arc::new(
-                    http_compat::Request::fake_builder()
+                    http_ext::Request::fake_builder()
                         .headers(Default::default())
                         .body(Default::default())
                         .build()
@@ -496,7 +496,7 @@ impl SubgraphRequest {
                 )
             }),
             subgraph_request.unwrap_or_else(|| {
-                http_compat::Request::fake_builder()
+                http_ext::Request::fake_builder()
                     .headers(Default::default())
                     .body(Default::default())
                     .build()
@@ -509,12 +509,12 @@ impl SubgraphRequest {
 }
 
 assert_impl_all!(SubgraphResponse: Send);
-/// [`Context`] and [`http_compat::Response<Response>`] for the response.
+/// [`Context`] and [`http_ext::Response<Response>`] for the response.
 ///
 /// This consists of the subgraph response and the context.
 #[derive(Clone, Debug)]
 pub struct SubgraphResponse {
-    pub response: http_compat::Response<Response>,
+    pub response: http_ext::Response<Response>,
 
     pub context: Context,
 }
@@ -526,7 +526,7 @@ impl SubgraphResponse {
     /// In this case, you already have a valid response and just wish to associate it with a context
     /// and create a SubgraphResponse.
     pub fn new_from_response(
-        response: http_compat::Response<Response>,
+        response: http_ext::Response<Response>,
         context: Context,
     ) -> SubgraphResponse {
         Self { response, context }
@@ -562,7 +562,7 @@ impl SubgraphResponse {
             .expect("Response is serializable; qed");
 
         // Create a compatible Response
-        let compat_response = http_compat::Response {
+        let compat_response = http_ext::Response {
             inner: http_response,
         };
 
@@ -623,7 +623,7 @@ assert_impl_all!(ExecutionRequest: Send);
 /// [`Context`] and [`QueryPlan`] for the request.
 pub struct ExecutionRequest {
     /// Original request to the Router.
-    pub originating_request: http_compat::Request<Request>,
+    pub originating_request: http_ext::Request<Request>,
 
     pub query_plan: Arc<QueryPlan>,
 
@@ -638,7 +638,7 @@ impl ExecutionRequest {
     /// set and be correct to create a ExecutionRequest.
     #[builder]
     pub fn new(
-        originating_request: http_compat::Request<Request>,
+        originating_request: http_ext::Request<Request>,
         query_plan: Arc<QueryPlan>,
         context: Context,
     ) -> ExecutionRequest {
@@ -656,13 +656,13 @@ impl ExecutionRequest {
     /// difficult to construct and not required for the pusposes of the test.
     #[builder]
     pub fn fake_new(
-        originating_request: Option<http_compat::Request<Request>>,
+        originating_request: Option<http_ext::Request<Request>>,
         query_plan: Option<QueryPlan>,
         context: Option<Context>,
     ) -> ExecutionRequest {
         ExecutionRequest::new(
             originating_request.unwrap_or_else(|| {
-                http_compat::Request::fake_builder()
+                http_ext::Request::fake_builder()
                     .headers(Default::default())
                     .body(Default::default())
                     .build()
@@ -675,11 +675,11 @@ impl ExecutionRequest {
 }
 
 assert_impl_all!(ExecutionResponse<BoxStream<'static, Response>>: Send);
-/// [`Context`] and [`http_compat::Response<Response>`] for the response.
+/// [`Context`] and [`http_ext::Response<Response>`] for the response.
 ///
 /// This consists of the execution response and the context.
 pub struct ExecutionResponse<T: Stream<Item = Response>> {
-    pub response: http_compat::Response<T>,
+    pub response: http_ext::Response<T>,
 
     pub context: Context,
 }
@@ -716,7 +716,7 @@ impl ExecutionResponse<Once<Ready<Response>>> {
             .expect("Response is serializable; qed");
 
         // Create a compatible Response
-        let compat_response = http_compat::Response {
+        let compat_response = http_ext::Response {
             inner: http_response,
         };
 
@@ -780,7 +780,7 @@ impl<T: Stream<Item = Response> + Send + 'static> ExecutionResponse<T> {
     ///
     /// In this case, you already have a valid request and just wish to associate it with a context
     /// and create a ExecutionResponse.
-    pub fn new_from_response(response: http_compat::Response<T>, context: Context) -> Self {
+    pub fn new_from_response(response: http_ext::Response<T>, context: Context) -> Self {
         Self { response, context }
     }
 
@@ -805,13 +805,13 @@ impl<T: Stream<Item = Response> + Send + Unpin + 'static> ExecutionResponse<T> {
     }
 }
 
-impl AsRef<Request> for http_compat::Request<Request> {
+impl AsRef<Request> for http_ext::Request<Request> {
     fn as_ref(&self) -> &Request {
         self.body()
     }
 }
 
-impl AsRef<Request> for Arc<http_compat::Request<Request>> {
+impl AsRef<Request> for Arc<http_ext::Request<Request>> {
     fn as_ref(&self) -> &Request {
         self.body()
     }

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -173,7 +173,7 @@ where
                             )
                             .await?;
 
-                        let (parts, response_stream) = response.into_parts();
+                        let (parts, response_stream) = http::Response::from(response).into_parts();
                         Ok(RouterResponse {
                             context,
                             response: http::Response::from_parts(

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -176,7 +176,7 @@ where
                         let (parts, response_stream) = response.into_parts();
                         Ok(RouterResponse {
                             context,
-                            response: crate::http_compat::Response::from_parts(
+                            response: http::Response::from_parts(
                                 parts,
                                 response_stream
                                     .map(move |mut response: Response| {
@@ -191,7 +191,8 @@ where
                                         ResponseBody::GraphQL(response)
                                     })
                                     .in_current_span(),
-                            ),
+                            )
+                            .into(),
                         }
                         .boxed())
                     }

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -263,7 +263,7 @@ mod tests {
     use tower::{service_fn, ServiceExt};
 
     use crate::query_planner::fetch::OperationKind;
-    use crate::{http_compat, json_ext::Object, Context, Request, Response, SubgraphRequest};
+    use crate::{http_ext, json_ext::Object, Context, Request, Response, SubgraphRequest};
 
     use super::*;
 
@@ -363,14 +363,14 @@ mod tests {
         let err = subgraph_service
             .oneshot(SubgraphRequest {
                 originating_request: Arc::new(
-                    http_compat::Request::fake_builder()
+                    http_ext::Request::fake_builder()
                         .header(HOST, "host")
                         .header(CONTENT_TYPE, "application/json")
                         .body(Request::builder().query("query").build())
                         .build()
                         .expect("expecting valid request"),
                 ),
-                subgraph_request: http_compat::Request::fake_builder()
+                subgraph_request: http_ext::Request::fake_builder()
                     .header(HOST, "rhost")
                     .header(CONTENT_TYPE, "application/json")
                     .uri(url)
@@ -398,14 +398,14 @@ mod tests {
         let err = subgraph_service
             .oneshot(SubgraphRequest {
                 originating_request: Arc::new(
-                    http_compat::Request::fake_builder()
+                    http_ext::Request::fake_builder()
                         .header(HOST, "host")
                         .header(CONTENT_TYPE, "application/json")
                         .body(Request::builder().query("query").build())
                         .build()
                         .expect("expecting valid request"),
                 ),
-                subgraph_request: http_compat::Request::fake_builder()
+                subgraph_request: http_ext::Request::fake_builder()
                     .header(HOST, "rhost")
                     .header(CONTENT_TYPE, "application/json")
                     .uri(url)
@@ -433,14 +433,14 @@ mod tests {
         let resp = subgraph_service
             .oneshot(SubgraphRequest {
                 originating_request: Arc::new(
-                    http_compat::Request::fake_builder()
+                    http_ext::Request::fake_builder()
                         .header(HOST, "host")
                         .header(CONTENT_TYPE, "application/json")
                         .body(Request::builder().query("query".to_string()).build())
                         .build()
                         .expect("expecting valid request"),
                 ),
-                subgraph_request: http_compat::Request::fake_builder()
+                subgraph_request: http_ext::Request::fake_builder()
                     .header(HOST, "rhost")
                     .header(CONTENT_TYPE, "application/json")
                     .header(CONTENT_ENCODING, "gzip")

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -89,7 +89,7 @@ impl tower::Service<crate::SubgraphRequest> for SubgraphService {
         let service_name = (*self.service).to_owned();
 
         Box::pin(async move {
-            let (parts, body) = subgraph_request.into_parts();
+            let (parts, body) = http::Request::from(subgraph_request).into_parts();
 
             let body = serde_json::to_string(&body).expect("JSON serialization should not fail");
 

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -388,7 +388,7 @@ impl<T> ResultExt<T> for Result<T, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::http_compat::{Request, Response};
+    use crate::http_ext::{Request, Response};
     use crate::http_server_factory::Listener;
     use crate::router_factory::RouterServiceFactory;
     use crate::ResponseBody;

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -2,7 +2,7 @@
 //! Please ensure that any tests added to this file use the tokio multi-threaded test executor.
 //!
 
-use apollo_router::http_compat;
+use apollo_router::http_ext;
 use apollo_router::json_ext::{Object, ValueExt};
 use apollo_router::plugin::Plugin;
 use apollo_router::plugins::csrf;
@@ -48,7 +48,7 @@ macro_rules! assert_federated_response {
             }
         };
 
-        let originating_request = http_compat::Request::fake_builder().method(Method::POST)
+        let originating_request = http_ext::Request::fake_builder().method(Method::POST)
             // otherwise the query would be a simple one,
             // and CSRF protection would reject it
             .header("content-type", "application/json")
@@ -111,7 +111,7 @@ async fn api_schema_hides_field() {
         ]))
         .build();
 
-    let originating_request = http_compat::Request::fake_builder()
+    let originating_request = http_ext::Request::fake_builder()
         .method(Method::POST)
         .header("content-type", "application/json")
         .body(request)
@@ -191,7 +191,7 @@ async fn queries_should_work_over_get() {
         "accounts".to_string()=>1,
     };
 
-    let originating_request = http_compat::Request::fake_builder()
+    let originating_request = http_ext::Request::fake_builder()
         .body(request)
         .header("content-type", "application/json")
         .build()
@@ -221,7 +221,7 @@ async fn simple_queries_should_not_work() {
         ]))
         .build();
 
-    let originating_request = http_compat::Request::fake_builder()
+    let originating_request = http_ext::Request::fake_builder()
         .body(request)
         .build()
         .expect("expecting valid request");
@@ -256,7 +256,7 @@ async fn queries_should_work_with_compression() {
         "accounts".to_string()=>1,
     };
 
-    let http_request = http_compat::Request::fake_builder()
+    let http_request = http_ext::Request::fake_builder()
         .method(Method::POST)
         .header("content-type", "application/json")
         .header("accept-encoding", "gzip")
@@ -291,7 +291,7 @@ async fn queries_should_work_over_post() {
         "accounts".to_string()=>1,
     };
 
-    let http_request = http_compat::Request::fake_builder()
+    let http_request = http_ext::Request::fake_builder()
         .method(Method::POST)
         .header("content-type", "application/json")
         .body(request)
@@ -323,7 +323,7 @@ async fn service_errors_should_be_propagated() {
 
     let expected_service_hits = hashmap! {};
 
-    let originating_request = http_compat::Request::fake_builder()
+    let originating_request = http_ext::Request::fake_builder()
         .body(request)
         .header("content-type", "application/json")
         .build()
@@ -362,7 +362,7 @@ async fn mutation_should_not_work_over_get() {
     // No services should be queried
     let expected_service_hits = hashmap! {};
 
-    let originating_request = http_compat::Request::fake_builder()
+    let originating_request = http_ext::Request::fake_builder()
         .body(request)
         .header("content-type", "application/json")
         .build()
@@ -403,7 +403,7 @@ async fn mutation_should_work_over_post() {
         "reviews".to_string()=>2,
     };
 
-    let http_request = http_compat::Request::fake_builder()
+    let http_request = http_ext::Request::fake_builder()
         .method(Method::POST)
         .header("content-type", "application/json")
         .body(request)
@@ -457,7 +457,7 @@ async fn automated_persisted_queries() {
     // No services should be queried
     let expected_service_hits = hashmap! {};
 
-    let originating_request = http_compat::Request::fake_builder()
+    let originating_request = http_ext::Request::fake_builder()
         .body(apq_only_request)
         .header("content-type", "application/json")
         .build()
@@ -481,7 +481,7 @@ async fn automated_persisted_queries() {
         "accounts".to_string()=>1,
     };
 
-    let originating_request = http_compat::Request::fake_builder()
+    let originating_request = http_ext::Request::fake_builder()
         .body(apq_request_with_query)
         .header("content-type", "application/json")
         .build()
@@ -500,7 +500,7 @@ async fn automated_persisted_queries() {
         "accounts".to_string()=>2,
     };
 
-    let originating_request = http_compat::Request::fake_builder()
+    let originating_request = http_ext::Request::fake_builder()
         .body(apq_only_request)
         .header("content-type", "application/json")
         .build()
@@ -557,7 +557,7 @@ async fn missing_variables() {
         )
         .build();
 
-    let originating_request = http_compat::Request::fake_builder()
+    let originating_request = http_ext::Request::fake_builder()
         .method(Method::POST)
         .header("content-type", "application/json")
         .body(request)

--- a/apollo-router/tests/rhai_tests.rs
+++ b/apollo-router/tests/rhai_tests.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 use std::sync::Arc;
 
-use apollo_router::http_compat;
+use apollo_router::http_ext;
 use apollo_router::plugin::{plugins, DynPlugin};
 use apollo_router::services::{PluggableRouterServiceBuilder, SubgraphService};
 use apollo_router::Request;
@@ -45,7 +45,7 @@ async fn all_rhai_callbacks_are_invoked() {
     }
     let (router, _) = builder.build().await.unwrap();
 
-    let request = http_compat::Request::fake_builder()
+    let request = http_ext::Request::fake_builder()
         .body(
             Request::builder()
                 .query(r#"{ topProducts { name } }"#.to_string())

--- a/examples/cookies-to-headers/src/main.rs
+++ b/examples/cookies-to-headers/src/main.rs
@@ -87,8 +87,16 @@ mod tests {
 
         let service_stack = rhai.subgraph_service("mock", mock_service.boxed());
 
-        let mut sub_request = http_compat::Request::mock();
-        let mut originating_request = http_compat::Request::mock();
+        let mut sub_request = http_compat::Request::fake_builder()
+            .headers(Default::default())
+            .body(Default::default())
+            .build()
+            .expect("fake builds should always work; qed");
+        let mut originating_request = http_compat::Request::fake_builder()
+            .headers(Default::default())
+            .body(Default::default())
+            .build()
+            .expect("fake builds should always work; qed");
 
         let headers = vec![(
             HeaderName::from_static("cookie"),
@@ -118,7 +126,8 @@ mod tests {
         assert_eq!(StatusCode::OK, service_response.response.status());
 
         // with the expected message
-        let graphql_response: apollo_router::Response = service_response.response.into_body();
+        let graphql_response: apollo_router::Response =
+            http::Response::from(service_response.response).into_body();
 
         assert!(graphql_response.errors.is_empty());
         assert_eq!(expected_mock_response_data, graphql_response.data.unwrap())

--- a/examples/cookies-to-headers/src/main.rs
+++ b/examples/cookies-to-headers/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use apollo_router::http_compat;
+    use apollo_router::http_ext;
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
     use apollo_router::plugins::rhai::{Conf, Rhai};
@@ -87,12 +87,12 @@ mod tests {
 
         let service_stack = rhai.subgraph_service("mock", mock_service.boxed());
 
-        let mut sub_request = http_compat::Request::fake_builder()
+        let mut sub_request = http_ext::Request::fake_builder()
             .headers(Default::default())
             .body(Default::default())
             .build()
             .expect("fake builds should always work; qed");
-        let mut originating_request = http_compat::Request::fake_builder()
+        let mut originating_request = http_ext::Request::fake_builder()
             .headers(Default::default())
             .body(Default::default())
             .build()


### PR DESCRIPTION
Summary:
 - rename `http_compat` module to `http_ext`
 - remove Request::mock()
 - remove various wrapper fn and replace with explicit conversion using `From`

fix #1147 

