### PR TITLE
Give JsonPath and JsonPathElement an importable path

### DIFF
--- a/apollo-router/src/graphql.rs
+++ b/apollo-router/src/graphql.rs
@@ -14,6 +14,8 @@ use crate::error::FetchError;
 use crate::error::Location;
 use crate::json_ext::Object;
 use crate::json_ext::Path;
+pub use crate::json_ext::Path as JsonPath;
+pub use crate::json_ext::PathElement as JsonPathElement;
 pub use crate::request::Request;
 pub use crate::response::Response;
 

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -1,4 +1,7 @@
 //! Performance oriented JSON manipulation.
+
+#![allow(missing_docs)] // FIXME
+
 use std::cmp::min;
 use std::fmt;
 


### PR DESCRIPTION
They were already public since reachable through graphql::Error

Fixes https://github.com/apollographql/router/issues/1305.
I haven’t managed to reproduce scripts to reliably find if other items are reachable but not importable, but these are the only ones I found manually.