### PR TITLE
infra: use gen2 Mac machine resource class on CircleCI + bump cache key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ executors:
   rust_macos: &rust_macos_executor
     macos:
       xcode: 11.7
+    resource_class: macos.x86.medium.gen2
   rust_windows: &rust_windows_executor
     machine:
       image: "windows-server-2019-vs2019:stable"
@@ -27,7 +28,7 @@ parameters:
   cache_version:
     type: string
     # increment that one to invalidate all the caches
-    default: v7.{{ checksum "rust-toolchain.toml" }}
+    default: v8.{{ checksum "rust-toolchain.toml" }}
 
 # These are common environment variables that we want to set on on all jobs.
 # While these could conceivably be set on the CircleCI project settings'


### PR DESCRIPTION
It's 75 credits instead of 50, but the newer generation processor makes a huge difference in our build times, which are often getting to 20 minutes and are reduced downward to about 10 with this change.

This can be seen in the [Product] documentation and the [Docs].

This also bumps the cache key because I don't trust the cache from the old Mac architecture to build cleanly.

[Docs]: https://circleci.com/docs/configuration-reference#macos-execution-environment
[Product]: https://circleci.com/product/features/resource-classes/#macos
