### PR TITLE
Add #[non_exhaustive] to relevant types

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -66,6 +66,53 @@ These items have been removed from the public API of `apollo_router::services::e
 
 By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/1568
 
+### Many structs and enums are now `#[non_exhaustive]` ([Issue #1550](https://github.com/apollographql/router/issues/1550))
+
+This means we may add struct fields or enum variants in the future.
+To prepare for that eventuality:
+
+When using a struct pattern (such as for deconstructing a value into its fields),
+use `..` to allow further fields:
+
+```diff
+-let PluginInit { config, supergraph_sdl } = init;
++let PluginInit { config, supergraph_sdl, .. } = init;
+```
+
+Or use field access instead:
+
+```diff
+-let PluginInit { config, supergraph_sdl } = init;
++let config = init.config;
++let supergraph_sdl = init.supergraph_sdl;
+```
+
+When constructing a struct, use a builder or constructor method instead of struct literal syntax:
+
+```diff
+-let error = graphql::Error {
+-    message: "something went wrong".to_string(),
+-    ..Default::default()
+-};
++let error = graphql::Error::builder()
++    .message("something went wrong")
++    .build();
+```
+
+When matching on an enum, add a wildcard match arm:
+
+```diff
+ match error {
+     SpecError::RecursionLimitExceeded => "recursion limit exceeded",
+     SpecError::InvalidType(_) => "invalid type",
+     SpecError::ParsingError(_) => "paring error",
+     SpecError::SubscriptionNotSupported => "subscription not supported",
++    _ => "other error",
+}
+```
+
+By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/1614
+
 ## 🚀 Features
 
 ### instrument the rhai plugin with a tracing span ([PR #1598](https://github.com/apollographql/router/pull/1598))

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -38,6 +38,7 @@ use crate::plugin::plugins;
 /// Configuration error.
 #[derive(Debug, Error, Display)]
 #[allow(missing_docs)] // FIXME
