### PR TITLE
re-enable the include_subgraph_errors plugin

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -31,7 +31,7 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 The module provides extensions to the `http` crate which are specific to the way we use that crate in the router. This change also cleans up the provided extensions and fixes a few potential sources of error (by removing them)
 such as the Request::mock() fn.
 
-By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1257
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1291
 
 ### Rework the entire public API structure ([PR #1216](https://github.com/apollographql/router/pull/1216),  [PR #1242](https://github.com/apollographql/router/pull/1242),  [PR #1267](https://github.com/apollographql/router/pull/1267),  [PR #1277](https://github.com/apollographql/router/pull/1277), [PR #1303](https://github.com/apollographql/router/pull/1303))
 
@@ -254,6 +254,12 @@ Previously, it was not possible to modify variables in a `Request` from a plugin
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1257
 
 ## 🐛 Fixes
+
+### Re-enable the subgraph error redaction functionality ([PR #1317](https://github.com/apollographql/router/pull/1317)
+
+In a re-factoring the "include_subgraph_errors" plugin was disabled. This meant that subgraph error handling was not working as intended. This change re-enables it and improves the functionality with additional logging. As part of the fix, the plugin initialisation mechanism was improved to ensure that plugins start in the required sequence.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1317
 
 ### Restrict static introspection to only `__schema` and `__type` ([PR #1299](https://github.com/apollographql/router/pull/1299))
 Queries with selected field names starting with `__` are recognized as introspection queries. This includes `__schema`, `__type` and `__typename`. However, `__typename` is introspection at query time which is different from `__schema` and `__type` because two of the later can be answered with queries with empty input variables. This change will restrict introspection to only `__schema` and `__type`.

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -3,7 +3,6 @@
 mod yaml;
 
 use crate::plugin::plugins;
-use crate::subscriber::is_global_subscriber_set;
 use derivative::Derivative;
 use displaydoc::Display;
 use envmnt::{ExpandOptions, ExpansionType};
