### PR TITLE
infra: reorganize the `RELEASE_CHECKLIST` to group version change steps

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -87,4 +87,12 @@ By [@nmoutschen](https://github.com/nmoutschen) in https://github.com/apollograp
 
 
 ## 🛠 Maintenance
+
+
+### Re-organize our release steps checklist ([PR #1605](https://github.com/apollographql/router/pull/1605))
+
+We've got a lot of manual steps we need to do in order to release the Router binarys, but we can at least organize them meaningfuly for ourselves to follow!  This is only a Router-team concern today!
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/1605)
+
 ## 📚 Documentation

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -12,7 +12,7 @@ If you are releasing a beta or a release candidate, no official changelog is
 needed, but you're not off the hook! You'll need to write testing instructions
 in lieu of an official changelog.
 
-1. Open the associated milestone. All issues and PRs should be closed. If
+1. Open the associated GitHub milestone for the release. All issues and PRs should be closed. If
     they are not you should reassign all open issues and PRs to future
     milestones.
 2. Go through the commit history since the last release. Ensure that all PRs
@@ -25,30 +25,31 @@ in lieu of an official changelog.
     breaking change, also add a BREAKING label.
 4. Set the release date in `NEXT_CHANGELOG.md`. Add this release to the
     `CHANGELOG.md`. Use the structure of previous entries.
-5. Update `docker.mdx` and `kubernetes.mdx` with the release version.
-6. Update `helm/chart/router/Chart.yaml` and in `helm/chart/router/README.md` as follows:
-   - increment the version. e.g. `version: 0.1.2` becomes `version: 0.1.3`
-   - update the appVersion to the release version. e.g.: `appVersion: "v0.9.0"`
-7. cd helm/chart && helm-docs router; cd - (if required, install [helm-docs](https://github.com/norwoodj/helm-docs))
-8. Update `federation-version-support.mdx` with the latest version info. Use https://github.com/apollographql/version_matrix to generate the version matrix.
-9. Update the version in docker-compose files in `dockerfiles` directory.
-10. Update the license list with `cargo about generate --workspace -o licenses.html about.hbs`.
-    You can install `cargo-about` by running `cargo install cargo-about`.
 
 ### Start a release PR
 
 1. Make sure you have `cargo` installed on your machine and in your `PATH`.
 2. Create a new branch "#.#.#" where "#.#.#" is this release's version
     (release) or "#.#.#-rc.#" (release candidate)
-3. Update the version in `*/Cargo.toml` (do not forget the ones in scaffold templates).
-4. Add a new section in `CHANGELOG.md` with the contents of `NEXT_CHANGELOG.md`
-5. Put a Release date and the version number on the new `CHANGELOG.md` section
-4. Update the version in `NEXT_CHANGELOG.md`.
-5. Clear `NEXT_CHANGELOG.md` leaving only the template.
-6. Run `cargo check` so the lock file gets updated.
-7. Run `cargo xtask check-compliance`.
-8. Push up a commit with all the changes. The commit message should be "release: v#.#.#" or "release: v#.#.#-rc.#"
-9. Request review from the Router team.
+3. Update the `version` in `*/Cargo.toml` (do not forget the ones in scaffold templates).
+   - Be certain to also update the ones in the `scaffold` templates
+4. Update `docker.mdx` and `kubernetes.mdx` with the release version.
+5. Update `helm/chart/router/Chart.yaml` and in `helm/chart/router/README.md` as follows:
+   - increment the version. e.g. `version: 0.1.2` becomes `version: 0.1.3`
+   - update the appVersion to the release version. e.g.: `appVersion: "v0.9.0"`
+6. cd helm/chart && helm-docs router; cd - (if required, install [helm-docs](https://github.com/norwoodj/helm-docs))
+7. Update `federation-version-support.mdx` with the latest version info. Use https://github.com/apollographql/version_matrix to generate the version matrix.
+8. Update the `version` in `docker-compose*` files in the `dockerfiles` directory.
+9. Update the license list with `cargo about generate --workspace -o licenses.html about.hbs`.
+    You can install `cargo-about` by running `cargo install cargo-about`.
+10. Add a new section in `CHANGELOG.md` with the contents of `NEXT_CHANGELOG.md`
+11. Put a Release date and the version number on the new `CHANGELOG.md` section
+12. Update the version in `NEXT_CHANGELOG.md`.
+13. Clear `NEXT_CHANGELOG.md` leaving only the template.
+14. Run `cargo check` so the lock file gets updated.
+15. Run `cargo xtask check-compliance`.
+16. Push up a commit with all the changes. The commit message should be "release: v#.#.#" or "release: v#.#.#-rc.#"
+17. Request review from the Router team.
 
 ### Review
 


### PR DESCRIPTION
We previously created a pattern where some of the manual version changes
that needed to be made were appearing in the "Prepare a Changelog (Full
release only)" section and some were in the "Start a release PR" section.

This wasn't the right organization and I found this to be counterintuiative
since many of the version bumps were actually important to make even for
non-full-releases and further challenging because they weren't about the
changelog but rather version bumps which were also happening in the other
section.

This puts all the (too many) steps in one ordered list.
