### PR TITLE
update buildstructor to 0.4.1 and add docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
  "atty",
  "axum",
  "backtrace",
- "buildstructor",
+ "buildstructor 0.4.1",
  "bytes",
  "clap 3.2.10",
  "dashmap 5.3.4",
@@ -662,6 +662,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "buildstructor"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a7772d3542812693473268c2308979967035162dd36d053ec728e6c947ba93f"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "str_inflector",
+ "syn",
+ "thiserror",
+ "try_match",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,7 +802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f6232669ff969fc9827d8a47dbc9e128a8eb1c7dffc9bcf1cf71be34dee5ef9"
 dependencies = [
  "anyhow",
- "buildstructor",
+ "buildstructor 0.3.2",
  "cargo",
  "clap 2.34.0",
  "console 0.12.0",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -32,7 +32,7 @@ async-trait = "0.1.56"
 atty = "0.2.14"
 axum = { version = "0.5.12", features = ["headers", "json", "original-uri"] }
 backtrace = "0.3.66"
-buildstructor = "0.3.2"
+buildstructor = "0.4.1"
 bytes = "1.1.0"
 clap = { version = "3.2.10", default-features = false, features = [
     "env",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,5 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 848
 expression: "&schema"
 ---
 {
@@ -10,6 +9,7 @@ expression: "&schema"
   "type": "object",
   "properties": {
     "csrf": {
+      "description": "CSRF Configuration.",
       "type": "object",
       "properties": {
         "required_headers": {

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -1,3 +1,4 @@
+//! Router errors.
 use std::sync::Arc;
 
 use displaydoc::Display;

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -135,7 +135,7 @@ impl fmt::Display for ProjectDir {
 
 /// This is the main router entrypoint.
 ///
-/// Refer to the examples if you would like how to run your own router with plugins.
+/// Refer to the examples if you would like to see how to run your own router with plugins.
 pub fn main() -> Result<()> {
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.enable_all();

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -1,3 +1,4 @@
+//! Performance oriented JSON manipulation.
 use std::cmp::min;
 use std::fmt;
 

--- a/apollo-router/src/layers/mod.rs
+++ b/apollo-router/src/layers/mod.rs
@@ -312,6 +312,7 @@ impl<L> ServiceBuilderExt<L> for ServiceBuilder<L> {
     }
 }
 
+/// Extension trait for [`Service`].
 pub trait ServiceExt<Request>: Service<Request> {
     /// Similar to map_future but also providing an opportunity to extract information out of the
     /// request for use when constructing the response.

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -1,4 +1,24 @@
-//! Starts a server that will handle http graphql requests.
+//! Components of a federated GraphQL Server.
+//!
+//! Most of these modules are of varying interest to different audiences.
+//!
+//! If your interests are confined to developing plugins, then the following modules
+//! are likely to be of most interest to you: [`self`] [`error`] [`graphql`] [`layers`] [`plugin`] [`services`]
+//!
+//! self - this module (apollo_router) contains high level building blocks for a federated GraphQL router
+//!
+//! error - the various errors that the router is expected to handle
+//!
+//! graphql - graphql specific functionality for requests, responses, errors
+//!
+//! layers - examples of tower layers used to implement plugins
+//!
+//! plugin - various APIs for implementing a plugin
+//!
+//! services - definition of the various services a plugin may process
+//!
+//! Ultimately, you might want to be interested in all aspects of the implementation, in which case
+//! you'll want to become familiar with all of the code.
 
 #![cfg_attr(feature = "failfast", allow(unreachable_code))]
 #![warn(unreachable_pub)]

--- a/apollo-router/src/plugin/serde.rs
+++ b/apollo-router/src/plugin/serde.rs
@@ -1,3 +1,4 @@
+//! serde support for commonly used data structures.
 use std::fmt::Formatter;
 use std::str::FromStr;
 

--- a/apollo-router/src/plugins/csrf.rs
+++ b/apollo-router/src/plugins/csrf.rs
@@ -1,3 +1,4 @@
+//! Cross Site Request Forgery (CSRF) plugin.
 use std::ops::ControlFlow;
 
 use http::header;
@@ -17,6 +18,7 @@ use crate::register_plugin;
 use crate::RouterRequest;
 use crate::RouterResponse;
 
+/// CSRF Configuration.
 #[derive(Deserialize, Debug, Clone, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct CSRFConfig {

--- a/apollo-router/src/plugins/mod.rs
+++ b/apollo-router/src/plugins/mod.rs
@@ -1,4 +1,4 @@
-//! plugins implementing router customizations.
+//! Plugins implementing router customizations.
 //!
 //! These plugins are compiled into the router and configured via YAML configuration.
 

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -1,3 +1,4 @@
+//! GraphQL operation planning.
 use std::collections::HashMap;
 use std::fmt::Write;
 use std::sync::Arc;
@@ -766,6 +767,7 @@ pub(crate) mod fetch {
     use crate::services::subgraph_service::SubgraphServiceFactory;
     use crate::*;
 
+    /// GraphQL operation type.
     #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub enum OperationKind {

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -320,6 +320,7 @@ pub struct QueryPlannerResponse {
     pub context: Context,
 }
 
+/// Query, QueryPlan and Introspection data.
 #[derive(Debug, Clone)]
 pub enum QueryPlannerContent {
     Plan {

--- a/apollo-router/src/services/new_service.rs
+++ b/apollo-router/src/services/new_service.rs
@@ -1,6 +1,8 @@
+//! Create a new tower Service instance.
 use tower::Service;
 
-pub trait NewService<Request> {
+/// Trait
+pub(crate) trait NewService<Request> {
     type Service: Service<Request>;
 
     fn new_service(&self) -> Self::Service;

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -365,6 +365,7 @@ impl PluggableRouterServiceBuilder {
     }
 }
 
+/// A collection of services and data which may be used to create a "router".
 #[derive(Clone)]
 pub struct RouterCreator {
     query_planner_service: Buffer<
@@ -446,6 +447,7 @@ impl RouterCreator {
             )
     }
 
+    /// Create a test service.
     pub fn test_service(
         &self,
     ) -> tower::util::BoxCloneService<RouterRequest, RouterResponse, BoxError> {

--- a/apollo-router/src/subscriber.rs
+++ b/apollo-router/src/subscriber.rs
@@ -1,4 +1,4 @@
-//! The apollo-router Subscriber.
+//! The apollo-router Tracing Subscriber.
 //!
 //! Here are some constraints:
 //!  - We'd like to use tower to compose our services

--- a/licenses.html
+++ b/licenses.html
@@ -10285,6 +10285,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/BrynCooke/buildstructor ">buildstructor</a></li>
                     <li><a href=" https://github.com/bikeshedder/deadpool ">deadpool-runtime</a></li>
                     <li><a href=" https://github.com/RustCrypto/signatures/tree/master/ecdsa ">ecdsa</a></li>
                     <li><a href=" https://github.com/graphql-rust/graphql-client ">graphql-introspection-query</a></li>


### PR DESCRIPTION
Enough minimal documentation so that we can reason more effectively
about what our API looks like. I've tried providing some very
rudimentary guidance for a notional plugin author.

I've also moved `NewService` from pub to pub(crate).
