### PR TITLE
Add an apollo_router::graphql::ResponseStream type alias

### DIFF
--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -25,7 +25,6 @@ use futures::channel::oneshot;
 use futures::future::ready;
 use futures::prelude::*;
 use futures::stream::once;
-use futures::stream::BoxStream;
 use futures::StreamExt;
 use http::header::CONTENT_ENCODING;
 use http::header::CONTENT_TYPE;
@@ -425,7 +424,7 @@ async fn handle_get(
     Host(host): Host,
     service: BoxService<
         http::Request<graphql::Request>,
-        http::Response<BoxStream<'static, graphql::Response>>,
+        http::Response<graphql::ResponseStream>,
         BoxError,
     >,
     http_request: Request<Body>,
@@ -457,7 +456,7 @@ async fn handle_post(
     Json(request): Json<graphql::Request>,
     service: BoxService<
         http::Request<graphql::Request>,
-        http::Response<BoxStream<'static, graphql::Response>>,
+        http::Response<graphql::ResponseStream>,
         BoxError,
     >,
     header_map: HeaderMap,
@@ -498,7 +497,7 @@ async fn run_graphql_request<RS>(
 where
     RS: Service<
             http::Request<graphql::Request>,
-            Response = http::Response<BoxStream<'static, graphql::Response>>,
+            Response = http::Response<graphql::ResponseStream>,
             Error = BoxError,
         > + Send,
 {
@@ -808,7 +807,7 @@ mod tests {
     mock! {
         #[derive(Debug)]
         SupergraphService {
-            fn service_call(&mut self, req: http::Request<graphql::Request>) -> Result<http::Response<BoxStream<'static, graphql::Response>>, BoxError>;
+            fn service_call(&mut self, req: http::Request<graphql::Request>) -> Result<http::Response<graphql::ResponseStream>, BoxError>;
         }
     }
 

--- a/apollo-router/src/graphql.rs
+++ b/apollo-router/src/graphql.rs
@@ -3,7 +3,9 @@
 #![allow(missing_docs)] // FIXME
 
 use std::fmt;
+use std::pin::Pin;
 
+use futures::Stream;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json_bytes::ByteString;
@@ -19,6 +21,16 @@ pub use crate::json_ext::PathElement as JsonPathElement;
 pub use crate::request::Request;
 pub use crate::response::IncrementalResponse;
 pub use crate::response::Response;
+
+/// An asynchronous [`Stream`] of GraphQL [`Response`]s.
+///
+/// In some cases such as with `@defer`, a single HTTP response from the Router
+/// may contain multiple GraphQL responses that will be sent at different times
+/// (as more data becomes available).
+///
+/// We represent this in Rust as a stream,
+/// even if that stream happens to only contain one item.
+pub type ResponseStream = Pin<Box<dyn Stream<Item = Response> + Send>>;
 
 /// Any GraphQL error.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Default)]

--- a/apollo-router/src/http_ext.rs
+++ b/apollo-router/src/http_ext.rs
@@ -392,7 +392,7 @@ pub(crate) struct Response<T> {
 #[cfg(test)]
 pub(crate) fn from_response_to_stream(
     http: http::response::Response<graphql::Response>,
-) -> http::Response<futures::stream::BoxStream<'static, graphql::Response>> {
+) -> http::Response<graphql::ResponseStream> {
     use futures::future::ready;
     use futures::stream::once;
     use futures::StreamExt;

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 // With regards to ELv2 licensing, this entire file is license key functionality
 use std::sync::Arc;
 
-use futures::stream::BoxStream;
 use serde_json::Map;
 use serde_json::Value;
 use tower::BoxError;
@@ -32,7 +31,7 @@ pub(crate) trait SupergraphServiceFactory:
 {
     type SupergraphService: Service<
             http::Request<graphql::Request>,
-            Response = http::Response<BoxStream<'static, graphql::Response>>,
+            Response = http::Response<graphql::ResponseStream>,
             Error = BoxError,
             Future = Self::Future,
         > + Send;

--- a/apollo-router/src/services/execution.rs
+++ b/apollo-router/src/services/execution.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 
 use futures::future::ready;
 use futures::stream::once;
-use futures::stream::BoxStream;
 use futures::stream::StreamExt;
 use http::StatusCode;
 use multimap::MultiMap;
@@ -81,7 +80,7 @@ impl Request {
 assert_impl_all!(Response: Send);
 #[non_exhaustive]
 pub struct Response {
-    pub response: http::Response<BoxStream<'static, graphql::Response>>,
+    pub response: http::Response<graphql::ResponseStream>,
 
     pub context: Context,
 }
@@ -176,7 +175,7 @@ impl Response {
     /// In this case, you already have a valid request and just wish to associate it with a context
     /// and create a ExecutionResponse.
     pub fn new_from_response(
-        response: http::Response<BoxStream<'static, graphql::Response>>,
+        response: http::Response<graphql::ResponseStream>,
         context: Context,
     ) -> Self {
         Self { response, context }
@@ -184,7 +183,7 @@ impl Response {
 
     pub fn map<F>(self, f: F) -> Response
     where
-        F: FnOnce(BoxStream<'static, graphql::Response>) -> BoxStream<'static, graphql::Response>,
+        F: FnOnce(graphql::ResponseStream) -> graphql::ResponseStream,
     {
         Response {
             context: self.context,

--- a/apollo-router/src/services/execution_service.rs
+++ b/apollo-router/src/services/execution_service.rs
@@ -6,7 +6,6 @@ use std::task::Poll;
 use futures::future::ready;
 use futures::future::BoxFuture;
 use futures::stream::once;
-use futures::stream::BoxStream;
 use futures::StreamExt;
 use tower::BoxError;
 use tower::ServiceBuilder;
@@ -18,7 +17,6 @@ use super::layers::allow_only_http_post_mutations::AllowOnlyHttpPostMutationsLay
 use super::new_service::NewService;
 use super::subgraph_service::SubgraphServiceFactory;
 use super::Plugins;
-use crate::graphql::Response;
 use crate::services::execution;
 use crate::ExecutionRequest;
 use crate::ExecutionResponse;
@@ -73,7 +71,7 @@ where
             let stream = once(ready(first)).chain(rest).boxed();
 
             Ok(ExecutionResponse::new_from_response(
-                http::Response::new(stream as BoxStream<'static, Response>),
+                http::Response::new(stream as _),
                 ctx,
             ))
         }

--- a/apollo-router/src/services/supergraph.rs
+++ b/apollo-router/src/services/supergraph.rs
@@ -2,7 +2,6 @@
 
 use futures::future::ready;
 use futures::stream::once;
-use futures::stream::BoxStream;
 use futures::stream::StreamExt;
 use http::header::HeaderName;
 use http::method::Method;
@@ -158,7 +157,7 @@ impl Request {
 assert_impl_all!(Response: Send);
 #[non_exhaustive]
 pub struct Response {
-    pub response: http::Response<BoxStream<'static, graphql::Response>>,
+    pub response: http::Response<graphql::ResponseStream>,
     pub context: Context,
 }
 
@@ -269,7 +268,7 @@ impl Response {
     }
 
     pub fn new_from_response(
-        response: http::Response<BoxStream<'static, graphql::Response>>,
+        response: http::Response<graphql::ResponseStream>,
         context: Context,
     ) -> Self {
         Self { response, context }
@@ -277,7 +276,7 @@ impl Response {
 
     pub fn map<F>(self, f: F) -> Response
     where
-        F: FnOnce(BoxStream<'static, graphql::Response>) -> BoxStream<'static, graphql::Response>,
+        F: FnOnce(graphql::ResponseStream) -> graphql::ResponseStream,
     {
         Response {
             context: self.context,

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -6,7 +6,6 @@ use std::task::Poll;
 use futures::future::ready;
 use futures::future::BoxFuture;
 use futures::stream::once;
-use futures::stream::BoxStream;
 use futures::stream::StreamExt;
 use futures::TryFutureExt;
 use http::header::ACCEPT;
@@ -471,7 +470,7 @@ pub(crate) struct RouterCreator {
 impl NewService<http::Request<graphql::Request>> for RouterCreator {
     type Service = BoxService<
         http::Request<graphql::Request>,
-        http::Response<BoxStream<'static, Response>>,
+        http::Response<graphql::ResponseStream>,
         BoxError,
     >;
     fn new_service(&self) -> Self::Service {
@@ -485,7 +484,7 @@ impl NewService<http::Request<graphql::Request>> for RouterCreator {
 impl SupergraphServiceFactory for RouterCreator {
     type SupergraphService = BoxService<
         http::Request<graphql::Request>,
-        http::Response<BoxStream<'static, Response>>,
+        http::Response<graphql::ResponseStream>,
         BoxError,
     >;
 

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -423,7 +423,6 @@ mod tests {
 
     use futures::channel::oneshot;
     use futures::future::BoxFuture;
-    use futures::stream::BoxStream;
     use mockall::mock;
     use mockall::Sequence;
     use test_log::test;
@@ -683,7 +682,7 @@ mod tests {
 
     //mockall does not handle well the lifetime on Context
     impl Service<http::Request<crate::graphql::Request>> for MockMyRouter {
-        type Response = http::Response<BoxStream<'static, graphql::Response>>;
+        type Response = http::Response<graphql::ResponseStream>;
         type Error = BoxError;
         type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 


### PR DESCRIPTION
It is equivalent to `BoxStream<'static, graphql::Response>` and makes some type signatures slightly simpler.