### PR TITLE
Restrict static introspection to only __schema and __type

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -262,6 +262,11 @@ By [@garypen](https://github.com/garypen) in https://github.com/apollographql/ro
 
 ## 🐛 Fixes
 
+### Restrict static introspection to only `__schema` and `__type` ([PR #1299](https://github.com/apollographql/router/pull/1299))
+Queries with selected field names starting with `__` are recognized as introspection queries. This includes `__schema`, `__type` and `__typename`. However, `__typename` is introspection at query time which is different from `__schema` and `__type` because two of the later can be answered with queries with empty input variables. This change will restrict introspection to only `__schema` and `__type`.
+
+By [@dingxiangfei2009](https://github.com/dingxiangfei2009) in https://github.com/apollographql/router/pull/1299
+
 ### Fix scaffold support ([PR #1293](https://github.com/apollographql/router/pull/1293))
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1293

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -727,7 +727,12 @@ impl Operation {
 
     fn is_introspection(&self) -> bool {
         self.selection_set.iter().all(|sel| match sel {
-            Selection::Field { name, .. } => name.as_str().starts_with("__"),
+            Selection::Field { name, .. } => {
+                let name = name.as_str();
+                // `__typename` can only be resolved in runtime,
+                // so this query cannot be seen as an introspection query
+                name == "__schema" || name == "__type"
+            }
             _ => false,
         })
     }


### PR DESCRIPTION
<!--
First, 🌠 thank you 🌠 for considering a contribution to Apollo!

Some of this information is also included in the /CONTRIBUTING.md file at the
root of this repository.  We suggest you read it!

  https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md

Here are some important details to keep in mind:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!  Documentation in the docs/ directory should be updated
        as necessary.  Finally, a /CHANGELOG.md entry should be added.

We hope you will find this to be a positive experience! Contribution can be
intimidating and we hope to alleviate that pain as much as possible. Without
following these guidelines, you may be missing context that can help you succeed
with your contribution, which is why we encourage discussion first. Ultimately,
there is no guarantee that we will be able to merge your pull-request, but by
following these guidelines we can try to avoid disappointment.

-->

This PR is related to apollographql/federation-rs#140.

Introspection field `__typename` is introspection in runtime, which attaches the type name of the select documents. However, it is incorrectly identified as static introspection like `__schema` or `__type("...")` which is executed as a query with empty parameters. Since `__typename` is purely runtime, identifying queries with `__typename` selected as introspection queries and executing them as such almost never works, especially if the queries have non-null parameters and an operation name must be taken in case there are multiple operations present.

This PR strict the set to `__schema` and `__type` only, excluding `__typename` even though the GraphQL terminology classifies it as is because it is a dynamic introspection depending on the actual query results.