### PR TITLE
Remove `tracing` panic hook in tests

### DIFF
--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -625,10 +625,6 @@ async fn setup_router_and_registry() -> (
     BoxCloneService<RouterRequest, RouterResponse<BoxStream<'static, graphql::Response>>, BoxError>,
     CountingServiceRegistry,
 ) {
-    std::panic::set_hook(Box::new(|e| {
-        let backtrace = backtrace::Backtrace::new();
-        tracing::error!("{}\n{:?}", e, backtrace)
-    }));
     let schema: Arc<Schema> =
         Arc::new(include_str!("fixtures/supergraph.graphql").parse().unwrap());
     let counting_registry = CountingServiceRegistry::new();


### PR DESCRIPTION
The default hook that prints to stderr is more useful in this context.