### PR TITLE
the opentelemetry-otlp crate needs a http-client feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3588,6 +3588,7 @@ dependencies = [
  "opentelemetry-http",
  "prost",
  "prost-build",
+ "reqwest",
  "thiserror",
  "tokio",
  "tonic",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -45,5 +45,13 @@ By [@garypen](https://github.com/garypen) in https://github.com/apollographql/ro
 
 ## 🚀 Features
 ## 🐛 Fixes
+
+### The opentelemetry-otlp crate needs a http-client feature [PR #1392](https://github.com/apollographql/router/pull/1392)
+
+The opentelemetry-otlp crate only checks at runtime if a HTTP client was added through
+cargo features. We now use reqwest for that.
+
+By [@geal](https://github.com/geal) in https://github.com/apollographql/router/pull/1392
+
 ## 🛠 Maintenance
 ## 📚 Documentation

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -85,6 +85,7 @@ opentelemetry-otlp = { version = "0.10.0", default-features = false, features = 
     "tls",
     "http-proto",
     "metrics",
+    "reqwest-client",
 ] }
 opentelemetry-semantic-conventions = "0.9.0"
 opentelemetry-zipkin = { version = "0.15.0", default-features = false, features = [


### PR DESCRIPTION
Fix #1386

Otherwise the HTTP exporter will not run
