### PR TITLE
release: v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,68 @@ All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.12.0] - 2022-08-18
+
+## ❗ BREAKING ❗
+
+### Move `experimental.rhai` out of `experimental` [PR #1365](https://github.com/apollographql/router/pull/1365)
+
+You will need to update your YAML configuration file to use the correct name for `rhai` plugin.
+
+```diff
+- plugins:
+-   experimental.rhai:
+-     filename: /path/to/myfile.rhai
++ rhai:
++   scripts: /path/to/directory/containing/all/my/rhai/scripts (./scripts by default)
++   main: <name of main script to execute> (main.rhai by default)
+```
+
+You can now modularise your rhai code. Rather than specifying a path to a filename containing your rhai code, the rhai plugin will now attempt to execute the script specified via `main`. If modules are imported, the rhai plugin will search for those modules in the `scripts` directory. for more details about how rhai makes use of modules, look at [the rhai documentation](https://rhai.rs/book/ref/modules/import.html).
+
+The simplest migration will be to set `scripts` to the directory containing your `myfile.rhai` and to rename your `myfile.rhai` to `main.rhai`.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1365
+
+## 🐛 Fixes
+
+### The opentelemetry-otlp crate needs a http-client feature [PR #1392](https://github.com/apollographql/router/pull/1392)
+
+The opentelemetry-otlp crate only checks at runtime if a HTTP client was added through
+cargo features. We now use reqwest for that.
+
+By [@geal](https://github.com/geal) in https://github.com/apollographql/router/pull/1392
+
+### Expose the custom endpoints from RouterServiceFactory ([PR #1402](https://github.com/apollographql/router/pull/1402))
+
+Plugin HTTP endpoints registration was broken during the Tower refactoring. We now make sure that the list
+of endpoints is generated from the `RouterServiceFactory` instance.
+
+By [@geal](https://github.com/geal) in https://github.com/apollographql/router/pull/1402
+
+## 🛠 Maintenance
+
+### Dependency updates [PR #1389](https://github.com/apollographql/router/issues/1389) [PR #1394](https://github.com/apollographql/router/issues/1394) [PR #1395](https://github.com/apollographql/router/issues/1395)
+
+Dependency updates were blocked for some time due to incompatibilities:
+
+- #1389: the router-bridge crate needed a new version of `deno_core` in its workspace that would not fix the version of `once_cell`. Now that it is done we can update `once_cell` in the router
+- #1395: `clap` at version 3.2 changed the way values are extracted from matched arguments, which resulted in panics. This is now fixed and we can update `clap` in the router and related crates
+- #1394: broader dependency updates now that everything is locked
+- #1410: revert tracing update that caused two telemetry tests to fail (the router binary is not affected)
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1389 https://github.com/apollographql/router/pull/1394 https://github.com/apollographql/router/pull/1395 and [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1410
+
+### Insert the full target triplet in the package name [PR #1393](https://github.com/apollographql/router/pull/1393)
+
+The released package names will now contain the full target triplet in their name:
+
+- `router-0.12.0-x86_64-linux.tar.gz` -> `router-0.12.0-x86_64-unknown-linux-gnu.tar.gz`
+- `router-0.12.0-x86_64-macos.tar.gz` -> `router-0.12.0-x86_64-apple-darwin.tar.gz`
+- `router-0.12.0-x86_64-windows.tar.gz` -> `router-0.12.0-x86_64-pc-windows-msvc.tar.gz`
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1393
+
 # [0.11.0] - 2022-07-12
 
 ## ❗ BREAKING ❗

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,16 +56,6 @@ Dependency updates were blocked for some time due to incompatibilities:
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1389 https://github.com/apollographql/router/pull/1394 https://github.com/apollographql/router/pull/1395 and [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1410
 
-### Insert the full target triplet in the package name [PR #1393](https://github.com/apollographql/router/pull/1393)
-
-The released package names will now contain the full target triplet in their name:
-
-- `router-0.12.0-x86_64-linux.tar.gz` -> `router-0.12.0-x86_64-unknown-linux-gnu.tar.gz`
-- `router-0.12.0-x86_64-macos.tar.gz` -> `router-0.12.0-x86_64-apple-darwin.tar.gz`
-- `router-0.12.0-x86_64-windows.tar.gz` -> `router-0.12.0-x86_64-pc-windows-msvc.tar.gz`
-
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1393
-
 # [0.11.0] - 2022-07-12
 
 ## ❗ BREAKING ❗

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "apollo-router",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,7 +110,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "access-json",
  "anyhow",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "apollo-router",
  "async-trait",
@@ -250,7 +250,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-spaceport"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "clap 3.2.10",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-uplink"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "futures",
  "graphql_client",
@@ -6370,7 +6370,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -23,62 +23,14 @@ Description! And a link to a [reference](http://url)
 By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/router/pull/PULL_NUMBER
 -->
 
-# [0.11.1] (unreleased) - 2022-mm-dd
+# [0.12.1] (unreleased) - 2022-mm-dd
+
 ## ❗ BREAKING ❗
 
-### Move `experimental.rhai` out of `experimental` [PR #1365](https://github.com/apollographql/router/pull/1365)
-You will need to update your YAML configuration file to use the correct name for `rhai` plugin.
-
-```diff
-- plugins:
--   experimental.rhai:
--     filename: /path/to/myfile.rhai
-+ rhai:
-+   scripts: /path/to/directory/containing/all/my/rhai/scripts (./scripts by default)
-+   main: <name of main script to execute> (main.rhai by default)
-```
-You can now modularise your rhai code. Rather than specifying a path to a filename containing your rhai code, the rhai plugin will now attempt to execute the script specified via `main`. If modules are imported, the rhai plugin will search for those modules in the `scripts` directory. for more details about how rhai makes use of modules, look at [the rhai documentation](https://rhai.rs/book/ref/modules/import.html).
-
-The simplest migration will be to set `scripts` to the directory containing your `myfile.rhai` and to rename your `myfile.rhai` to `main.rhai`.
-
-By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1365
-
 ## 🚀 Features
+
 ## 🐛 Fixes
 
-### The opentelemetry-otlp crate needs a http-client feature [PR #1392](https://github.com/apollographql/router/pull/1392)
-
-The opentelemetry-otlp crate only checks at runtime if a HTTP client was added through
-cargo features. We now use reqwest for that.
-
-By [@geal](https://github.com/geal) in https://github.com/apollographql/router/pull/1392
-
-### Expose the custom endpoints from RouterServiceFactory ([PR #1402](https://github.com/apollographql/router/pull/1402))
-
-Plugin HTTP endpoints registration was broken during the Tower refactoring. We now make sure that the list
-of endpoints is generated from the `RouterServiceFactory` instance.
-
-By [@geal](https://github.com/geal) in https://github.com/apollographql/router/pull/1402
-
 ## 🛠 Maintenance
-
-### Dependency updates [PR #1389](https://github.com/apollographql/router/issues/1389) [PR #1394](https://github.com/apollographql/router/issues/1394) [PR #1395](https://github.com/apollographql/router/issues/1395)
-
-Dependency updates were blocked for some time due to incompatibilities:
-- #1389: the router-bridge crate needed a new version of `deno_core` in its workspace that would not fix the version of `once_cell`. Now that it is done we can update `once_cell` in the router
-- #1395: `clap` at version 3.2 changed the way values are extracted from matched arguments, which resulted in panics. This is now fixed and we can update `clap` in the router and related crates
-- #1394: broader dependency updates now that everything is locked
-- #1410: revert tracing update that caused two telemetry tests to fail (the router binary is not affected)
-
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1389 https://github.com/apollographql/router/pull/1394 https://github.com/apollographql/router/pull/1395 and [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1410 
-### Insert the full target triplet in the package name [PR #1393](https://github.com/apollographql/router/pull/1393)
-
-The released package names will now contain the full target triplet in their name:
-
-* `router-0.11.0-x86_64-linux.tar.gz` -> `router-0.11.0-x86_64-unknown-linux-gnu.tar.gz`
-* `router-0.11.0-x86_64-macos.tar.gz` -> `router-0.11.0-x86_64-apple-darwin.tar.gz`
-* `router-0.11.0-x86_64-windows.tar.gz` -> `router-0.11.0-x86_64-pc-windows-msvc.tar.gz`
-
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1393
 
 ## 📚 Documentation

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -13,7 +13,7 @@ apollo-router-scaffold = { path ="{{integration_test}}apollo-router-scaffold" }
 {{#if branch}}
 apollo-router-scaffold = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
-apollo-router-scaffold = { git="https://github.com/apollographql/router.git", tag="v0.11.0"}
+apollo-router-scaffold = { git="https://github.com/apollographql/router.git", tag="v0.12.0"}
 {{/if}}
 {{/if}}
 anyhow = "=1.0.58"

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xtask"
 edition = "2021"
 publish = false
-version = "0.1.0"
+version = "0.12.0"
 
 [dependencies]
 # This dependency should stay in line with your router version

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"
@@ -22,7 +22,12 @@ anyhow = "1.0.58"
 apollo-parser = "0.2.8"
 apollo-spaceport = { path = "../apollo-spaceport" }
 apollo-uplink = { path = "../uplink" }
-async-compression = { version = "0.3.14", features = ["tokio", "brotli", "gzip", "deflate"] }
+async-compression = { version = "0.3.14", features = [
+    "tokio",
+    "brotli",
+    "gzip",
+    "deflate",
+] }
 async-trait = "0.1.56"
 atty = "0.2.14"
 axum = { version = "0.5.12", features = ["headers", "json", "original-uri"] }
@@ -95,7 +100,7 @@ opentelemetry-zipkin = { version = "0.15.0", default-features = false, features 
 opentelemetry-prometheus = "0.10.0"
 paste = "1.0.7"
 prometheus = "0.13"
-rhai = { version="1.8.0", features = ["sync", "serde", "internals"] }
+rhai = { version = "1.8.0", features = ["sync", "serde", "internals"] }
 regex = "1.6.0"
 reqwest = { version = "0.11.11", default-features = false, features = [
     "rustls-tls",
@@ -118,7 +123,16 @@ tokio = { version = "1.19.2", features = ["full"] }
 tokio-util = { version = "0.7.3", features = ["net", "codec"] }
 tonic = { version = "0.6.2", features = ["transport", "tls"] }
 tower = { version = "0.4.13", features = ["full"] }
-tower-http = { version = "0.3.4", features = ["trace", "cors", "compression-br", "compression-deflate", "compression-gzip", "decompression-br", "decompression-deflate", "decompression-gzip"] }
+tower-http = { version = "0.3.4", features = [
+    "trace",
+    "cors",
+    "compression-br",
+    "compression-deflate",
+    "compression-gzip",
+    "decompression-br",
+    "decompression-deflate",
+    "decompression-gzip",
+] }
 tower-service = "0.3.2"
 tower-test = "0.4.0"
 tracing = "=0.1.34"

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-spaceport"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"
@@ -10,7 +10,10 @@ publish = false
 
 [dependencies]
 bytes = "1.1.0"
-clap = { version = "3.2.10", default-features = false, features = ["std", "derive"] }
+clap = { version = "3.2.10", default-features = false, features = [
+    "std",
+    "derive",
+] }
 flate2 = "1.0.24"
 prost = "0.9.0"
 prost-types = "0.9.0"
@@ -18,7 +21,7 @@ reqwest = { version = "0.11.11", default_features = false, features = [
     "rustls-tls",
     "json",
 ] }
-serde = {version = "1.0.139", features = ["derive"] }
+serde = { version = "1.0.139", features = ["derive"] }
 sys-info = "0.9.1"
 tonic = "0.6.2"
 tokio = { version = "1.19.2", features = ["macros", "rt-multi-thread"] }

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -5,7 +5,7 @@ FROM --platform=linux/amd64 alpine:latest AS build
 ARG ROUTER_RELEASE
 
 # Pull release from GH
-ADD https://github.com/apollographql/router/releases/download/v${ROUTER_RELEASE}/router-${ROUTER_RELEASE}-x86_64-unknown-linux-gnu.tar.gz /tmp/router.tar.gz
+ADD https://github.com/apollographql/router/releases/download/v${ROUTER_RELEASE}/router-${ROUTER_RELEASE}-x86_64-linux.tar.gz /tmp/router.tar.gz
 
 WORKDIR /tmp
 

--- a/dockerfiles/tracing/docker-compose.datadog.yml
+++ b/dockerfiles/tracing/docker-compose.datadog.yml
@@ -3,11 +3,19 @@ services:
 
   apollo-router:
     container_name: apollo-router
-    image: ghcr.io/apollographql/router:v0.11.0
+    image: ghcr.io/apollographql/router:v0.12.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/datadog.router.yaml:/etc/config/configuration.yaml
-    command: [ "-c", "/etc/config/configuration.yaml", "-s", "/etc/config/supergraph.graphql", "--log", "info" ]
+    command:
+      [
+        "-c",
+        "/etc/config/configuration.yaml",
+        "-s",
+        "/etc/config/supergraph.graphql",
+        "--log",
+        "info"
+      ]
     ports:
       - 4000:4000
     depends_on:

--- a/dockerfiles/tracing/docker-compose.jaeger.yml
+++ b/dockerfiles/tracing/docker-compose.jaeger.yml
@@ -4,11 +4,19 @@ services:
   apollo-router:
     container_name: apollo-router
     #build: ./router
-    image: ghcr.io/apollographql/router:v0.11.0
+    image: ghcr.io/apollographql/router:v0.12.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/jaeger.router.yaml:/etc/config/configuration.yaml
-    command: [ "-c", "/etc/config/configuration.yaml", "-s", "/etc/config/supergraph.graphql", "--log", "info" ]
+    command:
+      [
+        "-c",
+        "/etc/config/configuration.yaml",
+        "-s",
+        "/etc/config/supergraph.graphql",
+        "--log",
+        "info"
+      ]
     ports:
       - 4000:4000
     depends_on:

--- a/dockerfiles/tracing/docker-compose.zipkin.yml
+++ b/dockerfiles/tracing/docker-compose.zipkin.yml
@@ -4,11 +4,19 @@ services:
   apollo-router:
     container_name: apollo-router
     build: ./router
-    image: ghcr.io/apollographql/router:v0.11.0
+    image: ghcr.io/apollographql/router:v0.12.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/zipkin.router.yaml:/etc/config/configuration.yaml
-    command: [ "-c", "/etc/config/configuration.yaml", "-s", "/etc/config/supergraph.graphql", "--log", "info" ]
+    command:
+      [
+        "-c",
+        "/etc/config/configuration.yaml",
+        "-s",
+        "/etc/config/supergraph.graphql",
+        "--log",
+        "info"
+      ]
     ports:
       - 4000:4000
     environment:

--- a/docs/source/containerization/docker.mdx
+++ b/docs/source/containerization/docker.mdx
@@ -11,7 +11,7 @@ The default behaviour of the router images is suitable for a quickstart or devel
 
 Note: The [docker documentation](https://docs.docker.com/engine/reference/run/) for the run command may be helpful when reading through the examples.
 
-Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v0.11.0`
+Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v0.12.0`
 
 ## Override the configuration
 
@@ -92,10 +92,10 @@ Usage: build_docker_image.sh [-b] [<release>]
 	Example 1: Building HEAD from the repo
 		build_docker_image.sh -b
 	Example 2: Building tag from the repo
-		build_docker_image.sh -b v0.11.0
+		build_docker_image.sh -b v0.12.0
 	Example 3: Building commit hash from the repo
 		build_docker_image.sh -b 7f7d223f42af34fad35b898d976bc07d0f5440c5
-	Example 4: Building tag v0.11.0 from the released tarball
-		build_docker_image.sh v0.11.0
+	Example 4: Building tag v0.12.0 from the released tarball
+		build_docker_image.sh v0.12.0
 ```
 Note: The script has to be run from the `dockerfiles/diy` directory because it makes assumptions about the relative availability of various files. The example uses [distroless images](https://github.com/GoogleContainerTools/distroless) for the final image build. Feel free to modify the script to use images which better suit your own needs.

--- a/docs/source/containerization/kubernetes.mdx
+++ b/docs/source/containerization/kubernetes.mdx
@@ -50,7 +50,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.11.0"
+    app.kubernetes.io/version: "v0.12.0"
 ---
 # Source: router/templates/secret.yaml
 apiVersion: v1
@@ -60,7 +60,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.11.0"
+    app.kubernetes.io/version: "v0.12.0"
 data:
   managedFederationApiKey: "REDACTED"
 ---
@@ -72,7 +72,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.11.0"
+    app.kubernetes.io/version: "v0.12.0"
 data:
   configuration.yaml: |
     server:
@@ -90,7 +90,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.11.0"
+    app.kubernetes.io/version: "v0.12.0"
 spec:
   type: ClusterIP
   ports:
@@ -110,7 +110,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.11.0"
+    app.kubernetes.io/version: "v0.12.0"
   annotations:
     prometheus.io/path: /plugins/apollo.telemetry/prometheus
     prometheus.io/port: "80"
@@ -134,7 +134,7 @@ spec:
         - name: router
           securityContext:
             {}
-          image: "ghcr.io/apollographql/router:v0.11.0"
+          image: "ghcr.io/apollographql/router:v0.12.0"
           imagePullPolicy: IfNotPresent
           args:
             - --hot-reload

--- a/docs/source/federation-version-support.mdx
+++ b/docs/source/federation-version-support.mdx
@@ -22,6 +22,17 @@ Apollo Federation is an evolving project, and it will receive new features and b
     <tbody>
     <tr>
         <td>
+            v0.12.0
+        </td>
+        <td>
+            2.0.2
+        </td>
+        <td>
+            2022-07-18
+        </td>
+    </tr>
+    <tr>
+        <td>
             v0.11.0
         </td>
         <td>

--- a/helm/chart/router/Chart.yaml
+++ b/helm/chart/router/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.14
+version: 0.1.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.11.0"
+appVersion: "v0.12.0"

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -2,11 +2,11 @@
 
 [router](https://github.com/apollographql/router) Rust Graph Routing runtime for Apollo Federation
 
-![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.11.0](https://img.shields.io/badge/AppVersion-v0.11.0-informational?style=flat-square)
+![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.0](https://img.shields.io/badge/AppVersion-v0.12.0-informational?style=flat-square)
 
 ## Prerequisites
 
-* Kubernetes v1.19+
+- Kubernetes v1.19+
 
 ## Get Repo Info
 
@@ -33,53 +33,51 @@ See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_h
 helm show values apollographql/router
 ```
 
-
-
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| affinity | object | `{}` |  |
-| autoscaling.enabled | bool | `false` |  |
-| autoscaling.maxReplicas | int | `100` |  |
-| autoscaling.minReplicas | int | `1` |  |
-| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| containerPorts.http | int | `80` | If you override the port in `router.configuration.server.listen` then make sure to match the listen port here |
-| extraEnvVars | list | `[]` |  |
-| extraEnvVarsCM | string | `""` |  |
-| extraEnvVarsSecret | string | `""` |  |
-| extraVolumeMounts | list | `[]` |  |
-| extraVolumes | list | `[]` |  |
-| fullnameOverride | string | `""` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/apollographql/router"` |  |
-| image.tag | string | `""` |  |
-| imagePullSecrets | list | `[]` |  |
-| ingress.annotations | object | `{}` |  |
-| ingress.className | string | `""` |  |
-| ingress.enabled | bool | `false` |  |
-| ingress.hosts[0].host | string | `"chart-example.local"` |  |
-| ingress.hosts[0].paths[0].path | string | `"/"` |  |
-| ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
-| ingress.tls | list | `[]` |  |
-| managedFederation.apiKey | string | `nil` | If using managed federation, the graph API key to identify router to Studio |
-| managedFederation.existingSecret | string | `nil` | If using managed federation, use existing Secret which stores the graph API key instead of creating a new one. If set along `managedFederation.apiKey`, a secret with the graph API key will be created using this parameter as name  |
-| managedFederation.graphRef | string | `""` | If using managed federation, the variant of which graph to use |
-| nameOverride | string | `""` |  |
-| nodeSelector | object | `{}` |  |
-| podAnnotations | object | `{}` |  |
-| podSecurityContext | object | `{}` |  |
-| replicaCount | int | `1` |  |
-| resources | object | `{}` |  |
-| router | object | `{"args":["--hot-reload"],"configuration":{"server":{"listen":"0.0.0.0:80"}}}` | See https://www.apollographql.com/docs/router/configuration/overview#configuration-file for yaml structure |
-| securityContext | object | `{}` |  |
-| service.port | int | `80` |  |
-| service.type | string | `"ClusterIP"` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
-| tolerations | list | `[]` |  |
+| Key                                        | Type   | Default                                                                        | Description                                                                                                                                                                                                                          |
+| ------------------------------------------ | ------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| affinity                                   | object | `{}`                                                                           |                                                                                                                                                                                                                                      |
+| autoscaling.enabled                        | bool   | `false`                                                                        |                                                                                                                                                                                                                                      |
+| autoscaling.maxReplicas                    | int    | `100`                                                                          |                                                                                                                                                                                                                                      |
+| autoscaling.minReplicas                    | int    | `1`                                                                            |                                                                                                                                                                                                                                      |
+| autoscaling.targetCPUUtilizationPercentage | int    | `80`                                                                           |                                                                                                                                                                                                                                      |
+| containerPorts.http                        | int    | `80`                                                                           | If you override the port in `router.configuration.server.listen` then make sure to match the listen port here                                                                                                                        |
+| extraEnvVars                               | list   | `[]`                                                                           |                                                                                                                                                                                                                                      |
+| extraEnvVarsCM                             | string | `""`                                                                           |                                                                                                                                                                                                                                      |
+| extraEnvVarsSecret                         | string | `""`                                                                           |                                                                                                                                                                                                                                      |
+| extraVolumeMounts                          | list   | `[]`                                                                           |                                                                                                                                                                                                                                      |
+| extraVolumes                               | list   | `[]`                                                                           |                                                                                                                                                                                                                                      |
+| fullnameOverride                           | string | `""`                                                                           |                                                                                                                                                                                                                                      |
+| image.pullPolicy                           | string | `"IfNotPresent"`                                                               |                                                                                                                                                                                                                                      |
+| image.repository                           | string | `"ghcr.io/apollographql/router"`                                               |                                                                                                                                                                                                                                      |
+| image.tag                                  | string | `""`                                                                           |                                                                                                                                                                                                                                      |
+| imagePullSecrets                           | list   | `[]`                                                                           |                                                                                                                                                                                                                                      |
+| ingress.annotations                        | object | `{}`                                                                           |                                                                                                                                                                                                                                      |
+| ingress.className                          | string | `""`                                                                           |                                                                                                                                                                                                                                      |
+| ingress.enabled                            | bool   | `false`                                                                        |                                                                                                                                                                                                                                      |
+| ingress.hosts[0].host                      | string | `"chart-example.local"`                                                        |                                                                                                                                                                                                                                      |
+| ingress.hosts[0].paths[0].path             | string | `"/"`                                                                          |                                                                                                                                                                                                                                      |
+| ingress.hosts[0].paths[0].pathType         | string | `"ImplementationSpecific"`                                                     |                                                                                                                                                                                                                                      |
+| ingress.tls                                | list   | `[]`                                                                           |                                                                                                                                                                                                                                      |
+| managedFederation.apiKey                   | string | `nil`                                                                          | If using managed federation, the graph API key to identify router to Studio                                                                                                                                                          |
+| managedFederation.existingSecret           | string | `nil`                                                                          | If using managed federation, use existing Secret which stores the graph API key instead of creating a new one. If set along `managedFederation.apiKey`, a secret with the graph API key will be created using this parameter as name |
+| managedFederation.graphRef                 | string | `""`                                                                           | If using managed federation, the variant of which graph to use                                                                                                                                                                       |
+| nameOverride                               | string | `""`                                                                           |                                                                                                                                                                                                                                      |
+| nodeSelector                               | object | `{}`                                                                           |                                                                                                                                                                                                                                      |
+| podAnnotations                             | object | `{}`                                                                           |                                                                                                                                                                                                                                      |
+| podSecurityContext                         | object | `{}`                                                                           |                                                                                                                                                                                                                                      |
+| replicaCount                               | int    | `1`                                                                            |                                                                                                                                                                                                                                      |
+| resources                                  | object | `{}`                                                                           |                                                                                                                                                                                                                                      |
+| router                                     | object | `{"args":["--hot-reload"],"configuration":{"server":{"listen":"0.0.0.0:80"}}}` | See https://www.apollographql.com/docs/router/configuration/overview#configuration-file for yaml structure                                                                                                                           |
+| securityContext                            | object | `{}`                                                                           |                                                                                                                                                                                                                                      |
+| service.port                               | int    | `80`                                                                           |                                                                                                                                                                                                                                      |
+| service.type                               | string | `"ClusterIP"`                                                                  |                                                                                                                                                                                                                                      |
+| serviceAccount.annotations                 | object | `{}`                                                                           |                                                                                                                                                                                                                                      |
+| serviceAccount.create                      | bool   | `true`                                                                         |                                                                                                                                                                                                                                      |
+| serviceAccount.name                        | string | `""`                                                                           |                                                                                                                                                                                                                                      |
+| tolerations                                | list   | `[]`                                                                           |                                                                                                                                                                                                                                      |
 
+---
 
-----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.10.0](https://github.com/norwoodj/helm-docs/releases/v1.10.0)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -77,7 +77,7 @@ download_binary() {
 
     # Download asset file.
     say "Downloading router from $_url"
-
+    
     curl -sSfL -H 'Accept: application/octet-stream' "$_url" -o "$_file"
     if [ $? != 0 ]; then
       say "Failed to download $_url"
@@ -137,15 +137,15 @@ get_architecture() {
 
     case "$_ostype" in
         Linux)
-            _ostype=unknown-linux-gnu
+            _ostype=linux
             ;;
 
         Darwin)
-            _ostype=apple-darwin
+            _ostype=macos
             ;;
 
         MINGW* | MSYS* | CYGWIN*)
-            _ostype=pc-windows-msvc
+            _ostype=windows
             ;;
 
         *)

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-uplink"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 build = "build.rs"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -1,9 +1,7 @@
 #[cfg(target_os = "macos")]
 mod macos;
 
-use std::fmt;
 use std::path::Path;
-use std::str::FromStr;
 
 use anyhow::ensure;
 use anyhow::Context;
@@ -13,16 +11,6 @@ use structopt::StructOpt;
 use xtask::*;
 
 const INCLUDE: &[&str] = &["README.md", "LICENSE", "licenses.html"];
-pub(crate) const TARGET_X86_64_MUSL_LINUX: &str = "x86_64-unknown-linux-musl";
-pub(crate) const TARGET_X86_64_GNU_LINUX: &str = "x86_64-unknown-linux-gnu";
-pub(crate) const TARGET_X86_64_WINDOWS: &str = "x86_64-pc-windows-msvc";
-pub(crate) const TARGET_X86_64_MACOS: &str = "x86_64-apple-darwin";
-pub(crate) const POSSIBLE_TARGETS: [&str; 4] = [
-    TARGET_X86_64_MUSL_LINUX,
-    TARGET_X86_64_GNU_LINUX,
-    TARGET_X86_64_WINDOWS,
-    TARGET_X86_64_MACOS,
-];
 
 #[derive(Debug, StructOpt)]
 pub struct Package {
@@ -33,9 +21,6 @@ pub struct Package {
     #[cfg(target_os = "macos")]
     #[structopt(flatten)]
     macos: macos::PackageMacos,
-
-    #[structopt(long, default_value, possible_values = &POSSIBLE_TARGETS)]
-    target: Target,
 }
 
 impl Package {
@@ -57,8 +42,13 @@ impl Package {
             }
             self.output.to_owned()
         } else if self.output.is_dir() {
-            self.output
-                .join(format!("router-{}-{}.tar.gz", *PKG_VERSION, self.target))
+            self.output.join(format!(
+                "router-{}-{}-{}.tar.gz",
+                *PKG_VERSION,
+                // NOTE: same as xtask
+                std::env::consts::ARCH,
+                std::env::consts::OS,
+            ))
         } else {
             self.output.to_owned()
         };
@@ -90,65 +80,5 @@ impl Package {
         ar.finish().context("could not finish TGZ archive")?;
 
         Ok(())
-    }
-}
-
-#[derive(Debug, PartialEq, Clone)]
-pub(crate) enum Target {
-    MuslLinux,
-    GnuLinux,
-    Windows,
-    MacOS,
-    Other,
-}
-
-impl Default for Target {
-    fn default() -> Self {
-        if cfg!(target_arch = "x86_64") {
-            if cfg!(target_os = "windows") {
-                Target::Windows
-            } else if cfg!(target_os = "linux") {
-                if cfg!(target_env = "gnu") {
-                    Target::GnuLinux
-                } else if cfg!(target_env = "musl") {
-                    Target::MuslLinux
-                } else {
-                    Target::Other
-                }
-            } else if cfg!(target_os = "macos") {
-                Target::MacOS
-            } else {
-                Target::Other
-            }
-        } else {
-            Target::Other
-        }
-    }
-}
-
-impl FromStr for Target {
-    type Err = anyhow::Error;
-
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        match input {
-            TARGET_X86_64_MUSL_LINUX => Ok(Self::MuslLinux),
-            TARGET_X86_64_GNU_LINUX => Ok(Self::GnuLinux),
-            TARGET_X86_64_WINDOWS => Ok(Self::Windows),
-            TARGET_X86_64_MACOS => Ok(Self::MacOS),
-            _ => Ok(Self::Other),
-        }
-    }
-}
-
-impl fmt::Display for Target {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let msg = match &self {
-            Target::MuslLinux => TARGET_X86_64_MUSL_LINUX,
-            Target::GnuLinux => TARGET_X86_64_GNU_LINUX,
-            Target::Windows => TARGET_X86_64_WINDOWS,
-            Target::MacOS => TARGET_X86_64_MACOS,
-            Target::Other => "unknown-target",
-        };
-        write!(f, "{}", msg)
     }
 }


### PR DESCRIPTION
# [0.12.0] - 2022-08-18

## ❗ BREAKING ❗

### Move `experimental.rhai` out of `experimental` [PR #1365](https://github.com/apollographql/router/pull/1365)

You will need to update your YAML configuration file to use the correct name for `rhai` plugin.

```diff
- plugins:
-   experimental.rhai:
-     filename: /path/to/myfile.rhai
+ rhai:
+   scripts: /path/to/directory/containing/all/my/rhai/scripts (./scripts by default)
+   main: <name of main script to execute> (main.rhai by default)
```

You can now modularise your rhai code. Rather than specifying a path to a filename containing your rhai code, the rhai plugin will now attempt to execute the script specified via `main`. If modules are imported, the rhai plugin will search for those modules in the `scripts` directory. for more details about how rhai makes use of modules, look at [the rhai documentation](https://rhai.rs/book/ref/modules/import.html).

The simplest migration will be to set `scripts` to the directory containing your `myfile.rhai` and to rename your `myfile.rhai` to `main.rhai`.

By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1365

## 🐛 Fixes

### The opentelemetry-otlp crate needs a http-client feature [PR #1392](https://github.com/apollographql/router/pull/1392)

The opentelemetry-otlp crate only checks at runtime if a HTTP client was added through
cargo features. We now use reqwest for that.

By [@geal](https://github.com/geal) in https://github.com/apollographql/router/pull/1392

### Expose the custom endpoints from RouterServiceFactory ([PR #1402](https://github.com/apollographql/router/pull/1402))

Plugin HTTP endpoints registration was broken during the Tower refactoring. We now make sure that the list
of endpoints is generated from the `RouterServiceFactory` instance.

By [@geal](https://github.com/geal) in https://github.com/apollographql/router/pull/1402

## 🛠 Maintenance

### Dependency updates [PR #1389](https://github.com/apollographql/router/issues/1389) [PR #1394](https://github.com/apollographql/router/issues/1394) [PR #1395](https://github.com/apollographql/router/issues/1395)

Dependency updates were blocked for some time due to incompatibilities:

- #1389: the router-bridge crate needed a new version of `deno_core` in its workspace that would not fix the version of `once_cell`. Now that it is done we can update `once_cell` in the router
- #1395: `clap` at version 3.2 changed the way values are extracted from matched arguments, which resulted in panics. This is now fixed and we can update `clap` in the router and related crates
- #1394: broader dependency updates now that everything is locked
- #1410: revert tracing update that caused two telemetry tests to fail (the router binary is not affected)

By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1389 https://github.com/apollographql/router/pull/1394 https://github.com/apollographql/router/pull/1395 and [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1410