### PR TITLE
extract and group various configuration elements from server

### DIFF
--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__it_does_not_leak_env_variable_values.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__it_does_not_leak_env_variable_values.snap
@@ -3,9 +3,9 @@ source: apollo-router/src/configuration/mod.rs
 expression: error.to_string()
 ---
 configuration had errors: 
-1. /server/introspection
+1. /graphql/introspection
 
 
-server:
+graphql:
   introspection: ${TEST_CONFIG_NUMERIC_ENV_UNIQUE:true}
                  ^----- "${TEST_CONFIG_NUMERIC_ENV_UNIQUE:true}" is not of type "boolean"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_bad_type.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_bad_type.snap
@@ -3,11 +3,11 @@ source: apollo-router/src/configuration/mod.rs
 expression: error.to_string()
 ---
 configuration had errors: 
-1. /server/listen
+1. /listeners/data
 
 
-server:
+listeners:
   # The socket address and port to listen on
   # Defaults to 127.0.0.1:4000
-  listen: true
-          ^----- true is not valid under any of the given schemas
+  data: true
+        ^----- true is not valid under any of the given schemas

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field.snap
@@ -1,16 +1,15 @@
 ---
 source: apollo-router/src/configuration/mod.rs
-assertion_line: 737
 expression: error.to_string()
 ---
 configuration had errors: 
 1. /server
 
-
+listeners:
+  # The socket address and port to listen on
+  # Defaults to 127.0.0.1:4000
+  data: 127.0.0.1:4000
 server:
-┌   # The socket address and port to listen on
-|   # Defaults to 127.0.0.1:4000
-|   listen: 127.0.0.1:4000
-|   bad: "donotwork"
+┌   bad: "donotwork"
 |   another_one: true
 └-----> Additional properties are not allowed ('bad', 'another_one' were unexpected)

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field_env_expansion.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field_env_expansion.snap
@@ -5,11 +5,11 @@ expression: error.to_string()
 configuration had errors: 
 1. /server
 
-
+listeners:
+  # The socket address and port to listen on
+  # Defaults to 127.0.0.1:4000
+  data: 127.0.0.1:4000
 server:
-┌   # The socket address and port to listen on
-|   # Defaults to 127.0.0.1:4000
-|   listen: 127.0.0.1:4000
-|   ${TEST_CONFIG_NUMERIC_ENV_UNIQUE:true}: 5
+┌   ${TEST_CONFIG_NUMERIC_ENV_UNIQUE:true}: 5
 |   another_one: ${TEST_CONFIG_NUMERIC_ENV_UNIQUE:true}
 └-----> Additional properties are not allowed ('${TEST_CONFIG_NUMERIC_ENV_UNIQUE:true}', 'another_one' were unexpected)

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_inline_sequence.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_inline_sequence.snap
@@ -5,9 +5,9 @@ expression: error.to_string()
 configuration had errors: 
 1. /server/cors/allow_headers/1
 
-  # The socket address and port to listen on
   # Defaults to 127.0.0.1:4000
-  listen: 127.0.0.1:4000
+  data: 127.0.0.1:4000
+server:
   cors:
     allow_headers: [ Content-Type, 5 ]
                                    ^----- 5 is not of type "string"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_inline_sequence_env_expansion.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_inline_sequence_env_expansion.snap
@@ -5,9 +5,9 @@ expression: error.to_string()
 configuration had errors: 
 1. /server/cors/allow_headers/1
 
-  # The socket address and port to listen on
   # Defaults to 127.0.0.1:4000
-  listen: 127.0.0.1:4000
+  data: 127.0.0.1:4000
+server:
   cors:
     allow_headers: [ Content-Type, "${TEST_CONFIG_NUMERIC_ENV_UNIQUE}" ]
                                    ^----- "${TEST_CONFIG_NUMERIC_ENV_UNIQUE}" is not of type "string"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_sequence.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_sequence.snap
@@ -5,7 +5,7 @@ expression: error.to_string()
 configuration had errors: 
 1. /server/cors/allow_headers/1
 
