### PR TITLE
Fix: do not check for listen adddress conflicts with a disabled sandbox.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -28,5 +28,23 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 ## ❗ BREAKING ❗
 ## 🚀 Features
 ## 🐛 Fixes
+
+
+### ### Do not check for listen adddress conflicts with a disabled sandbox. [PR #1781](https://github.com/apollographql/router/pull/1781)
+
+Setting `supergraph.listen` to `0.0.0.0:4000` would conflict with the sandbox's default `127.0.0.1:4000` regardless of whether the sandbox is enabled or not.
+
+A workaround before next release is to change `sandbox.listen` to either match `supergraph.listen` or bind it to an other port:
+
+```yaml
+supergraph:
+  listen: 0.0.0.0:4000
+sandbox:
+  listen: 0.0.0.0:4000
+  enabled: false
+```
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1781
+
 ## 🛠 Maintenance
 ## 📚 Documentation

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -2895,6 +2895,7 @@ Content-Type: application/json\r
             .sandbox(
                 Sandbox::fake_builder()
                     .listen(SocketAddr::from_str("0.0.0.0:4010").unwrap())
+                    .enabled(true)
                     .build(),
             )
             .build();
@@ -2919,7 +2920,6 @@ Content-Type: application/json\r
             .sandbox(
                 crate::configuration::Sandbox::fake_builder()
                     .listen(SocketAddr::from_str("127.0.0.1:4000").unwrap())
-                    .enabled(false)
                     .build(),
             )
             .build();


### PR DESCRIPTION
Fixes #1783 

Setting `supergraph.listen` to `0.0.0.0:4000` would conflict with the sandbox's default `127.0.0.1:4000` regardless of whether the sandbox is enabled or not.

A workaround before next release is to change `sandbox.listen` to either match `supergraph.listen` or bind it to an other port:

```yaml
supergraph:
  listen: 0.0.0.0:4000
sandbox:
  listen: 0.0.0.0:4000
  enabled: false
```
