### PR TITLE
insert the full target triplet in the package name

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -28,4 +28,15 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 ## 🚀 Features
 ## 🐛 Fixes
 ## 🛠 Maintenance
+
+### Insert the full target triplet in the package name [PR #1393](https://github.com/apollographql/router/pull/1393)
+
+The released package names will now contain the full target triplet in their name:
+
+* `router-0.11.0-x86_64-linux.tar.gz` -> `router-0.11.0-x86_64-unknown-linux-gnu.tar.gz`
+* `router-0.11.0-x86_64-macos.tar.gz` -> `router-0.11.0-x86_64-apple-darwin.tar.gz`
+* `router-0.11.0-x86_64-windows.tar.gz` -> `router-0.11.0-x86_64-pc-windows-msvc.tar.gz`
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1393
+
 ## 📚 Documentation

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -5,7 +5,7 @@ FROM --platform=linux/amd64 alpine:latest AS build
 ARG ROUTER_RELEASE
 
 # Pull release from GH
-ADD https://github.com/apollographql/router/releases/download/v${ROUTER_RELEASE}/router-${ROUTER_RELEASE}-x86_64-linux.tar.gz /tmp/router.tar.gz
+ADD https://github.com/apollographql/router/releases/download/v${ROUTER_RELEASE}/router-${ROUTER_RELEASE}-x86_64-unknown-linux-gnu.tar.gz /tmp/router.tar.gz
 
 WORKDIR /tmp
 

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -1,7 +1,9 @@
 #[cfg(target_os = "macos")]
 mod macos;
 
+use std::fmt;
 use std::path::Path;
+use std::str::FromStr;
 
 use anyhow::ensure;
 use anyhow::Context;
@@ -11,6 +13,16 @@ use structopt::StructOpt;
 use xtask::*;
 
 const INCLUDE: &[&str] = &["README.md", "LICENSE", "licenses.html"];
+pub(crate) const TARGET_MUSL_LINUX: &str = "x86_64-unknown-linux-musl";
+pub(crate) const TARGET_GNU_LINUX: &str = "x86_64-unknown-linux-gnu";
+pub(crate) const TARGET_WINDOWS: &str = "x86_64-pc-windows-msvc";
+pub(crate) const TARGET_MACOS: &str = "x86_64-apple-darwin";
+pub(crate) const POSSIBLE_TARGETS: [&str; 4] = [
+    TARGET_MUSL_LINUX,
+    TARGET_GNU_LINUX,
+    TARGET_WINDOWS,
+    TARGET_MACOS,
+];
 
 #[derive(Debug, StructOpt)]
 pub struct Package {
@@ -21,6 +33,9 @@ pub struct Package {
     #[cfg(target_os = "macos")]
     #[structopt(flatten)]
     macos: macos::PackageMacos,
+
+    #[structopt(long, default_value, possible_values = &POSSIBLE_TARGETS)]
+    target: Target,
 }
 
 impl Package {
@@ -42,13 +57,8 @@ impl Package {
             }
             self.output.to_owned()
         } else if self.output.is_dir() {
-            self.output.join(format!(
-                "router-{}-{}-{}.tar.gz",
-                *PKG_VERSION,
-                // NOTE: same as xtask
-                std::env::consts::ARCH,
-                std::env::consts::OS,
-            ))
+            self.output
+                .join(format!("router-{}-{}.tar.gz", *PKG_VERSION, self.target))
         } else {
             self.output.to_owned()
         };
@@ -80,5 +90,65 @@ impl Package {
         ar.finish().context("could not finish TGZ archive")?;
 
         Ok(())
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) enum Target {
+    MuslLinux,
+    GnuLinux,
+    Windows,
+    MacOS,
+    Other,
+}
+
+impl Default for Target {
+    fn default() -> Self {
+        if cfg!(target_arch = "x86_64") {
+            if cfg!(target_os = "windows") {
+                Target::Windows
+            } else if cfg!(target_os = "linux") {
+                if cfg!(target_env = "gnu") {
+                    Target::GnuLinux
+                } else if cfg!(target_env = "musl") {
+                    Target::MuslLinux
+                } else {
+                    Target::Other
+                }
+            } else if cfg!(target_os = "macos") {
+                Target::MacOS
+            } else {
+                Target::Other
+            }
+        } else {
+            Target::Other
+        }
+    }
+}
+
+impl FromStr for Target {
+    type Err = anyhow::Error;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input {
+            TARGET_MUSL_LINUX => Ok(Self::MuslLinux),
+            TARGET_GNU_LINUX => Ok(Self::GnuLinux),
+            TARGET_WINDOWS => Ok(Self::Windows),
+            TARGET_MACOS => Ok(Self::MacOS),
+            _ => Ok(Self::Other),
+        }
+    }
+}
+
+impl fmt::Display for Target {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = match &self {
+            Target::MuslLinux => TARGET_MUSL_LINUX,
+            Target::GnuLinux => TARGET_GNU_LINUX,
+            Target::Windows => TARGET_WINDOWS,
+            Target::MacOS => TARGET_MACOS,
+            Target::Other => "unknown-target",
+        };
+        write!(f, "{}", msg)
     }
 }

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -13,15 +13,15 @@ use structopt::StructOpt;
 use xtask::*;
 
 const INCLUDE: &[&str] = &["README.md", "LICENSE", "licenses.html"];
