### PR TITLE
remove the HTTP request from QueryPlannerRequest

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -35,6 +35,13 @@ This generic type complicates the API with limited benefit because we use BoxStr
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1420
 
+### Remove the HTTP request from QueryPlannerRequest ([PR #1439](https://github.com/apollographql/router/pull/1439)
+
+The content of `QueryPlannerRequest` is used as argument to the query planner and as a cache key,
+so it should not change depending on the variables or HTTP headers.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1439
+
 ## 🚀 Features
 
 ### Experimental support for the `@defer` directive ([PR #1182](https://github.com/apollographql/router/pull/1182)

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -1358,7 +1358,31 @@ impl Rhai {
             })
             .register_fn("to_string", |x: &mut Uri| -> String { format!("{:?}", x) });
 
-        register_rhai_interface!(engine, router, query_planner, execution, subgraph);
+        register_rhai_interface!(engine, router, execution, subgraph);
+
+        engine
+            .register_get_result("context", |obj: &mut SharedMut<query_planner::Request>| {
+                Ok(obj.with_mut(|request| request.context.clone()))
+            })
+            .register_get_result("context", |obj: &mut SharedMut<query_planner::Response>| {
+                Ok(obj.with_mut(|response| response.context.clone()))
+            });
+
+        engine
+            .register_set_result(
+                "context",
+                |obj: &mut SharedMut<query_planner::Request>, context: Context| {
+                    obj.with_mut(|request| request.context = context);
+                    Ok(())
+                },
+            )
+            .register_set_result(
+                "context",
+                |obj: &mut SharedMut<query_planner::Response>, context: Context| {
+                    obj.with_mut(|response| response.context = context);
+                    Ok(())
+                },
+            );
 
         engine
     }

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -148,13 +148,10 @@ impl Service<QueryPlannerRequest> for BridgeQueryPlanner {
     fn call(&mut self, req: QueryPlannerRequest) -> Self::Future {
         let this = self.clone();
         let fut = async move {
-            let body = req.originating_request.body();
             match this
                 .get((
-                    body.query.clone().expect(
-                        "presence of a query has been checked by the RouterService before; qed",
-                    ),
-                    body.operation_name.to_owned(),
+                    req.query.clone(),
+                    req.operation_name.to_owned(),
                     req.query_plan_options,
                 ))
                 .await

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -91,13 +91,9 @@ where
     }
 
     fn call(&mut self, request: QueryPlannerRequest) -> Self::Future {
-        let body = request.originating_request.body();
-
         let key = (
-            body.query
-                .clone()
-                .expect("presence of a query has been checked by the RouterService before; qed"),
-            body.operation_name.to_owned(),
+            request.query.clone(),
+            request.operation_name.to_owned(),
             request.query_plan_options,
         );
         let qp = self.clone();

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -284,8 +284,8 @@ assert_impl_all!(QueryPlannerRequest: Send);
 /// [`Context`] and [`QueryPlanOptions`] for the request.
 #[derive(Clone, Debug)]
 pub struct QueryPlannerRequest {
-    /// Original request to the Router.
-    pub originating_request: http_ext::Request<Request>,
+    pub query: String,
+    pub operation_name: Option<String>,
     /// Query plan options
     pub query_plan_options: QueryPlanOptions,
 
@@ -299,12 +299,14 @@ impl QueryPlannerRequest {
     /// Required parameters are required in non-testing code to create a QueryPlannerRequest.
     #[builder]
     pub fn new(
-        originating_request: http_ext::Request<Request>,
+        query: String,
+        operation_name: Option<String>,
         query_plan_options: QueryPlanOptions,
         context: Context,
     ) -> QueryPlannerRequest {
         Self {
-            originating_request,
+            query,
+            operation_name,
             query_plan_options,
             context,
         }

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -118,7 +118,12 @@ where
             let QueryPlannerResponse { content, context } = planning
                 .call(
                     QueryPlannerRequest::builder()
-                        .originating_request(req.originating_request.clone())
+                        .query(
+                            body.query
+                                .clone()
+                                .expect("the query presence was already checked by a plugin"),
+                        )
+                        .and_operation_name(body.operation_name.clone())
                         .query_plan_options(QueryPlanOptions::default())
                         .context(context)
                         .build(),


### PR DESCRIPTION
the query planner only uses the query, operation name and query plan
options, so the QueryPlannerRequest should only provide those fields
along with the context