### PR TITLE
update the released package name in Docker image construction

### DIFF
--- a/dockerfiles/diy/dockerfiles/Dockerfile.release
+++ b/dockerfiles/diy/dockerfiles/Dockerfile.release
@@ -8,7 +8,7 @@ FROM --platform=linux/amd64 alpine:latest AS build
 ARG ROUTER_RELEASE
 
 # Pull release from GH
-ADD https://github.com/apollographql/router/releases/download/v${ROUTER_RELEASE}/router-${ROUTER_RELEASE}-x86_64-linux.tar.gz /tmp/router.tar.gz
+ADD https://github.com/apollographql/router/releases/download/v${ROUTER_RELEASE}/router-${ROUTER_RELEASE}-x86_64-unknown-linux-gnu.tar.gz /tmp/router.tar.gz
 
 WORKDIR /tmp
 


### PR DESCRIPTION
We changed the released package names in #1393 to include the full
target triplet

:warning: **do not merge this until we have published a release containing #1393**