### PR TITLE
Remove the generic stream type from RouterResponse and ExecutioNResponse

### DIFF
--- a/apollo-router-benchmarks/src/shared.rs
+++ b/apollo-router-benchmarks/src/shared.rs
@@ -10,7 +10,6 @@ use once_cell::sync::Lazy;
 use serde_json::json;
 use std::sync::Arc;
 use tower::{util::BoxCloneService, BoxError, Service, ServiceExt};
-use futures::stream::{BoxStream};
 
 static EXPECTED_RESPONSE: Lazy<Response> = Lazy::new(|| {
     serde_json::from_str(r#"{"data":{"topProducts":[{"upc":"1","name":"Table","reviews":[{"id":"1","product":{"name":"Table"},"author":{"id":"1","name":"Ada Lovelace"}},{"id":"4","product":{"name":"Table"},"author":{"id":"2","name":"Alan Turing"}}]},{"upc":"2","name":"Couch","reviews":[{"id":"2","product":{"name":"Couch"},"author":{"id":"1","name":"Ada Lovelace"}}]}]}}"#).unwrap()
@@ -19,7 +18,7 @@ static EXPECTED_RESPONSE: Lazy<Response> = Lazy::new(|| {
 static QUERY: &str = r#"query TopProducts($first: Int) { topProducts(first: $first) { upc name reviews { id product { name } author { id name } } } }"#;
 
 pub async fn basic_composition_benchmark(
-    mut router_service: BoxCloneService<RouterRequest, RouterResponse<BoxStream<'static,Response>>, BoxError>,
+    mut router_service: BoxCloneService<RouterRequest, RouterResponse, BoxError>,
 ) {
     let request = RouterRequest::fake_builder()
         .query(QUERY.to_string())

--- a/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
+++ b/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
@@ -1,12 +1,10 @@
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
 {{#if type_basic}}
-use apollo_router::graphql::Response;
 use apollo_router::services::{ExecutionRequest, ExecutionResponse};
 use apollo_router::services::{QueryPlannerRequest, QueryPlannerResponse};
 use apollo_router::services::{RouterRequest, RouterResponse};
 use apollo_router::services::{SubgraphRequest, SubgraphResponse};
-use futures::stream::BoxStream;
 {{/if}}
 {{#if type_auth}}
 use apollo_router::services::{RouterRequest, RouterResponse};
@@ -77,8 +75,8 @@ impl Plugin for {{pascal_name}} {
     // Delete this function if you are not customizing it.
     fn execution_service(
         &self,
-        service: BoxService<ExecutionRequest, ExecutionResponse<BoxStream<'static, Response>>, BoxError>,
-    ) -> BoxService<ExecutionRequest, ExecutionResponse<BoxStream<'static, Response>>, BoxError> {
+        service: BoxService<ExecutionRequest, ExecutionResponse, BoxError>,
+    ) -> BoxService<ExecutionRequest, ExecutionResponse, BoxError> {
         service
     }
 

--- a/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
+++ b/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
@@ -1,11 +1,12 @@
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
-use apollo_router::graphql::Response;
 {{#if type_basic}}
+use apollo_router::graphql::Response;
 use apollo_router::services::{ExecutionRequest, ExecutionResponse};
 use apollo_router::services::{QueryPlannerRequest, QueryPlannerResponse};
 use apollo_router::services::{RouterRequest, RouterResponse};
 use apollo_router::services::{SubgraphRequest, SubgraphResponse};
+use futures::stream::BoxStream;
 {{/if}}
 {{#if type_auth}}
 use apollo_router::services::{RouterRequest, RouterResponse};
@@ -20,7 +21,6 @@ use apollo_router::layers::ServiceBuilderExt;
 use tower::ServiceExt;
 use tower::ServiceBuilder;
 {{/if}}
-use futures::stream::BoxStream;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::util::BoxService;
@@ -53,8 +53,8 @@ impl Plugin for {{pascal_name}} {
     // Delete this function if you are not customizing it.
     fn router_service(
         &self,
-        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse, BoxError> {
         // Always use service builder to compose your plugins.
         // It provides off the shelf building blocks for your plugin.
         //
@@ -105,8 +105,8 @@ impl Plugin for {{pascal_name}} {
 
     fn router_service(
         &self,
-        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse, BoxError> {
 
         ServiceBuilder::new()
                     .checkpoint_async(|request : RouterRequest| async {
@@ -132,8 +132,8 @@ impl Plugin for {{pascal_name}} {
 
     fn router_service(
         &self,
-        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse, BoxError> {
 
         ServiceBuilder::new()
                     .instrument(|_request| {

--- a/apollo-router/src/layers/async_checkpoint.rs
+++ b/apollo-router/src/layers/async_checkpoint.rs
@@ -160,8 +160,7 @@ mod async_checkpoint_tests {
             .returning(move |_req: crate::ExecutionRequest| {
                 Ok(ExecutionResponse::fake_builder()
                     .label(expected_label.to_string())
-                    .build()
-                    .boxed())
+                    .build())
             });
 
         let service = execution_service.build();
@@ -198,8 +197,7 @@ mod async_checkpoint_tests {
             .returning(move |_req| {
                 Ok(ExecutionResponse::fake_builder()
                     .label(expected_label.to_string())
-                    .build()
-                    .boxed())
+                    .build())
             });
 
         let service = router_service.build();
@@ -234,8 +232,7 @@ mod async_checkpoint_tests {
             Ok(ControlFlow::Break(
                 ExecutionResponse::fake_builder()
                     .label("returned_before_mock_service".to_string())
-                    .build()
-                    .boxed(),
+                    .build(),
             ))
         })
         .layer(service);

--- a/apollo-router/src/layers/map_future_with_context.rs
+++ b/apollo-router/src/layers/map_future_with_context.rs
@@ -78,14 +78,12 @@ where
 
 #[cfg(test)]
 mod test {
-    use futures::stream::BoxStream;
     use http::HeaderValue;
     use tower::BoxError;
     use tower::Service;
     use tower::ServiceBuilder;
     use tower::ServiceExt;
 
-    use crate::graphql::Response;
     use crate::layers::ServiceBuilderExt;
     use crate::plugin::test::MockRouterService;
     use crate::RouterRequest;
@@ -97,7 +95,7 @@ mod test {
         mock_service
             .expect_call()
             .once()
-            .returning(|_| Ok(RouterResponse::fake_builder().build().unwrap().boxed()));
+            .returning(|_| Ok(RouterResponse::fake_builder().build().unwrap()));
 
         let mut service = ServiceBuilder::new()
             .map_future_with_context(
@@ -109,8 +107,7 @@ mod test {
                         .unwrap()
                 },
                 |ctx: HeaderValue, resp| async move {
-                    let resp: Result<RouterResponse<BoxStream<'static, Response>>, BoxError> =
-                        resp.await;
+                    let resp: Result<RouterResponse, BoxError> = resp.await;
                     resp.map(|mut response| {
                         response.response.headers_mut().insert("hello", ctx.clone());
                         response

--- a/apollo-router/src/layers/mod.rs
+++ b/apollo-router/src/layers/mod.rs
@@ -98,20 +98,18 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// ```rust
     /// # use std::ops::ControlFlow;
     /// # use http::Method;
-    /// # use futures::stream::BoxStream;
     /// # use tower::ServiceBuilder;
     /// # use tower_service::Service;
     /// # use tracing::info_span;
-    /// # use apollo_router::graphql::Response;
     /// # use apollo_router::services::{RouterRequest, RouterResponse};
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse<BoxStream<'static, Response>>, Box<dyn std::error::Error + Send + Sync>>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
+    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse, Box<dyn std::error::Error + Send + Sync>>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
     /// let _ = ServiceBuilder::new()
     ///             .checkpoint(|req:RouterRequest|{
     ///                if req.originating_request.method() == Method::GET {
     ///                  Ok(ControlFlow::Break(RouterResponse::builder()
     ///                      .data("Only get requests allowed")
-    ///                      .context(req.context).build().map(|r| r.boxed()))
+    ///                      .context(req.context).build())
     ///                    )
     ///                }
     ///                else {
@@ -161,20 +159,18 @@ pub trait ServiceBuilderExt<L>: Sized {
     /// # use std::ops::ControlFlow;
     /// use futures::FutureExt;
     /// # use http::Method;
-    /// # use futures::stream::BoxStream;
     /// # use tower::ServiceBuilder;
     /// # use tower_service::Service;
     /// # use tracing::info_span;
-    /// # use apollo_router::graphql::Response;
     /// # use apollo_router::services::{RouterRequest, RouterResponse};
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse<BoxStream<'static, Response>>, Box<dyn std::error::Error + Send + Sync>>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
+    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse, Box<dyn std::error::Error + Send + Sync>>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
     /// let _ = ServiceBuilder::new()
     ///             .checkpoint_async(|req:RouterRequest| async {
     ///                if req.originating_request.method() == Method::GET {
     ///                  Ok(ControlFlow::Break(RouterResponse::builder()
     ///                      .data("Only get requests allowed")
-    ///                      .context(req.context).build().map(|r| r.boxed()))
+    ///                      .context(req.context).build())
     ///                    )
     ///                }
     ///                else {
@@ -270,16 +266,14 @@ pub trait ServiceBuilderExt<L>: Sized {
     ///
     /// ```rust
     /// # use std::future::Future;
-    /// # use futures::stream::BoxStream;
     /// # use tower::{BoxError, ServiceBuilder, ServiceExt};
     /// # use tower::util::BoxService;
     /// # use tower_service::Service;
     /// # use tracing::info_span;
     /// # use apollo_router::Context;
-    /// # use apollo_router::graphql::Response;
     /// # use apollo_router::services::{RouterRequest, RouterResponse};
     /// # use apollo_router::layers::ServiceBuilderExt;
-    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse<BoxStream<'static, Response>>, BoxError>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
+    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse, BoxError>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
     /// let _ : BoxService<RouterRequest, S::Response, S::Error> = ServiceBuilder::new()
     ///             .map_future_with_context(|req: &RouterRequest| req.context.clone(), |ctx : Context, fut| async {
     ///                 fut.await
@@ -333,17 +327,15 @@ pub trait ServiceExt<Request>: Service<Request> {
     ///
     /// ```rust
     /// # use std::future::Future;
-    /// # use futures::stream::BoxStream;
     /// # use tower::{BoxError, ServiceBuilder, ServiceExt};
     /// # use tower::util::BoxService;
     /// # use tower_service::Service;
     /// # use tracing::info_span;
     /// # use apollo_router::Context;
-    /// # use apollo_router::graphql::Response;
     /// # use apollo_router::services::{RouterRequest, RouterResponse};
     /// # use apollo_router::layers::ServiceBuilderExt;
     /// # use apollo_router::layers::ServiceExt as ApolloServiceExt;
-    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse<BoxStream<'static, Response>>, BoxError>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
+    /// # fn test<S: Service<RouterRequest, Response = Result<RouterResponse, BoxError>> + 'static + Send>(service: S) where <S as Service<RouterRequest>>::Future: Send, <S as Service<RouterRequest>>::Error: Send + Sync + std::error::Error, <S as Service<RouterRequest>>::Response: Send {
     /// let _ : BoxService<RouterRequest, S::Response, S::Error> = service
     ///             .map_future_with_context(|req: &RouterRequest| req.context.clone(), |ctx : Context, fut| async {
     ///                 fut.await

--- a/apollo-router/src/layers/sync_checkpoint.rs
+++ b/apollo-router/src/layers/sync_checkpoint.rs
@@ -188,8 +188,7 @@ mod checkpoint_tests {
             .returning(move |_req: crate::ExecutionRequest| {
                 Ok(ExecutionResponse::fake_builder()
                     .label(expected_label.to_string())
-                    .build()
-                    .boxed())
+                    .build())
             });
 
         let service = execution_service.build();
@@ -224,8 +223,7 @@ mod checkpoint_tests {
             .returning(move |_req| {
                 Ok(ExecutionResponse::fake_builder()
                     .label(expected_label.to_string())
-                    .build()
-                    .boxed())
+                    .build())
             });
 
         let service = router_service.build();
@@ -259,8 +257,7 @@ mod checkpoint_tests {
             Ok(ControlFlow::Break(
                 ExecutionResponse::fake_builder()
                     .label("returned_before_mock_service".to_string())
-                    .build()
-                    .boxed(),
+                    .build(),
             ))
         })
         .layer(service);

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -121,8 +121,8 @@ pub trait Plugin: Send + Sync + 'static + Sized {
     /// For example, this is a good opportunity to perform JWT verification before allowing a request to proceed further.
     fn router_service(
         &self,
-        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse, BoxError> {
         service
     }
 
@@ -193,8 +193,8 @@ pub trait DynPlugin: Send + Sync + 'static {
     /// For example, this is a good opportunity to perform JWT verification before allowing a request to proceed further.
     fn router_service(
         &self,
-        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>;
+        service: BoxService<RouterRequest, RouterResponse, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse, BoxError>;
 
     /// This service handles generating the query plan for each incoming request.
     /// Define `query_planning_service` if your customization needs to interact with query planning functionality (for example, to log query plan details).
@@ -244,8 +244,8 @@ where
 
     fn router_service(
         &self,
-        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse, BoxError> {
         self.router_service(service)
     }
 

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -27,7 +27,6 @@ use ::serde::Deserialize;
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::future::BoxFuture;
-use futures::stream::BoxStream;
 use once_cell::sync::Lazy;
 use schemars::gen::SchemaGenerator;
 use schemars::JsonSchema;
@@ -38,7 +37,6 @@ use tower::BoxError;
 use tower::Service;
 use tower::ServiceBuilder;
 
-use crate::graphql::Response;
 use crate::http_ext;
 use crate::layers::ServiceBuilderExt;
 use crate::ExecutionRequest;
@@ -139,13 +137,8 @@ pub trait Plugin: Send + Sync + 'static + Sized {
     /// Define `execution_service` if your customization includes logic to govern execution (for example, if you want to block a particular query based on a policy decision).
     fn execution_service(
         &self,
-        service: BoxService<
-            ExecutionRequest,
-            ExecutionResponse<BoxStream<'static, Response>>,
-            BoxError,
-        >,
-    ) -> BoxService<ExecutionRequest, ExecutionResponse<BoxStream<'static, Response>>, BoxError>
-    {
+        service: BoxService<ExecutionRequest, ExecutionResponse, BoxError>,
+    ) -> BoxService<ExecutionRequest, ExecutionResponse, BoxError> {
         service
     }
 
@@ -207,12 +200,8 @@ pub trait DynPlugin: Send + Sync + 'static {
     /// Define `execution_service` if your customization includes logic to govern execution (for example, if you want to block a particular query based on a policy decision).
     fn execution_service(
         &self,
-        service: BoxService<
-            ExecutionRequest,
-            ExecutionResponse<BoxStream<'static, Response>>,
-            BoxError,
-        >,
-    ) -> BoxService<ExecutionRequest, ExecutionResponse<BoxStream<'static, Response>>, BoxError>;
+        service: BoxService<ExecutionRequest, ExecutionResponse, BoxError>,
+    ) -> BoxService<ExecutionRequest, ExecutionResponse, BoxError>;
 
     /// This service handles communication between the Apollo Router and your subgraphs.
     /// Define `subgraph_service` to configure this communication (for example, to dynamically add headers to pass to a subgraph).
@@ -258,13 +247,8 @@ where
 
     fn execution_service(
         &self,
-        service: BoxService<
-            ExecutionRequest,
-            ExecutionResponse<BoxStream<'static, Response>>,
-            BoxError,
-        >,
-    ) -> BoxService<ExecutionRequest, ExecutionResponse<BoxStream<'static, Response>>, BoxError>
-    {
+        service: BoxService<ExecutionRequest, ExecutionResponse, BoxError>,
+    ) -> BoxService<ExecutionRequest, ExecutionResponse, BoxError> {
         self.execution_service(service)
     }
 

--- a/apollo-router/src/plugin/test/mod.rs
+++ b/apollo-router/src/plugin/test/mod.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use futures::stream::BoxStream;
 use indexmap::IndexMap;
 pub use mock::subgraph::MockSubgraph;
 pub use service::MockExecutionService;
@@ -22,7 +21,6 @@ use tower::ServiceBuilder;
 use tower::ServiceExt;
 
 use super::DynPlugin;
-use crate::graphql::Response;
 use crate::introspection::Introspection;
 use crate::layers::DEFAULT_BUFFER_SIZE;
 use crate::plugin::Plugin;
@@ -40,8 +38,7 @@ use crate::RouterService;
 use crate::Schema;
 
 pub struct PluginTestHarness {
-    router_service:
-        BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
+    router_service: BoxService<RouterRequest, RouterResponse, BoxError>,
 }
 pub enum IntoSchema {
     String(String),
@@ -188,17 +185,12 @@ impl PluginTestHarness {
     }
 
     /// Call the test harness with a request. Not that you will need to have set up appropriate responses via mocks.
-    pub async fn call(
-        &mut self,
-        request: RouterRequest,
-    ) -> Result<RouterResponse<BoxStream<'static, Response>>, BoxError> {
+    pub async fn call(&mut self, request: RouterRequest) -> Result<RouterResponse, BoxError> {
         self.router_service.ready().await?.call(request).await
     }
 
     /// If using the canned schema this canned request will give a response.
-    pub async fn call_canned(
-        &mut self,
-    ) -> Result<RouterResponse<BoxStream<'static, Response>>, BoxError> {
+    pub async fn call_canned(&mut self) -> Result<RouterResponse, BoxError> {
         self.router_service
             .ready()
             .await?

--- a/apollo-router/src/plugin/test/service.rs
+++ b/apollo-router/src/plugin/test/service.rs
@@ -44,11 +44,7 @@ macro_rules! mock_service {
     };
 }
 
-mock_service!(
-    Router,
-    RouterRequest,
-    RouterResponse<BoxStream<'static, Response>>
-);
+mock_service!(Router, RouterRequest, RouterResponse);
 mock_service!(QueryPlanning, QueryPlannerRequest, QueryPlannerResponse);
 mock_service!(
     Execution,

--- a/apollo-router/src/plugin/test/service.rs
+++ b/apollo-router/src/plugin/test/service.rs
@@ -1,6 +1,3 @@
-use futures::stream::BoxStream;
-
-use crate::graphql::Response;
 use crate::ExecutionRequest;
 use crate::ExecutionResponse;
 use crate::QueryPlannerRequest;
@@ -46,9 +43,5 @@ macro_rules! mock_service {
 
 mock_service!(Router, RouterRequest, RouterResponse);
 mock_service!(QueryPlanning, QueryPlannerRequest, QueryPlannerResponse);
-mock_service!(
-    Execution,
-    ExecutionRequest,
-    ExecutionResponse<BoxStream<'static, Response>>
-);
+mock_service!(Execution, ExecutionRequest, ExecutionResponse);
 mock_service!(Subgraph, SubgraphRequest, SubgraphResponse);

--- a/apollo-router/src/plugins/csrf.rs
+++ b/apollo-router/src/plugins/csrf.rs
@@ -1,6 +1,5 @@
 use std::ops::ControlFlow;
 
-use futures::stream::BoxStream;
 use http::header;
 use http::HeaderMap;
 use http::StatusCode;
@@ -11,7 +10,6 @@ use tower::BoxError;
 use tower::ServiceBuilder;
 use tower::ServiceExt;
 
-use crate::graphql::Response;
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::Plugin;
 use crate::register_plugin;
@@ -100,8 +98,8 @@ impl Plugin for Csrf {
 
     fn router_service(
         &self,
-        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse, BoxError> {
         if !self.config.unsafe_disabled {
             let required_headers = self.config.required_headers.clone();
             ServiceBuilder::new()
@@ -124,7 +122,7 @@ impl Plugin for Csrf {
                             .status_code(StatusCode::BAD_REQUEST)
                             .context(req.context)
                             .build()?;
-                        Ok(ControlFlow::Break(res.boxed()))
+                        Ok(ControlFlow::Break(res))
                     }
                 })
                 .service(service)
@@ -303,8 +301,7 @@ mod csrf_tests {
             Ok(RouterResponse::fake_builder()
                 .data(json!({ "test": 1234_u32 }))
                 .build()
-                .unwrap()
-                .boxed())
+                .unwrap())
         });
 
         let mock = mock_service.build();

--- a/apollo-router/src/plugins/include_subgraph_errors.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors.rs
@@ -88,7 +88,6 @@ mod test {
     use std::sync::Arc;
 
     use bytes::Bytes;
-    use futures::stream::BoxStream;
     use serde_json::Value as jValue;
     use serde_json_bytes::ByteString;
     use serde_json_bytes::Value;
@@ -133,11 +132,7 @@ mod test {
     async fn execute_router_test(
         query: &str,
         body: &Response,
-        mut router_service: BoxCloneService<
-            RouterRequest,
-            RouterResponse<BoxStream<'static, Response>>,
-            BoxError,
-        >,
+        mut router_service: BoxCloneService<RouterRequest, RouterResponse, BoxError>,
     ) {
         let request = RouterRequest::fake_builder()
             .query(query.to_string())
@@ -160,8 +155,7 @@ mod test {
 
     async fn build_mock_router(
         plugin: Box<dyn DynPlugin>,
-    ) -> BoxCloneService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>
-    {
+    ) -> BoxCloneService<RouterRequest, RouterResponse, BoxError> {
         let mut extensions = Object::new();
         extensions.insert("test", Value::String(ByteString::from("value")));
 

--- a/apollo-router/src/plugins/telemetry/metrics/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/mod.rs
@@ -7,7 +7,6 @@ use access_json::JSONQuery;
 use bytes::Bytes;
 use futures::future::ready;
 use futures::stream::once;
-use futures::stream::BoxStream;
 use futures::StreamExt;
 use http::header::HeaderName;
 use http::HeaderMap;
@@ -25,7 +24,6 @@ use tower::util::BoxService;
 use tower::BoxError;
 
 use crate::graphql::Request;
-use crate::graphql::Response;
 use crate::http_ext;
 use crate::plugin::serde::deserialize_header_name;
 use crate::plugin::serde::deserialize_json_query;
@@ -197,11 +195,8 @@ impl Forward {
 impl AttributesForwardConf {
     pub(crate) async fn get_attributes_from_router_response(
         &self,
-        response: RouterResponse<BoxStream<'static, Response>>,
-    ) -> (
-        RouterResponse<BoxStream<'static, Response>>,
-        HashMap<String, String>,
-    ) {
+        response: RouterResponse,
+    ) -> (RouterResponse, HashMap<String, String>) {
         let mut attributes = HashMap::new();
 
         // Fill from static

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -13,7 +13,6 @@ use apollo_spaceport::server::ReportSpaceport;
 use apollo_spaceport::StatsContext;
 use bytes::Bytes;
 use futures::future::BoxFuture;
-use futures::stream::BoxStream;
 use futures::FutureExt;
 use futures::StreamExt;
 use http::HeaderValue;
@@ -41,7 +40,6 @@ use url::Url;
 use self::config::Conf;
 use self::metrics::AttributesForwardConf;
 use self::metrics::MetricsAttributesConf;
-use crate::graphql::Response;
 use crate::http_ext;
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::Handler;
@@ -349,13 +347,8 @@ impl Plugin for Telemetry {
 
     fn execution_service(
         &self,
-        service: BoxService<
-            ExecutionRequest,
-            ExecutionResponse<BoxStream<'static, Response>>,
-            BoxError,
-        >,
-    ) -> BoxService<ExecutionRequest, ExecutionResponse<BoxStream<'static, Response>>, BoxError>
-    {
+        service: BoxService<ExecutionRequest, ExecutionResponse, BoxError>,
+    ) -> BoxService<ExecutionRequest, ExecutionResponse, BoxError> {
         ServiceBuilder::new()
             .instrument(move |_| info_span!("execution", "otel.kind" = %SpanKind::Internal))
             .service(service)

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -144,7 +144,6 @@ register_plugin!("apollo", "traffic_shaping", TrafficShaping);
 mod test {
     use std::sync::Arc;
 
-    use futures::stream::BoxStream;
     use once_cell::sync::Lazy;
     use serde_json_bytes::ByteString;
     use serde_json_bytes::Value;
@@ -170,11 +169,7 @@ mod test {
     async fn execute_router_test(
         query: &str,
         body: &Response,
-        mut router_service: BoxCloneService<
-            RouterRequest,
-            RouterResponse<BoxStream<'static, Response>>,
-            BoxError,
-        >,
+        mut router_service: BoxCloneService<RouterRequest, RouterResponse, BoxError>,
     ) {
         let request = RouterRequest::fake_builder()
             .query(query.to_string())
@@ -197,8 +192,7 @@ mod test {
 
     async fn build_mock_router_with_variable_dedup_optimization(
         plugin: Box<dyn DynPlugin>,
-    ) -> BoxCloneService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>
-    {
+    ) -> BoxCloneService<RouterRequest, RouterResponse, BoxError> {
         let mut extensions = Object::new();
         extensions.insert("test", Value::String(ByteString::from("value")));
 

--- a/apollo-router/src/services/execution_service.rs
+++ b/apollo-router/src/services/execution_service.rs
@@ -46,7 +46,7 @@ impl<SF> Service<ExecutionRequest> for ExecutionService<SF>
 where
     SF: SubgraphServiceFactory,
 {
-    type Response = ExecutionResponse<BoxStream<'static, Response>>;
+    type Response = ExecutionResponse;
     type Error = BoxError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
@@ -98,7 +98,7 @@ pub(crate) trait ExecutionServiceFactory:
 {
     type ExecutionService: Service<
             ExecutionRequest,
-            Response = ExecutionResponse<BoxStream<'static, Response>>,
+            Response = ExecutionResponse,
             Error = BoxError,
             Future = Self::Future,
         > + Send;
@@ -116,8 +116,7 @@ impl<SF> NewService<ExecutionRequest> for ExecutionCreator<SF>
 where
     SF: SubgraphServiceFactory,
 {
-    type Service =
-        BoxService<ExecutionRequest, ExecutionResponse<BoxStream<'static, Response>>, BoxError>;
+    type Service = BoxService<ExecutionRequest, ExecutionResponse, BoxError>;
 
     fn new_service(&self) -> Self::Service {
         ServiceBuilder::new()
@@ -137,8 +136,7 @@ where
 }
 
 impl<SF: SubgraphServiceFactory> ExecutionServiceFactory for ExecutionCreator<SF> {
-    type ExecutionService =
-        BoxService<ExecutionRequest, ExecutionResponse<BoxStream<'static, Response>>, BoxError>;
+    type ExecutionService = BoxService<ExecutionRequest, ExecutionResponse, BoxError>;
     type Future = <<ExecutionCreator<SF> as NewService<ExecutionRequest>>::Service as Service<
         ExecutionRequest,
     >>::Future;

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -88,7 +88,7 @@ where
     QueryPlannerService::Future: Send + 'static,
     ExecutionFactory: ExecutionServiceFactory,
 {
-    type Response = RouterResponse<BoxStream<'static, Response>>;
+    type Response = RouterResponse;
     type Error = BoxError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
@@ -125,30 +125,30 @@ where
                 .await?;
 
             match content {
-                QueryPlannerContent::Introspection { response } => {
-                    return Ok(
-                        RouterResponse::new_from_graphql_response(*response, context).boxed(),
-                    );
-                }
+                QueryPlannerContent::Introspection { response } => Ok(
+                    RouterResponse::new_from_graphql_response(*response, context),
+                ),
                 QueryPlannerContent::IntrospectionDisabled => {
-                    let mut resp = http::Response::new(once(ready(
-                        graphql::Response::builder()
-                            .errors(vec![crate::error::Error::builder()
-                                .message(String::from("introspection has been disabled"))
-                                .build()])
-                            .build(),
-                    )));
+                    let mut resp = http::Response::new(
+                        once(ready(
+                            graphql::Response::builder()
+                                .errors(vec![crate::error::Error::builder()
+                                    .message(String::from("introspection has been disabled"))
+                                    .build()])
+                                .build(),
+                        ))
+                        .boxed(),
+                    );
                     *resp.status_mut() = StatusCode::BAD_REQUEST;
 
-                    return Ok(RouterResponse {
+                    Ok(RouterResponse {
                         response: resp.into(),
                         context,
-                    }
-                    .boxed());
+                    })
                 }
                 QueryPlannerContent::Plan { query, plan } => {
                     if let Some(err) = query.validate_variables(body, &schema).err() {
-                        Ok(RouterResponse::new_from_graphql_response(err, context).boxed())
+                        Ok(RouterResponse::new_from_graphql_response(err, context))
                     } else {
                         let operation_name = body.operation_name.clone();
 
@@ -179,11 +179,11 @@ where
                                         });
                                         response
                                     })
-                                    .in_current_span(),
+                                    .in_current_span()
+                                    .boxed(),
                             )
                             .into(),
-                        }
-                        .boxed())
+                        })
                     }
                 }
             }
@@ -211,8 +211,7 @@ where
                 .status_code(status_code)
                 .context(context_cloned)
                 .build()
-                .expect("building a response like this should not fail")
-                .boxed())
+                .expect("building a response like this should not fail"))
         });
 
         Box::pin(fut)
@@ -394,9 +393,9 @@ impl RouterCreator {
         &self,
     ) -> impl Service<
         RouterRequest,
-        Response = RouterResponse<BoxStream<'static, Response>>,
+        Response = RouterResponse,
         Error = BoxError,
-        Future = BoxFuture<'static, Result<RouterResponse<BoxStream<'static, Response>>, BoxError>>,
+        Future = BoxFuture<'static, Result<RouterResponse, BoxError>>,
     > + Send {
         ServiceBuilder::new()
             .layer(self.apq.clone())
@@ -421,11 +420,7 @@ impl RouterCreator {
 
     pub fn test_service(
         &self,
-    ) -> tower::util::BoxCloneService<
-        RouterRequest,
-        RouterResponse<BoxStream<'static, Response>>,
-        BoxError,
-    > {
+    ) -> tower::util::BoxCloneService<RouterRequest, RouterResponse, BoxError> {
         Buffer::new(self.make(), 512).boxed_clone()
     }
 }

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -25,7 +25,6 @@ use apollo_router::services::SubgraphRequest;
 use apollo_router::services::SubgraphService;
 use apollo_router::Context;
 use apollo_router::Schema;
-use futures::stream::BoxStream;
 use http::Method;
 use maplit::hashmap;
 use serde_json::to_string_pretty;
@@ -622,7 +621,7 @@ async fn query_rust(
 }
 
 async fn setup_router_and_registry() -> (
-    BoxCloneService<RouterRequest, RouterResponse<BoxStream<'static, graphql::Response>>, BoxError>,
+    BoxCloneService<RouterRequest, RouterResponse, BoxError>,
     CountingServiceRegistry,
 ) {
     let schema: Arc<Schema> =
@@ -661,11 +660,7 @@ async fn setup_router_and_registry() -> (
 }
 
 async fn query_with_router(
-    router: BoxCloneService<
-        RouterRequest,
-        RouterResponse<BoxStream<'static, graphql::Response>>,
-        BoxError,
-    >,
+    router: BoxCloneService<RouterRequest, RouterResponse, BoxError>,
     request: RouterRequest,
 ) -> graphql::Response {
     router

--- a/examples/add-timestamp-header/src/main.rs
+++ b/examples/add-timestamp-header/src/main.rs
@@ -38,8 +38,7 @@ mod tests {
                     .context(req.context)
                     .data(expected_mock_response_data)
                     .build()
-                    .unwrap()
-                    .boxed())
+                    .unwrap())
             });
 
         // The mock has been set up, we can now build a service from it

--- a/examples/context/src/context_data.rs
+++ b/examples/context/src/context_data.rs
@@ -1,11 +1,9 @@
-use apollo_router::graphql;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
 use apollo_router::services::RouterRequest;
 use apollo_router::services::RouterResponse;
 use apollo_router::services::SubgraphRequest;
 use apollo_router::services::SubgraphResponse;
-use futures::stream::BoxStream;
 use http::StatusCode;
 use tower::util::BoxService;
 use tower::BoxError;
@@ -47,13 +45,8 @@ impl Plugin for ContextData {
 
     fn router_service(
         &self,
-        service: BoxService<
-            RouterRequest,
-            RouterResponse<BoxStream<'static, graphql::Response>>,
-            BoxError,
-        >,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, graphql::Response>>, BoxError>
-    {
+        service: BoxService<RouterRequest, RouterResponse, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse, BoxError> {
         // `ServiceBuilder` provides us with `map_request` and `map_response` methods.
         //
         // These allow basic interception and transformation of request and response messages.

--- a/examples/hello-world/src/hello_world.rs
+++ b/examples/hello-world/src/hello_world.rs
@@ -1,4 +1,3 @@
-use apollo_router::graphql::Response;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
 use apollo_router::services::ExecutionRequest;
@@ -9,7 +8,6 @@ use apollo_router::services::RouterRequest;
 use apollo_router::services::RouterResponse;
 use apollo_router::services::SubgraphRequest;
 use apollo_router::services::SubgraphResponse;
-use futures::stream::BoxStream;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::util::BoxService;
@@ -71,13 +69,8 @@ impl Plugin for HelloWorld {
 
     fn execution_service(
         &self,
-        service: BoxService<
-            ExecutionRequest,
-            ExecutionResponse<BoxStream<'static, Response>>,
-            BoxError,
-        >,
-    ) -> BoxService<ExecutionRequest, ExecutionResponse<BoxStream<'static, Response>>, BoxError>
-    {
+        service: BoxService<ExecutionRequest, ExecutionResponse, BoxError>,
+    ) -> BoxService<ExecutionRequest, ExecutionResponse, BoxError> {
         //This is the default implementation and does not modify the default service.
         // The trait also has this implementation, and we just provide it here for illustration.
         service

--- a/examples/hello-world/src/hello_world.rs
+++ b/examples/hello-world/src/hello_world.rs
@@ -40,8 +40,8 @@ impl Plugin for HelloWorld {
 
     fn router_service(
         &self,
-        service: BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError>,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, Response>>, BoxError> {
+        service: BoxService<RouterRequest, RouterResponse, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse, BoxError> {
         // Say hello when our service is added to the router_service
         // stage of the router plugin pipeline.
         #[cfg(test)]

--- a/examples/jwt-auth/src/jwt.rs
+++ b/examples/jwt-auth/src/jwt.rs
@@ -70,7 +70,6 @@ use apollo_router::register_plugin;
 use apollo_router::services::RouterRequest;
 use apollo_router::services::RouterResponse;
 use apollo_router::Context;
-use futures::stream::BoxStream;
 use http::header::AUTHORIZATION;
 use http::StatusCode;
 use jwt_simple::prelude::*;
@@ -212,13 +211,8 @@ impl Plugin for JwtAuth {
 
     fn router_service(
         &self,
-        service: BoxService<
-            RouterRequest,
-            RouterResponse<BoxStream<'static, graphql::Response>>,
-            BoxError,
-        >,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, graphql::Response>>, BoxError>
-    {
+        service: BoxService<RouterRequest, RouterResponse, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse, BoxError> {
         // We are going to use the `jwt-simple` crate for our JWT verification.
         // The crate provides straightforward support for the popular JWT algorithms.
 
@@ -243,7 +237,7 @@ impl Plugin for JwtAuth {
                     context: Context,
                     msg: String,
                     status: StatusCode,
-                ) -> Result<ControlFlow<RouterResponse<BoxStream<'static, graphql::Response>>, RouterRequest>, BoxError> {
+                ) -> Result<ControlFlow<RouterResponse, RouterRequest>, BoxError> {
                     let res = RouterResponse::error_builder()
                         .errors(vec![graphql::Error {
                             message: msg,
@@ -252,7 +246,7 @@ impl Plugin for JwtAuth {
                         .status_code(status)
                         .context(context)
                         .build()?;
-                    Ok(ControlFlow::Break(res.boxed()))
+                    Ok(ControlFlow::Break(res))
                 }
 
                 // The http_request is stored in a `RouterRequest` context.
@@ -584,8 +578,7 @@ mod tests {
                 Ok(RouterResponse::fake_builder()
                     .data(expected_mock_response_data)
                     .build()
-                    .expect("expecting valid request")
-                    .boxed())
+                    .expect("expecting valid request"))
             });
 
         // The mock has been set up, we can now build a service from it

--- a/examples/op-name-to-header/src/main.rs
+++ b/examples/op-name-to-header/src/main.rs
@@ -44,8 +44,7 @@ mod tests {
                 Ok(RouterResponse::fake_builder()
                     .data(expected_mock_response_data)
                     .build()
-                    .unwrap()
-                    .boxed())
+                    .unwrap())
             });
 
         // The mock has been set up, we can now build a service from it

--- a/examples/rhai-logging/src/main.rs
+++ b/examples/rhai-logging/src/main.rs
@@ -37,8 +37,7 @@ mod tests {
                 Ok(RouterResponse::fake_builder()
                     .data(expected_mock_response_data)
                     .build()
-                    .unwrap()
-                    .boxed())
+                    .unwrap())
             });
 
         // The mock has been set up, we can now build a service from it

--- a/examples/status-code-propagation/src/propagate_status_code.rs
+++ b/examples/status-code-propagation/src/propagate_status_code.rs
@@ -1,11 +1,9 @@
-use apollo_router::graphql;
 use apollo_router::plugin::Plugin;
 use apollo_router::register_plugin;
 use apollo_router::services::RouterRequest;
 use apollo_router::services::RouterResponse;
 use apollo_router::services::SubgraphRequest;
 use apollo_router::services::SubgraphResponse;
-use futures::stream::BoxStream;
 use http::StatusCode;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -71,13 +69,8 @@ impl Plugin for PropagateStatusCode {
     // At this point, all subgraph_services will have pushed their status codes if they match the `watch list`.
     fn router_service(
         &self,
-        service: BoxService<
-            RouterRequest,
-            RouterResponse<BoxStream<'static, graphql::Response>>,
-            BoxError,
-        >,
-    ) -> BoxService<RouterRequest, RouterResponse<BoxStream<'static, graphql::Response>>, BoxError>
-    {
+        service: BoxService<RouterRequest, RouterResponse, BoxError>,
+    ) -> BoxService<RouterRequest, RouterResponse, BoxError> {
         service
             .map_response(move |mut res| {
                 if let Some(code) = res
@@ -226,8 +219,7 @@ mod tests {
                 Ok(RouterResponse::fake_builder()
                     .context(context)
                     .build()
-                    .unwrap()
-                    .boxed())
+                    .unwrap())
             });
 
         let mock_service = mock_service.build();
@@ -267,8 +259,7 @@ mod tests {
                 Ok(RouterResponse::fake_builder()
                     .context(context)
                     .build()
-                    .unwrap()
-                    .boxed())
+                    .unwrap())
             });
 
         let mock_service = mock_service.build();


### PR DESCRIPTION
Fix #1220

This generic type complicates the API with limited benefit because we use BoxStream everywhere in plugins
