### PR TITLE
Update apollo-router-scaffold to use the published router crate

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -29,4 +29,11 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 ## 🚀 Features
 ## 🐛 Fixes
 ## 🛠 Maintenance
+
+### Update apollo-router-scaffold to use published router crate [PR #1782](https://github.com/apollographql/router/pull/1782)
+
+Now that apollo-router version "1.0.0-rc.0" is released on [crates.io](https://crates.io/crates/apollo-router), we can update scaffold to it relies on the published crate instead of the git tag.
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1782
+
 ## 📚 Documentation

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -30,7 +30,7 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 ## 🐛 Fixes
 ## 🛠 Maintenance
 
-### Update apollo-router-scaffold to use published router crate [PR #1782](https://github.com/apollographql/router/pull/1782)
+### Update apollo-router-scaffold to use the published router crate [PR #1782](https://github.com/apollographql/router/pull/1782)
 
 Now that apollo-router version "1.0.0-rc.0" is released on [crates.io](https://crates.io/crates/apollo-router), we can update scaffold to it relies on the published crate instead of the git tag.
 

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -22,7 +22,7 @@ apollo-router = { path ="{{integration_test}}apollo-router" }
 apollo-router = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
 # Note if you update these dependencies then also update xtask/Cargo.toml
-apollo-router = { git="https://github.com/apollographql/router.git", tag="v1.0.0-rc.0" }
+apollo-router = "1.0.0-rc.0"
 {{/if}}
 {{/if}}
 async-trait = "0.1.52"


### PR DESCRIPTION
## 🛠 Maintenance

### Update apollo-router-scaffold to use the published router crate [PR #1782](https://github.com/apollographql/router/pull/1782)

Now that apollo-router version "1.0.0-rc.0" is released on [crates.io](https://crates.io/crates/apollo-router), we can update scaffold to it relies on the published crate instead of the git tag.

By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1782