### PR TITLE
deps: update to `router-bridge@0.1.3`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4315,9 +4315,9 @@ dependencies = [
 
 [[package]]
 name = "router-bridge"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dfffd561d68c0b604db40293bec1f69b4e67f19ad92791a9a4d103952ddd918"
+checksum = "197f136a65e5f3f8ed95c65523f0469a08d4df09f5d11b195fb17505a5e937b2"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -27,5 +27,17 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 ## ❗ BREAKING ❗
 ## 🚀 Features
 ## 🐛 Fixes
+
+### Numerous fixes to preview `@defer` query planning ([Issue #1698](https://github.com/apollographql/router/issues/1698))
+
+Updated to [Federation `2.1.2-alpha.0`](https://github.com/apollographql/federation/pull/2132) which brings in a number of fixes for the preview `@defer` support.  These fixes include:
+
+ - [Empty selection set produced with @defer'd query `federation#2123`](https://github.com/apollographql/federation/issues/2123)
+ - [Include directive with operation argument errors out in Fed 2.1 `federation#2124`](https://github.com/apollographql/federation/issues/2124)
+ - [query plan sequencing affected with __typename in fragment `federation#2128`](https://github.com/apollographql/federation/issues/2128)
+ - [Router Returns Error if __typename Omitted `router#1668`](https://github.com/apollographql/router/issues/1668)
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/1711
+
 ## 🛠 Maintenance
 ## 📚 Documentation

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -120,7 +120,7 @@ reqwest = { version = "0.11.11", default-features = false, features = [
     "json",
     "stream",
 ] }
-router-bridge = "0.1.2"
+router-bridge = "0.1.3"
 schemars = { version = "0.8.10", features = ["url"] }
 sha2 = "0.10.5"
 serde = { version = "1.0.144", features = ["derive", "rc"] }


### PR DESCRIPTION
Brings in https://github.com/apollographql/federation/pull/2132, including fixes for the following issues:

- [x] https://github.com/apollographql/federation/issues/2123
  - PR: https://github.com/apollographql/federation/pull/2125
- [x] https://github.com/apollographql/federation/issues/2124
	- PR: https://github.com/apollographql/federation/pull/2126
- [x] https://github.com/apollographql/federation/issues/2128
	- PR: https://github.com/apollographql/federation/pull/2129

Via https://github.com/apollographql/federation-rs/pull/170

Closes https://github.com/apollographql/router/issues/1698
Closes https://github.com/apollographql/router/issues/1668