### PR TITLE
add documentation to various modules

### DIFF
--- a/apollo-router/src/layers/async_checkpoint.rs
+++ b/apollo-router/src/layers/async_checkpoint.rs
@@ -1,11 +1,13 @@
-//! Asynchronous Checkpoint [`Layer`].
+//! Asynchronous Checkpoint
 //!
 //! Provides a general mechanism for controlling the flow of a request. Useful in any situation
 //! where the caller wishes to provide control flow for a request.
 //!
 //! If the evaluated closure succeeds then the request is passed onto the next service in the
-//! chain of responsibilities. If it fails, then the control flow is broken a response is passed
+//! chain of responsibilities. If it fails, then the control flow is broken and a response is passed
 //! back to the invoking service.
+//!
+//! See [`Layer`] and [`Service`] for more details.
 
 use std::marker::PhantomData;
 use std::ops::ControlFlow;
@@ -19,7 +21,7 @@ use tower::Layer;
 use tower::Service;
 use tower::ServiceExt;
 
-/// [`Layer`] for Asynchronous Checkpoints.
+/// [`Layer`] for Asynchronous Checkpoints. See [`ServiceBuilderExt::checkpoint_async()`](crate::layers::ServiceBuilderExt::checkpoint_async()).
 #[allow(clippy::type_complexity)]
 pub struct AsyncCheckpointLayer<S, Fut, Request>
 where
@@ -65,7 +67,7 @@ where
     }
 }
 
-/// [`Service`] for Asynchronous Checkpoints.
+/// [`Service`] for Asynchronous Checkpoints. See [`ServiceBuilderExt::checkpoint_async()`](crate::layers::ServiceBuilderExt::checkpoint_async()).
 #[allow(clippy::type_complexity)]
 pub struct AsyncCheckpointService<S, Fut, Request>
 where

--- a/apollo-router/src/layers/instrument.rs
+++ b/apollo-router/src/layers/instrument.rs
@@ -1,7 +1,5 @@
 //! Instrumentation layer that allows services to be wrapped in a span.
 //!
-//! See [`Layer`] and [`Service`] for more details.
-//!
 //! Using ServiceBuilderExt:
 //! ```rust
 //! # use tower::ServiceBuilder;
@@ -16,6 +14,7 @@
 //! ```
 //! Now calls to the wrapped service will be wrapped in a span. You can attach attributes to the span from the request.
 //!
+//! See [`Layer`] and [`Service`] for more details.
 
 use std::marker::PhantomData;
 use std::task::Context;
@@ -25,7 +24,7 @@ use tower::Layer;
 use tower_service::Service;
 use tracing::Instrument;
 
-/// [`Layer`] for instrumentation.
+/// [`Layer`] for instrumentation. See [`ServiceBuilderExt::instrument()`](crate::layers::ServiceBuilderExt::instrument()).
 pub struct InstrumentLayer<F, Request>
 where
     F: Fn(&Request) -> tracing::Span,
@@ -63,7 +62,7 @@ where
     }
 }
 
-/// [`Service`] for instrumentation.
+/// [`Service`] for instrumentation. See [`ServiceBuilderExt::instrument()`](crate::layers::ServiceBuilderExt::instrument()).
 pub struct InstrumentService<F, S, Request>
 where
     S: Service<Request>,

--- a/apollo-router/src/layers/map_first_graphql_response.rs
+++ b/apollo-router/src/layers/map_first_graphql_response.rs
@@ -1,4 +1,6 @@
-#![allow(missing_docs)]
+//! Extension of map_future layer. Allows mapping of the first graphql response. Useful when working with a stream of responses.
+//!
+//! See [`Layer`] and [`Service`] for more details.
 
 use std::future::ready;
 use std::task::Poll;
@@ -14,10 +16,12 @@ use crate::graphql;
 use crate::services::supergraph;
 use crate::Context;
 
