### PR TITLE
Fix: Pin dependency to Rhai

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -67,6 +67,15 @@ By [@BrynCooke](https://github.com/BrynCooke) & [@bnjjj](https://github.com/bnjj
 
 ## 🐛 Fixes
 
+### Pin dependency to Rhai ([#1740](https://github.com/apollographql/router/issues/1740))
+    
+Rhai just released a 1.10 version that adds deprecation notices, and changes the way variables get registered. This causes scaffold to fail to compile.
+
+This PR works around it by pinning rhai to 1.9.1, until we update our use of the crate.
+
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1742
+
 ### Set correctly hasNext for the last chunk of a deferred response ([#1687](https://github.com/apollographql/router/issues/1687))
 
 You no longer will receive a last chunk `{"hasNext": false}` in a deferred response.

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -117,7 +117,7 @@ paste = "1.0.9"
 pin-project-lite = "0.2.9"
 prometheus = "0.13"
 rand = "0.8.5"
-rhai = { version = "1.9.1", features = ["sync", "serde", "internals"] }
+rhai = { version = "=1.9.1", features = ["sync", "serde", "internals"] }
 regex = "1.6.0"
 reqwest = { version = "0.11.11", default-features = false, features = [
     "rustls-tls",

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -1163,7 +1163,12 @@ impl Rhai {
                             .map_err(|e| e.to_string())?,
                     ),
                     None => {
-                        Some(PathAndQuery::from_maybe_shared(value).map_err(|e| e.to_string())?)
+                        // Rustc fails to infer the lifetime of value (probably a rustc bug)
+                        #[allow(clippy::unnecessary_to_owned)]
+                        Some(
+                            PathAndQuery::from_maybe_shared(value.to_string())
+                                .map_err(|e| e.to_string())?,
+                        )
                     }
                 };
                 *x = Uri::from_parts(parts).map_err(|e| e.to_string())?;
@@ -1183,10 +1188,16 @@ impl Rhai {
                             Authority::from_maybe_shared(format!("{}:{}", value, port))
                                 .map_err(|e| e.to_string())?
                         } else {
-                            Authority::from_maybe_shared(value).map_err(|e| e.to_string())?
+                            // Rustc fails to infer the lifetime of value (probably a rustc bug)
+                            #[allow(clippy::unnecessary_to_owned)]
+                            Authority::from_maybe_shared(value.to_string())
+                                .map_err(|e| e.to_string())?
                         }
                     }
-                    None => Authority::from_maybe_shared(value).map_err(|e| e.to_string())?,
+                    // Rustc fails to infer the lifetime of value (probably a rustc bug)
+                    #[allow(clippy::unnecessary_to_owned)]
+                    None => Authority::from_maybe_shared(value.to_string())
+                        .map_err(|e| e.to_string())?,
                 };
                 parts.authority = Some(new_authority);
                 *x = Uri::from_parts(parts).map_err(|e| e.to_string())?;

--- a/licenses.html
+++ b/licenses.html
@@ -44,7 +44,7 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#MIT">MIT License</a> (80)</li>
+            <li><a href="#MIT">MIT License</a> (79)</li>
             <li><a href="#Apache-2.0">Apache License 2.0</a> (53)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (8)</li>
             <li><a href="#ISC">ISC License</a> (8)</li>
@@ -10944,39 +10944,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/SimonSapin/rust-std-candidates ">matches</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2014-2016 Simon Sapin
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the &quot;Software&quot;), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
 </pre>
             </li>
             <li class="license">


### PR DESCRIPTION
Fixes #1740

Rhai just released a 1.10 version that adds deprecation notices, and changes the way variables get registered. 

This causes the router to fail to compile, since we don't allow warnings, and the way 1.10 works around references fails the borrow checker (See #1710 for reproduction)

This PR works around it by pinning rhai to 1.9.1, until we update our use of the crate.
