### PR TITLE
Fix: Propagate graphql response regardless of the subgraph HTTP status code.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -62,6 +62,17 @@ The 2.1.0 release of the query planner comes with fixes to fragment interpretati
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1650
 
+
+
+### Propagate graphql response regardless of the subgraph HTTP status code. ([#1664](https://github.com/apollographql/router/issues/1664))
+
+Subgraph service calls used to return an error when the received HTTP status code isn't 200.
+There's however no mention in the GraphQL specification that leads us to assume any intent behind the HTTP status code returned by a GraphQL server.
+
+This commit removes our HTTP status code check in the subgraph_service.
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1664
+
 ## 🛠 Maintenance
 
 ### Remove cache layer ([PR #1647](https://github.com/apollographql/router/pull/1647))

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -17,7 +17,6 @@ use http::header::CONTENT_TYPE;
 use http::header::{self};
 use http::HeaderMap;
 use http::HeaderValue;
-use http::StatusCode;
 use hyper::client::HttpConnector;
 use hyper_rustls::HttpsConnector;
 use opentelemetry::global;
@@ -197,16 +196,6 @@ impl tower::Service<crate::SubgraphRequest> for SubgraphService {
                         reason: err.to_string(),
                     }
                 })?;
-            if parts.status != StatusCode::OK {
-                return Err(BoxError::from(FetchError::SubrequestHttpError {
-                    service: service_name.clone(),
-                    reason: format!(
-                        "subgraph HTTP status error '{}': {}",
-                        parts.status,
-                        String::from_utf8_lossy(&body)
-                    ),
-                }));
-            }
 
             let graphql: graphql::Response = tracing::debug_span!("parse_subgraph_response")
                 .in_scope(|| {

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -331,6 +331,7 @@ mod tests {
 
     use axum::Server;
     use http::header::HOST;
+    use http::StatusCode;
     use http::Uri;
     use hyper::service::make_service_fn;
     use hyper::Body;


### PR DESCRIPTION
Fix: Propagate graphql response regardless of the subgraph HTTP status code.

fixes: #1335, #1662

Subgraph service calls used to return an error when the received HTTP status code isn't 200.
There's however no mention in the GraphQL specification that leads us to assume any intent behind the HTTP status code returned by a GraphQL server.

This commit removes our HTTP status code check in the `subgraph_service`.