+/// [`Layer`] for mapping first graphql responses. See [`ServiceBuilderExt::map_first_graphql_response()`](crate::layers::ServiceBuilderExt::map_first_graphql_response()).
 pub struct MapFirstGraphqlResponseLayer<Callback> {
     pub(super) callback: Callback,
 }
 
+/// [`Service`] for mapping first graphql responses. See [`ServiceBuilderExt::map_first_graphql_response()`](crate::layers::ServiceBuilderExt::map_first_graphql_response()).
 pub struct MapFirstGraphqlResponseService<InnerService, Callback> {
     inner: InnerService,
     callback: Callback,

--- a/apollo-router/src/layers/map_future_with_request_data.rs
+++ b/apollo-router/src/layers/map_future_with_request_data.rs
@@ -1,8 +1,6 @@
-//! Extension of map_future layer. Allows mapping of the future using some information obtained from the request.
+//! Extension of map_future layer. Allows mapping of the future using information obtained from the request.
 //!
 //! See [`Layer`] and [`Service`] for more details.
-
-#![allow(missing_docs)] // FIXME
 
 use std::future::Future;
 use std::task::Context;
@@ -11,6 +9,7 @@ use std::task::Poll;
 use tower::Layer;
 use tower::Service;
 
+/// [`Layer`] for mapping futures with request data. See [`ServiceBuilderExt::map_future_with_request_data()`](crate::layers::ServiceBuilderExt::map_future_with_request_data()).
 #[derive(Clone)]
 pub struct MapFutureWithRequestDataLayer<RF, MF> {
     req_fn: RF,
@@ -18,6 +17,7 @@ pub struct MapFutureWithRequestDataLayer<RF, MF> {
 }
 
 impl<RF, MF> MapFutureWithRequestDataLayer<RF, MF> {
+    /// Create a new instance.
     pub fn new(req_fn: RF, map_fn: MF) -> Self {
         Self { req_fn, map_fn }
     }
@@ -35,6 +35,7 @@ where
     }
 }
 
+/// [`Service`] for mapping futures with request data. See [`ServiceBuilderExt::map_future_with_request_data()`](crate::layers::ServiceBuilderExt::map_future_with_request_data()).
 pub struct MapFutureWithRequestDataService<S, RF, MF> {
     inner: S,
     req_fn: RF,
@@ -42,6 +43,7 @@ pub struct MapFutureWithRequestDataService<S, RF, MF> {
 }
 
 impl<S, RF, MF> MapFutureWithRequestDataService<S, RF, MF> {
+    /// Create a new instance.
     pub fn new(inner: S, req_fn: RF, map_fn: MF) -> MapFutureWithRequestDataService<S, RF, MF>
     where
         RF: Clone,

--- a/apollo-router/src/layers/sync_checkpoint.rs
+++ b/apollo-router/src/layers/sync_checkpoint.rs
@@ -1,11 +1,13 @@
-//! Synchronous Checkpoint [`Layer`].
+//! Synchronous Checkpoint.
 //!
 //! Provides a general mechanism for controlling the flow of a request. Useful in any situation
 //! where the caller wishes to provide control flow for a request.
 //!
 //! If the evaluated closure succeeds then the request is passed onto the next service in the
-//! chain of responsibilities. If it fails, then the control flow is broken a response is passed
+//! chain of responsibilities. If it fails, then the control flow is broken and a response is passed
 //! back to the invoking service.
+//!
+//! See [`Layer`] and [`Service`] for more details.
 
 use std::ops::ControlFlow;
 use std::sync::Arc;
@@ -15,7 +17,7 @@ use tower::BoxError;
 use tower::Layer;
 use tower::Service;
 
-/// [`Layer`] for Synchronous Checkpoints.
+/// [`Layer`] for Synchronous Checkpoints. See [`ServiceBuilderExt::checkpoint()`](crate::layers::ServiceBuilderExt::checkpoint()).
 #[allow(clippy::type_complexity)]
 pub struct CheckpointLayer<S, Request>
 where
@@ -81,9 +83,9 @@ where
     }
 }
 
+/// [`Service`] for Synchronous Checkpoints. See [`ServiceBuilderExt::checkpoint()`](crate::layers::ServiceBuilderExt::checkpoint()).
 #[derive(Clone)]
 #[allow(clippy::type_complexity)]
-#[allow(missing_docs)] // FIXME
 pub struct CheckpointService<S, Request>
 where
     Request: Send + 'static,

--- a/apollo-router/src/plugin/serde.rs
+++ b/apollo-router/src/plugin/serde.rs
@@ -1,7 +1,5 @@
 //! serde support for commonly used data structures.
 
-#![allow(missing_docs)] // FIXME
-
 use std::fmt::Formatter;
 use std::str::FromStr;
 
@@ -15,6 +13,7 @@ use serde::de::SeqAccess;
 use serde::de::Visitor;
 use serde::Deserializer;
 
+/// De-serialize an optional [`HeaderName`].
 pub fn deserialize_option_header_name<'de, D>(
     deserializer: D,
 ) -> Result<Option<HeaderName>, D::Error>
