### PR TITLE
small optimizations

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -45,6 +45,16 @@ In Rhai plugins, accessors that mutate the originating request are not available
 
 By @SimonSapin
 
+### Optimizations ([PR #1423](https://github.com/apollographql/router/pull/1423)
+
+* do not clone the client request during query plan execution
+* do not clone the usage reporting
+* avoid path allocations when iterating over JSON values
+
+The benchmarks show that this PR gives a 23% gain in requests per second compared to main
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1423
+
 ## 🛠 Maintenance
 
 ## 📚 Documentation

--- a/apollo-router/src/context.rs
+++ b/apollo-router/src/context.rs
@@ -82,9 +82,7 @@ impl Context {
 
     /// Insert a value int the context using the provided key and value.
     ///
-    /// Semantics:
-    ///  - If the operation fails, then the pair has not been inserted.
-    ///  - If the operation succeeds, the result is the old value as an [`Option`].
+    /// Semantics: the result is the old value as an [`Option`].
     pub fn insert_json_value<K>(&self, key: K, value: Value) -> Option<Value>
     where
         K: Into<String>,

--- a/apollo-router/src/context.rs
+++ b/apollo-router/src/context.rs
@@ -80,7 +80,7 @@ impl Context {
         }
     }
 
-    /// Insert a value int the context using the provided key and value.
+    /// Insert a value in the context using the provided key and value.
     ///
     /// Semantics: the result is the old value as an [`Option`].
     pub fn insert_json_value<K>(&self, key: K, value: Value) -> Option<Value>
@@ -90,7 +90,7 @@ impl Context {
         self.entries.insert(key.into(), value)
     }
 
-    /// Upsert a value int the context using the provided key and resolving
+    /// Upsert a value in the context using the provided key and resolving
     /// function.
     ///
     /// The resolving function must yield a value to be used in the context. It

--- a/apollo-router/src/context.rs
+++ b/apollo-router/src/context.rs
@@ -80,6 +80,18 @@ impl Context {
         }
     }
 
