### PR TITLE
update clap and add a special case for PathBuf arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
  "backtrace",
  "buildstructor",
  "bytes",
- "clap 3.1.18",
+ "clap 3.2.10",
  "dashmap 5.3.4",
  "deadpool",
  "derivative",
@@ -228,7 +228,7 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "cargo-scaffold",
- "clap 3.1.18",
+ "clap 3.2.10",
  "copy_dir",
  "regex",
  "str_inflector",
@@ -253,7 +253,7 @@ name = "apollo-spaceport"
 version = "0.11.0"
 dependencies = [
  "bytes",
- "clap 3.1.18",
+ "clap 3.2.10",
  "flate2",
  "prost",
  "prost-types",
@@ -708,7 +708,7 @@ dependencies = [
  "bytesize",
  "cargo-platform",
  "cargo-util",
- "clap 3.1.18",
+ "clap 3.2.10",
  "crates-io",
  "crossbeam-utils 0.8.8",
  "curl",
@@ -884,16 +884,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.18"
+version = "3.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2dbdf4bdacb33466e854ce889eee8dfd5729abf7ccd7664d0a2d60cd384440b"
+checksum = "69c5a7f9997be616e47f0577ee38c91decb33392c5be4866494f34cdf329a9aa"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim 0.10.0",
  "termcolor",
  "textwrap 0.15.0",
@@ -901,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.18"
+version = "3.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25320346e922cffe59c0bbc5410c8d8784509efb321488971081313cb1e1a33c"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -46,4 +46,13 @@ By [@garypen](https://github.com/garypen) in https://github.com/apollographql/ro
 ## 🚀 Features
 ## 🐛 Fixes
 ## 🛠 Maintenance
+
+### Dependency updates [PR #1389](https://github.com/apollographql/router/issues/1389) [PR #1395](https://github.com/apollographql/router/issues/1395)
+
+Dependency updates were blocked for some time due to incompatibilities:
+- #1389: the router-bridge crate needed a new version of `deno_core` in its workspace that would not fix the version of `once_cell`. Now that it is done we can update `once_cell` in the router
+- #1395: `clap` at version 3.2 changed the way values are extracted from matched arguments, which resulted in panics. This is now fixed and we can update `clap` in the router and related crates
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1389 https://github.com/apollographql/router/pull/1395
+
 ## 📚 Documentation

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.58"
-clap = { version = "=3.1.18", features = ["derive"] }
+clap = { version = "3.2.10", features = ["derive"] }
 cargo-scaffold = { version = "0.8.4", default-features = false }
 regex = "1"
 str_inflector = "0.12.0"

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -17,4 +17,4 @@ apollo-router-scaffold = { git="https://github.com/apollographql/router.git", ta
 {{/if}}
 {{/if}}
 anyhow = "=1.0.58"
-clap = "=3.1.18"
+clap = "3.2.10"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -29,7 +29,7 @@ axum = { version = "0.5.9", features = ["headers", "json", "original-uri"] }
 backtrace = "0.3.65"
 buildstructor = "0.3.2"
 bytes = "1.1.0"
-clap = { version = "=3.1.18", default-features = false, features = [
+clap = { version = "3.2.10", default-features = false, features = [
     "env",
     "derive",
     "std",

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -2,6 +2,7 @@
 
 use std::env;
 use std::ffi::OsStr;
+use std::ffi::OsString;
 use std::fmt;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -348,10 +349,12 @@ fn copy_args_to_env() {
     Opt::command().get_arguments().for_each(|a| {
         if let Some(env) = a.get_env() {
             if a.is_allow_invalid_utf8_set() {
-                if let Some(value) = matches.value_of_os(a.get_id()) {
+                if let Some(value) = matches.get_one::<OsString>(a.get_id()) {
                     env::set_var(env, value);
                 }
-            } else if let Some(value) = matches.value_of(a.get_id()) {
+            } else if let Ok(Some(value)) = matches.try_get_one::<PathBuf>(a.get_id()) {
+                env::set_var(env, value);
+            } else if let Ok(Some(value)) = matches.try_get_one::<String>(a.get_id()) {
                 env::set_var(env, value);
             }
         }

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 bytes = "1.1.0"
-clap = { version = "=3.1.18", default-features = false, features = ["std", "derive"] }
+clap = { version = "3.2.10", default-features = false, features = ["std", "derive"] }
 flate2 = "1.0.23"
 prost = "0.9.0"
 prost-types = "0.9.0"


### PR DESCRIPTION
Fix #1231 

argument parsing changed in clap 3.2, which resulted in the
`ArgMatches::value_of` method panicking when trying to downcast a
`PathBuf` to a `String`. This adds a special case to try and downcast to
`PathBuf` directly and uses non panicking methods