### PR TITLE
chore: Display licenses.html diff if the license check failed in CI

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -373,4 +373,12 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 
 ## 🛠 Maintenance
 
+## 🚀 Features
+
+### Display licenses.html diff in CI if the check failed ([#1524](https://github.com/apollographql/router/issues/1524))
+
+The CI check that ensures that the `license.html` file is up to date now displays what has changed when the file is out of sync.
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o)
+
 ## 📚 Documentation

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -373,12 +373,12 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 
 ## 🛠 Maintenance
 
-## 🚀 Features
-
 ### Display licenses.html diff in CI if the check failed ([#1524](https://github.com/apollographql/router/issues/1524))
 
 The CI check that ensures that the `license.html` file is up to date now displays what has changed when the file is out of sync.
 
 By [@o0Ignition0o](https://github.com/o0Ignition0o)
+
+## 🚀 Features
 
 ## 📚 Documentation

--- a/xtask/src/commands/all.rs
+++ b/xtask/src/commands/all.rs
@@ -17,11 +17,11 @@ pub struct All {
 
 impl All {
     pub fn run(&self) -> Result<()> {
+        eprintln!("Checking licenses...");
+        self.compliance.run_local()?;
         eprintln!("Checking format and clippy...");
         self.lint.run_local()?;
         eprintln!("Running tests...");
-        self.test.run()?;
-        eprintln!("Checking licenses...");
-        self.compliance.run_local()
+        self.test.run()
     }
 }

--- a/xtask/src/commands/compliance.rs
+++ b/xtask/src/commands/compliance.rs
@@ -39,10 +39,9 @@ impl Compliance {
             eprintln!(
                 "{}",
                 String::from_utf8_lossy(
-                    Command::new(which::which("git").unwrap())
+                    Command::new(which::which("git")?)
                         .args(["diff", LICENSES_HTML_PATH])
-                        .output()
-                        .unwrap()
+                        .output()?
                         .stdout
                         .as_slice()
                 )


### PR DESCRIPTION
This PR displays the `git diff` output if the license check failed in CI.
This will hopefully help us diagnose license check fails.

This pr also changes the order of the steps performed in `cargo xtask all` to run them from the fastest to the slowest.

<!--
First, 🌠 thank you 🌠 for considering a contribution to Apollo!

Some of this information is also included in the /CONTRIBUTING.md file at the
root of this repository.  We suggest you read it!

  https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md

Here are some important details to keep in mind:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!  Documentation in the docs/ directory should be updated
        as necessary.  Finally, a /CHANGELOG.md entry should be added.

We hope you will find this to be a positive experience! Contribution can be
intimidating and we hope to alleviate that pain as much as possible. Without
following these guidelines, you may be missing context that can help you succeed
with your contribution, which is why we encourage discussion first. Ultimately,
there is no guarantee that we will be able to merge your pull-request, but by
following these guidelines we can try to avoid disappointment.

-->
