### PR TITLE
Rename `Server::endpoint` to `Server::graphql_path`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -35,6 +35,21 @@ Terminating after logging the panic details is the best choice here.
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1602
 
+### Rename the `endpoint` parameter to `graphql_path` ([#1606](https://github.com/apollographql/router/issues/1606))
+
+The `endpoint` parameter within the `server` portion of the YAML configuration has been renamed to `graphql_path` to more accurately reflect its behavior.
+
+If you used this option, the necessary change would look like:
+
+```diff
+- server:
+-   endpoint: /graphql
++ server:
++   graphql_path: /graphql
+```
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/TODO
+
 ### Remove `activate()` from the plugin API ([PR #1569](https://github.com/apollographql/router/pull/1569))
 
 Recent changes to configuration reloading means that the only known consumer of this API, telemetry, is no longer using it.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -48,7 +48,7 @@ If you used this option, the necessary change would look like:
 +   graphql_path: /graphql
 ```
 
-By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/TODO
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/1609
 
 ### Remove `activate()` from the plugin API ([PR #1569](https://github.com/apollographql/router/pull/1569))
 

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -108,15 +108,15 @@ impl HttpServerFactory for AxumHttpServerFactory {
                         },
                     )
                 })?;
-            let graphql_endpoint = if configuration.server.endpoint.ends_with("/*") {
+            let graphql_path = if configuration.server.graphql_path.ends_with("/*") {
                 // Needed for axum (check the axum docs for more information about wildcards https://docs.rs/axum/latest/axum/struct.Router.html#wildcards)
-                format!("{}router_extra_path", configuration.server.endpoint)
+                format!("{}router_extra_path", configuration.server.graphql_path)
             } else {
-                configuration.server.endpoint.clone()
+                configuration.server.graphql_path.clone()
             };
             let mut router = Router::new()
                 .route(
-                    &graphql_endpoint,
+                    &graphql_path,
                     get({
                         let display_landing_page = configuration.server.landing_page;
                         move |host: Host,
@@ -211,7 +211,7 @@ impl HttpServerFactory for AxumHttpServerFactory {
             tracing::info!(
                 "GraphQL endpoint exposed at {}{} 🚀",
                 actual_listen_address,
-                configuration.server.endpoint
+                configuration.server.graphql_path
             );
             // this server reproduces most of hyper::server::Server's behaviour
             // we select over the stop_listen_receiver channel and the listener's
@@ -1262,7 +1262,7 @@ mod tests {
                             .origins(vec!["http://studio".to_string()])
                             .build(),
                     )
-                    .endpoint(String::from("/graphql"))
+                    .graphql_path(String::from("/graphql"))
                     .build(),
             )
             .build();
@@ -1331,7 +1331,7 @@ mod tests {
                             .origins(vec!["http://studio".to_string()])
                             .build(),
                     )
-                    .endpoint(String::from("/:my_prefix/graphql"))
+                    .graphql_path(String::from("/:my_prefix/graphql"))
                     .build(),
             )
             .build();
@@ -1400,7 +1400,7 @@ mod tests {
                             .origins(vec!["http://studio".to_string()])
                             .build(),
                     )
-                    .endpoint(String::from("/graphql/*"))
+                    .graphql_path(String::from("/graphql/*"))
                     .build(),
             )
             .build();
@@ -1619,7 +1619,7 @@ mod tests {
                 crate::configuration::Server::builder()
                     .listen(SocketAddr::from_str("127.0.0.1:0").unwrap())
                     .cors(Cors::builder().build())
-                    .endpoint(String::from("/graphql/*"))
+                    .graphql_path(String::from("/graphql/*"))
                     .build(),
             )
             .build();

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,5 +1,6 @@
 ---
 source: apollo-router/src/configuration/mod.rs
+assertion_line: 932
 expression: "&schema"
 ---
 {
@@ -341,7 +342,7 @@ expression: "&schema"
         },
         "introspection": true,
         "landing_page": true,
-        "endpoint": "/",
+        "graphql_path": "/",
         "health_check_path": "/.well-known/apollo/server-health",
         "experimental_defer_support": false,
         "experimental_parser_recursion_limit": 4096
@@ -428,11 +429,6 @@ expression: "&schema"
           },
           "additionalProperties": false
         },
-        "endpoint": {
-          "description": "GraphQL endpoint default: \"/\"",
-          "default": "/",
-          "type": "string"
-        },
         "experimental_defer_support": {
           "description": "Experimental @defer directive support default: false",
           "default": false,
@@ -444,6 +440,11 @@ expression: "&schema"
           "type": "integer",
           "format": "uint",
           "minimum": 0.0
+        },
+        "graphql_path": {
+          "description": "The HTTP path on which GraphQL requests will be served. default: \"/\"",
+          "default": "/",
+          "type": "string"
         },
         "health_check_path": {
           "description": "healthCheck path default: \"/.well-known/apollo/server-health\"",

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -240,19 +240,19 @@ server:
 
 By default, the router starts an HTTP server that exposes a `POST`/`GET` endpoint at path `/`.
 
-You can change this path by setting `server.endpoint`:
+You can change this path by setting `server.graphql_path`:
 
 ```yaml title="router.yaml"
 #
 # server: Configuration of the HTTP server
 #
 server:
-  # The exposed endpoint to answer to GraphQL queries
+  # The path for GraphQL execution
   # (Defaults to /)
-  endpoint: /graphql
+  graphql_path: /graphql
 ```
 
-The endpoint path must start with `/`.
+The path must start with `/`.
 
 Path parameters and wildcards are supported. For example:
 


### PR DESCRIPTION
This more accurately represents the behavior of the option which changes the
path at which your Router will respond to GraphQL requests.

The previous name gave the impression that it might be the full "endpoint"
which it was not (again, just a path!)

Closes https://github.com/apollographql/router/issues/1606