@@ -81,10 +80,6 @@ pub struct Configuration {
 
 const APOLLO_PLUGIN_PREFIX: &str = "apollo.";
 
-// Add your plugin to this list so it gets automatically set up if its not been provided a custom configuration.
-// ! requires the plugin configuration to implement Default
-const MANDATORY_APOLLO_PLUGINS: &[&str] = &["csrf"];
-
 fn default_listen() -> ListenAddr {
     SocketAddr::from_str("127.0.0.1:4000").unwrap().into()
 }
@@ -112,14 +107,8 @@ impl Configuration {
         Box::new(self)
     }
 
-    pub(crate) fn plugins(&self) -> Map<String, Value> {
-        let mut plugins = Vec::default();
-
-        if is_global_subscriber_set() {
-            // Add the reporting plugin, this will be overridden if such a plugin actually exists in the config.
-            // Note that this can only be done if the global subscriber has been set, i.e. we're not unit testing.
-            plugins.push(("apollo.telemetry".into(), Value::Object(Map::new())));
-        }
+    pub(crate) fn plugins(&self) -> Vec<(String, Value)> {
+        let mut plugins = vec![];
 
         // Add all the apollo plugins
         for (plugin, config) in &self.apollo_plugins.plugins {
@@ -131,19 +120,6 @@ impl Configuration {
             plugins.push((plugin_full_name, config.clone()));
         }
 
-        // Add the mandatory apollo plugins with defaults,
-        // if a custom configuration hasn't been provided by the user
-        MANDATORY_APOLLO_PLUGINS.iter().for_each(|plugin_name| {
-            let plugin_full_name = format!("{}{}", APOLLO_PLUGIN_PREFIX, plugin_name);
-            if !plugins.iter().any(|p| p.0 == plugin_full_name) {
-                tracing::debug!(
-                    "adding plugin {} with default configuration",
-                    plugin_full_name.as_str()
-                );
-                plugins.push((plugin_full_name, Value::Object(Map::new())));
-            }
-        });
-
         // Add all the user plugins
         if let Some(config_map) = self.plugins.plugins.as_ref() {
             for (plugin, config) in config_map {
@@ -151,19 +127,7 @@ impl Configuration {
             }
         }
 
-        // Plugins must be sorted. For now this sort is hard coded, but we may add something generic.
-        plugins.sort_by_key(|(name, _)| match name.as_str() {
-            "apollo.telemetry" => -100,
-            "apollo.rhai" => 100,
-            _ => 0,
-        });
-
-        let mut final_plugins = Map::new();
-        for (plugin, config) in plugins {
-            final_plugins.insert(plugin, config);
-        }
-
-        final_plugins
+        plugins
     }
 }
 

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -535,6 +535,10 @@ pub(crate) mod fetch {
                     .oneshot(subgraph_request)
                     .instrument(tracing::trace_span!("subfetch_stream"))
                     .await
+                    // TODO this is a problem since it restores details about failed service
+                    // when errors have been redacted in the include_subgraph_errors module.
+                    // Unfortunately, not easy to fix here, because at this point we don't
+                    // know if we should be redacting errors for this subgraph...
                     .map_err(|e| FetchError::SubrequestHttpError {
                         service: service_name.to_string(),
                         reason: e.to_string(),

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -10,8 +10,8 @@ use crate::{PluggableRouterServiceBuilder, ResponseBody, Schema};
 use envmnt::types::ExpandOptions;
 use envmnt::ExpansionType;
 use futures::stream::BoxStream;
+use serde_json::Map;
 use serde_json::Value;
-use std::collections::HashMap;
 use std::sync::Arc;
 use tower::buffer::Buffer;
 use tower::util::{BoxCloneService, BoxService};
@@ -107,15 +107,22 @@ impl RouterServiceFactory for YamlRouterServiceFactory {
 async fn create_plugins(
     configuration: &Configuration,
     schema: &Schema,
-) -> Result<HashMap<String, Box<dyn DynPlugin>>, BoxError> {
+) -> Result<Vec<(String, Box<dyn DynPlugin>)>, BoxError> {
+    // List of mandatory plugins. Ordering is important!!
+    let mut mandatory_plugins = vec!["experimental.include_subgraph_errors", "apollo.csrf"];
+
+    // Telemetry is *only* mandatory if the global subscriber is set
+    if crate::subscriber::is_global_subscriber_set() {
+        mandatory_plugins.insert(0, "apollo.telemetry");
+    }
+
     let mut errors = Vec::new();
     let plugin_registry = crate::plugin::plugins();
     let mut plugin_instances = Vec::new();
 
     for (name, mut configuration) in configuration.plugins().into_iter() {
-        // Ugly hack to get the schema sha into the the telemetry plugin
-
         let name = name.clone();
+
         match plugin_registry.get(name.as_str()) {
             Some(factory) => {
                 tracing::debug!(
@@ -124,7 +131,7 @@ async fn create_plugins(
                     configuration
                 );
                 if name == "apollo.telemetry" {
-                    inject_schema_id(schema, &mut configuration)
+                    inject_schema_id(schema, &mut configuration);
                 }
                 // expand any env variables in the config before processing.
                 let configuration = expand_env_variables(&configuration);
@@ -142,27 +149,59 @@ async fn create_plugins(
         }
     }
 
-    // The "include_subgraph_errors" plugin must always be active. If it is not
-    // configured, add an instance with default configuration to ensure that
-    // subgraph errors are correctly redacted.
-    let subgraph_error_plugin = "experimental.include_subgraph_errors".to_string();
-    if !plugin_instances
-        .iter()
-        .any(|(x, _)| x == &subgraph_error_plugin)
-    {
-        match plugin_registry.get(&subgraph_error_plugin) {
-            Some(factory) => match factory.create_instance(&serde_json::json!({})).await {
-                Ok(plugin) => {
-                    plugin_instances.push((subgraph_error_plugin, plugin));
+    // At this point we've processed all of the plugins that were provided in configuration.
+    // We now need to do process our list of mandatory plugins:
+    //  - If a mandatory plugin is already in the list, then it must be re-located
+    //    to its mandatory location
+    //  - If it is missing, it must be added at its mandatory location
+
+    for (desired_position, name) in mandatory_plugins.iter().enumerate() {
+        let position_maybe = plugin_instances.iter().position(|(x, _)| x == name);
+        match position_maybe {
+            Some(actual_position) => {
+                // Found it, re-locate if required.
+                if actual_position != desired_position {
+                    let temp = plugin_instances.remove(actual_position);
+                    plugin_instances.insert(desired_position, temp);
                 }
-                Err(err) => errors.push(ConfigurationError::PluginConfiguration {
-                    plugin: subgraph_error_plugin,
-                    error: err.to_string(),
-                }),
-            },
-            None => errors.push(ConfigurationError::PluginUnknown(subgraph_error_plugin)),
+            }
+            None => {
+                // Didn't find it, insert
+                match plugin_registry.get(*name) {
+                    // Create an instance with no configuration
+                    // Some(factory) => match factory.create_instance(&serde_json::json!({})).await {
+                    Some(factory) => {
+                        // Create default (empty) config
+                        let mut config = Value::Object(Map::new());
+                        // The apollo.telemetry" plugin isn't happy with no config, so we give
+                        // it some. If any of the other mandatory plugins need special
+                        // treatment, then we'll have to perform it here.
+                        // This is *required* by the telemetry module or it will fail...
+                        if *name == "apollo.telemetry" {
+                            inject_schema_id(schema, &mut config);
+                        }
+                        match factory.create_instance(&config).await {
+                            Ok(plugin) => {
+                                plugin_instances
+                                    .insert(desired_position, (name.to_string(), plugin));
+                            }
+                            Err(err) => errors.push(ConfigurationError::PluginConfiguration {
+                                plugin: name.to_string(),
+                                error: err.to_string(),
+                            }),
+                        }
+                    }
+                    None => errors.push(ConfigurationError::PluginUnknown(name.to_string())),
+                }
+            }
         }
     }
+
+    let plugin_details = plugin_instances
+        .iter()
+        .map(|(name, plugin)| (name, plugin.name()))
+        .collect::<Vec<(&String, &str)>>();
+    tracing::info!(?plugin_details, "list of plugins");
 
     if !errors.is_empty() {
         for error in &errors {
@@ -177,7 +216,7 @@ async fn create_plugins(
                 .join("\n"),
         ))
     } else {
-        Ok(plugin_instances.into_iter().collect())
+        Ok(plugin_instances)
     }
 }
 

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -168,13 +168,12 @@ async fn create_plugins(
             None => {
                 // Didn't find it, insert
                 match plugin_registry.get(*name) {
-                    // Create an instance with no configuration
-                    // Some(factory) => match factory.create_instance(&serde_json::json!({})).await {
+                    // Create an instance
                     Some(factory) => {
                         // Create default (empty) config
                         let mut config = Value::Object(Map::new());
-                        // The apollo.telemetry" plugin isn't happy with no config, so we give
-                        // it some. If any of the other mandatory plugins need special
+                        // The apollo.telemetry" plugin isn't happy with empty config, so we
+                        // give it some. If any of the other mandatory plugins need special
                         // treatment, then we'll have to perform it here.
                         // This is *required* by the telemetry module or it will fail...
                         if *name == "apollo.telemetry" {


### PR DESCRIPTION
prompted by the problems identified in #1184.

This isn't a complete fix to those issues, but a patching PR which
provides a temporary improvement until we have resolved how to best
to address the issue.

also:
 - add support for redacting errors as well as responses
 - add a log line noting when errors are redacted
 - add comment to problem area in query planner processing
 - remove unnecessary clone

The scope of this set of fixes has expanded to include plugin initialisation. Here's the explanation why from the commit message:

    improve plugin initialization
    
    Prompted by Bryn's previous comment about ordering, I looked further
    into the plugin registration process and discovered bugs (which caused
    plugins not to be ordered) and, in discussion with Bryn, identified
    opportunities to improve plugin registration and initialization.
    
    Thus:
    
     - mandatory plugins are now handled during router factory creation
     - order of plugins is now maintained (and logged)
     - enforced ordering of mandatory plugins
    
    Previously we tried to maintain plugin sequence up to a certain point
    and then we inserted them into a HashMap, which meant plugin sequencing
    was unpredictable.
    
    Sample log line:
 
    2022-06-29T07:34:53.114688Z  INFO apollo_router::router_factory: list of plugins plugin_details=[("apollo.telemetry", "apollo_router::plugins::telemetry::Telemetry"), ("experimental.include_subgraph_errors", "apollo_router::plugins::include_subgraph_errors::IncludeSubgraphErrors"), ("apollo.csrf", "apollo_router::plugins::csrf::Csrf"), ("example.context_data", "context_data::context_data::ContextData")]
    
    Note that plugins are listed in processing sequence.

