### PR TITLE
Move apollo_router::{Request, Response, error::Error} to a new graphql module

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -33,7 +33,7 @@ such as the Request::mock() fn.
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1257
 
-### Rework the entire public API structure ([PR #1216](https://github.com/apollographql/router/pull/1216),  [PR #1242](https://github.com/apollographql/router/pull/1242),  [PR #1267](https://github.com/apollographql/router/pull/1267),  [PR #1277](https://github.com/apollographql/router/pull/1277))
+### Rework the entire public API structure ([PR #1216](https://github.com/apollographql/router/pull/1216),  [PR #1242](https://github.com/apollographql/router/pull/1242),  [PR #1267](https://github.com/apollographql/router/pull/1267),  [PR #1277](https://github.com/apollographql/router/pull/1277), [PR #1303](https://github.com/apollographql/router/pull/1303))
 
 * Many items have been removed from the public API and made private.
   If you still need some of them, please file an issue.
@@ -76,6 +76,7 @@ use apollo_router::ApolloRouter;
 use apollo_router::Configuration;
 use apollo_router::ConfigurationKind;
 use apollo_router::Context;
+use apollo_router::Error;
 use apollo_router::Executable;
 use apollo_router::Request;
 use apollo_router::Response;
@@ -83,17 +84,19 @@ use apollo_router::Schema;
 use apollo_router::SchemaKind;
 use apollo_router::ShutdownKind;
 use apollo_router::error::CacheResolverError;
-use apollo_router::error::Error;
 use apollo_router::error::FetchError;
 use apollo_router::error::JsonExtError;
 use apollo_router::error::Location;
-use apollo_router::error::NewErrorBuilder;
 use apollo_router::error::ParseErrors;
 use apollo_router::error::PlannerErrors;
 use apollo_router::error::QueryPlannerError;
 use apollo_router::error::SchemaError;
 use apollo_router::error::ServiceBuildError;
 use apollo_router::error::SpecError;
+use apollo_router::graphql::Error;
+use apollo_router::graphql::NewErrorBuilder;
+use apollo_router::graphql::Request;
+use apollo_router::graphql::Response;
 use apollo_router::json_ext::Object;
 use apollo_router::json_ext::Path;
 use apollo_router::json_ext::PathElement;

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -1,4 +1,3 @@
-use crate::json_ext::Object;
 use crate::json_ext::Path;
 use crate::json_ext::Value;
 use crate::*;
@@ -16,6 +15,8 @@ use tracing::level_filters::LevelFilter;
 
 pub use crate::spec::SpecError;
 pub use router_bridge::planner::{PlanError, PlannerError};
+
+pub(crate) use crate::graphql::Error;
 
 /// Error types for execution.
 ///
@@ -122,88 +123,6 @@ impl FetchError {
             errors: vec![self.to_graphql_error(None)],
             extensions: Default::default(),
         }
-    }
-}
-
-/// Any error.
-#[derive(Error, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
-#[error("{message}")]
-#[serde(rename_all = "camelCase")]
-pub struct Error {
-    /// The error message.
-    pub message: String,
-
-    /// The locations of the error from the originating request.
-    pub locations: Vec<Location>,
-
-    /// The path of the error.
-    pub path: Option<Path>,
-
-    /// The optional graphql extensions.
-    #[serde(default, skip_serializing_if = "Object::is_empty")]
-    pub extensions: Object,
-}
-
-#[buildstructor::buildstructor]
-impl Error {
-    #[builder]
-    pub fn new(
-        message: String,
-        locations: Vec<Location>,
-        path: Option<Path>,
-        extensions: Option<Object>,
-    ) -> Self {
-        Self {
-            message,
-            locations,
-            path,
-            extensions: extensions.unwrap_or_default(),
-        }
-    }
-
-    pub fn from_value(service_name: &str, value: Value) -> Result<Error, FetchError> {
-        let mut object =
-            ensure_object!(value).map_err(|error| FetchError::SubrequestMalformedResponse {
-                service: service_name.to_string(),
-                reason: error.to_string(),
-            })?;
-
-        let extensions =
-            extract_key_value_from_object!(object, "extensions", Value::Object(o) => o)
-                .map_err(|err| FetchError::SubrequestMalformedResponse {
-                    service: service_name.to_string(),
-                    reason: err.to_string(),
-                })?
-                .unwrap_or_default();
-        let message = extract_key_value_from_object!(object, "message", Value::String(s) => s)
-            .map_err(|err| FetchError::SubrequestMalformedResponse {
-                service: service_name.to_string(),
-                reason: err.to_string(),
-            })?
-            .map(|s| s.as_str().to_string())
-            .unwrap_or_default();
-        let locations = extract_key_value_from_object!(object, "locations")
-            .map(serde_json_bytes::from_value)
-            .transpose()
-            .map_err(|err| FetchError::SubrequestMalformedResponse {
-                service: service_name.to_string(),
-                reason: err.to_string(),
-            })?
-            .unwrap_or_default();
-        let path = extract_key_value_from_object!(object, "path")
-            .map(serde_json_bytes::from_value)
-            .transpose()
-            .map_err(|err| FetchError::SubrequestMalformedResponse {
-                service: service_name.to_string(),
-                reason: err.to_string(),
-            })?;
-
-        Ok(Error {
-            message,
-            locations,
-            path,
-            extensions,
-        })
     }
 }
 

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -1,6 +1,6 @@
+use crate::graphql::Response;
 use crate::json_ext::Path;
 use crate::json_ext::Value;
