### PR TITLE
Remove non-GraphQL body variants from RouterResponse

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -233,6 +233,36 @@ Migration tips:
 
 By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/1227 https://github.com/apollographql/router/pull/1234 https://github.com/apollographql/router/pull/1239 https://github.com/apollographql/router/pull/1263
 
+### Non-GraphQL response body variants removed from `RouterResponse` ([PR #1307](https://github.com/apollographql/router/pull/1307))
+
+Previously the `ResponseBody` enum was used in `RouterResponse`.
+One of this enum’s variants contains a `apollo_router::graphql::Response`,
+which is now used directly instead.
+
+Various type signatures will need changes such as:
+
+```diff
+- RouterResponse<BoxStream<'static, ResponseBody>>
++ RouterResponse<BoxStream<'static, graphql::Response>>
+```
+
+Necessary code changes might look like:
+
+```diff
+- return ResponseBody::GraphQL(response);
++ return response;
+```
+```diff
+- if let ResponseBody::GraphQL(graphql_response) = res {
+-     assert_eq!(&graphql_response.errors[0], expected_error);
+- } else {
+-     panic!("expected a graphql response");
+- }
++ assert_eq!(&res.errors[0], expected_error);
+```
+
+By [@SimonSapin](https://github.com/SimonSapin)
+
 ### Fixed control flow in helm chart for volume mounts & environment variables ([PR #1283](https://github.com/apollographql/router/issues/1283))
 
 You will now be able to actually use the helm chart without being on a managed graph. 

--- a/apollo-router-benchmarks/src/shared.rs
+++ b/apollo-router-benchmarks/src/shared.rs
@@ -2,23 +2,24 @@
 // include!() instead of as a pub module, so it is only compiled
 // in dev mode
 use apollo_router::plugin::test::MockSubgraph;
-use apollo_router::services::{ResponseBody, RouterRequest, RouterResponse};
+use apollo_router::services::{ RouterRequest, RouterResponse};
 use apollo_router::services::PluggableRouterServiceBuilder;
 use apollo_router::Schema;
+use apollo_router::graphql::Response;
 use once_cell::sync::Lazy;
 use serde_json::json;
 use std::sync::Arc;
 use tower::{util::BoxCloneService, BoxError, Service, ServiceExt};
 use futures::stream::{BoxStream};
 
-static EXPECTED_RESPONSE: Lazy<ResponseBody> = Lazy::new(|| {
-    ResponseBody::GraphQL(serde_json::from_str(r#"{"data":{"topProducts":[{"upc":"1","name":"Table","reviews":[{"id":"1","product":{"name":"Table"},"author":{"id":"1","name":"Ada Lovelace"}},{"id":"4","product":{"name":"Table"},"author":{"id":"2","name":"Alan Turing"}}]},{"upc":"2","name":"Couch","reviews":[{"id":"2","product":{"name":"Couch"},"author":{"id":"1","name":"Ada Lovelace"}}]}]}}"#).unwrap())
+static EXPECTED_RESPONSE: Lazy<Response> = Lazy::new(|| {
+    serde_json::from_str(r#"{"data":{"topProducts":[{"upc":"1","name":"Table","reviews":[{"id":"1","product":{"name":"Table"},"author":{"id":"1","name":"Ada Lovelace"}},{"id":"4","product":{"name":"Table"},"author":{"id":"2","name":"Alan Turing"}}]},{"upc":"2","name":"Couch","reviews":[{"id":"2","product":{"name":"Couch"},"author":{"id":"1","name":"Ada Lovelace"}}]}]}}"#).unwrap()
 });
 
 static QUERY: &str = r#"query TopProducts($first: Int) { topProducts(first: $first) { upc name reviews { id product { name } author { id name } } } }"#;
 
 pub async fn basic_composition_benchmark(
-    mut router_service: BoxCloneService<RouterRequest, RouterResponse<BoxStream<'static,ResponseBody>>, BoxError>,
+    mut router_service: BoxCloneService<RouterRequest, RouterResponse<BoxStream<'static,Response>>, BoxError>,
 ) {
     let request = RouterRequest::fake_builder()
         .query(QUERY.to_string())

--- a/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
+++ b/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
@@ -1,15 +1,13 @@
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
-{{#if type_basic}}
 use apollo_router::graphql::Response;
-use apollo_router::services::ResponseBody;
+{{#if type_basic}}
 use apollo_router::services::{ExecutionRequest, ExecutionResponse};
 use apollo_router::services::{QueryPlannerRequest, QueryPlannerResponse};
 use apollo_router::services::{RouterRequest, RouterResponse};
 use apollo_router::services::{SubgraphRequest, SubgraphResponse};
 {{/if}}
 {{#if type_auth}}
-use apollo_router::services::ResponseBody;
 use apollo_router::services::{RouterRequest, RouterResponse};
 use apollo_router::layers::ServiceBuilderExt;
 use std::ops::ControlFlow;
@@ -17,7 +15,6 @@ use tower::ServiceExt;
 use tower::ServiceBuilder;
 {{/if}}
 {{#if type_tracing}}
-use apollo_router::services::ResponseBody;
 use apollo_router::services::{RouterRequest, RouterResponse};
 use apollo_router::layers::ServiceBuilderExt;
 use tower::ServiceExt;
@@ -56,8 +53,8 @@ impl Plugin for {{pascal_name}} {
     // Delete this function if you are not customizing it.
     fn router_service(
         &mut self,
-        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError>,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError> {
         // Always use service builder to compose your plugins.
         // It provides off the shelf building blocks for your plugin.
         //
@@ -108,8 +105,8 @@ impl Plugin for {{pascal_name}} {
 
     fn router_service(
         &mut self,
-        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError>,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError> {
 
         ServiceBuilder::new()
                     .checkpoint_async(|request : RouterRequest| async {
@@ -135,8 +132,8 @@ impl Plugin for {{pascal_name}} {
 
     fn router_service(
         &mut self,
-        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError>,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError> {
 
         ServiceBuilder::new()
                     .instrument(|_request| {
@@ -166,7 +163,6 @@ mod tests {
     use apollo_router::plugin::test::IntoSchema::Canned;
     use apollo_router::plugin::test::PluginTestHarness;
     use apollo_router::plugin::Plugin;
-    use apollo_router::services::ResponseBody;
     use tower::BoxError;
 
     #[tokio::test]
@@ -204,11 +200,7 @@ mod tests {
             .await
             .expect("couldn't get primary response");
 
-        if let ResponseBody::GraphQL(graphql) = first_response {
-            assert!(graphql.data.is_some());
-        } else {
-            panic!("expected graphql response")
-        }
+        assert!(first_response.data.is_some());
 
         // You could keep calling result.next_response() until it yields None if you're expexting more parts.
         assert!(result.next_response().await.is_none());

--- a/apollo-router/src/http_server_factory.rs
+++ b/apollo-router/src/http_server_factory.rs
@@ -16,7 +16,6 @@ use crate::graphql;
 use crate::http_ext::Request;
 use crate::http_ext::Response;
 use crate::plugin::Handler;
-use crate::ResponseBody;
 
 /// Factory for creating the http server component.
 ///
@@ -35,7 +34,7 @@ pub(crate) trait HttpServerFactory {
     where
         RS: Service<
                 Request<graphql::Request>,
-                Response = Response<BoxStream<'static, ResponseBody>>,
+                Response = Response<BoxStream<'static, graphql::Response>>,
                 Error = BoxError,
             > + Send
             + Sync
@@ -101,7 +100,7 @@ impl HttpServerHandle {
         SF: HttpServerFactory,
         RS: Service<
                 Request<graphql::Request>,
-                Response = Response<BoxStream<'static, ResponseBody>>,
+                Response = Response<BoxStream<'static, graphql::Response>>,
                 Error = BoxError,
             > + Send
             + Sync

--- a/apollo-router/src/layers/map_future_with_context.rs
+++ b/apollo-router/src/layers/map_future_with_context.rs
@@ -85,9 +85,9 @@ mod test {
     use tower::ServiceBuilder;
     use tower::ServiceExt;
 
+    use crate::graphql::Response;
     use crate::layers::ServiceBuilderExt;
     use crate::plugin::test::MockRouterService;
-    use crate::ResponseBody;
     use crate::RouterRequest;
     use crate::RouterResponse;
 
@@ -109,7 +109,7 @@ mod test {
                         .unwrap()
                 },
                 |ctx: HeaderValue, resp| async move {
-                    let resp: Result<RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> =
+                    let resp: Result<RouterResponse<BoxStream<'static, Response>>, BoxError> =
                         resp.await;
                     resp.map(|mut response| {
                         response.response.headers_mut().insert("hello", ctx.clone());

--- a/apollo-router/src/layers/mod.rs
+++ b/apollo-router/src/layers/mod.rs
@@ -53,7 +53,7 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// # use tower::ServiceBuilder;
     /// # use tower_service::Service;
     /// # use tracing::info_span;
-    /// # use apollo_router::services::ResponseBody;
+    /// # use apollo_router::graphql::Response;
     /// # use apollo_router::services::{RouterRequest, RouterResponse};
     /// # use apollo_router::layers::ServiceBuilderExt;
     /// # fn test<S: Service<RouterRequest> + Send>(service: S) {
@@ -102,10 +102,10 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// # use tower::ServiceBuilder;
     /// # use tower_service::Service;
     /// # use tracing::info_span;
-    /// # use apollo_router::services::ResponseBody;
+    /// # use apollo_router::graphql::Response;
     /// # use apollo_router::services::{RouterRequest, RouterResponse};
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse<BoxStream<'static, ResponseBody>>, Box<dyn std::error::Error + Send + Sync>>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
+    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse<BoxStream<'static, Response>>, Box<dyn std::error::Error + Send + Sync>>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
     /// let _ = ServiceBuilder::new()
     ///             .checkpoint(|req:RouterRequest|{
     ///                if req.originating_request.method() == Method::GET {
@@ -165,10 +165,10 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// # use tower::ServiceBuilder;
     /// # use tower_service::Service;
     /// # use tracing::info_span;
-    /// # use apollo_router::services::ResponseBody;
+    /// # use apollo_router::graphql::Response;
     /// # use apollo_router::services::{RouterRequest, RouterResponse};
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse<BoxStream<'static, ResponseBody>>, Box<dyn std::error::Error + Send + Sync>>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
+    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse<BoxStream<'static, Response>>, Box<dyn std::error::Error + Send + Sync>>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
     /// let _ = ServiceBuilder::new()
     ///             .checkpoint_async(|req:RouterRequest| async {
     ///                if req.originating_request.method() == Method::GET {
@@ -276,10 +276,10 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// # use tower_service::Service;
     /// # use tracing::info_span;
     /// # use apollo_router::Context;
-    /// # use apollo_router::services::ResponseBody;
+    /// # use apollo_router::graphql::Response;
     /// # use apollo_router::services::{RouterRequest, RouterResponse};
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse<BoxStream<'static, ResponseBody>>, BoxError>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
+    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse<BoxStream<'static, Response>>, BoxError>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
     /// let _ : BoxService<RouterRequest, S::Response, S::Error> = ServiceBuilder::new()
     ///             .map_future_with_context(|req: &RouterRequest| req.context.clone(), |ctx : Context, fut| async {
     ///                 fut.await
@@ -339,11 +339,11 @@ pub trait ServiceExt<Request>: Service<Request> {
     /// # use tower_service::Service;
     /// # use tracing::info_span;
     /// # use apollo_router::Context;
-    /// # use apollo_router::services::ResponseBody;
+    /// # use apollo_router::graphql::Response;
     /// # use apollo_router::services::{RouterRequest, RouterResponse};
     /// # use apollo_router::layers::ServiceBuilderExt;
     /// # use apollo_router::layers::ServiceExt as ApolloServiceExt;
-    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse<BoxStream<'static, ResponseBody>>, BoxError>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
+    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse<BoxStream<'static, Response>>, BoxError>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
     /// let _ : BoxService<RouterRequest, S::Response, S::Error> = service
     ///             .map_future_with_context(|req: &RouterRequest| req.context.clone(), |ctx : Context, fut| async {
     ///                 fut.await

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -122,12 +122,8 @@ pub trait Plugin: Send + Sync + 'static + Sized {
     /// For example, this is a good opportunity to perform JWT verification before allowing a request to proceed further.
     fn router_service(
         &mut self,
-        service: BoxService<
-            RouterRequest,
-            RouterResponse<BoxStream<'static, ResponseBody>>,
-            BoxError,
-        >,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError> {
         service
     }
 
@@ -198,12 +194,8 @@ pub trait DynPlugin: Send + Sync + 'static {
     /// For example, this is a good opportunity to perform JWT verification before allowing a request to proceed further.
     fn router_service(
         &mut self,
-        service: BoxService<
-            RouterRequest,
-            RouterResponse<BoxStream<'static, ResponseBody>>,
-            BoxError,
-        >,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError>;
+        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>;
 
     /// This service handles generating the query plan for each incoming request.
     /// Define `query_planning_service` if your customization needs to interact with query planning functionality (for example, to log query plan details).
@@ -253,12 +245,8 @@ where
 
     fn router_service(
         &mut self,
-        service: BoxService<
-            RouterRequest,
-            RouterResponse<BoxStream<'static, ResponseBody>>,
-            BoxError,
-        >,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError> {
         self.router_service(service)
     }
 

--- a/apollo-router/src/plugin/test/service.rs
+++ b/apollo-router/src/plugin/test/service.rs
@@ -5,7 +5,6 @@ use crate::ExecutionRequest;
 use crate::ExecutionResponse;
 use crate::QueryPlannerRequest;
 use crate::QueryPlannerResponse;
-use crate::ResponseBody;
 use crate::RouterRequest;
 use crate::RouterResponse;
 use crate::SubgraphRequest;
@@ -48,7 +47,7 @@ macro_rules! mock_service {
 mock_service!(
     Router,
     RouterRequest,
-    RouterResponse<BoxStream<'static, ResponseBody>>
+    RouterResponse<BoxStream<'static, Response>>
 );
 mock_service!(QueryPlanning, QueryPlannerRequest, QueryPlannerResponse);
 mock_service!(

--- a/apollo-router/src/plugins/csrf.rs
+++ b/apollo-router/src/plugins/csrf.rs
@@ -11,10 +11,10 @@ use tower::BoxError;
 use tower::ServiceBuilder;
 use tower::ServiceExt;
 
+use crate::graphql::Response;
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::Plugin;
 use crate::register_plugin;
-use crate::ResponseBody;
 use crate::RouterRequest;
 use crate::RouterResponse;
 
@@ -100,12 +100,8 @@ impl Plugin for Csrf {
 
     fn router_service(
         &mut self,
-        service: BoxService<
-            RouterRequest,
-            RouterResponse<BoxStream<'static, ResponseBody>>,
-            BoxError,
-        >,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError> {
         if !self.config.unsafe_disabled {
             let required_headers = self.config.required_headers.clone();
             ServiceBuilder::new()
@@ -235,7 +231,6 @@ mod csrf_tests {
 
     use super::*;
     use crate::plugin::test::MockRouterService;
-    use crate::ResponseBody;
 
     #[tokio::test]
     async fn it_lets_preflighted_request_pass_through() {
@@ -325,12 +320,7 @@ mod csrf_tests {
             .await
             .unwrap();
 
-        match res {
-            ResponseBody::GraphQL(res) => {
-                assert_eq!(res.data.unwrap(), json!({ "test": 1234_u32 }));
-            }
-            other => panic!("expected graphql response, found {:?}", other),
-        }
+        assert_eq!(res.data.unwrap(), json!({ "test": 1234_u32 }));
     }
 
     async fn assert_rejected(config: CSRFConfig, request: RouterRequest) {
@@ -347,21 +337,16 @@ mod csrf_tests {
             .await
             .unwrap();
 
-        match res {
-            ResponseBody::GraphQL(res) => {
-                assert_eq!(
-                    1,
-                    res.errors.len(),
-                    "expected one(1) error in the RouterResponse, found {}\n{:?}",
-                    res.errors.len(),
-                    res.errors
-                );
-                assert_eq!(res.errors[0].message, "This operation has been blocked as a potential Cross-Site Request Forgery (CSRF). \
+        assert_eq!(
+            1,
+            res.errors.len(),
+            "expected one(1) error in the RouterResponse, found {}\n{:?}",
+            res.errors.len(),
+            res.errors
+        );
+        assert_eq!(res.errors[0].message, "This operation has been blocked as a potential Cross-Site Request Forgery (CSRF). \
                 Please either specify a 'content-type' header \
                 (with a mime-type that is not one of application/x-www-form-urlencoded, multipart/form-data, text/plain) \
                 or provide one of the following headers: x-apollo-operation-name, apollo-require-preflight");
-            }
-            other => panic!("expected graphql response, found {:?}", other),
-        }
     }
 }

--- a/apollo-router/src/plugins/include_subgraph_errors.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors.rs
@@ -88,30 +88,27 @@ mod test {
     use crate::plugin::test::MockSubgraph;
     use crate::plugin::DynPlugin;
     use crate::PluggableRouterServiceBuilder;
-    use crate::ResponseBody;
     use crate::RouterRequest;
     use crate::RouterResponse;
     use crate::Schema;
 
-    static UNREDACTED_PRODUCT_RESPONSE: Lazy<ResponseBody> = Lazy::new(|| {
-        ResponseBody::GraphQL(serde_json::from_str(r#"{"data": {"topProducts":null}, "errors":[{"message": "couldn't find mock for query", "locations": [], "path": null, "extensions": { "test": "value" }}]}"#).unwrap())
+    static UNREDACTED_PRODUCT_RESPONSE: Lazy<Response> = Lazy::new(|| {
+        serde_json::from_str(r#"{"data": {"topProducts":null}, "errors":[{"message": "couldn't find mock for query", "locations": [], "path": null, "extensions": { "test": "value" }}]}"#).unwrap()
     });
 
-    static REDACTED_PRODUCT_RESPONSE: Lazy<ResponseBody> = Lazy::new(|| {
-        ResponseBody::GraphQL(serde_json::from_str(r#"{"data": {"topProducts":null}, "errors":[{"message": "Subgraph errors redacted", "locations": [], "path": null, "extensions": {}}]}"#).unwrap())
+    static REDACTED_PRODUCT_RESPONSE: Lazy<Response> = Lazy::new(|| {
+        serde_json::from_str(r#"{"data": {"topProducts":null}, "errors":[{"message": "Subgraph errors redacted", "locations": [], "path": null, "extensions": {}}]}"#).unwrap()
     });
 
-    static REDACTED_ACCOUNT_RESPONSE: Lazy<ResponseBody> = Lazy::new(|| {
-        ResponseBody::GraphQL(
-            Response::from_bytes("account", Bytes::from_static(r#"{
+    static REDACTED_ACCOUNT_RESPONSE: Lazy<Response> = Lazy::new(|| {
+        Response::from_bytes("account", Bytes::from_static(r#"{
                 "data": null,
                 "errors":[{"message": "Subgraph errors redacted", "locations": [], "path": null, "extensions": {}}]}"#.as_bytes())
     ).unwrap()
-    )
     });
 
-    static EXPECTED_RESPONSE: Lazy<ResponseBody> = Lazy::new(|| {
-        ResponseBody::GraphQL(serde_json::from_str(r#"{"data":{"topProducts":[{"upc":"1","name":"Table","reviews":[{"id":"1","product":{"name":"Table"},"author":{"id":"1","name":"Ada Lovelace"}},{"id":"4","product":{"name":"Table"},"author":{"id":"2","name":"Alan Turing"}}]},{"upc":"2","name":"Couch","reviews":[{"id":"2","product":{"name":"Couch"},"author":{"id":"1","name":"Ada Lovelace"}}]}]}}"#).unwrap())
+    static EXPECTED_RESPONSE: Lazy<Response> = Lazy::new(|| {
+        serde_json::from_str(r#"{"data":{"topProducts":[{"upc":"1","name":"Table","reviews":[{"id":"1","product":{"name":"Table"},"author":{"id":"1","name":"Ada Lovelace"}},{"id":"4","product":{"name":"Table"},"author":{"id":"2","name":"Alan Turing"}}]},{"upc":"2","name":"Couch","reviews":[{"id":"2","product":{"name":"Couch"},"author":{"id":"1","name":"Ada Lovelace"}}]}]}}"#).unwrap()
     });
 
     static VALID_QUERY: &str = r#"query TopProducts($first: Int) { topProducts(first: $first) { upc name reviews { id product { name } author { id name } } } }"#;
@@ -122,10 +119,10 @@ mod test {
 
     async fn execute_router_test(
         query: &str,
-        body: &ResponseBody,
+        body: &Response,
         mut router_service: BoxCloneService<
             RouterRequest,
-            RouterResponse<BoxStream<'static, ResponseBody>>,
+            RouterResponse<BoxStream<'static, Response>>,
             BoxError,
         >,
     ) {
@@ -150,7 +147,7 @@ mod test {
 
     async fn build_mock_router(
         plugin: Box<dyn DynPlugin>,
-    ) -> BoxCloneService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError>
+    ) -> BoxCloneService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>
     {
         let mut extensions = Object::new();
         extensions.insert("test", Value::String(ByteString::from("value")));

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -257,7 +257,7 @@ mod router_plugin_mod {
     pub(crate) fn get_originating_headers_router_response(
         obj: &mut SharedRouterResponse,
     ) -> Result<HeaderMap, Box<EvalAltResult>> {
-        obj.with_mut(get_originating_headers_response_response_body)
+        obj.with_mut(get_originating_headers_response_response)
     }
 
     #[rhai_fn(get = "headers", pure, return_raw)]
@@ -277,8 +277,8 @@ mod router_plugin_mod {
     #[rhai_fn(get = "body", pure, return_raw)]
     pub(crate) fn get_originating_body_router_response(
         obj: &mut SharedRouterResponse,
-    ) -> Result<ResponseBody, Box<EvalAltResult>> {
-        obj.with_mut(get_originating_body_response_response_body)
+    ) -> Result<Response, Box<EvalAltResult>> {
+        obj.with_mut(get_originating_body_response_response)
     }
 
     #[rhai_fn(get = "body", pure, return_raw)]
@@ -300,7 +300,7 @@ mod router_plugin_mod {
         obj: &mut SharedRouterResponse,
         headers: HeaderMap,
     ) -> Result<(), Box<EvalAltResult>> {
-        obj.with_mut(|response| set_originating_headers_response_response_body(response, headers))
+        obj.with_mut(|response| set_originating_headers_response_response(response, headers))
     }
 
     #[rhai_fn(set = "headers", return_raw)]
@@ -322,9 +322,9 @@ mod router_plugin_mod {
     #[rhai_fn(set = "body", return_raw)]
     pub(crate) fn set_originating_body_router_response(
         obj: &mut SharedRouterResponse,
-        body: ResponseBody,
+        body: Response,
     ) -> Result<(), Box<EvalAltResult>> {
-        obj.with_mut(|response| set_originating_body_response_response_body(response, body))
+        obj.with_mut(|response| set_originating_body_response_response(response, body))
     }
 
     #[rhai_fn(set = "body", return_raw)]
@@ -375,22 +375,6 @@ mod router_plugin_mod {
         Ok(obj.accessor().uri().clone())
     }
 
-    fn get_originating_headers_response_response_body<
-        T: Accessor<http_ext::Response<ResponseBody>>,
-    >(
-        obj: &mut T,
-    ) -> Result<HeaderMap, Box<EvalAltResult>> {
-        Ok(obj.accessor().headers().clone())
-    }
-
-    fn get_originating_body_response_response_body<
-        T: Accessor<http_ext::Response<ResponseBody>>,
-    >(
-        obj: &mut T,
-    ) -> Result<ResponseBody, Box<EvalAltResult>> {
-        Ok(obj.accessor().body().clone())
-    }
-
     fn get_originating_headers_response_response<T: Accessor<http_ext::Response<Response>>>(
         obj: &mut T,
     ) -> Result<HeaderMap, Box<EvalAltResult>> {
@@ -424,26 +408,6 @@ mod router_plugin_mod {
         uri: Uri,
     ) -> Result<(), Box<EvalAltResult>> {
         *obj.accessor_mut().uri_mut() = uri;
-        Ok(())
-    }
-
-    fn set_originating_headers_response_response_body<
-        T: Accessor<http_ext::Response<ResponseBody>>,
-    >(
-        obj: &mut T,
-        headers: HeaderMap,
-    ) -> Result<(), Box<EvalAltResult>> {
-        *obj.accessor_mut().headers_mut() = headers;
-        Ok(())
-    }
-
-    fn set_originating_body_response_response_body<
-        T: Accessor<http_ext::Response<ResponseBody>>,
-    >(
-        obj: &mut T,
-        body: ResponseBody,
-    ) -> Result<(), Box<EvalAltResult>> {
-        *obj.accessor_mut().body_mut() = body;
         Ok(())
     }
 
@@ -504,12 +468,8 @@ impl Plugin for Rhai {
 
     fn router_service(
         &mut self,
-        service: BoxService<
-            RouterRequest,
-            RouterResponse<BoxStream<'static, ResponseBody>>,
-            BoxError,
-        >,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError> {
         const FUNCTION_NAME_SERVICE: &str = "router_service";
         if !self.ast_has_function(FUNCTION_NAME_SERVICE) {
             return service;
@@ -834,12 +794,12 @@ impl Accessor<http_ext::Response<Response>> for RhaiExecutionResponse {
     }
 }
 
-impl Accessor<http_ext::Response<ResponseBody>> for RhaiRouterResponse {
-    fn accessor(&self) -> &http_ext::Response<ResponseBody> {
+impl Accessor<http_ext::Response<Response>> for RhaiRouterResponse {
+    fn accessor(&self) -> &http_ext::Response<Response> {
         &self.response
     }
 
-    fn accessor_mut(&mut self) -> &mut http_ext::Response<ResponseBody> {
+    fn accessor_mut(&mut self) -> &mut http_ext::Response<Response> {
         &mut self.response
     }
 }
@@ -869,9 +829,7 @@ impl Accessor<http_ext::Response<Response>> for SubgraphResponse {
 #[allow(dead_code)]
 type SharedRouterService = Arc<
     Mutex<
-        Option<
-            BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError>,
-        >,
+        Option<BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>>,
     >,
 >;
 #[allow(dead_code)]
@@ -879,7 +837,7 @@ type SharedRouterRequest = Arc<Mutex<Option<RouterRequest>>>;
 
 pub(crate) struct RhaiRouterResponse {
     context: Context,
-    response: http_ext::Response<ResponseBody>,
+    response: http_ext::Response<Response>,
 }
 
 #[allow(dead_code)]
@@ -984,7 +942,7 @@ impl ServiceStep {
                                 status: StatusCode,
                             ) -> Result<
                                 ControlFlow<
-                                    RouterResponse<BoxStream<'static, ResponseBody>>,
+                                    RouterResponse<BoxStream<'static, Response>>,
                                     RouterRequest,
                                 >,
                                 BoxError,
@@ -1118,97 +1076,101 @@ impl ServiceStep {
             ServiceStep::Router(service) => {
                 // gen_map_response!(router, service, rhai_service, callback);
                 service.replace(|service| {
-                    BoxService::new(service
-                        .and_then(
-                            |router_response: RouterResponse<
-                                BoxStream<'static, ResponseBody>,
-                            >| async move {
-                                // Let's define a local function to build an error response
-                                // XXX: This isn't ideal. We already have a response, so ideally we'd
-                                // like to append this error into the existing response. However,
-                                // the significantly different treatment of errors in different
-                                // response types makes this extremely painful. This needs to be
-                                // re-visited at some point post GA.
-                                fn failure_message(
-                                    context: Context,
-                                    msg: String,
-                                    status: StatusCode,
-                                ) -> RouterResponse<BoxStream<'static, ResponseBody>>
-                                {
-                                    let res = RouterResponse::error_builder()
-                                        .errors(vec![Error {
-                                            message: msg,
-                                            ..Default::default()
-                                        }])
-                                        .status_code(status)
-                                        .context(context)
-                                        .build()
-                                        .expect("can't fail to build our error message");
-                                    res.boxed()
-                                }
+                    BoxService::new(service.and_then(
+                        |router_response: RouterResponse<BoxStream<'static, Response>>| async move {
+                            // Let's define a local function to build an error response
+                            // XXX: This isn't ideal. We already have a response, so ideally we'd
+                            // like to append this error into the existing response. However,
+                            // the significantly different treatment of errors in different
+                            // response types makes this extremely painful. This needs to be
+                            // re-visited at some point post GA.
+                            fn failure_message(
+                                context: Context,
+                                msg: String,
+                                status: StatusCode,
+                            ) -> RouterResponse<BoxStream<'static, Response>>
+                            {
+                                let res = RouterResponse::error_builder()
+                                    .errors(vec![Error {
+                                        message: msg,
+                                        ..Default::default()
+                                    }])
+                                    .status_code(status)
+                                    .context(context)
+                                    .build()
+                                    .expect("can't fail to build our error message");
+                                res.boxed()
+                            }
 
-                                // we split the response stream into headers+first response, then a stream of deferred responses
-                                // for which we will implement mapping later
-                                let RouterResponse { response, context } = router_response;
-                                let (parts, stream) = http::Response::from(response).into_parts();
-                                let (first, rest) = stream.into_future().await;
+                            // we split the response stream into headers+first response, then a stream of deferred responses
+                            // for which we will implement mapping later
+                            let RouterResponse { response, context } = router_response;
+                            let (parts, stream) = http::Response::from(response).into_parts();
+                            let (first, rest) = stream.into_future().await;
 
-                                if first.is_none() {
-                                    return Ok(failure_message(
-                                        context,
-                                        "rhai execution error: empty response".to_string(),
-                                        StatusCode::INTERNAL_SERVER_ERROR,
-                                    ));
-                                }
-
-                                let response = RhaiRouterResponse {
+                            if first.is_none() {
+                                return Ok(failure_message(
                                     context,
-                                    response: http::Response::from_parts(parts, first.expect("already checked")).into(),
-                                };
-                                let shared_response =
-                                Shared::new(Mutex::new(Some(response)));
+                                    "rhai execution error: empty response".to_string(),
+                                    StatusCode::INTERNAL_SERVER_ERROR,
+                                ));
+                            }
 
-                                let result: Result<Dynamic, String> = if callback.is_curried() {
-                                    callback
-                                        .call(
-                                            &rhai_service.engine,
-                                            &rhai_service.ast,
-                                            (shared_response.clone(),),
-                                        )
-                                        .map_err(|err| err.to_string())
-                                } else {
-                                    let mut scope = rhai_service.scope.clone();
-                                    rhai_service
-                                        .engine
-                                        .call_fn(
-                                            &mut scope,
-                                            &rhai_service.ast,
-                                            callback.fn_name(),
-                                            (shared_response.clone(),),
-                                        )
-                                        .map_err(|err| err.to_string())
-                                };
-                                if let Err(error) = result {
-                                    tracing::error!("map_response callback failed: {error}");
-                                    let mut guard = shared_response.lock().unwrap();
-                                    let response_opt = guard.take();
-                                    return Ok(failure_message(
-                                        response_opt.unwrap().context,
-                                        format!("rhai execution error: '{}'", error),
-                                        StatusCode::INTERNAL_SERVER_ERROR,
-                                    ));
-                                }
+                            let response = RhaiRouterResponse {
+                                context,
+                                response: http::Response::from_parts(
+                                    parts,
+                                    first.expect("already checked"),
+                                )
+                                .into(),
+                            };
+                            let shared_response = Shared::new(Mutex::new(Some(response)));
 
+                            let result: Result<Dynamic, String> = if callback.is_curried() {
+                                callback
+                                    .call(
+                                        &rhai_service.engine,
+                                        &rhai_service.ast,
+                                        (shared_response.clone(),),
+                                    )
+                                    .map_err(|err| err.to_string())
+                            } else {
+                                let mut scope = rhai_service.scope.clone();
+                                rhai_service
+                                    .engine
+                                    .call_fn(
+                                        &mut scope,
+                                        &rhai_service.ast,
+                                        callback.fn_name(),
+                                        (shared_response.clone(),),
+                                    )
+                                    .map_err(|err| err.to_string())
+                            };
+                            if let Err(error) = result {
+                                tracing::error!("map_response callback failed: {error}");
                                 let mut guard = shared_response.lock().unwrap();
                                 let response_opt = guard.take();
-                                let RhaiRouterResponse { context, response } = response_opt.unwrap();
-                                let (parts, body)  = http::Response::from(response).into_parts();
+                                return Ok(failure_message(
+                                    response_opt.unwrap().context,
+                                    format!("rhai execution error: '{}'", error),
+                                    StatusCode::INTERNAL_SERVER_ERROR,
+                                ));
+                            }
 
-                                //FIXME we should also map over the stream of future responses
-                                let response = http::Response::from_parts(parts,once(ready(body)).chain(rest).boxed()).into();
-                                Ok(RouterResponse {context, response})
-                            },
-                        ))
+                            let mut guard = shared_response.lock().unwrap();
+                            let response_opt = guard.take();
+                            let RhaiRouterResponse { context, response } = response_opt.unwrap();
+                            let (parts, body) = http::Response::from(response).into_parts();
+
+                            //FIXME we should also map over the stream of future responses
+                            let response = http::Response::from_parts(
+                                parts,
+                                once(ready(body)).chain(rest).boxed(),
+                            )
+                            .into();
+                            Ok(RouterResponse { context, response })
+                        },
+                    ))
                 })
             }
             ServiceStep::QueryPlanner(service) => {
@@ -1780,7 +1742,6 @@ mod tests {
     use crate::plugin::test::MockRouterService;
     use crate::plugin::DynPlugin;
     use crate::Context;
-    use crate::ResponseBody;
     use crate::RouterRequest;
     use crate::RouterResponse;
 
@@ -1817,23 +1778,16 @@ mod tests {
         let headers = router_resp.response.headers().clone();
         let context = router_resp.context.clone();
         // Check if it fails
-        let body = router_resp.next_response().await.unwrap();
-        match body {
-            ResponseBody::GraphQL(resp) => {
-                if !resp.errors.is_empty() {
-                    panic!(
-                        "Contains errors : {}",
-                        resp.errors
-                            .into_iter()
-                            .map(|err| err.to_string())
-                            .collect::<Vec<String>>()
-                            .join("\n")
-                    );
-                }
-            }
-            _ => {
-                panic!("should not be this kind of response")
-            }
+        let resp = router_resp.next_response().await.unwrap();
+        if !resp.errors.is_empty() {
+            panic!(
+                "Contains errors : {}",
+                resp.errors
+                    .into_iter()
+                    .map(|err| err.to_string())
+                    .collect::<Vec<String>>()
+                    .join("\n")
+            );
         }
 
         assert_eq!(headers.get("coucou").unwrap(), &"hello");

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -152,27 +152,27 @@ mod test {
     use tower::Service;
 
     use super::*;
+    use crate::graphql::Response;
     use crate::json_ext::Object;
     use crate::plugin::test::MockSubgraph;
     use crate::plugin::DynPlugin;
     use crate::PluggableRouterServiceBuilder;
-    use crate::ResponseBody;
     use crate::RouterRequest;
     use crate::RouterResponse;
     use crate::Schema;
 
-    static EXPECTED_RESPONSE: Lazy<ResponseBody> = Lazy::new(|| {
-        ResponseBody::GraphQL(serde_json::from_str(r#"{"data":{"topProducts":[{"upc":"1","name":"Table","reviews":[{"id":"1","product":{"name":"Table"},"author":{"id":"1","name":"Ada Lovelace"}},{"id":"4","product":{"name":"Table"},"author":{"id":"2","name":"Alan Turing"}}]},{"upc":"2","name":"Couch","reviews":[{"id":"2","product":{"name":"Couch"},"author":{"id":"1","name":"Ada Lovelace"}}]}]}}"#).unwrap())
+    static EXPECTED_RESPONSE: Lazy<Response> = Lazy::new(|| {
+        serde_json::from_str(r#"{"data":{"topProducts":[{"upc":"1","name":"Table","reviews":[{"id":"1","product":{"name":"Table"},"author":{"id":"1","name":"Ada Lovelace"}},{"id":"4","product":{"name":"Table"},"author":{"id":"2","name":"Alan Turing"}}]},{"upc":"2","name":"Couch","reviews":[{"id":"2","product":{"name":"Couch"},"author":{"id":"1","name":"Ada Lovelace"}}]}]}}"#).unwrap()
     });
 
     static VALID_QUERY: &str = r#"query TopProducts($first: Int) { topProducts(first: $first) { upc name reviews { id product { name } author { id name } } } }"#;
 
     async fn execute_router_test(
         query: &str,
-        body: &ResponseBody,
+        body: &Response,
         mut router_service: BoxCloneService<
             RouterRequest,
-            RouterResponse<BoxStream<'static, ResponseBody>>,
+            RouterResponse<BoxStream<'static, Response>>,
             BoxError,
         >,
     ) {
@@ -197,7 +197,7 @@ mod test {
 
     async fn build_mock_router_with_variable_dedup_optimization(
         plugin: Box<dyn DynPlugin>,
-    ) -> BoxCloneService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError>
+    ) -> BoxCloneService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>
     {
         let mut extensions = Object::new();
         extensions.insert("test", Value::String(ByteString::from("value")));

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -23,7 +23,6 @@ use crate::layers::ServiceBuilderExt;
 use crate::plugin::DynPlugin;
 use crate::services::Plugins;
 use crate::PluggableRouterServiceBuilder;
-use crate::ResponseBody;
 use crate::Schema;
 use crate::SubgraphService;
 
@@ -35,7 +34,7 @@ use crate::SubgraphService;
 pub(crate) trait RouterServiceFactory: Send + Sync + 'static {
     type RouterService: Service<
             Request<graphql::Request>,
-            Response = Response<BoxStream<'static, ResponseBody>>,
+            Response = Response<BoxStream<'static, graphql::Response>>,
             Error = BoxError,
             Future = Self::Future,
         > + Send
@@ -61,7 +60,7 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
     type RouterService = Buffer<
         BoxCloneService<
             Request<graphql::Request>,
-            Response<BoxStream<'static, ResponseBody>>,
+            Response<BoxStream<'static, graphql::Response>>,
             BoxError,
         >,
         Request<graphql::Request>,

--- a/apollo-router/src/services/http_ext.rs
+++ b/apollo-router/src/services/http_ext.rs
@@ -19,7 +19,7 @@ use http::HeaderValue;
 use http::Method;
 use multimap::MultiMap;
 
-use crate::ResponseBody;
+use crate::graphql;
 
 /// Temporary holder of header name while for use while building requests and responses. Required
 /// because header name creation is fallible.
@@ -241,8 +241,8 @@ impl<T> Response<T> {
     }
 }
 
-impl Response<BoxStream<'static, ResponseBody>> {
-    pub fn from_response_to_stream(http: http::response::Response<ResponseBody>) -> Self {
+impl Response<BoxStream<'static, graphql::Response>> {
+    pub fn from_response_to_stream(http: http::response::Response<graphql::Response>) -> Self {
         let (parts, body) = http.into_parts();
         Response {
             inner: http::Response::from_parts(parts, Box::pin(once(ready(body)))),
@@ -297,7 +297,7 @@ impl<T: Clone> Clone for Response<T> {
     }
 }
 
-impl IntoResponse for Response<ResponseBody> {
+impl IntoResponse for Response<graphql::Response> {
     fn into_response(self) -> axum::response::Response {
         // todo: chunks?
         let (mut parts, body) = http::Response::from(self).into_parts();

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -17,8 +17,8 @@ use tower::Layer;
 use tower::Service;
 
 use crate::error::Error;
+use crate::graphql::Response;
 use crate::layers::sync_checkpoint::CheckpointService;
-use crate::ResponseBody;
 use crate::RouterRequest;
 use crate::RouterResponse;
 
@@ -51,7 +51,7 @@ impl Default for APQLayer {
 
 impl<S> Layer<S> for APQLayer
 where
-    S: Service<RouterRequest, Response = RouterResponse<BoxStream<'static, ResponseBody>>>
+    S: Service<RouterRequest, Response = RouterResponse<BoxStream<'static, Response>>>
         + Send
         + 'static,
     <S as Service<RouterRequest>>::Future: Send + 'static,
@@ -147,7 +147,6 @@ mod apq_tests {
     use crate::error::Error;
     use crate::plugin::test::MockRouterService;
     use crate::Context;
-    use crate::ResponseBody;
 
     #[tokio::test]
     async fn it_works() {
@@ -381,11 +380,7 @@ mod apq_tests {
         assert_error_matches(&expected_apq_miss_error, second_apq_error);
     }
 
-    fn assert_error_matches(expected_error: &Error, res: crate::ResponseBody) {
-        if let ResponseBody::GraphQL(graphql_response) = res {
-            assert_eq!(&graphql_response.errors[0], expected_error);
-        } else {
-            panic!("expected a graphql response");
-        }
+    fn assert_error_matches(expected_error: &Error, res: Response) {
+        assert_eq!(&res.errors[0], expected_error);
     }
 }

--- a/apollo-router/src/services/layers/ensure_query_presence.rs
+++ b/apollo-router/src/services/layers/ensure_query_presence.rs
@@ -13,8 +13,8 @@ use tower::BoxError;
 use tower::Layer;
 use tower::Service;
 
+use crate::graphql::Response;
 use crate::layers::sync_checkpoint::CheckpointService;
-use crate::ResponseBody;
 use crate::RouterRequest;
 use crate::RouterResponse;
 
@@ -23,7 +23,7 @@ pub(crate) struct EnsureQueryPresence {}
 
 impl<S> Layer<S> for EnsureQueryPresence
 where
-    S: Service<RouterRequest, Response = RouterResponse<BoxStream<'static, ResponseBody>>>
+    S: Service<RouterRequest, Response = RouterResponse<BoxStream<'static, Response>>>
         + Send
         + 'static,
     <S as Service<RouterRequest>>::Future: Send + 'static,
@@ -68,7 +68,6 @@ mod ensure_query_presence_tests {
 
     use super::*;
     use crate::plugin::test::MockRouterService;
-    use crate::ResponseBody;
 
     #[tokio::test]
     async fn it_works_with_query() {
@@ -112,11 +111,7 @@ mod ensure_query_presence_tests {
             .next_response()
             .await
             .unwrap();
-        let actual_error = if let ResponseBody::GraphQL(b) = response {
-            b.errors[0].message.clone()
-        } else {
-            panic!("response body should have been GraphQL");
-        };
+        let actual_error = response.errors[0].message.clone();
 
         assert_eq!(expected_error, actual_error);
     }
@@ -140,11 +135,7 @@ mod ensure_query_presence_tests {
             .next_response()
             .await
             .unwrap();
-        let actual_error = if let ResponseBody::GraphQL(b) = response {
-            b.errors[0].message.clone()
-        } else {
-            panic!("response body should have been GraphQL");
-        };
+        let actual_error = response.errors[0].message.clone();
         assert_eq!(expected_error, actual_error);
     }
 }

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -419,11 +419,11 @@ mod tests {
     use tower::Service;
 
     use super::*;
+    use crate::graphql;
     use crate::http_ext::Request;
     use crate::http_ext::Response;
     use crate::http_server_factory::Listener;
     use crate::router_factory::RouterServiceFactory;
-    use crate::ResponseBody;
 
     fn example_schema() -> Schema {
         include_str!("testdata/supergraph.graphql").parse().unwrap()
@@ -649,7 +649,7 @@ mod tests {
 
     //mockall does not handle well the lifetime on Context
     impl Service<Request<crate::graphql::Request>> for MockMyRouter {
-        type Response = Response<BoxStream<'static, ResponseBody>>;
+        type Response = Response<BoxStream<'static, graphql::Response>>;
         type Error = BoxError;
         type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
@@ -684,7 +684,7 @@ mod tests {
         where
             RS: Service<
                     Request<crate::graphql::Request>,
-                    Response = Response<BoxStream<'static, ResponseBody>>,
+                    Response = Response<BoxStream<'static, graphql::Response>>,
                     Error = BoxError,
                 > + Send
                 + Sync

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -19,7 +19,6 @@ use apollo_router::plugins::telemetry::config::Tracing;
 use apollo_router::plugins::telemetry::Telemetry;
 use apollo_router::plugins::telemetry::{self};
 use apollo_router::services::PluggableRouterServiceBuilder;
-use apollo_router::services::ResponseBody;
 use apollo_router::services::RouterRequest;
 use apollo_router::services::RouterResponse;
 use apollo_router::services::SubgraphRequest;
@@ -623,7 +622,7 @@ async fn query_rust(
 }
 
 async fn setup_router_and_registry() -> (
-    BoxCloneService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError>,
+    BoxCloneService<RouterRequest, RouterResponse<BoxStream<'static, graphql::Response>>, BoxError>,
     CountingServiceRegistry,
 ) {
     std::panic::set_hook(Box::new(|e| {
@@ -668,25 +667,18 @@ async fn setup_router_and_registry() -> (
 async fn query_with_router(
     router: BoxCloneService<
         RouterRequest,
-        RouterResponse<BoxStream<'static, ResponseBody>>,
+        RouterResponse<BoxStream<'static, graphql::Response>>,
         BoxError,
     >,
     request: RouterRequest,
 ) -> graphql::Response {
-    let response = router
+    router
         .oneshot(request)
         .await
         .unwrap()
         .next_response()
         .await
-        .unwrap();
-
-    match response {
-        ResponseBody::GraphQL(response) => response,
-        _ => {
-            panic!("Expected graphql response")
-        }
-    }
+        .unwrap()
 }
 
 #[derive(Debug, Clone)]

--- a/examples/add-timestamp-header/src/main.rs
+++ b/examples/add-timestamp-header/src/main.rs
@@ -80,13 +80,8 @@ mod tests {
             .expect("x-elapsed-time is present");
 
         // with the expected message
-        if let apollo_router::services::ResponseBody::GraphQL(response) =
-            service_response.next_response().await.unwrap()
-        {
-            assert!(response.errors.is_empty());
-            assert_eq!(expected_mock_response_data, response.data.as_ref().unwrap());
-        } else {
-            panic!("unexpected response");
-        }
+        let response = service_response.next_response().await.unwrap();
+        assert!(response.errors.is_empty());
+        assert_eq!(expected_mock_response_data, response.data.as_ref().unwrap());
     }
 }

--- a/examples/async-auth/src/allow_client_id_from_file.rs
+++ b/examples/async-auth/src/allow_client_id_from_file.rs
@@ -5,7 +5,6 @@ use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
-use apollo_router::services::ResponseBody;
 use apollo_router::services::RouterRequest;
 use apollo_router::services::RouterResponse;
 use futures::stream::BoxStream;
@@ -53,10 +52,11 @@ impl Plugin for AllowClientIdFromFile {
         &mut self,
         service: BoxService<
             RouterRequest,
-            RouterResponse<BoxStream<'static, ResponseBody>>,
+            RouterResponse<BoxStream<'static, graphql::Response>>,
             BoxError,
         >,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, graphql::Response>>, BoxError>
+    {
         let header_key = self.header.clone();
         // async_checkpoint is an async function.
         // this means it will run whenever the service `await`s it
@@ -239,12 +239,7 @@ mod tests {
         assert_eq!(StatusCode::UNAUTHORIZED, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: graphql::Response = service_response
-            .next_response()
-            .await
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let graphql_response: graphql::Response = service_response.next_response().await.unwrap();
 
         assert_eq!(
             "Missing 'x-client-id' header".to_string(),
@@ -285,12 +280,7 @@ mod tests {
         assert_eq!(StatusCode::FORBIDDEN, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: graphql::Response = service_response
-            .next_response()
-            .await
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let graphql_response: graphql::Response = service_response.next_response().await.unwrap();
 
         assert_eq!(
             "client-id is not allowed".to_string(),
@@ -359,12 +349,7 @@ mod tests {
         assert_eq!(StatusCode::OK, service_response.response.status());
 
         // ...with the expected data
-        let graphql_response: graphql::Response = service_response
-            .next_response()
-            .await
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let graphql_response: graphql::Response = service_response.next_response().await.unwrap();
 
         assert_eq!(
             // we're allowed to unwrap() here because we know the json is a str()

--- a/examples/context/src/context_data.rs
+++ b/examples/context/src/context_data.rs
@@ -1,6 +1,6 @@
+use apollo_router::graphql;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
-use apollo_router::services::ResponseBody;
 use apollo_router::services::RouterRequest;
 use apollo_router::services::RouterResponse;
 use apollo_router::services::SubgraphRequest;
@@ -49,10 +49,11 @@ impl Plugin for ContextData {
         &mut self,
         service: BoxService<
             RouterRequest,
-            RouterResponse<BoxStream<'static, ResponseBody>>,
+            RouterResponse<BoxStream<'static, graphql::Response>>,
             BoxError,
         >,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, graphql::Response>>, BoxError>
+    {
         // `ServiceBuilder` provides us with `map_request` and `map_response` methods.
         //
         // These allow basic interception and transformation of request and response messages.

--- a/examples/forbid-anonymous-operations/src/forbid_anonymous_operations.rs
+++ b/examples/forbid-anonymous-operations/src/forbid_anonymous_operations.rs
@@ -4,7 +4,6 @@ use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
-use apollo_router::services::ResponseBody;
 use apollo_router::services::RouterRequest;
 use apollo_router::services::RouterResponse;
 use futures::stream::BoxStream;
@@ -38,10 +37,11 @@ impl Plugin for ForbidAnonymousOperations {
         &mut self,
         service: BoxService<
             RouterRequest,
-            RouterResponse<BoxStream<'static, ResponseBody>>,
+            RouterResponse<BoxStream<'static, graphql::Response>>,
             BoxError,
         >,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, graphql::Response>>, BoxError>
+    {
         // `ServiceBuilder` provides us with a `checkpoint` method.
         //
         // This method allows us to return ControlFlow::Continue(request) if we want to let the request through,
@@ -153,12 +153,7 @@ mod tests {
         assert_eq!(StatusCode::BAD_REQUEST, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: graphql::Response = service_response
-            .next_response()
-            .await
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let graphql_response: graphql::Response = service_response.next_response().await.unwrap();
 
         assert_eq!(
             "Anonymous operations are not allowed".to_string(),
@@ -194,12 +189,7 @@ mod tests {
         assert_eq!(StatusCode::BAD_REQUEST, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: graphql::Response = service_response
-            .next_response()
-            .await
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let graphql_response: graphql::Response = service_response.next_response().await.unwrap();
 
         assert_eq!(
             "Anonymous operations are not allowed".to_string(),
@@ -262,12 +252,7 @@ mod tests {
         assert_eq!(StatusCode::OK, service_response.response.status());
 
         // ...with the expected data
-        let graphql_response: graphql::Response = service_response
-            .next_response()
-            .await
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let graphql_response: graphql::Response = service_response.next_response().await.unwrap();
 
         assert_eq!(
             // we're allowed to unwrap() here because we know the json is a str()

--- a/examples/hello-world/src/hello_world.rs
+++ b/examples/hello-world/src/hello_world.rs
@@ -5,7 +5,6 @@ use apollo_router::services::ExecutionRequest;
 use apollo_router::services::ExecutionResponse;
 use apollo_router::services::QueryPlannerRequest;
 use apollo_router::services::QueryPlannerResponse;
-use apollo_router::services::ResponseBody;
 use apollo_router::services::RouterRequest;
 use apollo_router::services::RouterResponse;
 use apollo_router::services::SubgraphRequest;
@@ -41,12 +40,8 @@ impl Plugin for HelloWorld {
 
     fn router_service(
         &mut self,
-        service: BoxService<
-            RouterRequest,
-            RouterResponse<BoxStream<'static, ResponseBody>>,
-            BoxError,
-        >,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError> {
         // Say hello when our service is added to the router_service
         // stage of the router plugin pipeline.
         #[cfg(test)]

--- a/examples/jwt-auth/src/jwt.rs
+++ b/examples/jwt-auth/src/jwt.rs
@@ -67,7 +67,6 @@ use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
-use apollo_router::services::ResponseBody;
 use apollo_router::services::RouterRequest;
 use apollo_router::services::RouterResponse;
 use apollo_router::Context;
@@ -215,10 +214,11 @@ impl Plugin for JwtAuth {
         &mut self,
         service: BoxService<
             RouterRequest,
-            RouterResponse<BoxStream<'static, ResponseBody>>,
+            RouterResponse<BoxStream<'static, graphql::Response>>,
             BoxError,
         >,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, graphql::Response>>, BoxError>
+    {
         // We are going to use the `jwt-simple` crate for our JWT verification.
         // The crate provides straightforward support for the popular JWT algorithms.
 
@@ -243,7 +243,7 @@ impl Plugin for JwtAuth {
                     context: Context,
                     msg: String,
                     status: StatusCode,
-                ) -> Result<ControlFlow<RouterResponse<BoxStream<'static, ResponseBody>>, RouterRequest>, BoxError> {
+                ) -> Result<ControlFlow<RouterResponse<BoxStream<'static, graphql::Response>>, RouterRequest>, BoxError> {
                     let res = RouterResponse::error_builder()
                         .errors(vec![graphql::Error {
                             message: msg,
@@ -442,12 +442,7 @@ mod tests {
         assert_eq!(StatusCode::UNAUTHORIZED, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: graphql::Response = service_response
-            .next_response()
-            .await
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let graphql_response: graphql::Response = service_response.next_response().await.unwrap();
 
         assert_eq!(
             "Missing 'authorization' header".to_string(),
@@ -482,12 +477,7 @@ mod tests {
         assert_eq!(StatusCode::BAD_REQUEST, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: graphql::Response = service_response
-            .next_response()
-            .await
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let graphql_response: graphql::Response = service_response.next_response().await.unwrap();
 
         assert_eq!(
             "'should start with Bearer' is not correctly formatted",
@@ -522,12 +512,7 @@ mod tests {
         assert_eq!(StatusCode::BAD_REQUEST, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: graphql::Response = service_response
-            .next_response()
-            .await
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let graphql_response: graphql::Response = service_response.next_response().await.unwrap();
 
         assert_eq!(
             "'Bearer  ' is not correctly formatted",
@@ -566,12 +551,7 @@ mod tests {
         );
 
         // with the expected error message
-        let graphql_response: graphql::Response = service_response
-            .next_response()
-            .await
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let graphql_response: graphql::Response = service_response.next_response().await.unwrap();
 
         assert_eq!(
             "Only hmac support is implemented. Check configuration for typos",
@@ -654,12 +634,7 @@ mod tests {
         assert_eq!(StatusCode::OK, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: graphql::Response = service_response
-            .next_response()
-            .await
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let graphql_response: graphql::Response = service_response.next_response().await.unwrap();
 
         assert!(graphql_response.errors.is_empty());
         assert_eq!(expected_mock_response_data, graphql_response.data.unwrap())
@@ -709,12 +684,7 @@ mod tests {
         assert_eq!(StatusCode::FORBIDDEN, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: graphql::Response = service_response
-            .next_response()
-            .await
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let graphql_response: graphql::Response = service_response.next_response().await.unwrap();
 
         assert_eq!(
             format!("{token} is not authorized: expiry period exceeds policy limit"),
@@ -771,12 +741,7 @@ mod tests {
         assert_eq!(StatusCode::FORBIDDEN, service_response.response.status());
 
         // with the expected error message
-        let graphql_response: graphql::Response = service_response
-            .next_response()
-            .await
-            .unwrap()
-            .try_into()
-            .unwrap();
+        let graphql_response: graphql::Response = service_response.next_response().await.unwrap();
 
         assert_eq!(
             format!("{token} is not authorized: Token has expired"),

--- a/examples/op-name-to-header/src/main.rs
+++ b/examples/op-name-to-header/src/main.rs
@@ -16,7 +16,6 @@ mod tests {
     use apollo_router::plugin::Plugin;
     use apollo_router::plugins::rhai::Conf;
     use apollo_router::plugins::rhai::Rhai;
-    use apollo_router::services::ResponseBody;
     use apollo_router::services::RouterRequest;
     use apollo_router::services::RouterResponse;
     use http::StatusCode;
@@ -80,11 +79,8 @@ mod tests {
         assert_eq!(StatusCode::OK, service_response.response.status());
 
         // with the expected message
-        if let ResponseBody::GraphQL(response) = service_response.next_response().await.unwrap() {
-            assert!(response.errors.is_empty());
-            assert_eq!(expected_mock_response_data, response.data.as_ref().unwrap());
-        } else {
-            panic!("unexpected response");
-        }
+        let response = service_response.next_response().await.unwrap();
+        assert!(response.errors.is_empty());
+        assert_eq!(expected_mock_response_data, response.data.as_ref().unwrap());
     }
 }

--- a/examples/rhai-logging/src/main.rs
+++ b/examples/rhai-logging/src/main.rs
@@ -17,7 +17,6 @@ mod tests {
     use apollo_router::plugin::Plugin;
     use apollo_router::plugins::rhai::Conf;
     use apollo_router::plugins::rhai::Rhai;
-    use apollo_router::services::ResponseBody;
     use apollo_router::services::RouterRequest;
     use apollo_router::services::RouterResponse;
     use http::StatusCode;
@@ -73,11 +72,8 @@ mod tests {
         assert_eq!(StatusCode::OK, service_response.response.status());
 
         // with the expected message
-        if let ResponseBody::GraphQL(response) = service_response.next_response().await.unwrap() {
-            assert!(response.errors.is_empty());
-            assert_eq!(expected_mock_response_data, response.data.as_ref().unwrap());
-        } else {
-            panic!("unexpected response");
-        }
+        let response = service_response.next_response().await.unwrap();
+        assert!(response.errors.is_empty());
+        assert_eq!(expected_mock_response_data, response.data.as_ref().unwrap());
     }
 }

--- a/examples/status-code-propagation/src/propagate_status_code.rs
+++ b/examples/status-code-propagation/src/propagate_status_code.rs
@@ -1,6 +1,6 @@
+use apollo_router::graphql;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
-use apollo_router::services::ResponseBody;
 use apollo_router::services::RouterRequest;
 use apollo_router::services::RouterResponse;
 use apollo_router::services::SubgraphRequest;
@@ -73,10 +73,11 @@ impl Plugin for PropagateStatusCode {
         &mut self,
         service: BoxService<
             RouterRequest,
-            RouterResponse<BoxStream<'static, ResponseBody>>,
+            RouterResponse<BoxStream<'static, graphql::Response>>,
             BoxError,
         >,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, ResponseBody>>, BoxError> {
+    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, graphql::Response>>, BoxError>
+    {
         service
             .map_response(move |mut res| {
                 if let Some(code) = res


### PR DESCRIPTION
Fixes https://github.com/apollographql/router/issues/1140

The body type inside `RouterResponse` is now `graphql::Response` instead of `ResponseBody`.

`ResponseBody` is an enum for either `graphql::Response`, a JSON value, or a String. However except for one unit test only the GraphQL variant was ever used.

The diff is big but (again except for that test) the only meaningful change is:

```diff
--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
 /// [`Context`] and [`http_ext::Response<ResponseBody>`] for the response.
 ///
 /// This consists of the response body and the context.
 #[derive(Clone, Debug)]
-pub struct RouterResponse<T: Stream<Item = ResponseBody>> {
+pub struct RouterResponse<T: Stream<Item = Response>> {
     pub response: http_ext::Response<T>,
     pub context: Context,
 }
```

The test in question is `it_checks_the_shape_of_router_request` where the response body was changed from a single JSON string to a GraphQL response with that same string in `data`.

`BodyResponse` is still used for custom endpoints in plugins (which is where non-GraphQL responses are used), but that part of the API does not use `RouterResponse` so it is not affected by this PR.

Everything else was made with search-and-replace or following compiler errors, and so should be fairly mechanical.
