### PR TITLE
0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,80 @@ All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [0.15.0] - 2022-08-09
+
+## ❗ BREAKING ❗
+
+### CORS: Deprecate newly-added `allow_any_header` option and return to previous behavior ([PR #1480](https://github.com/apollographql/router/pull/1480))
+
+We've re-considered and reverted changes we shipped in the last release with regards to how we handle the [`Access-Control-Request-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Headers) *request* header and its corresponding [`Access-Control-Allow-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) response header.  We've reverted to the previous releases' behavior, including the removal of the recently-added `allow_any_header` option.
+
+The previous default behavior was to **reflect** the client's `Access-Control-Request-Headers` request header values back in the `Access-Control-Allow-Headers` response header.  This previous behavior is in fact a common default behavior in other CORS libraries as well, including the [`cors`](https://npm.im/cors) Node.js package and we think it's worth keeping as it was previously, rather than requiring users to specify `allow_any_header` for the _majority_ of use cases.  We believe this to be a safe and secure default that is also more user-friendly.
+
+It is not typically necessary to change this default behavior, but if you wish to allow a more specific set of headers, you can disable the default header reflection and specify a list of headers using the `allow_headers` option, which will allow only those headers in negotiating a response:
+
+```yaml title="router.yaml"
+server:
+  cors:
+    allow_any_origin: true
+    # Including this `allow_headers` isn't typically necessary (can be removed) but
+    # will *restrict* the permitted Access-Control-Allow-Headers response values.
+    allow_headers:
+      - Content-Type
+      - Authorization
+      - x-my-custom-header
+```
+
+By [@o0Ignition0o](https://github.com/o0ignition0o) in https://github.com/apollographql/router/pull/1480
+
+### Reference-counting for the schema string given to plugins ([PR #???](https://github.com/apollographql/router/pull/))
+
+The type of the `supergraph_sdl` field of the `apollo_router::plugin::PluginInit` struct
+was changed from `String` to `Arc<String>`.
+This reduces the number of copies of this string we keep in memory, as schemas can get large.
+
+By [@SimonSapin](https://github.com/SimonSapin)
+
+## 🚀 Features
+
+## 🐛 Fixes
+
+### Update span attributes to be compliant with the opentelemetry for GraphQL specs ([PR #1449](https://github.com/apollographql/router/pull/1449))
+
+Change attribute name `query` to `graphql.document` and `operation_name` to `graphql.operation.name` in spans.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1449 
+
+### Configuration handling enhancements ([PR #1454](https://github.com/apollographql/router/pull/1454))
+
+Router config handling now:
+* Allows completely empty configuration without error.
+* Prevents unknown tags at the root of the configuration from being silently ignored.
+
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/1454
+
+
+## 🛠 Maintenance
+
+## 📚 Documentation
+
+
+### CORS: Fix trailing slashes, and display defaults ([PR #1471](https://github.com/apollographql/router/pull/1471))
+
+The CORS documentation now displays a valid `origins` configuration (without trailing slash!), and the full configuration section displays its default settings.
+
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1471
+
+
+
+### Add helm OCI example ([PR #1457](https://github.com/apollographql/router/pull/1457))
+
+Update existing filesystem based example to illustrate how to do the same thing using our OCI stored helm chart.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1457
+
+
 # [0.14.0] - 2022-08-02
 
 ## ❗ BREAKING ❗

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,13 +30,13 @@ server:
 
 By [@o0Ignition0o](https://github.com/o0ignition0o) in https://github.com/apollographql/router/pull/1480
 
-### Reference-counting for the schema string given to plugins ([PR #???](https://github.com/apollographql/router/pull/))
+### Reference-counting for the schema string given to plugins ([PR #1462](https://github.com/apollographql/router/pull/1462))
 
 The type of the `supergraph_sdl` field of the `apollo_router::plugin::PluginInit` struct
 was changed from `String` to `Arc<String>`.
 This reduces the number of copies of this string we keep in memory, as schemas can get large.
 
-By [@SimonSapin](https://github.com/SimonSapin)
+By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/1462
 
 ## 🐛 Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,6 @@ This reduces the number of copies of this string we keep in memory, as schemas c
 
 By [@SimonSapin](https://github.com/SimonSapin)
 
-## 🚀 Features
-
 ## 🐛 Fixes
 
 ### Update span attributes to be compliant with the opentelemetry for GraphQL specs ([PR #1449](https://github.com/apollographql/router/pull/1449))
@@ -56,9 +54,6 @@ Router config handling now:
 
 By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/1454
 
-
-## 🛠 Maintenance
-
 ## 📚 Documentation
 
 
@@ -68,7 +63,6 @@ The CORS documentation now displays a valid `origins` configuration (without tra
 
 
 By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1471
-
 
 
 ### Add helm OCI example ([PR #1457](https://github.com/apollographql/router/pull/1457))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4479,7 +4479,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.0"
-source = "git+https://github.com/apollographql/federation-rs.git?branch=geal/defer#72f1fff5e57a80b4ed4fcbf13ef2ac33b0314b80"
+source = "git+https://github.com/apollographql/federation-rs.git?tag=defer-alpha1#72f1fff5e57a80b4ed4fcbf13ef2ac33b0314b80"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "access-json",
  "anyhow",
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "apollo-router",
  "async-trait",
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-scaffold"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "cargo-scaffold",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-spaceport"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bytes",
  "clap 3.2.10",
@@ -286,7 +286,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-uplink"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "futures",
  "graphql_client",
@@ -6471,7 +6471,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -23,75 +23,14 @@ Description! And a link to a [reference](http://url)
 By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/router/pull/PULL_NUMBER
 -->
 
-# [0.14.1] (unreleased) - 2022-mm-dd
+# [0.15.1] (unreleased) - 2022-mm-dd
 
 ## ❗ BREAKING ❗
-
-### CORS: Deprecate newly-added `allow_any_header` option and return to previous behavior ([PR #1480](https://github.com/apollographql/router/pull/1480))
-
-We've re-considered and reverted changes we shipped in the last release with regards to how we handle the [`Access-Control-Request-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Headers) *request* header and its corresponding [`Access-Control-Allow-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) response header.  We've reverted to the previous releases' behavior, including the removal of the recently-added `allow_any_header` option.
-
-The previous default behavior was to **reflect** the client's `Access-Control-Request-Headers` request header values back in the `Access-Control-Allow-Headers` response header.  This previous behavior is in fact a common default behavior in other CORS libraries as well, including the [`cors`](https://npm.im/cors) Node.js package and we think it's worth keeping as it was previously, rather than requiring users to specify `allow_any_header` for the _majority_ of use cases.  We believe this to be a safe and secure default that is also more user-friendly.
-
-It is not typically necessary to change this default behavior, but if you wish to allow a more specific set of headers, you can disable the default header reflection and specify a list of headers using the `allow_headers` option, which will allow only those headers in negotiating a response:
-
-```yaml title="router.yaml"
-server:
-  cors:
-    allow_any_origin: true
-    # Including this `allow_headers` isn't typically necessary (can be removed) but
-    # will *restrict* the permitted Access-Control-Allow-Headers response values.
-    allow_headers:
-      - Content-Type
-      - Authorization
-      - x-my-custom-header
-```
-
-By [@o0Ignition0o](https://github.com/o0ignition0o) in https://github.com/apollographql/router/pull/1480
-
-### Reference-counting for the schema string given to plugins ([PR #???](https://github.com/apollographql/router/pull/))
-
-The type of the `supergraph_sdl` field of the `apollo_router::plugin::PluginInit` struct
-was changed from `String` to `Arc<String>`.
-This reduces the number of copies of this string we keep in memory, as schemas can get large.
-
-By [@SimonSapin](https://github.com/SimonSapin)
 
 ## 🚀 Features
 
 ## 🐛 Fixes
 
-### Update span attributes to be compliant with the opentelemetry for GraphQL specs ([PR #1449](https://github.com/apollographql/router/pull/1449))
-
-Change attribute name `query` to `graphql.document` and `operation_name` to `graphql.operation.name` in spans.
-
-By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1449 
-
-### Configuration handling enhancements ([PR #1454](https://github.com/apollographql/router/pull/1454))
-
-Router config handling now:
-* Allows completely empty configuration without error.
-* Prevents unknown tags at the root of the configuration from being silently ignored.
-
-By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/1454
-
-
 ## 🛠 Maintenance
 
 ## 📚 Documentation
-
-
-### CORS: Fix trailing slashes, and display defaults ([PR #1471](https://github.com/apollographql/router/pull/1471))
-
-The CORS documentation now displays a valid `origins` configuration (without trailing slash!), and the full configuration section displays its default settings.
-
-
-By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1471
-
-
-
-### Add helm OCI example ([PR #1457](https://github.com/apollographql/router/pull/1457))
-
-Update existing filesystem based example to illustrate how to do the same thing using our OCI stored helm chart.
-
-By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1457

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-scaffold"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -22,7 +22,7 @@ apollo-router = { path ="{{integration_test}}apollo-router" }
 apollo-router = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
 # Note if you update these dependencies then also update xtask/Cargo.toml
-apollo-router = { git="https://github.com/apollographql/router.git", tag="v0.14.0" }
+apollo-router = { git="https://github.com/apollographql/router.git", tag="v0.15.0" }
 {{/if}}
 {{/if}}
 async-trait = "0.1.52"

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -2,7 +2,7 @@
 name = "xtask"
 edition = "2021"
 publish = false
-version = "0.14.0"
+version = "0.15.0"
 
 [dependencies]
 # This dependency should stay in line with your router version
@@ -13,7 +13,7 @@ apollo-router-scaffold = { path ="{{integration_test}}apollo-router-scaffold" }
 {{#if branch}}
 apollo-router-scaffold = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
-apollo-router-scaffold = { git="https://github.com/apollographql/router.git", tag="v0.14.0"}
+apollo-router-scaffold = { git="https://github.com/apollographql/router.git", tag="v0.15.0"}
 {{/if}}
 {{/if}}
 anyhow = "=1.0.58"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -107,7 +107,7 @@ reqwest = { version = "0.11.11", default-features = false, features = [
     "json",
     "stream",
 ] }
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", branch = "geal/defer" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", tag = "defer-alpha1" }
 schemars = { version = "0.8.10", features = ["url"] }
 sha2 = "0.10.2"
 serde = { version = "1.0.139", features = ["derive", "rc"] }

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-spaceport"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/dockerfiles/tracing/docker-compose.datadog.yml
+++ b/dockerfiles/tracing/docker-compose.datadog.yml
@@ -3,7 +3,7 @@ services:
 
   apollo-router:
     container_name: apollo-router
-    image: ghcr.io/apollographql/router:v0.14.0
+    image: ghcr.io/apollographql/router:v0.15.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/datadog.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.jaeger.yml
+++ b/dockerfiles/tracing/docker-compose.jaeger.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     #build: ./router
-    image: ghcr.io/apollographql/router:v0.14.0
+    image: ghcr.io/apollographql/router:v0.15.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/jaeger.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.zipkin.yml
+++ b/dockerfiles/tracing/docker-compose.zipkin.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     build: ./router
-    image: ghcr.io/apollographql/router:v0.14.0
+    image: ghcr.io/apollographql/router:v0.15.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/zipkin.router.yaml:/etc/config/configuration.yaml

--- a/docs/source/containerization/docker.mdx
+++ b/docs/source/containerization/docker.mdx
@@ -11,7 +11,7 @@ The default behaviour of the router images is suitable for a quickstart or devel
 
 Note: The [docker documentation](https://docs.docker.com/engine/reference/run/) for the run command may be helpful when reading through the examples.
 
-Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v0.14.0`
+Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v0.15.0`
 
 ## Override the configuration
 
@@ -92,10 +92,10 @@ Usage: build_docker_image.sh [-b] [<release>]
 	Example 1: Building HEAD from the repo
 		build_docker_image.sh -b
 	Example 2: Building tag from the repo
-		build_docker_image.sh -b v0.14.0
+		build_docker_image.sh -b v0.15.0
 	Example 3: Building commit hash from the repo
-		build_docker_image.sh -b 7f7d223f42af34fad35b898d976bc07d0f5440c5
-	Example 4: Building tag v0.14.0 from the released tarball
-		build_docker_image.sh v0.14.0
+		build_docker_image.sh -b 1c220d35acf9ad2537b8edc58c498390b6701d3d
+	Example 4: Building tag v0.15.0 from the released tarball
+		build_docker_image.sh v0.15.0
 ```
 Note: The script has to be run from the `dockerfiles/diy` directory because it makes assumptions about the relative availability of various files. The example uses [distroless images](https://github.com/GoogleContainerTools/distroless) for the final image build. Feel free to modify the script to use images which better suit your own needs.

--- a/docs/source/containerization/kubernetes.mdx
+++ b/docs/source/containerization/kubernetes.mdx
@@ -13,7 +13,7 @@ import { Link } from 'gatsby';
 
 [Helm](https://helm.sh) is the package manager for kubernetes.
 
-There is a complete [helm chart definition](https://github.com/apollographql/router/tree/v0.14.0/helm/chart/router) in the repo which illustrates how to use helm to deploy the router in kubernetes.
+There is a complete [helm chart definition](https://github.com/apollographql/router/tree/v0.15.0/helm/chart/router) in the repo which illustrates how to use helm to deploy the router in kubernetes.
 
 In both the following examples, we are using helm to install the router:
  - into namespace "router-deploy" (create namespace if it doesn't exist)
@@ -29,7 +29,7 @@ router docker images.
 You can use helm to install charts from an OCI registry as follows:
 
 ```bash
-helm install --set router.configuration.telemetry.metrics.prometheus.enabled=true --set managedFederation.apiKey="REDACTED" --set managedFederation.graphRef="REDACTED" --create-namespace --namespace router-deploy router-test oci://ghcr.io/apollographql/helm-charts/router --version 0.14.0 --values router/values.yaml
+helm install --set router.configuration.telemetry.metrics.prometheus.enabled=true --set managedFederation.apiKey="REDACTED" --set managedFederation.graphRef="REDACTED" --create-namespace --namespace router-deploy router-test oci://ghcr.io/apollographql/helm-charts/router --version 0.15.0 --values router/values.yaml
 ```
 
 For more details about using helm with OCI based registries, see [here](https://helm.sh/docs/topics/registries/)
@@ -66,7 +66,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.15.0"
 ---
 # Source: router/templates/secret.yaml
 apiVersion: v1
@@ -76,7 +76,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.15.0"
 data:
   managedFederationApiKey: "REDACTED"
 ---
@@ -88,7 +88,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.15.0"
 data:
   configuration.yaml: |
     server:
@@ -106,7 +106,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.15.0"
 spec:
   type: ClusterIP
   ports:
@@ -126,7 +126,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v0.14.0"
+    app.kubernetes.io/version: "v0.15.0"
   annotations:
     prometheus.io/path: /plugins/apollo.telemetry/prometheus
     prometheus.io/port: "80"
@@ -150,7 +150,7 @@ spec:
         - name: router
           securityContext:
             {}
-          image: "ghcr.io/apollographql/router:v0.14.0"
+          image: "ghcr.io/apollographql/router:v0.15.0"
           imagePullPolicy: IfNotPresent
           args:
             - --hot-reload

--- a/docs/source/federation-version-support.mdx
+++ b/docs/source/federation-version-support.mdx
@@ -22,6 +22,17 @@ Apollo Federation is an evolving project, and it will receive new features and b
     <tbody>
     <tr>
         <td>
+            v0.15.0
+        </td>
+        <td>
+            2.0.2
+        </td>
+        <td>
+            2022-08-09
+        </td>
+    </tr>
+    <tr>
+        <td>
             v0.14.0
         </td>
         <td>

--- a/helm/chart/router/Chart.yaml
+++ b/helm/chart/router/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.16
+version: 0.1.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.14.0"
+appVersion: "v0.15.0"

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -2,7 +2,7 @@
 
 [router](https://github.com/apollographql/router) Rust Graph Routing runtime for Apollo Federation
 
-![Version: 0.1.16](https://img.shields.io/badge/Version-0.1.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.14.0](https://img.shields.io/badge/AppVersion-v0.14.0-informational?style=flat-square)
+![Version: 0.1.17](https://img.shields.io/badge/Version-0.1.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.15.0](https://img.shields.io/badge/AppVersion-v0.15.0-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-uplink"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 build = "build.rs"
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"


### PR DESCRIPTION

# [0.15.0] - 2022-08-09

## ❗ BREAKING ❗

### CORS: Deprecate newly-added `allow_any_header` option and return to previous behavior ([PR #1480](https://github.com/apollographql/router/pull/1480))

We've re-considered and reverted changes we shipped in the last release with regards to how we handle the [`Access-Control-Request-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Request-Headers) *request* header and its corresponding [`Access-Control-Allow-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) response header.  We've reverted to the previous releases' behavior, including the removal of the recently-added `allow_any_header` option.

The previous default behavior was to **reflect** the client's `Access-Control-Request-Headers` request header values back in the `Access-Control-Allow-Headers` response header.  This previous behavior is in fact a common default behavior in other CORS libraries as well, including the [`cors`](https://npm.im/cors) Node.js package and we think it's worth keeping as it was previously, rather than requiring users to specify `allow_any_header` for the _majority_ of use cases.  We believe this to be a safe and secure default that is also more user-friendly.

It is not typically necessary to change this default behavior, but if you wish to allow a more specific set of headers, you can disable the default header reflection and specify a list of headers using the `allow_headers` option, which will allow only those headers in negotiating a response:

```yaml title="router.yaml"
server:
  cors:
    allow_any_origin: true
    # Including this `allow_headers` isn't typically necessary (can be removed) but
    # will *restrict* the permitted Access-Control-Allow-Headers response values.
    allow_headers:
      - Content-Type
      - Authorization
      - x-my-custom-header
```

By [@o0Ignition0o](https://github.com/o0ignition0o) in https://github.com/apollographql/router/pull/1480

### Reference-counting for the schema string given to plugins ([PR #???](https://github.com/apollographql/router/pull/))

The type of the `supergraph_sdl` field of the `apollo_router::plugin::PluginInit` struct
was changed from `String` to `Arc<String>`.
This reduces the number of copies of this string we keep in memory, as schemas can get large.

By [@SimonSapin](https://github.com/SimonSapin)

## 🐛 Fixes

### Update span attributes to be compliant with the opentelemetry for GraphQL specs ([PR #1449](https://github.com/apollographql/router/pull/1449))

Change attribute name `query` to `graphql.document` and `operation_name` to `graphql.operation.name` in spans.

By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1449 

### Configuration handling enhancements ([PR #1454](https://github.com/apollographql/router/pull/1454))

Router config handling now:
* Allows completely empty configuration without error.
* Prevents unknown tags at the root of the configuration from being silently ignored.

By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/1454

## 📚 Documentation


### CORS: Fix trailing slashes, and display defaults ([PR #1471](https://github.com/apollographql/router/pull/1471))

The CORS documentation now displays a valid `origins` configuration (without trailing slash!), and the full configuration section displays its default settings.


By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1471


### Add helm OCI example ([PR #1457](https://github.com/apollographql/router/pull/1457))

Update existing filesystem based example to illustrate how to do the same thing using our OCI stored helm chart.

By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1457
