### PR TITLE
introduce an argument type for query plan execution

### DIFF
--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -573,12 +573,12 @@ impl PlanNode {
                         let (v, _subselect, err) = node
                             .execute_recursively(
                                 &ExecutionParameters {
-                                    context: &parameters.context,
-                                    service_factory: &parameters.service_factory,
-                                    schema: &parameters.schema,
-                                    originating_request: &parameters.originating_request,
+                                    context: parameters.context,
+                                    service_factory: parameters.service_factory,
+                                    schema: parameters.schema,
+                                    originating_request: parameters.originating_request,
                                     deferred_fetches: &deferred_fetches,
-                                    options: &parameters.options,
+                                    options: parameters.options,
                                 },
                                 current_dir,
                                 &value,

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -1519,18 +1519,18 @@ mod tests {
 
         // primary response
         assert_eq!(
-            serde_json::to_string(&response).unwrap(),
-            r#"{"data":{"t":{"id":1234,"__typename":"T","x":"X"}}}"#
+            serde_json::to_value(&response).unwrap(),
+            serde_json::json! {{"data":{"t":{"id":1234,"__typename":"T","x":"X"}}}}
         );
 
         let response = receiver.next().await.unwrap();
 
         // deferred response
         assert_eq!(
-            serde_json::to_string(&response).unwrap(),
+            serde_json::to_value(&response).unwrap(),
             // the primary response appears there because the deferred response gets data from it
             // unneeded parts are removed in response formatting
-            r#"{"data":{"t":{"y":"Y","__typename":"T","id":1234,"x":"X"}},"path":["t"]}"#
+            serde_json::json! {{"data":{"t":{"y":"Y","__typename":"T","id":1234,"x":"X"}},"path":["t"]}}
         );
     }
 }

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -311,7 +311,6 @@ pub(crate) struct ExecutionParameters<'a, SF> {
 }
 
 impl PlanNode {
-    #[allow(clippy::too_many_arguments)]
     fn execute_recursively<'a, SF>(
         &'a self,
         parameters: &'a ExecutionParameters<'a, SF>,

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -571,7 +571,19 @@ impl PlanNode {
                     let span = tracing::info_span!("primary");
                     if let Some(node) = node {
                         let (v, _subselect, err) = node
-                            .execute_recursively(parameters, current_dir, &value, sender)
+                            .execute_recursively(
+                                &ExecutionParameters {
+                                    context: &parameters.context,
+                                    service_factory: &parameters.service_factory,
+                                    schema: &parameters.schema,
+                                    originating_request: &parameters.originating_request,
+                                    deferred_fetches: &deferred_fetches,
+                                    options: &parameters.options,
+                                },
+                                current_dir,
+                                &value,
+                                sender,
+                            )
                             .instrument(span.clone())
                             .in_current_span()
                             .await;


### PR DESCRIPTION
The execution is performed with recursive calls that share some
immutable arguments. To make the code easier to read, we assemble them
in a structure that can be passed unchanged