### PR TITLE
renovate: correct rustc regex to not use line-boundaries

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -28,7 +28,7 @@
         "^\\.tool-versions$",
         "^dockerfiles/diy/dockerfiles/Dockerfile\\.repo$",
         "^rust-toolchain\\.toml$",
-        "^docs/\\.mdx$"
+        "^docs/.*?\\.mdx$"
       ],
       "matchStrings": [
         "(#|<!--)\\s*renovate-automation: rustc version\\s*(?:-->)?\\n[^.]*?(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\b"

--- a/renovate.json5
+++ b/renovate.json5
@@ -24,7 +24,12 @@
   //
   "regexManagers": [
     {
-      "fileMatch": ["^\\.tool-versions$", "Dockerfile\\.repo$", "^rust-toolchain\\.toml$", "\\.mdx$"],
+      "fileMatch": [
+        "^\\.tool-versions$",
+        "^dockerfiles/diy/dockerfiles/Dockerfile\\.repo$",
+        "^rust-toolchain\\.toml$",
+        "^docs/\\.mdx$"
+      ],
       "matchStrings": [
         "(#|<!--)\\s*renovate-automation: rustc version\\s*(?:-->)?\\n[^.]*?(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\b"
       ],

--- a/renovate.json5
+++ b/renovate.json5
@@ -24,9 +24,9 @@
   //
   "regexManagers": [
     {
-      "fileMatch": ["^\\.tool-versions$", "^Dockerfile", "\\.mdx$"],
+      "fileMatch": ["^\\.tool-versions$", "Dockerfile\\.repo$", "^rust-toolchain\\.toml$", "\\.mdx$"],
       "matchStrings": [
-        "(^#|<!--)\\s*renovate-automation: rustc version\\s*(?:-->)?$\\n[^.]*?(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\b"
+        "(#|<!--)\\s*renovate-automation: rustc version\\s*(?:-->)?\\n[^.]*?(?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+)\\b"
       ],
       "depNameTemplate": "rust",
       "datasourceTemplate": "docker"
@@ -39,6 +39,7 @@
       "matchPackageNames": ["rust"],
       "matchManagers": "regex",
       "groupName": "rustc",
+      "branchName": "{{{branchPrefix}}}rustc"
     },
     // Bunch up all non-major npm dependencies into a single PR.  In the common case
     // where the upgrades apply cleanly, this causes less noise and is resolved faster


### PR DESCRIPTION
Follows up on https://github.com/apollographql/router/pull/1336

The regex I used in the last PR turned out to be incorrect because the
(m)ultiline flag is not passed to the Renovate Regex-invocation.  Instead,
the match is processed against a "joined" string of the file contents.

I've also added a couple more files which were meant to be grouped into this
originally, now that I'm more confident in the behavior after reviewing the
[Renovate dashboard] and specified a branch name explicitly, to avoid the
`docker-` prefixing which was somewhat counter-intuiative.

[Renovate dashboard]: https://app.renovatebot.com/