### PR TITLE
patch async-compression to compress responses in streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,8 +364,7 @@ dependencies = [
 [[package]]
 name = "async-compression"
 version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345fd392ab01f746c717b1357165b76f0b67a60192007b234058c9045fdcf695"
+source = "git+https://github.com/geal/async-compression?branch=encoder-flush#9800cd0d36be7f3414fbb98b25f9f61900ec8c7c"
 dependencies = [
  "brotli",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,11 @@ members = [
 # debug = false
 strip = "debuginfo"
 incremental = false
+
+# Temporary patch to async-compression
+# It is used by tower-http's CompressionLayer. The compression code was not handling
+# the Poll::Pending result from the underlying stream, so it was accumulating the
+# entire compressed response in memory before sending it, which creates issues with
+# deferred responses getting received too late
+[patch.crates-io]
+async-compression = { git = 'https://github.com/geal/async-compression', branch = 'encoder-flush' }

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -63,6 +63,13 @@ Remove the closed parenthesis at the end of error messages resulting from HTTP e
 
 By [@nmoutschen](https://github.com/nmoutschen) in https://github.com/apollographql/router/pull/1593
 
+### Patch async-compression to compress responses in streaming ([PR #1604](https://github.com/apollographql/router/issues/1604))
+
+async-compression is a dependency used for response compression. Its implementation accumulates the entire compressed response
+in memory before sending it, which creates problems for deferred responses, where we want the responses to come as soon as
+possible, and not all at once after a while.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1604
 
 ## 🛠 Maintenance
 ## 📚 Documentation


### PR DESCRIPTION
Fix #1572

async-compression is used in tower-http's CompressionLayer. Inside the
AsyncRead based compression code, if the underlying stream returns
Poll::Pending, it will be returned directly, while in the case of
deferred responses, the next one might come way later, so we want to
send whatever data we have available right now.
We will have to switch to an AsyncWrite interface instead, which will be
more flexible, but considering the timing of the release, this patch
will hold for now.

This uses the code from https://github.com/Nemo157/async-compression/pull/155