### PR TITLE
remove some over-exposed functions from the public API

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -26,6 +26,16 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 # [x.x.x] (unreleased) - 2022-mm-dd
 
 ## ❗ BREAKING ❗
+
+### Remove over-exposed functions from the public API ([PR #XXXX](https://github.com/apollographql/router/pull/XXXX))
+
+The following functions are only required for router implementation, so removing from external API.
+subgraph::new_from_response
+supergraph::new_from_response
+supergraph::new_from_graphql_response
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/XXXX
+
 ### Span client_name and client_version attributes renamed ([#1514](https://github.com/apollographql/router/issues/1514))
 OpenTelemetry attributes should be grouped by `.` rather than `_`, therefore the following attributes have changed:
 
@@ -41,7 +51,7 @@ By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographq
 There is a new global constant `apollo_sdl` which can be use to read the
 supergraph SDL as a string.
 
-By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/XXXX
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1737
 
 ### Add federated tracing support to Apollo studio usage reporting ([#1514](https://github.com/apollographql/router/issues/1514))
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -27,14 +27,14 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 
 ## ❗ BREAKING ❗
 
-### Remove over-exposed functions from the public API ([PR #XXXX](https://github.com/apollographql/router/pull/XXXX))
+### Remove over-exposed functions from the public API ([PR #1746](https://github.com/apollographql/router/pull/1746))
 
 The following functions are only required for router implementation, so removing from external API.
 subgraph::new_from_response
 supergraph::new_from_response
 supergraph::new_from_graphql_response
 
-By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/XXXX
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1746
 
 ### Span client_name and client_version attributes renamed ([#1514](https://github.com/apollographql/router/issues/1514))
 OpenTelemetry attributes should be grouped by `.` rather than `_`, therefore the following attributes have changed:

--- a/apollo-router/src/services/subgraph.rs
+++ b/apollo-router/src/services/subgraph.rs
@@ -89,7 +89,7 @@ impl Response {
     ///
     /// In this case, you already have a valid response and just wish to associate it with a context
     /// and create a Response.
-    pub fn new_from_response(
+    pub(crate) fn new_from_response(
         response: http::Response<graphql::Response>,
         context: Context,
     ) -> Response {

--- a/apollo-router/src/services/supergraph.rs
+++ b/apollo-router/src/services/supergraph.rs
@@ -259,7 +259,7 @@ impl Response {
         )
     }
 
-    pub fn new_from_graphql_response(response: graphql::Response, context: Context) -> Self {
+    pub(crate) fn new_from_graphql_response(response: graphql::Response, context: Context) -> Self {
         Self {
             response: http::Response::new(once(ready(response)).boxed()),
             context,
@@ -272,7 +272,7 @@ impl Response {
         self.response.body_mut().next().await
     }
 
-    pub fn new_from_response(
+    pub(crate) fn new_from_response(
         response: http::Response<graphql::ResponseStream>,
         context: Context,
     ) -> Self {

--- a/licenses.html
+++ b/licenses.html
@@ -44,7 +44,7 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#MIT">MIT License</a> (80)</li>
+            <li><a href="#MIT">MIT License</a> (79)</li>
             <li><a href="#Apache-2.0">Apache License 2.0</a> (53)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (8)</li>
             <li><a href="#ISC">ISC License</a> (8)</li>
@@ -10944,39 +10944,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/SimonSapin/rust-std-candidates ">matches</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2014-2016 Simon Sapin
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the &quot;Software&quot;), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
 </pre>
             </li>
             <li class="license">


### PR DESCRIPTION
Removing:
 - subgraph::new_from_response
 - supergraph::new_from_response
 - supergraph::new_from_graphql_response
