### PR TITLE
return the original query planner error and add extensions code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4315,8 +4315,7 @@ dependencies = [
 
 [[package]]
 name = "router-bridge"
-version = "0.1.2"
-source = "git+https://github.com/apollographql/federation-rs.git?branch=garypen/1519-slghtly-better-errors#3f8297970c318734f2d642a4c4d8e17cc1996d78"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4316,8 +4316,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dfffd561d68c0b604db40293bec1f69b4e67f19ad92791a9a4d103952ddd918"
+source = "git+https://github.com/apollographql/federation-rs.git?branch=garypen/1519-slghtly-better-errors#3f8297970c318734f2d642a4c4d8e17cc1996d78"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4316,6 +4316,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.1.3"
+source = "git+https://github.com/apollographql/federation-rs.git?branch=garypen/1519-slghtly-better-errors#a96d5501fb3e8c7f3e11368d32d77dcbc6ae355b"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4315,8 +4315,9 @@ dependencies = [
 
 [[package]]
 name = "router-bridge"
-version = "0.1.3"
-source = "git+https://github.com/apollographql/federation-rs.git?branch=garypen/1519-slghtly-better-errors#a96d5501fb3e8c7f3e11368d32d77dcbc6ae355b"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3355e0c609386f2a13ffe00012d4ae24ffe5678d2cc7d4b573cbd81aadaa2e31"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4328,7 +4329,6 @@ dependencies = [
  "tower",
  "tower-service",
  "tracing",
- "uuid 0.8.2",
  "which",
 ]
 

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -120,7 +120,8 @@ reqwest = { version = "0.11.11", default-features = false, features = [
     "json",
     "stream",
 ] }
-router-bridge = "0.1.2"
+# router-bridge = "0.1.2"
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", branch = "garypen/1519-slghtly-better-errors"}
 schemars = { version = "0.8.10", features = ["url"] }
 sha2 = "0.10.5"
 serde = { version = "1.0.144", features = ["derive", "rc"] }

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -121,8 +121,7 @@ reqwest = { version = "0.11.11", default-features = false, features = [
     "stream",
 ] }
 # router-bridge = "0.1.3"
-# router-bridge = { git = "https://github.com/apollographql/federation-rs.git", branch = "garypen/1519-slghtly-better-errors"}
-router-bridge = { path = "../../federation-rs/federation-2/router-bridge" }
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", branch = "garypen/1519-slghtly-better-errors"}
 schemars = { version = "0.8.10", features = ["url"] }
 sha2 = "0.10.5"
 serde = { version = "1.0.144", features = ["derive", "rc"] }

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -121,7 +121,8 @@ reqwest = { version = "0.11.11", default-features = false, features = [
     "stream",
 ] }
 # router-bridge = "0.1.3"
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", branch = "garypen/1519-slghtly-better-errors"}
+# router-bridge = { git = "https://github.com/apollographql/federation-rs.git", branch = "garypen/1519-slghtly-better-errors"}
+router-bridge = { path = "../../federation-rs/federation-2/router-bridge" }
 schemars = { version = "0.8.10", features = ["url"] }
 sha2 = "0.10.5"
 serde = { version = "1.0.144", features = ["derive", "rc"] }

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -120,8 +120,7 @@ reqwest = { version = "0.11.11", default-features = false, features = [
     "json",
     "stream",
 ] }
-# router-bridge = "0.1.3"
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", branch = "garypen/1519-slghtly-better-errors"}
+router-bridge = "0.1.4"
 schemars = { version = "0.8.10", features = ["url"] }
 sha2 = "0.10.5"
 serde = { version = "1.0.144", features = ["derive", "rc"] }

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -19,6 +19,7 @@ use tracing::level_filters::LevelFilter;
 
 pub(crate) use crate::configuration::ConfigurationError;
 pub(crate) use crate::graphql::Error;
+use crate::graphql::IntoGraphQLErrors;
 use crate::graphql::Response;
 use crate::json_ext::Path;
 use crate::json_ext::Value;
@@ -136,10 +137,19 @@ impl FetchError {
 #[serde(rename_all = "camelCase")]
 pub struct Location {
     /// The line number.
-    pub line: i32,
+    pub line: u32,
 
     /// The column number.
-    pub column: i32,
+    pub column: u32,
+}
+
+impl From<router_bridge::planner::Location> for Location {
+    fn from(loc: router_bridge::planner::Location) -> Self {
+        Self {
+            line: loc.line,
+            column: loc.column,
+        }
+    }
 }
 
 impl From<QueryPlannerError> for FetchError {
@@ -201,9 +211,38 @@ pub(crate) enum QueryPlannerError {
     Introspection(IntrospectionError),
 }
 
+impl IntoGraphQLErrors for QueryPlannerError {
+    fn into_graphql_errors(self) -> Result<Vec<Error>, Self> {
+        match self {
+            // TODO add all cases
+            QueryPlannerError::SpecError(err) => Ok(vec![Error {
+                message: err.to_string(),
+                ..Default::default()
+            }]),
+            QueryPlannerError::SchemaValidationErrors(errs) => errs
+                .into_graphql_errors()
+                .map_err(QueryPlannerError::SchemaValidationErrors),
+            QueryPlannerError::PlanningErrors(planning_errors) => Ok(planning_errors
+                .errors
+                .iter()
+                .map(|p_err| Error::from(p_err.clone()))
+                .collect()),
+            err => Err(err),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Error)]
 /// Container for planner setup errors
 pub(crate) struct PlannerErrors(Arc<Vec<PlannerError>>);
+
+impl IntoGraphQLErrors for PlannerErrors {
+    fn into_graphql_errors(self) -> Result<Vec<Error>, Self> {
+        let errors = self.0.iter().map(|e| Error::from(e.clone())).collect();
+
+        Ok(errors)
+    }
+}
 
 impl std::fmt::Display for PlannerErrors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -132,26 +132,6 @@ impl FetchError {
     }
 }
 
-/// A location in the request that triggered a graphql error.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Location {
-    /// The line number.
-    pub line: u32,
-
-    /// The column number.
-    pub column: u32,
-}
-
-impl From<router_bridge::planner::Location> for Location {
-    fn from(loc: router_bridge::planner::Location) -> Self {
-        Self {
-            line: loc.line,
-            column: loc.column,
-        }
-    }
-}
-
 impl From<QueryPlannerError> for FetchError {
     fn from(err: QueryPlannerError) -> Self {
         FetchError::ValidationPlanningError {

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -214,7 +214,6 @@ pub(crate) enum QueryPlannerError {
 impl IntoGraphQLErrors for QueryPlannerError {
     fn into_graphql_errors(self) -> Result<Vec<Error>, Self> {
         match self {
-            // TODO add all cases
             QueryPlannerError::SpecError(err) => Ok(vec![Error {
                 message: err.to_string(),
                 ..Default::default()

--- a/apollo-router/src/graphql.rs
+++ b/apollo-router/src/graphql.rs
@@ -2,14 +2,12 @@
 
 #![allow(missing_docs)] // FIXME
 
-use std::convert::TryFrom;
 use std::fmt;
 use std::pin::Pin;
 
 use futures::Stream;
 use router_bridge::planner::PlanError;
 use router_bridge::planner::PlanErrorExtensions;
-use router_bridge::planner::PlanErrors;
 use router_bridge::planner::PlannerError;
 use router_bridge::planner::WorkerError;
 use router_bridge::planner::WorkerGraphQLError;
@@ -22,8 +20,6 @@ use serde_json_bytes::Value;
 
 use crate::error::FetchError;
 pub use crate::error::Location;
-use crate::error::PlannerErrors;
-use crate::error::QueryPlannerError;
 use crate::json_ext::Object;
 use crate::json_ext::Path;
 pub use crate::json_ext::Path as JsonPath;
@@ -55,6 +51,7 @@ pub struct Error {
     pub locations: Vec<Location>,
 
     /// The path of the error.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<Path>,
 
     /// The optional graphql extensions.
@@ -139,55 +136,14 @@ where
     fn into_graphql_errors(self) -> Result<Vec<Error>, Self>;
 }
 
-// impl From<PlanErrors> for Error {
-//     fn from(p_err: PlanErrors) -> Self {
-//         if p_err.errors.len() == 1 {
-//             let error = p_err.errors[0].clone();
-//             Self {
-//                 message: error
-//                     .message
-//                     .unwrap_or_else(|| String::from("query plan error")),
-//                 extensions: error
-//                     .extensions
-//                     .map(|ext| {
-//                         let mut map = serde_json_bytes::map::Map::new();
-//                         map.insert("code", Value::from(ext.code));
-
-//                         map
-//                     })
-//                     .unwrap_or_default(),
-//                 ..Default::default()
-//             }
-//         } else {
-//             Self {
-//                 message: p_err
-//                     .errors
-//                     .iter()
-//                     .filter_map(|err| err.message.clone())
-//                     .collect::<Vec<String>>()
-//                     .join("\n"),
-//                 ..Default::default()
-//             }
-//         }
-//     }
-// }
-
 impl From<PlanError> for Error {
     fn from(err: PlanError) -> Self {
-        let mut extensions = Object::new();
-        if let Some(ext) = err.extensions {
-            extensions.insert("code", ext.code.into());
-            extensions.insert(
-                "exception",
-                json!({
-                    "stacktrace": ext.exception.map(|e| serde_json_bytes::Value::from(e.stacktrace))
-                }),
-            );
-        }
-
         Self {
             message: err.message.unwrap_or_else(|| String::from("plan error")),
-            extensions,
+            extensions: err
+                .extensions
+                .map(convert_extensions_to_map)
+                .unwrap_or_default(),
             ..Default::default()
         }
     }
@@ -204,20 +160,13 @@ impl From<PlannerError> for Error {
 
 impl From<WorkerError> for Error {
     fn from(err: WorkerError) -> Self {
-        let mut extensions = Object::new();
-        if let Some(ext) = err.extensions {
-            extensions.insert("code", ext.code.into());
-            extensions.insert(
-                "exception",
-                json!({
-                    "stacktrace": ext.exception.map(|e| serde_json_bytes::Value::from(e.stacktrace))
-                }),
-            );
-        }
         Self {
             message: err.message.unwrap_or_else(|| String::from("worker error")),
             locations: err.locations.into_iter().map(Location::from).collect(),
-            extensions,
+            extensions: err
+                .extensions
+                .map(convert_extensions_to_map)
+                .unwrap_or_default(),
             ..Default::default()
         }
     }
@@ -225,6 +174,29 @@ impl From<WorkerError> for Error {
 
 impl From<WorkerGraphQLError> for Error {
     fn from(err: WorkerGraphQLError) -> Self {
-        todo!()
+        Self {
+            message: err.message,
+            locations: err.locations.into_iter().map(Location::from).collect(),
+            extensions: err
+                .extensions
+                .map(convert_extensions_to_map)
+                .unwrap_or_default(),
+            ..Default::default()
+        }
     }
+}
+
+fn convert_extensions_to_map(ext: PlanErrorExtensions) -> Object {
+    let mut extensions = Object::new();
+    extensions.insert("code", ext.code.into());
+    if let Some(exception) = ext.exception {
+        extensions.insert(
+            "exception",
+            json!({
+                "stacktrace": serde_json_bytes::Value::from(exception.stacktrace)
+            }),
+        );
+    }
+
+    extensions
 }

--- a/apollo-router/src/graphql.rs
+++ b/apollo-router/src/graphql.rs
@@ -129,6 +129,7 @@ impl fmt::Display for Error {
     }
 }
 
+/// Trait used to convert expected errors into a list of GraphQL errors
 pub(crate) trait IntoGraphQLErrors
 where
     Self: Sized,

--- a/apollo-router/src/graphql.rs
+++ b/apollo-router/src/graphql.rs
@@ -6,6 +6,7 @@ use std::fmt;
 use std::pin::Pin;
 
 use futures::Stream;
+pub use router_bridge::planner::Location;
 use router_bridge::planner::PlanError;
 use router_bridge::planner::PlanErrorExtensions;
 use router_bridge::planner::PlannerError;
@@ -19,7 +20,6 @@ use serde_json_bytes::Map as JsonMap;
 use serde_json_bytes::Value;
 
 use crate::error::FetchError;
-pub use crate::error::Location;
 use crate::json_ext::Object;
 use crate::json_ext::Path;
 pub use crate::json_ext::Path as JsonPath;

--- a/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__bridge_query_planner__tests__plan_invalid_query_errors.snap
+++ b/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__bridge_query_planner__tests__plan_invalid_query_errors.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/query_planner/bridge_query_planner.rs
-assertion_line: 269
+assertion_line: 304
 expression: plan_errors.errors
 ---
 [
@@ -11,6 +11,7 @@ expression: plan_errors.errors
         extensions: Some(
             PlanErrorExtensions {
                 code: "GRAPHQL_VALIDATION_FAILED",
+                exception: None,
             },
         ),
     },

--- a/apollo-router/src/response.rs
+++ b/apollo-router/src/response.rs
@@ -220,14 +220,13 @@ impl IncrementalResponse {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
+    use router_bridge::planner::Location;
     use serde_json::json;
     use serde_json_bytes::json as bjson;
 
     use super::*;
-    use crate::error::Location;
 
     #[test]
     fn test_append_errors_path_fallback_and_override() {

--- a/apollo-router/src/response.rs
+++ b/apollo-router/src/response.rs
@@ -219,6 +219,8 @@ impl IncrementalResponse {
         self.errors.append(errors)
     }
 }
+
+
 #[cfg(test)]
 mod tests {
     use serde_json::json;

--- a/apollo-router/tests/snapshots/integration_tests__defer_path_with_disabled_config.snap
+++ b/apollo-router/tests/snapshots/integration_tests__defer_path_with_disabled_config.snap
@@ -1,13 +1,12 @@
 ---
 source: apollo-router/tests/integration_tests.rs
-assertion_line: 558
+assertion_line: 561
 expression: only
 ---
 {
   "errors": [
     {
       "message": "Unknown directive \"@defer\".",
-      "path": null,
       "extensions": {
         "code": "GRAPHQL_VALIDATION_FAILED"
       }

--- a/apollo-router/tests/snapshots/integration_tests__defer_query_without_accept.snap
+++ b/apollo-router/tests/snapshots/integration_tests__defer_query_without_accept.snap
@@ -1,13 +1,12 @@
 ---
 source: apollo-router/tests/integration_tests.rs
-assertion_line: 644
+assertion_line: 673
 expression: first
 ---
 {
   "errors": [
     {
-      "message": "the router received a query with the @defer directive but the client does not accept multipart/mixed HTTP responses. To enable @defer support, add the HTTP header 'Accept: multipart/mixed; deferSpec=20220824'",
-      "path": null
+      "message": "the router received a query with the @defer directive but the client does not accept multipart/mixed HTTP responses. To enable @defer support, add the HTTP header 'Accept: multipart/mixed; deferSpec=20220824'"
     }
   ]
 }


### PR DESCRIPTION
TLDR I'm not very proud of what I did here. It's very hard to return specific errors or just catch an error in our codebase due to our usage of `BoxError`. That's why I had to downcast and so one ...

I think in a long term we should think about a better way to handle errors. Let's discuss about it.


close #1560 