### PR TITLE
Change verbosity of state machine logs to `trace`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -57,6 +57,12 @@ Move the location of the `text` field when exposing the query plan and fill it w
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1557
 
+### Change state machine log messages to `trace` ([#1578](https://github.com/apollographql/router/issues/1578))
+
+We no longer show internal state machine log events at the `info` level since they are unnecessary during normal operation.  They are instead emitted at the `trace` level and can be enabled selectively using the `--log trace` flag.
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/1597
+
 
 ## 🛠 Maintenance
 ## 📚 Documentation

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -227,7 +227,7 @@ where
                 }
             };
 
-            tracing::info!("transitioned to {}", &new_state);
+            tracing::trace!("transitioned to {}", &new_state);
             state = new_state;
 
             // If we're running then let those waiting proceed.


### PR DESCRIPTION
This changes the verbosity of messages like `transitioned to starting` from
the `info` level to the `trace` level since messages about the state machine
aren't necessary user-facing information during normal operation.

I waffled a bit on whether this should be `trace` or `debug`.  To some degree this seems like deeper inards of the Router than most people should ever need to encounter.  Since I think debugging the state machine might be a a particularly detailed operation in the general sense, I chose to use `trace` since it's my undersatnding the user can still use other log/env filters to tune the scope of what they're receiving log messages for, even at the `trace` level.

Anyway, I'm happy to change it to `debug` — just say the word.

Closes https://github.com/apollographql/router/issues/1578