### PR TITLE
add the next multipart delimiter at the end of the chunk

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -57,6 +57,13 @@ Move the location of the `text` field when exposing the query plan and fill it w
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1557
 
+### Only send one report for a response with deferred responses ([PR #1596](https://github.com/apollographql/router/issues/1596))
+
+deferred responses come as multipart elements, send as individual HTTP response chunks. When a client receives one chunk,
+it should contain the next delimiter, so the client knows that the response can be processed, instead of waiting for the
+next chunk to see the delimiter.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1596
 
 ## 🛠 Maintenance
 ## 📚 Documentation

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -533,19 +533,31 @@ where
                         }
                         Some(response) => {
                             if response.has_next.unwrap_or(false) {
-                                let stream = once(ready(response)).chain(stream);
+                                // each chunk contains a response and the next delimiter, to let client parsers
+                                // know that they can process the response right away
+                                let mut first_buf = Vec::from(
+                                    &b"\r\n--graphql\r\ncontent-type: application/json\r\n\r\n"[..],
+                                );
+                                serde_json::to_writer(&mut first_buf, &response).unwrap();
+                                first_buf.extend_from_slice(b"\r\n--graphql\r\n");
 
-                                let body = stream
-                                    .flat_map(|res| {
-                                        once(ready(Bytes::from_static(
-                                            b"--graphql\r\ncontent-type: application/json\r\n\r\n",
-                                        )))
-                                        .chain(once(ready(
-                                            serde_json::to_vec(&res).unwrap().into(),
-                                        )))
-                                        .chain(once(ready(Bytes::from_static(b"\r\n"))))
-                                    })
-                                    .map(Ok::<_, BoxError>);
+                                let body = once(ready(Ok(Bytes::from(first_buf)))).chain(
+                                    stream.map(|res| {
+                                        let mut buf = Vec::from(
+                                            &b"content-type: application/json\r\n\r\n"[..],
+                                        );
+                                        serde_json::to_writer(&mut buf, &res).unwrap();
+
+                                        // the last chunk has a different end delimiter
+                                        if res.has_next.unwrap_or(false) {
+                                            buf.extend_from_slice(b"\r\n--graphql\r\n");
+                                        } else {
+                                            buf.extend_from_slice(b"\r\n--graphql--\r\n");
+                                        }
+
+                                        Ok::<_, BoxError>(buf.into())
+                                    }),
+                                );
 
                                 (parts, StreamBody::new(body)).into_response()
                             } else {


### PR DESCRIPTION
Fix #1588

deferred responses come as multipart elements, send as individual HTTP
response chunks. When a client receives one chunk, it should contain the
next delimiter, so the client knows that the response can be processed,
instead of waiting for the next chunk to see the delimiter.

Side note: fixed the format of the last delimiter that was missing a
trailing --