### PR TITLE
Rename RouterService to SupergraphService in various places

### DIFF
--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -64,7 +64,7 @@ use crate::plugin::Handler;
 use crate::plugins::traffic_shaping::Elapsed;
 use crate::plugins::traffic_shaping::RateLimited;
 use crate::router::ApolloRouterError;
-use crate::router_factory::RouterServiceFactory;
+use crate::router_factory::SupergraphServiceFactory;
 
 /// A basic http server using Axum.
 /// Uses streaming as primary method of response.
@@ -89,7 +89,7 @@ impl HttpServerFactory for AxumHttpServerFactory {
         plugin_handlers: HashMap<String, Handler>,
     ) -> Self::Future
     where
-        RF: RouterServiceFactory,
+        RF: SupergraphServiceFactory,
     {
         Box::pin(async move {
             let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
@@ -787,11 +787,11 @@ mod tests {
     >;
 
     #[derive(Clone)]
-    struct TestRouterServiceFactory {
+    struct TestSupergraphServiceFactory {
         inner: MockSupergraphServiceType,
     }
 
-    impl NewService<Request<graphql::Request>> for TestRouterServiceFactory {
+    impl NewService<Request<graphql::Request>> for TestSupergraphServiceFactory {
         type Service = MockSupergraphServiceType;
 
         fn new_service(&self) -> Self::Service {
@@ -799,10 +799,10 @@ mod tests {
         }
     }
 
-    impl RouterServiceFactory for TestRouterServiceFactory {
-        type RouterService = MockSupergraphServiceType;
+    impl SupergraphServiceFactory for TestSupergraphServiceFactory {
+        type SupergraphService = MockSupergraphServiceType;
 
-        type Future = <<TestRouterServiceFactory as NewService<
+        type Future = <<TestSupergraphServiceFactory as NewService<
             http_ext::Request<graphql::Request>,
         >>::Service as Service<http_ext::Request<graphql::Request>>>::Future;
 
@@ -827,7 +827,7 @@ mod tests {
         });
         let server = server_factory
             .create(
-                TestRouterServiceFactory {
+                TestSupergraphServiceFactory {
                     inner: service.into_inner(),
                 },
                 Arc::new(
@@ -875,7 +875,7 @@ mod tests {
         });
         let server = server_factory
             .create(
-                TestRouterServiceFactory {
+                TestSupergraphServiceFactory {
                     inner: service.into_inner(),
                 },
                 Arc::new(conf),
@@ -915,7 +915,7 @@ mod tests {
         });
         let server = server_factory
             .create(
-                TestRouterServiceFactory {
+                TestSupergraphServiceFactory {
                     inner: service.into_inner(),
                 },
                 Arc::new(

--- a/apollo-router/src/http_server_factory.rs
+++ b/apollo-router/src/http_server_factory.rs
@@ -10,7 +10,7 @@ use super::router::ApolloRouterError;
 use crate::configuration::Configuration;
 use crate::configuration::ListenAddr;
 use crate::plugin::Handler;
-use crate::router_factory::RouterServiceFactory;
+use crate::router_factory::SupergraphServiceFactory;
 
 /// Factory for creating the http server component.
 ///
@@ -27,7 +27,7 @@ pub(crate) trait HttpServerFactory {
         plugin_handlers: HashMap<String, Handler>,
     ) -> Self::Future
     where
-        RF: RouterServiceFactory;
+        RF: SupergraphServiceFactory;
 }
 
 /// A handle with with a client can shut down the server gracefully.
@@ -85,7 +85,7 @@ impl HttpServerHandle {
     ) -> Result<Self, ApolloRouterError>
     where
         SF: HttpServerFactory,
-        RF: RouterServiceFactory,
+        RF: SupergraphServiceFactory,
     {
         // we tell the currently running server to stop
         if let Err(_err) = self.shutdown_sender.send(()) {

--- a/apollo-router/src/plugins/expose_query_plan.rs
+++ b/apollo-router/src/plugins/expose_query_plan.rs
@@ -115,7 +115,7 @@ mod tests {
     use crate::json_ext::Object;
     use crate::plugin::test::MockSubgraph;
     use crate::plugin::DynPlugin;
-    use crate::services::PluggableRouterServiceBuilder;
+    use crate::services::PluggableSupergraphServiceBuilder;
     use crate::Schema;
 
     static EXPECTED_RESPONSE_WITH_QUERY_PLAN: Lazy<Response> = Lazy::new(|| {
@@ -170,7 +170,7 @@ mod tests {
             include_str!("../../../apollo-router-benchmarks/benches/fixtures/supergraph.graphql");
         let schema = Arc::new(Schema::parse(schema, &Default::default()).unwrap());
 
-        let builder = PluggableRouterServiceBuilder::new(schema.clone());
+        let builder = PluggableSupergraphServiceBuilder::new(schema.clone());
         let builder = builder
             .with_dyn_plugin("experimental.expose_query_plan".to_string(), plugin)
             .with_subgraph_service("accounts", account_service.clone())

--- a/apollo-router/src/plugins/include_subgraph_errors.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors.rs
@@ -97,7 +97,7 @@ mod test {
     use crate::json_ext::Object;
     use crate::plugin::test::MockSubgraph;
     use crate::plugin::DynPlugin;
-    use crate::PluggableRouterServiceBuilder;
+    use crate::PluggableSupergraphServiceBuilder;
     use crate::Schema;
     use crate::SupergraphRequest;
     use crate::SupergraphResponse;
@@ -190,7 +190,7 @@ mod test {
             include_str!("../../../apollo-router-benchmarks/benches/fixtures/supergraph.graphql");
         let schema = Arc::new(Schema::parse(schema, &Default::default()).unwrap());
 
-        let builder = PluggableRouterServiceBuilder::new(schema.clone());
+        let builder = PluggableSupergraphServiceBuilder::new(schema.clone());
         let builder = builder
             .with_dyn_plugin("experimental.include_subgraph_errors".to_string(), plugin)
             .with_subgraph_service("accounts", account_service.clone())

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -279,7 +279,7 @@ mod test {
     use crate::plugin::test::MockSubgraph;
     use crate::plugin::test::MockSupergraphService;
     use crate::plugin::DynPlugin;
-    use crate::PluggableRouterServiceBuilder;
+    use crate::PluggableSupergraphServiceBuilder;
     use crate::Schema;
     use crate::SupergraphRequest;
     use crate::SupergraphResponse;
@@ -354,7 +354,7 @@ mod test {
         );
         let schema: Arc<Schema> = Arc::new(Schema::parse(schema, &Default::default()).unwrap());
 
-        let builder = PluggableRouterServiceBuilder::new(schema.clone());
+        let builder = PluggableSupergraphServiceBuilder::new(schema.clone());
 
         let builder = builder
             .with_dyn_plugin("apollo.traffic_shaping".to_string(), plugin)

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -33,7 +33,7 @@ use crate::axum_http_server_factory::AxumHttpServerFactory;
 use crate::configuration::validate_configuration;
 use crate::configuration::Configuration;
 use crate::configuration::ListenAddr;
-use crate::router_factory::YamlRouterServiceFactory;
+use crate::router_factory::YamlSupergraphServiceFactory;
 use crate::state_machine::StateMachine;
 
 type SchemaStream = Pin<Box<dyn Stream<Item = String> + Send>>;
@@ -445,7 +445,7 @@ impl RouterHttpServer {
             shutdown_receiver,
         );
         let server_factory = AxumHttpServerFactory::new();
-        let router_factory = YamlRouterServiceFactory::default();
+        let router_factory = YamlSupergraphServiceFactory::default();
         let state_machine = StateMachine::new(server_factory, router_factory);
         let listen_address = state_machine.listen_address.clone();
         let result = spawn(

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -18,17 +18,21 @@ use crate::plugin::Handler;
 use crate::services::new_service::NewService;
 use crate::services::RouterCreator;
 use crate::services::SubgraphService;
-use crate::PluggableRouterServiceBuilder;
+use crate::PluggableSupergraphServiceBuilder;
 use crate::Schema;
 
-/// Factory for creating a RouterService
+/// Factory for creating a SupergraphService
 ///
 /// Instances of this traits are used by the HTTP server to generate a new
-/// RouterService on each request
-pub(crate) trait RouterServiceFactory:
-    NewService<Request<graphql::Request>, Service = Self::RouterService> + Clone + Send + Sync + 'static
+/// SupergraphService on each request
+pub(crate) trait SupergraphServiceFactory:
+    NewService<Request<graphql::Request>, Service = Self::SupergraphService>
+    + Clone
+    + Send
+    + Sync
+    + 'static
 {
-    type RouterService: Service<
+    type SupergraphService: Service<
             Request<graphql::Request>,
             Response = Response<BoxStream<'static, graphql::Response>>,
             Error = BoxError,
@@ -39,42 +43,42 @@ pub(crate) trait RouterServiceFactory:
     fn custom_endpoints(&self) -> HashMap<String, Handler>;
 }
 
-/// Factory for creating a RouterServiceFactory
+/// Factory for creating a SupergraphServiceFactory
 ///
 /// Instances of this traits are used by the StateMachine to generate a new
-/// RouterServiceFactory from configuration when it changes
+/// SupergraphServiceFactory from configuration when it changes
 #[async_trait::async_trait]
-pub(crate) trait RouterServiceConfigurator: Send + Sync + 'static {
-    type RouterServiceFactory: RouterServiceFactory;
+pub(crate) trait SupergraphServiceConfigurator: Send + Sync + 'static {
+    type SupergraphServiceFactory: SupergraphServiceFactory;
 
     async fn create<'a>(
         &'a mut self,
         configuration: Arc<Configuration>,
         schema: Arc<crate::Schema>,
-        previous_router: Option<&'a Self::RouterServiceFactory>,
+        previous_router: Option<&'a Self::SupergraphServiceFactory>,
         extra_plugins: Option<Vec<(String, Box<dyn DynPlugin>)>>,
-    ) -> Result<Self::RouterServiceFactory, BoxError>;
+    ) -> Result<Self::SupergraphServiceFactory, BoxError>;
 }
 
-/// Main implementation of the RouterService factory, supporting the extensions system
+/// Main implementation of the SupergraphService factory, supporting the extensions system
 #[derive(Default)]
-pub(crate) struct YamlRouterServiceFactory;
+pub(crate) struct YamlSupergraphServiceFactory;
 
 #[async_trait::async_trait]
-impl RouterServiceConfigurator for YamlRouterServiceFactory {
-    type RouterServiceFactory = RouterCreator;
+impl SupergraphServiceConfigurator for YamlSupergraphServiceFactory {
+    type SupergraphServiceFactory = RouterCreator;
 
     async fn create<'a>(
         &'a mut self,
         configuration: Arc<Configuration>,
         schema: Arc<Schema>,
-        _previous_router: Option<&'a Self::RouterServiceFactory>,
+        _previous_router: Option<&'a Self::SupergraphServiceFactory>,
         extra_plugins: Option<Vec<(String, Box<dyn DynPlugin>)>>,
-    ) -> Result<Self::RouterServiceFactory, BoxError> {
+    ) -> Result<Self::SupergraphServiceFactory, BoxError> {
         // Process the plugins.
         let plugins = create_plugins(&configuration, &schema, extra_plugins).await?;
 
-        let mut builder = PluggableRouterServiceBuilder::new(schema.clone());
+        let mut builder = PluggableSupergraphServiceBuilder::new(schema.clone());
         builder = builder.with_configuration(configuration);
 
         for (name, _) in schema.subgraphs() {
@@ -109,7 +113,7 @@ pub async fn create_test_service_factory_from_yaml(schema: &str, configuration: 
 
     let schema: Schema = Schema::parse(schema, &Default::default()).unwrap();
 
-    let service = YamlRouterServiceFactory::default()
+    let service = YamlSupergraphServiceFactory::default()
         .create(Arc::new(config), Arc::new(schema), None, None)
         .await;
     assert_eq!(
@@ -285,8 +289,8 @@ mod test {
     use crate::plugin::PluginInit;
     use crate::register_plugin;
     use crate::router_factory::inject_schema_id;
-    use crate::router_factory::RouterServiceConfigurator;
-    use crate::router_factory::YamlRouterServiceFactory;
+    use crate::router_factory::SupergraphServiceConfigurator;
+    use crate::router_factory::YamlSupergraphServiceFactory;
     use crate::Schema;
 
     #[derive(Debug)]
@@ -402,7 +406,7 @@ mod test {
         let schema = include_str!("testdata/supergraph.graphql");
         let schema = Schema::parse(schema, &config).unwrap();
 
-        let service = YamlRouterServiceFactory::default()
+        let service = YamlSupergraphServiceFactory::default()
             .create(Arc::new(config), Arc::new(schema), None, None)
             .await;
         service.map(|_| ())

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -23,8 +23,8 @@ use super::state_machine::State::Startup;
 use super::state_machine::State::Stopped;
 use crate::configuration::Configuration;
 use crate::configuration::ListenAddr;
-use crate::router_factory::RouterServiceConfigurator;
-use crate::router_factory::RouterServiceFactory;
+use crate::router_factory::SupergraphServiceConfigurator;
+use crate::router_factory::SupergraphServiceFactory;
 use crate::Schema;
 
 /// This state maintains private information that is not exposed to the user via state listener.
@@ -67,7 +67,7 @@ impl<T> Display for State<T> {
 pub(crate) struct StateMachine<S, FA>
 where
     S: HttpServerFactory,
-    FA: RouterServiceConfigurator,
+    FA: SupergraphServiceConfigurator,
 {
     http_server_factory: S,
     router_configurator: FA,
@@ -80,8 +80,8 @@ where
 impl<S, FA> StateMachine<S, FA>
 where
     S: HttpServerFactory,
-    FA: RouterServiceConfigurator + Send,
-    FA::RouterServiceFactory: RouterServiceFactory,
+    FA: SupergraphServiceConfigurator + Send,
+    FA::SupergraphServiceFactory: SupergraphServiceFactory,
 {
     pub(crate) fn new(http_server_factory: S, router_factory: FA) -> Self {
         let ready = Arc::new(RwLock::new(None));
@@ -254,7 +254,7 @@ where
 
     async fn maybe_update_listen_address(
         &mut self,
-        state: &mut State<<FA as RouterServiceConfigurator>::RouterServiceFactory>,
+        state: &mut State<<FA as SupergraphServiceConfigurator>::SupergraphServiceFactory>,
     ) {
         let listen_address = if let Running { server_handle, .. } = &state {
             let listen_address = server_handle.listen_address().clone();
@@ -274,10 +274,10 @@ where
 
     async fn maybe_transition_to_running(
         &mut self,
-        state: State<<FA as RouterServiceConfigurator>::RouterServiceFactory>,
+        state: State<<FA as SupergraphServiceConfigurator>::SupergraphServiceFactory>,
     ) -> Result<
-        State<<FA as RouterServiceConfigurator>::RouterServiceFactory>,
-        State<<FA as RouterServiceConfigurator>::RouterServiceFactory>,
+        State<<FA as SupergraphServiceConfigurator>::SupergraphServiceFactory>,
+        State<<FA as SupergraphServiceConfigurator>::SupergraphServiceFactory>,
     > {
         if let Startup {
             configuration: Some(configuration),
@@ -338,13 +338,13 @@ where
         &mut self,
         configuration: Arc<Configuration>,
         schema: Arc<Schema>,
-        router_service: <FA as RouterServiceConfigurator>::RouterServiceFactory,
+        router_service: <FA as SupergraphServiceConfigurator>::SupergraphServiceFactory,
         server_handle: HttpServerHandle,
         new_configuration: Option<Arc<Configuration>>,
         new_schema: Option<Arc<Schema>>,
     ) -> Result<
-        State<<FA as RouterServiceConfigurator>::RouterServiceFactory>,
-        State<<FA as RouterServiceConfigurator>::RouterServiceFactory>,
+        State<<FA as SupergraphServiceConfigurator>::SupergraphServiceFactory>,
+        State<<FA as SupergraphServiceConfigurator>::SupergraphServiceFactory>,
     > {
         let new_schema = new_schema.unwrap_or_else(|| schema.clone());
         let new_configuration = new_configuration.unwrap_or_else(|| configuration.clone());
@@ -437,8 +437,8 @@ mod tests {
     use crate::http_server_factory::Listener;
     use crate::plugin::DynPlugin;
     use crate::plugin::Handler;
-    use crate::router_factory::RouterServiceConfigurator;
-    use crate::router_factory::RouterServiceFactory;
+    use crate::router_factory::SupergraphServiceConfigurator;
+    use crate::router_factory::SupergraphServiceFactory;
     use crate::services::new_service::NewService;
 
     fn example_schema() -> String {
@@ -639,8 +639,8 @@ mod tests {
         MyRouterConfigurator {}
 
         #[async_trait::async_trait]
-        impl RouterServiceConfigurator for MyRouterConfigurator {
-            type RouterServiceFactory = MockMyRouterFactory;
+        impl SupergraphServiceConfigurator for MyRouterConfigurator {
+            type SupergraphServiceFactory = MockMyRouterFactory;
 
             async fn create<'a>(
                 &'a mut self,
@@ -656,9 +656,9 @@ mod tests {
         #[derive(Debug)]
         MyRouterFactory {}
 
-        impl RouterServiceFactory for MyRouterFactory {
-            type RouterService = MockMyRouter;
-            type Future = <Self::RouterService as Service<Request<graphql::Request>>>::Future;
+        impl SupergraphServiceFactory for MyRouterFactory {
+            type SupergraphService = MockMyRouter;
+            type Future = <Self::SupergraphService as Service<Request<graphql::Request>>>::Future;
             fn custom_endpoints(&self) -> std::collections::HashMap<String, crate::plugin::Handler>;
         }
         impl  NewService<Request<graphql::Request>> for MyRouterFactory {
@@ -718,7 +718,7 @@ mod tests {
             _plugin_handlers: HashMap<String, Handler>,
         ) -> Self::Future
         where
-            RF: RouterServiceFactory,
+            RF: SupergraphServiceFactory,
         {
             let res = self.create_server(configuration, listener);
             Box::pin(async move { res })

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -8,8 +8,8 @@ use crate::plugin::test::canned;
 use crate::plugin::DynPlugin;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
-use crate::router_factory::RouterServiceConfigurator;
-use crate::router_factory::YamlRouterServiceFactory;
+use crate::router_factory::SupergraphServiceConfigurator;
+use crate::router_factory::YamlSupergraphServiceFactory;
 use crate::stages::execution;
 use crate::stages::query_planner;
 use crate::stages::subgraph;
@@ -135,7 +135,7 @@ impl<'a> TestHarness<'a> {
         self,
         callback: impl Fn(supergraph::BoxService) -> supergraph::BoxService + Send + Sync + 'static,
     ) -> Self {
-        self.extra_plugin(RouterServicePlugin(callback))
+        self.extra_plugin(SupergraphServicePlugin(callback))
     }
 
     /// Adds an ad-hoc plugin that has [`Plugin::query_planner_service`] implemented with `callback`.
@@ -206,7 +206,7 @@ impl<'a> TestHarness<'a> {
         let canned_schema = include_str!("../../examples/graphql/local.graphql");
         let schema = builder.schema.unwrap_or(canned_schema);
         let schema = Arc::new(Schema::parse(schema, &config)?);
-        let router_creator = YamlRouterServiceFactory
+        let router_creator = YamlSupergraphServiceFactory
             .create(config, schema, None, Some(builder.extra_plugins))
             .await?;
         Ok(tower::service_fn(move |request| {
@@ -217,13 +217,13 @@ impl<'a> TestHarness<'a> {
     }
 }
 
-struct RouterServicePlugin<F>(F);
+struct SupergraphServicePlugin<F>(F);
 struct QueryPlannerServicePlugin<F>(F);
 struct ExecutionServicePlugin<F>(F);
 struct SubgraphServicePlugin<F>(F);
 
 #[async_trait::async_trait]
-impl<F> Plugin for RouterServicePlugin<F>
+impl<F> Plugin for SupergraphServicePlugin<F>
 where
     F: 'static + Send + Sync + Fn(supergraph::BoxService) -> supergraph::BoxService,
 {

--- a/docs/source/customizations/native.mdx
+++ b/docs/source/customizations/native.mdx
@@ -174,8 +174,8 @@ Before implementing a layer yourself, always check whether an existing layer imp
 
 Sometimes you might need to pass custom information between services. For example:
 
-* Authentication information obtained by the `RouterService` might be required by `SubgraphService`s.
-* Cache control headers from `SubgraphService`s might be aggregated and returned to the client by the `RouterService`.
+* Authentication information obtained by the `SupergraphService` might be required by `SubgraphService`s.
+* Cache control headers from `SubgraphService`s might be aggregated and returned to the client by the `SupergraphService`.
 
 Whenever the Apollo Router receives a request, it creates a corresponding `context` object and passes it along to each service. This object can store anything that's Serde-compatible (e.g., all simple types or a custom type).
 

--- a/docs/source/customizations/overview.mdx
+++ b/docs/source/customizations/overview.mdx
@@ -27,15 +27,15 @@ Before building an Apollo Router customization, it helps first to understand how
 ```mermaid
 sequenceDiagram
     actor Client
-    participant RouterService
+    participant SupergraphService
     participant QueryPlannerService
     participant ExecutionService
     participant SubgraphService(s)
 
-    Client->>RouterService: Sends request
-    RouterService->>QueryPlannerService: Fetches<br/>query plan
-    QueryPlannerService-->>RouterService: 
-    RouterService->>ExecutionService: Initiates query plan execution
+    Client->>SupergraphService: Sends request
+    SupergraphService->>QueryPlannerService: Fetches<br/>query plan
+    QueryPlannerService-->>SupergraphService: 
+    SupergraphService->>ExecutionService: Initiates query plan execution
     par
     ExecutionService->>SubgraphService(s): Initiates<br/>sub-operation
     SubgraphService(s)-->>ExecutionService: 
@@ -46,11 +46,11 @@ sequenceDiagram
     ExecutionService->>SubgraphService(s): Initiates<br/>sub-operation
     SubgraphService(s)-->>ExecutionService: 
     end
-    ExecutionService-->>RouterService: Assembles and returns response
-    RouterService-->>Client: Returns response
+    ExecutionService-->>SupergraphService: Assembles and returns response
+    SupergraphService-->>Client: Returns response
 ```
 
-As execution proceeds "left to right" from the `RouterService` to individual `SubgraphService`s, each service passes the client's original request along to the _next_ service. Similarly, as execution continues "right to left" from `SubgraphService`s to the `RouterService`, each service passes the response to the client.
+As execution proceeds "left to right" from the `SupergraphService` to individual `SubgraphService`s, each service passes the client's original request along to the _next_ service. Similarly, as execution continues "right to left" from `SubgraphService`s to the `SupergraphService`, each service passes the response to the client.
 
 Apollo Router customizations can hook into _any combination_ of these services and modify the request, response, or related metadata as they're passed along.
 

--- a/examples/context/README.md
+++ b/examples/context/README.md
@@ -15,23 +15,23 @@ The request lifecycle looks like this:
 ```mermaid
 sequenceDiagram
     actor Client
-    participant RouterService
+    participant SupergraphService
     participant QueryPlannerService
     participant ExecutionService
     participant SubgraphService(s)
 
-    Client->>RouterService: request
-    RouterService->>QueryPlannerService: plan
-    QueryPlannerService-->>RouterService: 
-    RouterService->>ExecutionService: execute
+    Client->>SupergraphService: request
+    SupergraphService->>QueryPlannerService: plan
+    QueryPlannerService-->>SupergraphService: 
+    SupergraphService->>ExecutionService: execute
     ExecutionService-)SubgraphService(s): sub-request
     SubgraphService(s)--)ExecutionService: 
     ExecutionService-)SubgraphService(s): sub-request
     SubgraphService(s)--)ExecutionService: 
     ExecutionService-)SubgraphService(s): sub-request
     SubgraphService(s)--)ExecutionService: 
-    ExecutionService-->>RouterService: response
-    RouterService-->>Client: response
+    ExecutionService-->>SupergraphService: response
+    SupergraphService-->>Client: response
 ```
 
 For each request a single instance of `Context` is created and maintained .

--- a/examples/status-code-propagation/README.md
+++ b/examples/status-code-propagation/README.md
@@ -16,15 +16,15 @@ The request lifecycle looks like this:
 ```mermaid
 sequenceDiagram
     actor Client
-    participant RouterService
+    participant SupergraphService
     participant QueryPlannerService
     participant ExecutionService
     participant SubgraphService(s)
 
-    Client->>RouterService: request
-    RouterService->>QueryPlannerService: plan
-    QueryPlannerService-->>RouterService: 
-    RouterService->>ExecutionService: execute
+    Client->>SupergraphService: request
+    SupergraphService->>QueryPlannerService: plan
+    QueryPlannerService-->>SupergraphService: 
+    SupergraphService->>ExecutionService: execute
     par
     ExecutionService-)SubgraphService(s): sub-request
     SubgraphService(s)--)ExecutionService: 
@@ -35,8 +35,8 @@ sequenceDiagram
     ExecutionService-)SubgraphService(s): sub-request
     SubgraphService(s)--)ExecutionService: 
     end
-    ExecutionService-->>RouterService: response
-    RouterService-->>Client: response
+    ExecutionService-->>SupergraphService: response
+    SupergraphService-->>Client: response
 ```
 
 On each subgraph response the value `upsert` is called on the context to potentially place the http response code

--- a/examples/status-code-propagation/src/propagate_status_code.rs
+++ b/examples/status-code-propagation/src/propagate_status_code.rs
@@ -124,7 +124,7 @@ mod tests {
     // Unit testing this plugin will be a tad more complicated than testing the other ones.
     // We will first ensure the SubgraphService pushes the right status codes.
     //
-    // We will then make sure the RouterService is able to turn the relevant ordered status codes
+    // We will then make sure the SupergraphService is able to turn the relevant ordered status codes
     // into the relevant http response status.
 
     #[tokio::test]
@@ -201,7 +201,7 @@ mod tests {
     }
 
     // Now that our status codes mechanism has been tested,
-    // we can unit test the RouterService part of our plugin
+    // we can unit test the SupergraphService part of our plugin
 
     #[tokio::test]
     async fn router_service_override_status_code() {

--- a/examples/supergraph_sdl/README.md
+++ b/examples/supergraph_sdl/README.md
@@ -15,23 +15,23 @@ The request lifecycle looks like this:
 ```mermaid
 sequenceDiagram
     actor Client
-    participant RouterService
+    participant SupergraphService
     participant QueryPlannerService
     participant ExecutionService
     participant SubgraphService(s)
 
-    Client->>RouterService: request
-    RouterService->>QueryPlannerService: plan
-    QueryPlannerService-->>RouterService: 
-    RouterService->>ExecutionService: execute
+    Client->>SupergraphService: request
+    SupergraphService->>QueryPlannerService: plan
+    QueryPlannerService-->>SupergraphService: 
+    SupergraphService->>ExecutionService: execute
     ExecutionService-)SubgraphService(s): sub-request
     SubgraphService(s)--)ExecutionService: 
     ExecutionService-)SubgraphService(s): sub-request
     SubgraphService(s)--)ExecutionService: 
     ExecutionService-)SubgraphService(s): sub-request
     SubgraphService(s)--)ExecutionService: 
-    ExecutionService-->>RouterService: response
-    RouterService-->>Client: response
+    ExecutionService-->>SupergraphService: response
+    SupergraphService-->>Client: response
 ```
 
 In this example we:


### PR DESCRIPTION
Follow up to https://github.com/apollographql/router/pull/1534

This does not affect the public API