### PR TITLE
feat(telemetry): add error section in custom attributes configuration

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -45,6 +45,28 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 
 ## 🚀 Features
 
+### Add support of error section in telemetry to add custom attributes ([PR #1443](https://github.com/apollographql/router/pull/1443))
+
+The telemetry is now able to hook at the error stage if router or a subgraph is returning an error. Here is an example of configuration:
+
+```yaml
+telemetry:
+  metrics:
+    prometheus:
+      enabled: true
+    common:
+      attributes:
+        subgraph:
+          all:
+            errors: # Only works if it's a valid GraphQL error
+              include_messages: true # Will include the error message in a message attribute
+              extensions: # Include extension data
+                - name: subgraph_error_extended_type # Name of the attribute
+                  path: .type # JSON query path to fetch data from extensions
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1443
+
 ### Experimental support for the `@defer` directive ([PR #1182](https://github.com/apollographql/router/pull/1182))
 
 The router can now understand the `@defer` directive, used to tag parts of a query so the response is split into

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -472,7 +472,7 @@ expression: "&schema"
                       "type": "object",
                       "properties": {
                         "context": {
-                          "description": "Configuration to forward values from the context custom attributes/labels in metrics",
+                          "description": "Configuration to forward values from the context to custom attributes/labels in metrics",
                           "type": "array",
                           "items": {
                             "description": "Configuration to forward context values in metric attributes/labels",
@@ -497,8 +497,47 @@ expression: "&schema"
                           },
                           "nullable": true
                         },
+                        "errors": {
+                          "description": "Configuration to forward values from the error to custom attributes/labels in metrics",
+                          "type": "object",
+                          "properties": {
+                            "extensions": {
+                              "description": "Forward extensions values as custom attributes/labels in metrics",
+                              "type": "array",
+                              "items": {
+                                "description": "Configuration to forward body values in metric attributes/labels",
+                                "type": "object",
+                                "required": [
+                                  "name",
+                                  "path"
+                                ],
+                                "properties": {
+                                  "default": {
+                                    "type": "string",
+                                    "nullable": true
+                                  },
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "path": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              },
+                              "nullable": true
+                            },
+                            "include_messages": {
+                              "description": "Will include the error message in a \"message\" attribute",
+                              "default": false,
+                              "type": "boolean"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "nullable": true
+                        },
                         "request": {
-                          "description": "Configuration to forward headers or body values from the request custom attributes/labels in metrics",
+                          "description": "Configuration to forward headers or body values from the request to custom attributes/labels in metrics",
                           "type": "object",
                           "properties": {
                             "body": {
@@ -576,7 +615,7 @@ expression: "&schema"
                           "nullable": true
                         },
                         "response": {
-                          "description": "Configuration to forward headers or body values from the response custom attributes/labels in metrics",
+                          "description": "Configuration to forward headers or body values from the response to custom attributes/labels in metrics",
                           "type": "object",
                           "properties": {
                             "body": {
@@ -687,7 +726,7 @@ expression: "&schema"
                           "type": "object",
                           "properties": {
                             "context": {
-                              "description": "Configuration to forward values from the context custom attributes/labels in metrics",
+                              "description": "Configuration to forward values from the context to custom attributes/labels in metrics",
                               "type": "array",
                               "items": {
                                 "description": "Configuration to forward context values in metric attributes/labels",
@@ -712,8 +751,47 @@ expression: "&schema"
                               },
                               "nullable": true
                             },
+                            "errors": {
+                              "description": "Configuration to forward values from the error to custom attributes/labels in metrics",
+                              "type": "object",
+                              "properties": {
+                                "extensions": {
+                                  "description": "Forward extensions values as custom attributes/labels in metrics",
+                                  "type": "array",
+                                  "items": {
+                                    "description": "Configuration to forward body values in metric attributes/labels",
+                                    "type": "object",
+                                    "required": [
+                                      "name",
+                                      "path"
+                                    ],
+                                    "properties": {
+                                      "default": {
+                                        "type": "string",
+                                        "nullable": true
+                                      },
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "path": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "additionalProperties": false
+                                  },
+                                  "nullable": true
+                                },
+                                "include_messages": {
+                                  "description": "Will include the error message in a \"message\" attribute",
+                                  "default": false,
+                                  "type": "boolean"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "nullable": true
+                            },
                             "request": {
-                              "description": "Configuration to forward headers or body values from the request custom attributes/labels in metrics",
+                              "description": "Configuration to forward headers or body values from the request to custom attributes/labels in metrics",
                               "type": "object",
                               "properties": {
                                 "body": {
@@ -791,7 +869,7 @@ expression: "&schema"
                               "nullable": true
                             },
                             "response": {
-                              "description": "Configuration to forward headers or body values from the response custom attributes/labels in metrics",
+                              "description": "Configuration to forward headers or body values from the response to custom attributes/labels in metrics",
                               "type": "object",
                               "properties": {
                                 "body": {
@@ -900,7 +978,7 @@ expression: "&schema"
                             "type": "object",
                             "properties": {
                               "context": {
-                                "description": "Configuration to forward values from the context custom attributes/labels in metrics",
+                                "description": "Configuration to forward values from the context to custom attributes/labels in metrics",
                                 "type": "array",
                                 "items": {
                                   "description": "Configuration to forward context values in metric attributes/labels",
@@ -925,8 +1003,47 @@ expression: "&schema"
                                 },
                                 "nullable": true
                               },
+                              "errors": {
+                                "description": "Configuration to forward values from the error to custom attributes/labels in metrics",
+                                "type": "object",
+                                "properties": {
+                                  "extensions": {
+                                    "description": "Forward extensions values as custom attributes/labels in metrics",
+                                    "type": "array",
+                                    "items": {
+                                      "description": "Configuration to forward body values in metric attributes/labels",
+                                      "type": "object",
+                                      "required": [
+                                        "name",
+                                        "path"
+                                      ],
+                                      "properties": {
+                                        "default": {
+                                          "type": "string",
+                                          "nullable": true
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "path": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "additionalProperties": false
+                                    },
+                                    "nullable": true
+                                  },
+                                  "include_messages": {
+                                    "description": "Will include the error message in a \"message\" attribute",
+                                    "default": false,
+                                    "type": "boolean"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "nullable": true
+                              },
                               "request": {
-                                "description": "Configuration to forward headers or body values from the request custom attributes/labels in metrics",
+                                "description": "Configuration to forward headers or body values from the request to custom attributes/labels in metrics",
                                 "type": "object",
                                 "properties": {
                                   "body": {
@@ -1004,7 +1121,7 @@ expression: "&schema"
                                 "nullable": true
                               },
                               "response": {
-                                "description": "Configuration to forward headers or body values from the response custom attributes/labels in metrics",
+                                "description": "Configuration to forward headers or body values from the response to custom attributes/labels in metrics",
                                 "type": "object",
                                 "properties": {
                                   "body": {

--- a/apollo-router/src/plugins/telemetry/metrics/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/mod.rs
@@ -108,16 +108,6 @@ pub(crate) struct ErrorsForward {
 #[derive(Clone, JsonSchema, Deserialize, Debug)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 #[serde(untagged)]
-pub(crate) enum IncludeOrFilter {
-    /// Include or not
-    Include(bool),
-    /// Only include with this filter
-    Filter(String),
-}
-
-#[derive(Clone, JsonSchema, Deserialize, Debug)]
-#[serde(rename_all = "snake_case", deny_unknown_fields)]
-#[serde(untagged)]
 /// Configuration to forward header values in metric labels
 pub(crate) enum HeaderForward {
     /// Using a named header

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -285,7 +285,7 @@ impl Plugin for Telemetry {
                         result = Self::update_metrics(
                             config.clone(),
                             ctx.clone(),
-                            metrics,
+                            metrics.clone(),
                             result,
                             start.elapsed(),
                         )
@@ -300,6 +300,25 @@ impl Plugin for Telemetry {
                                         start.elapsed(),
                                     );
                                 }
+                                let mut metric_attrs = Vec::new();
+                                dbg!(&e);
+                                // Fill attributes from error
+                                if let Some(subgraph_attributes_conf) = config
+                                    .metrics
+                                    .as_ref()
+                                    .and_then(|m| m.common.as_ref())
+                                    .and_then(|c| c.attributes.as_ref())
+                                    .and_then(|c| c.router.as_ref())
+                                {
+                                    metric_attrs.extend(
+                                        subgraph_attributes_conf
+                                            .get_attributes_from_error(&e)
+                                            .into_iter()
+                                            .map(|(k, v)| KeyValue::new(k, v)),
+                                    );
+                                }
+
+                                metrics.http_requests_error_total.add(1, &metric_attrs);
 
                                 Err(e)
                             }
@@ -413,6 +432,7 @@ impl Plugin for Telemetry {
                     let context = extend_config!(context);
                     let request = merge_config!(request);
                     let response = merge_config!(response);
+                    let errors = merge_config!(errors);
 
                     AttributesForwardConf {
                         insert: (!insert.is_empty()).then(|| insert),
@@ -420,6 +440,8 @@ impl Plugin for Telemetry {
                             .then(|| request),
                         response: (response.header.is_some() || response.body.is_some())
                             .then(|| response),
+                        errors: (errors.extensions.is_some() || errors.include_messages)
+                            .then(|| errors),
                         context: (!context.is_empty()).then(|| context),
                     }
                 }),
@@ -508,7 +530,17 @@ impl Plugin for Telemetry {
 
                                 metrics.http_requests_total.add(1, &metric_attrs);
                             }
-                            Err(_) => {
+                            Err(err) => {
+                                // Fill attributes from error
+                                if let Some(subgraph_attributes_conf) = &*subgraph_metrics_conf {
+                                    metric_attrs.extend(
+                                        subgraph_attributes_conf
+                                            .get_attributes_from_error(err)
+                                            .into_iter()
+                                            .map(|(k, v)| KeyValue::new(k, v)),
+                                    );
+                                }
+
                                 metrics.http_requests_error_total.add(1, &metric_attrs);
                             }
                         }
@@ -917,6 +949,7 @@ mod tests {
     use tower::Service;
     use tower::ServiceExt;
 
+    use crate::error::FetchError;
     use crate::graphql::Error;
     use crate::graphql::Request;
     use crate::http_ext;
@@ -1094,7 +1127,7 @@ mod tests {
                 Ok(RouterResponse::fake_builder()
                     .context(req.context)
                     .header("x-custom", "coming_from_header")
-                    .data(json!({"data": {"my_value": 2}}))
+                    .data(json!({"data": {"my_value": 2usize}}))
                     .build()
                     .unwrap())
             });
@@ -1122,6 +1155,17 @@ mod tests {
                             .build(),
                     )
                     .build())
+            });
+
+        let mut mock_subgraph_service_in_error = MockSubgraphService::new();
+        mock_subgraph_service_in_error
+            .expect_call()
+            .times(1)
+            .returning(move |_req: SubgraphRequest| {
+                Err(Box::new(FetchError::SubrequestHttpError {
+                    service: String::from("my_subgraph_name_error"),
+                    reason: String::from("cannot contact the subgraph"),
+                }))
             });
 
         let dyn_plugin: Box<dyn DynPlugin> = crate::plugin::plugins()
@@ -1172,6 +1216,18 @@ mod tests {
                                 }
                             },
                             "subgraph": {
+                                "all": {
+                                    "errors": {
+                                        "include_messages": true,
+                                        "extensions": [{
+                                            "name": "subgraph_error_extended_type",
+                                            "path": ".type"
+                                        }, {
+                                            "name": "message",
+                                            "path": ".reason"
+                                        }]
+                                    }
+                                },
                                 "subgraphs": {
                                     "my_subgraph_name": {
                                         "request": {
@@ -1251,6 +1307,31 @@ mod tests {
             .call(subgraph_req)
             .await
             .unwrap();
+        // Another subgraph
+        let mut subgraph_service = dyn_plugin.subgraph_service(
+            "my_subgraph_name_error",
+            BoxService::new(mock_subgraph_service_in_error.build()),
+        );
+        let subgraph_req = SubgraphRequest::fake_builder()
+            .subgraph_request(
+                http_ext::Request::fake_builder()
+                    .header("test", "my_value_set")
+                    .body(
+                        Request::fake_builder()
+                            .query(String::from("query { test }"))
+                            .build(),
+                    )
+                    .build()
+                    .unwrap(),
+            )
+            .build();
+        let _subgraph_response = subgraph_service
+            .ready()
+            .await
+            .unwrap()
+            .call(subgraph_req)
+            .await
+            .expect_err("Must be in error");
 
         let handler = dyn_plugin.custom_endpoint().unwrap();
         let http_req_prom = http_ext::Request::fake_builder()
@@ -1275,6 +1356,7 @@ mod tests {
         let resp = handler.oneshot(http_req_prom).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
         let prom_metrics = String::from_utf8_lossy(resp.body());
+        assert!(prom_metrics.contains(r#"http_requests_error_total{message="cannot contact the subgraph",service_name="apollo-router",subgraph="my_subgraph_name_error",subgraph_error_extended_type="SubrequestHttpError"} 1"#));
         assert!(prom_metrics.contains(r#"http_requests_total{another_test="my_default_value",my_value="2",myname="label_value",renamed_value="my_value_set",service_name="apollo-router",status="200",x_custom="coming_from_header"} 1"#));
         assert!(prom_metrics.contains(r#"http_request_duration_seconds_count{another_test="my_default_value",my_value="2",myname="label_value",renamed_value="my_value_set",service_name="apollo-router",status="200",x_custom="coming_from_header"}"#));
         assert!(prom_metrics.contains(r#"http_request_duration_seconds_bucket{another_test="my_default_value",my_value="2",myname="label_value",renamed_value="my_value_set",service_name="apollo-router",status="200",x_custom="coming_from_header",le="0.001"}"#));

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -301,7 +301,6 @@ impl Plugin for Telemetry {
                                     );
                                 }
                                 let mut metric_attrs = Vec::new();
-                                dbg!(&e);
                                 // Fill attributes from error
                                 if let Some(subgraph_attributes_conf) = config
                                     .metrics

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -78,10 +78,10 @@ telemetry:
 
 You can add custom attributes (OpenTelemetry) and labels (Prometheus) to your generated metrics. You can apply these across _all_ requests, or you can selectively apply them based on the details of a particular request. These details include:
 
-* The presence of a particular HTTP header
-* The value at a particular JSON path within a request or response body (either from a subgraph or from the router itself)
-    * [See examples of querying a JSON path.](#example-json-path-queries)
-* A custom value provided via the router plugin context
+- The presence of a particular HTTP header
+- The value at a particular JSON path within a request or response body (either from a subgraph or from the router itself)
+  - [See examples of querying a JSON path.](#example-json-path-queries)
+- A custom value provided via the router plugin context
 
 Examples of all of these are shown in the file below:
 
@@ -114,6 +114,13 @@ telemetry:
               # Always apply this attribute to all metrics for all subgraphs
               - name: kind
                 value: subgraph_request
+            errors: # Only work if it's a valid GraphQL error (for example if the subgraph returns an http error or if the router can't reach the subgraph)
+              include_messages: true # Will include the error message in a message attribute
+              extensions: # Include extensions data
+                - name: subgraph_error_extended_type # Name of the attribute
+                  path: .type # JSON query path to fetch data from extensions
+                - name: message
+                  path: .reason
           subgraphs:
             my_subgraph_name: # Apply these rules only for the subgraph named `my_subgraph_name`
               request:

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -121,6 +121,7 @@ telemetry:
                   path: .type # JSON query path to fetch data from extensions
                 - name: message
                   path: .reason
+            # Will create this kind of metric for example http_requests_error_total{message="cannot contact the subgraph",service_name="apollo-router",subgraph="my_subgraph_name",subgraph_error_extended_type="SubrequestHttpError"}
           subgraphs:
             my_subgraph_name: # Apply these rules only for the subgraph named `my_subgraph_name`
               request:


### PR DESCRIPTION
close #1434 

Add the ability to add custom attributes on errors:

```yaml
telemetry:
  metrics:
    prometheus:
      enabled: true
    common:
      attributes:
        subgraph:
          all:
            errors: # Only works if it's a valid GraphQL error
              include_messages: true # Will include the error message in a message attribute
              extensions: # Include extension data
                - name: subgraph_error_extended_type # Name of the attribute
                  path: .type # JSON query path to fetch data from extensions
```