+#[non_exhaustive]
 pub enum ConfigurationError {
     /// could not read secret from file: {0}
     CannotReadSecretFromFile(std::io::Error),

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -32,6 +32,7 @@ pub use crate::spec::SpecError;
 #[derive(Error, Display, Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 #[ignore_extra_doc_attributes]
+#[non_exhaustive]
 #[allow(missing_docs)] // FIXME
 pub enum FetchError {
     /// query references unknown service '{service}'
@@ -256,6 +257,7 @@ impl From<QueryPlannerError> for Response {
 
 /// Error in the schema.
 #[derive(Debug, Error, Display)]
+#[non_exhaustive]
 pub enum SchemaError {
     /// IO error: {0}
     IoError(#[from] std::io::Error),

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -151,6 +151,7 @@ pub fn main() -> Result<()> {
 }
 
 /// Entry point into creating a router executable.
+#[non_exhaustive]
 pub struct Executable {}
 
 #[buildstructor::buildstructor]

--- a/apollo-router/src/graphql.rs
+++ b/apollo-router/src/graphql.rs
@@ -22,6 +22,7 @@ pub use crate::response::Response;
 /// Any GraphQL error.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct Error {
     /// The error message.
     pub message: String,

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -50,6 +50,7 @@ type InstanceFactory =
 type SchemaFactory = fn(&mut SchemaGenerator) -> schemars::schema::Schema;
 
 /// Initialise details for a plugin
+#[non_exhaustive]
 pub struct PluginInit<T> {
     /// Configuration
     pub config: T,

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -88,22 +88,23 @@ pub(crate) struct Propagation {
 
 #[derive(Default, Debug, Clone, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub struct Trace {
-    pub service_name: Option<String>,
-    pub service_namespace: Option<String>,
-    pub sampler: Option<SamplerOption>,
-    pub parent_based_sampler: Option<bool>,
-    pub max_events_per_span: Option<u32>,
-    pub max_attributes_per_span: Option<u32>,
-    pub max_links_per_span: Option<u32>,
-    pub max_attributes_per_event: Option<u32>,
-    pub max_attributes_per_link: Option<u32>,
-    pub attributes: Option<BTreeMap<String, AttributeValue>>,
+#[non_exhaustive]
+pub(crate) struct Trace {
+    pub(crate) service_name: Option<String>,
+    pub(crate) service_namespace: Option<String>,
+    pub(crate) sampler: Option<SamplerOption>,
+    pub(crate) parent_based_sampler: Option<bool>,
+    pub(crate) max_events_per_span: Option<u32>,
+    pub(crate) max_attributes_per_span: Option<u32>,
+    pub(crate) max_links_per_span: Option<u32>,
+    pub(crate) max_attributes_per_event: Option<u32>,
+    pub(crate) max_attributes_per_link: Option<u32>,
+    pub(crate) attributes: Option<BTreeMap<String, AttributeValue>>,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum AttributeValue {
+pub(crate) enum AttributeValue {
     /// bool values
     Bool(bool),
     /// i64 values
@@ -130,7 +131,7 @@ impl From<AttributeValue> for opentelemetry::Value {
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(untagged, deny_unknown_fields)]
-pub enum AttributeArray {
+pub(crate) enum AttributeArray {
     /// Array of bools
     Bool(Vec<bool>),
     /// Array of integers
@@ -154,7 +155,7 @@ impl From<AttributeArray> for opentelemetry::Array {
 
 #[derive(Clone, Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields, untagged)]
-pub enum SamplerOption {
+pub(crate) enum SamplerOption {
     /// Sample a given fraction of traces. Fractions >= 1 will always sample. If the parent span is
     /// sampled, then it's child spans will automatically be sampled. Fractions < 0 are treated as
     /// zero, but spans may still be sampled if their parent is.
@@ -164,7 +165,7 @@ pub enum SamplerOption {
 
 #[derive(Clone, Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub enum Sampler {
+pub(crate) enum Sampler {
     /// Always sample the trace
     AlwaysOn,
     /// Never sample the trace

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -752,6 +752,7 @@ pub(crate) mod fetch {
     /// GraphQL operation type.
     #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
     #[serde(rename_all = "camelCase")]
+    #[non_exhaustive]
     pub enum OperationKind {
         Query,
         Mutation,

--- a/apollo-router/src/request.rs
+++ b/apollo-router/src/request.rs
@@ -16,6 +16,7 @@ use crate::json_ext::Object;
 #[derive(Clone, Derivative, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 #[derivative(Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub struct Request {
     /// The graphql query.
     pub query: Option<String>,

--- a/apollo-router/src/response.rs
+++ b/apollo-router/src/response.rs
@@ -16,6 +16,7 @@ use crate::json_ext::Value;
 /// Used for federated and subgraph queries.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct Response {
     /// The label that was passed to the defer or stream directive for this patch.
     #[serde(skip_serializing_if = "Option::is_none", default)]
@@ -170,6 +171,7 @@ impl Response {
 /// Used with `@defer`
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
+#[non_exhaustive]
 pub struct IncrementalResponse {
     /// The label that was passed to the defer or stream directive for this patch.
     #[serde(skip_serializing_if = "Option::is_none", default)]

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -129,6 +129,7 @@ pub enum ApolloRouterError {
 /// The user supplied schema. Either a static string or a stream for hot reloading.
 #[derive(From, Display, Derivative)]
 #[derivative(Debug)]
+#[non_exhaustive]
 pub enum SchemaSource {
     /// A static schema.
     #[display(fmt = "String")]
@@ -245,6 +246,7 @@ type ConfigurationStream = Pin<Box<dyn Stream<Item = Configuration> + Send>>;
 /// The user supplied config. Either a static instance or a stream for hot reloading.
 #[derive(From, Display, Derivative)]
 #[derivative(Debug)]
+#[non_exhaustive]
 pub enum ConfigurationSource {
     /// A static configuration.
     ///
@@ -347,6 +349,7 @@ type ShutdownFuture = Pin<Box<dyn Future<Output = ()> + Send>>;
 /// Specifies when the Router’s HTTP server should gracefully shutdown
 #[derive(Display, Derivative)]
 #[derivative(Debug)]
+#[non_exhaustive]
 pub enum ShutdownSource {
     /// No graceful shutdown
     #[display(fmt = "None")]

--- a/apollo-router/src/services/execution.rs
+++ b/apollo-router/src/services/execution.rs
@@ -30,6 +30,7 @@ pub type ServiceResult = Result<Response, BoxError>;
 pub use crate::query_planner::QueryPlan;
 
 assert_impl_all!(Request: Send);
+#[non_exhaustive]
 pub struct Request {
     /// Original request to the Router.
     pub originating_request: http::Request<graphql::Request>,
@@ -78,6 +79,7 @@ impl Request {
 }
 
 assert_impl_all!(Response: Send);
+#[non_exhaustive]
 pub struct Response {
     pub response: http::Response<BoxStream<'static, graphql::Response>>,
 

--- a/apollo-router/src/services/subgraph.rs
+++ b/apollo-router/src/services/subgraph.rs
@@ -21,6 +21,7 @@ pub type BoxCloneService = tower::util::BoxCloneService<Request, Response, BoxEr
 pub type ServiceResult = Result<Response, BoxError>;
 
 assert_impl_all!(Request: Send);
+#[non_exhaustive]
 pub struct Request {
     /// Original request to the Router.
     pub originating_request: Arc<http::Request<graphql::Request>>,
@@ -75,6 +76,7 @@ impl Request {
 
 assert_impl_all!(Response: Send);
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct Response {
     pub response: http::Response<graphql::Response>,
 

--- a/apollo-router/src/services/supergraph.rs
+++ b/apollo-router/src/services/supergraph.rs
@@ -32,6 +32,7 @@ assert_impl_all!(Request: Send);
 /// Represents the router processing step of the processing pipeline.
 ///
 /// This consists of the parsed graphql Request, HTTP headers and contextual data for extensions.
+#[non_exhaustive]
 pub struct Request {
     /// Original request to the Router.
     pub originating_request: http::Request<graphql::Request>,
@@ -157,6 +158,7 @@ impl Request {
 }
 
 assert_impl_all!(Response: Send);
+#[non_exhaustive]
 pub struct Response {
     pub response: http::Response<BoxStream<'static, graphql::Response>>,
     pub context: Context,

--- a/apollo-router/src/spec/mod.rs
+++ b/apollo-router/src/spec/mod.rs
@@ -14,6 +14,7 @@ use thiserror::Error;
 
 /// GraphQL parsing errors.
 #[derive(Error, Debug, Display, Clone)]
+#[non_exhaustive]
 pub enum SpecError {
     /// selection processing recursion limit exceeded
     RecursionLimitExceeded,

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -178,13 +178,11 @@ async fn queries_should_work_over_get() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn simple_queries_should_not_work() {
-    let expected_error = graphql::Error {
-        message :"This operation has been blocked as a potential Cross-Site Request Forgery (CSRF). \
-        Please either specify a 'content-type' header \
-        (with a mime-type that is not one of application/x-www-form-urlencoded, multipart/form-data, text/plain) \
-        or provide one of the following headers: x-apollo-operation-name, apollo-require-preflight".to_string(),
-        ..Default::default()
-    };
+    let message = "This operation has been blocked as a potential Cross-Site Request Forgery (CSRF). \
+    Please either specify a 'content-type' header \
+    (with a mime-type that is not one of application/x-www-form-urlencoded, multipart/form-data, text/plain) \
+    or provide one of the following headers: x-apollo-operation-name, apollo-require-preflight";
+    let expected_error = graphql::Error::builder().message(message).build();
 
     let mut request = supergraph::Request::fake_builder()
         .query(r#"{ topProducts { upc name reviews {id product { name } author { id name } } } }"#)
@@ -256,10 +254,10 @@ async fn queries_should_work_over_post() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn service_errors_should_be_propagated() {
-    let expected_error = apollo_router::graphql::Error {
-        message :"value retrieval failed: couldn't plan query: query validation errors: Unknown operation named \"invalidOperationName\"".to_string(),
-        ..Default::default()
-    };
+    let message = "value retrieval failed: couldn't plan query: query validation errors: Unknown operation named \"invalidOperationName\"";
+    let expected_error = apollo_router::graphql::Error::builder()
+        .message(message)
+        .build();
 
     let request = supergraph::Request::fake_builder()
         .query(r#"{ topProducts { name } }"#)

--- a/examples/async-auth/src/allow_client_id_from_file.rs
+++ b/examples/async-auth/src/allow_client_id_from_file.rs
@@ -66,10 +66,11 @@ impl Plugin for AllowClientIdFromFile {
                 // Prepare an HTTP 401 response with a GraphQL error message
                 res = Some(
                     supergraph::Response::error_builder()
-                        .error(graphql::Error {
-                            message: format!("Missing '{header_key}' header"),
-                            ..Default::default()
-                        })
+                        .error(
+                            graphql::Error::builder()
+                                .message(format!("Missing '{header_key}' header"))
+                                .build(),
+                        )
                         .status_code(StatusCode::UNAUTHORIZED)
                         .context(req.context.clone())
                         .build()
@@ -100,10 +101,11 @@ impl Plugin for AllowClientIdFromFile {
                             res = Some(
                                 supergraph::Response::builder()
                                     .data(Value::default())
-                                    .error(graphql::Error {
-                                        message: "client-id is not allowed".to_string(),
-                                        ..Default::default()
-                                    })
+                                    .error(
+                                        graphql::Error::builder()
+                                            .message("client-id is not allowed")
+                                            .build(),
+                                    )
                                     .status_code(StatusCode::FORBIDDEN)
                                     .context(req.context.clone())
                                     .build()
@@ -115,10 +117,11 @@ impl Plugin for AllowClientIdFromFile {
                         // Prepare an HTTP 400 response with a GraphQL error message
                         res = Some(
                             supergraph::Response::error_builder()
-                                .error(graphql::Error {
-                                    message: format!("'{header_key}' value is not a string"),
-                                    ..Default::default()
-                                })
+                                .error(
+                                    graphql::Error::builder()
+                                        .message(format!("'{header_key}' value is not a string"))
+                                        .build(),
+                                )
                                 .status_code(StatusCode::BAD_REQUEST)
                                 .context(req.context.clone())
                                 .build()

--- a/examples/forbid-anonymous-operations/src/forbid_anonymous_operations.rs
+++ b/examples/forbid-anonymous-operations/src/forbid_anonymous_operations.rs
@@ -55,10 +55,11 @@ impl Plugin for ForbidAnonymousOperations {
 
                     // Prepare an HTTP 400 response with a GraphQL error message
                     let res = supergraph::Response::error_builder()
-                        .error(graphql::Error {
-                            message: "Anonymous operations are not allowed".to_string(),
-                            ..Default::default()
-                        })
+                        .error(
+                            graphql::Error::builder()
+                                .message("Anonymous operations are not allowed")
+                                .build(),
+                        )
                         .status_code(StatusCode::BAD_REQUEST)
                         .context(req.context)
                         .build()?;

--- a/examples/jwt-auth/src/jwt.rs
+++ b/examples/jwt-auth/src/jwt.rs
@@ -236,10 +236,7 @@ impl Plugin for JwtAuth {
                     status: StatusCode,
                 ) -> Result<ControlFlow<supergraph::Response, supergraph::Request>, BoxError> {
                     let res = supergraph::Response::error_builder()
-                        .errors(vec![graphql::Error {
-                            message: msg,
-                            ..Default::default()
-                        }])
+                        .error(graphql::Error::builder().message(msg).build())
                         .status_code(status)
                         .context(context)
                         .build()?;


### PR DESCRIPTION
… with a few exceptions like `Location` and `PathElement`.

Relevant types are:

* Public enums
* Public structs without any private field

See https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute

This will allow us adding struct fields or enum variants without it being a breaking change.

Fixes https://github.com/apollographql/router/issues/1550