### PR TITLE
fix: update scaffold to use 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-scaffold"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "cargo-scaffold",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -39,6 +39,12 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 
 ## 🐛 Fixes
 
+### Update the scaffold template so it targets router v0.12.0 ([#PR1431](https://github.com/apollographql/router/pull/1431))
+
+The cargo scaffold template will target the latest version of the router.
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1248
+
 ### **A Rhai error instead of a Rust panic** ([PR #1414 https://github.com/apollographql/router/pull/1414)
 
 In Rhai plugins, accessors that mutate the originating request are not available when in the subgraph phase. Previously trying to mutate anyway would cause a Rust panic. This has been changed to a Rhai error instead.

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-scaffold"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -22,7 +22,7 @@ apollo-router = { path ="{{integration_test}}apollo-router" }
 apollo-router = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
 # Note if you update these dependencies then also update xtask/Cargo.toml
-apollo-router = { git="https://github.com/apollographql/router.git", tag="v0.11.0" }
+apollo-router = { git="https://github.com/apollographql/router.git", tag="v0.12.0" }
 {{/if}}
 {{/if}}
 async-trait = "0.1.52"


### PR DESCRIPTION
I've made a mistake in the 0.12.0 release and forgot to update the scaffold template correctly.

This commit fixes it