### PR TITLE
Disable check-compliance on CI as it is flaky

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -666,10 +666,17 @@ workflows:
           matrix:
             parameters:
               platform: [rust_linux]
-      - check_compliance:
-          matrix:
-            parameters:
-              platform: [rust_linux]
+
+      # check-compliance is disabled for now because it is flaky
+      # `cargo about` seems to be non-deterministic and sometimes
+      # produces a different licenses.html file even though dependencies haven’t changed.
+      # For now, we’ll re-generate it for each release instead. (See RELEASE_CHECKLIST.md)
+
+      # - check_compliance:
+      #     matrix:
+      #       parameters:
+      #         platform: [rust_linux]
+
       - build:
           matrix:
             parameters:

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -32,6 +32,8 @@ in lieu of an official changelog.
 7. cd helm/chart && helm-docs router; cd - (if required, install [helm-docs](https://github.com/norwoodj/helm-docs))
 8. Update `federation-version-support.mdx` with the latest version info. Use https://github.com/apollographql/version_matrix to generate the version matrix.
 9. Update the version in docker-compose files in `dockerfiles` directory.
+10. Update the license list with `cargo about generate --workspace -o licenses.html about.hbs`.
+    You can install `cargo-about` by running `cargo install cargo-about`.
 
 ### Start a release PR
 


### PR DESCRIPTION
For now we’ll run it for releases.