### PR TITLE
Disable ftv1 traces reporting on defered queries.

### DIFF
--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
@@ -1,6 +1,5 @@
 ---
 source: apollo-router/tests/integration_tests.rs
-assertion_line: 136
 expression: get_spans()
 ---
 {
@@ -147,6 +146,10 @@ expression: get_spans()
               [
                 "otel.kind",
                 "internal"
+              ],
+              [
+                "ftv1_do_not_sample_reason",
+                ""
               ]
             ],
             "metadata": {
@@ -158,7 +161,8 @@ expression: get_spans()
                 "names": [
                   "graphql.document",
                   "graphql.operation.name",
-                  "otel.kind"
+                  "otel.kind",
+                  "ftv1_do_not_sample_reason"
                 ]
               }
             }

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
@@ -1,6 +1,5 @@
 ---
 source: apollo-router/tests/integration_tests.rs
-assertion_line: 120
 expression: get_spans()
 ---
 {
@@ -147,6 +146,10 @@ expression: get_spans()
               [
                 "otel.kind",
                 "internal"
+              ],
+              [
+                "ftv1_do_not_sample_reason",
+                ""
               ]
             ],
             "metadata": {
@@ -158,7 +161,8 @@ expression: get_spans()
                 "names": [
                   "graphql.document",
                   "graphql.operation.name",
-                  "otel.kind"
+                  "otel.kind",
+                  "ftv1_do_not_sample_reason"
                 ]
               }
             }


### PR DESCRIPTION
This commit allows to disable ftv1 traces reporting.

It does so by:
Allowing the telemetry plugin to add a do not sample (bool) entry to the context.
Allowing the telemetry plugin to add a do not sample reason to the execution span.

Having those enabled will:
  - Not propagate the ftv1 header to subgraphs.
  - Not create an ftv1 trace
  - log the reason why the trace is not being created in `debug`

The only reason at the moment is "query is defered" but we could add other eventually.
