### PR TITLE
fix docs side-bar

### DIFF
--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -15,7 +15,7 @@
       "Logging": "/configuration/logging",
       "Header propagation": "/configuration/header-propagation",
       "Traffic shaping": "/configuration/traffic-shaping",
-      "Subgraph error inclusion (experimental)": "/configuration/subgraph-error-inclusion"
+      "Subgraph error inclusion": "/configuration/subgraph-error-inclusion"
     },
     "Monitoring & Metrics": {
       "Health check": "/configuration/health-checks",


### PR DESCRIPTION
Remove the "experimental" designation from the side-bar.
follow up to: #1776 
fixes: #1773