### PR TITLE
Configure Regex based CORS rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,9 +436,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16705af05732b7d3258ec0f7b73c03a658a28925e050d8852d5b568ee8bcf4e"
+checksum = "6b9496f0c1d1afb7a2af4338bbe1d969cddfead41d87a9fb3aaa6d0bbc7af648"
 dependencies = [
  "async-trait",
  "axum-core",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -59,13 +59,17 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 ### Configure Regex based CORS rules ([PR #1444](https://github.com/apollographql/router/pull/1444))
 
 The router now supports regex based CORS rules, as explained in the [docs](https://www.apollographql.com/docs/router/configuration/cors)
+It also supports the `allow_any_header` setting that will mirror client's requested headers.
 
 ```yaml title="router.yaml"
 server:
   cors:
     match_origins:
       - "https://([a-z0-9]+[.])*api[.]example[.]com" # any host that uses https and ends with .api.example.com
+    allow_any_header: true # mirror client's headers
 ```
+
+The default CORS headers configuration of the router allows `content-type`, `apollographql-client-version` and `apollographql-client-name`.
 
 By [@o0Ignition0o](https://github.com/o0ignition0o) in https://github.com/apollographql/router/pull/1444
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -45,6 +45,19 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 
 ## 🚀 Features
 
+### Configure Regex based CORS rules ([PR #1444](https://github.com/apollographql/router/pull/1444))
+
+The router now supports regex based CORS rules, as explained in the [docs](https://www.apollographql.com/docs/router/configuration/cors)
+
+```yaml title="router.yaml"
+server:
+  cors:
+    match_origins:
+      - "https://([a-z0-9]+[.])*api[.]example[.]com" # any host that uses https and ends with .api.example.com
+```
+
+By [@o0Ignition0o](https://github.com/o0ignition0o) in https://github.com/apollographql/router/pull/1444
+
 ### Experimental support for the `@defer` directive ([PR #1182](https://github.com/apollographql/router/pull/1182))
 
 The router can now understand the `@defer` directive, used to tag parts of a query so the response is split into

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -30,7 +30,7 @@ async-compression = { version = "0.3.14", features = [
 ] }
 async-trait = "0.1.56"
 atty = "0.2.14"
-axum = { version = "0.5.12", features = ["headers", "json", "original-uri"] }
+axum = { version = "0.5.13", features = ["headers", "json", "original-uri"] }
 backtrace = "0.3.66"
 buildstructor = "0.3.2"
 bytes = "1.1.0"

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -1589,7 +1589,16 @@ mod tests {
     #[tokio::test]
     async fn cors_preflight() -> Result<(), ApolloRouterError> {
         let expectations = MockRouterService::new();
-        let (server, client) = init(expectations).await;
+        let conf = Configuration::builder()
+            .server(
+                crate::configuration::Server::builder()
+                    .listen(SocketAddr::from_str("127.0.0.1:0").unwrap())
+                    .cors(Cors::builder().allow_any_headers(true).build())
+                    .endpoint(String::from("/graphql/*"))
+                    .build(),
+            )
+            .build();
+        let (server, client) = init_with_config(expectations, conf, HashMap::new()).await;
 
         let response = client
             .request(Method::OPTIONS, &format!("{}/", server.listen_address()))

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -1593,7 +1593,7 @@ mod tests {
             .server(
                 crate::configuration::Server::builder()
                     .listen(SocketAddr::from_str("127.0.0.1:0").unwrap())
-                    .cors(Cors::builder().allow_any_headers(true).build())
+                    .cors(Cors::builder().allow_any_header(true).build())
                     .endpoint(String::from("/graphql/*"))
                     .build(),
             )
@@ -2117,7 +2117,6 @@ Content-Type: application/json\r
     fn assert_cors_origin(response: reqwest::Response, origin: &str) {
         assert!(response.status().is_success());
         let headers = response.headers();
-        dbg!(headers);
         assert_headers_valid(&response);
         assert!(origin_valid(headers, origin));
     }

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -246,7 +246,7 @@ pub(crate) struct Server {
 
     /// Cross origin request headers.
     #[serde(default)]
-    pub(crate) cors: Option<Cors>,
+    pub(crate) cors: Cors,
 
     /// introspection queries
     /// enabled by default
@@ -288,7 +288,7 @@ impl Server {
     ) -> Self {
         Self {
             listen: listen.unwrap_or_else(default_listen),
-            cors,
+            cors: cors.unwrap_or_default(),
             introspection: introspection.unwrap_or_else(default_introspection),
             landing_page: landing_page.unwrap_or_else(default_landing_page),
             endpoint: endpoint.unwrap_or_else(default_endpoint),
@@ -529,6 +529,7 @@ impl Cors {
                 },
             )))
         } else {
+            dbg!("list", &self.origins);
             Ok(cors.allow_origin(cors::AllowOrigin::list(
                 self.origins.into_iter().filter_map(|origin| {
                     origin
@@ -1138,7 +1139,6 @@ server:
         let error = cfg
             .server
             .cors
-            .expect("should not have resulted in an error")
             .into_layer()
             .expect_err("should have resulted in an error");
         assert_eq!(error, "Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Headers: *`");
@@ -1158,7 +1158,6 @@ server:
         let error = cfg
             .server
             .cors
-            .expect("should not have resulted in an error")
             .into_layer()
             .expect_err("should have resulted in an error");
         assert_eq!(error, "Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Methods: *`");
@@ -1178,7 +1177,6 @@ server:
         let error = cfg
             .server
             .cors
-            .expect("should not have resulted in an error")
             .into_layer()
             .expect_err("should have resulted in an error");
         assert_eq!(error, "Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Origin: *`");

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -506,6 +506,7 @@ impl Cors {
             )));
 
         if self.allow_any_origin.unwrap_or_default() {
+            dbg!("allow any origin");
             Ok(cors.allow_origin(cors::Any))
         } else if let Some(match_origins) = self.match_origins {
             let regexes = match_origins

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -506,7 +506,6 @@ impl Cors {
             )));
 
         if self.allow_any_origin.unwrap_or_default() {
-            dbg!("allow any origin");
             Ok(cors.allow_origin(cors::Any))
         } else if let Some(match_origins) = self.match_origins {
             let regexes = match_origins

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -377,7 +377,7 @@ pub(crate) struct Cors {
     /// the `mirror_request` mode, which mirrors the received
     /// `access-control-request-headers` preflight has sent..
     #[serde(default)]
-    pub(crate) allow_any_headers: bool,
+    pub(crate) allow_any_header: bool,
 
     /// Which response headers should be made available to scripts running in the browser,
     /// in response to a cross-origin request.
@@ -404,7 +404,7 @@ impl Default for Cors {
     fn default() -> Self {
         Self {
             allow_any_origin: Default::default(),
-            allow_any_headers: Default::default(),
+            allow_any_header: Default::default(),
             allow_credentials: Default::default(),
             allow_headers: default_headers(),
             expose_headers: Default::default(),
@@ -464,7 +464,7 @@ impl Cors {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         allow_any_origin: Option<bool>,
-        allow_any_headers: Option<bool>,
+        allow_any_header: Option<bool>,
         allow_credentials: Option<bool>,
         allow_headers: Option<Vec<String>>,
         expose_headers: Option<Vec<String>>,
@@ -474,7 +474,7 @@ impl Cors {
     ) -> Self {
         Self {
             allow_any_origin: allow_any_origin.unwrap_or_default(),
-            allow_any_headers: allow_any_headers.unwrap_or_default(),
+            allow_any_header: allow_any_header.unwrap_or_default(),
             allow_credentials: allow_credentials.unwrap_or_default(),
             allow_headers: allow_headers.unwrap_or_else(default_headers),
             expose_headers,
@@ -491,7 +491,7 @@ impl Cors {
 
         self.ensure_usable_cors_rules()?;
 
-        let allow_headers = if self.allow_any_headers {
+        let allow_headers = if self.allow_any_header {
             cors::AllowHeaders::mirror_request()
         } else {
             cors::AllowHeaders::list(self.allow_headers.iter().filter_map(|header| {
@@ -1000,8 +1000,8 @@ mod tests {
             "Allow any origin should be disabled by default"
         );
         assert!(
-            !cors.allow_any_headers,
-            "Allow any headers should be disabled by default"
+            !cors.allow_any_header,
+            "Allow any header should be disabled by default"
         );
 
         assert_eq!(

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -320,7 +320,21 @@ expression: "&schema"
       "description": "Configuration options pertaining to the http server component.",
       "default": {
         "listen": "127.0.0.1:4000",
-        "cors": null,
+        "cors": {
+          "allow_any_origin": null,
+          "allow_credentials": null,
+          "allow_headers": null,
+          "expose_headers": null,
+          "origins": [
+            "https://studio.apollographql.com"
+          ],
+          "match_origins": null,
+          "methods": [
+            "GET",
+            "POST",
+            "OPTIONS"
+          ]
+        },
         "introspection": true,
         "landing_page": true,
         "endpoint": "/",
@@ -331,7 +345,21 @@ expression: "&schema"
       "properties": {
         "cors": {
           "description": "Cross origin request headers.",
-          "default": null,
+          "default": {
+            "allow_any_origin": null,
+            "allow_credentials": null,
+            "allow_headers": null,
+            "expose_headers": null,
+            "origins": [
+              "https://studio.apollographql.com"
+            ],
+            "match_origins": null,
+            "methods": [
+              "GET",
+              "POST",
+              "OPTIONS"
+            ]
+          },
           "type": "object",
           "properties": {
             "allow_any_origin": {
@@ -396,8 +424,7 @@ expression: "&schema"
               }
             }
           },
-          "additionalProperties": false,
-          "nullable": true
+          "additionalProperties": false
         },
         "endpoint": {
           "description": "GraphQL endpoint default: \"/\"",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -328,7 +328,7 @@ expression: "&schema"
             "apollographql-client-version",
             "apollographql-client-name"
           ],
-          "allow_any_headers": false,
+          "allow_any_header": false,
           "expose_headers": null,
           "origins": [
             "https://studio.apollographql.com"
@@ -358,7 +358,7 @@ expression: "&schema"
               "apollographql-client-version",
               "apollographql-client-name"
             ],
-            "allow_any_headers": false,
+            "allow_any_header": false,
             "expose_headers": null,
             "origins": [
               "https://studio.apollographql.com"
@@ -372,7 +372,7 @@ expression: "&schema"
           },
           "type": "object",
           "properties": {
-            "allow_any_headers": {
+            "allow_any_header": {
               "description": "Set to true to mirror headers sent by clients.\n\nIf this is not set, we will default to the `mirror_request` mode, which mirrors the received `access-control-request-headers` preflight has sent..",
               "default": false,
               "type": "boolean"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -321,9 +321,14 @@ expression: "&schema"
       "default": {
         "listen": "127.0.0.1:4000",
         "cors": {
-          "allow_any_origin": null,
-          "allow_credentials": null,
-          "allow_headers": null,
+          "allow_any_origin": false,
+          "allow_credentials": false,
+          "allow_headers": [
+            "content-type",
+            "apollographql-client-version",
+            "apollographql-client-name"
+          ],
+          "allow_any_headers": false,
           "expose_headers": null,
           "origins": [
             "https://studio.apollographql.com"
@@ -346,9 +351,14 @@ expression: "&schema"
         "cors": {
           "description": "Cross origin request headers.",
           "default": {
-            "allow_any_origin": null,
-            "allow_credentials": null,
-            "allow_headers": null,
+            "allow_any_origin": false,
+            "allow_credentials": false,
+            "allow_headers": [
+              "content-type",
+              "apollographql-client-version",
+              "apollographql-client-name"
+            ],
+            "allow_any_headers": false,
             "expose_headers": null,
             "origins": [
               "https://studio.apollographql.com"
@@ -362,26 +372,32 @@ expression: "&schema"
           },
           "type": "object",
           "properties": {
+            "allow_any_headers": {
+              "description": "Set to true to mirror headers sent by clients.\n\nIf this is not set, we will default to the `mirror_request` mode, which mirrors the received `access-control-request-headers` preflight has sent..",
+              "default": false,
+              "type": "boolean"
+            },
             "allow_any_origin": {
               "description": "Set to true to allow any origin.\n\nDefaults to false Having this set to true is the only way to allow Origin: null.",
-              "default": null,
-              "type": "boolean",
-              "nullable": true
+              "default": false,
+              "type": "boolean"
             },
             "allow_credentials": {
               "description": "Set to true to add the `Access-Control-Allow-Credentials` header.",
-              "default": null,
-              "type": "boolean",
-              "nullable": true
+              "default": false,
+              "type": "boolean"
             },
             "allow_headers": {
-              "description": "The headers to allow. If this is not set, we will default to the `mirror_request` mode, which mirrors the received `access-control-request-headers` preflight has sent.\n\nNote that if you set headers here, you also want to have a look at your `CSRF` plugins configuration, and make sure you either: - accept `x-apollo-operation-name` AND / OR `apollo-require-preflight` - defined `csrf` required headers in your yml configuration, as shown in the `examples/cors-and-csrf/custom-headers.router.yaml` files.",
-              "default": null,
+              "description": "The headers to allow.\n\nDefaults to `default_headers`.\n\nNote that if you set headers here, you also want to have a look at your `CSRF` plugins configuration, and make sure you either: - accept `x-apollo-operation-name` AND / OR `apollo-require-preflight` - defined `csrf` required headers in your yml configuration, as shown in the `examples/cors-and-csrf/custom-headers.router.yaml` files.",
+              "default": [
+                "content-type",
+                "apollographql-client-version",
+                "apollographql-client-name"
+              ],
               "type": "array",
               "items": {
                 "type": "string"
-              },
-              "nullable": true
+              }
             },
             "expose_headers": {
               "description": "Which response headers should be made available to scripts running in the browser, in response to a cross-origin request.",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,5 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 848
 expression: "&schema"
 ---
 {
@@ -358,6 +357,15 @@ expression: "&schema"
             },
             "expose_headers": {
               "description": "Which response headers should be made available to scripts running in the browser, in response to a cross-origin request.",
+              "default": null,
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "nullable": true
+            },
+            "match_origins": {
+              "description": "`Regex`es you want to match the origins against to determine if they're allowed. Defaults to an empty list. Note that `origins` will be evaluated before `match_origins`",
               "default": null,
               "type": "array",
               "items": {

--- a/docs/source/configuration/cors.mdx
+++ b/docs/source/configuration/cors.mdx
@@ -38,7 +38,7 @@ server:
       - https://www.your-app.example.com/
       - https://studio.apollographql.com/ # Keep this so Apollo Studio can run queries against your router
     match_origins:
-      - "https://([a-z0-9]+[.])*api[.]example[.]com" # any host that uses https and ends with api.example.com
+      - "https://([a-z0-9]+[.])*api[.]example[.]com" # any host that uses https and ends with .api.example.com
 ```
 
 You can also disable CORS entirely by setting `origins` to an empty list:

--- a/docs/source/configuration/cors.mdx
+++ b/docs/source/configuration/cors.mdx
@@ -99,10 +99,14 @@ server:
     # (Defaults to false)
     allow_credentials: true
 
+    # Set to true to mirror a client's received `access-control-request-headers`
+    # This is equivalent to allowing any headers,
+    # except it will also work if allow_credentials is set to true
+    allow_any_header: true
+
     # The headers to allow.
-    # If this field is not set, CORS will default to the `mirror_request` mode,
-    # which mirrors the received `access-control-request-headers`
-    # (This is equivalent to allowing any headers)
+    # If this field is not set, and `allow_any_header` is not set to `true`
+    # CORS will default to accepting `content-type`, `apollographql-client-version` and `apollographql-client-name`,
     allow_headers: [ Content-Type, Authorization, x-my-custom-required-header, x-and-an-other-required-header ]
 
     # Allowed request methods

--- a/docs/source/configuration/cors.mdx
+++ b/docs/source/configuration/cors.mdx
@@ -13,12 +13,15 @@ By default, the Apollo Router enables _only_ Apollo Studio to initiate browser c
 
 * Add the origins of those web applications to the router's list of allowed `origins`.
     * Use this option if there is a known, finite list of web applications that consume your supergraph.
-    * You _must_ use this option if clients need to [authenticate their requests with cookies](#passing-credentials-with-cors).
+* Add a regex that matches the origins of those web applications to the router's list of allowed `origins`.
+    * This option comes in handy if you want to match origins against a pattern, see the example below that matches subdomains of a specific namespace.
 * Enable the `allow_any_origin` option.
     * Use this option if your supergraph is a public API with arbitrarily many web app consumers.
     * With this option enabled, the router sends the [wildcard (`*`)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#directives) value for the `Access-Control-Allow-Origin` header. This enables _any_ website to initiate browser connections to it (but they can't provide cookies or other credentials).
 
-The following snippet includes an example of each option (use only one):
+* You _must_ use the `origins` + `match_origins` option if clients need to [authenticate their requests with cookies](#passing-credentials-with-cors).
+
+The following snippet includes an example of each option (use either `allow_any_origin`, or `origins + match_origins`):
 
 ```yaml title="router.yaml"
 server:
@@ -34,6 +37,8 @@ server:
     origins:
       - https://www.your-app.example.com/
       - https://studio.apollographql.com/ # Keep this so Apollo Studio can run queries against your router
+    match_origins:
+      - "https://([a-z0-9]+[.])*api[.]example[.]com" # any host that uses https and ends with api.example.com
 ```
 
 You can also disable CORS entirely by setting `origins` to an empty list:


### PR DESCRIPTION
Fixes #1425, #1448 and #1390

### Configure Regex based CORS rules ([PR #1444](https://github.com/apollographql/router/pull/1444))

The router now supports regex based CORS rules, as explained in the [docs](https://www.apollographql.com/docs/router/configuration/cors)
It also supports the `allow_any_header` setting that will mirror client's requested headers.

```yaml title="router.yaml"
server:
  cors:
    match_origins:
      - "https://([a-z0-9]+[.])*api[.]example[.]com" # any host that uses https and ends with .api.example.com
    allow_any_header: true # mirror client's headers
```

The default CORS headers configuration of the router allows `content-type`, `apollographql-client-version` and `apollographql-client-name`.

By [@o0Ignition0o](https://github.com/o0ignition0o) in https://github.com/apollographql/router/pull/1444

