### PR TITLE
docs: update CORS examples

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -44,6 +44,16 @@ By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographq
 
 ## 📚 Documentation
 
+
+### CORS: Fix trailing slashes, and display defaults ([PR #1471](https://github.com/apollographql/router/pull/1471))
+
+The CORS documentation now displays a valid `origins` configuration (without trailing slash!), and the full configuration section displays its default settings.
+
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1471
+
+
+
 ### Add helm OCI example ([PR #1457](https://github.com/apollographql/router/pull/1457))
 
 Update existing filesystem based example to illustrate how to do the same thing using our OCI stored helm chart.

--- a/docs/source/configuration/cors.mdx
+++ b/docs/source/configuration/cors.mdx
@@ -75,7 +75,7 @@ For examples of sending cookies and authorization headers from Apollo Client, se
 
 ## All `cors` options
 
-The following snippet shows all CORS configuration for the Apollo Router:
+The following snippet shows all CORS configuration defaults for the Apollo Router:
 
 ```yaml title="router.yaml"
 server:
@@ -85,36 +85,35 @@ server:
   cors:
 
     # Set to true to allow any origin
-    # (Defaults to false)
-    allow_any_origin: true
+    allow_any_origin: false
 
     # List of accepted origins
-    # (Ignored if allow_any_origin is true)
-    # (Defaults to the Apollo Studio url: `https://studio.apollographql.com`)
+    # (Ignored if allow_any_origin is set to true)
     origins:
-      - https://www.your-app.example.com
       - https://studio.apollographql.com # Keep this so Apollo Studio can still run queries against your router
 
     # Set to true to add the `Access-Control-Allow-Credentials` header
-    # (Defaults to false)
-    allow_credentials: true
+    allow_credentials: false
 
     # Set to true to mirror a client's received `access-control-request-headers`
     # This is equivalent to allowing any headers,
     # except it will also work if allow_credentials is set to true
-    allow_any_header: true
+    allow_any_header: false
 
     # The headers to allow.
-    # If this field is not set, and `allow_any_header` is not set to `true`
-    # CORS will default to accepting `content-type`, `apollographql-client-version` and `apollographql-client-name`,
-    allow_headers: [ Content-Type, Authorization, x-my-custom-required-header, x-and-an-other-required-header ]
+    # (Ignored if allow_any_header is set to true)
+    allow_headers: 
+      - content-type
+      - apollographql-client-version
+      - apollographql-client-name
 
     # Allowed request methods
-    # (Defaults to [ GET, POST, OPTIONS ])
-    methods: [ POST, OPTIONS ]
+    methods:
+      - GET
+      - POST
+      - OPTIONS
 
     # Which response headers are available to scripts running in the
     # browser in response to a cross-origin request.
-    # (Defaults to empty array)
     expose_headers: []
 ```

--- a/docs/source/configuration/cors.mdx
+++ b/docs/source/configuration/cors.mdx
@@ -35,8 +35,8 @@ server:
     # (Ignored if allow_any_origin is true)
     # (Defaults to the Apollo Studio url: `https://studio.apollographql.com`)
     origins:
-      - https://www.your-app.example.com/
-      - https://studio.apollographql.com/ # Keep this so Apollo Studio can run queries against your router
+      - https://www.your-app.example.com
+      - https://studio.apollographql.com # Keep this so Apollo Studio can run queries against your router
     match_origins:
       - "https://([a-z0-9]+[.])*api[.]example[.]com" # any host that uses https and ends with .api.example.com
 ```
@@ -65,8 +65,8 @@ To allow browsers to pass credentials to the Apollo Router, set `allow_credentia
 server:
   cors:
     origins:
-      - https://www.your-app.example.com/
-      - https://studio.apollographql.com/
+      - https://www.your-app.example.com
+      - https://studio.apollographql.com
     allow_credentials: true
 ```
 
@@ -92,8 +92,8 @@ server:
     # (Ignored if allow_any_origin is true)
     # (Defaults to the Apollo Studio url: `https://studio.apollographql.com`)
     origins:
-      - https://www.your-app.example.com/
-      - https://studio.apollographql.com/ # Keep this so Apollo Studio can still run queries against your router
+      - https://www.your-app.example.com
+      - https://studio.apollographql.com # Keep this so Apollo Studio can still run queries against your router
 
     # Set to true to add the `Access-Control-Allow-Credentials` header
     # (Defaults to false)

--- a/docs/source/configuration/cors.mdx
+++ b/docs/source/configuration/cors.mdx
@@ -34,6 +34,9 @@ server:
     # List of accepted origins
     # (Ignored if allow_any_origin is true)
     # (Defaults to the Apollo Studio url: `https://studio.apollographql.com`)
+    #
+    # An origin is a combination of scheme, hostname and port.
+    # It does not have any path section, so no trailing slash.
     origins:
       - https://www.your-app.example.com
       - https://studio.apollographql.com # Keep this so Apollo Studio can run queries against your router
@@ -89,6 +92,9 @@ server:
 
     # List of accepted origins
     # (Ignored if allow_any_origin is set to true)
+    #
+    # An origin is a combination of scheme, hostname and port.
+    # It does not have any path section, so no trailing slash.
     origins:
       - https://studio.apollographql.com # Keep this so Apollo Studio can still run queries against your router
 


### PR DESCRIPTION
Fixes #1448 

This fixes a docs issue where we would set trailing slashes in the CORS `origins` section, which wouldn't work because CORS origins don't have the forward slash.

The docs full CORS example now displays the default settings.