### PR TITLE
terminate the router when a panic occurs

### DIFF
--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -345,6 +345,9 @@ fn setup_panic_handler(dispatcher: Dispatch) {
             } else {
                 tracing::error!("{}", e)
             }
+            // Once we've panic'ed the behaviour of the router is non-deterministic
+            // We've loged out the panic details. Terminate with an error code
+            std::process::exit(1);
         });
     }));
 }


### PR DESCRIPTION
We have a panic handler that logs a backtrace when a panic is
encountered. Many panic situations result in the router becoming
unusable. We should terminate the router once we have finished
writing panic details to the log.