### PR TITLE
relax plugin api mutability

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -308,6 +308,15 @@ Do not silently skip some bad configuration, now if you add an unknown configura
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1278
 
+### Relax plugin api mutability ([PR #1340](https://github.com/apollographql/router/pull/1340) ([PR #1289](https://github.com/apollographql/router/pull/1289)
+
+the `Plugin::*_service()` methods were taking a `&mut self` as argument, but since
+they work like a tower Layer, they can use `&self` instead. This change
+then allows us to move from Buffer to service factories for the query
+planner, execution and subgraph services
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1340 https://github.com/apollographql/router/pull/1289
+
 ## 🚀 Features ( :rocket: )
 
 ### Add support to add custom attributes on metrics. [PR #1300](https://github.com/apollographql/router/pull/1300)
@@ -425,5 +434,12 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 ### Remove typed-builder ([PR #1218](https://github.com/apollographql/router/pull/1218))
 Migrate all typed-builders code to buildstructor
 By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/1218
+
 ## 📚 Documentation ( :books: )
 
+### Replace Buffers of tower services with service factories([PR #1289](https://github.com/apollographql/router/pull/1289)
+
+tower services should be used by creating a new service instance for each new session
+instead of going through a Buffer.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1289

--- a/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
+++ b/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
@@ -68,7 +68,7 @@ impl Plugin for {{pascal_name}} {
 
     // Delete this function if you are not customizing it.
     fn query_planning_service(
-        &mut self,
+        &self,
         service: BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError>,
     ) -> BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError> {
         service
@@ -76,7 +76,7 @@ impl Plugin for {{pascal_name}} {
 
     // Delete this function if you are not customizing it.
     fn execution_service(
-        &mut self,
+        &self,
         service: BoxService<ExecutionRequest, ExecutionResponse<BoxStream<'static, Response>>, BoxError>,
     ) -> BoxService<ExecutionRequest, ExecutionResponse<BoxStream<'static, Response>>, BoxError> {
         service
@@ -84,7 +84,7 @@ impl Plugin for {{pascal_name}} {
 
     // Delete this function if you are not customizing it.
     fn subgraph_service(
-        &mut self,
+        &self,
         _name: &str,
         service: BoxService<SubgraphRequest, SubgraphResponse, BoxError>,
     ) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError> {

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -129,7 +129,7 @@ pub trait Plugin: Send + Sync + 'static + Sized {
     /// This service handles generating the query plan for each incoming request.
     /// Define `query_planning_service` if your customization needs to interact with query planning functionality (for example, to log query plan details).
     fn query_planning_service(
-        &mut self,
+        &self,
         service: BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError>,
     ) -> BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError> {
         service
@@ -138,7 +138,7 @@ pub trait Plugin: Send + Sync + 'static + Sized {
     /// This service handles initiating the execution of a query plan after it's been generated.
     /// Define `execution_service` if your customization includes logic to govern execution (for example, if you want to block a particular query based on a policy decision).
     fn execution_service(
-        &mut self,
+        &self,
         service: BoxService<
             ExecutionRequest,
             ExecutionResponse<BoxStream<'static, Response>>,
@@ -153,7 +153,7 @@ pub trait Plugin: Send + Sync + 'static + Sized {
     /// Define `subgraph_service` to configure this communication (for example, to dynamically add headers to pass to a subgraph).
     /// The `_subgraph_name` parameter is useful if you need to apply a customization only specific subgraphs.
     fn subgraph_service(
-        &mut self,
+        &self,
         _subgraph_name: &str,
         service: BoxService<SubgraphRequest, SubgraphResponse, BoxError>,
     ) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError> {
@@ -199,14 +199,14 @@ pub trait DynPlugin: Send + Sync + 'static {
     /// This service handles generating the query plan for each incoming request.
     /// Define `query_planning_service` if your customization needs to interact with query planning functionality (for example, to log query plan details).
     fn query_planning_service(
-        &mut self,
+        &self,
         service: BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError>,
     ) -> BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError>;
 
     /// This service handles initiating the execution of a query plan after it's been generated.
     /// Define `execution_service` if your customization includes logic to govern execution (for example, if you want to block a particular query based on a policy decision).
     fn execution_service(
-        &mut self,
+        &self,
         service: BoxService<
             ExecutionRequest,
             ExecutionResponse<BoxStream<'static, Response>>,
@@ -218,7 +218,7 @@ pub trait DynPlugin: Send + Sync + 'static {
     /// Define `subgraph_service` to configure this communication (for example, to dynamically add headers to pass to a subgraph).
     /// The `_subgraph_name` parameter is useful if you need to apply a customization only on specific subgraphs.
     fn subgraph_service(
-        &mut self,
+        &self,
         _subgraph_name: &str,
         service: BoxService<SubgraphRequest, SubgraphResponse, BoxError>,
     ) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError>;
@@ -250,14 +250,14 @@ where
     }
 
     fn query_planning_service(
-        &mut self,
+        &self,
         service: BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError>,
     ) -> BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError> {
         self.query_planning_service(service)
     }
 
     fn execution_service(
-        &mut self,
+        &self,
         service: BoxService<
             ExecutionRequest,
             ExecutionResponse<BoxStream<'static, Response>>,
@@ -269,7 +269,7 @@ where
     }
 
     fn subgraph_service(
-        &mut self,
+        &self,
         name: &str,
         service: BoxService<SubgraphRequest, SubgraphResponse, BoxError>,
     ) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError> {

--- a/apollo-router/src/plugin/test/mod.rs
+++ b/apollo-router/src/plugin/test/mod.rs
@@ -86,7 +86,7 @@ impl PluginTestHarness {
     ///
     #[builder]
     pub async fn new<P: Plugin>(
-        mut plugin: P,
+        plugin: P,
         schema: IntoSchema,
         mock_router_service: Option<MockRouterService>,
         mock_query_planner_service: Option<MockQueryPlanningService>,

--- a/apollo-router/src/plugins/forbid_mutations.rs
+++ b/apollo-router/src/plugins/forbid_mutations.rs
@@ -30,7 +30,7 @@ impl Plugin for ForbidMutations {
     }
 
     fn execution_service(
-        &mut self,
+        &self,
         service: BoxService<
             ExecutionRequest,
             ExecutionResponse<BoxStream<'static, Response>>,

--- a/apollo-router/src/plugins/headers.rs
+++ b/apollo-router/src/plugins/headers.rs
@@ -119,7 +119,7 @@ impl Plugin for Headers {
         Ok(Headers { config })
     }
     fn subgraph_service(
-        &mut self,
+        &self,
         name: &str,
         service: BoxService<SubgraphRequest, SubgraphResponse, BoxError>,
     ) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError> {

--- a/apollo-router/src/plugins/include_subgraph_errors.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors.rs
@@ -50,7 +50,7 @@ impl Plugin for IncludeSubgraphErrors {
     }
 
     fn subgraph_service(
-        &mut self,
+        &self,
         name: &str,
         service: BoxService<SubgraphRequest, SubgraphResponse, BoxError>,
     ) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError> {

--- a/apollo-router/src/plugins/override_url.rs
+++ b/apollo-router/src/plugins/override_url.rs
@@ -32,7 +32,7 @@ impl Plugin for OverrideSubgraphUrl {
     }
 
     fn subgraph_service(
-        &mut self,
+        &self,
         subgraph_name: &str,
         service: BoxService<SubgraphRequest, SubgraphResponse, BoxError>,
     ) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError> {
@@ -82,7 +82,7 @@ mod tests {
                     .build())
             });
 
-        let mut dyn_plugin: Box<dyn DynPlugin> = crate::plugin::plugins()
+        let dyn_plugin: Box<dyn DynPlugin> = crate::plugin::plugins()
             .get("apollo.override_subgraph_url")
             .expect("Plugin not found")
             .create_instance(

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -486,7 +486,7 @@ impl Plugin for Rhai {
     }
 
     fn query_planning_service(
-        &mut self,
+        &self,
         service: BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError>,
     ) -> BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError> {
         const FUNCTION_NAME_SERVICE: &str = "query_planner_service";
@@ -506,7 +506,7 @@ impl Plugin for Rhai {
     }
 
     fn execution_service(
-        &mut self,
+        &self,
         service: BoxService<
             ExecutionRequest,
             ExecutionResponse<BoxStream<'static, Response>>,
@@ -531,7 +531,7 @@ impl Plugin for Rhai {
     }
 
     fn subgraph_service(
-        &mut self,
+        &self,
         name: &str,
         service: BoxService<SubgraphRequest, SubgraphResponse, BoxError>,
     ) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError> {
@@ -1707,7 +1707,7 @@ mod tests {
                     .boxed())
             });
 
-        let mut dyn_plugin: Box<dyn DynPlugin> = crate::plugin::plugins()
+        let dyn_plugin: Box<dyn DynPlugin> = crate::plugin::plugins()
             .get("experimental.rhai")
             .expect("Plugin not found")
             .create_instance(

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -339,7 +339,7 @@ impl Plugin for Telemetry {
     }
 
     fn query_planning_service(
-        &mut self,
+        &self,
         service: BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError>,
     ) -> BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError> {
         ServiceBuilder::new()
@@ -349,7 +349,7 @@ impl Plugin for Telemetry {
     }
 
     fn execution_service(
-        &mut self,
+        &self,
         service: BoxService<
             ExecutionRequest,
             ExecutionResponse<BoxStream<'static, Response>>,
@@ -364,7 +364,7 @@ impl Plugin for Telemetry {
     }
 
     fn subgraph_service(
-        &mut self,
+        &self,
         name: &str,
         service: BoxService<SubgraphRequest, SubgraphResponse, BoxError>,
     ) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError> {
@@ -1121,7 +1121,7 @@ mod tests {
                     .build())
             });
 
-        let mut dyn_plugin: Box<dyn DynPlugin> = crate::plugin::plugins()
+        let dyn_plugin: Box<dyn DynPlugin> = crate::plugin::plugins()
             .get("apollo.telemetry")
             .expect("Plugin not found")
             .create_instance(

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -78,7 +78,7 @@ impl Plugin for TrafficShaping {
     }
 
     fn subgraph_service(
-        &mut self,
+        &self,
         name: &str,
         service: BoxService<SubgraphRequest, SubgraphResponse, BoxError>,
     ) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError> {
@@ -112,7 +112,7 @@ impl Plugin for TrafficShaping {
     }
 
     fn query_planning_service(
-        &mut self,
+        &self,
         service: BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError>,
     ) -> BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError> {
         if matches!(self.config.variables_deduplication, Some(true)) {
@@ -287,7 +287,7 @@ mod test {
         )
         .unwrap();
 
-        let mut plugin = get_traffic_shaping_plugin(&config).await;
+        let plugin = get_traffic_shaping_plugin(&config).await;
         let request = SubgraphRequest::fake_builder().build();
 
         let test_service = MockSubgraph::new(HashMap::new()).map_request(|req: SubgraphRequest| {

--- a/examples/context/src/context_data.rs
+++ b/examples/context/src/context_data.rs
@@ -81,7 +81,7 @@ impl Plugin for ContextData {
     }
 
     fn subgraph_service(
-        &mut self,
+        &self,
         _name: &str,
         service: BoxService<SubgraphRequest, SubgraphResponse, BoxError>,
     ) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError> {

--- a/examples/cookies-to-headers/src/main.rs
+++ b/examples/cookies-to-headers/src/main.rs
@@ -85,7 +85,7 @@ mod tests {
         .expect("json must be valid");
 
         // Build a rhai plugin instance from our conf
-        let mut rhai = Rhai::new(conf)
+        let rhai = Rhai::new(conf)
             .await
             .expect("valid configuration should succeed");
 

--- a/examples/hello-world/src/hello_world.rs
+++ b/examples/hello-world/src/hello_world.rs
@@ -61,7 +61,7 @@ impl Plugin for HelloWorld {
     }
 
     fn query_planning_service(
-        &mut self,
+        &self,
         service: BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError>,
     ) -> BoxService<QueryPlannerRequest, QueryPlannerResponse, BoxError> {
         // This is the default implementation and does not modify the default service.
@@ -70,7 +70,7 @@ impl Plugin for HelloWorld {
     }
 
     fn execution_service(
-        &mut self,
+        &self,
         service: BoxService<
             ExecutionRequest,
             ExecutionResponse<BoxStream<'static, Response>>,
@@ -85,7 +85,7 @@ impl Plugin for HelloWorld {
 
     // Called for each subgraph
     fn subgraph_service(
-        &mut self,
+        &self,
         _name: &str,
         service: BoxService<SubgraphRequest, SubgraphResponse, BoxError>,
     ) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError> {

--- a/examples/status-code-propagation/src/propagate_status_code.rs
+++ b/examples/status-code-propagation/src/propagate_status_code.rs
@@ -38,7 +38,7 @@ impl Plugin for PropagateStatusCode {
     }
 
     fn subgraph_service(
-        &mut self,
+        &self,
         _name: &str,
         service: BoxService<SubgraphRequest, SubgraphResponse, BoxError>,
     ) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError> {


### PR DESCRIPTION
the Plugin::*_service() methods were taking a &mut self as argument, but since
  they work like a tower Layer, they can use &self instead. This change
  then allows us to move from Buffer to service factories for the query
  planner, execution and subgraph services
