### PR TITLE
fix(apollo-router): fix typo in error message

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -57,6 +57,12 @@ Move the location of the `text` field when exposing the query plan and fill it w
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1557
 
+### Fix typo on HTTP errors from subgraph ([#1593](https://github.com/apollographql/router/pull/1593))
+
+Remove the closed parenthesis at the end of error messages resulting from HTTP errors from subgraphs.
+
+By [@nmoutschen](https://github.com/nmoutschen) in https://github.com/apollographql/router/pull/1593
+
 
 ## 🛠 Maintenance
 ## 📚 Documentation

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -201,7 +201,7 @@ impl tower::Service<crate::SubgraphRequest> for SubgraphService {
                 return Err(BoxError::from(FetchError::SubrequestHttpError {
                     service: service_name.clone(),
                     reason: format!(
-                        "subgraph HTTP status error '{}': {})",
+                        "subgraph HTTP status error '{}': {}",
                         parts.status,
                         String::from_utf8_lossy(&body)
                     ),
@@ -475,7 +475,7 @@ mod tests {
             .unwrap_err();
         assert_eq!(
             err.to_string(),
-            "HTTP fetch failed from 'test': subgraph HTTP status error '400 Bad Request': BAD REQUEST)"
+            "HTTP fetch failed from 'test': subgraph HTTP status error '400 Bad Request': BAD REQUEST"
         );
     }
 


### PR DESCRIPTION
This fixes a typo in an error message that would add a closing parenthesis on HTTP errors from subgraphs.