### PR TITLE
Future-proof installer script and re-introduce target triplets

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -66,6 +66,16 @@ These items have been removed from the public API of `apollo_router::services::e
 
 By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/1568
 
+### Insert the full target triplet in the package name [PR #1393](https://github.com/apollographql/router/pull/1393)
+
+The released package names will now contain the full target triplet in their name:
+
+* `router-0.12.1-x86_64-linux.tar.gz` -> `router-0.12.1-x86_64-unknown-linux-gnu.tar.gz`
+* `router-0.12.1-x86_64-macos.tar.gz` -> `router-0.12.1-x86_64-apple-darwin.tar.gz`
+* `router-0.12.1-x86_64-windows.tar.gz` -> `router-0.12.1-x86_64-pc-windows-msvc.tar.gz`
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1393
+
 ## 🚀 Features
 
 ### instrument the rhai plugin with a tracing span ([PR #1598](https://github.com/apollographql/router/pull/1598))

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -66,15 +66,15 @@ These items have been removed from the public API of `apollo_router::services::e
 
 By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/1568
 
-### Insert the full target triplet in the package name [PR #1393](https://github.com/apollographql/router/pull/1393)
+### Insert the full target triplet in the package name, and prefix with `v` ([Issue #1385](https://github.com/apollographql/router/issues/1385))
 
-The released package names will now contain the full target triplet in their name:
+The release tarballs now contain the full target triplet in their name along with a `v` prefix to be consistent with our other packaging techniques (e.g., Rover):
 
