### PR TITLE
Remove `delay_interval` in telemetry configuration

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -23,9 +23,25 @@ Description! And a link to a [reference](http://url)
 By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/router/pull/PULL_NUMBER
 -->
 
-# [0.15.1] (unreleased) - 2022-mm-dd
+# [0.16] (unreleased) - 2022-mm-dd
 
 ## ❗ BREAKING ❗
+
+### Removed `delay_interval` in telemetry configuration. [PR #FIXME]
+
+It was doing nothing.
+
+```yaml title="router.yaml"
+telemetry:
+  metrics:
+    common:
+      # Removed, will now cause an error on Router startup:
+      delay_interval:
+        secs: 9
+        nanos: 500000000
+```
+
+By [@SimonSapin](https://github.com/SimonSapin)
 
 ## 🚀 Features
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,5 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 914
 expression: "&schema"
 ---
 {
@@ -1273,26 +1272,6 @@ expression: "&schema"
                     }
                   },
                   "additionalProperties": false,
-                  "nullable": true
-                },
-                "delay_interval": {
-                  "type": "object",
-                  "required": [
-                    "nanos",
-                    "secs"
-                  ],
-                  "properties": {
-                    "nanos": {
-                      "type": "integer",
-                      "format": "uint32",
-                      "minimum": 0.0
-                    },
-                    "secs": {
-                      "type": "integer",
-                      "format": "uint64",
-                      "minimum": 0.0
-                    }
-                  },
                   "nullable": true
                 },
                 "resources": {

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -1,7 +1,6 @@
 //! Configuration for the telemetry plugin.
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::time::Duration;
 
 use opentelemetry::sdk::Resource;
 use opentelemetry::Array;
@@ -59,7 +58,6 @@ pub struct Metrics {
 #[derive(Clone, Default, Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub struct MetricsCommon {
-    pub delay_interval: Option<Duration>,
     /// Configuration to add custom labels/attributes to metrics
     pub attributes: Option<MetricsAttributesConf>,
     #[serde(default)]


### PR DESCRIPTION
It does nothing.

It was added in https://github.com/apollographql/router/commit/74b20a3671c1745828f75f93ad36bad305904580 / https://github.com/apollographql/router/pull/782 and was already doing nothing then. I haven’t found someone who can guess what it might have been meant to be.