### PR TITLE
CI: Upgrade the macOS image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ executors:
     resource_class: large
   rust_macos: &rust_macos_executor
     macos:
-      xcode: 11.4
+      xcode: 11.7
   rust_windows: &rust_windows_executor
     machine:
       image: "windows-server-2019-vs2019:stable"


### PR DESCRIPTION
The previous version is being removed by Circle-CI:

https://discuss.circleci.com/t/xcode-image-deprecation/44294
https://circleci.com/docs/testing-ios#supported-xcode-versions