### PR TITLE
Reformat with imports_granularity = Item and group_imports = StdExternalCrate

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# .git-blame-ignore-revs
+
+# Reformat with imports_granularity = Item and group_imports = StdExternalCrate
+af3209126ffee9b825b694ee6913745873e8115b

--- a/apollo-router-benchmarks/benches/basic_composition.rs
+++ b/apollo-router-benchmarks/benches/basic_composition.rs
@@ -1,4 +1,6 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
 
 include!("../src/shared.rs");
 

--- a/apollo-router-scaffold/src/lib.rs
+++ b/apollo-router-scaffold/src/lib.rs
@@ -1,8 +1,9 @@
 mod plugin;
 
-use crate::plugin::PluginAction;
 use anyhow::Result;
 use clap::Subcommand;
+
+use crate::plugin::PluginAction;
 
 #[derive(Subcommand, Debug)]
 pub enum RouterAction {
@@ -23,13 +24,18 @@ impl RouterAction {
 
 #[cfg(test)]
 mod test {
-    use anyhow::{bail, Result};
-    use cargo_scaffold::{Opts, ScaffoldDescription};
-    use inflector::Inflector;
     use std::collections::BTreeMap;
     use std::env;
-    use std::path::{Path, PathBuf, MAIN_SEPARATOR};
+    use std::path::Path;
+    use std::path::PathBuf;
+    use std::path::MAIN_SEPARATOR;
     use std::process::Command;
+
+    use anyhow::bail;
+    use anyhow::Result;
+    use cargo_scaffold::Opts;
+    use cargo_scaffold::ScaffoldDescription;
+    use inflector::Inflector;
     use tempfile::TempDir;
 
     #[test]

--- a/apollo-router-scaffold/src/plugin.rs
+++ b/apollo-router-scaffold/src/plugin.rs
@@ -1,10 +1,12 @@
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
 use anyhow::Result;
 use cargo_scaffold::ScaffoldDescription;
 use clap::Subcommand;
 use inflector::Inflector;
 use regex::Regex;
-use std::fs;
-use std::path::{Path, PathBuf};
 use toml::Value;
 
 #[derive(Subcommand, Debug)]

--- a/apollo-router/src/cache.rs
+++ b/apollo-router/src/cache.rs
@@ -1,15 +1,18 @@
-use crate::error::CacheResolverError;
-use crate::traits::CacheResolver;
-use derivative::Derivative;
-use futures::lock::Mutex;
-use lru::LruCache;
 use std::cmp::Eq;
 use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
 use std::sync::Arc;
-use tokio::sync::broadcast::{self, Sender};
+
+use derivative::Derivative;
+use futures::lock::Mutex;
+use lru::LruCache;
+use tokio::sync::broadcast::Sender;
+use tokio::sync::broadcast::{self};
 use tokio::sync::oneshot;
+
+use crate::error::CacheResolverError;
+use crate::traits::CacheResolver;
 
 /// A caching map optimised for slow value resolution.
 ///
@@ -147,12 +150,14 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::error::CacheResolverError;
     use async_trait::async_trait;
-    use futures::stream::{FuturesUnordered, StreamExt};
+    use futures::stream::FuturesUnordered;
+    use futures::stream::StreamExt;
     use mockall::mock;
     use test_log::test;
+
+    use super::*;
+    use crate::error::CacheResolverError;
 
     struct HasACache {
         cm: CachingMap<usize, usize>,

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -2,25 +2,35 @@
 // This entire file is license key functionality
 mod yaml;
 
-use crate::plugin::plugins;
-use crate::subscriber::is_global_subscriber_set;
-use derivative::Derivative;
-use displaydoc::Display;
-use envmnt::{ExpandOptions, ExpansionType};
-use itertools::Itertools;
-use jsonschema::{Draft, JSONSchema};
-use schemars::gen::{SchemaGenerator, SchemaSettings};
-use schemars::schema::{ObjectValidation, RootSchema, Schema, SchemaObject};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-use serde_json::Map;
-use serde_json::Value;
 use std::cmp::Ordering;
 use std::fmt;
 use std::net::SocketAddr;
 use std::str::FromStr;
+
+use derivative::Derivative;
+use displaydoc::Display;
+use envmnt::ExpandOptions;
+use envmnt::ExpansionType;
+use itertools::Itertools;
+use jsonschema::Draft;
+use jsonschema::JSONSchema;
+use schemars::gen::SchemaGenerator;
+use schemars::gen::SchemaSettings;
+use schemars::schema::ObjectValidation;
+use schemars::schema::RootSchema;
+use schemars::schema::Schema;
+use schemars::schema::SchemaObject;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json::Map;
+use serde_json::Value;
 use thiserror::Error;
-use tower_http::cors::{self, CorsLayer};
+use tower_http::cors::CorsLayer;
+use tower_http::cors::{self};
+
+use crate::plugin::plugins;
+use crate::subscriber::is_global_subscriber_set;
 
 /// Configuration error.
 #[derive(Debug, Error, Display)]
@@ -799,18 +809,20 @@ pub(crate) fn validate_configuration(raw_yaml: &str) -> Result<Configuration, Co
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::error::SchemaError;
+    use std::collections::HashMap;
+    use std::fs;
+
     use http::Uri;
     #[cfg(unix)]
     use insta::assert_json_snapshot;
     use regex::Regex;
     #[cfg(unix)]
     use schemars::gen::SchemaSettings;
-    use std::collections::HashMap;
-    use std::fs;
     use walkdir::DirEntry;
     use walkdir::WalkDir;
+
+    use super::*;
+    use crate::error::SchemaError;
 
     #[cfg(unix)]
     #[test]

--- a/apollo-router/src/configuration/yaml.rs
+++ b/apollo-router/src/configuration/yaml.rs
@@ -1,11 +1,15 @@
-use crate::configuration::ConfigurationError;
+use std::collections::HashMap;
+
 use derivative::Derivative;
 use indexmap::IndexMap;
-use jsonschema::paths::{JSONPointer, PathChunk};
-use std::collections::HashMap;
-use yaml_rust::parser::{MarkedEventReceiver, Parser};
+use jsonschema::paths::JSONPointer;
+use jsonschema::paths::PathChunk;
+use yaml_rust::parser::MarkedEventReceiver;
+use yaml_rust::parser::Parser;
 use yaml_rust::scanner::Marker;
 use yaml_rust::Event;
+
+use crate::configuration::ConfigurationError;
 
 #[derive(Derivative, Clone, Debug, Eq)]
 #[derivative(Hash, PartialEq)]
@@ -190,8 +194,9 @@ impl MarkedEventReceiver for MarkedYaml {
 
 #[cfg(test)]
 mod test {
-    use crate::configuration::yaml::parse;
     use insta::assert_snapshot;
+
+    use crate::configuration::yaml::parse;
 
     #[test]
     fn test() {

--- a/apollo-router/src/context.rs
+++ b/apollo-router/src/context.rs
@@ -3,12 +3,15 @@
 //! Router plugins accept a mutable [`Context`] when invoked and this contains a DashMap which
 //! allows additional data to be passed back and forth along the request invocation pipeline.
 
-use crate::json_ext::Value;
-use dashmap::mapref::multiple::{RefMulti, RefMutMulti};
+use std::sync::Arc;
+
+use dashmap::mapref::multiple::RefMulti;
+use dashmap::mapref::multiple::RefMutMulti;
 use dashmap::DashMap;
 use serde::Serialize;
-use std::sync::Arc;
 use tower::BoxError;
+
+use crate::json_ext::Value;
 
 /// Holds [`Context`] entries.
 pub(crate) type Entries = Arc<DashMap<String, Value>>;

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -1,22 +1,26 @@
-use crate::graphql::Response;
-use crate::json_ext::Path;
-use crate::json_ext::Value;
-use displaydoc::Display;
-use miette::{Diagnostic, NamedSource, Report, SourceSpan};
-use router_bridge::{
-    introspect::IntrospectionError,
-    planner::{PlanErrors, UsageReporting},
-};
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+
+use displaydoc::Display;
+use miette::Diagnostic;
+use miette::NamedSource;
+use miette::Report;
+use miette::SourceSpan;
+use router_bridge::introspect::IntrospectionError;
+pub use router_bridge::planner::PlanError;
+use router_bridge::planner::PlanErrors;
+pub use router_bridge::planner::PlannerError;
+use router_bridge::planner::UsageReporting;
+use serde::Deserialize;
+use serde::Serialize;
 use thiserror::Error;
 use tokio::task::JoinError;
 use tracing::level_filters::LevelFilter;
 
-pub use crate::spec::SpecError;
-pub use router_bridge::planner::{PlanError, PlannerError};
-
 pub(crate) use crate::graphql::Error;
+use crate::graphql::Response;
+use crate::json_ext::Path;
+use crate::json_ext::Value;
+pub use crate::spec::SpecError;
 
 /// Error types for execution.
 ///

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -1,24 +1,32 @@
 //! Main entry point for CLI command to start server.
 
-use crate::configuration::{generate_config_schema, ConfigurationError};
+use std::env;
+use std::ffi::OsStr;
+use std::fmt;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+use clap::AppSettings;
+use clap::CommandFactory;
+use clap::Parser;
+use directories::ProjectDirs;
+use once_cell::sync::OnceCell;
+use tracing_subscriber::EnvFilter;
+use url::ParseError;
+use url::Url;
+
+use crate::configuration::generate_config_schema;
+use crate::configuration::Configuration;
+use crate::configuration::ConfigurationError;
 use crate::router::ApolloRouter;
 use crate::router::ConfigurationKind;
 use crate::router::SchemaKind;
 use crate::router::ShutdownKind;
-use crate::{
-    configuration::Configuration,
-    subscriber::{set_global_subscriber, RouterSubscriber},
-};
-use anyhow::{anyhow, Context, Result};
-use clap::{AppSettings, CommandFactory, Parser};
-use directories::ProjectDirs;
-use once_cell::sync::OnceCell;
-use std::ffi::OsStr;
-use std::path::PathBuf;
-use std::time::Duration;
-use std::{env, fmt};
-use tracing_subscriber::EnvFilter;
-use url::{ParseError, Url};
+use crate::subscriber::set_global_subscriber;
+use crate::subscriber::RouterSubscriber;
 
 static GLOBAL_ENV_FILTER: OnceCell<String> = OnceCell::new();
 

--- a/apollo-router/src/files.rs
+++ b/apollo-router/src/files.rs
@@ -1,8 +1,9 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
 use futures::channel::mpsc;
 use futures::prelude::*;
 use hotwatch::Hotwatch;
-use std::path::PathBuf;
-use std::time::Duration;
 
 /// Creates a stream events whenever the file at the path has changes. The stream never terminates
 /// and must be dropped to finish watching.
@@ -59,11 +60,15 @@ pub(crate) fn watch(path: PathBuf, delay: Option<Duration>) -> impl Stream<Item 
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use super::*;
     use std::env::temp_dir;
     use std::fs::File;
-    use std::io::{Seek, SeekFrom, Write};
+    use std::io::Seek;
+    use std::io::SeekFrom;
+    use std::io::Write;
+
     use test_log::test;
+
+    use super::*;
 
     #[test(tokio::test)]
     async fn basic_watch() {

--- a/apollo-router/src/graphql.rs
+++ b/apollo-router/src/graphql.rs
@@ -1,12 +1,15 @@
 //! Namespace for the GraphQL [`Request`], [`Response`], and [`Error`] types.
 
-use crate::error::{FetchError, Location};
+use std::fmt;
+
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::error::FetchError;
+use crate::error::Location;
 use crate::json_ext::Object;
 use crate::json_ext::Path;
 use crate::json_ext::Value;
-use serde::{Deserialize, Serialize};
-use std::fmt;
-
 pub use crate::request::Request;
 pub use crate::response::Response;
 

--- a/apollo-router/src/http_server_factory.rs
+++ b/apollo-router/src/http_server_factory.rs
@@ -1,16 +1,22 @@
-use super::router::ApolloRouterError;
-use crate::configuration::{Configuration, ListenAddr};
-use crate::graphql;
-use crate::http_ext::{Request, Response};
-use crate::plugin::Handler;
-use crate::ResponseBody;
-use derivative::Derivative;
-use futures::prelude::*;
-use futures::{channel::oneshot, stream::BoxStream};
+use std::collections::HashMap;
+use std::pin::Pin;
 use std::sync::Arc;
-use std::{collections::HashMap, pin::Pin};
+
+use derivative::Derivative;
+use futures::channel::oneshot;
+use futures::prelude::*;
+use futures::stream::BoxStream;
 use tower::BoxError;
 use tower::Service;
+
+use super::router::ApolloRouterError;
+use crate::configuration::Configuration;
+use crate::configuration::ListenAddr;
+use crate::graphql;
+use crate::http_ext::Request;
+use crate::http_ext::Response;
+use crate::plugin::Handler;
+use crate::ResponseBody;
 
 /// Factory for creating the http server component.
 ///
@@ -190,11 +196,13 @@ impl Listener {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use futures::channel::oneshot;
     use std::net::SocketAddr;
     use std::str::FromStr;
+
+    use futures::channel::oneshot;
     use test_log::test;
+
+    use super::*;
 
     #[test(tokio::test)]
     async fn sanity() {

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -1,9 +1,12 @@
-use crate::graphql::Response;
-use crate::*;
+use std::collections::HashMap;
+
 use include_dir::include_dir;
 use once_cell::sync::Lazy;
-use router_bridge::introspect::{self, IntrospectionError};
-use std::collections::HashMap;
+use router_bridge::introspect::IntrospectionError;
+use router_bridge::introspect::{self};
+
+use crate::graphql::Response;
+use crate::*;
 
 /// KNOWN_INTROSPECTION_QUERIES we will serve through Introspection.
 ///

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -1,9 +1,14 @@
-use crate::error::FetchError;
-use serde::{Deserialize, Serialize};
-pub use serde_json_bytes::Value;
-use serde_json_bytes::{ByteString, Entry, Map};
 use std::cmp::min;
 use std::fmt;
+
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json_bytes::ByteString;
+use serde_json_bytes::Entry;
+use serde_json_bytes::Map;
+pub use serde_json_bytes::Value;
+
+use crate::error::FetchError;
 
 /// A JSON object.
 pub type Object = Map<ByteString, Value>;
@@ -547,8 +552,9 @@ impl fmt::Display for Path {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json_bytes::json;
+
+    use super::*;
 
     macro_rules! assert_is_subset {
         ($a:expr, $b:expr $(,)?) => {

--- a/apollo-router/src/layers/async_checkpoint.rs
+++ b/apollo-router/src/layers/async_checkpoint.rs
@@ -7,12 +7,17 @@
 //! chain of responsibilities. If it fails, then the control flow is broken a response is passed
 //! back to the invoking service.
 
+use std::marker::PhantomData;
+use std::ops::ControlFlow;
+use std::pin::Pin;
+use std::sync::Arc;
+
 use futures::future::BoxFuture;
 use futures::Future;
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::{ops::ControlFlow, sync::Arc};
-use tower::{BoxError, Layer, Service, ServiceExt};
+use tower::BoxError;
+use tower::Layer;
+use tower::Service;
+use tower::ServiceExt;
 
 /// [`Layer`] for Asynchronous Checkpoints.
 #[allow(clippy::type_complexity)]
@@ -132,11 +137,16 @@ where
 
 #[cfg(test)]
 mod async_checkpoint_tests {
+    use tower::BoxError;
+    use tower::Layer;
+    use tower::ServiceBuilder;
+    use tower::ServiceExt;
+
     use super::*;
     use crate::layers::ServiceBuilderExt;
     use crate::plugin::test::MockExecutionService;
-    use crate::{ExecutionRequest, ExecutionResponse};
-    use tower::{BoxError, Layer, ServiceBuilder, ServiceExt};
+    use crate::ExecutionRequest;
+    use crate::ExecutionResponse;
 
     #[tokio::test]
     async fn test_service_builder() {

--- a/apollo-router/src/layers/cache.rs
+++ b/apollo-router/src/layers/cache.rs
@@ -1,15 +1,18 @@
 //! Provides a CachingLayer used to implement the cache functionality of [`crate::layers::ServiceBuilderExt`].
 
-use futures::future::BoxFuture;
-use futures::FutureExt;
-use futures::TryFutureExt;
-use moka::sync::Cache;
 use std::hash::Hash;
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::task::Poll;
+
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use futures::TryFutureExt;
+use moka::sync::Cache;
 use tokio::sync::RwLock;
-use tower::{BoxError, Layer, Service};
+use tower::BoxError;
+use tower::Layer;
+use tower::Service;
 
 type Sentinel<Value> = Arc<RwLock<Option<Value>>>;
 
@@ -168,13 +171,17 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::mock_service;
+    use std::time::Duration;
+
     use mockall::predicate::eq;
     use moka::sync::CacheBuilder;
-    use std::time::Duration;
     use tower::filter::AsyncPredicate;
-    use tower::{BoxError, ServiceBuilder, ServiceExt};
+    use tower::BoxError;
+    use tower::ServiceBuilder;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::mock_service;
 
     #[derive(Default, Clone)]
     struct Slow;

--- a/apollo-router/src/layers/instrument.rs
+++ b/apollo-router/src/layers/instrument.rs
@@ -18,7 +18,9 @@
 //!
 
 use std::marker::PhantomData;
-use std::task::{Context, Poll};
+use std::task::Context;
+use std::task::Poll;
+
 use tower::Layer;
 use tower_service::Service;
 use tracing::Instrument;

--- a/apollo-router/src/layers/map_future_with_context.rs
+++ b/apollo-router/src/layers/map_future_with_context.rs
@@ -4,7 +4,9 @@
 //!
 
 use std::future::Future;
-use std::task::{Context, Poll};
+use std::task::Context;
+use std::task::Poll;
+
 use tower::Layer;
 use tower::Service;
 
@@ -76,13 +78,18 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::layers::ServiceBuilderExt;
-    use crate::plugin::test::MockRouterService;
-    use crate::{ResponseBody, RouterRequest, RouterResponse};
     use futures::stream::BoxStream;
     use http::HeaderValue;
-    use tower::{BoxError, Service};
-    use tower::{ServiceBuilder, ServiceExt};
+    use tower::BoxError;
+    use tower::Service;
+    use tower::ServiceBuilder;
+    use tower::ServiceExt;
+
+    use crate::layers::ServiceBuilderExt;
+    use crate::plugin::test::MockRouterService;
+    use crate::ResponseBody;
+    use crate::RouterRequest;
+    use crate::RouterResponse;
 
     #[tokio::test]
     async fn test_layer() -> Result<(), BoxError> {

--- a/apollo-router/src/layers/mod.rs
+++ b/apollo-router/src/layers/mod.rs
@@ -1,21 +1,24 @@
 //! Reusable layers
 //! Layers that are specific to one plugin should not be placed in this module.
+use std::future::Future;
+use std::ops::ControlFlow;
+use std::sync::Arc;
+
+use moka::sync::Cache;
+use tokio::sync::RwLock;
+use tower::buffer::BufferLayer;
+use tower::layer::util::Stack;
+use tower::BoxError;
+use tower::ServiceBuilder;
+use tower_service::Service;
+use tracing::Span;
+
 use crate::layers::async_checkpoint::AsyncCheckpointLayer;
 use crate::layers::cache::CachingLayer;
 use crate::layers::instrument::InstrumentLayer;
 use crate::layers::map_future_with_context::MapFutureWithContextLayer;
 use crate::layers::map_future_with_context::MapFutureWithContextService;
 use crate::layers::sync_checkpoint::CheckpointLayer;
-use moka::sync::Cache;
-use std::future::Future;
-use std::ops::ControlFlow;
-use std::sync::Arc;
-use tokio::sync::RwLock;
-use tower::buffer::BufferLayer;
-use tower::layer::util::Stack;
-use tower::{BoxError, ServiceBuilder};
-use tower_service::Service;
-use tracing::Span;
 
 pub mod map_future_with_context;
 

--- a/apollo-router/src/layers/sync_checkpoint.rs
+++ b/apollo-router/src/layers/sync_checkpoint.rs
@@ -7,9 +7,13 @@
 //! chain of responsibilities. If it fails, then the control flow is broken a response is passed
 //! back to the invoking service.
 
+use std::ops::ControlFlow;
+use std::sync::Arc;
+
 use futures::future::BoxFuture;
-use std::{ops::ControlFlow, sync::Arc};
-use tower::{BoxError, Layer, Service};
+use tower::BoxError;
+use tower::Layer;
+use tower::Service;
 
 /// [`Layer`] for Synchronous Checkpoints.
 #[allow(clippy::type_complexity)]
@@ -161,12 +165,16 @@ where
 
 #[cfg(test)]
 mod checkpoint_tests {
+    use tower::BoxError;
+    use tower::Layer;
+    use tower::ServiceBuilder;
+    use tower::ServiceExt;
+
     use super::*;
-    use crate::{
-        layers::ServiceBuilderExt, plugin::test::MockExecutionService, ExecutionRequest,
-        ExecutionResponse,
-    };
-    use tower::{BoxError, Layer, ServiceBuilder, ServiceExt};
+    use crate::layers::ServiceBuilderExt;
+    use crate::plugin::test::MockExecutionService;
+    use crate::ExecutionRequest;
+    use crate::ExecutionResponse;
 
     #[tokio::test]
     async fn test_service_builder() {

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -56,8 +56,12 @@ mod traits;
 
 pub use configuration::Configuration;
 pub use context::Context;
-pub use executable::{main, Executable};
-pub use router::{ApolloRouter, ConfigurationKind, SchemaKind, ShutdownKind};
+pub use executable::main;
+pub use executable::Executable;
+pub use router::ApolloRouter;
+pub use router::ConfigurationKind;
+pub use router::SchemaKind;
+pub use router::ShutdownKind;
 pub use services::http_ext;
 pub use spec::Schema;
 

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -17,13 +17,13 @@
 pub mod serde;
 pub mod test;
 
-use crate::graphql::Response;
-use crate::layers::ServiceBuilderExt;
-use crate::{
-    http_ext, ExecutionRequest, ExecutionResponse, QueryPlannerRequest, QueryPlannerResponse,
-    ResponseBody, RouterRequest, RouterResponse, SubgraphRequest, SubgraphResponse,
-};
-use ::serde::{de::DeserializeOwned, Deserialize};
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::task::Context;
+use std::task::Poll;
+
+use ::serde::de::DeserializeOwned;
+use ::serde::Deserialize;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::future::BoxFuture;
@@ -31,13 +31,25 @@ use futures::stream::BoxStream;
 use once_cell::sync::Lazy;
 use schemars::gen::SchemaGenerator;
 use schemars::JsonSchema;
-use std::collections::HashMap;
-use std::sync::Mutex;
-use std::task::{Context, Poll};
 use tower::buffer::future::ResponseFuture;
 use tower::buffer::Buffer;
 use tower::util::BoxService;
-use tower::{BoxError, Service, ServiceBuilder};
+use tower::BoxError;
+use tower::Service;
+use tower::ServiceBuilder;
+
+use crate::graphql::Response;
+use crate::http_ext;
+use crate::layers::ServiceBuilderExt;
+use crate::ExecutionRequest;
+use crate::ExecutionResponse;
+use crate::QueryPlannerRequest;
+use crate::QueryPlannerResponse;
+use crate::ResponseBody;
+use crate::RouterRequest;
+use crate::RouterResponse;
+use crate::SubgraphRequest;
+use crate::SubgraphResponse;
 
 type InstanceFactory = fn(&serde_json::Value) -> BoxFuture<Result<Box<dyn DynPlugin>, BoxError>>;
 

--- a/apollo-router/src/plugin/serde.rs
+++ b/apollo-router/src/plugin/serde.rs
@@ -1,10 +1,13 @@
+use std::fmt::Formatter;
+use std::str::FromStr;
+
 use http::header::HeaderName;
 use http::HeaderValue;
 use regex::Regex;
-use serde::de::{Error, Visitor};
-use serde::{de, Deserializer};
-use std::fmt::Formatter;
-use std::str::FromStr;
+use serde::de;
+use serde::de::Error;
+use serde::de::Visitor;
+use serde::Deserializer;
 
 pub fn deserialize_option_header_name<'de, D>(
     deserializer: D,

--- a/apollo-router/src/plugin/test/mock/canned.rs
+++ b/apollo-router/src/plugin/test/mock/canned.rs
@@ -1,7 +1,8 @@
 //! Canned data for use with MockSugbraph.
 //! Eventually we may replace this with a real subgraph.
-use crate::plugin::test::MockSubgraph;
 use serde_json::json;
+
+use crate::plugin::test::MockSubgraph;
 
 /// Canned responses for accounts_subgraphs.
 pub(crate) fn accounts_subgraph() -> MockSubgraph {

--- a/apollo-router/src/plugin/test/mock/subgraph.rs
+++ b/apollo-router/src/plugin/test/mock/subgraph.rs
@@ -1,12 +1,19 @@
 //! Mock subgraph implementation
 
-use crate::graphql::{Request, Response};
-use crate::json_ext::Object;
-use crate::{SubgraphRequest, SubgraphResponse};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::task::Poll;
+
 use futures::future;
 use http::StatusCode;
-use std::{collections::HashMap, sync::Arc, task::Poll};
-use tower::{BoxError, Service};
+use tower::BoxError;
+use tower::Service;
+
+use crate::graphql::Request;
+use crate::graphql::Response;
+use crate::json_ext::Object;
+use crate::SubgraphRequest;
+use crate::SubgraphResponse;
 
 type MockResponses = HashMap<Request, Response>;
 

--- a/apollo-router/src/plugin/test/mod.rs
+++ b/apollo-router/src/plugin/test/mod.rs
@@ -3,10 +3,22 @@
 mod mock;
 mod service;
 
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use futures::stream::BoxStream;
 pub use mock::subgraph::MockSubgraph;
-pub use service::{
-    MockExecutionService, MockQueryPlanningService, MockRouterService, MockSubgraphService,
-};
+pub use service::MockExecutionService;
+pub use service::MockQueryPlanningService;
+pub use service::MockRouterService;
+pub use service::MockSubgraphService;
+use tower::buffer::Buffer;
+use tower::util::BoxService;
+use tower::BoxError;
+use tower::Service;
+use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use crate::introspection::Introspection;
 use crate::layers::DEFAULT_BUFFER_SIZE;
@@ -17,18 +29,10 @@ use crate::services::layers::apq::APQLayer;
 use crate::services::layers::ensure_query_presence::EnsureQueryPresence;
 use crate::ExecutionService;
 use crate::ResponseBody;
+use crate::RouterRequest;
+use crate::RouterResponse;
 use crate::RouterService;
 use crate::Schema;
-use crate::{RouterRequest, RouterResponse};
-use futures::stream::BoxStream;
-use std::collections::HashMap;
-use std::str::FromStr;
-use std::sync::Arc;
-use tower::buffer::Buffer;
-use tower::util::BoxService;
-use tower::Service;
-use tower::ServiceExt;
-use tower::{BoxError, ServiceBuilder};
 
 pub struct PluginTestHarness {
     router_service:
@@ -211,8 +215,9 @@ impl PluginTestHarness {
 
 #[cfg(test)]
 mod testing {
-    use super::*;
     use insta::assert_json_snapshot;
+
+    use super::*;
 
     struct EmptyPlugin {}
     #[async_trait::async_trait]

--- a/apollo-router/src/plugin/test/service.rs
+++ b/apollo-router/src/plugin/test/service.rs
@@ -1,9 +1,15 @@
-use crate::graphql::Response;
-use crate::{
-    ExecutionRequest, ExecutionResponse, QueryPlannerRequest, QueryPlannerResponse, ResponseBody,
-    RouterRequest, RouterResponse, SubgraphRequest, SubgraphResponse,
-};
 use futures::stream::BoxStream;
+
+use crate::graphql::Response;
+use crate::ExecutionRequest;
+use crate::ExecutionResponse;
+use crate::QueryPlannerRequest;
+use crate::QueryPlannerResponse;
+use crate::ResponseBody;
+use crate::RouterRequest;
+use crate::RouterResponse;
+use crate::SubgraphRequest;
+use crate::SubgraphResponse;
 
 /// Build a mock service handler for the router pipeline.
 #[macro_export]

--- a/apollo-router/src/plugins/csrf.rs
+++ b/apollo-router/src/plugins/csrf.rs
@@ -1,14 +1,22 @@
-use crate::layers::ServiceBuilderExt;
-use crate::plugin::Plugin;
-use crate::{register_plugin, ResponseBody, RouterRequest, RouterResponse};
+use std::ops::ControlFlow;
+
 use futures::stream::BoxStream;
 use http::header;
-use http::{HeaderMap, StatusCode};
+use http::HeaderMap;
+use http::StatusCode;
 use schemars::JsonSchema;
 use serde::Deserialize;
-use std::ops::ControlFlow;
 use tower::util::BoxService;
-use tower::{BoxError, ServiceBuilder, ServiceExt};
+use tower::BoxError;
+use tower::ServiceBuilder;
+use tower::ServiceExt;
+
+use crate::layers::ServiceBuilderExt;
+use crate::plugin::Plugin;
+use crate::register_plugin;
+use crate::ResponseBody;
+use crate::RouterRequest;
+use crate::RouterResponse;
 
 #[derive(Deserialize, Debug, Clone, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -222,10 +230,12 @@ mod csrf_tests {
             .unwrap();
     }
 
-    use super::*;
-    use crate::{plugin::test::MockRouterService, ResponseBody};
     use serde_json_bytes::json;
     use tower::ServiceExt;
+
+    use super::*;
+    use crate::plugin::test::MockRouterService;
+    use crate::ResponseBody;
 
     #[tokio::test]
     async fn it_lets_preflighted_request_pass_through() {

--- a/apollo-router/src/plugins/forbid_mutations.rs
+++ b/apollo-router/src/plugins/forbid_mutations.rs
@@ -1,13 +1,20 @@
-use crate::graphql::Response;
-use crate::{
-    error::Error, json_ext::Object, layers::ServiceBuilderExt, plugin::Plugin, register_plugin,
-    ExecutionRequest, ExecutionResponse,
-};
+use std::ops::ControlFlow;
+
 use futures::stream::BoxStream;
 use http::StatusCode;
-use std::ops::ControlFlow;
 use tower::util::BoxService;
-use tower::{BoxError, ServiceBuilder, ServiceExt};
+use tower::BoxError;
+use tower::ServiceBuilder;
+use tower::ServiceExt;
+
+use crate::error::Error;
+use crate::graphql::Response;
+use crate::json_ext::Object;
+use crate::layers::ServiceBuilderExt;
+use crate::plugin::Plugin;
+use crate::register_plugin;
+use crate::ExecutionRequest;
+use crate::ExecutionResponse;
 
 #[derive(Debug, Clone)]
 struct ForbidMutations {
@@ -62,15 +69,18 @@ impl Plugin for ForbidMutations {
 
 #[cfg(test)]
 mod forbid_http_get_mutations_tests {
+    use http::Method;
+    use http::StatusCode;
+    use serde_json::json;
+    use tower::ServiceExt;
+
     use super::*;
     use crate::graphql;
     use crate::http_ext::Request;
     use crate::plugin::test::MockExecutionService;
     use crate::query_planner::fetch::OperationKind;
-    use crate::query_planner::{PlanNode, QueryPlan};
-    use http::{Method, StatusCode};
-    use serde_json::json;
-    use tower::ServiceExt;
+    use crate::query_planner::PlanNode;
+    use crate::query_planner::QueryPlan;
 
     #[tokio::test]
     async fn it_lets_queries_pass_through() {

--- a/apollo-router/src/plugins/headers.rs
+++ b/apollo-router/src/plugins/headers.rs
@@ -1,23 +1,39 @@
-use crate::plugin::serde::{
-    deserialize_header_name, deserialize_header_value, deserialize_option_header_name,
-    deserialize_option_header_value, deserialize_regex,
-};
-use crate::plugin::Plugin;
-use crate::{register_plugin, SubgraphRequest, SubgraphResponse};
-use http::header::{
-    HeaderName, CONNECTION, CONTENT_LENGTH, CONTENT_TYPE, HOST, PROXY_AUTHENTICATE,
-    PROXY_AUTHORIZATION, TE, TRAILER, TRANSFER_ENCODING, UPGRADE,
-};
+use std::collections::HashMap;
+use std::task::Context;
+use std::task::Poll;
+
+use http::header::HeaderName;
+use http::header::CONNECTION;
+use http::header::CONTENT_LENGTH;
+use http::header::CONTENT_TYPE;
+use http::header::HOST;
+use http::header::PROXY_AUTHENTICATE;
+use http::header::PROXY_AUTHORIZATION;
+use http::header::TE;
+use http::header::TRAILER;
+use http::header::TRANSFER_ENCODING;
+use http::header::UPGRADE;
 use http::HeaderValue;
 use lazy_static::lazy_static;
 use regex::Regex;
 use schemars::JsonSchema;
 use serde::Deserialize;
-use std::collections::HashMap;
-use std::task::{Context, Poll};
 use tower::util::BoxService;
-use tower::{BoxError, Layer, ServiceBuilder, ServiceExt};
+use tower::BoxError;
+use tower::Layer;
+use tower::ServiceBuilder;
+use tower::ServiceExt;
 use tower_service::Service;
+
+use crate::plugin::serde::deserialize_header_name;
+use crate::plugin::serde::deserialize_header_value;
+use crate::plugin::serde::deserialize_option_header_name;
+use crate::plugin::serde::deserialize_option_header_value;
+use crate::plugin::serde::deserialize_regex;
+use crate::plugin::Plugin;
+use crate::register_plugin;
+use crate::SubgraphRequest;
+use crate::SubgraphResponse;
 
 register_plugin!("apollo", "headers", Headers);
 
@@ -232,17 +248,23 @@ where
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use crate::graphql::{Request, Response};
-    use crate::http_ext;
-    use crate::plugin::test::MockSubgraphService;
-    use crate::plugins::headers::{Config, HeadersLayer};
-    use crate::query_planner::fetch::OperationKind;
-    use crate::{Context, SubgraphRequest, SubgraphResponse};
     use std::collections::HashSet;
     use std::str::FromStr;
     use std::sync::Arc;
+
     use tower::BoxError;
+
+    use super::*;
+    use crate::graphql::Request;
+    use crate::graphql::Response;
+    use crate::http_ext;
+    use crate::plugin::test::MockSubgraphService;
+    use crate::plugins::headers::Config;
+    use crate::plugins::headers::HeadersLayer;
+    use crate::query_planner::fetch::OperationKind;
+    use crate::Context;
+    use crate::SubgraphRequest;
+    use crate::SubgraphResponse;
 
     #[test]
     fn test_subgraph_config() {

--- a/apollo-router/src/plugins/include_subgraph_errors.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors.rs
@@ -1,12 +1,17 @@
-use crate::error::Error as SubgraphError;
-use crate::plugin::Plugin;
-use crate::{register_plugin, SubgraphRequest, SubgraphResponse};
+use std::collections::HashMap;
+
 use once_cell::sync::Lazy;
 use schemars::JsonSchema;
 use serde::Deserialize;
-use std::collections::HashMap;
 use tower::util::BoxService;
-use tower::{BoxError, ServiceExt};
+use tower::BoxError;
+use tower::ServiceExt;
+
+use crate::error::Error as SubgraphError;
+use crate::plugin::Plugin;
+use crate::register_plugin;
+use crate::SubgraphRequest;
+use crate::SubgraphResponse;
 
 #[allow(clippy::field_reassign_with_default)]
 static REDACTED_ERROR_MESSAGE: Lazy<Vec<SubgraphError>> = Lazy::new(|| {
@@ -67,20 +72,26 @@ impl Plugin for IncludeSubgraphErrors {
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
+    use bytes::Bytes;
+    use futures::stream::BoxStream;
+    use serde_json::Value as jValue;
+    use serde_json_bytes::ByteString;
+    use serde_json_bytes::Value;
+    use tower::util::BoxCloneService;
+    use tower::Service;
+
     use super::*;
     use crate::graphql::Response;
     use crate::json_ext::Object;
     use crate::plugin::test::MockSubgraph;
     use crate::plugin::DynPlugin;
-    use crate::{
-        PluggableRouterServiceBuilder, ResponseBody, RouterRequest, RouterResponse, Schema,
-    };
-    use bytes::Bytes;
-    use futures::stream::BoxStream;
-    use serde_json::Value as jValue;
-    use serde_json_bytes::{ByteString, Value};
-    use std::sync::Arc;
-    use tower::{util::BoxCloneService, Service};
+    use crate::PluggableRouterServiceBuilder;
+    use crate::ResponseBody;
+    use crate::RouterRequest;
+    use crate::RouterResponse;
+    use crate::Schema;
 
     static UNREDACTED_PRODUCT_RESPONSE: Lazy<ResponseBody> = Lazy::new(|| {
         ResponseBody::GraphQL(serde_json::from_str(r#"{"data": {"topProducts":null}, "errors":[{"message": "couldn't find mock for query", "locations": [], "path": null, "extensions": { "test": "value" }}]}"#).unwrap())

--- a/apollo-router/src/plugins/override_url.rs
+++ b/apollo-router/src/plugins/override_url.rs
@@ -1,12 +1,17 @@
 //! Allows subgraph URLs to be overridden.
 
-use crate::plugin::Plugin;
-use crate::{register_plugin, SubgraphRequest, SubgraphResponse};
-use http::Uri;
 use std::collections::HashMap;
 use std::str::FromStr;
+
+use http::Uri;
 use tower::util::BoxService;
-use tower::{BoxError, ServiceExt};
+use tower::BoxError;
+use tower::ServiceExt;
+
+use crate::plugin::Plugin;
+use crate::register_plugin;
+use crate::SubgraphRequest;
+use crate::SubgraphResponse;
 
 #[derive(Debug, Clone)]
 struct OverrideSubgraphUrl {
@@ -48,13 +53,19 @@ register_plugin!("apollo", "override_subgraph_url", OverrideSubgraphUrl);
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::plugin::DynPlugin;
-    use crate::{plugin::test::MockSubgraphService, Context, SubgraphRequest};
+    use std::str::FromStr;
+
     use http::Uri;
     use serde_json::Value;
-    use std::str::FromStr;
-    use tower::{util::BoxService, Service, ServiceExt};
+    use tower::util::BoxService;
+    use tower::Service;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::plugin::test::MockSubgraphService;
+    use crate::plugin::DynPlugin;
+    use crate::Context;
+    use crate::SubgraphRequest;
 
     #[tokio::test]
     async fn plugin_registered() {

--- a/apollo-router/src/plugins/telemetry/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/apollo.rs
@@ -1,10 +1,11 @@
 //! Configuration for apollo telemetry.
 // This entire file is license key functionality
-use crate::plugin::serde::deserialize_header_name;
 use http::header::HeaderName;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use url::Url;
+
+use crate::plugin::serde::deserialize_header_name;
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -1,14 +1,18 @@
 //! Configuration for the telemetry plugin.
-use super::metrics::MetricsAttributesConf;
-use super::*;
-use crate::plugins::telemetry::metrics;
-use opentelemetry::sdk::Resource;
-use opentelemetry::{Array, KeyValue, Value};
-use schemars::JsonSchema;
-use serde::Deserialize;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::time::Duration;
+
+use opentelemetry::sdk::Resource;
+use opentelemetry::Array;
+use opentelemetry::KeyValue;
+use opentelemetry::Value;
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use super::metrics::MetricsAttributesConf;
+use super::*;
+use crate::plugins::telemetry::metrics;
 
 pub trait GenericWith<T>
 where

--- a/apollo-router/src/plugins/telemetry/metrics/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo.rs
@@ -1,21 +1,28 @@
 // This entire file is license key functionality
 //! Apollo metrics
-use crate::plugins::telemetry::apollo::Config;
-use crate::plugins::telemetry::config::MetricsCommon;
-use crate::plugins::telemetry::metrics::{MetricsBuilder, MetricsConfigurator};
-use apollo_spaceport::{ReportHeader, Reporter, ReporterError};
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use apollo_spaceport::ReportHeader;
+use apollo_spaceport::Reporter;
+use apollo_spaceport::ReporterError;
 use async_trait::async_trait;
+use deadpool::managed;
 use deadpool::managed::Pool;
-use deadpool::{managed, Runtime};
+use deadpool::Runtime;
 use futures::channel::mpsc;
 use futures::stream::StreamExt;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::time::Duration;
 use studio::Report;
 use studio::SingleReport;
 use sys_info::hostname;
 use tower::BoxError;
 use url::Url;
+
+use crate::plugins::telemetry::apollo::Config;
+use crate::plugins::telemetry::config::MetricsCommon;
+use crate::plugins::telemetry::metrics::MetricsBuilder;
+use crate::plugins::telemetry::metrics::MetricsConfigurator;
 
 mod duration_histogram;
 pub(crate) mod studio;
@@ -237,18 +244,20 @@ impl managed::Manager for ReporterManager {
 
 #[cfg(test)]
 mod test {
-    use crate::plugin::test::IntoSchema::Canned;
-    use crate::plugin::test::PluginTestHarness;
-    use crate::plugin::Plugin;
-    use crate::Context;
-    use crate::RouterRequest;
-    use http::header::HeaderName;
     use std::future::Future;
 
-    use crate::plugins::telemetry::{apollo, Telemetry, STUDIO_EXCLUDE};
+    use http::header::HeaderName;
 
     use super::super::super::config;
     use super::*;
+    use crate::plugin::test::IntoSchema::Canned;
+    use crate::plugin::test::PluginTestHarness;
+    use crate::plugin::Plugin;
+    use crate::plugins::telemetry::apollo;
+    use crate::plugins::telemetry::Telemetry;
+    use crate::plugins::telemetry::STUDIO_EXCLUDE;
+    use crate::Context;
+    use crate::RouterRequest;
 
     #[tokio::test]
     async fn apollo_metrics_disabled() -> Result<(), BoxError> {

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/duration_histogram.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/duration_histogram.rs
@@ -1,5 +1,6 @@
-use serde::Serialize;
 use std::time::Duration;
+
+use serde::Serialize;
 #[derive(Serialize, Debug)]
 pub(crate) struct DurationHistogram {
     pub(crate) buckets: Vec<i64>,

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/studio.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/studio.rs
@@ -1,10 +1,15 @@
-use super::duration_histogram::DurationHistogram;
-use apollo_spaceport::{ReferencedFieldsForType, ReportHeader, StatsContext};
-use itertools::Itertools;
-use serde::Serialize;
 use std::collections::HashMap;
 use std::ops::AddAssign;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
+use std::time::SystemTime;
+
+use apollo_spaceport::ReferencedFieldsForType;
+use apollo_spaceport::ReportHeader;
+use apollo_spaceport::StatsContext;
+use itertools::Itertools;
+use serde::Serialize;
+
+use super::duration_histogram::DurationHistogram;
 
 impl Report {
     #[cfg(test)]
@@ -309,7 +314,8 @@ impl From<FieldStat> for apollo_spaceport::FieldStat {
 }
 
 pub(crate) mod vectorize {
-    use serde::{Serialize, Serializer};
+    use serde::Serialize;
+    use serde::Serializer;
 
     pub(crate) fn serialize<'a, T, K, V, S>(target: T, ser: S) -> Result<S::Ok, S::Error>
     where
@@ -325,10 +331,12 @@ pub(crate) mod vectorize {
 
 #[cfg(test)]
 mod test {
-    use super::*;
-    use apollo_spaceport::ReferencedFieldsForType;
     use std::collections::HashMap;
     use std::time::Duration;
+
+    use apollo_spaceport::ReferencedFieldsForType;
+
+    use super::*;
 
     #[test]
     fn test_aggregation() {

--- a/apollo-router/src/plugins/telemetry/metrics/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/mod.rs
@@ -1,20 +1,28 @@
-use crate::plugin::serde::{deserialize_header_name, deserialize_regex};
-use crate::plugin::Handler;
-use crate::plugins::telemetry::config::MetricsCommon;
-use crate::plugins::telemetry::metrics::apollo::Sender;
-use crate::{http_ext, ResponseBody};
-use ::serde::Deserialize;
-use bytes::Bytes;
-use http::header::HeaderName;
-use opentelemetry::metrics::{Counter, Meter, MeterProvider, Number, ValueRecorder};
-use opentelemetry::KeyValue;
-use regex::Regex;
-use schemars::JsonSchema;
 use std::any::Any;
 use std::collections::HashMap;
 use std::sync::Arc;
+
+use ::serde::Deserialize;
+use bytes::Bytes;
+use http::header::HeaderName;
+use opentelemetry::metrics::Counter;
+use opentelemetry::metrics::Meter;
+use opentelemetry::metrics::MeterProvider;
+use opentelemetry::metrics::Number;
+use opentelemetry::metrics::ValueRecorder;
+use opentelemetry::KeyValue;
+use regex::Regex;
+use schemars::JsonSchema;
 use tower::util::BoxService;
 use tower::BoxError;
+
+use crate::http_ext;
+use crate::plugin::serde::deserialize_header_name;
+use crate::plugin::serde::deserialize_regex;
+use crate::plugin::Handler;
+use crate::plugins::telemetry::config::MetricsCommon;
+use crate::plugins::telemetry::metrics::apollo::Sender;
+use crate::ResponseBody;
 
 pub(crate) mod apollo;
 pub(crate) mod otlp;

--- a/apollo-router/src/plugins/telemetry/metrics/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/otlp.rs
@@ -1,11 +1,16 @@
-use crate::plugins::telemetry::config::MetricsCommon;
-use crate::plugins::telemetry::metrics::{MetricsBuilder, MetricsConfigurator};
-use futures::{Stream, StreamExt};
+use std::time::Duration;
+
+use futures::Stream;
+use futures::StreamExt;
 use opentelemetry::sdk::metrics::selectors;
 use opentelemetry::util::tokio_interval_stream;
-use opentelemetry_otlp::{HttpExporterBuilder, TonicExporterBuilder};
-use std::time::Duration;
+use opentelemetry_otlp::HttpExporterBuilder;
+use opentelemetry_otlp::TonicExporterBuilder;
 use tower::BoxError;
+
+use crate::plugins::telemetry::config::MetricsCommon;
+use crate::plugins::telemetry::metrics::MetricsBuilder;
+use crate::plugins::telemetry::metrics::MetricsConfigurator;
 
 // TODO Remove MetricExporterBuilder once upstream issue is fixed
 // This has to exist because Http is not currently supported for metrics export

--- a/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
@@ -1,19 +1,28 @@
-use crate::plugins::telemetry::config::MetricsCommon;
-use crate::plugins::telemetry::metrics::{MetricsBuilder, MetricsConfigurator};
-use crate::{http_ext, ResponseBody};
+use std::task::Context;
+use std::task::Poll;
+
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use http::StatusCode;
 use opentelemetry::sdk::Resource;
-use opentelemetry::{Key, KeyValue, Value};
-use prometheus::{Encoder, Registry, TextEncoder};
+use opentelemetry::Key;
+use opentelemetry::KeyValue;
+use opentelemetry::Value;
+use prometheus::Encoder;
+use prometheus::Registry;
+use prometheus::TextEncoder;
 use schemars::JsonSchema;
 use serde::Deserialize;
-use std::task::{Context, Poll};
-use tower::{BoxError, ServiceExt};
+use tower::BoxError;
+use tower::ServiceExt;
 use tower_service::Service;
 
 use super::MetricsAttributesConf;
+use crate::http_ext;
+use crate::plugins::telemetry::config::MetricsCommon;
+use crate::plugins::telemetry::metrics::MetricsBuilder;
+use crate::plugins::telemetry::metrics::MetricsConfigurator;
+use crate::ResponseBody;
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/apollo-router/src/plugins/telemetry/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/otlp.rs
@@ -1,17 +1,23 @@
 //! Shared configuration for Otlp tracing and metrics.
-use crate::configuration::ConfigurationError;
-use crate::plugins::telemetry::config::GenericWith;
-use opentelemetry_otlp::{HttpExporterBuilder, TonicExporterBuilder, WithExportConfig};
-use schemars::JsonSchema;
-use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::Value;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::Duration;
+
+use opentelemetry_otlp::HttpExporterBuilder;
+use opentelemetry_otlp::TonicExporterBuilder;
+use opentelemetry_otlp::WithExportConfig;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde_json::Value;
 use tonic::metadata::MetadataMap;
 use tonic::transport::ClientTlsConfig;
 use tower::BoxError;
 use url::Url;
+
+use crate::configuration::ConfigurationError;
+use crate::plugins::telemetry::config::GenericWith;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -187,9 +193,12 @@ impl Default for Protocol {
 }
 
 mod metadata_map_serde {
-    use super::*;
     use std::collections::HashMap;
-    use tonic::metadata::{KeyAndValueRef, MetadataKey};
+
+    use tonic::metadata::KeyAndValueRef;
+    use tonic::metadata::MetadataKey;
+
+    use super::*;
 
     pub(crate) fn serialize<S>(map: &Option<MetadataMap>, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/apollo-router/src/plugins/telemetry/tracing/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo.rs
@@ -1,11 +1,14 @@
 //! Tracing configuration for apollo telemetry.
 // This entire file is license key functionality
-use crate::plugins::telemetry::apollo::Config;
-use crate::plugins::telemetry::config::Trace;
-use crate::plugins::telemetry::tracing::apollo_telemetry::{SpaceportConfig, StudioGraph};
-use crate::plugins::telemetry::tracing::{apollo_telemetry, TracingConfigurator};
 use opentelemetry::sdk::trace::Builder;
 use tower::BoxError;
+
+use crate::plugins::telemetry::apollo::Config;
+use crate::plugins::telemetry::config::Trace;
+use crate::plugins::telemetry::tracing::apollo_telemetry;
+use crate::plugins::telemetry::tracing::apollo_telemetry::SpaceportConfig;
+use crate::plugins::telemetry::tracing::apollo_telemetry::StudioGraph;
+use crate::plugins::telemetry::tracing::TracingConfigurator;
 
 impl TracingConfigurator for Config {
     fn apply(&self, builder: Builder, trace_config: &Trace) -> Result<Builder, BoxError> {

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -26,24 +26,24 @@
 //!     shutdown_tracer_provider(); // sending remaining spans
 //! }
 //! ```
-use apollo_spaceport::Reporter;
-use async_trait::async_trait;
-use derivative::Derivative;
-use opentelemetry::{
-    global,
-    runtime::Tokio,
-    sdk,
-    sdk::export::{
-        trace::{ExportResult, SpanData, SpanExporter},
-        ExportError,
-    },
-    trace::TracerProvider,
-};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::str::FromStr;
+
+use apollo_spaceport::Reporter;
+use async_trait::async_trait;
+use derivative::Derivative;
+use opentelemetry::global;
+use opentelemetry::runtime::Tokio;
+use opentelemetry::sdk;
+use opentelemetry::sdk::export::trace::ExportResult;
+use opentelemetry::sdk::export::trace::SpanData;
+use opentelemetry::sdk::export::trace::SpanExporter;
+use opentelemetry::sdk::export::ExportError;
+use opentelemetry::trace::TracerProvider;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
 use tokio::task::JoinError;
 
 const DEFAULT_SERVER_URL: &str = "https://127.0.0.1:50051";

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -1,12 +1,15 @@
 //! Configuration for datadog tracing.
-use crate::plugins::telemetry::config::{GenericWith, Trace};
-use crate::plugins::telemetry::tracing::TracingConfigurator;
 use opentelemetry::sdk::trace::Builder;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use tower::BoxError;
 
-use super::{deser_endpoint, AgentEndpoint};
+use super::deser_endpoint;
+use super::AgentEndpoint;
+use crate::plugins::telemetry::config::GenericWith;
+use crate::plugins::telemetry::config::Trace;
+use crate::plugins::telemetry::tracing::TracingConfigurator;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -41,9 +44,8 @@ impl TracingConfigurator for Config {
 mod tests {
     use reqwest::Url;
 
-    use crate::plugins::telemetry::tracing::AgentDefault;
-
     use super::*;
+    use crate::plugins::telemetry::tracing::AgentDefault;
 
     #[test]
     fn endpoint_configuration() {

--- a/apollo-router/src/plugins/telemetry/tracing/jaeger.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/jaeger.rs
@@ -1,16 +1,22 @@
 //! Configuration for jaeger tracing.
-use crate::plugins::telemetry::config::{GenericWith, Trace};
-use crate::plugins::telemetry::tracing::TracingConfigurator;
-use opentelemetry::sdk::trace::{BatchSpanProcessor, Builder};
-use schemars::gen::SchemaGenerator;
-use schemars::schema::{Schema, SchemaObject};
-use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
 use std::time::Duration;
+
+use opentelemetry::sdk::trace::BatchSpanProcessor;
+use opentelemetry::sdk::trace::Builder;
+use schemars::gen::SchemaGenerator;
+use schemars::schema::Schema;
+use schemars::schema::SchemaObject;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
 use tower::BoxError;
 use url::Url;
 
-use super::{deser_endpoint, AgentEndpoint};
+use super::deser_endpoint;
+use super::AgentEndpoint;
+use crate::plugins::telemetry::config::GenericWith;
+use crate::plugins::telemetry::config::Trace;
+use crate::plugins::telemetry::tracing::TracingConfigurator;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 // Can't use #[serde(deny_unknown_fields)] because we're using flatten for endpoint

--- a/apollo-router/src/plugins/telemetry/tracing/mod.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/mod.rs
@@ -1,9 +1,12 @@
-use crate::plugins::telemetry::config::Trace;
 use opentelemetry::sdk::trace::Builder;
 use reqwest::Url;
 use schemars::JsonSchema;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
 use tower::BoxError;
+
+use crate::plugins::telemetry::config::Trace;
 
 pub(crate) mod apollo;
 pub(crate) mod apollo_telemetry;

--- a/apollo-router/src/plugins/telemetry/tracing/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/otlp.rs
@@ -1,10 +1,12 @@
 //! Configuration for Otlp tracing.
-use crate::plugins::telemetry::config::Trace;
-use crate::plugins::telemetry::tracing::TracingConfigurator;
+use std::result::Result;
+
 use opentelemetry::sdk::trace::Builder;
 use opentelemetry_otlp::SpanExporterBuilder;
-use std::result::Result;
 use tower::BoxError;
+
+use crate::plugins::telemetry::config::Trace;
+use crate::plugins::telemetry::tracing::TracingConfigurator;
 
 impl TracingConfigurator for super::super::otlp::Config {
     fn apply(&self, builder: Builder, _trace_config: &Trace) -> Result<Builder, BoxError> {

--- a/apollo-router/src/plugins/telemetry/tracing/zipkin.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/zipkin.rs
@@ -1,13 +1,17 @@
 //! Configuration for zipkin tracing.
-use crate::plugins::telemetry::config::{GenericWith, Trace};
-use crate::plugins::telemetry::tracing::TracingConfigurator;
 use opentelemetry::sdk::trace::Builder;
 use schemars::JsonSchema;
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
 use tower::BoxError;
 use url::Url;
 
-use super::{AgentDefault, AgentEndpoint};
+use super::AgentDefault;
+use super::AgentEndpoint;
+use crate::plugins::telemetry::config::GenericWith;
+use crate::plugins::telemetry::config::Trace;
+use crate::plugins::telemetry::tracing::TracingConfigurator;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]

--- a/apollo-router/src/plugins/traffic_shaping/deduplication.rs
+++ b/apollo-router/src/plugins/traffic_shaping/deduplication.rs
@@ -2,17 +2,24 @@
 //!
 //! See [`Layer`] and [`tower::Service`] for more details.
 
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::task::Poll;
+
+use futures::future::BoxFuture;
+use futures::lock::Mutex;
+use tokio::sync::broadcast::Sender;
+use tokio::sync::broadcast::{self};
+use tokio::sync::oneshot;
+use tower::BoxError;
+use tower::Layer;
+use tower::ServiceExt;
+
 use crate::graphql::Request;
 use crate::http_ext;
 use crate::query_planner::fetch::OperationKind;
-use crate::{SubgraphRequest, SubgraphResponse};
-use futures::{future::BoxFuture, lock::Mutex};
-use std::{collections::HashMap, sync::Arc, task::Poll};
-use tokio::sync::{
-    broadcast::{self, Sender},
-    oneshot,
-};
-use tower::{BoxError, Layer, ServiceExt};
+use crate::SubgraphRequest;
+use crate::SubgraphResponse;
 
 #[derive(Default)]
 pub(crate) struct QueryDeduplicationLayer;

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -13,20 +13,25 @@ mod deduplication;
 
 use std::collections::HashMap;
 
-use http::header::{ACCEPT_ENCODING, CONTENT_ENCODING};
+use http::header::ACCEPT_ENCODING;
+use http::header::CONTENT_ENCODING;
 use http::HeaderValue;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::util::BoxService;
-use tower::{BoxError, ServiceBuilder, ServiceExt};
+use tower::BoxError;
+use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::Plugin;
 use crate::plugins::traffic_shaping::deduplication::QueryDeduplicationLayer;
+use crate::register_plugin;
 use crate::services::subgraph_service::Compression;
-use crate::{
-    register_plugin, QueryPlannerRequest, QueryPlannerResponse, SubgraphRequest, SubgraphResponse,
-};
+use crate::QueryPlannerRequest;
+use crate::QueryPlannerResponse;
+use crate::SubgraphRequest;
+use crate::SubgraphResponse;
 
 #[derive(PartialEq, Debug, Clone, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -141,17 +146,20 @@ mod test {
 
     use futures::stream::BoxStream;
     use once_cell::sync::Lazy;
-    use serde_json_bytes::{ByteString, Value};
-    use tower::{util::BoxCloneService, Service};
+    use serde_json_bytes::ByteString;
+    use serde_json_bytes::Value;
+    use tower::util::BoxCloneService;
+    use tower::Service;
 
+    use super::*;
     use crate::json_ext::Object;
     use crate::plugin::test::MockSubgraph;
     use crate::plugin::DynPlugin;
-    use crate::{
-        PluggableRouterServiceBuilder, ResponseBody, RouterRequest, RouterResponse, Schema,
-    };
-
-    use super::*;
+    use crate::PluggableRouterServiceBuilder;
+    use crate::ResponseBody;
+    use crate::RouterRequest;
+    use crate::RouterResponse;
+    use crate::Schema;
 
     static EXPECTED_RESPONSE: Lazy<ResponseBody> = Lazy::new(|| {
         ResponseBody::GraphQL(serde_json::from_str(r#"{"data":{"topProducts":[{"upc":"1","name":"Table","reviews":[{"id":"1","product":{"name":"Table"},"author":{"id":"1","name":"Ada Lovelace"}},{"id":"4","product":{"name":"Table"},"author":{"id":"2","name":"Alan Turing"}}]},{"upc":"2","name":"Couch","reviews":[{"id":"2","product":{"name":"Couch"},"author":{"id":"1","name":"Ada Lovelace"}}]}]}}"#).unwrap())

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -1,5 +1,18 @@
 //! Calls out to nodejs query planner
 
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use futures::future::BoxFuture;
+use opentelemetry::trace::SpanKind;
+use router_bridge::planner::PlanSuccess;
+use router_bridge::planner::Planner;
+use serde::Deserialize;
+use tower::BoxError;
+use tower::Service;
+use tracing::Instrument;
+
 use super::PlanNode;
 use super::QueryPlanOptions;
 use crate::error::QueryPlannerError;
@@ -7,17 +20,6 @@ use crate::introspection::Introspection;
 use crate::services::QueryPlannerContent;
 use crate::traits::QueryPlanner;
 use crate::*;
-use async_trait::async_trait;
-use futures::future::BoxFuture;
-use opentelemetry::trace::SpanKind;
-use router_bridge::planner::PlanSuccess;
-use router_bridge::planner::Planner;
-use serde::Deserialize;
-use std::fmt::Debug;
-use std::sync::Arc;
-use tower::BoxError;
-use tower::Service;
-use tracing::Instrument;
 
 pub(crate) static USAGE_REPORTING: &str = "apollo_telemetry::usage_reporting";
 
@@ -180,9 +182,10 @@ struct QueryPlan {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json::json;
     use test_log::test;
+
+    use super::*;
 
     #[test(tokio::test)]
     async fn test_plan() {

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -1,3 +1,13 @@
+use std::collections::HashMap;
+use std::marker::PhantomData;
+use std::ops::Deref;
+use std::sync::Arc;
+use std::task;
+
+use async_trait::async_trait;
+use futures::future::BoxFuture;
+use router_bridge::planner::UsageReporting;
+
 use super::QueryPlanOptions;
 use super::USAGE_REPORTING;
 use crate::cache::CachingMap;
@@ -8,14 +18,6 @@ use crate::traits::CacheResolver;
 use crate::traits::QueryKey;
 use crate::traits::QueryPlanner;
 use crate::*;
-use async_trait::async_trait;
-use futures::future::BoxFuture;
-use router_bridge::planner::UsageReporting;
-use std::collections::HashMap;
-use std::marker::PhantomData;
-use std::ops::Deref;
-use std::sync::Arc;
-use std::task;
 
 type PlanResult = Result<QueryPlannerContent, QueryPlannerError>;
 
@@ -155,10 +157,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use mockall::{mock, predicate::*};
-    use router_bridge::planner::{PlanErrors, UsageReporting};
+    use mockall::mock;
+    use mockall::predicate::*;
+    use router_bridge::planner::PlanErrors;
+    use router_bridge::planner::UsageReporting;
     use test_log::test;
+
+    use super::*;
 
     mock! {
         #[derive(Debug)]

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -1,9 +1,5 @@
-use crate::error::Error;
-use crate::error::FetchError;
-use crate::graphql::{Request, Response};
-use crate::json_ext::{Path, Value, ValueExt};
-use crate::service_registry::ServiceRegistry;
-use crate::*;
+use std::collections::HashSet;
+
 pub(crate) use bridge_query_planner::*;
 pub(crate) use caching_query_planner::*;
 pub use fetch::OperationKind;
@@ -11,8 +7,17 @@ use futures::prelude::*;
 use opentelemetry::trace::SpanKind;
 use router_bridge::planner::UsageReporting;
 use serde::Deserialize;
-use std::collections::HashSet;
 use tracing::Instrument;
+
+use crate::error::Error;
+use crate::error::FetchError;
+use crate::graphql::Request;
+use crate::graphql::Response;
+use crate::json_ext::Path;
+use crate::json_ext::Value;
+use crate::json_ext::ValueExt;
+use crate::service_registry::ServiceRegistry;
+use crate::*;
 
 mod bridge_query_planner;
 mod caching_query_planner;
@@ -306,18 +311,28 @@ impl PlanNode {
 }
 
 pub(crate) mod fetch {
-    use super::selection::{select_object, Selection};
-    use super::QueryPlanOptions;
-    use crate::error::{Error, FetchError};
-    use crate::graphql::Request;
-    use crate::json_ext::{Object, Path, Value, ValueExt};
-    use crate::service_registry::ServiceRegistry;
-    use crate::*;
+    use std::collections::HashMap;
+    use std::fmt::Display;
+    use std::sync::Arc;
+
     use indexmap::IndexSet;
     use serde::Deserialize;
-    use std::{collections::HashMap, fmt::Display, sync::Arc};
     use tower::ServiceExt;
-    use tracing::{instrument, Instrument};
+    use tracing::instrument;
+    use tracing::Instrument;
+
+    use super::selection::select_object;
+    use super::selection::Selection;
+    use super::QueryPlanOptions;
+    use crate::error::Error;
+    use crate::error::FetchError;
+    use crate::graphql::Request;
+    use crate::json_ext::Object;
+    use crate::json_ext::Path;
+    use crate::json_ext::Value;
+    use crate::json_ext::ValueExt;
+    use crate::service_registry::ServiceRegistry;
+    use crate::*;
 
     #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize)]
     #[serde(rename_all = "camelCase")]
@@ -638,8 +653,11 @@ pub(crate) struct FlattenNode {
 // separately from the query planner logs, as follows:
 // `router -s supergraph.graphql --log info,crate::query_planner::log=trace`
 mod log {
+    use serde_json_bytes::ByteString;
+    use serde_json_bytes::Map;
+    use serde_json_bytes::Value;
+
     use crate::query_planner::PlanNode;
-    use serde_json_bytes::{ByteString, Map, Value};
 
     pub(crate) fn trace_query_plan(plan: &PlanNode) {
         tracing::trace!("query plan\n{:?}", plan);
@@ -663,13 +681,17 @@ mod log {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use http::Method;
+    use std::collections::HashMap;
     use std::str::FromStr;
+    use std::sync::atomic::AtomicBool;
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
-    use std::{collections::HashMap, sync::atomic::AtomicBool};
-    use tower::{ServiceBuilder, ServiceExt};
+
+    use http::Method;
+    use tower::ServiceBuilder;
+    use tower::ServiceExt;
+
+    use super::*;
     macro_rules! test_query_plan {
         () => {
             include_str!("testdata/query_plan.json")

--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -1,8 +1,11 @@
-use crate::error::FetchError;
-use crate::json_ext::{Object, Value, ValueExt};
-use crate::*;
 use serde::Deserialize;
 use serde_json_bytes::Entry;
+
+use crate::error::FetchError;
+use crate::json_ext::Object;
+use crate::json_ext::Value;
+use crate::json_ext::ValueExt;
+use crate::*;
 
 /// A selection that is part of a fetch.
 /// Selections are used to propagate data to subgraph fetches.
@@ -130,12 +133,13 @@ fn select_value(
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+    use serde_json_bytes::json as bjson;
+
     use super::Selection;
     use super::*;
     use crate::graphql::Response;
     use crate::json_ext::Path;
-    use serde_json::json;
-    use serde_json_bytes::json as bjson;
 
     fn select<'a>(
         response: &Response,

--- a/apollo-router/src/reload.rs
+++ b/apollo-router/src/reload.rs
@@ -17,19 +17,21 @@
 //!
 //! [`Layer` type]: struct.Layer.html
 //! [`Layer` trait]: ../layer/trait.Layer.html
-use tracing_subscriber::layer;
+use std::any::TypeId;
+use std::error;
+use std::fmt;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::sync::RwLock;
+use std::sync::Weak;
 
-use std::{
-    any::TypeId,
-    error, fmt,
-    marker::PhantomData,
-    sync::{Arc, RwLock, Weak},
-};
-use tracing_core::{
-    callsite, span,
-    subscriber::{Interest, Subscriber},
-    Event, Metadata,
-};
+use tracing_core::callsite;
+use tracing_core::span;
+use tracing_core::subscriber::Interest;
+use tracing_core::subscriber::Subscriber;
+use tracing_core::Event;
+use tracing_core::Metadata;
+use tracing_subscriber::layer;
 
 macro_rules! try_lock {
     ($lock:expr) => {

--- a/apollo-router/src/request.rs
+++ b/apollo-router/src/request.rs
@@ -1,7 +1,11 @@
-use crate::json_ext::{Object, Value};
 use bytes::Bytes;
 use derivative::Derivative;
-use serde::{de::Error, Deserialize, Serialize};
+use serde::de::Error;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::json_ext::Object;
+use crate::json_ext::Value;
 
 /// A graphql request.
 /// Used for federated and subgraph queries.
@@ -144,10 +148,11 @@ fn get_from_urldecoded<'a, T: Deserialize<'a>>(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use serde_json::json;
     use serde_json_bytes::json as bjson;
     use test_log::test;
+
+    use super::*;
 
     #[test]
     fn test_request() {

--- a/apollo-router/src/response.rs
+++ b/apollo-router/src/response.rs
@@ -1,10 +1,14 @@
-use crate::error::Error;
-use crate::error::FetchError;
-use crate::json_ext::{Object, Path, Value};
 use bytes::Bytes;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use serde_json_bytes::ByteString;
 use serde_json_bytes::Map;
+
+use crate::error::Error;
+use crate::error::FetchError;
+use crate::json_ext::Object;
+use crate::json_ext::Path;
+use crate::json_ext::Value;
 
 /// A graphql primary response.
 /// Used for federated and subgraph queries.
@@ -120,11 +124,11 @@ impl Response {
 
 #[cfg(test)]
 mod tests {
-    use crate::error::Location;
-
-    use super::*;
     use serde_json::json;
     use serde_json_bytes::json as bjson;
+
+    use super::*;
+    use crate::error::Location;
 
     #[test]
     fn test_append_errors_path_fallback_and_override() {

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -1,28 +1,37 @@
-use crate::axum_http_server_factory::AxumHttpServerFactory;
-use crate::configuration::Configuration;
-use crate::configuration::{validate_configuration, ListenAddr};
-use crate::reload::Error as ReloadError;
-use crate::router_factory::YamlRouterServiceFactory;
-use crate::state_machine::StateMachine;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+use std::time::Duration;
+
 use derivative::Derivative;
-use derive_more::{Display, From};
+use derive_more::Display;
+use derive_more::From;
 use displaydoc::Display as DisplayDoc;
 use futures::channel::oneshot;
 use futures::prelude::*;
 use futures::FutureExt;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
-use std::time::Duration;
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tokio::task::spawn;
 use tracing::subscriber::SetGlobalDefaultError;
 use url::Url;
-use Event::{NoMoreConfiguration, NoMoreSchema};
-use Event::{Shutdown, UpdateConfiguration, UpdateSchema};
+use Event::NoMoreConfiguration;
+use Event::NoMoreSchema;
+use Event::Shutdown;
+use Event::UpdateConfiguration;
+use Event::UpdateSchema;
+
+use crate::axum_http_server_factory::AxumHttpServerFactory;
+use crate::configuration::validate_configuration;
+use crate::configuration::Configuration;
+use crate::configuration::ListenAddr;
+use crate::reload::Error as ReloadError;
+use crate::router_factory::YamlRouterServiceFactory;
+use crate::state_machine::StateMachine;
 
 type SchemaStream = Pin<Box<dyn Stream<Item = crate::Schema> + Send>>;
 
@@ -514,13 +523,16 @@ impl ApolloRouter {
 
 #[cfg(test)]
 mod tests {
+    use std::env::temp_dir;
+
+    use serde_json::to_string_pretty;
+    use test_log::test;
+
     use super::*;
-    use crate::files::tests::{create_temp_file, write_and_flush};
+    use crate::files::tests::create_temp_file;
+    use crate::files::tests::write_and_flush;
     use crate::graphql;
     use crate::graphql::Request;
-    use serde_json::to_string_pretty;
-    use std::env::temp_dir;
-    use test_log::test;
 
     fn init_with_server() -> RouterHandle {
         let configuration =

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -1,22 +1,31 @@
 // This entire file is license key functionality
-use crate::configuration::{Configuration, ConfigurationError};
-use crate::graphql;
-use crate::http_ext::{Request, Response};
-use crate::layers::ServiceBuilderExt;
-use crate::plugin::DynPlugin;
-use crate::services::Plugins;
-use crate::SubgraphService;
-use crate::{PluggableRouterServiceBuilder, ResponseBody, Schema};
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use envmnt::types::ExpandOptions;
 use envmnt::ExpansionType;
 use futures::stream::BoxStream;
 use serde_json::Value;
-use std::collections::HashMap;
-use std::sync::Arc;
 use tower::buffer::Buffer;
-use tower::util::{BoxCloneService, BoxService};
-use tower::{BoxError, ServiceBuilder, ServiceExt};
+use tower::util::BoxCloneService;
+use tower::util::BoxService;
+use tower::BoxError;
+use tower::ServiceBuilder;
+use tower::ServiceExt;
 use tower_service::Service;
+
+use crate::configuration::Configuration;
+use crate::configuration::ConfigurationError;
+use crate::graphql;
+use crate::http_ext::Request;
+use crate::http_ext::Response;
+use crate::layers::ServiceBuilderExt;
+use crate::plugin::DynPlugin;
+use crate::services::Plugins;
+use crate::PluggableRouterServiceBuilder;
+use crate::ResponseBody;
+use crate::Schema;
+use crate::SubgraphService;
 
 /// Factory for creating a RouterService
 ///
@@ -204,19 +213,22 @@ fn visit(value: &mut serde_json::Value) {
 
 #[cfg(test)]
 mod test {
-    use crate::configuration::Configuration;
-    use crate::plugin::Plugin;
-    use crate::register_plugin;
-    use crate::router_factory::YamlRouterServiceFactory;
-    use crate::router_factory::{inject_schema_id, RouterServiceFactory};
-    use crate::Schema;
-    use schemars::JsonSchema;
-    use serde::Deserialize;
-    use serde_json::json;
     use std::error::Error;
     use std::fmt;
     use std::sync::Arc;
+
+    use schemars::JsonSchema;
+    use serde::Deserialize;
+    use serde_json::json;
     use tower_http::BoxError;
+
+    use crate::configuration::Configuration;
+    use crate::plugin::Plugin;
+    use crate::register_plugin;
+    use crate::router_factory::inject_schema_id;
+    use crate::router_factory::RouterServiceFactory;
+    use crate::router_factory::YamlRouterServiceFactory;
+    use crate::Schema;
 
     #[derive(Debug)]
     struct PluginError;
@@ -331,8 +343,10 @@ mod test {
     // be encountered. (See https://github.com/open-telemetry/opentelemetry-rust/issues/536)
     #[tokio::test(flavor = "multi_thread")]
     async fn test_telemetry_doesnt_hang_with_invalid_schema() {
-        use crate::subscriber::{set_global_subscriber, RouterSubscriber};
         use tracing_subscriber::EnvFilter;
+
+        use crate::subscriber::set_global_subscriber;
+        use crate::subscriber::RouterSubscriber;
 
         // A global subscriber must be set before we start up the telemetry plugin
         let _ = set_global_subscriber(RouterSubscriber::JsonSubscriber(

--- a/apollo-router/src/service_registry.rs
+++ b/apollo-router/src/service_registry.rs
@@ -1,11 +1,15 @@
 //! Registry of subgraph services.
 
-use crate::{SubgraphRequest, SubgraphResponse};
 use std::collections::HashMap;
+
 use tower::buffer::Buffer;
-use tower::util::{BoxCloneService, BoxService};
+use tower::util::BoxCloneService;
+use tower::util::BoxService;
 use tower::BoxError;
 use tower::ServiceExt;
+
+use crate::SubgraphRequest;
+use crate::SubgraphResponse;
 
 /// Collection of subgraph services.
 pub struct ServiceRegistry {

--- a/apollo-router/src/services/execution_service.rs
+++ b/apollo-router/src/services/execution_service.rs
@@ -1,22 +1,28 @@
 //! Implements the Execution phase of the request lifecycle.
 
-use crate::graphql::Response;
-use crate::service_registry::ServiceRegistry;
-use crate::Schema;
-use crate::{ExecutionRequest, ExecutionResponse, SubgraphRequest, SubgraphResponse};
-use futures::future::{ready, BoxFuture};
-use futures::stream::{once, BoxStream};
-use futures::StreamExt;
-use http::StatusCode;
-
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::task::Poll;
+
+use futures::future::ready;
+use futures::future::BoxFuture;
+use futures::stream::once;
+use futures::stream::BoxStream;
+use futures::StreamExt;
+use http::StatusCode;
 use tower::buffer::Buffer;
 use tower::util::BoxService;
 use tower::BoxError;
 use tower_service::Service;
 use tracing::Instrument;
+
+use crate::graphql::Response;
+use crate::service_registry::ServiceRegistry;
+use crate::ExecutionRequest;
+use crate::ExecutionResponse;
+use crate::Schema;
+use crate::SubgraphRequest;
+use crate::SubgraphResponse;
 
 /// [`Service`] for query execution.
 #[derive(Clone)]

--- a/apollo-router/src/services/http_ext.rs
+++ b/apollo-router/src/services/http_ext.rs
@@ -2,22 +2,22 @@
 //!
 //! To improve their usability.
 
-use axum::{body::boxed, response::IntoResponse};
+use std::cmp::PartialEq;
+use std::hash::Hash;
+use std::ops::Deref;
+use std::ops::DerefMut;
+
+use axum::body::boxed;
+use axum::response::IntoResponse;
 use bytes::Bytes;
-use futures::{
-    future::ready,
-    stream::{once, BoxStream},
-};
-use http::{
-    header::{self, HeaderName},
-    HeaderValue, Method,
-};
+use futures::future::ready;
+use futures::stream::once;
+use futures::stream::BoxStream;
+use http::header::HeaderName;
+use http::header::{self};
+use http::HeaderValue;
+use http::Method;
 use multimap::MultiMap;
-use std::{
-    cmp::PartialEq,
-    hash::Hash,
-    ops::{Deref, DerefMut},
-};
 
 use crate::ResponseBody;
 
@@ -323,8 +323,11 @@ impl IntoResponse for Response<Bytes> {
 
 #[cfg(test)]
 mod test {
+    use http::HeaderValue;
+    use http::Method;
+    use http::Uri;
+
     use crate::http_ext::Request;
-    use http::{HeaderValue, Method, Uri};
 
     #[test]
     fn builder() {

--- a/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
+++ b/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
@@ -2,14 +2,22 @@
 //!
 //! See [`Layer`] and [`Service`] for more details.
 
-use crate::graphql::{Error, Response};
+use std::ops::ControlFlow;
+
+use futures::stream::BoxStream;
+use http::header::HeaderName;
+use http::Method;
+use http::StatusCode;
+use tower::BoxError;
+use tower::Layer;
+use tower::Service;
+
+use crate::graphql::Error;
+use crate::graphql::Response;
 use crate::json_ext::Object;
 use crate::layers::sync_checkpoint::CheckpointService;
-use crate::{ExecutionRequest, ExecutionResponse};
-use futures::stream::BoxStream;
-use http::{header::HeaderName, Method, StatusCode};
-use std::ops::ControlFlow;
-use tower::{BoxError, Layer, Service};
+use crate::ExecutionRequest;
+use crate::ExecutionResponse;
 
 #[derive(Default)]
 pub(crate) struct AllowOnlyHttpPostMutationsLayer {}
@@ -58,15 +66,17 @@ where
 
 #[cfg(test)]
 mod forbid_http_get_mutations_tests {
+    use serde_json::json;
+    use tower::ServiceExt;
+
     use super::*;
     use crate::error::Error;
     use crate::graphql;
     use crate::http_ext;
     use crate::plugin::test::MockExecutionService;
-    use crate::query_planner::{fetch::OperationKind, PlanNode, QueryPlan};
-
-    use serde_json::json;
-    use tower::ServiceExt;
+    use crate::query_planner::fetch::OperationKind;
+    use crate::query_planner::PlanNode;
+    use crate::query_planner::QueryPlan;
 
     #[tokio::test]
     async fn it_lets_http_post_queries_pass_through() {

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -5,15 +5,22 @@
 
 use std::ops::ControlFlow;
 
-use crate::error::Error;
-use crate::layers::sync_checkpoint::CheckpointService;
-use crate::{ResponseBody, RouterRequest, RouterResponse};
 use futures::stream::BoxStream;
 use moka::sync::Cache;
 use serde::Deserialize;
-use serde_json_bytes::{json, Value};
-use sha2::{Digest, Sha256};
-use tower::{BoxError, Layer, Service};
+use serde_json_bytes::json;
+use serde_json_bytes::Value;
+use sha2::Digest;
+use sha2::Sha256;
+use tower::BoxError;
+use tower::Layer;
+use tower::Service;
+
+use crate::error::Error;
+use crate::layers::sync_checkpoint::CheckpointService;
+use crate::ResponseBody;
+use crate::RouterRequest;
+use crate::RouterResponse;
 
 /// A persisted query.
 #[derive(Deserialize, Clone, Debug)]
@@ -130,13 +137,17 @@ fn query_matches_hash(query: &str, hash: &[u8]) -> bool {
 
 #[cfg(test)]
 mod apq_tests {
-    use super::*;
-    use crate::error::Error;
-    use crate::{plugin::test::MockRouterService, Context, ResponseBody};
-    use serde_json_bytes::json;
     use std::borrow::Cow;
     use std::collections::HashMap;
+
+    use serde_json_bytes::json;
     use tower::ServiceExt;
+
+    use super::*;
+    use crate::error::Error;
+    use crate::plugin::test::MockRouterService;
+    use crate::Context;
+    use crate::ResponseBody;
 
     #[tokio::test]
     async fn it_works() {

--- a/apollo-router/src/services/layers/ensure_query_presence.rs
+++ b/apollo-router/src/services/layers/ensure_query_presence.rs
@@ -4,13 +4,19 @@
 //!
 //! If the request does not contain a query, then the request is rejected.
 
-use crate::layers::sync_checkpoint::CheckpointService;
-use crate::{ResponseBody, RouterRequest, RouterResponse};
+use std::ops::ControlFlow;
+
 use futures::stream::BoxStream;
 use http::StatusCode;
 use serde_json_bytes::Value;
-use std::ops::ControlFlow;
-use tower::{BoxError, Layer, Service};
+use tower::BoxError;
+use tower::Layer;
+use tower::Service;
+
+use crate::layers::sync_checkpoint::CheckpointService;
+use crate::ResponseBody;
+use crate::RouterRequest;
+use crate::RouterResponse;
 
 #[derive(Default)]
 pub(crate) struct EnsureQueryPresence {}
@@ -58,10 +64,11 @@ where
 
 #[cfg(test)]
 mod ensure_query_presence_tests {
+    use tower::ServiceExt;
+
     use super::*;
     use crate::plugin::test::MockRouterService;
     use crate::ResponseBody;
-    use tower::ServiceExt;
 
     #[tokio::test]
     async fn it_works_with_query() {

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -1,33 +1,44 @@
 //! Implementation of the various steps in the router's processing pipeline.
 
-pub use self::execution_service::*;
-pub use self::router_service::*;
-use crate::error::Error;
-use crate::graphql::{Request, Response};
-use crate::json_ext::{Object, Path, Value};
-use crate::query_planner::fetch::OperationKind;
-use crate::query_planner::QueryPlan;
-use crate::query_planner::QueryPlanOptions;
-use crate::*;
-use futures::{
-    future::{ready, Ready},
-    stream::{once, BoxStream, Once, StreamExt},
-    Stream,
-};
-use http::{header::HeaderName, HeaderValue, StatusCode};
-use http::{method::Method, Uri};
-use http_ext::IntoHeaderName;
-use http_ext::IntoHeaderValue;
-use multimap::MultiMap;
-use serde::{Deserialize, Serialize};
-use serde_json_bytes::ByteString;
-use static_assertions::assert_impl_all;
 use std::collections::HashMap;
 use std::convert::Infallible;
 use std::str::FromStr;
 use std::sync::Arc;
+
+use futures::future::ready;
+use futures::future::Ready;
+use futures::stream::once;
+use futures::stream::BoxStream;
+use futures::stream::Once;
+use futures::stream::StreamExt;
+use futures::Stream;
+use http::header::HeaderName;
+use http::method::Method;
+use http::HeaderValue;
+use http::StatusCode;
+use http::Uri;
+use http_ext::IntoHeaderName;
+use http_ext::IntoHeaderValue;
+use multimap::MultiMap;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json_bytes::ByteString;
+use static_assertions::assert_impl_all;
 pub use subgraph_service::SubgraphService;
 use tower::BoxError;
+
+pub use self::execution_service::*;
+pub use self::router_service::*;
+use crate::error::Error;
+use crate::graphql::Request;
+use crate::graphql::Response;
+use crate::json_ext::Object;
+use crate::json_ext::Path;
+use crate::json_ext::Value;
+use crate::query_planner::fetch::OperationKind;
+use crate::query_planner::QueryPlan;
+use crate::query_planner::QueryPlanOptions;
+use crate::*;
 
 mod execution_service;
 pub mod http_ext;
@@ -820,10 +831,16 @@ impl AsRef<Request> for Arc<http_ext::Request<Request>> {
 
 #[cfg(test)]
 mod test {
-    use crate::graphql;
-    use crate::{Context, ResponseBody, RouterRequest, RouterResponse};
-    use http::{HeaderValue, Method, Uri};
+    use http::HeaderValue;
+    use http::Method;
+    use http::Uri;
     use serde_json::json;
+
+    use crate::graphql;
+    use crate::Context;
+    use crate::ResponseBody;
+    use crate::RouterRequest;
+    use crate::RouterResponse;
 
     #[test]
     fn router_request_builder() {

--- a/apollo-router/src/spec/field_type.rs
+++ b/apollo-router/src/spec/field_type.rs
@@ -1,7 +1,9 @@
-use crate::json_ext::{Value, ValueExt};
-use crate::*;
 use apollo_parser::ast;
 use displaydoc::Display;
+
+use crate::json_ext::Value;
+use crate::json_ext::ValueExt;
+use crate::*;
 
 #[derive(Debug)]
 pub(crate) struct InvalidValue;

--- a/apollo-router/src/spec/fragments.rs
+++ b/apollo-router/src/spec/fragments.rs
@@ -1,6 +1,8 @@
-use crate::*;
-use apollo_parser::ast;
 use std::collections::HashMap;
+
+use apollo_parser::ast;
+
+use crate::*;
 
 #[derive(Debug, Default)]
 pub(crate) struct Fragments {

--- a/apollo-router/src/spec/mod.rs
+++ b/apollo-router/src/spec/mod.rs
@@ -4,14 +4,12 @@ mod query;
 mod schema;
 mod selection;
 
+use displaydoc::Display;
 pub(crate) use field_type::*;
 pub(crate) use fragments::*;
 pub(crate) use query::*;
-pub(crate) use selection::*;
-
 pub use schema::Schema;
-
-use displaydoc::Display;
+pub(crate) use selection::*;
 use thiserror::Error;
 
 /// GraphQL parsing errors.

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -2,16 +2,21 @@
 //!
 //! Parsing, formatting and manipulation of queries.
 
-use crate::error::FetchError;
-use crate::graphql::{Request, Response};
-use crate::json_ext::{Object, Value};
-use crate::query_planner::fetch::OperationKind;
-use crate::*;
+use std::collections::HashMap;
+use std::collections::HashSet;
+
 use apollo_parser::ast;
 use derivative::Derivative;
 use serde_json_bytes::ByteString;
-use std::collections::{HashMap, HashSet};
 use tracing::level_filters::LevelFilter;
+
+use crate::error::FetchError;
+use crate::graphql::Request;
+use crate::graphql::Response;
+use crate::json_ext::Object;
+use crate::json_ext::Value;
+use crate::query_planner::fetch::OperationKind;
+use crate::*;
 
 const TYPENAME: &str = "__typename";
 
@@ -811,10 +816,11 @@ fn parse_value(value: &ast::Value) -> Option<Value> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::json_ext::ValueExt;
     use serde_json_bytes::json;
     use test_log::test;
+
+    use super::*;
+    use crate::json_ext::ValueExt;
 
     macro_rules! assert_eq_and_ordered {
         ($a:expr, $b:expr $(,)?) => {

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -1,17 +1,21 @@
 //! GraphQL schema.
 
-use crate::error::ParseErrors;
-use crate::error::SchemaError;
-use crate::json_ext::{Object, Value};
-use crate::query_planner::OperationKind;
-use crate::*;
+use std::collections::HashMap;
+use std::collections::HashSet;
+
 use apollo_parser::ast;
 use http::Uri;
 use itertools::Itertools;
 use router_bridge::api_schema;
 use sha2::Digest;
 use sha2::Sha256;
-use std::collections::{HashMap, HashSet};
+
+use crate::error::ParseErrors;
+use crate::error::SchemaError;
+use crate::json_ext::Object;
+use crate::json_ext::Value;
+use crate::query_planner::OperationKind;
+use crate::*;
 
 /// A GraphQL schema.
 #[derive(Debug, Default, Clone)]
@@ -630,8 +634,9 @@ implement_input_object_type_or_interface!(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::str::FromStr;
+
+    use super::*;
 
     fn with_supergraph_boilerplate(content: &str) -> String {
         format!(

--- a/apollo-router/src/spec/selection.rs
+++ b/apollo-router/src/spec/selection.rs
@@ -1,7 +1,11 @@
-use crate::json_ext::Object;
-use crate::{FieldType, Schema, SpecError};
-use apollo_parser::ast::{self, Value};
+use apollo_parser::ast::Value;
+use apollo_parser::ast::{self};
 use serde_json_bytes::ByteString;
+
+use crate::json_ext::Object;
+use crate::FieldType;
+use crate::Schema;
+use crate::SpecError;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) enum Selection {

--- a/apollo-router/src/subscriber.rs
+++ b/apollo-router/src/subscriber.rs
@@ -59,18 +59,32 @@
 //!     a pointer and execute through that pointer.
 //!  We will need to validate that this remains true as the various moving
 //!  parts change (upgrade) over time.
-use crate::reload::{Handle, Layer as ReloadLayer};
-use crate::router::ApolloRouterError;
-use once_cell::sync::OnceCell;
 use std::any::TypeId;
-use tracing::span::{Attributes, Record};
+
+use once_cell::sync::OnceCell;
+use tracing::span::Attributes;
+use tracing::span::Record;
 use tracing::subscriber::set_global_default;
-use tracing::{Event as TracingEvent, Id, Metadata, Subscriber};
+use tracing::Event as TracingEvent;
+use tracing::Id;
+use tracing::Metadata;
+use tracing::Subscriber;
 use tracing_core::span::Current;
-use tracing_core::{Interest, LevelFilter};
-use tracing_subscriber::fmt::format::{DefaultFields, Format, Json, JsonFields};
-use tracing_subscriber::registry::{Data, LookupSpan};
-use tracing_subscriber::{EnvFilter, FmtSubscriber, Layer};
+use tracing_core::Interest;
+use tracing_core::LevelFilter;
+use tracing_subscriber::fmt::format::DefaultFields;
+use tracing_subscriber::fmt::format::Format;
+use tracing_subscriber::fmt::format::Json;
+use tracing_subscriber::fmt::format::JsonFields;
+use tracing_subscriber::registry::Data;
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::FmtSubscriber;
+use tracing_subscriber::Layer;
+
+use crate::reload::Handle;
+use crate::reload::Layer as ReloadLayer;
+use crate::router::ApolloRouterError;
 
 pub(crate) type BoxedLayer = Box<dyn Layer<RouterSubscriber> + Send + Sync>;
 

--- a/apollo-router/src/traits.rs
+++ b/apollo-router/src/traits.rs
@@ -1,10 +1,12 @@
+use std::fmt::Debug;
+
+use async_trait::async_trait;
+
 use crate::error::CacheResolverError;
 use crate::error::QueryPlannerError;
 use crate::query_planner::CachingQueryPlanner;
 use crate::query_planner::QueryPlanOptions;
 use crate::services::QueryPlannerContent;
-use async_trait::async_trait;
-use std::fmt::Debug;
 
 /// A cache resolution trait.
 ///
@@ -55,8 +57,9 @@ impl<T: ?Sized> WithCaching for T where T: QueryPlanner + Sized + 'static {}
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use static_assertions::*;
+
+    use super::*;
 
     assert_obj_safe!(QueryPlanner);
 }

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -1,22 +1,30 @@
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Child;
+use std::process::Command;
+use std::process::Stdio;
+use std::time::Duration;
+
 use http::header::CONTENT_TYPE;
-use http::{Method, Request, Uri};
+use http::Method;
+use http::Request;
+use http::Uri;
 use jsonpath_lib::Selector;
 use opentelemetry::global;
 use opentelemetry::propagation::TextMapPropagator;
 use opentelemetry::sdk::trace::Tracer;
 use opentelemetry_http::HttpClient;
 use serde_json::Value;
-use std::fs;
-use std::io::Write;
-use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
-use std::time::Duration;
 use tower::BoxError;
 use tracing::info_span;
 use tracing_core::LevelFilter;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::{EnvFilter, Layer, Registry};
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::Layer;
+use tracing_subscriber::Registry;
 use uuid::Uuid;
 
 pub struct TracingTest {

--- a/apollo-router/tests/datadog_test.rs
+++ b/apollo-router/tests/datadog_test.rs
@@ -1,7 +1,9 @@
 mod common;
-use crate::common::TracingTest;
 use std::path::Path;
+
 use tower::BoxError;
+
+use crate::common::TracingTest;
 
 #[ignore]
 #[tokio::test(flavor = "multi_thread")]

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -2,17 +2,28 @@
 //! Please ensure that any tests added to this file use the tokio multi-threaded test executor.
 //!
 
+use std::collections::hash_map::Entry;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
 use apollo_router::graphql;
 use apollo_router::graphql::Request;
 use apollo_router::http_ext;
-use apollo_router::json_ext::{Object, ValueExt};
+use apollo_router::json_ext::Object;
+use apollo_router::json_ext::ValueExt;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugins::csrf;
+use apollo_router::plugins::telemetry::apollo;
 use apollo_router::plugins::telemetry::config::Tracing;
-use apollo_router::plugins::telemetry::{self, apollo, Telemetry};
+use apollo_router::plugins::telemetry::Telemetry;
+use apollo_router::plugins::telemetry::{self};
 use apollo_router::services::PluggableRouterServiceBuilder;
-use apollo_router::services::{ResponseBody, RouterRequest, RouterResponse};
-use apollo_router::services::{SubgraphRequest, SubgraphService};
+use apollo_router::services::ResponseBody;
+use apollo_router::services::RouterRequest;
+use apollo_router::services::RouterResponse;
+use apollo_router::services::SubgraphRequest;
+use apollo_router::services::SubgraphService;
 use apollo_router::Context;
 use apollo_router::Schema;
 use futures::stream::BoxStream;
@@ -20,9 +31,6 @@ use http::Method;
 use maplit::hashmap;
 use serde_json::to_string_pretty;
 use serde_json_bytes::json;
-use std::collections::hash_map::Entry;
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
 use test_span::prelude::*;
 use tower::util::BoxCloneService;
 use tower::BoxError;

--- a/apollo-router/tests/jaeger_test.rs
+++ b/apollo-router/tests/jaeger_test.rs
@@ -1,24 +1,30 @@
 mod common;
 
-use crate::common::TracingTest;
-use crate::common::ValueExt;
-use http::{Request, Response, StatusCode};
-use hyper::{
-    server::Server,
-    service::{make_service_fn, service_fn},
-    Body,
-};
-use opentelemetry::{
-    propagation::TextMapPropagator,
-    trace::{Span, Tracer, TracerProvider},
-};
-use serde_json::{json, Value};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::path::Path;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
+use std::time::SystemTime;
+
+use http::Request;
+use http::Response;
+use http::StatusCode;
+use hyper::server::Server;
+use hyper::service::make_service_fn;
+use hyper::service::service_fn;
+use hyper::Body;
+use opentelemetry::propagation::TextMapPropagator;
+use opentelemetry::trace::Span;
+use opentelemetry::trace::Tracer;
+use opentelemetry::trace::TracerProvider;
+use serde_json::json;
+use serde_json::Value;
 use tower::BoxError;
+
+use crate::common::TracingTest;
+use crate::common::ValueExt;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_jaeger_tracing() -> Result<(), BoxError> {

--- a/apollo-router/tests/otlp_test.rs
+++ b/apollo-router/tests/otlp_test.rs
@@ -1,9 +1,11 @@
 mod common;
-use crate::common::TracingTest;
-use opentelemetry::sdk::propagation::TraceContextPropagator;
 use std::path::Path;
 use std::result::Result;
+
+use opentelemetry::sdk::propagation::TraceContextPropagator;
 use tower::BoxError;
+
+use crate::common::TracingTest;
 
 #[ignore]
 #[tokio::test(flavor = "multi_thread")]

--- a/apollo-router/tests/rhai_tests.rs
+++ b/apollo-router/tests/rhai_tests.rs
@@ -3,8 +3,10 @@ use std::sync::Arc;
 
 use apollo_router::graphql::Request;
 use apollo_router::http_ext;
-use apollo_router::plugin::{plugins, DynPlugin};
-use apollo_router::services::{PluggableRouterServiceBuilder, SubgraphService};
+use apollo_router::plugin::plugins;
+use apollo_router::plugin::DynPlugin;
+use apollo_router::services::PluggableRouterServiceBuilder;
+use apollo_router::services::SubgraphService;
 use apollo_router::Schema;
 use serde_json::Value;
 use tower::ServiceExt;

--- a/apollo-router/tests/zipkin_test.rs
+++ b/apollo-router/tests/zipkin_test.rs
@@ -1,7 +1,9 @@
 mod common;
-use crate::common::TracingTest;
 use std::path::Path;
+
 use tower::BoxError;
+
+use crate::common::TracingTest;
 #[ignore]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_tracing() -> Result<(), BoxError> {

--- a/apollo-spaceport/build.rs
+++ b/apollo-spaceport/build.rs
@@ -1,8 +1,7 @@
-use std::{
-    error::Error,
-    fs::File,
-    io::{copy, Read},
-};
+use std::error::Error;
+use std::fs::File;
+use std::io::copy;
+use std::io::Read;
 
 fn main() -> Result<(), Box<dyn Error>> {
     // Retrieve a live version of the reports.proto file

--- a/apollo-spaceport/src/lib.rs
+++ b/apollo-spaceport/src/lib.rs
@@ -10,16 +10,20 @@ mod agent {
 /// The server module contains the server components
 pub mod server;
 
+use std::error::Error;
+
 use agent::reporter_client::ReporterClient;
 pub use agent::*;
 pub use prost_types::Timestamp;
 pub use report::*;
-use std::error::Error;
 use sys_info::hostname;
 use tokio::task::JoinError;
 use tonic::codegen::http::uri::InvalidUri;
-use tonic::transport::{Channel, Endpoint};
-use tonic::{Request, Response, Status};
+use tonic::transport::Channel;
+use tonic::transport::Endpoint;
+use tonic::Request;
+use tonic::Response;
+use tonic::Status;
 
 /// Reporting Error type
 #[derive(Debug)]

--- a/apollo-spaceport/src/server.rs
+++ b/apollo-spaceport/src/server.rs
@@ -1,26 +1,30 @@
 // This entire file is license key functionality
-use crate::{
-    agent::{
-        reporter_server::{Reporter, ReporterServer},
-        ReporterRequest, ReporterResponse,
-    },
-    report::Report,
-};
+use std::future::Future;
+use std::io::Write;
+use std::net::SocketAddr;
+use std::pin::Pin;
+
 use bytes::BytesMut;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use prost::Message;
 use reqwest::Client;
-use std::future::Future;
-use std::io::Write;
-use std::net::SocketAddr;
-use std::pin::Pin;
+use tokio::net::TcpListener;
+use tokio::sync::mpsc::error::TrySendError;
 use tokio::sync::mpsc::Sender;
 use tokio::time::Duration;
-use tokio::{net::TcpListener, sync::mpsc::error::TrySendError};
 use tokio_stream::wrappers::TcpListenerStream;
-use tonic::transport::{Error, Server};
-use tonic::{Request, Response, Status};
+use tonic::transport::Error;
+use tonic::transport::Server;
+use tonic::Request;
+use tonic::Response;
+use tonic::Status;
+
+use crate::agent::reporter_server::Reporter;
+use crate::agent::reporter_server::ReporterServer;
+use crate::agent::ReporterRequest;
+use crate::agent::ReporterResponse;
+use crate::report::Report;
 
 static DEFAULT_APOLLO_USAGE_REPORTING_INGRESS_URL: &str =
     "https://usage-reporting.api.apollographql.com/api/ingress/traces";

--- a/examples/add-timestamp-header/src/main.rs
+++ b/examples/add-timestamp-header/src/main.rs
@@ -14,8 +14,10 @@ fn main() -> Result<()> {
 mod tests {
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
-    use apollo_router::plugins::rhai::{Conf, Rhai};
-    use apollo_router::services::{RouterRequest, RouterResponse};
+    use apollo_router::plugins::rhai::Conf;
+    use apollo_router::plugins::rhai::Rhai;
+    use apollo_router::services::RouterRequest;
+    use apollo_router::services::RouterResponse;
     use http::StatusCode;
     use tower::util::ServiceExt;
 

--- a/examples/async-auth/src/allow_client_id_from_file.rs
+++ b/examples/async-auth/src/allow_client_id_from_file.rs
@@ -1,15 +1,22 @@
+use std::ops::ControlFlow;
+use std::path::PathBuf;
+
 use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
-use apollo_router::services::{ResponseBody, RouterRequest, RouterResponse};
+use apollo_router::services::ResponseBody;
+use apollo_router::services::RouterRequest;
+use apollo_router::services::RouterResponse;
 use futures::stream::BoxStream;
 use http::StatusCode;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json_bytes::Value;
-use std::{ops::ControlFlow, path::PathBuf};
-use tower::{util::BoxService, BoxError, ServiceBuilder, ServiceExt};
+use tower::util::BoxService;
+use tower::BoxError;
+use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 // This structure is the one we'll deserialize the yml configuration into
 #[derive(Deserialize, JsonSchema)]
@@ -174,16 +181,17 @@ register_plugin!(
 // and test your plugins in isolation:
 #[cfg(test)]
 mod tests {
-    use crate::allow_client_id_from_file::AllowClientIdConfig;
-
-    use super::AllowClientIdFromFile;
     use apollo_router::graphql;
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
-    use apollo_router::services::{RouterRequest, RouterResponse};
+    use apollo_router::services::RouterRequest;
+    use apollo_router::services::RouterResponse;
     use http::StatusCode;
     use serde_json::json;
     use tower::ServiceExt;
+
+    use super::AllowClientIdFromFile;
+    use crate::allow_client_id_from_file::AllowClientIdConfig;
 
     // This test ensures the router will be able to
     // find our `allow-client-id-from-file` plugin,

--- a/examples/context/src/context_data.rs
+++ b/examples/context/src/context_data.rs
@@ -1,10 +1,16 @@
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
 use apollo_router::services::ResponseBody;
-use apollo_router::services::{RouterRequest, RouterResponse, SubgraphRequest, SubgraphResponse};
+use apollo_router::services::RouterRequest;
+use apollo_router::services::RouterResponse;
+use apollo_router::services::SubgraphRequest;
+use apollo_router::services::SubgraphResponse;
 use futures::stream::BoxStream;
 use http::StatusCode;
-use tower::{util::BoxService, BoxError, ServiceBuilder, ServiceExt};
+use tower::util::BoxService;
+use tower::BoxError;
+use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 #[derive(Default)]
 // Global state for our plugin would live here.

--- a/examples/cookies-to-headers/src/main.rs
+++ b/examples/cookies-to-headers/src/main.rs
@@ -35,9 +35,13 @@ mod tests {
     use apollo_router::http_ext;
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
-    use apollo_router::plugins::rhai::{Conf, Rhai};
-    use apollo_router::services::{SubgraphRequest, SubgraphResponse};
-    use http::{header::HeaderName, HeaderValue, StatusCode};
+    use apollo_router::plugins::rhai::Conf;
+    use apollo_router::plugins::rhai::Rhai;
+    use apollo_router::services::SubgraphRequest;
+    use apollo_router::services::SubgraphResponse;
+    use http::header::HeaderName;
+    use http::HeaderValue;
+    use http::StatusCode;
     use tower::util::ServiceExt;
 
     #[tokio::test]

--- a/examples/embedded/src/main.rs
+++ b/examples/embedded/src/main.rs
@@ -1,10 +1,14 @@
-use anyhow::{anyhow, Result};
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use anyhow::Result;
 use apollo_router::services::PluggableRouterServiceBuilder;
 use apollo_router::services::RouterRequest;
 use apollo_router::services::SubgraphService;
-use apollo_router::subscriber::{set_global_subscriber, RouterSubscriber};
-use std::sync::Arc;
-use tower::{util::BoxService, ServiceExt};
+use apollo_router::subscriber::set_global_subscriber;
+use apollo_router::subscriber::RouterSubscriber;
+use tower::util::BoxService;
+use tower::ServiceExt;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]

--- a/examples/forbid-anonymous-operations/src/forbid_anonymous_operations.rs
+++ b/examples/forbid-anonymous-operations/src/forbid_anonymous_operations.rs
@@ -4,10 +4,15 @@ use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
-use apollo_router::services::{ResponseBody, RouterRequest, RouterResponse};
+use apollo_router::services::ResponseBody;
+use apollo_router::services::RouterRequest;
+use apollo_router::services::RouterResponse;
 use futures::stream::BoxStream;
 use http::StatusCode;
-use tower::{util::BoxService, BoxError, ServiceBuilder, ServiceExt};
+use tower::util::BoxService;
+use tower::BoxError;
+use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 #[derive(Default)]
 // Global state for our plugin would live here.
@@ -96,13 +101,16 @@ register_plugin!(
 // and test your plugins in isolation:
 #[cfg(test)]
 mod tests {
-    use super::ForbidAnonymousOperations;
     use apollo_router::graphql;
-    use apollo_router::plugin::{test, Plugin};
-    use apollo_router::services::{RouterRequest, RouterResponse};
+    use apollo_router::plugin::test;
+    use apollo_router::plugin::Plugin;
+    use apollo_router::services::RouterRequest;
+    use apollo_router::services::RouterResponse;
     use http::StatusCode;
     use serde_json::Value;
     use tower::ServiceExt;
+
+    use super::ForbidAnonymousOperations;
 
     // This test ensures the router will be able to
     // find our `forbid_anonymous_operations` plugin,

--- a/examples/hello-world/src/hello_world.rs
+++ b/examples/hello-world/src/hello_world.rs
@@ -1,16 +1,22 @@
 use apollo_router::graphql::Response;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
+use apollo_router::services::ExecutionRequest;
+use apollo_router::services::ExecutionResponse;
+use apollo_router::services::QueryPlannerRequest;
+use apollo_router::services::QueryPlannerResponse;
 use apollo_router::services::ResponseBody;
-use apollo_router::services::{ExecutionRequest, ExecutionResponse};
-use apollo_router::services::{QueryPlannerRequest, QueryPlannerResponse};
-use apollo_router::services::{RouterRequest, RouterResponse};
-use apollo_router::services::{SubgraphRequest, SubgraphResponse};
+use apollo_router::services::RouterRequest;
+use apollo_router::services::RouterResponse;
+use apollo_router::services::SubgraphRequest;
+use apollo_router::services::SubgraphResponse;
 use futures::stream::BoxStream;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::util::BoxService;
-use tower::{BoxError, ServiceBuilder, ServiceExt};
+use tower::BoxError;
+use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 #[derive(Debug)]
 struct HelloWorld {
@@ -110,11 +116,12 @@ register_plugin!("example", "hello_world", HelloWorld);
 
 #[cfg(test)]
 mod tests {
-    use super::{Conf, HelloWorld};
-
     use apollo_router::plugin::test::IntoSchema::Canned;
     use apollo_router::plugin::test::PluginTestHarness;
     use apollo_router::plugin::Plugin;
+
+    use super::Conf;
+    use super::HelloWorld;
 
     #[tokio::test]
     async fn plugin_registered() {

--- a/examples/jwt-auth/src/jwt.rs
+++ b/examples/jwt-auth/src/jwt.rs
@@ -60,12 +60,16 @@
 //!  - Token refresh
 //!  - ...
 
+use std::ops::ControlFlow;
+use std::str::FromStr;
+
 use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
 use apollo_router::services::ResponseBody;
-use apollo_router::services::{RouterRequest, RouterResponse};
+use apollo_router::services::RouterRequest;
+use apollo_router::services::RouterResponse;
 use apollo_router::Context;
 use futures::stream::BoxStream;
 use http::header::AUTHORIZATION;
@@ -75,10 +79,11 @@ use jwt_simple::Error;
 use schemars::JsonSchema;
 use serde::de;
 use serde::Deserialize;
-use std::ops::ControlFlow;
-use std::str::FromStr;
 use strum_macros::EnumString;
-use tower::{util::BoxService, BoxError, ServiceBuilder, ServiceExt};
+use tower::util::BoxService;
+use tower::BoxError;
+use tower::ServiceBuilder;
+use tower::ServiceExt;
 
 // It's a shame that we can't just have one enum which finds the algorithm and contains
 // the verifier, but the verification structs don't support Default, so we can't
@@ -389,11 +394,13 @@ register_plugin!("example", "jwt", JwtAuth);
 // and test your plugins in isolation:
 #[cfg(test)]
 mod tests {
-    use super::*;
     use apollo_router::graphql;
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
-    use apollo_router::services::{RouterRequest, RouterResponse};
+    use apollo_router::services::RouterRequest;
+    use apollo_router::services::RouterResponse;
+
+    use super::*;
 
     // This test ensures the router will be able to
     // find our `JwtAuth` plugin,

--- a/examples/op-name-to-header/src/main.rs
+++ b/examples/op-name-to-header/src/main.rs
@@ -14,9 +14,11 @@ fn main() -> Result<()> {
 mod tests {
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
-    use apollo_router::plugins::rhai::{Conf, Rhai};
+    use apollo_router::plugins::rhai::Conf;
+    use apollo_router::plugins::rhai::Rhai;
     use apollo_router::services::ResponseBody;
-    use apollo_router::services::{RouterRequest, RouterResponse};
+    use apollo_router::services::RouterRequest;
+    use apollo_router::services::RouterResponse;
     use http::StatusCode;
     use tower::util::ServiceExt;
 

--- a/examples/rhai-data-response-mutate/src/main.rs
+++ b/examples/rhai-data-response-mutate/src/main.rs
@@ -15,7 +15,8 @@ mod tests {
     use apollo_router::plugin::test::IntoSchema::Canned;
     use apollo_router::plugin::test::PluginTestHarness;
     use apollo_router::plugin::Plugin;
-    use apollo_router::plugins::rhai::{Conf, Rhai};
+    use apollo_router::plugins::rhai::Conf;
+    use apollo_router::plugins::rhai::Rhai;
     use apollo_router::services::RouterRequest;
     use apollo_router::Context;
     use http::StatusCode;

--- a/examples/rhai-error-response-mutate/src/main.rs
+++ b/examples/rhai-error-response-mutate/src/main.rs
@@ -15,7 +15,8 @@ mod tests {
     use apollo_router::plugin::test::IntoSchema::Canned;
     use apollo_router::plugin::test::PluginTestHarness;
     use apollo_router::plugin::Plugin;
-    use apollo_router::plugins::rhai::{Conf, Rhai};
+    use apollo_router::plugins::rhai::Conf;
+    use apollo_router::plugins::rhai::Rhai;
     use apollo_router::services::RouterRequest;
     use apollo_router::Context;
     use http::StatusCode;

--- a/examples/rhai-logging/src/main.rs
+++ b/examples/rhai-logging/src/main.rs
@@ -15,9 +15,11 @@ fn main() -> Result<()> {
 mod tests {
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
-    use apollo_router::plugins::rhai::{Conf, Rhai};
+    use apollo_router::plugins::rhai::Conf;
+    use apollo_router::plugins::rhai::Rhai;
     use apollo_router::services::ResponseBody;
-    use apollo_router::services::{RouterRequest, RouterResponse};
+    use apollo_router::services::RouterRequest;
+    use apollo_router::services::RouterResponse;
     use http::StatusCode;
     use tower::util::ServiceExt;
 

--- a/examples/rhai-subgraph-request-log/src/main.rs
+++ b/examples/rhai-subgraph-request-log/src/main.rs
@@ -15,7 +15,8 @@ mod tests {
     use apollo_router::plugin::test::IntoSchema::Canned;
     use apollo_router::plugin::test::PluginTestHarness;
     use apollo_router::plugin::Plugin;
-    use apollo_router::plugins::rhai::{Conf, Rhai};
+    use apollo_router::plugins::rhai::Conf;
+    use apollo_router::plugins::rhai::Rhai;
     use apollo_router::services::RouterRequest;
     use apollo_router::Context;
     use http::StatusCode;

--- a/examples/rhai-surrogate-cache-key/src/main.rs
+++ b/examples/rhai-surrogate-cache-key/src/main.rs
@@ -15,7 +15,8 @@ mod tests {
     use apollo_router::plugin::test::IntoSchema::Canned;
     use apollo_router::plugin::test::PluginTestHarness;
     use apollo_router::plugin::Plugin;
-    use apollo_router::plugins::rhai::{Conf, Rhai};
+    use apollo_router::plugins::rhai::Conf;
+    use apollo_router::plugins::rhai::Rhai;
     use apollo_router::services::RouterRequest;
     use apollo_router::Context;
     use http::StatusCode;

--- a/examples/status-code-propagation/src/propagate_status_code.rs
+++ b/examples/status-code-propagation/src/propagate_status_code.rs
@@ -1,13 +1,18 @@
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
 use apollo_router::services::ResponseBody;
-use apollo_router::services::{RouterRequest, RouterResponse};
-use apollo_router::services::{SubgraphRequest, SubgraphResponse};
+use apollo_router::services::RouterRequest;
+use apollo_router::services::RouterResponse;
+use apollo_router::services::SubgraphRequest;
+use apollo_router::services::SubgraphResponse;
 use futures::stream::BoxStream;
 use http::StatusCode;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
-use tower::{util::BoxService, BoxError, ServiceExt};
+use serde::Deserialize;
+use serde::Serialize;
+use tower::util::BoxService;
+use tower::BoxError;
+use tower::ServiceExt;
 
 // This configuration will be used
 // to Deserialize the yml configuration
@@ -98,14 +103,18 @@ register_plugin!("example", "propagate_status_code", PropagateStatusCode);
 // and test your plugins in isolation:
 #[cfg(test)]
 mod tests {
-    use crate::propagate_status_code::{PropagateStatusCode, PropagateStatusCodeConfig};
     use apollo_router::plugin::test;
     use apollo_router::plugin::Plugin;
-    use apollo_router::services::{RouterRequest, RouterResponse};
-    use apollo_router::services::{SubgraphRequest, SubgraphResponse};
+    use apollo_router::services::RouterRequest;
+    use apollo_router::services::RouterResponse;
+    use apollo_router::services::SubgraphRequest;
+    use apollo_router::services::SubgraphResponse;
     use http::StatusCode;
     use serde_json::json;
     use tower::ServiceExt;
+
+    use crate::propagate_status_code::PropagateStatusCode;
+    use crate::propagate_status_code::PropagateStatusCodeConfig;
 
     // This test ensures the router will be able to
     // find our `propagate_status_code` plugin,

--- a/fuzz/fuzz_targets/federation.rs
+++ b/fuzz/fuzz_targets/federation.rs
@@ -1,10 +1,12 @@
 #![no_main]
+use std::fs::OpenOptions;
+use std::io::Write;
+
 use libfuzzer_sys::fuzz_target;
 use log::debug;
 use router_fuzz::generate_valid_operation;
-use serde_json::{json, Value};
-use std::fs::OpenOptions;
-use std::io::Write;
+use serde_json::json;
+use serde_json::Value;
 
 const GATEWAY_FED1_URL: &str = "http://localhost:4100/graphql";
 const GATEWAY_FED2_URL: &str = "http://localhost:4200/graphql";

--- a/fuzz/fuzz_targets/router.rs
+++ b/fuzz/fuzz_targets/router.rs
@@ -1,11 +1,13 @@
 #![no_main]
 
+use std::fs::OpenOptions;
+use std::io::Write;
+
 use libfuzzer_sys::fuzz_target;
 use log::debug;
 use router_fuzz::generate_valid_operation;
-use serde_json::{json, Value};
-use std::fs::OpenOptions;
-use std::io::Write;
+use serde_json::json;
+use serde_json::Value;
 
 const GATEWAY_URL: &str = "http://localhost:4100/graphql";
 const ROUTER_URL: &str = "http://localhost:4000/graphql";

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -1,8 +1,10 @@
 use std::fs;
 
 use apollo_parser::Parser;
-use apollo_smith::{Document, DocumentBuilder};
-use libfuzzer_sys::arbitrary::{Result, Unstructured};
+use apollo_smith::Document;
+use apollo_smith::DocumentBuilder;
+use libfuzzer_sys::arbitrary::Result;
+use libfuzzer_sys::arbitrary::Unstructured;
 use log::debug;
 
 /// This generate an arbitrary valid GraphQL operation

--- a/uplink/build.rs
+++ b/uplink/build.rs
@@ -1,15 +1,13 @@
 #[cfg(not(windows))]
 fn main() {
-    use std::{
-        fs::File,
-        io::{Read, Write},
-    };
-
-    use launchpad::{
-        blocking::GraphQLClient,
-        introspect::{self, GraphIntrospectInput},
-    };
     use std::collections::HashMap;
+    use std::fs::File;
+    use std::io::Read;
+    use std::io::Write;
+
+    use launchpad::blocking::GraphQLClient;
+    use launchpad::introspect::GraphIntrospectInput;
+    use launchpad::introspect::{self};
 
     if let Ok("debug") = std::env::var("PROFILE").as_deref() {
         let client = GraphQLClient::new(

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 
 use futures::Stream;
-use graphql_client::{GraphQLQuery, QueryBody, Response};
+use graphql_client::GraphQLQuery;
+use graphql_client::QueryBody;
+use graphql_client::Response;
 use supergraph_sdl::FetchErrorCode;
 use tokio::sync::mpsc::channel;
 use tokio_stream::wrappers::ReceiverStream;

--- a/xtask/src/commands/all.rs
+++ b/xtask/src/commands/all.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 use structopt::StructOpt;
 
-use super::{Compliance, Lint, Test};
+use super::Compliance;
+use super::Lint;
+use super::Test;
 
 #[derive(Debug, StructOpt)]
 pub struct All {

--- a/xtask/src/commands/all.rs
+++ b/xtask/src/commands/all.rs
@@ -15,10 +15,10 @@ pub struct All {
 
 impl All {
     pub fn run(&self) -> Result<()> {
-        eprintln!("Running tests...");
-        self.test.run()?;
         eprintln!("Checking format and clippy...");
         self.lint.run_local()?;
+        eprintln!("Running tests...");
+        self.test.run()?;
         eprintln!("Checking licenses...");
         self.compliance.run_local()
     }

--- a/xtask/src/commands/compliance.rs
+++ b/xtask/src/commands/compliance.rs
@@ -1,6 +1,10 @@
-use anyhow::{ensure, Result};
-use sha2::{Digest, Sha256};
-use std::{fs::File, io};
+use std::fs::File;
+use std::io;
+
+use anyhow::ensure;
+use anyhow::Result;
+use sha2::Digest;
+use sha2::Sha256;
 use structopt::StructOpt;
 use xtask::*;
 

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -9,6 +9,8 @@ pub struct Lint {}
 
 const RUSTFMT_TOOLCHAIN: &str = "nightly-2022-06-26";
 
+const RUSTFMT_CONFIG: &[&str] = &["imports_granularity=Item", "group_imports=StdExternalCrate"];
+
 impl Lint {
     pub fn run(&self) -> Result<()> {
         Self::install_rustfmt()?;
@@ -69,6 +71,8 @@ impl Lint {
             "fmt",
             "--all",
             "--",
+            "--config",
+            &RUSTFMT_CONFIG.join(","),
         ]);
         Ok(command)
     }

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -1,6 +1,8 @@
-use anyhow::{ensure, Result};
 use std::process::Command;
 use std::process::Stdio;
+
+use anyhow::ensure;
+use anyhow::Result;
 use structopt::StructOpt;
 use xtask::*;
 

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -1,41 +1,90 @@
 use anyhow::{ensure, Result};
+use std::process::Command;
+use std::process::Stdio;
 use structopt::StructOpt;
 use xtask::*;
 
 #[derive(Debug, StructOpt)]
 pub struct Lint {}
 
+const RUSTFMT_TOOLCHAIN: &str = "nightly-2022-06-26";
+
 impl Lint {
     pub fn run(&self) -> Result<()> {
+        Self::install_rustfmt()?;
         Self::check_fmt()?;
         cargo!(["clippy", "--all", "--all-targets", "--", "-D", "warnings"]);
-
         Ok(())
     }
 
     pub fn run_local(&self) -> Result<()> {
-        cargo!(["clippy", "--all", "--all-targets", "--", "-D", "warnings"]);
-
+        Self::install_rustfmt()?;
         if Self::check_fmt().is_err() {
             // cargo fmt check failed, this means there is some formatting to do
             // given this task is running locally, let's do it and let our user know
-            cargo!(["fmt", "--all"]);
+            let status = Self::fmt_command()?.status()?;
+            ensure!(status.success(), "cargo fmt failed");
             eprintln!(
                 "🧹 cargo fmt job is complete 🧹\n\
                 Commit the changes and you should be good to go!"
             );
         };
+        cargo!(["clippy", "--all", "--all-targets", "--", "-D", "warnings"]);
 
+        Ok(())
+    }
+
+    fn install_rustfmt() -> Result<()> {
+        let nightly = RUSTFMT_TOOLCHAIN;
+        if !output("rustup", &["toolchain", "list"])?
+            .lines()
+            .any(|line| line.starts_with(nightly))
+        {
+            let args = ["toolchain", "install", nightly, "--profile", "minimal"];
+            run("rustup", &args)?
+        }
+        let args = ["component", "list", "--installed", "--toolchain", nightly];
+        if !output("rustup", &args)?
+            .lines()
+            .any(|line| line.starts_with("rustfmt"))
+        {
+            let args = ["component", "add", "rustfmt", "--toolchain", nightly];
+            run("rustup", &args)?
+        }
         Ok(())
     }
 
     fn check_fmt() -> Result<()> {
-        let cargo = which::which("cargo")?;
-        let mut command = ::std::process::Command::new(cargo);
-        command.args(["fmt", "--all", "--", "--check"]);
-
-        let status = command.current_dir(&*PKG_PROJECT_ROOT).status()?;
+        let status = Self::fmt_command()?.arg("--check").status()?;
         ensure!(status.success(), "cargo fmt check failed");
         Ok(())
     }
+
+    fn fmt_command() -> Result<Command> {
+        let mut command = Command::new(which::which("rustup")?);
+        command.current_dir(&*PKG_PROJECT_ROOT).args([
+            "run",
+            RUSTFMT_TOOLCHAIN,
+            "cargo",
+            "fmt",
+            "--all",
+            "--",
+        ]);
+        Ok(command)
+    }
+}
+
+fn run(program: &str, args: &[&str]) -> Result<()> {
+    let status = Command::new(which::which(program)?).args(args).status()?;
+    ensure!(status.success(), "{} failed", program);
+    Ok(())
+}
+
+fn output(program: &str, args: &[&str]) -> Result<String> {
+    let output = Command::new(which::which(program)?)
+        .args(args)
+        .stderr(Stdio::piped())
+        .output()?;
+    ensure!(output.status.success(), "{} failed", program);
+    Ok(String::from_utf8(output.stdout)?)
 }

--- a/xtask/src/commands/package/macos.rs
+++ b/xtask/src/commands/package/macos.rs
@@ -1,8 +1,13 @@
-use anyhow::{bail, ensure, Context, Result};
-use serde_json_traversal::serde_json_traversal;
 use std::io::Write as _;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Command;
+use std::process::Stdio;
+
+use anyhow::bail;
+use anyhow::ensure;
+use anyhow::Context;
+use anyhow::Result;
+use serde_json_traversal::serde_json_traversal;
 use structopt::StructOpt;
 use xtask::*;
 

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -1,9 +1,12 @@
 #[cfg(target_os = "macos")]
 mod macos;
 
-use anyhow::{ensure, Context, Result};
-use camino::Utf8PathBuf;
 use std::path::Path;
+
+use anyhow::ensure;
+use anyhow::Context;
+use anyhow::Result;
+use camino::Utf8PathBuf;
 use structopt::StructOpt;
 use xtask::*;
 

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -1,6 +1,7 @@
 use std::process::Stdio;
 
-use anyhow::{ensure, Result};
+use anyhow::ensure;
+use anyhow::Result;
 use structopt::StructOpt;
 use xtask::*;
 

--- a/xtask/src/federation_demo.rs
+++ b/xtask/src/federation_demo.rs
@@ -1,11 +1,12 @@
-use crate::*;
+use std::process::Command;
+use std::process::Stdio;
+use std::thread::sleep;
+use std::time::Duration;
+
 use anyhow::Result;
 use camino::Utf8PathBuf;
-use std::{
-    process::{Command, Stdio},
-    thread::sleep,
-    time::Duration,
-};
+
+use crate::*;
 
 pub struct FederationDemoRunner {
     path: Utf8PathBuf,

--- a/xtask/src/jaeger.rs
+++ b/xtask/src/jaeger.rs
@@ -1,12 +1,13 @@
-use crate::*;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
+use std::thread::sleep;
+use std::time::Duration;
+
 use anyhow::Result;
 use camino::Utf8PathBuf;
-use std::path::PathBuf;
-use std::{
-    process::{Command, Stdio},
-    thread::sleep,
-    time::Duration,
-};
+
+use crate::*;
 
 pub struct JaegerRunner {
     path: Utf8PathBuf,

--- a/xtask/src/lib.rs
+++ b/xtask/src/lib.rs
@@ -1,15 +1,20 @@
 mod federation_demo;
 mod jaeger;
 
+use std::convert::TryFrom;
+use std::env;
+use std::process::Child;
+use std::process::Command;
+use std::str;
+
 pub use anyhow;
-use anyhow::{Context, Result};
+use anyhow::Context;
+use anyhow::Result;
 use camino::Utf8PathBuf;
 use cargo_metadata::MetadataCommand;
 pub use federation_demo::*;
 pub use jaeger::*;
 use once_cell::sync::Lazy;
-use std::process::{Child, Command};
-use std::{convert::TryFrom, env, str};
 
 const MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 #[cfg(not(windows))]


### PR DESCRIPTION
`cargo xtask lint` now automatically installs a Nightly toolchain with rustfmt in order to to use these unstable options.

The last commit is auto-generated, let’s not squash.