### PR TITLE
docs: updates federation version support table for alpha.3

### DIFF
--- a/docs/source/federation-version-support.mdx
+++ b/docs/source/federation-version-support.mdx
@@ -21,9 +21,17 @@ The table below shows which version of federation each router release is compile
     </tr>
     </thead>
     <tbody>
+        <tr>
+        <td>
+            v1.0.0-alpha.3 and later (<a href="https://github.com/apollographql/router/releases">see latest releases</a>)
+        </td>
+        <td>
+            2.1.2-alpha.0
+        </td>
+    </tr>
     <tr>
         <td>
-            v1.0.0-alpha.1 and later (<a href="https://github.com/apollographql/router/releases">see latest releases</a>)
+            v1.0.0-alpha.1 - v1.0.0-alpha.2
         </td>
         <td>
             2.1.1


### PR DESCRIPTION
fixes #1723 by updating the federation version support table for router `1.0.0-alpha.3` to point to federation version `2.1.2-alpha.0`