### PR TITLE
Propagate errors from `QueryPlannerResponse::error_new`

### DIFF
--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -101,6 +101,7 @@ impl BridgeQueryPlanner {
                     options,
                 }),
                 query: Arc::new(selections),
+                errors: Vec::new(),
             }),
             PlanSuccess {
                 data: QueryPlan { node: None },

--- a/apollo-router/src/services/http_ext.rs
+++ b/apollo-router/src/services/http_ext.rs
@@ -235,7 +235,7 @@ pub struct Response<T> {
 impl<T> Response<T> {
     pub fn map<F, U>(self, f: F) -> Response<U>
     where
-        F: FnMut(T) -> U,
+        F: FnOnce(T) -> U,
     {
         self.inner.map(f).into()
     }

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -329,6 +329,7 @@ pub enum QueryPlannerContent {
     Plan {
         query: Arc<Query>,
         plan: Arc<QueryPlan>,
+        errors: Vec<Error>,
     },
     Introspection {
         response: Box<Response>,
@@ -357,11 +358,11 @@ impl QueryPlannerResponse {
         headers: MultiMap<IntoHeaderName, IntoHeaderValue>,
         context: Context,
     ) -> Result<QueryPlannerResponse, BoxError> {
-        tracing::warn!("no way to propagate error response from QueryPlanner");
         Ok(QueryPlannerResponse::new(
             QueryPlannerContent::Plan {
                 plan: Arc::new(QueryPlan::fake_builder().build()),
                 query: Arc::new(Query::default()),
+                errors,
             },
             context,
         ))

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -164,8 +164,13 @@ where
                     }
                     .boxed());
                 }
-                QueryPlannerContent::Plan { query, plan } => {
-                    if let Some(err) = query.validate_variables(body, &schema).err() {
+                QueryPlannerContent::Plan {
+                    query,
+                    mut errors,
+                    plan,
+                } => {
+                    if let Some(mut err) = query.validate_variables(body, &schema).err() {
+                        err.append_errors(&mut errors);
                         Ok(RouterResponse::new_from_graphql_response(err, context).boxed())
                     } else {
                         let operation_name = body.operation_name.clone();
@@ -181,6 +186,12 @@ where
                                     .build(),
                             )
                             .await?;
+                        let response = response.map(move |stream| {
+                            stream.map(move |mut r| {
+                                r.errors.extend(errors.iter().cloned());
+                                r
+                            })
+                        });
 
                         let (parts, response_stream) = http::Response::from(response).into_parts();
                         Ok(RouterResponse {


### PR DESCRIPTION
Fixes https://github.com/apollographql/router/issues/1142
