### PR TITLE
release: v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,88 @@ All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.11.0] - 2022-07-12
+
+## ❗ BREAKING ❗
+
+### Relax plugin api mutability ([PR #1340](https://github.com/apollographql/router/pull/1340) ([PR #1289](https://github.com/apollographql/router/pull/1289)
+
+the `Plugin::*_service()` methods were taking a `&mut self` as argument, but since
+they work like a tower Layer, they can use `&self` instead. This change
+then allows us to move from Buffer to service factories for the query
+planner, execution and subgraph services
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1340 https://github.com/apollographql/router/pull/1289
+
+## 🚀 Features
+
+### Add support to add custom resources on metrics. [PR #1354](https://github.com/apollographql/router/pull/1354)
+
+Resources are almost like attributes but there are more globals. They are directly configured on the metrics exporter which means you'll always have these resources on each of your metrics. It could be pretty useful to set
+a service name for example to let you more easily find metrics related to a specific service.
+
+```yaml
+telemetry:
+  metrics:
+    common:
+      resources:
+        # Set the service name to easily find metrics related to the apollo-router in your metrics dashboards
+        service.name: "apollo-router"
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1354
+
+## 🐛 Fixes
+
+### Fix fragment on interface without typename [PR #1371](https://github.com/apollographql/router/pull/1371)
+
+When the subgraph doesn't return the typename and the type condition of a fragment is an interface, we should return the values if the entity implements the interface
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1371
+
+### Fix detection of an introspection query [PR #1370](https://github.com/apollographql/router/pull/1370)
+
+A query with at the root only one selection field equals to `__typename` must be considered as an introspection query
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1370
+
+### Accept nullable list as input [PR #1363](https://github.com/apollographql/router/pull/1363)
+
+Do not throw a validation error when you give `null` for an input variable of type `[Int!]`.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1363
+
+## 🛠 Maintenance
+
+### Replace Buffers of tower services with service factories([PR #1289](https://github.com/apollographql/router/pull/1289) [PR #1355](https://github.com/apollographql/router/pull/1355))
+
+tower services should be used by creating a new service instance for each new session
+instead of going through a Buffer.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1289  https://github.com/apollographql/router/pull/1355
+
+### execute the query plan's first response directly ([PR #1357](https://github.com/apollographql/router/issues/1357))
+
+The query plan was entirely executed in a spawned task to prepare for the `@defer` implementation, but we can actually
+generate the first response right inside the same future.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1357
+
+### Remove deprecated `failure` crate from the dependency tree [PR #1373](https://github.com/apollographql/router/pull/1373)
+
+This should fix automated reports about [GHSA-jq66-xh47-j9f3](https://github.com/advisories/GHSA-jq66-xh47-j9f3).
+
+By [@yanns](https://github.com/yanns) in https://github.com/apollographql/router/pull/1373
+
+## 📚 Documentation
+
+### Various documentation edits ([PR #1329](https://github.com/apollographql/router/issues/1329))
+
+By [@StephenBarlow](https://github.com/StephenBarlow) in https://github.com/apollographql/router/pull/1329
+
 
 # [0.10.0] - 2022-07-05
+
 ## ❗ BREAKING ❗
 
 ### Change configuration for custom attributes for metrics in telemetry plugin ([PR #1300](https://github.com/apollographql/router/pull/1300)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,8 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 
 ### Add support to add custom resources on metrics. [PR #1354](https://github.com/apollographql/router/pull/1354)
 
-Resources are almost like attributes but there are more globals. They are directly configured on the metrics exporter which means you'll always have these resources on each of your metrics. It could be pretty useful to set
-a service name for example to let you more easily find metrics related to a specific service.
+Resources are almost like attributes but more global. They are directly configured on the metrics exporter which means you'll always have these resources on each of your metrics.  This functionality can be used to, for example,
+apply a `service.name` to metrics to make them easier to find in larger infrastructure, as demonstrated here:
 
 ```yaml
 telemetry:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 the `Plugin::*_service()` methods were taking a `&mut self` as argument, but since
 they work like a tower Layer, they can use `&self` instead. This change
 then allows us to move from Buffer to service factories for the query
-planner, execution and subgraph services
+planner, execution and subgraph services.
+
+**Services are now created on the fly at session creation, so if any state must be shared
+between executions, it should be stored in an `Arc<Mutex<_>>` in the plugin and cloned
+into the new service in the `Plugin::*_service()` methods**.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1340 https://github.com/apollographql/router/pull/1289
 
