### PR TITLE
update kubernetes documentation to add helm OCI example

### DIFF
--- a/docs/source/containerization/kubernetes.mdx
+++ b/docs/source/containerization/kubernetes.mdx
@@ -15,10 +15,26 @@ import { Link } from 'gatsby';
 
 There is a complete [helm chart definition](https://github.com/apollographql/router/tree/main/helm/chart/router) in the repo which illustrates how to use helm to deploy the router in kubernetes.
 
-Here's an example which would use helm to install the router:
+In both the following examples, we are using helm to install the router:
  - into namespace "router-deploy" (create namespace if it doesn't exist)
  - with helm install name "router-test"
  - with support for prometheus enabled
+
+#### Using helm chart from our Open Container Initiative (OCI) registry
+
+Starting with release 0.14.0, each time we release the router, we'll release
+our helm chart and store it in the same OCI registry in which we store our
+router docker images.
+
+You can use helm to install charts from an OCI registry as follows:
+
+```bash
+helm install --set router.configuration.telemetry.metrics.prometheus.enabled=true --set managedFederation.apiKey="REDACTED" --set managedFederation.graphRef="REDACTED" --create-namespace --namespace router-deploy router-test oci://ghcr.io/apollographql/helm-charts/router --version 0.14.0 --values router/values.yaml
+```
+
+For more details about using helm with OCI based registries, see [here](https://helm.sh/docs/topics/registries/)
+
+#### Using helm chart from your filesystem
 
 You would run this command from "repo"/helm/chart directory.
 


### PR DESCRIPTION
Now that we have a helm chart in our OCI registry, we should have an
example to show how to use it.

fixes: #1456