### PR TITLE
chore: Use published `router-bridge`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,0 @@
-# If updating this, you *must* also change the channel in rust-toolchain.toml
-# renovate-automation: rustc version
-rust 1.61.0
-
-nodejs 16.9.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "1.6.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2114d64672151c0c5eaa5e131ec84a74f06e1e559830dabba01ca30605d66319"
+checksum = "e14485364214912d3b19cc3435dde4df66065127f05fa0d75c712f36f12c2f28"
 dependencies = [
  "concurrent-queue",
  "event-listener",
@@ -4008,10 +4008,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9"
 dependencies = [
+ "once_cell",
  "thiserror",
  "toml",
 ]
@@ -4483,8 +4484,9 @@ dependencies = [
 
 [[package]]
 name = "router-bridge"
-version = "0.1.0"
-source = "git+https://github.com/apollographql/federation-rs.git?tag=defer-alpha4#5ce2e2b3fc8e4f8e6f8350bb1b68d8e8d639bf26"
+version = "0.1.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f76769e567afde5e5e51f36f96bc734b35eb77d38668f6cf07e2784b3f303ed"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -105,11 +105,11 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 
 ## 🛠 Maintenance
 
-### Depend on published `router-bridge` ([PR #XXX](https://github.com/apollographql/router/issues/XXX))
+### Depend on published `router-bridge` ([PR #1613](https://github.com/apollographql/router/issues/1613))
 
 We have published the `router-bridge` to crates.io, which removes the need for router developers to have nodejs installed.
 
-By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/XXX
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1613
 
 ### Re-organize our release steps checklist ([PR #1605](https://github.com/apollographql/router/pull/1605))
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -105,6 +105,11 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 
 ## 🛠 Maintenance
 
+### Depend on published `router-bridge` ([PR #XXX](https://github.com/apollographql/router/issues/XXX))
+
+We have published the `router-bridge` to crates.io, which removes the need for router developers to have nodejs installed.
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/XXX
 
 ### Re-organize our release steps checklist ([PR #1605](https://github.com/apollographql/router/pull/1605))
 

--- a/apollo-router-scaffold/templates/base/.tool-versions
+++ b/apollo-router-scaffold/templates/base/.tool-versions
@@ -1,4 +1,0 @@
-# renovate-automation: rustc version
-rust 1.61.0
-
-nodejs 16.9.1

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -119,7 +119,7 @@ reqwest = { version = "0.11.11", default-features = false, features = [
     "json",
     "stream",
 ] }
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", tag = "defer-alpha4" }
+router-bridge = "0.1.0-alpha.1"
 schemars = { version = "0.8.10", features = ["url"] }
 sha2 = "0.10.2"
 serde = { version = "1.0.144", features = ["derive", "rc"] }

--- a/apollo-router/src/graphql.rs
+++ b/apollo-router/src/graphql.rs
@@ -14,6 +14,8 @@ use crate::error::FetchError;
 use crate::error::Location;
 use crate::json_ext::Object;
 use crate::json_ext::Path;
+pub use crate::json_ext::Path as JsonPath;
+pub use crate::json_ext::PathElement as JsonPathElement;
 pub use crate::request::Request;
 pub use crate::response::Response;
 

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -1,4 +1,7 @@
 //! Performance oriented JSON manipulation.
+
+#![allow(missing_docs)] // FIXME
+
 use std::cmp::min;
 use std::fmt;
 


### PR DESCRIPTION
part of #491

We have published the `router-bridge` to crates.io, which removes the need for router developers to have nodejs installed.