-pub(crate) const TARGET_MUSL_LINUX: &str = "x86_64-unknown-linux-musl";
-pub(crate) const TARGET_GNU_LINUX: &str = "x86_64-unknown-linux-gnu";
-pub(crate) const TARGET_WINDOWS: &str = "x86_64-pc-windows-msvc";
-pub(crate) const TARGET_MACOS: &str = "x86_64-apple-darwin";
+pub(crate) const TARGET_X86_64_MUSL_LINUX: &str = "x86_64-unknown-linux-musl";
+pub(crate) const TARGET_X86_64_GNU_LINUX: &str = "x86_64-unknown-linux-gnu";
+pub(crate) const TARGET_X86_64_WINDOWS: &str = "x86_64-pc-windows-msvc";
+pub(crate) const TARGET_X86_64_MACOS: &str = "x86_64-apple-darwin";
 pub(crate) const POSSIBLE_TARGETS: [&str; 4] = [
-    TARGET_MUSL_LINUX,
-    TARGET_GNU_LINUX,
-    TARGET_WINDOWS,
-    TARGET_MACOS,
+    TARGET_X86_64_MUSL_LINUX,
+    TARGET_X86_64_GNU_LINUX,
+    TARGET_X86_64_WINDOWS,
+    TARGET_X86_64_MACOS,
 ];
 
 #[derive(Debug, StructOpt)]
@@ -131,10 +131,10 @@ impl FromStr for Target {
 
     fn from_str(input: &str) -> Result<Self, Self::Err> {
         match input {
-            TARGET_MUSL_LINUX => Ok(Self::MuslLinux),
-            TARGET_GNU_LINUX => Ok(Self::GnuLinux),
-            TARGET_WINDOWS => Ok(Self::Windows),
-            TARGET_MACOS => Ok(Self::MacOS),
+            TARGET_X86_64_MUSL_LINUX => Ok(Self::MuslLinux),
+            TARGET_X86_64_GNU_LINUX => Ok(Self::GnuLinux),
+            TARGET_X86_64_WINDOWS => Ok(Self::Windows),
+            TARGET_X86_64_MACOS => Ok(Self::MacOS),
             _ => Ok(Self::Other),
         }
     }
@@ -143,10 +143,10 @@ impl FromStr for Target {
 impl fmt::Display for Target {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match &self {
-            Target::MuslLinux => TARGET_MUSL_LINUX,
-            Target::GnuLinux => TARGET_GNU_LINUX,
-            Target::Windows => TARGET_WINDOWS,
-            Target::MacOS => TARGET_MACOS,
+            Target::MuslLinux => TARGET_X86_64_MUSL_LINUX,
+            Target::GnuLinux => TARGET_X86_64_GNU_LINUX,
+            Target::Windows => TARGET_X86_64_WINDOWS,
+            Target::MacOS => TARGET_X86_64_MACOS,
             Target::Other => "unknown-target",
         };
         write!(f, "{}", msg)


### PR DESCRIPTION
Fix #1385

code extracted from rover's xtask command

I updated the URL in the Dockerfile, but that means it would not work until the next release, should that go into a separate PR instead?