+    /// Insert a value int the context using the provided key and value.
+    ///
+    /// Semantics:
+    ///  - If the operation fails, then the pair has not been inserted.
+    ///  - If the operation succeeds, the result is the old value as an [`Option`].
+    pub fn insert_json_value<K>(&self, key: K, value: Value) -> Option<Value>
+    where
+        K: Into<String>,
+    {
+        self.entries.insert(key.into(), value)
+    }
+
     /// Upsert a value int the context using the provided key and resolving
     /// function.
     ///

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -278,7 +278,6 @@ impl PlanNode {
 }
 
 pub(crate) mod fetch {
-    use std::collections::HashMap;
     use std::fmt::Display;
     use std::sync::Arc;
 
@@ -583,7 +582,7 @@ pub(crate) mod fetch {
                                     // when we do not deduplicate, there will be only one user of the
                                     // entity, so we should not clone the entity
                                     if let Some(path) = path_list.last() {
-                                        value.insert(&path, entity)?;
+                                        value.insert(path, entity)?;
                                     }
                                 }
                             }

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -103,7 +103,7 @@ impl QueryPlan {
         &self,
         context: &'a Context,
         service_factory: &'a Arc<SF>,
-        originating_request: http_ext::Request<Request>,
+        originating_request: &'a Arc<http_ext::Request<Request>>,
         schema: &'a Schema,
 
         _sender: futures::channel::mpsc::Sender<Response>,
@@ -144,7 +144,7 @@ impl PlanNode {
         context: &'a Context,
         service_factory: &'a Arc<SF>,
         schema: &'a Schema,
-        originating_request: http_ext::Request<Request>,
+        originating_request: &'a Arc<http_ext::Request<Request>>,
         parent_value: &'a Value,
         options: &'a QueryPlanOptions,
     ) -> future::BoxFuture<(Value, Vec<Error>)>
@@ -168,7 +168,7 @@ impl PlanNode {
                                 context,
                                 service_factory,
                                 schema,
-                                originating_request.clone(),
+                                originating_request,
                                 &value,
                                 options,
                             )
@@ -192,7 +192,7 @@ impl PlanNode {
                                 context,
                                 service_factory,
                                 schema,
-                                originating_request.clone(),
+                                originating_request,
                                 parent_value,
                                 options,
                             )
@@ -362,7 +362,7 @@ pub(crate) mod fetch {
             variable_usages: &[String],
             data: &Value,
             current_dir: &Path,
-            request: http_ext::Request<Request>,
+            request: &Arc<http_ext::Request<Request>>,
             schema: &Schema,
             enable_variable_deduplication: bool,
         ) -> Option<Variables> {
@@ -444,7 +444,7 @@ pub(crate) mod fetch {
             current_dir: &'a Path,
             context: &'a Context,
             service_factory: &'a Arc<SF>,
-            originating_request: http_ext::Request<Request>,
+            originating_request: &'a Arc<http_ext::Request<Request>>,
             schema: &'a Schema,
             options: &QueryPlanOptions,
         ) -> Result<(Value, Vec<Error>), FetchError>
@@ -465,7 +465,7 @@ pub(crate) mod fetch {
                 data,
                 current_dir,
                 // Needs the original request here
-                originating_request.clone(),
+                originating_request,
                 schema,
                 options.enable_variable_deduplication,
             )
@@ -478,7 +478,7 @@ pub(crate) mod fetch {
             };
 
             let subgraph_request = SubgraphRequest::builder()
-                .originating_request(Arc::new(originating_request))
+                .originating_request(originating_request.clone())
                 .subgraph_request(
                     http_ext::Request::builder()
                         .method(http::Method::POST)
@@ -736,11 +736,13 @@ mod tests {
             .execute(
                 &Context::new(),
                 &sf,
-                http_ext::Request::fake_builder()
-                    .headers(Default::default())
-                    .body(Default::default())
-                    .build()
-                    .expect("fake builds should always work; qed"),
+                &Arc::new(
+                    http_ext::Request::fake_builder()
+                        .headers(Default::default())
+                        .body(Default::default())
+                        .build()
+                        .expect("fake builds should always work; qed"),
+                ),
                 &Schema::from_str(test_schema!()).unwrap(),
                 sender,
             )
@@ -795,11 +797,13 @@ mod tests {
             .execute(
                 &Context::new(),
                 &sf,
-                http_ext::Request::fake_builder()
-                    .headers(Default::default())
-                    .body(Default::default())
-                    .build()
-                    .expect("fake builds should always work; qed"),
+                &Arc::new(
+                    http_ext::Request::fake_builder()
+                        .headers(Default::default())
+                        .body(Default::default())
+                        .build()
+                        .expect("fake builds should always work; qed"),
+                ),
                 &Schema::from_str(test_schema!()).unwrap(),
                 sender,
             )
@@ -848,11 +852,13 @@ mod tests {
             .execute(
                 &Context::new(),
                 &sf,
-                http_ext::Request::fake_builder()
-                    .headers(Default::default())
-                    .body(Default::default())
-                    .build()
-                    .expect("fake builds should always work; qed"),
+                &Arc::new(
+                    http_ext::Request::fake_builder()
+                        .headers(Default::default())
+                        .body(Default::default())
+                        .build()
+                        .expect("fake builds should always work; qed"),
+                ),
                 &Schema::from_str(test_schema!()).unwrap(),
                 sender,
             )

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -384,10 +384,10 @@ pub(crate) mod fetch {
                                 match values.get_index_of(&value) {
                                     Some(index) => {
                                         // paths and values should have the same number of elements
-                                        paths[index].push(path);
+                                        paths[index].push(path.clone());
                                     }
                                     None => {
-                                        paths.push(vec![path]);
+                                        paths.push(vec![path.clone()]);
                                         values.insert(value);
                                     }
                                 }
@@ -405,7 +405,7 @@ pub(crate) mod fetch {
                     data.select_values_and_paths(current_dir, |path, value| {
                         if let Value::Object(content) = value {
                             if let Ok(Some(value)) = select_object(content, requires, schema) {
-                                paths.push(vec![path]);
+                                paths.push(vec![path.clone()]);
                                 values.push(value);
                             }
                         }

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -352,7 +352,7 @@ pub(crate) mod fetch {
 
     struct Variables {
         variables: Object,
-        paths: HashMap<Path, usize>,
+        paths: HashMap<usize, Vec<Path>>,
     }
 
     impl Variables {
@@ -376,7 +376,7 @@ pub(crate) mod fetch {
                         .map(|(variable_key, value)| (variable_key.clone(), value.clone()))
                 }));
 
-                let mut paths: HashMap<Path, usize> = HashMap::new();
+                let mut paths: HashMap<usize, Vec<Path>> = HashMap::new();
                 let (paths, representations) = if enable_variable_deduplication {
                     let mut values: IndexSet<Value> = IndexSet::new();
                     data.select_values_and_paths(current_dir, |path, value| {
@@ -384,10 +384,10 @@ pub(crate) mod fetch {
                             if let Ok(Some(value)) = select_object(content, requires, schema) {
                                 match values.get_index_of(&value) {
                                     Some(index) => {
-                                        paths.insert(path, index);
+                                        paths.entry(index).or_default().push(path);
                                     }
                                     None => {
-                                        paths.insert(path, values.len());
+                                        paths.entry(values.len()).or_default().push(path);
                                         values.insert(value);
                                     }
                                 }
@@ -405,7 +405,7 @@ pub(crate) mod fetch {
                     data.select_values_and_paths(current_dir, |path, value| {
                         if let Value::Object(content) = value {
                             if let Ok(Some(value)) = select_object(content, requires, schema) {
-                                paths.insert(path, values.len());
+                                paths.entry(values.len()).or_default().push(path);
                                 values.push(value);
                             }
                         }
@@ -561,7 +561,7 @@ pub(crate) mod fetch {
         fn response_at_path<'a>(
             &'a self,
             current_dir: &'a Path,
-            paths: HashMap<Path, usize>,
+            paths: HashMap<usize, Vec<Path>>,
             data: Value,
         ) -> Result<Value, FetchError> {
             if !self.requires.is_empty() {
@@ -573,18 +573,20 @@ pub(crate) mod fetch {
 
                         if let Value::Array(array) = entities {
                             let mut value = Value::default();
-                            for (path, entity_idx) in paths {
-                                value.insert(
-                                    &path,
-                                    array
-                                        .get(entity_idx)
-                                        .ok_or_else(|| FetchError::ExecutionInvalidContent {
-                                            reason: "Received invalid content for key `_entities`!"
-                                                .to_string(),
-                                        })?
-                                        .clone(),
-                                )?;
+                            for (index, entity) in array.into_iter().enumerate() {
+                                if let Some(path_list) = paths.get(&index) {
+                                    for path in &path_list[..path_list.len() - 1] {
+                                        value.insert(path, entity.clone())?;
+                                    }
+
+                                    // when we do not deduplicate, there will be only one user of the
+                                    // entity, so we should not clone the entity
+                                    if let Some(path) = path_list.last() {
+                                        value.insert(&path, entity)?;
+                                    }
+                                }
                             }
+
                             return Ok(value);
                         } else {
                             return Err(FetchError::ExecutionInvalidContent {

--- a/apollo-router/src/services/execution_service.rs
+++ b/apollo-router/src/services/execution_service.rs
@@ -73,7 +73,7 @@ where
                 .execute(
                     &context,
                     &this.subgraph_creator,
-                    req.originating_request.clone(),
+                    &Arc::new(req.originating_request),
                     &this.schema,
                     sender,
                 )


### PR DESCRIPTION
* do not clone the client request during query plan execution (~19% perf improvement)
* do not clone the usage reporting (2-6% perf improvement)
* avoid path allocations when iterating over JSON values (1-3% perf improvement)

The benchmarks show that this PR gives a 23% gain in requests per second compared to main

I tried another possible optimization linked to variable deduplication: we always clone the entity returned by the subgraph, even when deduplication is not active. Unfortunately removing the clone slows down the router :thinking: (I'm pretty sure there's a way to get a perf gain there, maybe someone else will find it!)