### PR TITLE
queries with defer must have the Accept: multipart/mixed header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,7 @@ dependencies = [
  "libc",
  "lru",
  "maplit",
+ "mediatype",
  "miette 5.3.0",
  "mime",
  "mockall",
@@ -3015,6 +3016,12 @@ name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
+name = "mediatype"
+version = "0.19.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac0db9ec602cd88b078efab731831a15461f90eb100c4a7da457d8cd6a917d2f"
 
 [[package]]
 name = "memchr"

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -93,6 +93,14 @@ next chunk to see the delimiter.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1596
 
+### Queries with defer must have the Accept: multipart/mixed header ([PR #1610](https://github.com/apollographql/router/issues/1610))
+
+Since deferred responses can come back as multipart responses, we must check that the client supports that content type.
+This will allow older clients to show a meaningful error message instead of a parsing error if the `@defer` directive is
+used but they don't support it.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1610
+
 ## 🛠 Maintenance
 
 

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -167,6 +167,7 @@ url = { version = "2.2.2", features = ["serde"] }
 urlencoding = "2.1.0"
 yaml-rust = "0.4.5"
 pin-project-lite = "0.2.9"
+mediatype = "0.19.7"
 
 [target.'cfg(macos)'.dependencies]
 uname = "0.1.1"

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -434,7 +434,7 @@ async fn handle_get(
     http_request: Request<Body>,
     display_landing_page: bool,
 ) -> impl IntoResponse {
-    if prefers_html(&http_request.headers()) && display_landing_page {
+    if prefers_html(http_request.headers()) && display_landing_page {
         return display_home_page().into_response();
     }
 

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -154,7 +154,7 @@ where
                 QueryPlannerContent::Plan { query, plan } => {
                     let can_be_deferred = plan.root.contains_defer();
 
-                    if can_be_deferred && !req.originating_request.headers().get_all(ACCEPT).iter().filter_map(|value| value.to_str().ok()).flat_map(|value| value.split(',')
+                    if can_be_deferred && !req.originating_request.headers().get_all(ACCEPT).iter().filter_map(|value| value.to_str().ok()).flat_map(|value| value.split(';')
                     .map(|a| a.trim())).any(|value|
                         value == "multipart/mixed") {
                             tracing::error!("tried to send a defer request without accept: multipart/mixed");

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -154,7 +154,7 @@ where
                 QueryPlannerContent::Plan { query, plan } => {
                     let can_be_deferred = plan.root.contains_defer();
 
-                    if can_be_deferred && !req.originating_request.headers().get_all(ACCEPT).iter().filter_map(|value| value.to_str().ok()).flat_map(|value| value.split(';')
+                    if can_be_deferred && !req.originating_request.headers().get_all(ACCEPT).iter().filter_map(|value| value.to_str().ok()).flat_map(|value| value.split(',')
                     .map(|a| a.trim())).any(|value|
                         value == "multipart/mixed") {
                             tracing::error!("tried to send a defer request without accept: multipart/mixed");

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -155,9 +155,8 @@ where
                     let can_be_deferred = plan.root.contains_defer();
 
                     if can_be_deferred && !req.originating_request.headers().get_all(ACCEPT).iter().filter_map(|value| value.to_str().ok()).flat_map(|value| value.split(',')
-                    .map(|a| a.trim())).any(|value| {
-                        println!("testing value {:?}", value);
-                        value == "multipart/mixed"}) {
+                    .map(|a| a.trim())).any(|value|
+                        value == "multipart/mixed") {
                             tracing::error!("tried to send a defer request without accept: multipart/mixed");
                             let mut resp = http::Response::new(
                                 once(ready(
@@ -174,103 +173,101 @@ where
                                 response: resp,
                                 context,
                             })
+                    } else  if let Some(err) = query.validate_variables(body, &schema).err() {
+                        let mut res = SupergraphResponse::new_from_graphql_response(err, context);
+                        *res.response.status_mut() = StatusCode::BAD_REQUEST;
+                        Ok(res)
                     } else {
-                        if let Some(err) = query.validate_variables(body, &schema).err() {
-                            let mut res = SupergraphResponse::new_from_graphql_response(err, context);
-                            *res.response.status_mut() = StatusCode::BAD_REQUEST;
-                            Ok(res)
-                        } else {
-                            let operation_name = body.operation_name.clone();
+                        let operation_name = body.operation_name.clone();
 
-                            let ExecutionResponse { response, context } = execution
-                                .oneshot(
-                                    ExecutionRequest::builder()
-                                        .originating_request(req.originating_request)
-                                        .query_plan(plan)
-                                        .context(context)
-                                        .build(),
+                        let ExecutionResponse { response, context } = execution
+                            .oneshot(
+                                ExecutionRequest::builder()
+                                    .originating_request(req.originating_request)
+                                    .query_plan(plan)
+                                    .context(context)
+                                    .build(),
+                            )
+                            .await?;
+
+                        let (parts, response_stream) = response.into_parts();
+
+                        let stream = response_stream
+                        .map(move |mut response: Response| {
+                            tracing::debug_span!("format_response").in_scope(|| {
+                                query.format_response(
+                                    &mut response,
+                                    operation_name.as_deref(),
+                                    variables.clone(),
+                                    schema.api_schema(),
                                 )
-                                .await?;
-
-                            let (parts, response_stream) = response.into_parts();
-
-                            let stream = response_stream
-                            .map(move |mut response: Response| {
-                                tracing::debug_span!("format_response").in_scope(|| {
-                                    query.format_response(
-                                        &mut response,
-                                        operation_name.as_deref(),
-                                        variables.clone(),
-                                        schema.api_schema(),
-                                    )
-                                });
-
-                                match (response.path.as_ref(), response.data.as_ref()) {
-                                    (None, _) | (_, None) => {
-                                        if can_be_deferred {
-                                            response.has_next = Some(true);
-                                        }
-
-                                        response
-                                    }
-                                    // if the deferred response specified a path, we must extract the
-                                    //values matched by that path and create a separate response for
-                                    //each of them.
-                                    // While { "data": { "a": { "b": 1 } } } and { "data": { "b": 1 }, "path: ["a"] }
-                                    // would merge in the same ways, some clients will generate code
-                                    // that checks the specific type of the deferred response at that
-                                    // path, instead of starting from the root object, so to support
-                                    // this, we extract the value at that path.
-                                    // In particular, that means that a deferred fragment in an object
-                                    // under an array would generate one response par array element
-                                    (Some(response_path), Some(response_data)) => {
-                                        let mut sub_responses = Vec::new();
-                                        response_data.select_values_and_paths(
-                                            response_path,
-                                            |path, value| {
-                                                sub_responses
-                                                    .push((path.clone(), value.clone()));
-                                            },
-                                        );
-
-                                        Response::builder()
-                                            .has_next(true)
-                                            .incremental(
-                                                sub_responses
-                                                    .into_iter()
-                                                    .map(move |(path, data)| {
-                                                        IncrementalResponse::builder()
-                                                            .and_label(
-                                                                response.label.clone(),
-                                                            )
-                                                            .data(data)
-                                                            .path(path)
-                                                            .errors(response.errors.clone())
-                                                            .extensions(
-                                                                response.extensions.clone(),
-                                                            )
-                                                            .build()
-                                                    })
-                                                    .collect(),
-                                            )
-                                            .build()
-                                    }
-                                }
                             });
 
-                            Ok(SupergraphResponse {
-                                context,
-                                response: http::Response::from_parts(
-                                    parts,
+                            match (response.path.as_ref(), response.data.as_ref()) {
+                                (None, _) | (_, None) => {
                                     if can_be_deferred {
-                                        stream.chain(once(ready(Response::builder().has_next(false).build()))).left_stream()
-                                    } else {
-                                        stream.right_stream()
-                                    }.in_current_span()
-                                    .boxed(),
-                                )
-                            })
-                        }
+                                        response.has_next = Some(true);
+                                    }
+
+                                    response
+                                }
+                                // if the deferred response specified a path, we must extract the
+                                //values matched by that path and create a separate response for
+                                //each of them.
+                                // While { "data": { "a": { "b": 1 } } } and { "data": { "b": 1 }, "path: ["a"] }
+                                // would merge in the same ways, some clients will generate code
+                                // that checks the specific type of the deferred response at that
+                                // path, instead of starting from the root object, so to support
+                                // this, we extract the value at that path.
+                                // In particular, that means that a deferred fragment in an object
+                                // under an array would generate one response par array element
+                                (Some(response_path), Some(response_data)) => {
+                                    let mut sub_responses = Vec::new();
+                                    response_data.select_values_and_paths(
+                                        response_path,
+                                        |path, value| {
+                                            sub_responses
+                                                .push((path.clone(), value.clone()));
+                                        },
+                                    );
+
+                                    Response::builder()
+                                        .has_next(true)
+                                        .incremental(
+                                            sub_responses
+                                                .into_iter()
+                                                .map(move |(path, data)| {
+                                                    IncrementalResponse::builder()
+                                                        .and_label(
+                                                            response.label.clone(),
+                                                        )
+                                                        .data(data)
+                                                        .path(path)
+                                                        .errors(response.errors.clone())
+                                                        .extensions(
+                                                            response.extensions.clone(),
+                                                        )
+                                                        .build()
+                                                })
+                                                .collect(),
+                                        )
+                                        .build()
+                                }
+                            }
+                        });
+
+                        Ok(SupergraphResponse {
+                            context,
+                            response: http::Response::from_parts(
+                                parts,
+                                if can_be_deferred {
+                                    stream.chain(once(ready(Response::builder().has_next(false).build()))).left_stream()
+                                } else {
+                                    stream.right_stream()
+                                }.in_current_span()
+                                .boxed(),
+                            )
+                        })
                     }
                 }
             }

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -13,6 +13,7 @@ use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::services::subgraph;
 use apollo_router::services::supergraph;
+use http::header::ACCEPT;
 use http::Method;
 use http::StatusCode;
 use maplit::hashmap;
@@ -547,6 +548,7 @@ async fn defer_path() {
             }
         }"#,
         )
+        .header(ACCEPT, "multipart/mixed")
         .build()
         .expect("expecting valid request");
 
@@ -589,6 +591,7 @@ async fn defer_path_in_array() {
                 }
             }"#,
         )
+        .header(ACCEPT, "multipart/mixed")
         .build()
         .expect("expecting valid request");
 
@@ -601,6 +604,46 @@ async fn defer_path_in_array() {
 
     let second = stream.next_response().await.unwrap();
     insta::assert_json_snapshot!(second);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn defer_query_without_accept() {
+    let config = serde_json::json!({
+        "server": {
+            "experimental_defer_support": true
+        },
+        "plugins": {
+            "experimental.include_subgraph_errors": {
+                "all": true
+            }
+        }
+    });
+    let request = supergraph::Request::fake_builder()
+        .query(
+            r#"{
+                me {
+                    reviews {
+                        id
+                        author {
+                            id
+                            ... @defer(label: "author name") {
+                            name
+                            }
+                        }
+                    }
+                }
+            }"#,
+        )
+        .header(ACCEPT, "application/json")
+        .build()
+        .expect("expecting valid request");
+
+    let (router, _) = setup_router_and_registry(config).await;
+
+    let mut stream = router.oneshot(request).await.unwrap();
+
+    let first = stream.next_response().await.unwrap();
+    insta::assert_json_snapshot!(first);
 }
 
 async fn query_node(

--- a/apollo-router/tests/snapshots/integration_tests__defer_query_without_accept.snap
+++ b/apollo-router/tests/snapshots/integration_tests__defer_query_without_accept.snap
@@ -1,0 +1,14 @@
+---
+source: apollo-router/tests/integration_tests.rs
+assertion_line: 646
+expression: first
+---
+{
+  "errors": [
+    {
+      "message": "the router received a query with the @defer directive but the client does not accept multipart/mixed HTTP responses",
+      "locations": [],
+      "path": null
+    }
+  ]
+}


### PR DESCRIPTION
Fix #1618 

Since deferred responses can come back as multipart responses, we must
check that the client supports that content type. This will allow older
clients to show a meaningful error message instead of a parsing error if
the `@defer` directive is used but they don't support it
