### PR TITLE
relax trait bound on Plugin

### DIFF
--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -150,7 +150,7 @@ pub(crate) fn plugins() -> HashMap<String, PluginFactory> {
 /// The trait also provides a default implementations for each hook, which returns the associated service unmodified.
 /// For more information about the plugin lifecycle please check this documentation <https://www.apollographql.com/docs/router/customizations/native/#plugin-lifecycle>
 #[async_trait]
-pub trait Plugin: Send + Sync + 'static + Sized {
+pub trait Plugin: Send + Sync + 'static {
     /// The configuration for this plugin.
     /// Typically a `struct` with `#[derive(serde::Deserialize)]`.
     ///
@@ -163,7 +163,9 @@ pub trait Plugin: Send + Sync + 'static + Sized {
 
     /// This is invoked once after the router starts and compiled-in
     /// plugins are registered.
-    async fn new(init: PluginInit<Self::Config>) -> Result<Self, BoxError>;
+    async fn new(init: PluginInit<Self::Config>) -> Result<Self, BoxError>
+    where
+        Self: Sized;
 
     /// This service runs at the very beginning and very end of the request lifecycle.
     /// Define supergraph_service if your customization needs to interact at the earliest or latest point possible.
@@ -196,7 +198,10 @@ pub trait Plugin: Send + Sync + 'static + Sized {
     }
 
     /// Return the name of the plugin.
-    fn name(&self) -> &'static str {
+    fn name(&self) -> &'static str
+    where
+        Self: Sized,
+    {
         get_type_of(self)
     }
 }


### PR DESCRIPTION
There's no need to require the whole trait to be Sized.

fixes: #1591

