### PR TITLE
chore: update the `apollo-router` crate readme

### DIFF
--- a/apollo-router/README.md
+++ b/apollo-router/README.md
@@ -1,22 +1,19 @@
-# Server
-Server implementation is in this crate.
+# Apollo Router
 
-Supports:
-* graceful shutdown
-* hot reloading config
-* hot reloading schema
+[<img alt="Apollo Router" src="https://raw.githubusercontent.com/apollographql/space-kit/main/src/illustrations/svgs/satellite1.svg" height="144">](https://www.apollographql.com/docs/router/)
 
-## Components
-* FederatedServer - The main entry point. Can be configured with config, schema and a shutdown hook.
-* StateMachine - Responds to a stream of events to startup, hot reload, or shutdown.  
-* HttpServerFactory - Interface for creating an http implementation.
-* HyperHttpServerFactory - An implementation of HttpServerFactory that uses Hyper.
+The **Apollo Router** is a configurable, high-performance **graph router** written in Rust to run a [federated supergraph](https://www.apollographql.com/docs/federation/) that uses [Apollo Federation 2](https://www.apollographql.com/docs/federation/v2/federation-2/new-in-federation-2).
 
-# Example execution
-![Server sequence diagram](./images/sequence.svg)
-1. Configuration, Schema and Shutdown event streams.
-1. Combine streams to one unified stream for feeding to the state machine.
-1. State machine processes events until drained.
-1. State machine may start/restart/stop http server.
-1. Result of the state machine supplied back to the caller.
+Apollo Router is well-tested, regularly benchmarked, includes most major features of Apollo Gateway and is able to serve production-scale workloads.  Please note that the (pre-1.0) version is not yet "semver stable" and we may still make breaking changes.  Generally speaking, we expect most breaking changes to be on the plugin API and the configuration file format.  We will clearly convey such changes in the release notes.
 
+New releases and their release notes (along with notes about any breaking changes) can be found on the [Releases](https://github.com/apollographql/router/releases) page, and the latest release can always be found [on the latest page](https://github.com/apollographql/router/releases/latest).
+
+## Getting started
+
+Follow the [quickstart tutorial](https://www.apollographql.com/docs/router/quickstart/) to get up and running with the Apollo Router.
+
+See [the documentation](https://www.apollographql.com/docs/router) for more details.
+
+## Using the Apollo Router as a library
+
+See our section on [native customizations](https://www.apollographql.com/docs/router/customizations/native) for information on how to use `apollo-router` as a library.


### PR DESCRIPTION
note this is subtly different than the root `README`, but only in very minor
ways.  happy to iterate on this in the future, but wanted to solidify what
we just shipped to https://crates.io/crates/apollo-router/1.0.0-rc.0.