@@ -47,6 +46,7 @@ where
     deserializer.deserialize_option(OptionHeaderNameVisitor)
 }
 
+/// De-serialize a vector of [`HeaderName`].
 pub fn deserialize_vec_header_name<'de, D>(deserializer: D) -> Result<Vec<HeaderName>, D::Error>
 where
     D: Deserializer<'de>,
@@ -75,6 +75,7 @@ where
     deserializer.deserialize_seq(VecHeaderNameVisitor)
 }
 
+/// De-serialize an optional [`HeaderValue`].
 pub fn deserialize_option_header_value<'de, D>(
     deserializer: D,
 ) -> Result<Option<HeaderValue>, D::Error>
@@ -126,6 +127,7 @@ impl<'de> Visitor<'de> for HeaderNameVisitor {
     }
 }
 
+/// De-serialize a [`HeaderName`].
 pub fn deserialize_header_name<'de, D>(deserializer: D) -> Result<HeaderName, D::Error>
 where
     D: Deserializer<'de>,
@@ -151,6 +153,7 @@ impl<'de> Visitor<'de> for JSONQueryVisitor {
     }
 }
 
+/// De-serialize a [`JSONQuery`].
 pub fn deserialize_json_query<'de, D>(deserializer: D) -> Result<JSONQuery, D::Error>
 where
     D: Deserializer<'de>,
@@ -176,6 +179,7 @@ impl<'de> Visitor<'de> for HeaderValueVisitor {
     }
 }
 
+/// De-serialize a [`HeaderValue`].
 pub fn deserialize_header_value<'de, D>(deserializer: D) -> Result<HeaderValue, D::Error>
 where
     D: Deserializer<'de>,
@@ -183,6 +187,7 @@ where
     deserializer.deserialize_str(HeaderValueVisitor)
 }
 
+/// De-serialize a [`Regex`].
 pub fn deserialize_regex<'de, D>(deserializer: D) -> Result<Regex, D::Error>
 where
     D: Deserializer<'de>,

--- a/apollo-router/src/tracer.rs
+++ b/apollo-router/src/tracer.rs
@@ -1,7 +1,6 @@
 //! Trace Ids for the router.
 
 #![warn(unreachable_pub)]
-#![warn(missing_docs)]
 use std::fmt;
 
 use opentelemetry::trace::TraceContextExt;


### PR DESCRIPTION
partially fixes: #799

Adds documentation for:

 apollo-router/src/layers/instrument.rs (🔒 @garypen )
 apollo-router/src/layers/map_first_graphql_response.rs (🔒 @garypen )
 apollo-router/src/layers/map_future_with_request_data.rs (🔒 @garypen )
 apollo-router/src/layers/sync_checkpoint.rs (🔒 @garypen)
 apollo-router/src/plugin/serde.rs (🔒 @garypen)
 apollo-router/src/tracer.rs (🔒 @garypen)
