### PR TITLE
fix(telemetry): fix telemetry propagation

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -27,5 +27,12 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 ## ❗ BREAKING ❗
 ## 🚀 Features
 ## 🐛 Fixes
+
+### Fix telemetry propagation with headers ([#1701](https://github.com/apollographql/router/issues/1701))
+
+Span context is now correctly propagated if you're trying to propagate tracing context to the router.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1701
+
 ## 🛠 Maintenance
 ## 📚 Documentation

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -573,8 +573,8 @@ impl Telemetry {
                 None,
             );
 
-            opentelemetry::global::set_tracer_provider(tracer_provider);
-            opentelemetry::global::set_error_handler(handle_error)
+            global::set_tracer_provider(tracer_provider);
+            global::set_error_handler(handle_error)
                 .expect("otel error handler lock poisoned, fatal");
             global::set_text_map_propagator(Self::create_propagator(&config));
 
@@ -652,6 +652,12 @@ impl Telemetry {
         let tracing = config.clone().tracing.unwrap_or_default();
 
         let mut propagators: Vec<Box<dyn TextMapPropagator + Send + Sync + 'static>> = Vec::new();
+        // TLDR the jaeger propagator MUST BE the first one because the version of opentelemetry_jaeger is buggy.
+        // It overrides the current span context with an empty one if it doesn't find the corresponding headers.
+        // Waiting for the >=0.16.1 release
+        if propagation.jaeger.unwrap_or_default() || tracing.jaeger.is_some() {
+            propagators.push(Box::new(opentelemetry_jaeger::Propagator::default()));
+        }
         if propagation.baggage.unwrap_or_default() {
             propagators.push(Box::new(BaggagePropagator::default()));
         }
@@ -660,9 +666,6 @@ impl Telemetry {
         }
         if propagation.zipkin.unwrap_or_default() || tracing.zipkin.is_some() {
             propagators.push(Box::new(opentelemetry_zipkin::Propagator::default()));
-        }
-        if propagation.jaeger.unwrap_or_default() || tracing.jaeger.is_some() {
-            propagators.push(Box::new(opentelemetry_jaeger::Propagator::default()));
         }
         if propagation.datadog.unwrap_or_default() || tracing.datadog.is_some() {
             propagators.push(Box::new(opentelemetry_datadog::DatadogPropagator::default()));


### PR DESCRIPTION
I found a bug in the current version of `opentelemetry-jaeger` which causes this bug #1488. [It has been fixed on main](https://github.com/open-telemetry/opentelemetry-rust/commit/cd3898d524937ec59ac7e240ae9f54232f6b76b9) but not released, I can't just take the commit to fix the bug because they break everything, the API is currently unstable. So .... the last release (the one we're using) has been released on January... I can't just fork it and fix it by myself or cherry-pick the commit because it means we would be blocked by this to release on crate.io. 

Then I wrote a workaround waiting for a proper release.

close #1488 