### PR TITLE
chore: update rhai to latest release (1.8.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4379,8 +4379,9 @@ dependencies = [
 
 [[package]]
 name = "rhai"
-version = "1.7.0"
-source = "git+https://github.com/rhaiscript/rhai.git?rev=6120b7a01a84a8d35d21fcdf2c44432455b68cdb#6120b7a01a84a8d35d21fcdf2c44432455b68cdb"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f8a1b0ce6aba109eb3628f36db9c1818c1d396bd5a56449d5203e96e4b713a7"
 dependencies = [
  "ahash",
  "bitflags",
@@ -4459,8 +4460,9 @@ dependencies = [
 
 [[package]]
 name = "rhai_codegen"
-version = "1.4.0"
-source = "git+https://github.com/rhaiscript/rhai.git?rev=6120b7a01a84a8d35d21fcdf2c44432455b68cdb#6120b7a01a84a8d35d21fcdf2c44432455b68cdb"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a39bc2aa9258b282ee5518dac493491a9c4c11a6d7361b9d2644c922fc6488"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -433,6 +433,12 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 
 ## 🛠 Maintenance ( :hammer_and_wrench: )
 
+### Update rhai to latest release (1.8.0)  ([PR #1337](https://github.com/apollographql/router/pull/1337)
+
+We had been depending on a pinned git version which had a fix we required. This now updates to the latest release.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1337
+
 ### Remove typed-builder ([PR #1218](https://github.com/apollographql/router/pull/1218))
 Migrate all typed-builders code to buildstructor
 By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/1218

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -92,8 +92,7 @@ opentelemetry-zipkin = { version = "0.15.0", default-features = false, features 
 opentelemetry-prometheus = "0.10.0"
 paste = "1.0.7"
 prometheus = "0.13"
-# Pinned to git revision until next rhai release
-rhai = { git="https://github.com/rhaiscript/rhai.git", features = ["sync", "serde", "internals"], rev="6120b7a01a84a8d35d21fcdf2c44432455b68cdb" }
+rhai = { version="1.8.0", features = ["sync", "serde", "internals"] }
 regex = "1.5.6"
 reqwest = { version = "0.11.11", default-features = false, features = [
     "rustls-tls",

--- a/deny.toml
+++ b/deny.toml
@@ -97,4 +97,4 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for
-github = ["open-telemetry", "apollographql", "tokio-rs", "rhaiscript"]
+github = ["open-telemetry", "apollographql", "tokio-rs"]

--- a/examples/cookies-to-headers/src/cookies_to_headers.rhai
+++ b/examples/cookies-to-headers/src/cookies_to_headers.rhai
@@ -10,21 +10,25 @@ fn subgraph_service(service, subgraph) {
 // If you only wish to convert certain cookies, you
 // can add logic to modify the processing.
 fn process_request(request) {
-    print("adding cookies as headers");
 
     // Find our cookies
-    let cookies = request.headers["cookie"].split(';');
-    for cookie in cookies {
-        // Split our cookies into name and value
-        let k_v = cookie.split('=', 2);
-        if k_v.len() == 2 {
-            // trim off any whitespace
-            k_v[0].trim();
-            k_v[1].trim();
-            // update our headers
-            // Note: we must update subgraph.headers, since we are
-            // setting a header in our sub graph request
-            request.subgraph.headers[k_v[0]] = k_v[1];
+    if "cookie" in request.headers {
+        print("adding cookies as headers");
+        let cookies = request.headers["cookie"].split(';');
+        for cookie in cookies {
+            // Split our cookies into name and value
+            let k_v = cookie.split('=', 2);
+            if k_v.len() == 2 {
+                // trim off any whitespace
+                k_v[0].trim();
+                k_v[1].trim();
+                // update our headers
+                // Note: we must update subgraph.headers, since we are
+                // setting a header in our sub graph request
+                request.subgraph.headers[k_v[0]] = k_v[1];
+            }
         }
+    } else {
+        print("no cookies in request");
     }
 }

--- a/licenses.html
+++ b/licenses.html
@@ -1097,7 +1097,6 @@
                     <li><a href=" https://github.com/assert-rs/predicates-rs ">predicates</a></li>
                     <li><a href=" https://github.com/assert-rs/predicates-rs/tree/master/predicates-core ">predicates-core</a></li>
                     <li><a href=" https://github.com/assert-rs/predicates-rs/tree/master/predicates-tree ">predicates-tree</a></li>
-                    <li><a href=" https://github.com/rhaiscript ">rhai</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -10300,6 +10299,7 @@ limitations under the License.
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-derive</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-types</a></li>
                     <li><a href=" https://github.com/RustCrypto/signatures/tree/master/rfc6979 ">rfc6979</a></li>
+                    <li><a href=" https://github.com/rhaiscript ">rhai</a></li>
                     <li><a href=" https://github.com/rhaiscript/rhai ">rhai_codegen</a></li>
                     <li><a href=" https://crates.io/crates/rustc-workspace-hack ">rustc-workspace-hack</a></li>
                     <li><a href=" https://github.com/ctz/rustls ">rustls</a></li>


### PR DESCRIPTION
We had been using a pinned git version to pull in a fix which geoffroy
had contributed.

I ran the full test suite and all the examples and all looks good.

I also updated one of the examples based on improvements I identified in
writing rhai script for another project.
