### PR TITLE
Add {Router,Execution}Response::map_stream helper

### DIFF
--- a/apollo-router/src/services/http_ext.rs
+++ b/apollo-router/src/services/http_ext.rs
@@ -277,7 +277,7 @@ pub struct Response<T> {
 impl<T> Response<T> {
     pub fn map<F, U>(self, f: F) -> Response<U>
     where
-        F: FnMut(T) -> U,
+        F: FnOnce(T) -> U,
     {
         self.inner.map(f).into()
     }

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -311,12 +311,16 @@ impl RouterResponse {
 
     pub fn map<F>(self, f: F) -> RouterResponse
     where
-        F: FnMut(BoxStream<'static, Response>) -> BoxStream<'static, Response>,
+        F: FnOnce(BoxStream<'static, Response>) -> BoxStream<'static, Response>,
     {
         RouterResponse {
             context: self.context,
             response: self.response.map(f),
         }
+    }
+
+    pub fn map_stream(self, f: impl FnMut(Response) -> Response + Send + 'static) -> Self {
+        self.map(move |stream| stream.map(f).boxed())
     }
 }
 
@@ -758,12 +762,16 @@ impl ExecutionResponse {
 
     pub fn map<F>(self, f: F) -> ExecutionResponse
     where
-        F: FnMut(BoxStream<'static, Response>) -> BoxStream<'static, Response>,
+        F: FnOnce(BoxStream<'static, Response>) -> BoxStream<'static, Response>,
     {
         ExecutionResponse {
             context: self.context,
             response: self.response.map(f),
         }
+    }
+
+    pub fn map_stream(self, f: impl FnMut(Response) -> Response + Send + 'static) -> Self {
+        self.map(move |stream| stream.map(f).boxed())
     }
 
     pub async fn next_response(&mut self) -> Option<Response> {


### PR DESCRIPTION
Follows up on https://github.com/apollographql/router/pull/1487#discussion_r944613174
Related to https://github.com/apollographql/router/issues/1219
