### PR TITLE
fix(deps): update cargo pre-1.0 packages but not for `tracing*`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,9 +414,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -451,9 +451,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.13"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9496f0c1d1afb7a2af4338bbe1d969cddfead41d87a9fb3aaa6d0bbc7af648"
+checksum = "9de18bc5f2e9df8f52da03856bf40e29b747de5a84e43aefff90e3dc4a21529b"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -1412,7 +1412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3495912c9c1ccf2e18976439f4443f3fee0fd61f424ff99fde6a66b15ecb448f"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown 0.12.1",
+ "hashbrown",
  "lock_api",
  "parking_lot_core 0.9.3",
  "serde",
@@ -1703,9 +1703,9 @@ dependencies = [
 
 [[package]]
 name = "envmnt"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbb2fcaad9e6c9e3388dfcc1b44ae5508ae864b7af36f163a8a7c1a48796eee"
+checksum = "4498d2bc21512b323c159d2c6dff3fe6799ea6cfa6c24b991e76099abcd2a1ca"
 dependencies = [
  "fsio",
  "indexmap",
@@ -1891,9 +1891,9 @@ dependencies = [
 
 [[package]]
 name = "fsio"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e87827efaf94c7a44b562ff57de06930712fe21b530c3797cdede26e6377eb"
+checksum = "dad0ce30be0cc441b325c5d705c8b613a0ca0d92b6a8953d41bd236dc09a36d0"
 dependencies = [
  "dunce",
 ]
@@ -2231,18 +2231,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -2579,7 +2573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg 1.1.0",
- "hashbrown 0.12.1",
+ "hashbrown",
  "serde",
 ]
 
@@ -2861,9 +2855,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.131"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "04c3b4822ccebfa39c02fc03d1534441b22ead323fa0f48bb7ddd8e6ba076a40"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2963,11 +2957,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84e6fe5655adc6ce00787cf7dcaf8dc4f998a0565d23eafc207a8b08ca3349a"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
- "hashbrown 0.11.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -3178,9 +3172,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5641e476bbaf592a3939a7485fa079f427b4db21407d5ebfd5bba4e07a1f6f4c"
+checksum = "e2be9a9090bc1cac2930688fa9478092a64c6a92ddc6ae0692d46b37d9cab709"
 dependencies = [
  "cfg-if 1.0.0",
  "downcast",
@@ -3193,9 +3187,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262d56735932ee0240d515656e5a7667af3af2a5b0af4da558c4cff2b2aeb0c7"
+checksum = "86d702a0530a0141cf4ed147cf5ec7be6f2c187d4e37fcbefc39cf34116bfe8f"
 dependencies = [
  "cfg-if 1.0.0",
  "proc-macro2",
@@ -3205,9 +3199,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6eb67e4dc6898bb8cffa0b16ba679de61227945673d9d9a0e7bffd25679db6"
+checksum = "0a89c33e91526792a0260425073c3db0b472cdca2cc6fcaa666dd6e65450462a"
 dependencies = [
  "async-io",
  "async-lock",
@@ -4516,7 +4510,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88acf7b001007e9e8c989fe7449f6601d909e5dd2c56399fc158977ad6c56e8"
 dependencies = [
  "countme",
- "hashbrown 0.12.1",
+ "hashbrown",
  "memoffset",
  "rustc-hash",
  "text-size",
@@ -4932,9 +4926,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec0091e1f5aa338283ce049bd9dfefd55e1f168ac233e85c1ffe0038fb48cbe"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
  "indexmap",
  "ryu",
@@ -5386,9 +5380,9 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "test-log"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4235dbf7ea878b3ef12dea20a59c134b405a66aafc4fc2c7b9935916e289e735"
+checksum = "38f0c854faeb68a048f0f2dc410c5ddae3bf83854ef0e4977d58306a5edef50e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5912,9 +5906,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-test"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6992d8a98f570be1c729fe8b6f464fb18c4117054c10f1f952c22d533b48a74"
+checksum = "9e3d272c44878d2bbc9f4a20ad463724f03e19dbc667c6e84ac433ab7ffcc70b"
 dependencies = [
  "lazy_static",
  "tracing-core",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -19,7 +19,7 @@ failfast = []
 [dependencies]
 access-json = "0.1.0"
 anyhow = "1.0.58"
-apollo-parser = "0.2.8"
+apollo-parser = "0.2.9"
 apollo-spaceport = { path = "../apollo-spaceport" }
 apollo-uplink = { path = "../uplink" }
 async-compression = { version = "0.3.14", features = [
@@ -28,9 +28,9 @@ async-compression = { version = "0.3.14", features = [
     "gzip",
     "deflate",
 ] }
-async-trait = "0.1.56"
+async-trait = "0.1.57"
 atty = "0.2.14"
-axum = { version = "0.5.13", features = ["headers", "json", "original-uri"] }
+axum = { version = "0.5.15", features = ["headers", "json", "original-uri"] }
 backtrace = "0.3.66"
 buildstructor = "0.4.1"
 bytes = "1.1.0"
@@ -48,7 +48,7 @@ derive_more = { version = "0.99.17", default-features = false, features = [
 ] }
 directories = "4.0.1"
 displaydoc = "0.2"
-envmnt = "0.10.0"
+envmnt = "0.10.1"
 futures = { version = "0.3.21", features = ["thread-pool"] }
 hex = "0.4.3"
 hotwatch = "0.4.6"
@@ -63,10 +63,10 @@ indexmap = { version = "1.9.1", features = ["serde-1"] }
 itertools = "0.10.3"
 jsonschema = { version = "0.16.0", default-features = false }
 lazy_static = "1.4.0"
-libc = "0.2.126"
-lru = "0.7.7"
-mockall = "0.11.1"
-moka = { version = "0.9.0", features = ["future", "futures-util"] }
+libc = "0.2.131"
+lru = "0.7.8"
+mockall = "0.11.2"
+moka = { version = "0.9.3", features = ["future", "futures-util"] }
 miette = { version = "5.1.1", features = ["fancy"] }
 mime = "0.3.16"
 multimap = "0.8.3"
@@ -114,7 +114,7 @@ serde = { version = "1.0.139", features = ["derive", "rc"] }
 serde_json_bytes = { version = "0.2.0", features = ["preserve_order"] }
 serde_json = { version = "1.0.82", features = ["preserve_order"] }
 serde_urlencoded = "0.7.1"
-serde_yaml = "0.8.25"
+serde_yaml = "0.8.26"
 startup = "0.1.1"
 static_assertions = "1.1.0"
 sys-info = "0.9.1"
@@ -157,13 +157,13 @@ uname = "0.1.1"
 insta = "1.15.0"
 jsonpath_lib = "0.3.0"
 maplit = "1.0.2"
-mockall = "0.11.1"
+mockall = "0.11.2"
 reqwest = { version = "0.11.11", default-features = false, features = [
     "json",
     "stream",
 ] }
 tempfile = "3.3.0"
-test-log = { version = "0.2.10", default-features = false, features = [
+test-log = { version = "0.2.11", default-features = false, features = [
     "trace",
 ] }
 test-span = "0.6"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 apollo-smith = { version = "0.1.3", features = ["parser-impl"] }
-apollo-parser = "0.2.8"
+apollo-parser = "0.2.9"
 env_logger = "0.9.0"
 log = "0.4"
 reqwest = { version = "0.11", features = ["json", "blocking"] }

--- a/licenses.html
+++ b/licenses.html
@@ -6954,6 +6954,7 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/dtolnay/dyn-clone ">dyn-clone</a></li>
                     <li><a href=" https://github.com/bluss/either ">either</a></li>
                     <li><a href=" https://github.com/env-logger-rs/env_logger/ ">env_logger</a></li>
+                    <li><a href=" https://github.com/sagiegurari/envmnt.git ">envmnt</a></li>
                     <li><a href=" https://github.com/dtolnay/erased-serde ">erased-serde</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/error-chain ">error-chain</a></li>
                     <li><a href=" https://github.com/smol-rs/event-listener ">event-listener</a></li>
@@ -6971,7 +6972,6 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/rust-lang/git2-rs ">git2-curl</a></li>
                     <li><a href=" https://github.com/rust-lang/glob ">glob</a></li>
                     <li><a href=" https://github.com/zkcrypto/group ">group</a></li>
-                    <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown</a></li>
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown</a></li>
                     <li><a href=" https://github.com/HdrHistogram/HdrHistogram_rust.git ">hdrhistogram</a></li>
                     <li><a href=" https://github.com/withoutboats/heck ">heck</a></li>


### PR DESCRIPTION
This is the same as https://github.com/apollographql/router/pull/1002 but without `tracing`.   If we land this, then we can clean up this backlog and then configure the `renovate.json5` file to ignore the `tracing` crates.  The way it stands right now though, we're not merging any updates because they're lumped into the grouped PR.  (We can also disable the grouping, but we agreed a while back that we liked the grouping.)