-  listen: 127.0.0.1:4000
+server:
   cors:
     allow_headers:
       - Content-Type

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_sequence_env_expansion.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_sequence_env_expansion.snap
@@ -5,7 +5,7 @@ expression: error.to_string()
 configuration had errors: 
 1. /server/cors/allow_headers/1
 
-  listen: 127.0.0.1:4000
+server:
   cors:
     allow_headers:
       - Content-Type

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -34,6 +34,35 @@ expression: "&schema"
     "forbid_mutations": {
       "type": "boolean"
     },
+    "graphql": {
+      "description": "Configuration options pertaining to graphql processing.",
+      "default": {
+        "introspection": true,
+        "experimental_defer_support": false,
+        "experimental_parser_recursion_limit": 4096
+      },
+      "type": "object",
+      "properties": {
+        "experimental_defer_support": {
+          "description": "Experimental @defer directive support default: false",
+          "default": false,
+          "type": "boolean"
+        },
+        "experimental_parser_recursion_limit": {
+          "description": "Experimental limitation of query depth default: 4096",
+          "default": 4096,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "introspection": {
+          "description": "introspection queries enabled by default",
+          "default": true,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "headers": {
       "type": "object",
       "properties": {
@@ -271,12 +300,72 @@ expression: "&schema"
       },
       "additionalProperties": false
     },
+    "listeners": {
+      "description": "Configuration options pertaining to the server listeners.",
+      "default": {
+        "data": "127.0.0.1:4000",
+        "admin": "127.0.0.1:5000"
+      },
+      "type": "object",
+      "properties": {
+        "admin": {
+          "description": "The socket address and port to listen on for the admin plane Defaults to 127.0.0.1:5000",
+          "default": "127.0.0.1:5000",
+          "anyOf": [
+            {
+              "description": "Socket address.",
+              "type": "string"
+            },
+            {
+              "description": "Unix socket.",
+              "type": "string"
+            }
+          ]
+        },
+        "data": {
+          "description": "The socket address and port to listen on for the data plane Defaults to 127.0.0.1:4000",
+          "default": "127.0.0.1:4000",
+          "anyOf": [
+            {
+              "description": "Socket address.",
+              "type": "string"
+            },
+            {
+              "description": "Unix socket.",
+              "type": "string"
+            }
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "override_subgraph_url": {
       "type": "object",
       "additionalProperties": {
         "type": "string",
         "format": "uri"
       }
+    },
+    "paths": {
+      "description": "Configuration options pertaining to the listening paths.",
+      "default": {
+        "graphql": "/",
+        "health_check": "/.well-known/apollo/server-health"
+      },
+      "type": "object",
+      "properties": {
+        "graphql": {
+          "description": "GraphQL path default: \"/\"",
+          "default": "/",
+          "type": "string"
+        },
+        "health_check": {
+          "description": "healthCheck path default: \"/.well-known/apollo/server-health\"",
+          "default": "/.well-known/apollo/server-health",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     },
     "plugins": {
       "description": "Plugin configuration",
@@ -323,7 +412,6 @@ expression: "&schema"
     "server": {
       "description": "Configuration options pertaining to the http server component.",
       "default": {
-        "listen": "127.0.0.1:4000",
         "cors": {
           "allow_any_origin": false,
           "allow_credentials": false,
@@ -339,12 +427,7 @@ expression: "&schema"
             "OPTIONS"
           ]
         },
-        "introspection": true,
-        "landing_page": true,
-        "endpoint": "/",
-        "health_check_path": "/.well-known/apollo/server-health",
-        "experimental_defer_support": false,
-        "experimental_parser_recursion_limit": 4096
+        "sandbox": true
       },
       "type": "object",
       "properties": {
@@ -428,51 +511,10 @@ expression: "&schema"
           },
           "additionalProperties": false
         },
-        "endpoint": {
-          "description": "GraphQL endpoint default: \"/\"",
-          "default": "/",
-          "type": "string"
-        },
-        "experimental_defer_support": {
-          "description": "Experimental @defer directive support default: false",
-          "default": false,
-          "type": "boolean"
-        },
-        "experimental_parser_recursion_limit": {
-          "description": "Experimental limitation of query depth default: 4096",
-          "default": 4096,
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0.0
-        },
-        "health_check_path": {
-          "description": "healthCheck path default: \"/.well-known/apollo/server-health\"",
-          "default": "/.well-known/apollo/server-health",
-          "type": "string"
-        },
-        "introspection": {
-          "description": "introspection queries enabled by default",
+        "sandbox": {
+          "description": "display sandbox enabled by default",
           "default": true,
           "type": "boolean"
-        },
-        "landing_page": {
-          "description": "display landing page enabled by default",
-          "default": true,
-          "type": "boolean"
-        },
-        "listen": {
-          "description": "The socket address and port to listen on Defaults to 127.0.0.1:4000",
-          "default": "127.0.0.1:4000",
-          "anyOf": [
-            {
-              "description": "Socket address.",
-              "type": "string"
-            },
-            {
-              "description": "Unix socket.",
-              "type": "string"
-            }
-          ]
         }
       },
       "additionalProperties": false

--- a/apollo-router/src/configuration/testdata/config_basic.router.yaml
+++ b/apollo-router/src/configuration/testdata/config_basic.router.yaml
@@ -1,2 +1,2 @@
-server:
-  listen: 1.2.3.4:5
+listeners:
+  data: 1.2.3.4:5

--- a/apollo-router/src/configuration/testdata/config_full.router.yaml
+++ b/apollo-router/src/configuration/testdata/config_full.router.yaml
@@ -1,5 +1,6 @@
+listeners:
+  data: 1.2.3.4:5
 server:
-  listen: 1.2.3.4:5
   cors:
     origins: [foo, bar, baz]
     methods: [foo, bar]

--- a/apollo-router/src/configuration/testdata/invalid_url.router.yaml
+++ b/apollo-router/src/configuration/testdata/invalid_url.router.yaml
@@ -1,2 +1,2 @@
-server:
-  listen: 127.0.0.1:0
+listeners:
+  data: 127.0.0.1:0

--- a/apollo-router/src/configuration/testdata/supergraph_config.router.yaml
+++ b/apollo-router/src/configuration/testdata/supergraph_config.router.yaml
@@ -1,5 +1,6 @@
+listeners:
+  data: "127.0.0.1:4001"
 server:
-  listen: "127.0.0.1:4001"
   cors:
     origins:
       - studio.apollographql.com

--- a/apollo-router/src/configuration/testdata/tracing_apollo.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_apollo.router.yaml
@@ -1,5 +1,5 @@
-server:
-  listen: 1.2.3.4:5
+listeners:
+  data: 1.2.3.4:5
 telemetry:
   apollo:
     endpoint: "http://example.com"

--- a/apollo-router/src/configuration/testdata/tracing_apollo_env.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_apollo_env.router.yaml
@@ -1,5 +1,5 @@
-server:
-  listen: 1.2.3.4:5
+listeners:
+  data: 1.2.3.4:5
 telemetry:
   apollo:
     endpoint: "${ENDPOINT}"

--- a/apollo-router/src/configuration/testdata/tracing_config.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_config.router.yaml
@@ -1,5 +1,5 @@
-server:
-  listen: 1.2.3.4:5
+listeners:
+  data: 1.2.3.4:5
 telemetry:
   tracing:
     trace_config:

--- a/apollo-router/src/configuration/testdata/tracing_datadog.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_datadog.router.yaml
@@ -1,5 +1,5 @@
-server:
-  listen: 1.2.3.4:5
+listeners:
+  data: 1.2.3.4:5
 telemetry:
   tracing:
     datadog:

--- a/apollo-router/src/configuration/testdata/tracing_datadog_env.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_datadog_env.router.yaml
@@ -1,5 +1,5 @@
-server:
-  listen: 1.2.3.4:5
+listeners:
+  data: 1.2.3.4:5
 telemetry:
   tracing:
     datadog:

--- a/apollo-router/src/configuration/testdata/tracing_jaeger_agent.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_jaeger_agent.router.yaml
@@ -1,5 +1,5 @@
-server:
-  listen: 1.2.3.4:5
+listeners:
+  data: 1.2.3.4:5
 telemetry:
   tracing:
     jaeger:

--- a/apollo-router/src/configuration/testdata/tracing_jaeger_collector.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_jaeger_collector.router.yaml
@@ -1,5 +1,5 @@
-server:
-  listen: 1.2.3.4:5
+listeners:
+  data: 1.2.3.4:5
 telemetry:
   tracing:
     jaeger:

--- a/apollo-router/src/configuration/testdata/tracing_jaeger_collector_env.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_jaeger_collector_env.router.yaml
@@ -1,5 +1,5 @@
-server:
-  listen: 1.2.3.4:5
+listeners:
+  data: 1.2.3.4:5
 telemetry:
   tracing:
     jaeger:

--- a/apollo-router/src/configuration/testdata/tracing_jaeger_full.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_jaeger_full.router.yaml
@@ -1,5 +1,5 @@
-server:
-  listen: 1.2.3.4:5
+listeners:
+  data: 1.2.3.4:5
 telemetry:
   tracing:
     jaeger:

--- a/apollo-router/src/configuration/testdata/tracing_otlp_full.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_otlp_full.router.yaml
@@ -1,5 +1,5 @@
-server:
-  listen: 1.2.3.4:5
+listeners:
+  data: 1.2.3.4:5
 telemetry:
   tracing:
     otlp:

--- a/apollo-router/src/configuration/testdata/tracing_otlp_grpc_basic.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_otlp_grpc_basic.router.yaml
@@ -1,5 +1,5 @@
-server:
-  listen: 1.2.3.4:5
+listeners:
+  data: 1.2.3.4:5
 telemetry:
   tracing:
     otlp:

--- a/apollo-router/src/configuration/testdata/tracing_otlp_grpc_basic_env.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_otlp_grpc_basic_env.router.yaml
@@ -1,5 +1,5 @@
-server:
-  listen: 1.2.3.4:5
+listeners:
+  data: 1.2.3.4:5
 telemetry:
   tracing:
     otlp:

--- a/apollo-router/src/configuration/testdata/tracing_otlp_http_basic.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_otlp_http_basic.router.yaml
@@ -1,5 +1,5 @@
-server:
-  listen: 1.2.3.4:5
+listeners:
+  data: 1.2.3.4:5
 telemetry:
   tracing:
     otlp:

--- a/apollo-router/src/http_server_factory.rs
+++ b/apollo-router/src/http_server_factory.rs
@@ -100,7 +100,7 @@ impl HttpServerHandle {
         tracing::debug!("previous server stopped");
 
         // we keep the TCP listener if it is compatible with the new configuration
-        let listener = if self.listen_address != configuration.server.listen {
+        let listener = if self.listen_address != configuration.listeners.data {
             None
         } else {
             match listener {

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -22,7 +22,7 @@ impl Introspection {
     pub(crate) async fn with_capacity(configuration: &Configuration, capacity: usize) -> Self {
         Self {
             cache: CacheStorage::new(capacity).await,
-            defer_support: configuration.server.experimental_defer_support,
+            defer_support: configuration.graphql.experimental_defer_support,
         }
     }
 

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -52,7 +52,7 @@ impl BridgeQueryPlanner {
                     schema.as_string().to_string(),
                     QueryPlannerConfig {
                         defer_stream_support: Some(DeferStreamSupport {
-                            enable_defer: Some(configuration.server.experimental_defer_support),
+                            enable_defer: Some(configuration.graphql.experimental_defer_support),
                         }),
                     },
                 )

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -350,7 +350,7 @@ impl PluggableSupergraphServiceBuilder {
             .and_then(|x| x.parse().ok())
             .unwrap_or(100);
 
-        let introspection = if configuration.server.introspection {
+        let introspection = if configuration.graphql.introspection {
             Some(Arc::new(Introspection::new(&configuration).await))
         } else {
             None

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -132,7 +132,7 @@ impl Query {
 
         let parser = apollo_parser::Parser::with_recursion_limit(
             string.as_str(),
-            configuration.server.experimental_parser_recursion_limit,
+            configuration.graphql.experimental_parser_recursion_limit,
         );
         let tree = parser.parse();
 

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -530,10 +530,10 @@ mod tests {
                     UpdateSchema(example_schema()),
                     UpdateConfiguration(
                         Configuration::builder()
-                            .server(
-                                crate::configuration::Server::builder()
-                                    .listen(SocketAddr::from_str("127.0.0.1:4001").unwrap())
-                                    .build()
+                            .listeners(
+                                crate::configuration::Listeners::builder()
+                                    .data(SocketAddr::from_str("127.0.0.1:4001").unwrap())
+                                    .build(),
                             )
                             .build()
                             .boxed()
@@ -768,7 +768,7 @@ mod tests {
                     Ok(HttpServerHandle::new(
                         shutdown_sender,
                         Box::pin(server),
-                        configuration.server.listen.clone(),
+                        configuration.listeners.data.clone(),
                     ))
                 },
             );

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -40,7 +40,7 @@ use crate::Schema;
 /// use tower::util::ServiceExt;
 ///
 /// # #[tokio::main] async fn main() -> Result<(), tower::BoxError> {
-/// let config = serde_json::json!({"server": {"introspection": false}});
+/// let config = serde_json::json!({"graphql": {"introspection": false}});
 /// let request = supergraph::Request::fake_builder()
 ///     // Request building here
 ///     .build()

--- a/apollo-router/src/testdata/supergraph_config.yaml
+++ b/apollo-router/src/testdata/supergraph_config.yaml
@@ -1,2 +1,2 @@
-server:
-  listen: 127.0.0.1:0
+listeners:
+  data: 127.0.0.1:0

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -485,7 +485,7 @@ async fn missing_variables() {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_under_recursion_limit() {
     let config = serde_json::json!({
-        "server": {"experimental_parser_recursion_limit": 12_usize}
+        "graphql": {"experimental_parser_recursion_limit": 12_usize}
     });
     let request = supergraph::Request::fake_builder()
         .query(r#"{ me { reviews { author { reviews { author { name } } } } } }"#)
@@ -506,7 +506,7 @@ async fn query_just_under_recursion_limit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_at_recursion_limit() {
     let config = serde_json::json!({
-        "server": {"experimental_parser_recursion_limit": 11_usize}
+        "graphql": {"experimental_parser_recursion_limit": 11_usize}
     });
     let request = supergraph::Request::fake_builder()
         .query(r#"{ me { reviews { author { reviews { author { name } } } } } }"#)
@@ -527,7 +527,7 @@ async fn query_just_at_recursion_limit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn defer_path() {
     let config = serde_json::json!({
-        "server": {
+        "graphql": {
             "experimental_defer_support": true
         },
         "plugins": {
@@ -564,7 +564,7 @@ async fn defer_path() {
 #[tokio::test(flavor = "multi_thread")]
 async fn defer_path_in_array() {
     let config = serde_json::json!({
-        "server": {
+        "graphql": {
             "experimental_defer_support": true
         },
         "plugins": {

--- a/docs/source/configuration/health-checks.mdx
+++ b/docs/source/configuration/health-checks.mdx
@@ -6,8 +6,8 @@ description: Determining the router's status
 Health checks are often used by load balancers to determine whether a server is available and ready to start serving traffic.
 
 The Apollo Router supports a basic HTTP-level health check. This is enabled by default and is served at the URL path `/.well-known/apollo/server-health`. This returns a `200` status code if the HTTP server is successfully serving. It does not invoke any GraphQL execution machinery.
-You can change this path by setting `server.health_check_path`:
+You can change this path by setting `paths.health_check`:
 ```yaml title="router.yaml"
-server:
-  health_check_path: /health
+paths:
+  health_check: /health
 ```

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -214,45 +214,45 @@ The Apollo Router takes an optional YAML configuration file as input via the `--
 
 This file enables you to customize the router's behavior in many ways:
 
-### Listen address
+### Data Listen address
 
 By default, the router starts an HTTP server that listens on `127.0.0.1:4000`. You can specify a different address like so:
 
 ```yaml title="router_unix.yaml"
 #
-# server: Configuration of the HTTP server
+# listeners: Configuration of the HTTP server
 #
-server:
+listeners:
   # The socket address and port to listen on
   # (Defaults to 127.0.0.1:4000)
-  listen: 127.0.0.1
+  data: 127.0.0.1
 ```
 
 The router can also listen on a Unix socket (not supported on Windows):
 
 ```yaml title="router_unix.yaml"
-server:
+listeners:
   # Absolute path to a Unix socket
-  listen: /tmp/router.sock
+  data: /tmp/router.sock
 ```
 
-### Endpoint path
+### GraphQL path
 
-By default, the router starts an HTTP server that exposes a `POST`/`GET` endpoint at path `/`.
+By default, the router starts an HTTP server that exposes a data `POST`/`GET` endpoint at path `/`.
 
-You can change this path by setting `server.endpoint`:
+You can change this path by setting `graphql.path`:
 
 ```yaml title="router.yaml"
 #
-# server: Configuration of the HTTP server
+# paths: Configuration of the HTTP server paths
 #
-server:
-  # The exposed endpoint to answer to GraphQL queries
+paths:
+  # The exposed path to answer to GraphQL queries
   # (Defaults to /)
-  endpoint: /graphql
+  graphql: /graphql
 ```
 
-The endpoint path must start with `/`.
+The path must start with `/`.
 
 Path parameters and wildcards are supported. For example:
 
@@ -267,22 +267,22 @@ By default, the router answers to some introspection queries. You can override t
 
 ```yaml title="router.yaml"
 #
-# server: Configuration of the HTTP server
+# graphql: Configuration of the graphql processing
 #
-server:
+graphql:
   introspection: false
 ```
 
 ### Landing page
 
-By default, the router displays a landing page if you access its endpoint path via your browser. You can override this behavior to disable the landing page like so:
+By default, the router displays a sandbox if you access its graphql path via your browser. You can override this behavior to disable the sandbox page like so:
 
 ```yaml title="router.yaml"
 #
 # server: Configuration of the HTTP server
 #
 server:
-  landing_page: false
+  sandbox: false
 ```
 
 ### Subgraph routing URLs

--- a/examples/unix-sockets/router_unix.yaml
+++ b/examples/unix-sockets/router_unix.yaml
@@ -1,2 +1,2 @@
-server:
-  listen: /tmp/router.sock
+listeners:
+  data: /tmp/router.sock


### PR DESCRIPTION
This introduces three new top-level configuration groupings:

 - Listeners (currently only one listener for data, but will add admin support in future so splitting out now)
 - Paths (health, graphql)
 - GraphqQL (introspection, experimental_defer, experimental_recursion)

and retains the existing Server configuration.
 - Server (cors, sandbox)

The purpose of the grouping is to be functional in nature. Clearly,
plugins don't fit in with this, but that's one for the future...

Various configuration options are extracted from Server into these new
groupings. The purpose of the new groups

Some renaming is done as well, e.g.: landing_page -> sandbox, endpoint
-> graphql

The docs are mainly modified, but I would like to re-structure them a
bit to reflect this grouping.

I'm aware that this goes way beyond the remit of 1606, but I figured I
may as well do some tidying up now, since the current situation is far
from ideal.

fixes: #1606


Sample new format configuration file to illustrate what it would look like:

```
listeners:
  data: 127.0.0.1:4000
server:
  # Leaving cors under server, because it still seems like a server responsibility...
  cors:
    allow_credentials: true
 # renamed from landing_page
  sandbox: true
paths:
 # renamed from endpoint
  graphql: /my_funky_path
  # renamed from health_check_path
  health_check: /health
graphql:
  introspection: false
  experimental_defer_support: true
```

Current format would look like this:
```
server:
  listen: 127.0.0.1:4000
  cors:
    allow_credentials: true
  landing_page: true
  endpoint: /my_funky_path
  health_check_path: /health
  introspection: false
  experimental_defer_support: true
```

Let me know what you think...