### PR TITLE
Fix for broken redirect: Client Awareness router doc URL

### DIFF
--- a/docs/source/_redirects
+++ b/docs/source/_redirects
@@ -1,2 +1,2 @@
 /configuration/spaceport* /docs/router/configuration/apollo-telemetry/
-/managed-federation/client%20awareness/ docs/router/managed-federation/client-awareness/
+/managed-federation/client%20awareness/ /docs/router/managed-federation/client-awareness/

--- a/docs/source/_redirects
+++ b/docs/source/_redirects
@@ -1,2 +1,2 @@
 /configuration/spaceport* /docs/router/configuration/apollo-telemetry/
-/managed-federation/client%20awareness/ /managed-federation/client-awareness/
+/managed-federation/client%20awareness/ docs/router/managed-federation/client-awareness/


### PR DESCRIPTION
This PR fixes the redirect URL for the Client Awareness router doc to include the /docs/router/ path so that the redirect goes to the new URL. 

### Original URL that was redirected when the source file was renamed to remove a space (%20)
https://www.apollographql.com/docs/router/managed-federation/client%20awareness/

### Current broken URL redirect
https://www.apollographql.com/managed-federation/client-awareness/

### Correct URL for the redirect
https://www.apollographql.com/docs/router/managed-federation/client-awareness/

### Changed in this PR
`/managed-federation/client%20awareness/ /managed-federation/client-awareness/`

updated to

`/managed-federation/client%20awareness/ /docs/router/managed-federation/client-awareness/`