-use crate::*;
 use displaydoc::Display;
 use miette::{Diagnostic, NamedSource, Report, SourceSpan};
 use router_bridge::{

--- a/apollo-router/src/graphql.rs
+++ b/apollo-router/src/graphql.rs
@@ -1,0 +1,91 @@
+use crate::error::{FetchError, Location};
+use crate::json_ext::Object;
+use crate::json_ext::Path;
+use crate::json_ext::Value;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+pub use crate::request::Request;
+pub use crate::response::Response;
+
+/// Any GraphQL error.
+#[derive(Error, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
+#[error("{message}")]
+#[serde(rename_all = "camelCase")]
+pub struct Error {
+    /// The error message.
+    pub message: String,
+
+    /// The locations of the error from the originating request.
+    pub locations: Vec<Location>,
+
+    /// The path of the error.
+    pub path: Option<Path>,
+
+    /// The optional graphql extensions.
+    #[serde(default, skip_serializing_if = "Object::is_empty")]
+    pub extensions: Object,
+}
+
+#[buildstructor::buildstructor]
+impl Error {
+    #[builder]
+    pub fn new(
+        message: String,
+        locations: Vec<Location>,
+        path: Option<Path>,
+        extensions: Option<Object>,
+    ) -> Self {
+        Self {
+            message,
+            locations,
+            path,
+            extensions: extensions.unwrap_or_default(),
+        }
+    }
+
+    pub fn from_value(service_name: &str, value: Value) -> Result<Error, FetchError> {
+        let mut object =
+            ensure_object!(value).map_err(|error| FetchError::SubrequestMalformedResponse {
+                service: service_name.to_string(),
+                reason: error.to_string(),
+            })?;
+
+        let extensions =
+            extract_key_value_from_object!(object, "extensions", Value::Object(o) => o)
+                .map_err(|err| FetchError::SubrequestMalformedResponse {
+                    service: service_name.to_string(),
+                    reason: err.to_string(),
+                })?
+                .unwrap_or_default();
+        let message = extract_key_value_from_object!(object, "message", Value::String(s) => s)
+            .map_err(|err| FetchError::SubrequestMalformedResponse {
+                service: service_name.to_string(),
+                reason: err.to_string(),
+            })?
+            .map(|s| s.as_str().to_string())
+            .unwrap_or_default();
+        let locations = extract_key_value_from_object!(object, "locations")
+            .map(serde_json_bytes::from_value)
+            .transpose()
+            .map_err(|err| FetchError::SubrequestMalformedResponse {
+                service: service_name.to_string(),
+                reason: err.to_string(),
+            })?
+            .unwrap_or_default();
+        let path = extract_key_value_from_object!(object, "path")
+            .map(serde_json_bytes::from_value)
+            .transpose()
+            .map_err(|err| FetchError::SubrequestMalformedResponse {
+                service: service_name.to_string(),
+                reason: err.to_string(),
+            })?;
+
+        Ok(Error {
+            message,
+            locations,
+            path,
+            extensions,
+        })
+    }
+}

--- a/apollo-router/src/graphql.rs
+++ b/apollo-router/src/graphql.rs
@@ -1,3 +1,5 @@
+//! Namespace for the GraphQL [`Request`], [`Response`], and [`Error`] types.
+
 use crate::error::{FetchError, Location};
 use crate::json_ext::Object;
 use crate::json_ext::Path;

--- a/apollo-router/src/graphql.rs
+++ b/apollo-router/src/graphql.rs
@@ -5,14 +5,13 @@ use crate::json_ext::Object;
 use crate::json_ext::Path;
 use crate::json_ext::Value;
 use serde::{Deserialize, Serialize};
-use thiserror::Error;
+use std::fmt;
 
 pub use crate::request::Request;
 pub use crate::response::Response;
 
 /// Any GraphQL error.
-#[derive(Error, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
-#[error("{message}")]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct Error {
     /// The error message.
@@ -89,5 +88,11 @@ impl Error {
             path,
             extensions,
         })
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.message.fmt(f)
     }
 }

--- a/apollo-router/src/http_server_factory.rs
+++ b/apollo-router/src/http_server_factory.rs
@@ -1,5 +1,6 @@
 use super::router::ApolloRouterError;
 use crate::configuration::{Configuration, ListenAddr};
+use crate::graphql;
 use crate::http_ext::{Request, Response};
 use crate::plugin::Handler;
 use crate::ResponseBody;
@@ -27,14 +28,14 @@ pub(crate) trait HttpServerFactory {
     ) -> Self::Future
     where
         RS: Service<
-                Request<crate::Request>,
+                Request<graphql::Request>,
                 Response = Response<BoxStream<'static, ResponseBody>>,
                 Error = BoxError,
             > + Send
             + Sync
             + Clone
             + 'static,
-        <RS as Service<Request<crate::Request>>>::Future: std::marker::Send;
+        <RS as Service<Request<graphql::Request>>>::Future: std::marker::Send;
 }
 
 /// A handle with with a client can shut down the server gracefully.
