### PR TITLE
TestHarness: rename extra_*_plugin to *_hook

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -43,6 +43,16 @@ Let's remove it since it's simple to add back if later required.
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1569
 
+### Rename TestHarness methods ([PR #1579](https://github.com/apollographql/router/pull/1579))
+
+Some methods of `apollo_router::TestHarness` were renamed:
+
+* `extra_supergraph_plugin` → `supergraph_hook`
+* `extra_execution_plugin` → `execution_hook`
+* `extra_subgraph_plugin` → `subgraph_hook`
+
+By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/1579
+
 ### Request and Response types from apollo_router::http_ext are private ([Issue #1589](https://github.com/apollographql/router/issues/1589))
 
 These types were wrappers around the `Request` and `Response` types from the `http` crate.

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -129,24 +129,24 @@ impl<'a> TestHarness<'a> {
         self
     }
 
-    /// Adds an ad-hoc plugin that has [`Plugin::supergraph_service`] implemented with `callback`.
-    pub fn extra_supergraph_plugin(
+    /// Adds a callback-based hook similar to [`Plugin::supergraph_service`]
+    pub fn supergraph_hook(
         self,
         callback: impl Fn(supergraph::BoxService) -> supergraph::BoxService + Send + Sync + 'static,
     ) -> Self {
         self.extra_plugin(SupergraphServicePlugin(callback))
     }
 
-    /// Adds an ad-hoc plugin that has [`Plugin::execution_service`] implemented with `callback`.
-    pub fn extra_execution_plugin(
+    /// Adds a callback-based hook similar to [`Plugin::execution_service`]
+    pub fn execution_hook(
         self,
         callback: impl Fn(execution::BoxService) -> execution::BoxService + Send + Sync + 'static,
     ) -> Self {
         self.extra_plugin(ExecutionServicePlugin(callback))
     }
 
-    /// Adds an ad-hoc plugin that has [`Plugin::subgraph_service`] implemented with `callback`.
-    pub fn extra_subgraph_plugin(
+    /// Adds a callback-based hook similar to [`Plugin::subgraph_service`]
+    pub fn subgraph_hook(
         self,
         callback: impl Fn(&str, subgraph::BoxService) -> subgraph::BoxService + Send + Sync + 'static,
     ) -> Self {
@@ -167,7 +167,7 @@ impl<'a> TestHarness<'a> {
     /// Builds the GraphQL service
     pub async fn build(self) -> Result<supergraph::BoxCloneService, BoxError> {
         let builder = if self.schema.is_none() {
-            self.extra_subgraph_plugin(|subgraph_name, default| match subgraph_name {
+            self.subgraph_hook(|subgraph_name, default| match subgraph_name {
                 "products" => canned::products_subgraph().boxed(),
                 "accounts" => canned::accounts_subgraph().boxed(),
                 "reviews" => canned::reviews_subgraph().boxed(),
@@ -179,7 +179,7 @@ impl<'a> TestHarness<'a> {
         let builder = if builder.subgraph_network_requests {
             builder
         } else {
-            builder.extra_subgraph_plugin(|_name, _default| {
+            builder.subgraph_hook(|_name, _default| {
                 tower::service_fn(|request: subgraph::Request| {
                     let empty_response = subgraph::Response::builder()
                         .extensions(crate::json_ext::Object::new())

--- a/examples/add-timestamp-header/src/main.rs
+++ b/examples/add-timestamp-header/src/main.rs
@@ -51,7 +51,7 @@ mod tests {
         let test_harness = apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .extra_supergraph_plugin(move |_| mock_service.clone().boxed())
+            .supergraph_hook(move |_| mock_service.clone().boxed())
             .build()
             .await
             .unwrap();

--- a/examples/cookies-to-headers/src/main.rs
+++ b/examples/cookies-to-headers/src/main.rs
@@ -85,8 +85,8 @@ mod tests {
         let test_harness = apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .extra_subgraph_plugin(move |_, _| mock_service.clone().boxed())
-            .extra_supergraph_plugin(|service| {
+            .subgraph_hook(move |_, _| mock_service.clone().boxed())
+            .supergraph_hook(|service| {
                 service
                     .map_response(|response| {
                         let mock_data = response.context.get("mock_data").unwrap();

--- a/examples/op-name-to-header/src/main.rs
+++ b/examples/op-name-to-header/src/main.rs
@@ -57,7 +57,7 @@ mod tests {
         let test_harness = apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .extra_supergraph_plugin(move |_| mock_service.clone().boxed())
+            .supergraph_hook(move |_| mock_service.clone().boxed())
             .build()
             .await
             .unwrap();

--- a/examples/rhai-logging/src/main.rs
+++ b/examples/rhai-logging/src/main.rs
@@ -50,7 +50,7 @@ mod tests {
         let test_harness = apollo_router::TestHarness::builder()
             .configuration_json(config)
             .unwrap()
-            .extra_supergraph_plugin(move |_| mock_service.clone().boxed())
+            .supergraph_hook(move |_| mock_service.clone().boxed())
             .build()
             .await
             .unwrap();


### PR DESCRIPTION
The previous verbosity was not helpful