-* `router-0.12.1-x86_64-linux.tar.gz` -> `router-0.12.1-x86_64-unknown-linux-gnu.tar.gz`
-* `router-0.12.1-x86_64-macos.tar.gz` -> `router-0.12.1-x86_64-apple-darwin.tar.gz`
-* `router-0.12.1-x86_64-windows.tar.gz` -> `router-0.12.1-x86_64-pc-windows-msvc.tar.gz`
+* `router-0.16.0-x86_64-linux.tar.gz` -> `router-v0.16.0-x86_64-unknown-linux-gnu.tar.gz`
+* `router-0.16.0-x86_64-macos.tar.gz` -> `router-v0.16.0-x86_64-apple-darwin.tar.gz`
+* `router-0.16.0-x86_64-windows.tar.gz` -> `router-v0.16.0-x86_64-pc-windows-msvc.tar.gz`
 
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1393
+By [@abernix](https://github.com/abernix) and [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1433 (which re-lands work done in https://github.com/apollographql/router/pull/1393)
 
 ## 🚀 Features
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -34,23 +34,23 @@ in lieu of an official changelog.
 3. Update the `version` in `*/Cargo.toml` (do not forget the ones in scaffold templates).
    - Be certain to also update the ones in the `scaffold` templates
 4. Update the `PACKAGE_VERSION` value in `scripts/install.sh` (it should be prefixed with `v`!)
-4. Update `docker.mdx` and `kubernetes.mdx` with the release version.
-5. Update `helm/chart/router/Chart.yaml` and in `helm/chart/router/README.md` as follows:
+5. Update `docker.mdx` and `kubernetes.mdx` with the release version.
+6. Update `helm/chart/router/Chart.yaml` and in `helm/chart/router/README.md` as follows:
    - increment the version. e.g. `version: 0.1.2` becomes `version: 0.1.3`
    - update the appVersion to the release version. e.g.: `appVersion: "v0.9.0"`
-6. cd helm/chart && helm-docs router; cd - (if required, install [helm-docs](https://github.com/norwoodj/helm-docs))
-7. Update `federation-version-support.mdx` with the latest version info. Use https://github.com/apollographql/version_matrix to generate the version matrix.
-8. Update the `version` in `docker-compose*` files in the `dockerfiles` directory.
-9. Update the license list with `cargo about generate --workspace -o licenses.html about.hbs`.
+7. cd helm/chart && helm-docs router; cd - (if required, install [helm-docs](https://github.com/norwoodj/helm-docs))
+8. Update `federation-version-support.mdx` with the latest version info. Use https://github.com/apollographql/version_matrix to generate the version matrix.
+9. Update the `version` in `docker-compose*` files in the `dockerfiles` directory.
+10. Update the license list with `cargo about generate --workspace -o licenses.html about.hbs`.
     You can install `cargo-about` by running `cargo install cargo-about`.
-10. Add a new section in `CHANGELOG.md` with the contents of `NEXT_CHANGELOG.md`
-11. Put a Release date and the version number on the new `CHANGELOG.md` section
-12. Update the version in `NEXT_CHANGELOG.md`.
-13. Clear `NEXT_CHANGELOG.md` leaving only the template.
-14. Run `cargo check` so the lock file gets updated.
-15. Run `cargo xtask check-compliance`.
-16. Push up a commit with all the changes. The commit message should be "release: v#.#.#" or "release: v#.#.#-rc.#"
-17. Request review from the Router team.
+11. Add a new section in `CHANGELOG.md` with the contents of `NEXT_CHANGELOG.md`
+12. Put a Release date and the version number on the new `CHANGELOG.md` section
+13. Update the version in `NEXT_CHANGELOG.md`.
+14. Clear `NEXT_CHANGELOG.md` leaving only the template.
+15. Run `cargo check` so the lock file gets updated.
+16. Run `cargo xtask check-compliance`.
+17. Push up a commit with all the changes. The commit message should be "release: v#.#.#" or "release: v#.#.#-rc.#"
+18. Request review from the Router team.
 
 ### Review
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -33,6 +33,7 @@ in lieu of an official changelog.
     (release) or "#.#.#-rc.#" (release candidate)
 3. Update the `version` in `*/Cargo.toml` (do not forget the ones in scaffold templates).
    - Be certain to also update the ones in the `scaffold` templates
+4. Update the `PACKAGE_VERSION` value in `scripts/install.sh` (it should be prefixed with `v`!)
 4. Update `docker.mdx` and `kubernetes.mdx` with the release version.
 5. Update `helm/chart/router/Chart.yaml` and in `helm/chart/router/README.md` as follows:
    - increment the version. e.g. `version: 0.1.2` becomes `version: 0.1.3`

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -5,7 +5,7 @@ FROM --platform=linux/amd64 alpine:latest AS build
 ARG ROUTER_RELEASE
 
 # Pull release from GH
-ADD https://github.com/apollographql/router/releases/download/v${ROUTER_RELEASE}/router-${ROUTER_RELEASE}-x86_64-linux.tar.gz /tmp/router.tar.gz
+ADD https://github.com/apollographql/router/releases/download/v${ROUTER_RELEASE}/router-${ROUTER_RELEASE}-x86_64-unknown-linux-gnu.tar.gz /tmp/router.tar.gz
 
 WORKDIR /tmp
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -77,7 +77,7 @@ download_binary() {
 
     # Download asset file.
     say "Downloading router from $_url"
-    
+
     curl -sSfL -H 'Accept: application/octet-stream' "$_url" -o "$_file"
     if [ $? != 0 ]; then
       say "Failed to download $_url"
@@ -137,15 +137,15 @@ get_architecture() {
 
     case "$_ostype" in
         Linux)
-            _ostype=linux
+            _ostype=unknown-linux-gnu
             ;;
 
         Darwin)
-            _ostype=macos
+            _ostype=apple-darwin
             ;;
 
         MINGW* | MSYS* | CYGWIN*)
-            _ostype=windows
+            _ostype=pc-windows-msvc
             ;;
 
         *)

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -1,7 +1,9 @@
 #[cfg(target_os = "macos")]
 mod macos;
 
+use std::fmt;
 use std::path::Path;
+use std::str::FromStr;
 
 use anyhow::ensure;
 use anyhow::Context;
@@ -11,6 +13,16 @@ use structopt::StructOpt;
 use xtask::*;
 
 const INCLUDE: &[&str] = &["README.md", "LICENSE", "licenses.html"];
+pub(crate) const TARGET_X86_64_MUSL_LINUX: &str = "x86_64-unknown-linux-musl";
+pub(crate) const TARGET_X86_64_GNU_LINUX: &str = "x86_64-unknown-linux-gnu";
+pub(crate) const TARGET_X86_64_WINDOWS: &str = "x86_64-pc-windows-msvc";
+pub(crate) const TARGET_X86_64_MACOS: &str = "x86_64-apple-darwin";
+pub(crate) const POSSIBLE_TARGETS: [&str; 4] = [
+    TARGET_X86_64_MUSL_LINUX,
+    TARGET_X86_64_GNU_LINUX,
+    TARGET_X86_64_WINDOWS,
+    TARGET_X86_64_MACOS,
+];
 
 #[derive(Debug, StructOpt)]
 pub struct Package {
@@ -21,6 +33,9 @@ pub struct Package {
     #[cfg(target_os = "macos")]
     #[structopt(flatten)]
     macos: macos::PackageMacos,
+
+    #[structopt(long, default_value, possible_values = &POSSIBLE_TARGETS)]
+    target: Target,
 }
 
 impl Package {
@@ -42,13 +57,8 @@ impl Package {
             }
             self.output.to_owned()
         } else if self.output.is_dir() {
-            self.output.join(format!(
-                "router-{}-{}-{}.tar.gz",
-                *PKG_VERSION,
-                // NOTE: same as xtask
-                std::env::consts::ARCH,
-                std::env::consts::OS,
-            ))
+            self.output
+                .join(format!("router-{}-{}.tar.gz", *PKG_VERSION, self.target))
         } else {
             self.output.to_owned()
         };
@@ -80,5 +90,65 @@ impl Package {
         ar.finish().context("could not finish TGZ archive")?;
 
         Ok(())
+    }
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub(crate) enum Target {
+    MuslLinux,
+    GnuLinux,
+    Windows,
+    MacOS,
+    Other,
+}
+
+impl Default for Target {
+    fn default() -> Self {
+        if cfg!(target_arch = "x86_64") {
+            if cfg!(target_os = "windows") {
+                Target::Windows
+            } else if cfg!(target_os = "linux") {
+                if cfg!(target_env = "gnu") {
+                    Target::GnuLinux
+                } else if cfg!(target_env = "musl") {
+                    Target::MuslLinux
+                } else {
+                    Target::Other
+                }
+            } else if cfg!(target_os = "macos") {
+                Target::MacOS
+            } else {
+                Target::Other
+            }
+        } else {
+            Target::Other
+        }
+    }
+}
+
+impl FromStr for Target {
+    type Err = anyhow::Error;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input {
+            TARGET_X86_64_MUSL_LINUX => Ok(Self::MuslLinux),
+            TARGET_X86_64_GNU_LINUX => Ok(Self::GnuLinux),
+            TARGET_X86_64_WINDOWS => Ok(Self::Windows),
+            TARGET_X86_64_MACOS => Ok(Self::MacOS),
+            _ => Ok(Self::Other),
+        }
+    }
+}
+
+impl fmt::Display for Target {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = match &self {
+            Target::MuslLinux => TARGET_X86_64_MUSL_LINUX,
+            Target::GnuLinux => TARGET_X86_64_GNU_LINUX,
+            Target::Windows => TARGET_X86_64_WINDOWS,
+            Target::MacOS => TARGET_X86_64_MACOS,
+            Target::Other => "unknown-target",
+        };
+        write!(f, "{}", msg)
     }
 }

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -58,7 +58,7 @@ impl Package {
             self.output.to_owned()
         } else if self.output.is_dir() {
             self.output
-                .join(format!("router-{}-{}.tar.gz", *PKG_VERSION, self.target))
+                .join(format!("router-v{}-{}.tar.gz", *PKG_VERSION, self.target))
         } else {
             self.output.to_owned()
         };


### PR DESCRIPTION
This is meant to reintroduce the [Target Triplet] pattern which was first introduced in https://github.com/apollographql/router/pull/1393 and the https://github.com/apollographql/router/pull/1405 follow-up, which were intentionally reverted prior to the 0.12.0 release because the existing installer script wouldn't correctly continue to pin the version in a way that wouldn't break existing users had we deployed that technique.  The reason that was challenging is that we hadn't fixed the underlying issue.

> This PR has meaningful individual commits that are worth reviewing.  The first two are literally cherry-picks from previous iterations, followed by other commits which solidify more durable behavior.  The previous installer should continue to work just fine, but as we're doing a major version bump, I suspect even if that doesn't work out we'll be okay for the long-term.

This also relates to (and still blocks) https://github.com/apollographql/router/pull/1397.

~There's some TODO items that we should account for before re-landing this, in particular, adopting the same pattern that Rover used which was more defensive in the way that it preserved the installation script within the Git tag of the release, making it possible for the Orbiter to reliably redirect a user to a immutable version of the install script that was current as of the time of the release.  (Rather than the method of today where the current release installer tries willingly to install any past release (which will fail after the target triplets change.)~

We originally cargo culted the Rover installer when making the Router installer exist, but a number of nuanced differences have emerged in it.  This updates the installer in a variety of ways to align with that and provide a more durable installer experience:

- The version of the installer is now embedded in the script itself as `PACKAGE_VERSION`.  This pushes the burden of determining what `latest` is to [Orbiter] (our AWS Lambda function which runs in Netlify).  It also allows the file that is in the commit that is in the Git release tag to be the installer that knows how to install that version best.

  In other words, this gives us freedom to make material changes to the way our installer process without relying on (the current) behavior which leaves every version's installer needing be able to install every version of the Router which is problematic in a variety of ways.  For example, if you want to change the filenames in the release (or the architecture negotiation), which brings me to my next point.

- We no longer use positional parameters to the install script to indicate the version we're going to solve.  The previous method wasn't durable for the reason listed above (and the reason we couldn't land what should have been a relatively simple change to the file formats of our release artifacts).   It is Orbiter's responsibility to point to the correct version of the installer for a particular version of the Router and pinning a version should be done via the Orbiter URL itself.  Behind the scenes that redirects to the Git tag of the release.  This also allows us to track our download counts through a centralized point.  See [this code](https://github.com/apollographql/orbiter/blob/2df4932628556a2c0d7823a6767993408d01aa40/src/functions/download-router/download-router.ts) for more details.

  The way to install the *latest* version of the Router — always — remains as it was:

  ```sh
  curl -sSL https://router.apollo.dev/download/nix/latest | sh
  ```

  The way to install a specific version of the Router also remains as it was:

   ```sh
   curl -sSL https://router.apollo.dev/download/nix/v0.15.1 | sh
   ```

- Introduces more specific filenames which use a standardized representation of the architecture - "target triples". Not only is this the pattern that we use on Rover which is meaningfully important for reducing cognitive overhead, but this it is also a more common representation in the general sense and necessary to support a full range of binaries.  Since Rover actually does the downloading, this also simplifies how it needs to think about our release artifacts, at least in the near term.  Also there is now a `v` in front of the version in the tarball name instead of being yet again subtly different than Rover.

- Adds support for `wget`, in addition to `curl` for downloading the release artifact from GitHub.  Containers often don't have either and sometimes just one or the other.  We literally have the code written already to negotiate between the two, so supporting both seems fine.  It's also just one less diff between the files.

- Adds a very necessary assertion that `mktemp` exists on the system.  Again, one less difference between what Rover does and Router and meaningful UX for installers.

[Target Triplet]: https://wiki.osdev.org/Target_Triplet

Fixes #1385 