@@ -93,14 +94,14 @@ impl HttpServerHandle {
     where
         SF: HttpServerFactory,
         RS: Service<
-                Request<crate::Request>,
+                Request<graphql::Request>,
                 Response = Response<BoxStream<'static, ResponseBody>>,
                 Error = BoxError,
             > + Send
             + Sync
             + Clone
             + 'static,
-        <RS as Service<Request<crate::Request>>>::Future: std::marker::Send,
+        <RS as Service<Request<graphql::Request>>>::Future: std::marker::Send,
     {
         // we tell the currently running server to stop
         if let Err(_err) = self.shutdown_sender.send(()) {

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -1,3 +1,4 @@
+use crate::graphql::Response;
 use crate::*;
 use include_dir::include_dir;
 use once_cell::sync::Lazy;

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -35,6 +35,7 @@ mod context;
 pub mod error;
 mod executable;
 mod files;
+pub mod graphql;
 mod http_server_factory;
 mod introspection;
 pub mod layers;
@@ -56,11 +57,13 @@ mod traits;
 pub use configuration::Configuration;
 pub use context::Context;
 pub use executable::{main, Executable};
-pub use request::Request;
-pub use response::Response;
 pub use router::{ApolloRouter, ConfigurationKind, SchemaKind, ShutdownKind};
 pub use services::http_ext;
 pub use spec::Schema;
+
+pub type Request = graphql::Request;
+pub type Response = graphql::Response;
+pub type Error = graphql::Error;
 
 // TODO: clean these up and import from relevant modules instead
 pub(crate) use services::*;

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -61,8 +61,11 @@ pub use router::{ApolloRouter, ConfigurationKind, SchemaKind, ShutdownKind};
 pub use services::http_ext;
 pub use spec::Schema;
 
+#[deprecated(note = "use apollo_router::graphql::Request instead")]
 pub type Request = graphql::Request;
+#[deprecated(note = "use apollo_router::graphql::Response instead")]
 pub type Response = graphql::Response;
+#[deprecated(note = "use apollo_router::graphql::Error instead")]
 pub type Error = graphql::Error;
 
 // TODO: clean these up and import from relevant modules instead

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -17,10 +17,11 @@
 pub mod serde;
 pub mod test;
 
+use crate::graphql::Response;
 use crate::layers::ServiceBuilderExt;
 use crate::{
     http_ext, ExecutionRequest, ExecutionResponse, QueryPlannerRequest, QueryPlannerResponse,
-    Response, ResponseBody, RouterRequest, RouterResponse, SubgraphRequest, SubgraphResponse,
+    ResponseBody, RouterRequest, RouterResponse, SubgraphRequest, SubgraphResponse,
 };
 use ::serde::{de::DeserializeOwned, Deserialize};
 use async_trait::async_trait;

--- a/apollo-router/src/plugin/test/mock/subgraph.rs
+++ b/apollo-router/src/plugin/test/mock/subgraph.rs
@@ -1,7 +1,8 @@
 //! Mock subgraph implementation
 
+use crate::graphql::{Request, Response};
 use crate::json_ext::Object;
-use crate::{Request, Response, SubgraphRequest, SubgraphResponse};
+use crate::{SubgraphRequest, SubgraphResponse};
 use futures::future;
 use http::StatusCode;
 use std::{collections::HashMap, sync::Arc, task::Poll};

--- a/apollo-router/src/plugin/test/service.rs
+++ b/apollo-router/src/plugin/test/service.rs
@@ -1,9 +1,9 @@
-use futures::stream::BoxStream;
-
+use crate::graphql::Response;
 use crate::{
-    ExecutionRequest, ExecutionResponse, QueryPlannerRequest, QueryPlannerResponse, Response,
-    ResponseBody, RouterRequest, RouterResponse, SubgraphRequest, SubgraphResponse,
+    ExecutionRequest, ExecutionResponse, QueryPlannerRequest, QueryPlannerResponse, ResponseBody,
+    RouterRequest, RouterResponse, SubgraphRequest, SubgraphResponse,
 };
+use futures::stream::BoxStream;
 
 /// Build a mock service handler for the router pipeline.
 #[macro_export]

--- a/apollo-router/src/plugins/forbid_mutations.rs
+++ b/apollo-router/src/plugins/forbid_mutations.rs
@@ -1,6 +1,7 @@
+use crate::graphql::Response;
 use crate::{
     error::Error, json_ext::Object, layers::ServiceBuilderExt, plugin::Plugin, register_plugin,
-    ExecutionRequest, ExecutionResponse, Response,
+    ExecutionRequest, ExecutionResponse,
 };
 use futures::stream::BoxStream;
 use http::StatusCode;
@@ -62,6 +63,7 @@ impl Plugin for ForbidMutations {
 #[cfg(test)]
 mod forbid_http_get_mutations_tests {
     use super::*;
+    use crate::graphql;
     use crate::http_ext::Request;
     use crate::plugin::test::MockExecutionService;
     use crate::query_planner::fetch::OperationKind;
@@ -184,7 +186,7 @@ mod forbid_http_get_mutations_tests {
 
         let request = Request::fake_builder()
             .method(method)
-            .body(crate::Request::default())
+            .body(graphql::Request::default())
             .build()
             .expect("expecting valid request");
         ExecutionRequest::fake_builder()

--- a/apollo-router/src/plugins/headers.rs
+++ b/apollo-router/src/plugins/headers.rs
@@ -233,11 +233,12 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::graphql::{Request, Response};
     use crate::http_ext;
     use crate::plugin::test::MockSubgraphService;
     use crate::plugins::headers::{Config, HeadersLayer};
     use crate::query_planner::fetch::OperationKind;
-    use crate::{Context, Request, Response, SubgraphRequest, SubgraphResponse};
+    use crate::{Context, SubgraphRequest, SubgraphResponse};
     use std::collections::HashSet;
     use std::str::FromStr;
     use std::sync::Arc;

--- a/apollo-router/src/plugins/include_subgraph_errors.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors.rs
@@ -68,12 +68,12 @@ impl Plugin for IncludeSubgraphErrors {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::graphql::Response;
     use crate::json_ext::Object;
     use crate::plugin::test::MockSubgraph;
     use crate::plugin::DynPlugin;
     use crate::{
-        PluggableRouterServiceBuilder, Response, ResponseBody, RouterRequest, RouterResponse,
-        Schema,
+        PluggableRouterServiceBuilder, ResponseBody, RouterRequest, RouterResponse, Schema,
     };
     use bytes::Bytes;
     use futures::stream::BoxStream;

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -1,14 +1,15 @@
 //! Customization via Rhai.
 
+use crate::error::Error;
+use crate::graphql::{Request, Response};
+use crate::http_ext;
+use crate::json_ext::{Object, Value};
+use crate::layers::ServiceBuilderExt;
+use crate::plugin::Plugin;
 use crate::{
-    error::Error,
-    http_ext,
-    json_ext::{Object, Value},
-    layers::ServiceBuilderExt,
-    plugin::Plugin,
     register_plugin, Context, ExecutionRequest, ExecutionResponse, QueryPlannerRequest,
-    QueryPlannerResponse, Request, Response, ResponseBody, RouterRequest, RouterResponse,
-    SubgraphRequest, SubgraphResponse,
+    QueryPlannerResponse, ResponseBody, RouterRequest, RouterResponse, SubgraphRequest,
+    SubgraphResponse,
 };
 use futures::future::ready;
 use futures::stream::{once, BoxStream};
@@ -1836,7 +1837,7 @@ mod tests {
             dyn_plugin.execution_service(BoxService::new(mock_service.build()));
         let fake_req = http_ext::Request::fake_builder()
             .header("x-custom-header", "CUSTOM_VALUE")
-            .body(crate::Request::builder().query(String::new()).build())
+            .body(Request::builder().query(String::new()).build())
             .build()?;
         let context = Context::new();
         context.insert("test", 5i64).unwrap();

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -1,5 +1,6 @@
 //! Telemetry plugin.
 // This entire file is license key functionality
+use crate::graphql::Response;
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::Handler;
 use crate::plugin::Plugin;
@@ -16,7 +17,7 @@ use crate::query_planner::USAGE_REPORTING;
 use crate::subscriber::replace_layer;
 use crate::{
     http_ext, register_plugin, Context, ExecutionRequest, ExecutionResponse, QueryPlannerRequest,
-    QueryPlannerResponse, Response, ResponseBody, RouterRequest, RouterResponse, SubgraphRequest,
+    QueryPlannerResponse, ResponseBody, RouterRequest, RouterResponse, SubgraphRequest,
     SubgraphResponse,
 };
 use ::tracing::{info_span, Span};

--- a/apollo-router/src/plugins/traffic_shaping/deduplication.rs
+++ b/apollo-router/src/plugins/traffic_shaping/deduplication.rs
@@ -2,8 +2,10 @@
 //!
 //! See [`Layer`] and [`tower::Service`] for more details.
 
+use crate::graphql::Request;
+use crate::http_ext;
 use crate::query_planner::fetch::OperationKind;
-use crate::{http_ext, Request, SubgraphRequest, SubgraphResponse};
+use crate::{SubgraphRequest, SubgraphResponse};
 use futures::{future::BoxFuture, lock::Mutex};
 use std::{collections::HashMap, sync::Arc, task::Poll};
 use tokio::sync::{

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 use crate::error::FetchError;
+use crate::graphql::{Request, Response};
 use crate::json_ext::{Path, Value, ValueExt};
 use crate::service_registry::ServiceRegistry;
 use crate::*;
@@ -308,6 +309,7 @@ pub(crate) mod fetch {
     use super::selection::{select_object, Selection};
     use super::QueryPlanOptions;
     use crate::error::{Error, FetchError};
+    use crate::graphql::Request;
     use crate::json_ext::{Object, Path, Value, ValueExt};
     use crate::service_registry::ServiceRegistry;
     use crate::*;
@@ -372,7 +374,7 @@ pub(crate) mod fetch {
             variable_usages: &[String],
             data: &Value,
             current_dir: &Path,
-            request: http_ext::Request<crate::Request>,
+            request: http_ext::Request<Request>,
             schema: &Schema,
             enable_variable_deduplication: bool,
         ) -> Option<Variables> {
@@ -641,7 +643,7 @@ mod log {
         service_name: &str,
         operation: &str,
         variables: &Map<ByteString, Value>,
-        response: &crate::Response,
+        response: &crate::graphql::Response,
     ) {
         tracing::trace!(
             "subgraph fetch to {}: operation = '{}', variables = {:?}, response:\n{}",

--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -132,6 +132,7 @@ fn select_value(
 mod tests {
     use super::Selection;
     use super::*;
+    use crate::graphql::Response;
     use crate::json_ext::Path;
     use serde_json::json;
     use serde_json_bytes::json as bjson;

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -516,7 +516,8 @@ impl ApolloRouter {
 mod tests {
     use super::*;
     use crate::files::tests::{create_temp_file, write_and_flush};
-    use crate::Request;
+    use crate::graphql;
+    use crate::graphql::Request;
     use serde_json::to_string_pretty;
     use std::env::temp_dir;
     use test_log::test;
@@ -554,8 +555,8 @@ mod tests {
 
     async fn query(
         listen_addr: &ListenAddr,
-        request: &crate::Request,
-    ) -> Result<crate::Response, crate::error::FetchError> {
+        request: &graphql::Request,
+    ) -> Result<graphql::Response, crate::error::FetchError> {
         Ok(reqwest::Client::new()
             .post(format!("{}/", listen_addr))
             .json(request)

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -1,13 +1,12 @@
 // This entire file is license key functionality
 use crate::configuration::{Configuration, ConfigurationError};
+use crate::graphql;
+use crate::http_ext::{Request, Response};
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::DynPlugin;
 use crate::services::Plugins;
 use crate::SubgraphService;
-use crate::{
-    http_ext::{Request, Response},
-    PluggableRouterServiceBuilder, ResponseBody, Schema,
-};
+use crate::{PluggableRouterServiceBuilder, ResponseBody, Schema};
 use envmnt::types::ExpandOptions;
 use envmnt::ExpansionType;
 use futures::stream::BoxStream;
@@ -26,7 +25,7 @@ use tower_service::Service;
 #[async_trait::async_trait]
 pub(crate) trait RouterServiceFactory: Send + Sync + 'static {
     type RouterService: Service<
-            Request<crate::Request>,
+            Request<graphql::Request>,
             Response = Response<BoxStream<'static, ResponseBody>>,
             Error = BoxError,
             Future = Self::Future,
@@ -52,13 +51,13 @@ pub(crate) struct YamlRouterServiceFactory;
 impl RouterServiceFactory for YamlRouterServiceFactory {
     type RouterService = Buffer<
         BoxCloneService<
-            Request<crate::Request>,
+            Request<graphql::Request>,
             Response<BoxStream<'static, ResponseBody>>,
             BoxError,
         >,
-        Request<crate::Request>,
+        Request<graphql::Request>,
     >;
-    type Future = <Self::RouterService as Service<Request<crate::Request>>>::Future;
+    type Future = <Self::RouterService as Service<Request<graphql::Request>>>::Future;
 
     async fn create<'a>(
         &'a mut self,
@@ -86,7 +85,7 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
         let (pluggable_router_service, mut plugins) = builder.build().await?;
         let service = ServiceBuilder::new().buffered().service(
             pluggable_router_service
-                .map_request(|http_request: Request<crate::Request>| http_request.into())
+                .map_request(|http_request: Request<graphql::Request>| http_request.into())
                 .map_response(|response| response.response)
                 .boxed_clone(),
         );

--- a/apollo-router/src/services/execution_service.rs
+++ b/apollo-router/src/services/execution_service.rs
@@ -1,8 +1,9 @@
 //! Implements the Execution phase of the request lifecycle.
 
+use crate::graphql::Response;
 use crate::service_registry::ServiceRegistry;
 use crate::Schema;
-use crate::{ExecutionRequest, ExecutionResponse, Response, SubgraphRequest, SubgraphResponse};
+use crate::{ExecutionRequest, ExecutionResponse, SubgraphRequest, SubgraphResponse};
 use futures::future::{ready, BoxFuture};
 use futures::stream::{once, BoxStream};
 use futures::StreamExt;

--- a/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
+++ b/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
@@ -2,10 +2,10 @@
 //!
 //! See [`Layer`] and [`Service`] for more details.
 
-use crate::{
-    error::Error, json_ext::Object, layers::sync_checkpoint::CheckpointService, ExecutionRequest,
-    ExecutionResponse, Response,
-};
+use crate::graphql::{Error, Response};
+use crate::json_ext::Object;
+use crate::layers::sync_checkpoint::CheckpointService;
+use crate::{ExecutionRequest, ExecutionResponse};
 use futures::stream::BoxStream;
 use http::{header::HeaderName, Method, StatusCode};
 use std::ops::ControlFlow;
@@ -60,6 +60,7 @@ where
 mod forbid_http_get_mutations_tests {
     use super::*;
     use crate::error::Error;
+    use crate::graphql;
     use crate::http_ext;
     use crate::plugin::test::MockExecutionService;
     use crate::query_planner::{fetch::OperationKind, PlanNode, QueryPlan};
@@ -220,7 +221,7 @@ mod forbid_http_get_mutations_tests {
 
         let request = http_ext::Request::fake_builder()
             .method(method)
-            .body(crate::Request::default())
+            .body(graphql::Request::default())
             .build()
             .expect("expecting valid request");
 

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -3,6 +3,7 @@
 pub use self::execution_service::*;
 pub use self::router_service::*;
 use crate::error::Error;
+use crate::graphql::{Request, Response};
 use crate::json_ext::{Object, Path, Value};
 use crate::query_planner::fetch::OperationKind;
 use crate::query_planner::QueryPlan;
@@ -819,6 +820,7 @@ impl AsRef<Request> for Arc<http_ext::Request<Request>> {
 
 #[cfg(test)]
 mod test {
+    use crate::graphql;
     use crate::{Context, ResponseBody, RouterRequest, RouterResponse};
     use http::{HeaderValue, Method, Uri};
     use serde_json::json;
@@ -873,7 +875,7 @@ mod test {
             .clone();
         assert_eq!(
             request.originating_request.body(),
-            &crate::Request::builder()
+            &graphql::Request::builder()
                 .variables(variables)
                 .extensions(extensions)
                 .operation_name("Default")
@@ -909,7 +911,7 @@ mod test {
         assert_eq!(
             response.next_response().await.unwrap(),
             ResponseBody::GraphQL(
-                crate::Response::builder()
+                graphql::Response::builder()
                     .extensions(extensions)
                     .data(json!({}))
                     .build()

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -1,6 +1,8 @@
 //! Implements the router phase of the request lifecycle.
 
 use crate::error::ServiceBuildError;
+use crate::graphql;
+use crate::graphql::Response;
 use crate::introspection::Introspection;
 use crate::layers::ServiceBuilderExt;
 use crate::layers::DEFAULT_BUFFER_SIZE;
@@ -15,8 +17,8 @@ use crate::{
             ensure_query_presence::EnsureQueryPresence,
         },
     },
-    ExecutionRequest, ExecutionResponse, QueryPlannerRequest, QueryPlannerResponse, Response,
-    ResponseBody, RouterRequest, RouterResponse, Schema, SubgraphRequest, SubgraphResponse,
+    ExecutionRequest, ExecutionResponse, QueryPlannerRequest, QueryPlannerResponse, ResponseBody,
+    RouterRequest, RouterResponse, Schema, SubgraphRequest, SubgraphResponse,
 };
 use futures::future::ready;
 use futures::stream::{once, BoxStream, StreamExt};
@@ -137,7 +139,7 @@ where
                 }
                 QueryPlannerContent::IntrospectionDisabled => {
                     let mut resp = http::Response::new(once(ready(ResponseBody::GraphQL(
-                        crate::Response::builder()
+                        graphql::Response::builder()
                             .errors(vec![crate::error::Error::builder()
                                 .message(String::from("introspection has been disabled"))
                                 .build()])

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -1,6 +1,7 @@
 //! Tower fetcher for subgraphs.
 
 use crate::error::FetchError;
+use crate::graphql;
 use ::serde::Deserialize;
 use async_compression::tokio::write::{BrotliEncoder, GzipEncoder, ZlibEncoder};
 use futures::future::BoxFuture;
@@ -190,9 +191,9 @@ impl tower::Service<crate::SubgraphRequest> for SubgraphService {
                 }));
             }
 
-            let graphql: crate::Response = tracing::debug_span!("parse_subgraph_response")
+            let graphql: graphql::Response = tracing::debug_span!("parse_subgraph_response")
                 .in_scope(|| {
-                    crate::Response::from_bytes(&service_name, body).map_err(|error| {
+                    graphql::Response::from_bytes(&service_name, body).map_err(|error| {
                         FetchError::SubrequestMalformedResponse {
                             service: service_name.clone(),
                             reason: error.to_string(),
@@ -262,8 +263,9 @@ mod tests {
     use serde_json_bytes::{ByteString, Value};
     use tower::{service_fn, ServiceExt};
 
+    use crate::graphql::{Request, Response};
     use crate::query_planner::fetch::OperationKind;
-    use crate::{http_ext, json_ext::Object, Context, Request, Response, SubgraphRequest};
+    use crate::{http_ext, json_ext::Object, Context, SubgraphRequest};
 
     use super::*;
 

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -3,6 +3,7 @@
 //! Parsing, formatting and manipulation of queries.
 
 use crate::error::FetchError;
+use crate::graphql::{Request, Response};
 use crate::json_ext::{Object, Value};
 use crate::query_planner::fetch::OperationKind;
 use crate::*;

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -603,7 +603,7 @@ mod tests {
         #[async_trait::async_trait]
         impl RouterServiceFactory for MyRouterFactory {
             type RouterService = MockMyRouter;
-            type Future = <Self::RouterService as Service<Request<crate::Request>>>::Future;
+            type Future = <Self::RouterService as Service<Request<crate::graphql::Request>>>::Future;
 
             async fn create<'a>(
                 &'a mut self,
@@ -618,7 +618,7 @@ mod tests {
         #[derive(Debug)]
         MyRouter {
             fn poll_ready(&mut self) -> Poll<Result<(), BoxError>>;
-            fn service_call(&mut self, req: Request<crate::Request>) -> <MockMyRouter as Service<Request<crate::Request>>>::Future;
+            fn service_call(&mut self, req: Request<crate::graphql::Request>) -> <MockMyRouter as Service<Request<crate::graphql::Request>>>::Future;
         }
 
         impl Clone for MyRouter {
@@ -627,7 +627,7 @@ mod tests {
     }
 
     //mockall does not handle well the lifetime on Context
-    impl Service<Request<crate::Request>> for MockMyRouter {
+    impl Service<Request<crate::graphql::Request>> for MockMyRouter {
         type Response = Response<BoxStream<'static, ResponseBody>>;
         type Error = BoxError;
         type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
@@ -635,7 +635,7 @@ mod tests {
         fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), BoxError>> {
             self.poll_ready()
         }
-        fn call(&mut self, req: Request<crate::Request>) -> Self::Future {
+        fn call(&mut self, req: Request<crate::graphql::Request>) -> Self::Future {
             self.service_call(req)
         }
     }
@@ -662,14 +662,14 @@ mod tests {
         ) -> Pin<Box<dyn Future<Output = Result<HttpServerHandle, ApolloRouterError>> + Send>>
         where
             RS: Service<
-                    Request<crate::Request>,
+                    Request<crate::graphql::Request>,
                     Response = Response<BoxStream<'static, ResponseBody>>,
                     Error = BoxError,
                 > + Send
                 + Sync
                 + Clone
                 + 'static,
-            <RS as Service<Request<crate::Request>>>::Future: std::marker::Send,
+            <RS as Service<Request<crate::graphql::Request>>>::Future: std::marker::Send,
         {
             let res = self.create_server(configuration, listener);
             Box::pin(async move { res })

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -205,7 +205,7 @@ async fn queries_should_work_over_get() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn simple_queries_should_not_work() {
-    let expected_error = apollo_router::error::Error {
+    let expected_error = apollo_router::graphql::Error {
         message :"This operation has been blocked as a potential Cross-Site Request Forgery (CSRF). \
         Please either specify a 'content-type' header \
         (with a mime-type that is not one of application/x-www-form-urlencoded, multipart/form-data, text/plain) \
@@ -311,7 +311,7 @@ async fn queries_should_work_over_post() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn service_errors_should_be_propagated() {
-    let expected_error = apollo_router::error::Error {
+    let expected_error = apollo_router::graphql::Error {
         message :"value retrieval failed: couldn't plan query: query validation errors: Unknown operation named \"invalidOperationName\"".to_string(),
         ..Default::default()
     };
@@ -433,7 +433,7 @@ async fn automated_persisted_queries() {
                 {"stacktrace":["PersistedQueryNotFoundError: PersistedQueryNotFound"]
         }),
     );
-    let expected_apq_miss_error = apollo_router::error::Error {
+    let expected_apq_miss_error = apollo_router::graphql::Error {
         message: "PersistedQueryNotFound".to_string(),
         extensions,
         ..Default::default()

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -2,6 +2,8 @@
 //! Please ensure that any tests added to this file use the tokio multi-threaded test executor.
 //!
 
+use apollo_router::graphql;
+use apollo_router::graphql::Request;
 use apollo_router::http_ext;
 use apollo_router::json_ext::{Object, ValueExt};
 use apollo_router::plugin::Plugin;
@@ -12,7 +14,6 @@ use apollo_router::services::PluggableRouterServiceBuilder;
 use apollo_router::services::{ResponseBody, RouterRequest, RouterResponse};
 use apollo_router::services::{SubgraphRequest, SubgraphService};
 use apollo_router::Context;
-use apollo_router::Request;
 use apollo_router::Schema;
 use futures::stream::BoxStream;
 use http::Method;
@@ -205,7 +206,7 @@ async fn queries_should_work_over_get() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn simple_queries_should_not_work() {
-    let expected_error = apollo_router::graphql::Error {
+    let expected_error = graphql::Error {
         message :"This operation has been blocked as a potential Cross-Site Request Forgery (CSRF). \
         Please either specify a 'content-type' header \
         (with a mime-type that is not one of application/x-www-form-urlencoded, multipart/form-data, text/plain) \
@@ -583,8 +584,8 @@ async fn missing_variables() {
 }
 
 async fn query_node(
-    request: &apollo_router::Request,
-) -> Result<apollo_router::Response, apollo_router::error::FetchError> {
+    request: &graphql::Request,
+) -> Result<graphql::Response, apollo_router::error::FetchError> {
     reqwest::Client::new()
         .post("https://federation-demo-gateway.fly.dev/")
         .json(request)
@@ -606,7 +607,9 @@ async fn query_node(
         )
 }
 
-async fn query_rust(request: RouterRequest) -> (apollo_router::Response, CountingServiceRegistry) {
+async fn query_rust(
+    request: RouterRequest,
+) -> (apollo_router::graphql::Response, CountingServiceRegistry) {
     let (router, counting_registry) = setup_router_and_registry().await;
     (query_with_router(router, request).await, counting_registry)
 }
@@ -661,7 +664,7 @@ async fn query_with_router(
         BoxError,
     >,
     request: RouterRequest,
-) -> apollo_router::Response {
+) -> graphql::Response {
     let response = router
         .oneshot(request)
         .await

--- a/apollo-router/tests/rhai_tests.rs
+++ b/apollo-router/tests/rhai_tests.rs
@@ -1,10 +1,10 @@
 use std::str::FromStr;
 use std::sync::Arc;
 
+use apollo_router::graphql::Request;
 use apollo_router::http_ext;
 use apollo_router::plugin::{plugins, DynPlugin};
 use apollo_router::services::{PluggableRouterServiceBuilder, SubgraphService};
-use apollo_router::Request;
 use apollo_router::Schema;
 use serde_json::Value;
 use tower::ServiceExt;

--- a/examples/async-auth/src/allow_client_id_from_file.rs
+++ b/examples/async-auth/src/allow_client_id_from_file.rs
@@ -68,7 +68,7 @@ impl Plugin for AllowClientIdFromFile {
                 // Prepare an HTTP 401 response with a GraphQL error message
                 res = Some(
                     RouterResponse::error_builder()
-                        .error(apollo_router::error::Error {
+                        .error(apollo_router::graphql::Error {
                             message: format!("Missing '{header_key}' header"),
                             ..Default::default()
                         })
@@ -102,7 +102,7 @@ impl Plugin for AllowClientIdFromFile {
                             res = Some(
                                 RouterResponse::builder()
                                     .data(Value::default())
-                                    .error(apollo_router::error::Error {
+                                    .error(apollo_router::graphql::Error {
                                         message: "client-id is not allowed".to_string(),
                                         ..Default::default()
                                     })
@@ -117,7 +117,7 @@ impl Plugin for AllowClientIdFromFile {
                         // Prepare an HTTP 400 response with a GraphQL error message
                         res = Some(
                             RouterResponse::error_builder()
-                                .error(apollo_router::error::Error {
+                                .error(apollo_router::graphql::Error {
                                     message: format!("'{header_key}' value is not a string"),
                                     ..Default::default()
                                 })

--- a/examples/async-auth/src/allow_client_id_from_file.rs
+++ b/examples/async-auth/src/allow_client_id_from_file.rs
@@ -1,3 +1,4 @@
+use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
@@ -68,7 +69,7 @@ impl Plugin for AllowClientIdFromFile {
                 // Prepare an HTTP 401 response with a GraphQL error message
                 res = Some(
                     RouterResponse::error_builder()
-                        .error(apollo_router::graphql::Error {
+                        .error(graphql::Error {
                             message: format!("Missing '{header_key}' header"),
                             ..Default::default()
                         })
@@ -102,7 +103,7 @@ impl Plugin for AllowClientIdFromFile {
                             res = Some(
                                 RouterResponse::builder()
                                     .data(Value::default())
-                                    .error(apollo_router::graphql::Error {
+                                    .error(graphql::Error {
                                         message: "client-id is not allowed".to_string(),
                                         ..Default::default()
                                     })
@@ -117,7 +118,7 @@ impl Plugin for AllowClientIdFromFile {
                         // Prepare an HTTP 400 response with a GraphQL error message
                         res = Some(
                             RouterResponse::error_builder()
-                                .error(apollo_router::graphql::Error {
+                                .error(graphql::Error {
                                     message: format!("'{header_key}' value is not a string"),
                                     ..Default::default()
                                 })
@@ -176,6 +177,7 @@ mod tests {
     use crate::allow_client_id_from_file::AllowClientIdConfig;
 
     use super::AllowClientIdFromFile;
+    use apollo_router::graphql;
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
     use apollo_router::services::{RouterRequest, RouterResponse};
@@ -229,7 +231,7 @@ mod tests {
         assert_eq!(StatusCode::UNAUTHORIZED, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: apollo_router::Response = service_response
+        let graphql_response: graphql::Response = service_response
             .next_response()
             .await
             .unwrap()
@@ -275,7 +277,7 @@ mod tests {
         assert_eq!(StatusCode::FORBIDDEN, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: apollo_router::Response = service_response
+        let graphql_response: graphql::Response = service_response
             .next_response()
             .await
             .unwrap()
@@ -349,7 +351,7 @@ mod tests {
         assert_eq!(StatusCode::OK, service_response.response.status());
 
         // ...with the expected data
-        let graphql_response: apollo_router::Response = service_response
+        let graphql_response: graphql::Response = service_response
             .next_response()
             .await
             .unwrap()

--- a/examples/cookies-to-headers/src/main.rs
+++ b/examples/cookies-to-headers/src/main.rs
@@ -126,7 +126,7 @@ mod tests {
         assert_eq!(StatusCode::OK, service_response.response.status());
 
         // with the expected message
-        let graphql_response: apollo_router::Response =
+        let graphql_response: apollo_router::graphql::Response =
             http::Response::from(service_response.response).into_body();
 
         assert!(graphql_response.errors.is_empty());

--- a/examples/forbid-anonymous-operations/src/forbid_anonymous_operations.rs
+++ b/examples/forbid-anonymous-operations/src/forbid_anonymous_operations.rs
@@ -1,5 +1,6 @@
 use std::ops::ControlFlow;
 
+use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
@@ -59,7 +60,7 @@ impl Plugin for ForbidAnonymousOperations {
 
                     // Prepare an HTTP 400 response with a GraphQL error message
                     let res = RouterResponse::error_builder()
-                        .error(apollo_router::graphql::Error {
+                        .error(graphql::Error {
                             message: "Anonymous operations are not allowed".to_string(),
                             ..Default::default()
                         })
@@ -96,6 +97,7 @@ register_plugin!(
 #[cfg(test)]
 mod tests {
     use super::ForbidAnonymousOperations;
+    use apollo_router::graphql;
     use apollo_router::plugin::{test, Plugin};
     use apollo_router::services::{RouterRequest, RouterResponse};
     use http::StatusCode;
@@ -143,7 +145,7 @@ mod tests {
         assert_eq!(StatusCode::BAD_REQUEST, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: apollo_router::Response = service_response
+        let graphql_response: graphql::Response = service_response
             .next_response()
             .await
             .unwrap()
@@ -184,7 +186,7 @@ mod tests {
         assert_eq!(StatusCode::BAD_REQUEST, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: apollo_router::Response = service_response
+        let graphql_response: graphql::Response = service_response
             .next_response()
             .await
             .unwrap()
@@ -252,7 +254,7 @@ mod tests {
         assert_eq!(StatusCode::OK, service_response.response.status());
 
         // ...with the expected data
-        let graphql_response: apollo_router::Response = service_response
+        let graphql_response: graphql::Response = service_response
             .next_response()
             .await
             .unwrap()

--- a/examples/forbid-anonymous-operations/src/forbid_anonymous_operations.rs
+++ b/examples/forbid-anonymous-operations/src/forbid_anonymous_operations.rs
@@ -59,7 +59,7 @@ impl Plugin for ForbidAnonymousOperations {
 
                     // Prepare an HTTP 400 response with a GraphQL error message
                     let res = RouterResponse::error_builder()
-                        .error(apollo_router::error::Error {
+                        .error(apollo_router::graphql::Error {
                             message: "Anonymous operations are not allowed".to_string(),
                             ..Default::default()
                         })

--- a/examples/hello-world/src/hello_world.rs
+++ b/examples/hello-world/src/hello_world.rs
@@ -1,3 +1,4 @@
+use apollo_router::graphql::Response;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
 use apollo_router::services::ResponseBody;
@@ -5,7 +6,6 @@ use apollo_router::services::{ExecutionRequest, ExecutionResponse};
 use apollo_router::services::{QueryPlannerRequest, QueryPlannerResponse};
 use apollo_router::services::{RouterRequest, RouterResponse};
 use apollo_router::services::{SubgraphRequest, SubgraphResponse};
-use apollo_router::Response;
 use futures::stream::BoxStream;
 use schemars::JsonSchema;
 use serde::Deserialize;

--- a/examples/jwt-auth/src/jwt.rs
+++ b/examples/jwt-auth/src/jwt.rs
@@ -239,7 +239,7 @@ impl Plugin for JwtAuth {
                     status: StatusCode,
                 ) -> Result<ControlFlow<RouterResponse<BoxStream<'static, ResponseBody>>, RouterRequest>, BoxError> {
                     let res = RouterResponse::error_builder()
-                        .errors(vec![apollo_router::error::Error {
+                        .errors(vec![apollo_router::graphql::Error {
                             message: msg,
                             ..Default::default()
                         }])

--- a/examples/jwt-auth/src/jwt.rs
+++ b/examples/jwt-auth/src/jwt.rs
@@ -60,6 +60,7 @@
 //!  - Token refresh
 //!  - ...
 
+use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
@@ -239,7 +240,7 @@ impl Plugin for JwtAuth {
                     status: StatusCode,
                 ) -> Result<ControlFlow<RouterResponse<BoxStream<'static, ResponseBody>>, RouterRequest>, BoxError> {
                     let res = RouterResponse::error_builder()
-                        .errors(vec![apollo_router::graphql::Error {
+                        .errors(vec![graphql::Error {
                             message: msg,
                             ..Default::default()
                         }])
@@ -389,6 +390,7 @@ register_plugin!("example", "jwt", JwtAuth);
 #[cfg(test)]
 mod tests {
     use super::*;
+    use apollo_router::graphql;
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
     use apollo_router::services::{RouterRequest, RouterResponse};
@@ -433,7 +435,7 @@ mod tests {
         assert_eq!(StatusCode::UNAUTHORIZED, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: apollo_router::Response = service_response
+        let graphql_response: graphql::Response = service_response
             .next_response()
             .await
             .unwrap()
@@ -473,7 +475,7 @@ mod tests {
         assert_eq!(StatusCode::BAD_REQUEST, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: apollo_router::Response = service_response
+        let graphql_response: graphql::Response = service_response
             .next_response()
             .await
             .unwrap()
@@ -513,7 +515,7 @@ mod tests {
         assert_eq!(StatusCode::BAD_REQUEST, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: apollo_router::Response = service_response
+        let graphql_response: graphql::Response = service_response
             .next_response()
             .await
             .unwrap()
@@ -557,7 +559,7 @@ mod tests {
         );
 
         // with the expected error message
-        let graphql_response: apollo_router::Response = service_response
+        let graphql_response: graphql::Response = service_response
             .next_response()
             .await
             .unwrap()
@@ -645,7 +647,7 @@ mod tests {
         assert_eq!(StatusCode::OK, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: apollo_router::Response = service_response
+        let graphql_response: graphql::Response = service_response
             .next_response()
             .await
             .unwrap()
@@ -700,7 +702,7 @@ mod tests {
         assert_eq!(StatusCode::FORBIDDEN, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: apollo_router::Response = service_response
+        let graphql_response: graphql::Response = service_response
             .next_response()
             .await
             .unwrap()
@@ -762,7 +764,7 @@ mod tests {
         assert_eq!(StatusCode::FORBIDDEN, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: apollo_router::Response = service_response
+        let graphql_response: graphql::Response = service_response
             .next_response()
             .await
             .unwrap()


### PR DESCRIPTION
I recommend looking at the diff by commit.

A deprecated `type` alias replaces the old locations, so that existing code can continue compile (but with a warning).