### PR TITLE
Update Docker build artifacts to new installer pattern

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,12 +492,11 @@ jobs:
       - run:
           name: Docker build
           command: |
-            ROUTER_RELEASE=${VERSION:1}
             ROUTER_TAG=ghcr.io/apollographql/router
             # Build debug image
-            docker build --build-arg ROUTER_RELEASE=${ROUTER_RELEASE} --build-arg DEBUG_IMAGE=":debug" -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:v${ROUTER_RELEASE}-debug .
+            docker build --build-arg ROUTER_RELEASE=${VERSION} --build-arg DEBUG_IMAGE=":debug" -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION}-debug .
             # Build release image
-            docker build --build-arg ROUTER_RELEASE=${ROUTER_RELEASE} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION} .
+            docker build --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION} .
             # Note: GH Token owned by apollo-bot2, no expire
             echo ${GITHUB_OCI_TOKEN} | docker login ghcr.io -u apollo-bot2 --password-stdin
             # Push debug image

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -1,22 +1,26 @@
 ARG DEBUG_IMAGE
 # Build is required to extract the release files
-FROM --platform=linux/amd64 alpine:latest AS build
+FROM --platform=linux/amd64 debian:bullseye-slim AS build
 
-ARG ROUTER_RELEASE
+ARG ROUTER_RELEASE=latest
 
-# Pull release from GH
-ADD https://github.com/apollographql/router/releases/download/v${ROUTER_RELEASE}/router-${ROUTER_RELEASE}-x86_64-unknown-linux-gnu.tar.gz /tmp/router.tar.gz
+WORKDIR /dist
 
