### PR TITLE
fix: return an HTTP 400 if variable validation fails.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -446,6 +446,12 @@ By [@SimonSapin](https://github.com/SimonSapin)
 
 ## 🐛 Fixes
 
+### Variables validation: return a 400 if variables validation fails ([#1403](https://github.com/apollographql/router/issues/1403))
+
+Failure to validate variables against a query and a schema will now return an HTTP 400.
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o)
+
 ### Expose query plan: move the behavior to the execution_service ([#1541](https://github.com/apollographql/router/issues/1541))
 
 There isn't much use for QueryPlanner plugins. Most of the logic done there can be done in `execution_service`. Moreover users could get inconsistent plugin behavior because it depends on whether the QueryPlanner cache hits or not.

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -161,7 +161,9 @@ where
                     let is_deferred = plan.root.contains_defer();
 
                     if let Some(err) = query.validate_variables(body, &schema).err() {
-                        Ok(SupergraphResponse::new_from_graphql_response(err, context))
+                        let mut res = SupergraphResponse::new_from_graphql_response(err, context);
+                        *res.response.status_mut() = StatusCode::BAD_REQUEST;
+                        Ok(res)
                     } else {
                         let operation_name = body.operation_name.clone();
 


### PR DESCRIPTION
fixes #1403

While the query planner would rightfully return an HTTP 400 if query validation fails, variable validation that occurred right after would return an HTTP 200.

This PR fixes it, and adds a test.
