### PR TITLE
release: v1.0.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 # [1.0.0-alpha.2] - 2022-09-06
 
+## 🚀 Features
+
+### Add `service_name` and `service_namespace` in `telemetry.metrics.common` ([Issue #1490](https://github.com/apollographql/router/issues/1490))
+
+Add `service_name` and `service_namespace` in `telemetry.metrics.common` to reflect the same configuration than tracing.
+
+```yaml
+telemetry:
+  metrics:
+    common:
+      # (Optional, default to "apollo-router") Set the service name to easily find metrics related to the apollo-router in your metrics dashboards
+      service_name: "apollo-router"
+      # (Optional)
+      service_namespace: "apollo"
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1492
+
 ## 🐛 Fixes
 
 ### Fix distributed tracing header propagation ([#1701](https://github.com/apollographql/router/issues/1701))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,40 @@ All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# [1.0.0-alpha.2] - 2022-09-06
+
+## 🐛 Fixes
+
+### Fix distributed tracing header propagation ([#1701](https://github.com/apollographql/router/issues/1701))
+
+Span context is now correctly propagated if you're trying to propagate tracing context to the router.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1701
+
+## 🛠 Maintenance
+
+### Replace `startup` crate with `ctor` crate ([#1704](https://github.com/apollographql/router/issues/1703))
+
+At startup, the router registers plugins. The crate we used to use ([`startup`](https://crates.io/crates/startup/versions)) has been yanked from crates.io and archived on GitHub.  We're unsure why the package was yanked, but we've decided to move to the [`ctor`](https://crates.io/crates/ctor) crate, which is more widely adopted and maintained.
+
+This should fix the sudden errors for those who were using the router as a library or attempting to scaffold a new plugin using `cargo scaffold`.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1704
+
+### macOS: Update Xcode build version from 11.7 to 13.4 ([PR #1702](https://github.com/apollographql/router/pull/1702))
+
+We now build our macOS binaries with Xcode 13.4 rather than 11.7.  This may result in the Router not working on very old versions of macOS but we'd rather get this out of the way before CircleCI potentially deprecates 11.x images themselves and we're unable to test on them anymore.
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/1702
+
+
 # [1.0.0-alpha.1] - 2022-09-02
 
 > 👋 We're getting closer to our release candidate stages so there are far less breaking changes to the API in this version, rather changes to configuration.  We'll have a bit more in the next release, but nothing as bad as the bumps from 0.15.x, through 0.16.0 and on to v1.0.0-alpha.0
 
 ## ❗ BREAKING ❗
 
-### Preserve plugin response `Vary` headers([PR #1660](https://github.com/apollographql/router/issues/1297))
+### Preserve plugin response `Vary` headers ([PR #1660](https://github.com/apollographql/router/issues/1297))
 
 It is now possible to set a `Vary` header in a client response from a plugin.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,7 +136,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "access-json",
  "anyhow",
@@ -235,7 +235,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "apollo-router",
  "async-trait",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-scaffold"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "cargo-scaffold",
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-spaceport"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "bytes",
  "clap 3.2.20",
@@ -298,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-uplink"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "futures",
  "graphql_client",
@@ -6235,7 +6235,7 @@ dependencies = [
 
 [[package]]
 name = "xtask"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -26,23 +26,6 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 # [x.x.x] (unreleased) - 2022-mm-dd
 ## ❗ BREAKING ❗
 ## 🚀 Features
-
-### Add `service_name` and `service_namespace` in `telemetry.metrics.common` ([PR #1492](https://github.com/apollographql/router/pull/1492))
-
-Add `service_name` and `service_namespace` in `telemetry.metrics.common` to reflect the same configuration than tracing.
-
-```yaml
-telemetry:
-  metrics:
-    common:
-      # (Optional, default to "apollo-router") Set the service name to easily find metrics related to the apollo-router in your metrics dashboards
-      service_name: "apollo-router"
-      # (Optional)
-      service_namespace: "apollo"
-```
-
-By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1492 
-
 ## 🐛 Fixes
 ## 🛠 Maintenance
 ## 📚 Documentation

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -27,19 +27,5 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 ## ❗ BREAKING ❗
 ## 🚀 Features
 ## 🐛 Fixes
-
-### Fix telemetry propagation with headers ([#1701](https://github.com/apollographql/router/issues/1701))
-
-Span context is now correctly propagated if you're trying to propagate tracing context to the router.
-
-By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1701
-
 ## 🛠 Maintenance
-
-### replace `startup` crate with `ctor` crate ([#1704](https://github.com/apollographql/router/issues/1703))
-
-At startup, the router registers plugins. The crate we used to use (`startup`) has been yanked from crates.io. We've decided to move to the `ctor` crate.
-
-By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1704
-
 ## 📚 Documentation

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-scaffold"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -22,7 +22,7 @@ apollo-router = { path ="{{integration_test}}apollo-router" }
 apollo-router = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
 # Note if you update these dependencies then also update xtask/Cargo.toml
-apollo-router = { git="https://github.com/apollographql/router.git", tag="v1.0.0-alpha.1" }
+apollo-router = { git="https://github.com/apollographql/router.git", tag="v1.0.0-alpha.2" }
 {{/if}}
 {{/if}}
 async-trait = "0.1.52"

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -13,7 +13,7 @@ apollo-router-scaffold = { path ="{{integration_test}}apollo-router-scaffold" }
 {{#if branch}}
 apollo-router-scaffold = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
-apollo-router-scaffold = { git="https://github.com/apollographql/router.git", tag="v1.0.0-alpha.1"}
+apollo-router-scaffold = { git="https://github.com/apollographql/router.git", tag="v1.0.0-alpha.2"}
 {{/if}}
 {{/if}}
 anyhow = "1.0.58"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"

--- a/apollo-spaceport/Cargo.toml
+++ b/apollo-spaceport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-spaceport"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "LicenseRef-ELv2"

--- a/dockerfiles/tracing/docker-compose.datadog.yml
+++ b/dockerfiles/tracing/docker-compose.datadog.yml
@@ -3,7 +3,7 @@ services:
 
   apollo-router:
     container_name: apollo-router
-    image: ghcr.io/apollographql/router:v1.0.0-alpha.1
+    image: ghcr.io/apollographql/router:v1.0.0-alpha.2
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/datadog.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.jaeger.yml
+++ b/dockerfiles/tracing/docker-compose.jaeger.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     #build: ./router
-    image: ghcr.io/apollographql/router:v1.0.0-alpha.1
+    image: ghcr.io/apollographql/router:v1.0.0-alpha.2
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/jaeger.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.zipkin.yml
+++ b/dockerfiles/tracing/docker-compose.zipkin.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     build: ./router
-    image: ghcr.io/apollographql/router:v1.0.0-alpha.1
+    image: ghcr.io/apollographql/router:v1.0.0-alpha.2
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/zipkin.router.yaml:/etc/config/configuration.yaml

--- a/docs/source/containerization/docker.mdx
+++ b/docs/source/containerization/docker.mdx
@@ -11,7 +11,7 @@ The default behaviour of the router images is suitable for a quickstart or devel
 
 Note: The [docker documentation](https://docs.docker.com/engine/reference/run/) for the run command may be helpful when reading through the examples.
 
-Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v1.0.0-alpha.1`
+Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v1.0.0-alpha.2`
 
 ## Override the configuration
 
@@ -92,10 +92,10 @@ Usage: build_docker_image.sh [-b] [<release>]
 	Example 1: Building HEAD from the repo
 		build_docker_image.sh -b
 	Example 2: Building tag from the repo
-		build_docker_image.sh -b v1.0.0-alpha.1
+		build_docker_image.sh -b v1.0.0-alpha.2
 	Example 3: Building commit hash from the repo
 		build_docker_image.sh -b 1c220d35acf9ad2537b8edc58c498390b6701d3d
-	Example 4: Building tag v1.0.0-alpha.1 from the released tarball
-		build_docker_image.sh v1.0.0-alpha.1
+	Example 4: Building tag v1.0.0-alpha.2 from the released tarball
+		build_docker_image.sh v1.0.0-alpha.2
 ```
 Note: The script has to be run from the `dockerfiles/diy` directory because it makes assumptions about the relative availability of various files. The example uses [distroless images](https://github.com/GoogleContainerTools/distroless) for the final image build. Feel free to modify the script to use images which better suit your own needs.

--- a/docs/source/containerization/kubernetes.mdx
+++ b/docs/source/containerization/kubernetes.mdx
@@ -13,7 +13,7 @@ import { Link } from 'gatsby';
 
 [Helm](https://helm.sh) is the package manager for kubernetes.
 
-There is a complete [helm chart definition](https://github.com/apollographql/router/tree/v1.0.0-alpha.1/helm/chart/router) in the repo which illustrates how to use helm to deploy the router in kubernetes.
+There is a complete [helm chart definition](https://github.com/apollographql/router/tree/v1.0.0-alpha.2/helm/chart/router) in the repo which illustrates how to use helm to deploy the router in kubernetes.
 
 In both the following examples, we are using helm to install the router:
  - into namespace "router-deploy" (create namespace if it doesn't exist)
@@ -66,7 +66,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v1.0.0-alpha.1"
+    app.kubernetes.io/version: "v1.0.0-alpha.2"
 ---
 # Source: router/templates/secret.yaml
 apiVersion: v1
@@ -76,7 +76,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v1.0.0-alpha.1"
+    app.kubernetes.io/version: "v1.0.0-alpha.2"
 data:
   managedFederationApiKey: "REDACTED"
 ---
@@ -88,7 +88,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v1.0.0-alpha.1"
+    app.kubernetes.io/version: "v1.0.0-alpha.2"
 data:
   configuration.yaml: |
     server:
@@ -106,7 +106,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v1.0.0-alpha.1"
+    app.kubernetes.io/version: "v1.0.0-alpha.2"
 spec:
   type: ClusterIP
   ports:
@@ -126,7 +126,7 @@ metadata:
   labels:
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: router-test
-    app.kubernetes.io/version: "v1.0.0-alpha.1"
+    app.kubernetes.io/version: "v1.0.0-alpha.2"
   annotations:
     prometheus.io/path: /plugins/apollo.telemetry/prometheus
     prometheus.io/port: "80"
@@ -150,7 +150,7 @@ spec:
         - name: router
           securityContext:
             {}
-          image: "ghcr.io/apollographql/router:v1.0.0-alpha.1"
+          image: "ghcr.io/apollographql/router:v1.0.0-alpha.2"
           imagePullPolicy: IfNotPresent
           args:
             - --hot-reload

--- a/helm/chart/router/Chart.yaml
+++ b/helm/chart/router/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.22
+version: 0.1.23
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.0.0-alpha.1"
+appVersion: "v1.0.0-alpha.2"

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -2,7 +2,7 @@
 
 [router](https://github.com/apollographql/router) Rust Graph Routing runtime for Apollo Federation
 
-![Version: 0.1.22](https://img.shields.io/badge/Version-0.1.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0-alpha.1](https://img.shields.io/badge/AppVersion-v1.0.0--alpha.1-informational?style=flat-square)
+![Version: 0.1.23](https://img.shields.io/badge/Version-0.1.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.0-alpha.2](https://img.shields.io/badge/AppVersion-v1.0.0--alpha.2-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@
 ## Get Repo Info
 
 ```console
-helm pull oci://ghcr.io/apollographql/helm-charts/router --version 0.1.22
+helm pull oci://ghcr.io/apollographql/helm-charts/router --version 0.1.23
 ```
 
 ## Install Chart
@@ -19,7 +19,7 @@ helm pull oci://ghcr.io/apollographql/helm-charts/router --version 0.1.22
 **Important:** only helm3 is supported
 
 ```console
-helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 0.1.22 --values my-values.yaml
+helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 0.1.23 --values my-values.yaml
 ```
 
 _See [configuration](#configuration) below._

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/router/releases/downloa
 
 # Router version defined in apollo-router's Cargo.toml
 # Note: Change this line manually during the release steps.
-PACKAGE_VERSION="v1.0.0-alpha.1"
+PACKAGE_VERSION="v1.0.0-alpha.2"
 
 download_binary() {
     downloader --check

--- a/uplink/Cargo.toml
+++ b/uplink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-uplink"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 edition = "2021"
 build = "build.rs"
 license = "LicenseRef-ELv2"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtask"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"


### PR DESCRIPTION
> 👋 We're getting closer to our release candidate stages so there are far less breaking changes to the API in these versions, rather changes to configuration.  We'll have a bit more in the next releases, but nothing as bad as the bumps from 0.15.x, through 0.16.0 and on to v1.0.0-alpha.0.  Thanks for your feedback and cooperation! ✨

## 🚀 Features

### Add `service_name` and `service_namespace` in `telemetry.metrics.common` ([Issue #1490](https://github.com/apollographql/router/issues/1490))

Add `service_name` and `service_namespace` in `telemetry.metrics.common` to reflect the same configuration than tracing.

```yaml
telemetry:
  metrics:
    common:
      # (Optional, default to "apollo-router") Set the service name to easily find metrics related to the apollo-router in your metrics dashboards
      service_name: "apollo-router"
      # (Optional)
      service_namespace: "apollo"
```

By @bnjjj in https://github.com/apollographql/router/pull/1492

## 🐛 Fixes

### Fix distributed tracing header propagation ([#1701](https://github.com/apollographql/router/issues/1701))

Span context is now correctly propagated if you're trying to propagate tracing context to the router.

By @bnjjj in https://github.com/apollographql/router/pull/1701

## 🛠 Maintenance

### Replace `startup` crate with `ctor` crate ([#1704](https://github.com/apollographql/router/issues/1703))

At startup, the router registers plugins. The crate we used to use ([`startup`](https://crates.io/crates/startup/versions)) has been yanked from crates.io and archived on GitHub.  We're unsure why the package was yanked, but we've decided to move to the [`ctor`](https://crates.io/crates/ctor) crate, which is more widely adopted and maintained.

This should fix the sudden errors for those who were using the router as a library or attempting to scaffold a new plugin using `cargo scaffold`.

By @garypen in https://github.com/apollographql/router/pull/1704

### macOS: Update Xcode build version from 11.7 to 13.4 ([PR #1702](https://github.com/apollographql/router/pull/1702))

We now build our macOS binaries with Xcode 13.4 rather than 11.7.  This may result in the Router not working on very old versions of macOS but we'd rather get this out of the way before CircleCI potentially deprecates 11.x images themselves and we're unable to test on them anymore.

By @abernix in https://github.com/apollographql/router/pull/1702

