### PR TITLE
docker: Define ENTRYPOINT as absolute path

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -50,6 +50,13 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 ## 🚀 Features
 ## 🐛 Fixes
 
+### Docker images: Use absolute path for `ENTRYPOINT` ([PR #1684](https://github.com/apollographql/router/pull/1684))
+
+This restores the absolute path in `ENTRYPOINT` in our `Dockerfile`s (and published images) to allow users to change their working directory without consequence (and without needing to change it back to `/dist` or override the `entrypoint`).
+
+By [@110y](https://github.com/110y) in https://github.com/apollographql/router/pull/1684
+
+
 ### Update our helm documentation to illustrate how to use our registry ([#1643](https://github.com/apollographql/router/issues/1643))
 
 The helm chart never used to have a registry, so our docs were really just placeholders. I've updated them to reflect the fact that we now store the chart in our OCI registry.

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -41,4 +41,4 @@ COPY --from=build --chown=root:root /dist .
 ENV APOLLO_ROUTER_CONFIG_PATH="/dist/config/router.yaml"
 
 # Default executable is the router
-ENTRYPOINT ["./router"]
+ENTRYPOINT ["/dist/router"]

--- a/dockerfiles/diy/dockerfiles/Dockerfile.release
+++ b/dockerfiles/diy/dockerfiles/Dockerfile.release
@@ -44,4 +44,4 @@ COPY --from=build --chown=root:root /dist .
 ENV APOLLO_ROUTER_CONFIG_PATH="/dist/config/router.yaml"
 
 # Default executable is the router
-ENTRYPOINT ["./router"]
+ENTRYPOINT ["/dist/router"]

--- a/dockerfiles/diy/dockerfiles/Dockerfile.repo
+++ b/dockerfiles/diy/dockerfiles/Dockerfile.repo
@@ -48,4 +48,4 @@ WORKDIR /dist
 ENV APOLLO_ROUTER_CONFIG_PATH="/dist/config/router.yaml"
 
 # Default executable is the router
-ENTRYPOINT ["./router"]
+ENTRYPOINT ["/dist/router"]


### PR DESCRIPTION
## What

- Use an absolute path for Dockerfile ENTRYPOINT

## Why

I'm running up `apollographql/router` by Docker Compose for my local development. And, I'm changing the working directory for the `router` image like below in order to mount my application repository:

```yaml
---
version: "3.8"

services:
  router:
    image: ghcr.io/apollographql/router:v1.0.0-alpha.0
    volumes:
      - .:/workspace:cached
    working_dir: /workspace
    command: --config router.yaml --supergraph schema.graphql
```

Since the current Dockerfile specifies a relative path (`./router`) for `ENTRYPOINT`, changing the working directory causes an error 

```
Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "./router": stat ./router: no such file or directory: unknown
```

Though I know specifying `entrypoint: /dist/router` to my `docker-compose.yml` fixes the problem, it requires users of the `router` image to recognize the working directory of the image (`/dist`) to do so, and I think it's not user friendly.
So, I created this PR that changes `ENTRYPOINT` from a relative `./router` to an absolute `/dist/router`.