### PR TITLE
only send one report for a response with deferred responses

### DIFF
--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -544,7 +544,7 @@ where
                                             serde_json::to_vec(&res).unwrap().into(),
                                         )))
                                         .chain(once(ready(Bytes::from_static(b"\r\n"))))
-                                    }).chain(once(ready(Bytes::from_static(b"--graphql--\r\ncontent-type: application/json\r\n\r\n{\"hasNext\":false}"))))
+                                    })
                                     .map(Ok::<_, BoxError>);
 
                                 (parts, StreamBody::new(body)).into_response()

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -225,7 +225,7 @@ impl Plugin for Telemetry {
                                 Err(e)
                             }
                             Ok(router_response) => {
-                                let is_not_success =
+                                let mut has_errors =
                                     !router_response.response.status().is_success();
                                 Ok(router_response.map(move |response_stream| {
                                     let sender = sender.clone();
@@ -233,14 +233,18 @@ impl Plugin for Telemetry {
 
                                     response_stream
                                         .map(move |response| {
-                                            let response_has_errors = !response.errors.is_empty();
+                                            if !response.errors.is_empty() {
+                                                has_errors = true;
+                                            }
 
-                                            if !matches!(sender, Sender::Noop) {
+                                            if !response.has_next.unwrap_or(false)
+                                                && !matches!(sender, Sender::Noop)
+                                            {
                                                 Self::update_apollo_metrics(
                                                     &ctx,
                                                     sender.clone(),
-                                                    is_not_success || response_has_errors,
-                                                    start.elapsed(),
+                                                    has_errors,
+                                                    dbg!(start.elapsed()),
                                                 );
                                             }
                                             response

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -238,7 +238,8 @@ where
                                                     .build()
                                             }
                                         }
-                                    })
+                                    }).chain(once(ready(Response::builder().has_next(false).build())))
+
                                     .in_current_span()
                                     .boxed(),
                             )


### PR DESCRIPTION
it must measure the latency of the entire operation