### PR TITLE
chore: Run scaffold tests in CI and xtask only.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,6 @@ common_job_environment: &common_job_environment
   NPM_VERSION: 7.10.0
 
 commands:
-
   linux_install_baseline:
     steps:
       - run:
@@ -292,7 +291,7 @@ commands:
           keys:
             - rust-cargo-<< pipeline.parameters.cache_version >>-test-windows-{{ checksum "Cargo.lock" }}
             - rust-cargo-<< pipeline.parameters.cache_version >>-test-windows
-      - run: cargo test --locked
+      - run: cargo test -p "apollo-router" -p "apollo-router-scaffold" --locked
       - save_cache:
           name: Save .cargo
           key: rust-cargo-<< pipeline.parameters.cache_version >>-test-windows-{{ checksum "Cargo.lock" }}
@@ -319,12 +318,12 @@ commands:
           condition:
             equal: [linux, << parameters.os >>]
           steps:
-            - run: cargo test --jobs 3 --locked
+            - run: cargo test --jobs 3 -p "apollo-router" -p "apollo-router-scaffold" --locked
       - when:
           condition:
             equal: [macos, << parameters.os >>]
           steps:
-            - run: cargo test --locked
+            - run: cargo test -p "apollo-router" -p "apollo-router-scaffold" --locked
 
       - save_cache:
           name: Save .cargo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-default-members = ["apollo-router", "apollo-router-scaffold"]
+default-members = ["apollo-router"]
 members = [
     "apollo-spaceport",
     "apollo-router",

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -5,7 +5,14 @@ use anyhow::Result;
 use structopt::StructOpt;
 use xtask::*;
 
-const TEST_DEFAULT_ARGS: &[&str] = &["test", "--locked"];
+const TEST_DEFAULT_ARGS: &[&str] = &[
+    "test",
+    "-p",
+    "apollo-router",
+    "-p",
+    "apollo-router-scaffold",
+    "--locked",
+];
 
 #[derive(Debug, StructOpt)]
 pub struct Test {


### PR DESCRIPTION
The scaffold test written in #1248 takes a long time to run (more than 60 seconds).
While we want to make sure the test passes before we merge code into main, it becomes a hindrance during regular development.

This PR changes the workspace members so that:
- `cargo test` will not run scaffold tests (so that the feedback loop remains short)
- `cargo xtask test` and `cargo xtask all` will run scaffold tests (so the commands keep being useful before opening a PR)
- circleCI will run scaffold tests (so we can make sure bugs/regressions are caught before merge)

<!--
First, 🌠 thank you 🌠 for considering a contribution to Apollo!

Some of this information is also included in the /CONTRIBUTING.md file at the
root of this repository.  We suggest you read it!

  https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md

Here are some important details to keep in mind:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!  Documentation in the docs/ directory should be updated
        as necessary.  Finally, a /CHANGELOG.md entry should be added.

We hope you will find this to be a positive experience! Contribution can be
intimidating and we hope to alleviate that pain as much as possible. Without
following these guidelines, you may be missing context that can help you succeed
with your contribution, which is why we encourage discussion first. Ultimately,
there is no guarantee that we will be able to merge your pull-request, but by
following these guidelines we can try to avoid disappointment.

-->