-WORKDIR /tmp
+# Install curl
+RUN \
+  apt-get update -y \
+  && apt-get install -y \
+    curl \
+  && rm -rf /var/lib/apt/lists/*
 
-# router.tar.gz extracts to "dist"
-RUN tar xvzf router.tar.gz -C /
+# Run the Router downloader which puts Router into current working directory
+RUN curl -sSL https://router.apollo.dev/download/nix/${ROUTER_RELEASE}/ | sh
 
 # Make directories for config and schema
-RUN mkdir /dist/config && mkdir /dist/schema
+RUN mkdir config schema
 
 # Copy configuration for docker image
-COPY dockerfiles/router.yaml /dist/config
+COPY dockerfiles/router.yaml config
 
 # Required so we can copy in libz.so.1
 FROM --platform=linux/amd64 gcr.io/distroless/java17-debian11${DEBUG_IMAGE} as libz-required
@@ -24,15 +28,15 @@ FROM --platform=linux/amd64 gcr.io/distroless/java17-debian11${DEBUG_IMAGE} as l
 # Final image uses distroless
 FROM --platform=linux/amd64 gcr.io/distroless/cc-debian11${DEBUG_IMAGE}
 
-LABEL org.opencontainers.image.authors="ApolloGraphQL https://github.com/apollographql/router"
+LABEL org.opencontainers.image.authors="Apollo Graph, Inc. https://github.com/apollographql/router"
 
 # Copy in the extracted/created files
 COPY --from=libz-required /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
 
-# Copy in the extracted/created files
-COPY --from=build --chown=root:root /dist /dist
-
 WORKDIR /dist
+
+# Copy in the extracted/created files
+COPY --from=build --chown=root:root /dist .
 
 ENV APOLLO_ROUTER_CONFIG_PATH="/dist/config/router.yaml"
 

--- a/dockerfiles/diy/build_docker_image.sh
+++ b/dockerfiles/diy/build_docker_image.sh
@@ -111,7 +111,7 @@ cp ../router.yaml "${BUILD_DIR}" || terminate "Couldn't copy ../router.yaml to $
 
 # Change to our build directory
 cd "${BUILD_DIR}" || terminate "Couldn't cd to ${BUILD_DIR}";
- 
+
 # If we are building, clone our repo
 if [ "${BUILD_IMAGE}" = true ]; then
     git clone https://github.com/apollographql/router.git > /dev/null 2>&1 || terminate "Couldn't clone repository"
@@ -131,9 +131,8 @@ if [ "${BUILD_IMAGE}" = true ]; then
 else
     # Let the user know what we are going to do
     echo "Building image: ${ROUTER_VERSION}" from released tarballs""
-    ROUTER_RELEASE="$(echo "${ROUTER_VERSION}" | cut -c2-)"
     docker build -q -t "router:${ROUTER_VERSION}" \
-        --build-arg ROUTER_RELEASE="${ROUTER_RELEASE}" \
+        --build-arg ROUTER_RELEASE="${ROUTER_VERSION}" \
         --no-cache -f Dockerfile.release . \
         || terminate "Couldn't build router image"
 fi

--- a/dockerfiles/diy/dockerfiles/Dockerfile.release
+++ b/dockerfiles/diy/dockerfiles/Dockerfile.release
@@ -3,23 +3,27 @@
 # builds to work on platforms such as Mac OS X/M1 (with some help from
 # rosetta)
 # Build is required to extract the release files
-FROM --platform=linux/amd64 alpine:latest AS build
+FROM --platform=linux/amd64 debian:bullseye-slim AS build
 
-ARG ROUTER_RELEASE
+ARG ROUTER_RELEASE=latest
 
-# Pull release from GH
-ADD https://github.com/apollographql/router/releases/download/v${ROUTER_RELEASE}/router-${ROUTER_RELEASE}-x86_64-linux.tar.gz /tmp/router.tar.gz
+WORKDIR /dist
 
-WORKDIR /tmp
+# Install curl
+RUN \
+  apt-get update -y \
+  && apt-get install -y \
+    curl \
+  && rm -rf /var/lib/apt/lists/*
 
-# router.tar.gz extracts to "dist"
-RUN tar xvzf router.tar.gz -C /
+# Run the Router downloader which puts Router into current working directory
+RUN curl -sSL https://router.apollo.dev/download/nix/${ROUTER_RELEASE}/ | sh
 
 # Make directories for config and schema
-RUN mkdir /dist/config && mkdir /dist/schema
+RUN mkdir config schema
 
 # Copy configuration for docker image
-COPY router.yaml /dist/config
+COPY router.yaml config
 
 # Required so we can copy in libz.so.1
 FROM --platform=linux/amd64 gcr.io/distroless/java17-debian11 as libz-required
@@ -27,15 +31,15 @@ FROM --platform=linux/amd64 gcr.io/distroless/java17-debian11 as libz-required
 # Final image uses distroless. Feel free to change this to an image that suits your needs.
 FROM --platform=linux/amd64 gcr.io/distroless/cc-debian11
 
-LABEL org.opencontainers.image.authors="ApolloGraphQL https://github.com/apollographql/router"
+LABEL org.opencontainers.image.authors="Apollo Graph, Inc. https://github.com/apollographql/router"
 
 # Copy in the extracted/created files
 COPY --from=libz-required /lib/x86_64-linux-gnu/libz.so.1 /lib/x86_64-linux-gnu/libz.so.1
 
-# Copy in the extracted/created files
-COPY --from=build --chown=root:root /dist /dist
-
 WORKDIR /dist
+
+# Copy in the extracted/created files
+COPY --from=build --chown=root:root /dist .
 
 ENV APOLLO_ROUTER_CONFIG_PATH="/dist/config/router.yaml"
 


### PR DESCRIPTION
Following up on https://github.com/apollographql/router/pull/1433 which re-introduced target triplets and the installer to support it, this utilizes the installer in our Docker build steps.

This consists of:

- Switching our direct downloading of releases to go through our unified installer endpoint.
- Durably uses the installer script to download the right architecture for a particular release using the logic in the installer for that release.
- There is now a default `ROUTER_RELEASE` value of `latest` on the images, though the argument still works (and is used by our releasing pipeline)
- Simplifies some logic (e.g., transforming version numbers to remove `v`).
- Switching from `alpine` to `debian` since our installer doesn't support `alpine` and fails.  This is _not_ a material change to the outcome because we were only using the alpine image to download a tarball, not for runtime.  (Fwiw, it's worth, this change wouldn't have been necessary, but our installer runs `router --version` at the end which fails on Alpine.) Conceviably our Oribiter endpoint can just redirect to the tarballs with a small change which it already does for Rover, but this was quicker.

