### PR TITLE
Respect supergraph path for kubernetes deployment probes

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -28,5 +28,14 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 ## ❗ BREAKING ❗
 ## 🚀 Features
 ## 🐛 Fixes
+
+### Respect supergraph path for kubernetes deployment probes (#1787)
+
+For cases where you configured the `supergraph.path` for the router when using the helm chart, the liveness 
+and readiness probes continued to use the default path of `/` and so the start failed.
+
+By @damienpontifex in #1788
+
+
 ## 🛠 Maintenance
 ## 📚 Documentation

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -92,14 +92,14 @@ spec:
               httpHeaders:
                 - name: Content-Type
                   value: application/json
-              path: "/?query={__typename}"
+              path: {{ .Values.router.configuration.supergraph.path | default "/" }}?query={__typename}
               port: {{ .Values.containerPorts.http }}
           readinessProbe:
             httpGet:
               httpHeaders:
                 - name: Content-Type
                   value: application/json
-              path: "/?query={__typename}"
+              path: {{ .Values.router.configuration.supergraph.path | default "/" }}?query={__typename}
               port: {{ .Values.containerPorts.http }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
- Test with `helm template router-test helm/chart/router`
- Retains probe path of `/?query={__typename}`
- Test with `helm template router-test helm/chart/router --set router.configuration.supergraph.path=/graphql`
- Utilises probe path of `/graphql?query={__typename}`
- Resolves #1787