### PR TITLE
CORS: Mirror client's requested headers by default

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -36,7 +36,7 @@ The latest release (0.14.0) introduced an `allow_any_header` setting, which is n
 #### How do I `allow_any_header` in the latest release?
 This is the default behavior, you can remove `allow_any_header` from your configuration.
 
-### How do I *not* `allow_any_header` in the latest release?
+#### How do I *not* `allow_any_header` in the latest release?
 You can provide a list of headers to allow by filling the `allow_headers` key:
 ```yaml title="router.yaml"
 server:

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -27,21 +27,20 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 
 ## ❗ BREAKING ❗
 
-### CORS: Mirror client's requested headers by default ([PR #1480](https://github.com/apollographql/router/pull/1480))
+### CORS: Deprecate newly-added `allow_any_header` option and return to previous behavior ([PR #1480](https://github.com/apollographql/router/pull/1480))
 
-The router now mirrors client's `Access-Control-Request-Headers` by default.
+We've re-considered and reverted changes we shipped in the last release with regards to how we handle the [`Access-Control-Request-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Headers) *request* header and its corresponding [`Access-Control-Allow-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) response header.  We've reverted to the previous releases' behavior, including the removal of the recently-added `allow_any_header` option.
 
-#### What has changed?
-The latest release (0.14.0) introduced an `allow_any_header` setting, which is now removed.
-#### How do I `allow_any_header` in the latest release?
-This is the default behavior, you can remove `allow_any_header` from your configuration.
+The previous default behavior was to **reflect** the client's `Access-Control-Request-Headers` request header values back in the `Access-Control-Allow-Headers` response header.  This previous behavior is in fact a common default behavior in other CORS libraries as well, including the [`cors`](https://npm.im/cors) Node.js package and we think it's worth keeping as it was previously, rather than requiring users to specify `allow_any_header` for the _majority_ of use cases.  We believe this to be a safe and secure default that is also more user-friendly.
 
-#### How do I *not* `allow_any_header` in the latest release?
-You can provide a list of headers to allow by filling the `allow_headers` key:
+It is not typically necessary to change this default behavior, but if you wish to allow a more specific set of headers, you can disable the default header reflection and specify a list of headers using the `allow_headers` option, which will allow only those headers in negotiating a response:
+
 ```yaml title="router.yaml"
 server:
   cors:
     allow_any_origin: true
+    # Including this `allow_headers` isn't typically necessary (can be removed) but
+    # will *restrict* the permitted Access-Control-Allow-Headers response values.
     allow_headers:
       - Content-Type
       - Authorization

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -27,6 +27,29 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 
 ## ❗ BREAKING ❗
 
+### CORS: Mirror client's requested headers by default ([PR #1480](https://github.com/apollographql/router/pull/1480))
+
+The router now mirrors client's `Access-Control-Request-Headers` by default.
+
+#### What has changed?
+The latest release (0.14.0) introduced an `allow_any_header` setting, which is now removed.
+#### How to I `allow_any_header` in the latest release?
+This is the default behavior, you can remove `allow_any_header` from your configuration.
+
+### How do I *not* `allow_any_header` in the latest release?
+You can provide a list of headers to allow by filling the `allow_headers` key:
+```yaml title="router.yaml"
+server:
+  cors:
+    allow_any_origin: true
+    allow_headers:
+      - Content-Type
+      - Authorization
+      - x-my-custom-header
+```
+
+By [@o0Ignition0o](https://github.com/o0ignition0o) in https://github.com/apollographql/router/pull/1480
+
 ### Reference-counting for the schema string given to plugins ([PR #???](https://github.com/apollographql/router/pull/))
 
 The type of the `supergraph_sdl` field of the `apollo_router::plugin::PluginInit` struct

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -33,7 +33,7 @@ The router now mirrors client's `Access-Control-Request-Headers` by default.
 
 #### What has changed?
 The latest release (0.14.0) introduced an `allow_any_header` setting, which is now removed.
-#### How to I `allow_any_header` in the latest release?
+#### How do I `allow_any_header` in the latest release?
 This is the default behavior, you can remove `allow_any_header` from your configuration.
 
 ### How do I *not* `allow_any_header` in the latest release?

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -1593,7 +1593,7 @@ mod tests {
             .server(
                 crate::configuration::Server::builder()
                     .listen(SocketAddr::from_str("127.0.0.1:0").unwrap())
-                    .cors(Cors::builder().allow_any_header(true).build())
+                    .cors(Cors::builder().build())
                     .endpoint(String::from("/graphql/*"))
                     .build(),
             )

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -369,7 +369,7 @@ pub(crate) struct Cors {
 
     /// The headers to allow.
     ///
-    /// Defaults to `default_headers`.
+    /// If this value is not set, the router will mirror client's `Access-Control-Request-Headers`.
     ///
     /// Note that if you set headers here,
     /// you also want to have a look at your `CSRF` plugins configuration,
@@ -377,16 +377,8 @@ pub(crate) struct Cors {
     /// - accept `x-apollo-operation-name` AND / OR `apollo-require-preflight`
     /// - defined `csrf` required headers in your yml configuration, as shown in the
     /// `examples/cors-and-csrf/custom-headers.router.yaml` files.
-    #[serde(default = "default_headers")]
-    pub(crate) allow_headers: Vec<String>,
-
-    /// Set to true to mirror headers sent by clients.
-    ///
-    /// If this is not set, we will default to
-    /// the `mirror_request` mode, which mirrors the received
-    /// `access-control-request-headers` preflight has sent..
     #[serde(default)]
-    pub(crate) allow_any_header: bool,
+    pub(crate) allow_headers: Vec<String>,
 
     /// Which response headers should be made available to scripts running in the browser,
     /// in response to a cross-origin request.
@@ -412,14 +404,13 @@ pub(crate) struct Cors {
 impl Default for Cors {
     fn default() -> Self {
         Self {
-            allow_any_origin: Default::default(),
-            allow_any_header: Default::default(),
-            allow_credentials: Default::default(),
-            allow_headers: default_headers(),
-            expose_headers: Default::default(),
-            match_origins: Default::default(),
             origins: default_origins(),
             methods: default_cors_methods(),
+            allow_any_origin: Default::default(),
+            allow_credentials: Default::default(),
+            allow_headers: Default::default(),
+            expose_headers: Default::default(),
+            match_origins: Default::default(),
         }
     }
 }
@@ -430,14 +421,6 @@ fn default_origins() -> Vec<String> {
 
 fn default_cors_methods() -> Vec<String> {
     vec!["GET".into(), "POST".into(), "OPTIONS".into()]
-}
-
-fn default_headers() -> Vec<String> {
-    vec![
-        "content-type".into(),
-        "apollographql-client-version".into(),
-        "apollographql-client-name".into(),
-    ]
 }
 
 fn default_introspection() -> bool {
@@ -480,7 +463,6 @@ impl Cors {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         allow_any_origin: Option<bool>,
-        allow_any_header: Option<bool>,
         allow_credentials: Option<bool>,
         allow_headers: Option<Vec<String>>,
         expose_headers: Option<Vec<String>>,
@@ -489,14 +471,13 @@ impl Cors {
         methods: Option<Vec<String>>,
     ) -> Self {
         Self {
-            allow_any_origin: allow_any_origin.unwrap_or_default(),
-            allow_any_header: allow_any_header.unwrap_or_default(),
-            allow_credentials: allow_credentials.unwrap_or_default(),
-            allow_headers: allow_headers.unwrap_or_else(default_headers),
             expose_headers,
             match_origins,
             origins: origins.unwrap_or_else(default_origins),
             methods: methods.unwrap_or_else(default_cors_methods),
+            allow_any_origin: allow_any_origin.unwrap_or_default(),
+            allow_credentials: allow_credentials.unwrap_or_default(),
+            allow_headers: allow_headers.unwrap_or_default(),
         }
     }
 }
@@ -507,7 +488,7 @@ impl Cors {
 
         self.ensure_usable_cors_rules()?;
 
-        let allow_headers = if self.allow_any_header {
+        let allow_headers = if self.allow_headers.is_empty() {
             cors::AllowHeaders::mirror_request()
         } else {
             cors::AllowHeaders::list(self.allow_headers.iter().filter_map(|header| {
@@ -1029,19 +1010,7 @@ mod tests {
             !cors.allow_any_origin,
             "Allow any origin should be disabled by default"
         );
-        assert!(
-            !cors.allow_any_header,
-            "Allow any header should be disabled by default"
-        );
-
-        assert_eq!(
-            vec![
-                "content-type".to_string(),
-                "apollographql-client-version".to_string(),
-                "apollographql-client-name".to_string(),
-            ],
-            cors.allow_headers,
-        );
+        assert!(cors.allow_headers.is_empty());
 
         assert!(
             cors.match_origins.is_none(),

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -324,12 +324,7 @@ expression: "&schema"
         "cors": {
           "allow_any_origin": false,
           "allow_credentials": false,
-          "allow_headers": [
-            "content-type",
-            "apollographql-client-version",
-            "apollographql-client-name"
-          ],
-          "allow_any_header": false,
+          "allow_headers": [],
           "expose_headers": null,
           "origins": [
             "https://studio.apollographql.com"
@@ -355,12 +350,7 @@ expression: "&schema"
           "default": {
             "allow_any_origin": false,
             "allow_credentials": false,
-            "allow_headers": [
-              "content-type",
-              "apollographql-client-version",
-              "apollographql-client-name"
-            ],
-            "allow_any_header": false,
+            "allow_headers": [],
             "expose_headers": null,
             "origins": [
               "https://studio.apollographql.com"
@@ -374,11 +364,6 @@ expression: "&schema"
           },
           "type": "object",
           "properties": {
-            "allow_any_header": {
-              "description": "Set to true to mirror headers sent by clients.\n\nIf this is not set, we will default to the `mirror_request` mode, which mirrors the received `access-control-request-headers` preflight has sent..",
-              "default": false,
-              "type": "boolean"
-            },
             "allow_any_origin": {
               "description": "Set to true to allow any origin.\n\nDefaults to false Having this set to true is the only way to allow Origin: null.",
               "default": false,
@@ -390,12 +375,8 @@ expression: "&schema"
               "type": "boolean"
             },
             "allow_headers": {
-              "description": "The headers to allow.\n\nDefaults to `default_headers`.\n\nNote that if you set headers here, you also want to have a look at your `CSRF` plugins configuration, and make sure you either: - accept `x-apollo-operation-name` AND / OR `apollo-require-preflight` - defined `csrf` required headers in your yml configuration, as shown in the `examples/cors-and-csrf/custom-headers.router.yaml` files.",
-              "default": [
-                "content-type",
-                "apollographql-client-version",
-                "apollographql-client-name"
-              ],
+              "description": "The headers to allow.\n\nIf this value is not set, the router will mirror client's `Access-Control-Request-Headers`.\n\nNote that if you set headers here, you also want to have a look at your `CSRF` plugins configuration, and make sure you either: - accept `x-apollo-operation-name` AND / OR `apollo-require-preflight` - defined `csrf` required headers in your yml configuration, as shown in the `examples/cors-and-csrf/custom-headers.router.yaml` files.",
+              "default": [],
               "type": "array",
               "items": {
                 "type": "string"

--- a/docs/source/configuration/cors.mdx
+++ b/docs/source/configuration/cors.mdx
@@ -101,17 +101,11 @@ server:
     # Set to true to add the `Access-Control-Allow-Credentials` header
     allow_credentials: false
 
-    # Set to true to mirror a client's received `access-control-request-headers`
+    # The headers to allow.
+    # Not setting this mirrors a client's received `access-control-request-headers`
     # This is equivalent to allowing any headers,
     # except it will also work if allow_credentials is set to true
-    allow_any_header: false
-
-    # The headers to allow.
-    # (Ignored if allow_any_header is set to true)
-    allow_headers: 
-      - content-type
-      - apollographql-client-version
-      - apollographql-client-name
+    allow_headers: []
 
     # Allowed request methods
     methods:


### PR DESCRIPTION
### CORS: Mirror client's requested headers by default ([PR #1480](https://github.com/apollographql/router/pull/1480))

The router now mirrors client's `Access-Control-Request-Headers` by default.

#### What has changed?
The latest release (0.14.0) introduced an `allow_any_header` setting, which is now removed.
#### How do I `allow_any_header` in the latest release?
This is the default behavior, you can remove `allow_any_header` from your configuration.

#### How do I *not* `allow_any_header` in the latest release?
You can provide a list of headers to allow by filling the `allow_headers` key:
```yaml title="router.yaml"
server:
  cors:
    allow_any_origin: true
    allow_headers:
      - Content-Type
      - Authorization
      - x-my-custom-header
```

By [@o0Ignition0o](https://github.com/o0ignition0o) in https://github.com/apollographql/router/pull/1480