### PR TITLE
fix(introspection): fix detection of an introspection query

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -45,6 +45,12 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 
 ## 🐛 Fixes
 
+### Fix detection of an introspection query [PR #1370](https://github.com/apollographql/router/pull/1370)
+
+A query with at the root only one selection field equals to `__typename` must be considered as an introspection query
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1370
+
 ### Accept nullable list as input [PR #1363](https://github.com/apollographql/router/pull/1363)
 
 Do not throw a validation error when you give `null` for an input variable of type `[Int!]`.

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -4848,7 +4848,12 @@ mod tests {
               }
             }
           }}";
-        let _ = Query::parse(query, api_schema).unwrap();
+        assert!(Query::parse(query, api_schema)
+            .unwrap()
+            .operations
+            .get(0)
+            .unwrap()
+            .is_introspection());
 
         let query = "query {
             __schema {
@@ -4858,7 +4863,23 @@ mod tests {
             }
           }";
 
-        let _ = Query::parse(query, api_schema).unwrap();
+        assert!(Query::parse(query, api_schema)
+            .unwrap()
+            .operations
+            .get(0)
+            .unwrap()
+            .is_introspection());
+
+        let query = "query {
+            __typename
+          }";
+
+        assert!(Query::parse(query, api_schema)
+            .unwrap()
+            .operations
+            .get(0)
+            .unwrap()
+            .is_introspection());
     }
 
     #[test]

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -724,6 +724,16 @@ impl Operation {
     }
 
     fn is_introspection(&self) -> bool {
+        // If the only field is `__typename` it's considered as an introspection query
+        if self.selection_set.len() == 1
+            && self
+                .selection_set
+                .get(0)
+                .map(|s| matches!(s, Selection::Field {name, ..} if name.as_str() == TYPENAME))
+                .unwrap_or_default()
+        {
+            return true;
+        }
         self.selection_set.iter().all(|sel| match sel {
             Selection::Field { name, .. } => {
                 let name = name.as_str();


### PR DESCRIPTION
A query with at the root only one selection field equals to `__typename` must be considered as an introspection query