### PR TITLE
update dependencies and relax version requirements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5789,13 +5789,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.14"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
+checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term",
+ "lazy_static",
  "matchers",
- "once_cell",
  "regex",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,9 +435,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.9"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d590cacd53140ff87cc2e192eb22fc3dc23c5b3f93b0d4f020677f98e8c629"
+checksum = "d16705af05732b7d3258ec0f7b73c03a658a28925e050d8852d5b568ee8bcf4e"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -467,9 +467,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4d047478b986f14a13edad31a009e2e05cb241f9805d0d75e4cba4e129ad4d"
+checksum = "e4f44a0e6200e9d11a1cdc989e4b358f6e3d354fbf48478f345a17f4e43f8635"
 dependencies = [
  "async-trait",
  "bytes",
@@ -492,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.65"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
@@ -690,9 +690,9 @@ checksum = "c1db59621ec70f09c5e9b597b220c7a2b43611f4710dc03ceb8748637775692c"
 
 [[package]]
 name = "camino"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
+checksum = "869119e97797867fd90f5e22af7d0bd274bd4635ebb9eb68c04f3f513ae6c412"
 dependencies = [
  "serde",
 ]
@@ -845,6 +845,12 @@ checksum = "4c24dab4283a142afa2fdca129b80ad2c6284e073930f964c3a1293c225ee39a"
 dependencies = [
  "rustc_version 0.4.0",
 ]
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -1153,12 +1159,12 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1604dafd25fba2fe2d5895a9da139f8dc9b319a5fe5354ca137cbbce4e178d10"
+checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
 dependencies = [
  "atty",
- "cast",
+ "cast 0.3.0",
  "clap 2.34.0",
  "criterion-plot",
  "csv",
@@ -1185,7 +1191,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d00996de9f2f7559f7f4dc286073197f83e92256a59ed395f9aac01fe717da57"
 dependencies = [
- "cast",
+ "cast 0.2.7",
  "itertools",
 ]
 
@@ -1403,7 +1409,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "hashbrown 0.12.1",
  "lock_api",
- "parking_lot_core 0.9.3",
+ "parking_lot_core",
  "serde",
 ]
 
@@ -1442,7 +1448,7 @@ dependencies = [
  "libc",
  "log",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot",
  "pin-project",
  "serde",
  "serde_json",
@@ -1779,13 +1785,11 @@ checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
 
 [[package]]
 name = "flate2"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39522e96686d38f4bc984b9198e3a0613264abaebaff2c5c918bfa6b6da09af"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
- "cfg-if 1.0.0",
  "crc32fast",
- "libc",
  "libz-sys",
  "miniz_oxide",
 ]
@@ -2433,9 +2437,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.19"
+version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2607,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689960f187c43c01650c805fb6bc6f55ab944499d86d4ffe9474ad78991d8e94"
+checksum = "4126dd76ebfe2561486a1bd6738a33d2029ffb068a99ac446b7f8c77b2e58dbc"
 dependencies = [
  "console 0.15.0",
  "once_cell",
@@ -2731,7 +2735,7 @@ dependencies = [
  "lazy_static",
  "memchr",
  "num-cmp",
- "parking_lot 0.12.0",
+ "parking_lot",
  "percent-encoding",
  "regex",
  "serde",
@@ -2763,9 +2767,9 @@ dependencies = [
 
 [[package]]
 name = "jwt-simple"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c036f167883e073626dbc41f92966acb27a30172bf04a3bbe8b24ac45c02d728"
+checksum = "6cf3a9f4c365a97b89e846cdb1c18dddbeafa692ebef1005cea26b8f04386e43"
 dependencies = [
  "anyhow",
  "coarsetime",
@@ -2912,9 +2916,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.6"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e7e15d7610cce1d9752e137625f14e61a28cd45929b6e12e47b50fe154ee2e"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
 dependencies = [
  "cc",
  "libc",
@@ -3034,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "5.1.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ec753a43fd71bb5f28751c9ec17fbe89d6d26ca8282d1e1f82f5ac3dbd5581e"
+checksum = "89d67f6972a70e33dbb5551875c6a3e46ae0a7cddd4661a2811ee48be51054e9"
 dependencies = [
  "atty",
  "backtrace",
@@ -3054,9 +3058,9 @@ dependencies = [
 
 [[package]]
 name = "miette-derive"
-version = "5.1.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdfc33ea15c5446600f91d319299dd40301614afff7143cdfa9bf4c09da3ca64"
+checksum = "426594bc7266dedee4d687cdaebc121c74c52a667e4ce933c83694ad035990a6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3179,9 +3183,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df72b50274c0988d9f4a6e808e06d9d926f265db6f8bbda1576bcaa658e72763"
+checksum = "21b3caf8ff6db712c7f7fe018e7fb6d2ddbaf428b74f94a48fe075ef09a6b8a1"
 dependencies = [
  "async-io",
  "async-lock",
@@ -3191,7 +3195,7 @@ dependencies = [
  "futures-util",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot",
  "quanta",
  "scheduled-thread-pool",
  "skeptic",
@@ -3199,7 +3203,7 @@ dependencies = [
  "tagptr",
  "thiserror",
  "triomphe",
- "uuid 0.8.2",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -3412,9 +3416,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40bec70ba014595f99f7aa110b84331ffe1ee9aece7fe6f387cc7e3ecda4d456"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
  "memchr",
 ]
@@ -3685,37 +3689,12 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.3",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if 1.0.0",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi 0.3.9",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -4011,15 +3990,15 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f64969ffd5dd8f39bd57a68ac53c163a095ed9d0fb707146da1b27025a3504"
+checksum = "cface98dfa6d645ea4c789839f176e4b072265d085bfcc48eaa8d137f58d3c39"
 dependencies = [
  "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot 0.11.2",
+ "parking_lot",
  "protobuf",
  "thiserror",
 ]
@@ -4229,9 +4208,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4249,9 +4228,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -4633,11 +4612,11 @@ dependencies = [
 
 [[package]]
 name = "scheduled-thread-pool"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+checksum = "977a7519bff143a44f842fd07e80ad1329295bd71686457f18e496736f4bf9bf"
 dependencies = [
- "parking_lot 0.11.2",
+ "parking_lot",
 ]
 
 [[package]]
@@ -4753,9 +4732,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "0171ebb889e45aa68b44aee0859b3eede84c6f5f5c228e6f140c0b2a0a46cad6"
 dependencies = [
  "serde_derive",
 ]
@@ -4772,9 +4751,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4803,9 +4782,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
 dependencies = [
  "indexmap",
  "itoa 1.0.1",
@@ -4867,9 +4846,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707d15895415db6628332b737c838b88c598522e4dc70647e59b72312924aebc"
+checksum = "1ec0091e1f5aa338283ce049bd9dfefd55e1f168ac233e85c1ffe0038fb48cbe"
 dependencies = [
  "indexmap",
  "ryu",
@@ -5145,18 +5124,18 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.24.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6878079b17446e4d3eba6192bb0a2950d5b14f0ed8424b852310e5a94345d0ef"
+checksum = "4faebde00e8ff94316c01800f9054fd2ba77d30d9e922541913051d1d978918b"
 dependencies = [
  "heck 0.4.0",
  "proc-macro2",
@@ -5477,7 +5456,7 @@ dependencies = [
  "mio 0.8.2",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -5728,9 +5707,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
+checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if 1.0.0",
  "log",
@@ -5752,11 +5731,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f54c8ca710e81886d498c2fd3331b56c93aa248d49de2222ad2742247c60072f"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
- "lazy_static",
+ "once_cell",
  "valuable",
 ]
 
@@ -5785,9 +5764,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.17.3"
+version = "0.17.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93600c803bb15e2a32bd376001b8625587f268fe887669b5ac86af524637c242"
+checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -5809,13 +5788,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.11"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
+checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
 dependencies = [
  "ansi_term",
- "lazy_static",
  "matchers",
+ "once_cell",
  "regex",
  "serde",
  "serde_json",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -55,12 +55,13 @@ By [@geal](https://github.com/geal) in https://github.com/apollographql/router/p
 
 ## 🛠 Maintenance
 
-### Dependency updates [PR #1389](https://github.com/apollographql/router/issues/1389) [PR #1395](https://github.com/apollographql/router/issues/1395)
+### Dependency updates [PR #1389](https://github.com/apollographql/router/issues/1389) [PR #1394](https://github.com/apollographql/router/issues/1394) [PR #1395](https://github.com/apollographql/router/issues/1395)
 
 Dependency updates were blocked for some time due to incompatibilities:
 - #1389: the router-bridge crate needed a new version of `deno_core` in its workspace that would not fix the version of `once_cell`. Now that it is done we can update `once_cell` in the router
 - #1395: `clap` at version 3.2 changed the way values are extracted from matched arguments, which resulted in panics. This is now fixed and we can update `clap` in the router and related crates
+- #1394: broader dependency updates now that everything is locked
 
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1389 https://github.com/apollographql/router/pull/1395
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1389 https://github.com/apollographql/router/pull/1394 https://github.com/apollographql/router/pull/1395
 
 ## 📚 Documentation

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -11,14 +11,14 @@ publish = false
 [dev-dependencies]
 apollo-router = { path = "../apollo-router" }
 criterion = { version = "0.3", features = ["async_tokio", "async_futures"] }
-futures = "0.3.21"
+futures = "0.3"
 once_cell = "1"
-serde_json = { version = "1.0.81", features = ["preserve_order"] }
+serde_json = { version = "1", features = ["preserve_order"] }
 serde_json_bytes = { version = "0.2.0", features = ["preserve_order"] }
 tokio = { version = "1", features = ["full"] }
-tracing-subscriber = { version = "0.3.11", features = ["json", "env-filter"] }
-async-trait = "0.1.56"
-tower = "0.4.13"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+async-trait = "0.1"
+tower = "0.4"
 
 
 [[bench]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -25,8 +25,8 @@ apollo-uplink = { path = "../uplink" }
 async-compression = { version = "0.3.14", features = ["tokio", "brotli", "gzip", "deflate"] }
 async-trait = "0.1.56"
 atty = "0.2.14"
-axum = { version = "0.5.9", features = ["headers", "json", "original-uri"] }
-backtrace = "0.3.65"
+axum = { version = "0.5.12", features = ["headers", "json", "original-uri"] }
+backtrace = "0.3.66"
 buildstructor = "0.3.2"
 bytes = "1.1.0"
 clap = { version = "=3.1.18", default-features = false, features = [
@@ -51,21 +51,21 @@ http = "0.2.8"
 http-body = "0.4.5"
 humantime = "2.1.0"
 humantime-serde = "1.1.1"
-hyper = { version = "0.14.19", features = ["server", "client"] }
+hyper = { version = "0.14.20", features = ["server", "client"] }
 hyper-rustls = { version = "0.23.0", features = ["http1", "http2"] }
 include_dir = "0.7.2"
-indexmap = "1.8.1"
+indexmap = "1.9.1"
 itertools = "0.10.3"
 jsonschema = { version = "0.16.0", default-features = false }
 lazy_static = "1.4.0"
 libc = "0.2.126"
 lru = "0.7.7"
 mockall = "0.11.1"
-moka = { version = "0.8.5", features = ["future", "futures-util"] }
-miette = { version = "5.1.0", features = ["fancy"] }
+moka = { version = "0.9.0", features = ["future", "futures-util"] }
+miette = { version = "5.1.1", features = ["fancy"] }
 mime = "0.3.16"
 multimap = "0.8.3"
-once_cell = "1.9.0"
+once_cell = "1.13.0"
 opentelemetry = { version = "0.17.0", features = [
     "rt-tokio",
     "serialize",
@@ -95,7 +95,7 @@ opentelemetry-prometheus = "0.10.0"
 paste = "1.0.7"
 prometheus = "0.13"
 rhai = { version="1.8.0", features = ["sync", "serde", "internals"] }
-regex = "1.5.6"
+regex = "1.6.0"
 reqwest = { version = "0.11.11", default-features = false, features = [
     "rustls-tls",
     "json",
@@ -104,11 +104,11 @@ reqwest = { version = "0.11.11", default-features = false, features = [
 router-bridge = { git = "https://github.com/apollographql/federation-rs.git", rev = "8897e21ccba26e811f248d8d2f3b263d57278e26" }
 schemars = { version = "0.8.10", features = ["url"] }
 sha2 = "0.10.2"
-serde = { version = "1.0.137", features = ["derive", "rc"] }
+serde = { version = "1.0.139", features = ["derive", "rc"] }
 serde_json_bytes = { version = "0.2.0", features = ["preserve_order"] }
-serde_json = { version = "1.0.81", features = ["preserve_order"] }
+serde_json = { version = "1.0.82", features = ["preserve_order"] }
 serde_urlencoded = "0.7.1"
-serde_yaml = "0.8.24"
+serde_yaml = "0.8.25"
 startup = "0.1.1"
 static_assertions = "1.1.0"
 sys-info = "0.9.1"
@@ -120,11 +120,11 @@ tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.3.4", features = ["trace", "cors", "compression-br", "compression-deflate", "compression-gzip", "decompression-br", "decompression-deflate", "decompression-gzip"] }
 tower-service = "0.3.2"
 tower-test = "0.4.0"
-tracing = "0.1.34"
-tracing-core = "0.1.26"
+tracing = "0.1.35"
+tracing-core = "0.1.28"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
-tracing-opentelemetry = "0.17.3"
-tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
+tracing-opentelemetry = "0.17.4"
+tracing-subscriber = { version = "0.3.14", features = ["env-filter", "json"] }
 url = { version = "2.2.2", features = ["serde"] }
 urlencoding = "2.1.0"
 yaml-rust = "0.4.5"
@@ -137,7 +137,7 @@ uname = "0.1.1"
 uname = "0.1.1"
 
 [dev-dependencies]
-insta = "1.14.0"
+insta = "1.15.0"
 jsonpath_lib = "0.3.0"
 maplit = "1.0.2"
 mockall = "0.11.1"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -125,7 +125,7 @@ tracing = "0.1.35"
 tracing-core = "0.1.28"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 tracing-opentelemetry = "0.17.4"
-tracing-subscriber = { version = "0.3.14", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
 url = { version = "2.2.2", features = ["serde"] }
 urlencoding = "2.1.0"
 yaml-rust = "0.4.5"

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -24,7 +24,7 @@ tonic = "0.6.2"
 tokio = { version = "1.19.2", features = ["macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1.9", features = ["net"] }
 tracing = "0.1.35"
-tracing-subscriber = { version = "0.3.14", features = ["env-filter", "json"] }
+tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
 
 [target.'cfg(macos)'.dependencies]
 uname = "0.1.1"

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -11,20 +11,20 @@ publish = false
 [dependencies]
 bytes = "1.1.0"
 clap = { version = "=3.1.18", default-features = false, features = ["std", "derive"] }
-flate2 = "1.0.23"
+flate2 = "1.0.24"
 prost = "0.9.0"
 prost-types = "0.9.0"
 reqwest = { version = "0.11.11", default_features = false, features = [
     "rustls-tls",
     "json",
 ] }
-serde = {version = "1.0.137", features = ["derive"] }
+serde = {version = "1.0.139", features = ["derive"] }
 sys-info = "0.9.1"
 tonic = "0.6.2"
-tokio = { version = "1.18.2", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.19.2", features = ["macros", "rt-multi-thread"] }
 tokio-stream = { version = "0.1.9", features = ["net"] }
-tracing = "0.1.34"
-tracing-subscriber = { version = "0.3.11", features = ["env-filter", "json"] }
+tracing = "0.1.35"
+tracing-subscriber = { version = "0.3.14", features = ["env-filter", "json"] }
 
 [target.'cfg(macos)'.dependencies]
 uname = "0.1.1"

--- a/examples/add-timestamp-header/Cargo.toml
+++ b/examples/add-timestamp-header/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1"
 apollo-router = { path = "../../apollo-router" }
-futures = "0.3.21"
-http = "0.2.6"
-serde_json = "1.0.79"
-tokio = { version = "1.17.0", features = ["full"] }
-tower = { version = "0.4.12", features = ["full"] }
+futures = "0.3"
+http = "0.2"
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.4", features = ["full"] }

--- a/examples/async-auth/Cargo.toml
+++ b/examples/async-auth/Cargo.toml
@@ -5,14 +5,14 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1"
 apollo-router = { path = "../../apollo-router" }
-async-trait = "0.1.53"
-futures = "0.3.21"
-http = "0.2.6"
-schemars = { version = "0.8.10", features = ["url"] }
-serde = "1.0.136"
-serde_json = "1.0.79"
-serde_json_bytes = "0.2.0"
-tokio = { version = "1.17.0", features = ["full"] }
-tower = { version = "0.4.12", features = ["full"] }
+async-trait = "0.1"
+futures = "0.3"
+http = "0.2"
+schemars = { version = "0.8", features = ["url"] }
+serde = "1"
+serde_json = "1"
+serde_json_bytes = "0.2"
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.4", features = ["full"] }

--- a/examples/context/Cargo.toml
+++ b/examples/context/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1"
 apollo-router = { path = "../../apollo-router" }
-async-trait = "0.1.53"
-futures = "0.3.21"
-http = "0.2.6"
-tower = { version = "0.4.12", features = ["full"] }
-tracing = "0.1.31"
+async-trait = "0.1"
+futures = "0.3"
+http = "0.2"
+tower = { version = "0.4", features = ["full"] }
+tracing = "0.1"

--- a/examples/cookies-to-headers/Cargo.toml
+++ b/examples/cookies-to-headers/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1"
 apollo-router = { path = "../../apollo-router" }
-http = "0.2.6"
-serde_json = "1.0.79"
-tokio = { version = "1.17.0", features = ["full"] }
-tower = { version = "0.4.12", features = ["full"] }
+http = "0.2"
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.4", features = ["full"] }

--- a/examples/embedded/Cargo.toml
+++ b/examples/embedded/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1"
 apollo-router = { path = "../../apollo-router" }
-futures = "0.3.21"
-serde_json = "1.0.79"
-tokio = { version = "1.17.0", features = ["full"] }
-tower = "0.4.12"
-tracing-subscriber = { version = "0.3.9", features = ["json", "env-filter"] }
+futures = "0.3"
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tower = "0.4"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }

--- a/examples/forbid-anonymous-operations/Cargo.toml
+++ b/examples/forbid-anonymous-operations/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1"
 apollo-router = { path = "../../apollo-router" }
-async-trait = "0.1.53"
-futures = "0.3.21"
-http = "0.2.6"
-serde_json = "1.0.79"
-tokio = { version = "1.17.0", features = ["full"] }
-tower = { version = "0.4.12", features = ["full"] }
-tracing = "0.1.31"
+async-trait = "0.1"
+futures = "0.3"
+http = "0.2"
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.4", features = ["full"] }
+tracing = "0.1"

--- a/examples/hello-world/Cargo.toml
+++ b/examples/hello-world/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1"
 apollo-router = { path = "../../apollo-router" }
-async-trait = "0.1.52"
-futures = "0.3.21"
-schemars = { version = "0.8.10", features = ["url"] }
-serde = "1.0.136"
-serde_json = "1.0.79"
-tokio = { version = "1.17.0", features = ["full"] }
-tower = { version = "0.4.12", features = ["full"] }
-tracing = "0.1.34"
+async-trait = "0.1"
+futures = "0.3"
+schemars = { version = "0.8", features = ["url"] }
+serde = "1"
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.4", features = ["full"] }
+tracing = "0.1"

--- a/examples/jwt-auth/Cargo.toml
+++ b/examples/jwt-auth/Cargo.toml
@@ -5,17 +5,17 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1"
 apollo-router = { path = "../../apollo-router" }
-async-trait = "0.1.53"
-futures = "0.3.21"
-hex = "0.4.3"
-http = "0.2.6"
-jwt-simple = "0.10.8"
-schemars = { version = "0.8.10", features = ["url"] }
-serde = "1.0.136"
-serde_json = "1.0.79"
-strum = { version = "0.24.0", features = ["derive"] }
-strum_macros = "0.24.0"
-tokio = { version = "1.17.0", features = ["full"] }
-tower = { version = "0.4.12", features = ["full"] }
+async-trait = "0.1"
+futures = "0.3"
+hex = "0.4"
+http = "0.2"
+jwt-simple = "0.11"
+schemars = { version = "0.8", features = ["url"] }
+serde = "1"
+serde_json = "1"
+strum = { version = "0.24", features = ["derive"] }
+strum_macros = "0.24"
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.4", features = ["full"] }

--- a/examples/op-name-to-header/Cargo.toml
+++ b/examples/op-name-to-header/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1"
 apollo-router = { path = "../../apollo-router" }
-futures = "0.3.21"
-http = "0.2.6"
-serde_json = "1.0.79"
-tokio = { version = "1.17.0", features = ["full"] }
-tower = { version = "0.4.12", features = ["full"] }
+futures = "0.3"
+http = "0.2"
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.4", features = ["full"] }

--- a/examples/rhai-data-response-mutate/Cargo.toml
+++ b/examples/rhai-data-response-mutate/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1"
 apollo-router = { path = "../../apollo-router" }
-futures = "0.3.21"
-http = "0.2.6"
-serde_json = "1.0.79"
-tokio = { version = "1.17.0", features = ["full"] }
-tower = { version = "0.4.12", features = ["full"] }
+futures = "0.3"
+http = "0.2"
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.4", features = ["full"] }

--- a/examples/rhai-error-response-mutate/Cargo.toml
+++ b/examples/rhai-error-response-mutate/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1"
 apollo-router = { path = "../../apollo-router" }
-futures = "0.3.21"
-http = "0.2.6"
-serde_json = "1.0.79"
-tokio = { version = "1.17.0", features = ["full"] }
-tower = { version = "0.4.12", features = ["full"] }
+futures = "0.3"
+http = "0.2"
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.4", features = ["full"] }

--- a/examples/rhai-logging/Cargo.toml
+++ b/examples/rhai-logging/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1"
 apollo-router = { path = "../../apollo-router" }
-futures = "0.3.21"
-http = "0.2.6"
-serde_json = "1.0.79"
-tokio = { version = "1.17.0", features = ["full"] }
-tower = { version = "0.4.12", features = ["full"] }
+futures = "0.3"
+http = "0.2"
+serde_json = "1"
+tokio = { version = "1.17", features = ["full"] }
+tower = { version = "0.4", features = ["full"] }

--- a/examples/rhai-subgraph-request-log/Cargo.toml
+++ b/examples/rhai-subgraph-request-log/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1"
 apollo-router = { path = "../../apollo-router" }
-futures = "0.3.21"
-http = "0.2.6"
-serde_json = "1.0.79"
-tokio = { version = "1.17.0", features = ["full"] }
-tower = { version = "0.4.12", features = ["full"] }
+futures = "0.3"
+http = "0.2"
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.4", features = ["full"] }

--- a/examples/rhai-surrogate-cache-key/Cargo.toml
+++ b/examples/rhai-surrogate-cache-key/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1"
 apollo-router = { path = "../../apollo-router" }
-futures = "0.3.21"
-http = "0.2.6"
-serde_json = "1.0.79"
-tokio = { version = "1.17.0", features = ["full"] }
-tower = { version = "0.4.12", features = ["full"] }
+futures = "0.3"
+http = "0.2"
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.4", features = ["full"] }

--- a/examples/status-code-propagation/Cargo.toml
+++ b/examples/status-code-propagation/Cargo.toml
@@ -5,13 +5,13 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-anyhow = "1.0.55"
+anyhow = "1"
 apollo-router = { path = "../../apollo-router" }
-async-trait = "0.1.53"
-futures = "0.3.21"
-http = "0.2.6"
-schemars = { version = "0.8.10", features = ["url"] }
-serde = "1.0.136"
-serde_json = "1.0.79"
-tokio = { version = "1.17.0", features = ["full"] }
-tower = { version = "0.4.12", features = ["full"] }
+async-trait = "0.1"
+futures = "0.3"
+http = "0.2"
+schemars = { version = "0.8", features = ["url"] }
+serde = "1"
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tower = { version = "0.4", features = ["full"] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,9 +14,9 @@ libfuzzer-sys = "0.4"
 apollo-smith = { version = "0.1.3", features = ["parser-impl"] }
 apollo-parser = "0.2.8"
 env_logger = "0.9.0"
-log = "0.4.17"
-reqwest = { version = "0.11.11", features = ["json", "blocking"] }
-serde_json = "1.0.81"
+log = "0.4"
+reqwest = { version = "0.11", features = ["json", "blocking"] }
+serde_json = "1"
 
 
 [[bin]]

--- a/licenses.html
+++ b/licenses.html
@@ -44,7 +44,7 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#MIT">MIT License</a> (81)</li>
+            <li><a href="#MIT">MIT License</a> (80)</li>
             <li><a href="#Apache-2.0">Apache License 2.0</a> (56)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (8)</li>
             <li><a href="#ISC">ISC License</a> (8)</li>
@@ -7023,8 +7023,6 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/alexcrichton/openssl-probe ">openssl-probe</a></li>
                     <li><a href=" https://github.com/stjepang/parking ">parking</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot</a></li>
-                    <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot</a></li>
-                    <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core</a></li>
                     <li><a href=" https://github.com/dtolnay/paste ">paste</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding</a></li>
@@ -8805,6 +8803,7 @@ limitations under the License.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/smol-rs/async-channel ">async-channel</a></li>
                     <li><a href=" https://github.com/rust-lang/log ">log</a></li>
+                    <li><a href=" https://github.com/uuid-rs/uuid ">uuid</a></li>
                     <li><a href=" https://github.com/uuid-rs/uuid ">uuid</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -11323,40 +11322,6 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.Apache License
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core</a></li>
-                </ul>
-                <pre class="license-text">
-Copyright (c) 2010 The Rust Project Developers
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the &quot;Software&quot;), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
 </pre>
             </li>
             <li class="license">

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -13,10 +13,10 @@ reqwest = { version = "0.11.11", default_features = false, features = [
     "rustls-tls",
     "json",
 ] }
-serde = { version = "1.0.137", features = ["derive", "rc"] }
-tokio = "1.18.2"
+serde = { version = "1.0.139", features = ["derive", "rc"] }
+tokio = "1.19.2"
 tokio-stream = "0.1.9"
-tracing = "0.1.34"
+tracing = "0.1.35"
 url = "2.2.2"
 
 [build-dependencies]
@@ -26,7 +26,7 @@ reqwest = { version = "0.11.11", default_features = false, features = [
 ] }
 
 [dev-dependencies]
-tokio = { version = "1.18.2", default-features = false, features = [
+tokio = { version = "1.19.2", default-features = false, features = [
     "macros",
     "rt-multi-thread",
 ] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 ansi_term = "0.12"
-anyhow = "1.0.58"
+anyhow = "1"
 base64 = "0.13"
 camino = "1"
 cargo_metadata = "0.15"


### PR DESCRIPTION
likely to improve performance with axum and tracing updates.

Dependency version requirements are not critical outside of the router
and the crates it uses, so we can relax the version requirements there
(example: in the benchmarks)