### PR TITLE
Make the query_planner module private

### DIFF
--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -65,7 +65,7 @@ mod http_server_factory;
 mod introspection;
 pub mod layers;
 mod plugins;
-pub mod query_planner;
+mod query_planner;
 mod request;
 mod response;
 mod router;

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -18,7 +18,7 @@ use tokio::sync::broadcast::Sender;
 use tokio_stream::wrappers::BroadcastStream;
 use tracing::Instrument;
 
-pub use self::fetch::OperationKind;
+pub(crate) use self::fetch::OperationKind;
 use crate::error::Error;
 use crate::graphql::Request;
 use crate::graphql::Response;


### PR DESCRIPTION
Its public items are already reexported in modules that use them in public APIs.