### PR TITLE
revert Using the new SPDX identifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ dependencies = [
 [[package]]
 name = "async-compression"
 version = "0.3.14"
-source = "git+https://github.com/geal/async-compression?branch=encoder-flush#9800cd0d36be7f3414fbb98b25f9f61900ec8c7c"
+source = "git+https://github.com/geal/async-compression?tag=encoder-flush#9800cd0d36be7f3414fbb98b25f9f61900ec8c7c"
 dependencies = [
  "brotli",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,4 @@ incremental = false
 # entire compressed response in memory before sending it, which creates issues with
 # deferred responses getting received too late
 [patch.crates-io]
-async-compression = { git = 'https://github.com/geal/async-compression', branch = 'encoder-flush' }
+async-compression = { git = 'https://github.com/geal/async-compression', tag = 'encoder-flush' }

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -3,7 +3,7 @@ name = "apollo-router-benchmarks"
 version = "0.15.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
-license = "Elastic-2.0"
+license = "LicenseRef-ELv2"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -3,7 +3,7 @@ name = "apollo-router-scaffold"
 version = "0.16.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
-license = "Elastic-2.0"
+license = "LicenseRef-ELv2"
 publish = false
 
 [dependencies]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -3,7 +3,7 @@ name = "apollo-router"
 version = "0.16.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
-license = "Elastic-2.0"
+license = "LicenseRef-ELv2"
 publish = false
 
 [[bin]]

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -3,7 +3,7 @@ name = "apollo-spaceport"
 version = "0.16.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
-license = "Elastic-2.0"
+license = "LicenseRef-ELv2"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/deny.toml
+++ b/deny.toml
@@ -44,6 +44,7 @@ allow = [
     "LicenseRef-ring",
     "MIT",
     "MPL-2.0",
+    "LicenseRef-ELv2",
 ]
 copyleft = "warn"
 allow-osi-fsf-free = "neither"
@@ -96,4 +97,4 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for
-github = ["open-telemetry", "apollographql", "tokio-rs"]
+github = ["open-telemetry", "apollographql", "tokio-rs", "geal"]

--- a/deny.toml
+++ b/deny.toml
@@ -97,4 +97,5 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for
+# FIXME: remove "geal" from the allowed orgs once we have a fix for `async-compression`
 github = ["open-telemetry", "apollographql", "tokio-rs", "geal"]

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -3,7 +3,7 @@ name = "apollo-uplink"
 version = "0.16.0"
 edition = "2021"
 build = "build.rs"
-license = "Elastic-2.0"
+license = "LicenseRef-ELv2"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -3,7 +3,7 @@ name = "xtask"
 version = "0.16.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
-license = "LicenseRef-ELv2"
+license = "Elastic-2.0"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
This commit reverts part of https://github.com/apollographql/router/pull/1620's changes to the SPDX Identifiers until the ecosystem relies on spdx 0.9.0.