### PR TITLE
Restore the ability to add custom schema and configuration sources when constructing an executable

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -65,6 +65,18 @@ telemetry:
 By [@BrynCooke](https://github.com/BrynCooke) & [@bnjjj](https://github.com/bnjjj) & [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1514
 
 
+### Restore the ability to specify custom schema and configuration sources ([#1733](https://github.com/apollographql/router/issues/1733))
+You and now specify custom schema and config sources when constructing an executable.
+```rust
+Executable::builder()
+  .shutdown(ShutdownSource::None)
+  .schema(SchemaSource::Stream(schemas))
+  .config(ConfigurationSource::Stream(configs))
+  .start()
+  .await
+```
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/1734
+
 ## 🐛 Fixes
 ## 🛠 Maintenance
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -66,7 +66,7 @@ By [@BrynCooke](https://github.com/BrynCooke) & [@bnjjj](https://github.com/bnjj
 
 
 ### Restore the ability to specify custom schema and configuration sources ([#1733](https://github.com/apollographql/router/issues/1733))
-You and now specify custom schema and config sources when constructing an executable.
+You may now specify custom schema and config sources when constructing an executable.
 ```rust
 Executable::builder()
   .shutdown(ShutdownSource::None)

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -159,15 +159,18 @@ impl Executable {
     /// Build an executable that will parse commandline options and set up logging,
     /// then start an HTTP server.
     ///
-    /// You may optionally specify when the server should gracefully shut down.
+    /// You may optionally specify when the server should gracefully shut down, the schema source and the configuration source.
     /// The default is on CTRL+C on the terminal (or a `SIGINT` signal).
     ///
     /// ```no_run
     /// use apollo_router::{Executable, ShutdownSource};
     /// # #[tokio::main]
     /// # async fn main() -> anyhow::Result<()> {
+    /// use apollo_router::{ConfigurationSource, SchemaSource};
     /// Executable::builder()
     ///   .shutdown(ShutdownSource::None)
+    ///   .schema(SchemaSource::Stream(schemas))
+    ///   .config(ConfigurationSource::Stream(configs))
     ///   .start()
     ///   .await
     /// # }
@@ -175,7 +178,11 @@ impl Executable {
     /// Note that if you do not specify a runtime you must be in the context of an existing tokio runtime.
     ///
     #[builder(entry = "builder", exit = "start", visibility = "pub")]
-    async fn start(shutdown: Option<ShutdownSource>) -> Result<()> {
+    async fn start(
+        shutdown: Option<ShutdownSource>,
+        schema: Option<SchemaSource>,
+        config: Option<ConfigurationSource>,
+    ) -> Result<()> {
         let opt = Opt::parse();
 
         if opt.version {
@@ -208,39 +215,55 @@ impl Executable {
         // The dispatcher we created is passed explicitely here to make sure we display the logs
         // in the initialization pahse and in the state machine code, before a global subscriber
         // is set using the configuration file
-        Self::inner_start(shutdown, opt, dispatcher.clone())
+        Self::inner_start(shutdown, schema, config, opt, dispatcher.clone())
             .with_subscriber(dispatcher)
             .await
     }
 
     async fn inner_start(
         shutdown: Option<ShutdownSource>,
+        schema: Option<SchemaSource>,
+        config: Option<ConfigurationSource>,
         opt: Opt,
         dispatcher: Dispatch,
     ) -> Result<()> {
         let current_directory = std::env::current_dir()?;
 
-        let configuration = opt
-            .config_path
-            .as_ref()
-            .map(|path| {
-                let path = if path.is_relative() {
-                    current_directory.join(path)
-                } else {
-                    path.to_path_buf()
-                };
+        let configuration = match (config, opt.config_path.as_ref()) {
+            (Some(_), Some(_)) => {
+                return Err(anyhow!(
+                    "--config cannot be used when a custom configuration source is in use"
+                ));
+            }
+            (Some(config), None) => config,
+            _ => opt
+                .config_path
+                .as_ref()
+                .map(|path| {
+                    let path = if path.is_relative() {
+                        current_directory.join(path)
+                    } else {
+                        path.to_path_buf()
+                    };
 
-                ConfigurationSource::File {
-                    path,
-                    watch: opt.hot_reload,
-                    delay: None,
-                }
-            })
-            .unwrap_or_else(|| Configuration::builder().build().into());
+                    ConfigurationSource::File {
+                        path,
+                        watch: opt.hot_reload,
+                        delay: None,
+                    }
+                })
+                .unwrap_or_else(|| Configuration::builder().build().into()),
+        };
 
         let apollo_router_msg = format!("Apollo Router v{} // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)", std::env!("CARGO_PKG_VERSION"));
-        let schema = match (opt.supergraph_path, opt.apollo_key) {
-            (Some(supergraph_path), _) => {
+        let schema = match (schema, opt.supergraph_path, opt.apollo_key) {
+            (Some(_), Some(_), _) => {
+                return Err(anyhow!(
+                    "--supergraph cannot be used when a custom schema source is in use"
+                ))
+            }
+            (Some(source), None, _) => source,
+            (_, Some(supergraph_path), _) => {
                 tracing::info!("{apollo_router_msg}");
                 setup_panic_handler(dispatcher.clone());
 
@@ -255,7 +278,7 @@ impl Executable {
                     delay: None,
                 }
             }
-            (None, Some(apollo_key)) => {
+            (_, None, Some(apollo_key)) => {
                 tracing::info!("{apollo_router_msg}");
 
                 let apollo_graph_ref = opt.apollo_graph_ref.ok_or_else(||anyhow!("cannot fetch the supergraph from Apollo Studio without setting the APOLLO_GRAPH_REF environment variable"))?;

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -166,6 +166,9 @@ impl Executable {
     /// use apollo_router::{Executable, ShutdownSource};
     /// # #[tokio::main]
     /// # async fn main() -> anyhow::Result<()> {
+    /// # use futures::StreamExt;
+    /// # let schemas = futures::stream::empty().boxed();
+    /// # let configs = futures::stream::empty().boxed();
     /// use apollo_router::{ConfigurationSource, SchemaSource};
     /// Executable::builder()
     ///   .shutdown(ShutdownSource::None)

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -235,7 +235,7 @@ impl Executable {
         let configuration = match (config, opt.config_path.as_ref()) {
             (Some(_), Some(_)) => {
                 return Err(anyhow!(
-                    "--config cannot be used when a custom configuration source is in use"
+                    "--config and APOLLO_ROUTER_CONFIG_PATH cannot be used when a custom configuration source is in use"
                 ));
             }
             (Some(config), None) => config,
@@ -262,7 +262,7 @@ impl Executable {
         let schema = match (schema, opt.supergraph_path, opt.apollo_key) {
             (Some(_), Some(_), _) => {
                 return Err(anyhow!(
-                    "--supergraph cannot be used when a custom schema source is in use"
+                    "--supergraph and APOLLO_ROUTER_SUPERGRAPH_PATH cannot be used when a custom schema source is in use"
                 ))
             }
             (Some(source), None, _) => source,


### PR DESCRIPTION
You and now specify custom schema and config sources when constructing an executable.
```rust
Executable::builder()
  .shutdown(ShutdownSource::None)
  .schema(SchemaSource::Stream(schemas))
  .config(ConfigurationSource::Stream(configs))
  .start()
  .await
```

<!--
First, 🌠 thank you 🌠 for considering a contribution to Apollo!

Some of this information is also included in the /CONTRIBUTING.md file at the
root of this repository.  We suggest you read it!

  https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md

Here are some important details to keep in mind:

* ⏰ Your time is important
        To save your precious time, if the contribution you are making will
        take more than an hour, please make sure it has been discussed in an
        issue first. This is especially true for feature requests!

* 💡 Features
        Feature requests can be created and discussed within a GitHub Issue.
        Be sure to search for existing feature requests (and related issues!)
        prior to opening a new request. If an existing issue covers the need,
        please upvote that issue by using the 👍 emote, rather than opening a
        new issue.

* 🕷 Bug fixes
        These can be created and discussed in this repository. When fixing a bug,
        please _try_ to add a test which verifies the fix.  If you cannot, you should
        still submit the PR but we may still ask you (and help you!) to create a test.

* 📖 Contribution guidelines
        Follow https://github.com/apollographql/router/blob/HEAD/CONTRIBUTING.md
        when submitting a pull request.  Make sure existing tests still pass, and add
        tests for all new behavior.

* ✏️ Explain your pull request
        Describe the big picture of your changes here to communicate to what
        your pull request is meant to accomplish. Provide 🔗 links 🔗 to
        associated issues!  Documentation in the docs/ directory should be updated
        as necessary.  Finally, a /CHANGELOG.md entry should be added.

We hope you will find this to be a positive experience! Contribution can be
intimidating and we hope to alleviate that pain as much as possible. Without
following these guidelines, you may be missing context that can help you succeed
with your contribution, which is why we encourage discussion first. Ultimately,
there is no guarantee that we will be able to merge your pull-request, but by
following these guidelines we can try to avoid disappointment.

-->
