### PR TITLE
silence tests which otherwise are outputting text to terminal

### DIFF
--- a/apollo-router/tests/infrastructure_tests.rs
+++ b/apollo-router/tests/infrastructure_tests.rs
@@ -1,4 +1,5 @@
 #[tokio::test]
+#[tracing_test::traced_test]
 async fn test_starstuff_supergraph_is_valid() {
     let schema = include_str!("../../examples/graphql/supergraph.graphql");
     apollo_router::TestHarness::builder()

--- a/apollo-router/tests/telemetry_test.rs
+++ b/apollo-router/tests/telemetry_test.rs
@@ -3,6 +3,7 @@ use apollo_router::_private::create_test_service_factory_from_yaml;
 // This test must use the multi_thread tokio executor or the opentelemetry hang bug will
 // be encountered. (See https://github.com/open-telemetry/opentelemetry-rust/issues/536)
 #[tokio::test(flavor = "multi_thread")]
+#[tracing_test::traced_test]
 async fn test_telemetry_doesnt_hang_with_invalid_schema() {
     create_test_service_factory_from_yaml(
         include_str!("../src/testdata/invalid_supergraph.graphql"),


### PR DESCRIPTION
When the TestHarness executes in tests, the list of plugins for the
associated router factory is output to the terminal. This change
annotates the tests to ensure that a subscriber is provided for the
tests which consumes the log text and means it isn't sent to the
terminal.
