### PR TITLE
reduce poll_ready calls in query deduplication

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -429,12 +429,19 @@ or valid data being nullified.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1295
 
-### Fix fragment selection on interfaces ([PR #1296](https://github.com/apollographql/router/pull/1296))
+### Fix fragment selection on queries ([PR #1296](https://github.com/apollographql/router/pull/1296))
 
 The schema object can specify objects for queries, mutations or subscriptions that are not named `Query`, `Mutation` or
-`Subscription`. Response formatting now supports it
+`Subscription`. Response formatting now supports it.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1296
+
+### Reduce `poll_ready` calls in query deduplication ([PR #1350](https://github.com/apollographql/router/pull/1350))
+
+The query deduplication service was making assumptions on the underlying service's behaviour, which could result in
+subgraph services panicking.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1350
 
 
 ## 🛠 Maintenance ( :hammer_and_wrench: )

--- a/apollo-router/src/plugins/traffic_shaping/deduplication.rs
+++ b/apollo-router/src/plugins/traffic_shaping/deduplication.rs
@@ -138,19 +138,19 @@ where
     type Error = BoxError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
-    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.service.poll_ready(cx)
+    fn poll_ready(&mut self, _cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, request: SubgraphRequest) -> Self::Future {
-        let mut service = self.service.clone();
+        let service = self.service.clone();
 
         if request.operation_kind == OperationKind::Query {
             let wait_map = self.wait_map.clone();
 
             Box::pin(async move { Self::dedup(service, wait_map, request).await })
         } else {
-            Box::pin(async move { service.call(request).await })
+            Box::pin(async move { service.oneshot(request).await })
         }
     }
 }


### PR DESCRIPTION
Related: #1343 (this PR might fix it, we don't know yet)

In its initial version, query deduplication was a layer directly above
the subgraph service, which has no requirements on `Service::poll_ready` calls.
Since its integration in the traffic shaping plugin, deduplication is
now a layer above a buffer above possibly other plugins then the
subgraph service.
[The Buffer service reserves slots in `poll_ready()` that are consumed when
`call()` is used](https://docs.rs/tower/latest/src/tower/buffer/layer.rs.html#25), and if `call()` is not used, those slots can take a
long time to drop and be reusable.
Since the query deduplication will prevent a lot of calls to the inner
service, it should not forward its `poll_ready` calls directly to the
underlying buffer, because that would hold a lot of slots.
Instead, this commit makes the query deduplication service return ok to
every `poll_ready` call, then uses `oneshot` or `ready_oneshot` on the
underlying service when the actual call is performed