### PR TITLE
✨ render embedded Sandbox instead of landing page

### DIFF
--- a/apollo-router/resources/index.html
+++ b/apollo-router/resources/index.html
@@ -47,7 +47,23 @@ curl --request POST \\
   --data '{"query":"query { __typename }"}'</code>
         </div>
     </div>
-    <script src="https://apollo-server-landing-page.cdn.apollographql.com/_latest/static/js/main.js"></script>
-</body>
+    <style>
+        iframe {
+          background-color: white;
+        }
+      </style>
+    <div
+    style="width: 100vw; height: 100vh; position: absolute; top: 0;"
+    id="embeddableSandbox"
+    ></div>
+    <script src="https://embeddable-sandbox.cdn.apollographql.com/_latest/embeddable-sandbox.umd.production.min.js"></script>
+    <script>
+      var initialEndpoint = window.location.href;
+      new window.EmbeddedSandbox({
+        target: '#embeddableSandbox',
+        initialEndpoint,
+        includeCookies: 'false',
+      });
+    </script></body>
 
 </html>


### PR DESCRIPTION
This PR renders the embeddable Sandbox by default in the router instead of the Apollo Server Landing Page as it did previously. 

**Why did we make this change?**
We are moving to rendering the embeddable Sandbox by default in Apollo Server, and want to keep this up to date. More more info on this decision see [this thread](https://apollograph.slack.com/archives/C032ZPPE5E1/p1653050271497329).

**Questions:** in Apollo Server, folks can can set `includeCookies` in their configuration options and that will be passed to the embedded Sandbox. We weren't passing this to the AS Landing Page before this PR, but I think we'd want to? Is that a config option in router? I couldn't find it