### PR TITLE
fix fragment selection on interfaces

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -13,7 +13,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## 🐛 Fixes
 ## 🛠 Maintenance
 ## 📚 Documentation
-## 🐛 Fixes
 
 ## Example section entry format
 
@@ -263,6 +262,10 @@ By [@garypen](https://github.com/garypen) in https://github.com/apollographql/ro
 
 ### Support introspection object types ([PR #1240](https://github.com/apollographql/router/pull/1240))
 
+Introspection queries can use a set of object types defined in the specification. The query parsing code was not recognizing them,
+resulting in some introspection queries not working.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1240
 
 ### Update the scaffold template so it works with streams ([#1247](https://github.com/apollographql/router/issues/1247))
 
@@ -272,10 +275,12 @@ This Pull request updates the scaffold template so it generates plugins that are
 By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1248
 
 
-Introspection queries can use a set of object types defined in the specification. The query parsing code was not recognizing them,
-resulting in some introspection queries not working.
+### Fix fragment selection on interfaces ([PR #1295](https://github.com/apollographql/router/pull/1295))
 
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1240
+Fragments type conditions were not checked correctly on interfaces, resulting in invalid null fields added to the response
+or valid data being nullified.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1295
 
 ## 🛠 Maintenance ( :hammer_and_wrench: )
 

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -446,11 +446,9 @@ impl Query {
                         let is_apply = if let Some(input_type) =
                             input.get(TYPENAME).and_then(|val| val.as_str())
                         {
-                            //First determine if fragment is for interface
-                            //Otherwise we assume concrete type is expected
-                            if let Some(interface) = known_type
-                                .as_deref()
-                                .and_then(|known_type| schema.interfaces.get(known_type))
+                            // First determine if the fragment matches an interface
+                            // Otherwise we assume a concrete type is expected
+                            if let Some(interface) = schema.interfaces.get(&fragment.type_condition)
                             {
                                 //Check if input implements interface
                                 schema.is_subtype(interface.name.as_str(), input_type)
@@ -4569,6 +4567,155 @@ mod tests {
                 },
                 "test_enum": null,
                 "test_enum2": "Z"
+            }},
+        );
+    }
+
+    #[test]
+    fn fragment_on_interface() {
+        let schema = "type Query
+        {
+            test_interface: Interface
+        }
+
+        interface Interface {
+            foo: String
+        }
+
+        type MyTypeA implements Interface {
+            foo: String
+            something: String
+        }
+
+        type MyTypeB implements Interface {
+            foo: String
+            somethingElse: String!
+        }
+        ";
+
+        assert_format_response_fed2!(
+            schema,
+            "query  {
+                test_interface {
+                    __typename
+                    foo
+                    ...FragmentA
+                }
+            }
+
+            fragment FragmentA on MyTypeA {
+                something
+            }
+
+            fragment FragmentB on MyTypeB {
+                somethingElse
+            }",
+            json! {{
+                "test_interface": {
+                    "__typename": "MyTypeA",
+                    "foo": "bar",
+                    "something": "something"
+                }
+            }},
+            None,
+            json! {{
+                "test_interface": {
+                    "__typename": "MyTypeA",
+                    "foo": "bar",
+                    "something": "something"
+                }
+            }},
+        );
+
+        assert_format_response_fed2!(
+            schema,
+            "query  {
+                test_interface {
+                    __typename
+                    ...FragmentI
+                }
+            }
+
+            fragment FragmentI on Interface {
+                foo
+            }
+            ",
+            json! {{
+                "test_interface": {
+                    "__typename": "MyTypeA",
+                    "foo": "bar"
+                }
+            }},
+            None,
+            json! {{
+                "test_interface": {
+                    "__typename": "MyTypeA",
+                    "foo": "bar"
+                }
+            }},
+        );
+
+        assert_format_response_fed2!(
+            schema,
+            "query  {
+                test_interface {
+                    __typename
+                    foo
+                    ... on MyTypeA {
+                        something
+                    }
+                    ... on MyTypeB {
+                        somethingElse
+                    }
+                }
+            }",
+            json! {{
+                "test_interface": {
+                    "__typename": "MyTypeA",
+                    "foo": "bar",
+                    "something": "something"
+                }
+            }},
+            None,
+            json! {{
+                "test_interface": {
+                    "__typename": "MyTypeA",
+                    "foo": "bar",
+                    "something": "something"
+                }
+            }},
+        );
+
+        assert_format_response_fed2!(
+            schema,
+            "query  {
+                test_interface {
+                    __typename
+                    foo
+                    ...FragmentB
+                }
+            }
+
+            fragment FragmentA on MyTypeA {
+                something
+            }
+
+            fragment FragmentB on MyTypeB {
+                somethingElse
+            }",
+            json! {{
+                "test_interface": {
+                    "__typename": "MyTypeA",
+                    "foo": "bar",
+                    "something": "something"
+                }
+            }},
+            None,
+            json! {{
+                "test_interface": {
+                    "__typename": "MyTypeA",
+                    "foo": "bar",
+                }
             }},
         );
     }


### PR DESCRIPTION
Fix #1286

the fragment's type condition was not checked on interfaces, and instead
was verifying that the known current type (the Interface type, know from
parsing the query) is a known interface, instead of looking up the
interface used in the type condition (if it's an interface) and matching
that to the actual object type