@@ -45,7 +49,7 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 
 ### Fix detection of an introspection query [PR #1370](https://github.com/apollographql/router/pull/1370)
 
-A query with at the root only one selection field equals to `__typename` must be considered as an introspection query
+A query that only contains __typename at the root must be considered as an introspection query
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1370
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,13 +43,13 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 
 ### Fix fragment on interface without typename [PR #1371](https://github.com/apollographql/router/pull/1371)
 
-When the subgraph doesn't return the typename and the type condition of a fragment is an interface, we should return the values if the entity implements the interface
+When the subgraph doesn't return the `__typename` and the type condition of a fragment is an interface, we should return the values if the entity implements the interface
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1371
 
 ### Fix detection of an introspection query [PR #1370](https://github.com/apollographql/router/pull/1370)
 
-A query that only contains __typename at the root must be considered as an introspection query
+A query that only contains `__typename` at the root will now special-cased as merely an introspection query and will bypass more complex query-planner execution (its value will just be `Query`).
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1370
 
@@ -61,16 +61,16 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 
 ## 🛠 Maintenance
 
-### Replace Buffers of tower services with service factories([PR #1289](https://github.com/apollographql/router/pull/1289) [PR #1355](https://github.com/apollographql/router/pull/1355))
+### Replace Buffers of tower services with service factories ([PR #1289](https://github.com/apollographql/router/pull/1289) [PR #1355](https://github.com/apollographql/router/pull/1355))
 
-tower services should be used by creating a new service instance for each new session
-instead of going through a Buffer.
+Tower services should be used by creating a new service instance for each new session
+instead of going through a `Buffer`.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1289  https://github.com/apollographql/router/pull/1355
 
-### execute the query plan's first response directly ([PR #1357](https://github.com/apollographql/router/issues/1357))
+### Execute the query plan's first response directly ([PR #1357](https://github.com/apollographql/router/issues/1357))
 
-The query plan was entirely executed in a spawned task to prepare for the `@defer` implementation, but we can actually
+The query plan was previously executed in a spawned task to prepare for the `@defer` implementation, but we can actually
 generate the first response right inside the same future.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1357

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "access-json",
  "anyhow",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "apollo-router",
  "async-trait",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-scaffold"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "cargo-scaffold",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-spaceport"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "bytes",
  "clap 3.1.18",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-uplink"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "futures",
  "graphql_client",
