### PR TITLE
Use SPDX identifiers and designate license key functionality

### DIFF
--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -3,7 +3,7 @@ name = "apollo-router-benchmarks"
 version = "0.15.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
-license = "LicenseRef-ELv2"
+license = "Elastic-2.0"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -20,7 +20,9 @@ failfast = []
 access-json = "0.1.0"
 anyhow = "1.0.62"
 apollo-parser = "0.2.10"
+# ELv2 licensing: The apollo-spaceport crate is license key functionality
 apollo-spaceport = { path = "../apollo-spaceport" }
+# ELv2 licensing: The apollo-uplink crate is license key functionality
 apollo-uplink = { path = "../uplink" }
 async-compression = { version = "0.3.14", features = [
     "tokio",

--- a/apollo-router/src/plugins/telemetry/metrics/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo.rs
@@ -1,5 +1,5 @@
-// This entire file is license key functionality
 //! Apollo metrics
+// With regards to ELv2 licensing, this entire file is license key functionality
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::time::Duration;

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -1,5 +1,5 @@
 //! Telemetry plugin.
-// This entire file is license key functionality
+// With regards to ELv2 licensing, this entire file is license key functionality
 use std::collections::HashMap;
 use std::error::Error;
 use std::fmt;

--- a/apollo-router/src/plugins/telemetry/tracing/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo.rs
@@ -1,5 +1,5 @@
 //! Tracing configuration for apollo telemetry.
-// This entire file is license key functionality
+// With regards to ELv2 licensing, this entire file is license key functionality
 use opentelemetry::sdk::trace::Builder;
 use tower::BoxError;
 

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -221,6 +221,8 @@ impl SchemaSource {
                 urls,
                 poll_interval,
             } => {
+                // With regards to ELv2 licensing, the code inside this block
+                // is license key functionality
                 apollo_uplink::stream_supergraph(apollo_key, apollo_graph_ref, urls, poll_interval)
                     .filter_map(|res| {
                         future::ready(match res {

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-// This entire file is license key functionality
+// With regards to ELv2 licensing, this entire file is license key functionality
 use std::sync::Arc;
 
 use futures::stream::BoxStream;

--- a/apollo-spaceport/proto/agents.proto
+++ b/apollo-spaceport/proto/agents.proto
@@ -1,4 +1,4 @@
-// This entire file is license key functionality
+// With regards to ELv2 licensing, this entire file is license key functionality
 syntax = "proto3";
 
 import "proto/reports.proto";

--- a/apollo-spaceport/src/lib.rs
+++ b/apollo-spaceport/src/lib.rs
@@ -1,4 +1,4 @@
-// This entire file is license key functionality
+// With regards to ELv2 licensing, this entire file is license key functionality
 pub mod report {
     tonic::include_proto!("report");
 }

--- a/apollo-spaceport/src/spaceport.rs
+++ b/apollo-spaceport/src/spaceport.rs
@@ -1,5 +1,5 @@
 //! Main entry point for CLI command to start spaceport.
-// This entire file is license key functionality
+// With regards to ELv2 licensing, this entire file is license key functionality
 use std::net::SocketAddr;
 
 use apollo_spaceport::server::ReportSpaceport;

--- a/deny.toml
+++ b/deny.toml
@@ -41,7 +41,6 @@ allow = [
     "BSD-3-Clause",
     "CC0-1.0",
     "ISC",
-    "LicenseRef-ELv2",
     "LicenseRef-ring",
     "MIT",
     "MPL-2.0",

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -3,6 +3,7 @@ name = "apollo-uplink"
 version = "0.16.0"
 edition = "2021"
 build = "build.rs"
+license = "Elastic-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/uplink/src/lib.rs
+++ b/uplink/src/lib.rs
@@ -1,3 +1,4 @@
+// With regards to ELv2 licensing, this entire file is license key functionality
 use std::time::Duration;
 
 use futures::Stream;


### PR DESCRIPTION
- Use the now-available SPDX identifiers for all crates in this workspace

  Since the `Elastic-2.0` SPDX identifier is now official, we can use it everywhere and should be able to remove this lingering dependency on an internal representation for it in our `cargo deny` implementation.
- Designate license key functionality clearly everywhere as ELv2

  This also makes it possible to just search for ELv2 in the project and find all occurrences.
