### PR TITLE
execute the query plan's first response directly

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -29,5 +29,13 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 ## 🚀 Features
 ## 🐛 Fixes
 ## 🛠 Maintenance
+
+### execute the query plan's first response directly  ([PR #1357](https://github.com/apollographql/router/issues/1357))
+
+The query plan was entirely executed in a spawned task to prepare for the `@defer` implementation, but we can actually
+generate the first response right inside the same future.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1357
+
 ## 📚 Documentation
 ## 🐛 Fixes

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -767,7 +767,6 @@ mod tests {
                 sender,
             )
             .await;
-        //let result = receiver.next().await.unwrap();
         assert_eq!(result.errors.len(), 1);
         let reason: String = serde_json_bytes::from_value(
             result.errors[0].extensions.get("reason").unwrap().clone(),
@@ -823,7 +822,6 @@ mod tests {
             )
             .await;
 
-        //receiver.next().await.unwrap();
         assert!(succeeded.load(Ordering::SeqCst), "incorrect operation name");
     }
 
@@ -872,7 +870,6 @@ mod tests {
             )
             .await;
 
-        //receiver.next().await.unwrap();
         assert!(
             succeeded.load(Ordering::SeqCst),
             "subgraph requests must be http post"


### PR DESCRIPTION
the query plan execution was done entirely in a spawned task to prepare
for the  `@defer` implementation, but we will not need to go that far:
the first response can be obtained directly, and append the receiver of
future responses that would be sent from tasks spawned inside query
planner execution