@@ -6334,7 +6334,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -23,64 +23,9 @@ Description! And a link to a [reference](http://url)
 By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/router/pull/PULL_NUMBER
 -->
 
-# [0.10.1] (unreleased) - 2022-mm-dd
+# [0.11.1] (unreleased) - 2022-mm-dd
 ## ❗ BREAKING ❗
-
-### Relax plugin api mutability ([PR #1340](https://github.com/apollographql/router/pull/1340) ([PR #1289](https://github.com/apollographql/router/pull/1289)
-
-the `Plugin::*_service()` methods were taking a `&mut self` as argument, but since
-they work like a tower Layer, they can use `&self` instead. This change
-then allows us to move from Buffer to service factories for the query
-planner, execution and subgraph services
-
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1340 https://github.com/apollographql/router/pull/1289
-
 ## 🚀 Features
-
-### Add support to add custom resources on metrics. [PR #1354](https://github.com/apollographql/router/pull/1354)
-
-Resources are almost like attributes but there are more globals. They are directly configured on the metrics exporter which means you'll always have these resources on each of your metrics. It could be pretty useful to set
-a service name for example to let you more easily find metrics related to a specific service.
-
-```yaml
-telemetry:
-  metrics:
-    common:
-      resources:
-        # Set the service name to easily find metrics related to the apollo-router in your metrics dashboards
-        service.name: "apollo-router"
-```
-
-By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1354
-
 ## 🐛 Fixes
-
-### Fix fragment on interface without typename [PR #1371](https://github.com/apollographql/router/pull/1371)
-
-When the subgraph doesn't return the typename and the type condition of a fragment is an interface, we should return the values if the entity implements the interface
-
-By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1371
-
-### Fix detection of an introspection query [PR #1370](https://github.com/apollographql/router/pull/1370)
-
-A query with at the root only one selection field equals to `__typename` must be considered as an introspection query
-
-By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1370
-
-### Accept nullable list as input [PR #1363](https://github.com/apollographql/router/pull/1363)
-
-Do not throw a validation error when you give `null` for an input variable of type `[Int!]`.
-
-By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1363
-
-
 ## 🛠 Maintenance
-
-### Replace Buffers of tower services with service factories([PR #1289](https://github.com/apollographql/router/pull/1289) [PR #1355](https://github.com/apollographql/router/pull/1355))
-
-tower services should be used by creating a new service instance for each new session
-instead of going through a Buffer.
-
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1289  https://github.com/apollographql/router/pull/1355
-
 ## 📚 Documentation

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-scaffold"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -22,7 +22,7 @@ apollo-router = { path ="{{integration_test}}apollo-router" }
 apollo-router = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
 # Note if you update these dependencies then also update xtask/Cargo.toml
-apollo-router = { git="https://github.com/apollographql/router.git", tag="v0.10.0" }
+apollo-router = { git="https://github.com/apollographql/router.git", tag="v0.11.0" }
 {{/if}}
 {{/if}}
 async-trait = "0.1.52"

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -13,7 +13,7 @@ apollo-router-scaffold = { path ="{{integration_test}}apollo-router-scaffold" }
 {{#if branch}}
 apollo-router-scaffold = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
-apollo-router-scaffold = { git="https://github.com/apollographql/router.git", tag="v0.10.0"}
+apollo-router-scaffold = { git="https://github.com/apollographql/router.git", tag="v0.11.0"}
 {{/if}}
 {{/if}}
 anyhow = "=1.0.58"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-spaceport"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/dockerfiles/tracing/docker-compose.datadog.yml
+++ b/dockerfiles/tracing/docker-compose.datadog.yml
@@ -3,7 +3,7 @@ services:
 
   apollo-router:
     container_name: apollo-router
-    image: ghcr.io/apollographql/router:v0.10.0
+    image: ghcr.io/apollographql/router:v0.11.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/datadog.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.jaeger.yml
+++ b/dockerfiles/tracing/docker-compose.jaeger.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     #build: ./router
-    image: ghcr.io/apollographql/router:v0.10.0
+    image: ghcr.io/apollographql/router:v0.11.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/jaeger.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.zipkin.yml
+++ b/dockerfiles/tracing/docker-compose.zipkin.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     build: ./router
-    image: ghcr.io/apollographql/router:v0.10.0
+    image: ghcr.io/apollographql/router:v0.11.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/zipkin.router.yaml:/etc/config/configuration.yaml

--- a/docs/source/containerization/docker.mdx
+++ b/docs/source/containerization/docker.mdx
@@ -11,7 +11,7 @@ The default behaviour of the router images is suitable for a quickstart or devel
 
 Note: The [docker documentation](https://docs.docker.com/engine/reference/run/) for the run command may be helpful when reading through the examples.
 
-Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v0.10.0`
+Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v0.11.0`
 
 ## Override the configuration
 
@@ -92,10 +92,10 @@ Usage: build_docker_image.sh [-b] [<release>]
 	Example 1: Building HEAD from the repo
 		build_docker_image.sh -b
 	Example 2: Building tag from the repo
-		build_docker_image.sh -b v0.10.0
+		build_docker_image.sh -b v0.11.0
 	Example 3: Building commit hash from the repo
 		build_docker_image.sh -b 7f7d223f42af34fad35b898d976bc07d0f5440c5
-	Example 4: Building tag v0.10.0 from the released tarball
-		build_docker_image.sh v0.10.0
+	Example 4: Building tag v0.11.0 from the released tarball
+		build_docker_image.sh v0.11.0
 ```
 Note: The script has to be run from the `dockerfiles/diy` directory because it makes assumptions about the relative availability of various files. The example uses [distroless images](https://github.com/GoogleContainerTools/distroless) for the final image build. Feel free to modify the script to use images which better suit your own needs.

--- a/docs/source/containerization/kubernetes.mdx
+++ b/docs/source/containerization/kubernetes.mdx
@@ -50,7 +50,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.10.0"
+    app.kubernetes.io/version: "v0.11.0"
 ---
 # Source: router/templates/secret.yaml
 apiVersion: v1
@@ -60,7 +60,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.10.0"
+    app.kubernetes.io/version: "v0.11.0"
 data:
   managedFederationApiKey: "REDACTED"
 ---
@@ -72,7 +72,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.10.0"
+    app.kubernetes.io/version: "v0.11.0"
 data:
   configuration.yaml: |
     server:
@@ -90,7 +90,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.10.0"
+    app.kubernetes.io/version: "v0.11.0"
 spec:
   type: ClusterIP
   ports:
@@ -110,7 +110,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.10.0"
+    app.kubernetes.io/version: "v0.11.0"
   annotations:
     prometheus.io/path: /plugins/apollo.telemetry/prometheus
     prometheus.io/port: "80"
@@ -134,7 +134,7 @@ spec:
         - name: router
           securityContext:
             {}
-          image: "ghcr.io/apollographql/router:v0.10.0"
+          image: "ghcr.io/apollographql/router:v0.11.0"
           imagePullPolicy: IfNotPresent
           args:
             - --hot-reload

--- a/docs/source/federation-version-support.mdx
+++ b/docs/source/federation-version-support.mdx
@@ -22,6 +22,17 @@ Apollo Federation is an evolving project, and it will receive new features and b
     <tbody>
     <tr>
         <td>
+            v0.11.0
+        </td>
+        <td>
+            2.0.2
+        </td>
+        <td>
+            2022-07-12
+        </td>
+    </tr>
+    <tr>
+        <td>
             v0.10.0
         </td>
         <td>

--- a/helm/chart/router/Chart.yaml
+++ b/helm/chart/router/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.13
+version: 0.1.14
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.10.0"
+appVersion: "v0.11.0"

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -2,7 +2,7 @@
 
 [router](https://github.com/apollographql/router) Rust Graph Routing runtime for Apollo Federation
 
-![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.10.0](https://img.shields.io/badge/AppVersion-v0.10.0-informational?style=flat-square) 
+![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.11.0](https://img.shields.io/badge/AppVersion-v0.11.0-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-uplink"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 build = "build.rs"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"


### PR DESCRIPTION
# [0.11.0] - 2022-07-12

## ❗ BREAKING ❗

### Relax plugin api mutability ([PR #1340](https://github.com/apollographql/router/pull/1340) ([PR #1289](https://github.com/apollographql/router/pull/1289)

the `Plugin::*_service()` methods were taking a `&mut self` as argument, but since
they work like a tower Layer, they can use `&self` instead. This change
then allows us to move from Buffer to service factories for the query
planner, execution and subgraph services

By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1340 https://github.com/apollographql/router/pull/1289

## 🚀 Features

### Add support to add custom resources on metrics. [PR #1354](https://github.com/apollographql/router/pull/1354)

Resources are almost like attributes but there are more globals. They are directly configured on the metrics exporter which means you'll always have these resources on each of your metrics. It could be pretty useful to set
a service name for example to let you more easily find metrics related to a specific service.

```yaml
telemetry:
  metrics:
    common:
      resources:
        # Set the service name to easily find metrics related to the apollo-router in your metrics dashboards
        service.name: "apollo-router"
```

By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1354

## 🐛 Fixes

### Fix fragment on interface without typename [PR #1371](https://github.com/apollographql/router/pull/1371)

When the subgraph doesn't return the typename and the type condition of a fragment is an interface, we should return the values if the entity implements the interface

By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1371

### Fix detection of an introspection query [PR #1370](https://github.com/apollographql/router/pull/1370)

A query with at the root only one selection field equals to `__typename` must be considered as an introspection query

By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1370

### Accept nullable list as input [PR #1363](https://github.com/apollographql/router/pull/1363)

Do not throw a validation error when you give `null` for an input variable of type `[Int!]`.

By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1363

## 🛠 Maintenance

### Replace Buffers of tower services with service factories([PR #1289](https://github.com/apollographql/router/pull/1289) [PR #1355](https://github.com/apollographql/router/pull/1355))

tower services should be used by creating a new service instance for each new session
instead of going through a Buffer.

By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1289  https://github.com/apollographql/router/pull/1355

### execute the query plan's first response directly ([PR #1357](https://github.com/apollographql/router/issues/1357))

The query plan was entirely executed in a spawned task to prepare for the `@defer` implementation, but we can actually
generate the first response right inside the same future.

By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1357

### Remove deprecated `failure` crate from the dependency tree [PR #1373](https://github.com/apollographql/router/pull/1373)

This should fix automated reports about [GHSA-jq66-xh47-j9f3](https://github.com/advisories/GHSA-jq66-xh47-j9f3).

By [@yanns](https://github.com/yanns) in https://github.com/apollographql/router/pull/1373

## 📚 Documentation

### Various documentation edits ([PR #1329](https://github.com/apollographql/router/issues/1329))

By [@StephenBarlow](https://github.com/StephenBarlow) in https://github.com/apollographql/router/pull/1329
