### PR TITLE
Feat: Fallible Configuration builder

### DIFF
--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -1227,7 +1227,7 @@ mod tests {
                     inner: service.into_inner(),
                 },
                 Arc::new(
-                    Configuration::builder()
+                    Configuration::fake_builder()
                         .sandbox(
                             crate::configuration::Sandbox::fake_builder()
                                 .enabled(true)
@@ -1243,7 +1243,8 @@ mod tests {
                                 .enabled(false)
                                 .build(),
                         )
-                        .build(),
+                        .build()
+                        .unwrap(),
                 ),
                 None,
                 vec![],
@@ -1332,7 +1333,8 @@ mod tests {
                                 .listen(ListenAddr::UnixSocket(temp_dir.as_ref().join("sock")))
                                 .build(),
                         )
-                        .build(),
+                        .build()
+                        .unwrap(),
                 ),
                 None,
                 vec![],
@@ -1351,7 +1353,8 @@ mod tests {
         let conf = Configuration::fake_builder()
             .sandbox(Sandbox::fake_builder().enabled(true).build())
             .homepage(Homepage::fake_builder().enabled(false).build())
-            .build();
+            .build()
+            .unwrap();
 
         let (server, client) =
             init_with_config(expectations, conf.clone(), MultiMap::new()).await?;
@@ -1391,7 +1394,8 @@ mod tests {
                     .enabled(true)
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
 
         let (server, client) =
             init_with_config(expectations, conf.clone(), Default::default()).await?;
@@ -1430,7 +1434,8 @@ mod tests {
                     .enabled(true)
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
 
         let (server, client) =
             init_with_config(expectations, conf.clone(), Default::default()).await?;
@@ -1731,7 +1736,8 @@ mod tests {
                     .path(String::from("/graphql"))
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
         let (server, client) = init_with_config(expectations, conf, MultiMap::new()).await?;
         let url = format!(
             "{}/graphql",
@@ -1797,7 +1803,8 @@ mod tests {
                     .path(String::from("/:my_prefix/graphql"))
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
         let (server, client) = init_with_config(expectations, conf, MultiMap::new()).await?;
         let url = format!(
             "{}/prefix/graphql",
@@ -1863,7 +1870,8 @@ mod tests {
                     .path(String::from("/graphql/*"))
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
         let (server, client) = init_with_config(expectations, conf, MultiMap::new()).await?;
         for url in &[
             format!(
@@ -2090,7 +2098,8 @@ mod tests {
                     .path(String::from("/graphql/*"))
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
         let (server, client) = init_with_config(expectations, conf, MultiMap::new()).await?;
 
         let response = client
@@ -2296,7 +2305,8 @@ Content-Type: application/json\r
                     .enabled(false)
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
         let (server, client) = init_with_config(expectations, conf, MultiMap::new()).await?;
         let response = client
             .get(&format!(
@@ -2322,7 +2332,8 @@ Content-Type: application/json\r
                     .enabled(false)
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
         let (server, client) = init_with_config(expectations, conf, MultiMap::new()).await?;
         let response = client
             .get(&format!(
@@ -2366,7 +2377,7 @@ Content-Type: application/json\r
             Endpoint::new("/an-other-custom-path".to_string(), endpoint.boxed()),
         );
 
-        let conf = Configuration::fake_builder().build();
+        let conf = Configuration::fake_builder().build().unwrap();
         let (server, client) = init_with_config(expectations, conf, web_endpoints).await?;
 
         for path in &["/a-custom-path", "/an-other-custom-path"] {
@@ -2413,7 +2424,8 @@ Content-Type: application/json\r
                     .build(),
             )
             .supergraph(crate::configuration::Supergraph::fake_builder().build())
-            .build();
+            .build()
+            .unwrap();
         let (server, client) =
             init_with_config(MockSupergraphService::new(), conf, MultiMap::new()).await?;
 
@@ -2465,7 +2477,8 @@ Content-Type: application/json\r
                     .enabled(true)
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
 
         let error = init_with_config(MockSupergraphService::new(), conf, MultiMap::new())
             .await
@@ -2499,7 +2512,7 @@ Content-Type: application/json\r
             Endpoint::new("/a-custom-path".to_string(), endpoint.boxed()),
         );
 
-        let conf = Configuration::fake_builder().build();
+        let conf = Configuration::fake_builder().build().unwrap();
         let error = init_with_config(MockSupergraphService::new(), conf, web_endpoints)
             .await
             .unwrap_err();
@@ -2597,7 +2610,8 @@ Content-Type: application/json\r
     async fn cors_allow_any_origin() -> Result<(), ApolloRouterError> {
         let conf = Configuration::fake_builder()
             .cors(Cors::builder().allow_any_origin(true).build())
-            .build();
+            .build()
+            .unwrap();
         let (server, client) =
             init_with_config(MockSupergraphService::new(), conf, MultiMap::new()).await?;
         let url = format!("{}/", server.graphql_listen_address().as_ref().unwrap());
@@ -2619,7 +2633,8 @@ Content-Type: application/json\r
                     .origins(vec![valid_origin.to_string()])
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
         let (server, client) =
             init_with_config(MockSupergraphService::new(), conf, MultiMap::new()).await?;
         let url = format!("{}/", server.graphql_listen_address().as_ref().unwrap());
@@ -2645,7 +2660,8 @@ Content-Type: application/json\r
                     .match_origins(vec![apollo_subdomains.to_string()])
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
         let (server, client) =
             init_with_config(MockSupergraphService::new(), conf, MultiMap::new()).await?;
         let url = format!("{}/", server.graphql_listen_address().as_ref().unwrap());
@@ -2875,7 +2891,7 @@ Content-Type: application/json\r
 
     #[tokio::test]
     async fn it_makes_sure_same_listenaddrs_are_accepted() {
-        let configuration = Configuration::fake_builder().build();
+        let configuration = Configuration::fake_builder().build().unwrap();
 
         init_with_config(MockSupergraphService::new(), configuration, MultiMap::new())
             .await
@@ -2895,7 +2911,8 @@ Content-Type: application/json\r
                     .listen(SocketAddr::from_str("0.0.0.0:4010").unwrap())
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
 
         let error = init_with_config(MockSupergraphService::new(), configuration, MultiMap::new())
             .await
@@ -2914,7 +2931,8 @@ Content-Type: application/json\r
                     .listen(SocketAddr::from_str("127.0.0.1:4010").unwrap())
                     .build(),
             )
-            .build();
+            .build()
+            .unwrap();
         let endpoint = service_fn(|_req: transport::Request| async move {
             Ok::<_, BoxError>(
                 http::Response::builder()
@@ -2949,7 +2967,8 @@ Content-Type: application/json\r
                         .listen(SocketAddr::from_str("127.0.0.1:4010").unwrap())
                         .build(),
                 )
-                .build(),
+                .build()
+                .unwrap(),
         );
         let endpoint = service_fn(|_req: transport::Request| async move {
             Ok::<_, BoxError>(

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -116,7 +116,7 @@ impl Expansion {
 /// Configuration error.
 #[derive(Debug, Error, Display)]
 #[non_exhaustive]
-pub(crate) enum ConfigurationError {
+pub enum ConfigurationError {
     /// could not expand variable: {key}, {cause}
     CannotExpandVariable { key: String, cause: String },
     /// could not expand variable: {key}. Variables must be prefixed with one of '{supported_modes}' followed by '.' e.g. 'env.'
@@ -144,7 +144,7 @@ pub(crate) enum ConfigurationError {
 ///
 /// Can be created through `serde::Deserialize` from various formats,
 /// or inline in Rust code with `serde_json::json!` and `serde_json::from_value`.
-#[derive(Clone, Derivative, Deserialize, Serialize, JsonSchema, Default)]
+#[derive(Clone, Derivative, Serialize, JsonSchema, Default)]
 #[derivative(Debug)]
 pub struct Configuration {
     /// Configuration options pertaining to the http server component.
@@ -177,6 +177,51 @@ pub struct Configuration {
     dev: Option<bool>,
 }
 
+impl<'de> serde::Deserialize<'de> for Configuration {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        // This intermediate structure will allow us to deserialize a Configuration
+        // yet still exercise the Configuration validation function
+        #[derive(Deserialize, Default)]
+        struct AdHocConfiguration {
+            #[serde(default)]
+            server: Server,
+            #[serde(default)]
+            sandbox: Sandbox,
+            #[serde(default)]
+            homepage: Homepage,
+            #[serde(default)]
+            supergraph: Supergraph,
+            #[serde(default)]
+            cors: Cors,
+            #[serde(default)]
+            plugins: UserPlugins,
+            #[serde(default)]
+            #[serde(flatten)]
+            apollo_plugins: ApolloPlugins,
+
+            // Dev mode
+            #[serde(skip)]
+            dev: Option<bool>,
+        }
+        let ad_hoc: AdHocConfiguration = serde::Deserialize::deserialize(deserializer)?;
+
+        Configuration::builder()
+            .server(ad_hoc.server)
+            .sandbox(ad_hoc.sandbox)
+            .homepage(ad_hoc.homepage)
+            .supergraph(ad_hoc.supergraph)
+            .cors(ad_hoc.cors)
+            .plugins(ad_hoc.plugins.plugins.unwrap_or_default())
+            .apollo_plugins(ad_hoc.apollo_plugins.plugins)
+            .and_dev(ad_hoc.dev)
+            .build()
+            .map_err(|e| serde::de::Error::custom(e.to_string()))
+    }
+}
+
 const APOLLO_PLUGIN_PREFIX: &str = "apollo.";
 const TELEMETRY_KEY: &str = "telemetry";
 
@@ -202,8 +247,8 @@ impl Configuration {
         plugins: Map<String, Value>,
         apollo_plugins: Map<String, Value>,
         dev: Option<bool>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, ConfigurationError> {
+        let conf = Self {
             server: server.unwrap_or_default(),
             supergraph: supergraph.unwrap_or_default(),
             sandbox: sandbox.unwrap_or_default(),
@@ -216,7 +261,9 @@ impl Configuration {
                 plugins: apollo_plugins,
             },
             dev,
-        }
+        };
+
+        conf.validate()
     }
 
     /// This should be executed after normal configuration processing
@@ -302,8 +349,8 @@ impl Configuration {
         plugins: Map<String, Value>,
         apollo_plugins: Map<String, Value>,
         dev: Option<bool>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, ConfigurationError> {
+        let configuration = Self {
             server: server.unwrap_or_default(),
             supergraph: supergraph.unwrap_or_else(|| Supergraph::fake_builder().build()),
             sandbox: sandbox.unwrap_or_else(|| Sandbox::fake_builder().build()),
@@ -316,16 +363,24 @@ impl Configuration {
                 plugins: apollo_plugins,
             },
             dev,
-        }
+        };
+
+        configuration.validate()
+    }
+}
+
+impl Configuration {
+    fn validate(self) -> Result<Self, ConfigurationError> {
+        Ok(self)
     }
 }
 
 /// Parse configuration from a string in YAML syntax
 impl FromStr for Configuration {
-    type Err = serde_yaml::Error;
+    type Err = ConfigurationError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        serde_yaml::from_str(s)
+        validate_yaml_configuration(s, Expansion::default()?)?.validate()
     }
 }
 
@@ -948,11 +1003,7 @@ pub(crate) fn generate_config_schema() -> RootSchema {
 ///
 /// There may still be serde validation issues later.
 ///
-pub(crate) fn validate_configuration(raw_yaml: &str) -> Result<Configuration, ConfigurationError> {
-    validate_configuration_internal(raw_yaml, Expansion::default()?)
-}
-
-fn validate_configuration_internal(
+fn validate_yaml_configuration(
     raw_yaml: &str,
     expansion: Expansion,
 ) -> Result<Configuration, ConfigurationError> {
@@ -1358,11 +1409,12 @@ mod tests {
 
     #[test]
     fn bad_graphql_path_configuration_without_slash() {
-        let error = validate_configuration(
+        let error = validate_yaml_configuration(
             r#"
 supergraph:
   path: test
   "#,
+            Expansion::default().unwrap(),
         )
         .expect_err("should have resulted in an error");
         assert_eq!(error.to_string(), String::from("invalid 'server.graphql_path' configuration: 'test' is invalid, it must be an absolute path and start with '/', you should try with '/test'"));
@@ -1370,11 +1422,12 @@ supergraph:
 
     #[test]
     fn bad_graphql_path_configuration_with_wildcard_as_prefix() {
-        let error = validate_configuration(
+        let error = validate_yaml_configuration(
             r#"
 supergraph:
   path: /*/test
   "#,
+            Expansion::default().unwrap(),
         )
         .expect_err("should have resulted in an error");
         assert_eq!(error.to_string(), String::from("invalid 'server.graphql_path' configuration: '/*/test' is invalid, if you need to set a path like '/*/graphql' then specify it as a path parameter with a name, for example '/:my_project_key/graphql'"));
@@ -1382,13 +1435,14 @@ supergraph:
 
     #[test]
     fn unknown_fields() {
-        let error = validate_configuration(
+        let error = validate_yaml_configuration(
             r#"
 supergraph:
   path: /
 subgraphs:
   account: true
   "#,
+            Expansion::default().unwrap(),
         )
         .expect_err("should have resulted in an error");
         assert_eq!(error.to_string(), String::from("unknown fields: additional properties are not allowed ('subgraphs' was/were unexpected)"));
@@ -1396,11 +1450,12 @@ subgraphs:
 
     #[test]
     fn unknown_fields_at_root() {
-        let error = validate_configuration(
+        let error = validate_yaml_configuration(
             r#"
 unknown:
   foo: true
   "#,
+            Expansion::default().unwrap(),
         )
         .expect_err("should have resulted in an error");
         assert_eq!(error.to_string(), String::from("unknown fields: additional properties are not allowed ('unknown' was/were unexpected)"));
@@ -1408,20 +1463,22 @@ unknown:
 
     #[test]
     fn empty_config() {
-        validate_configuration(
+        validate_yaml_configuration(
             r#"
   "#,
+            Expansion::default().unwrap(),
         )
         .expect("should have been ok with an empty config");
     }
 
     #[test]
     fn bad_graphql_path_configuration_with_bad_ending_wildcard() {
-        let error = validate_configuration(
+        let error = validate_yaml_configuration(
             r#"
 supergraph:
   path: /test*
   "#,
+            Expansion::default().unwrap(),
         )
         .expect_err("should have resulted in an error");
         assert_eq!(error.to_string(), String::from("invalid 'server.graphql_path' configuration: '/test*' is invalid, you can only set a wildcard after a '/'"));
@@ -1429,7 +1486,7 @@ supergraph:
 
     #[test]
     fn line_precise_config_errors() {
-        let error = validate_configuration(
+        let error = validate_yaml_configuration(
             r#"
 plugins:
   non_existant:
@@ -1438,6 +1495,7 @@ plugins:
 telemetry:
   another_non_existant: 3
   "#,
+            Expansion::default().unwrap(),
         )
         .expect_err("should have resulted in an error");
         insta::assert_snapshot!(error.to_string());
@@ -1445,7 +1503,7 @@ telemetry:
 
     #[test]
     fn line_precise_config_errors_with_errors_after_first_field() {
-        let error = validate_configuration(
+        let error = validate_yaml_configuration(
             r#"
 supergraph:
   # The socket address and port to listen on
@@ -1454,6 +1512,7 @@ supergraph:
   bad: "donotwork"
   another_one: true
         "#,
+            Expansion::default().unwrap(),
         )
         .expect_err("should have resulted in an error");
         insta::assert_snapshot!(error.to_string());
@@ -1461,13 +1520,14 @@ supergraph:
 
     #[test]
     fn line_precise_config_errors_bad_type() {
-        let error = validate_configuration(
+        let error = validate_yaml_configuration(
             r#"
 supergraph:
   # The socket address and port to listen on
   # Defaults to 127.0.0.1:4000
   listen: true
         "#,
+            Expansion::default().unwrap(),
         )
         .expect_err("should have resulted in an error");
         insta::assert_snapshot!(error.to_string());
@@ -1475,7 +1535,7 @@ supergraph:
 
     #[test]
     fn line_precise_config_errors_with_inline_sequence() {
-        let error = validate_configuration(
+        let error = validate_yaml_configuration(
             r#"
 supergraph:
   # The socket address and port to listen on
@@ -1484,6 +1544,7 @@ supergraph:
 cors:
   allow_headers: [ Content-Type, 5 ]
         "#,
+            Expansion::default().unwrap(),
         )
         .expect_err("should have resulted in an error");
         insta::assert_snapshot!(error.to_string());
@@ -1491,7 +1552,7 @@ cors:
 
     #[test]
     fn line_precise_config_errors_with_sequence() {
-        let error = validate_configuration(
+        let error = validate_yaml_configuration(
             r#"
 supergraph:
   # The socket address and port to listen on
@@ -1502,6 +1563,7 @@ cors:
     - Content-Type
     - 5
         "#,
+            Expansion::default().unwrap(),
         )
         .expect_err("should have resulted in an error");
         insta::assert_snapshot!(error.to_string());
@@ -1509,12 +1571,13 @@ cors:
 
     #[test]
     fn it_does_not_allow_invalid_cors_headers() {
-        let cfg = validate_configuration(
+        let cfg = validate_yaml_configuration(
             r#"
 cors:
   allow_credentials: true
   allow_headers: [ "*" ]
         "#,
+            Expansion::default().unwrap(),
         )
         .expect("should not have resulted in an error");
         let error = cfg
@@ -1526,12 +1589,13 @@ cors:
 
     #[test]
     fn it_does_not_allow_invalid_cors_methods() {
-        let cfg = validate_configuration(
+        let cfg = validate_yaml_configuration(
             r#"
 cors:
   allow_credentials: true
   methods: [ GET, "*" ]
         "#,
+            Expansion::default().unwrap(),
         )
         .expect("should not have resulted in an error");
         let error = cfg
@@ -1543,12 +1607,13 @@ cors:
 
     #[test]
     fn it_does_not_allow_invalid_cors_origins() {
-        let cfg = validate_configuration(
+        let cfg = validate_yaml_configuration(
             r#"
 cors:
   allow_credentials: true
   allow_any_origin: true
         "#,
+            Expansion::default().unwrap(),
         )
         .expect("should not have resulted in an error");
         let error = cfg
@@ -1608,7 +1673,9 @@ cors:
                 };
 
                 for yaml in yamls {
-                    if let Err(e) = validate_configuration(&yaml) {
+                    if let Err(e) =
+                        validate_yaml_configuration(&yaml, Expansion::default().unwrap())
+                    {
                         panic!(
                             "{} configuration error: \n{}",
                             entry.path().to_string_lossy(),
@@ -1623,11 +1690,12 @@ cors:
     #[test]
     fn it_does_not_leak_env_variable_values() {
         std::env::set_var("TEST_CONFIG_NUMERIC_ENV_UNIQUE", "5");
-        let error = validate_configuration(
+        let error = validate_yaml_configuration(
             r#"
 supergraph:
   introspection: ${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}
         "#,
+            Expansion::default().unwrap(),
         )
         .expect_err("Must have an error because we expect a boolean");
         insta::assert_snapshot!(error.to_string());
@@ -1636,7 +1704,7 @@ supergraph:
     #[test]
     fn line_precise_config_errors_with_inline_sequence_env_expansion() {
         std::env::set_var("TEST_CONFIG_NUMERIC_ENV_UNIQUE", "5");
-        let error = validate_configuration(
+        let error = validate_yaml_configuration(
             r#"
 supergraph:
   # The socket address and port to listen on
@@ -1645,6 +1713,7 @@ supergraph:
 cors:
   allow_headers: [ Content-Type, "${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE}" ]
         "#,
+            Expansion::default().unwrap(),
         )
         .expect_err("should have resulted in an error");
         insta::assert_snapshot!(error.to_string());
@@ -1654,7 +1723,7 @@ cors:
     fn line_precise_config_errors_with_sequence_env_expansion() {
         std::env::set_var("env.TEST_CONFIG_NUMERIC_ENV_UNIQUE", "5");
 
-        let error = validate_configuration(
+        let error = validate_yaml_configuration(
             r#"
 supergraph:
   # The socket address and port to listen on
@@ -1665,6 +1734,7 @@ cors:
     - Content-Type
     - "${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}"
         "#,
+            Expansion::default().unwrap(),
         )
         .expect_err("should have resulted in an error");
         insta::assert_snapshot!(error.to_string());
@@ -1672,7 +1742,7 @@ cors:
 
     #[test]
     fn line_precise_config_errors_with_errors_after_first_field_env_expansion() {
-        let error = validate_configuration(
+        let error = validate_yaml_configuration(
             r#"
 supergraph:
   # The socket address and port to listen on
@@ -1681,6 +1751,7 @@ supergraph:
   ${TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}: 5
   another_one: foo
         "#,
+            Expansion::default().unwrap(),
         )
         .expect_err("should have resulted in an error");
         insta::assert_snapshot!(error.to_string());
@@ -1688,11 +1759,12 @@ supergraph:
 
     #[test]
     fn expansion_failure_missing_variable() {
-        let error = validate_configuration(
+        let error = validate_yaml_configuration(
             r#"
 supergraph:
   introspection: ${env.TEST_CONFIG_UNKNOWN_WITH_NO_DEFAULT}
         "#,
+            Expansion::default().unwrap(),
         )
         .expect_err("must have an error because the env variable is unknown");
         insta::assert_snapshot!(error.to_string());
@@ -1700,7 +1772,7 @@ supergraph:
 
     #[test]
     fn expansion_failure_unknown_mode() {
-        let error = validate_configuration_internal(
+        let error = validate_yaml_configuration(
             r#"
 supergraph:
   introspection: ${unknown.TEST_CONFIG_UNKNOWN_WITH_NO_DEFAULT}
@@ -1717,7 +1789,7 @@ supergraph:
     #[test]
     fn expansion_prefixing() {
         std::env::set_var("TEST_CONFIG_NEEDS_PREFIX", "true");
-        validate_configuration_internal(
+        validate_yaml_configuration(
             r#"
 supergraph:
   introspection: ${env.NEEDS_PREFIX}
@@ -1737,7 +1809,7 @@ supergraph:
         path.push("configuration");
         path.push("testdata");
         path.push("true.txt");
-        let config = validate_configuration_internal(
+        let config = validate_yaml_configuration(
             &format!(
                 r#"
 supergraph:

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -249,24 +249,26 @@ impl Executable {
                 ));
             }
             (Some(config), None) => config,
-            _ => opt
-                .config_path
-                .as_ref()
-                .map(|path| {
-                    let path = if path.is_relative() {
-                        current_directory.join(path)
-                    } else {
-                        path.to_path_buf()
-                    };
+            _ => match opt.config_path.as_ref().map(|path| {
+                let path = if path.is_relative() {
+                    current_directory.join(path)
+                } else {
+                    path.to_path_buf()
+                };
 
-                    ConfigurationSource::File {
-                        path,
-                        watch: opt.hot_reload,
-                        delay: None,
-                        dev: opt.dev,
-                    }
-                })
-                .unwrap_or_else(|| Configuration::builder().dev(opt.dev).build().into()),
+                ConfigurationSource::File {
+                    path,
+                    watch: opt.hot_reload,
+                    delay: None,
+                    dev: opt.dev,
+                }
+            }) {
+                Some(configuration) => configuration,
+                None => Configuration::builder()
+                    .dev(opt.dev)
+                    .build()
+                    .map(std::convert::Into::into)?,
+            },
         };
 
         let is_telemetry_disabled = std::env::var("APOLLO_TELEMETRY_DISABLED").ok().is_some();

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -35,7 +35,6 @@ use self::Event::UpdateSchema;
 use crate::axum_http_server_factory::make_axum_router;
 use crate::axum_http_server_factory::AxumHttpServerFactory;
 use crate::axum_http_server_factory::ListenAddrAndRouter;
-use crate::configuration::validate_configuration;
 use crate::configuration::Configuration;
 use crate::configuration::ListenAddr;
 use crate::plugin::DynPlugin;
@@ -346,9 +345,7 @@ impl ConfigurationSource {
 
     fn read_config(path: &Path) -> Result<Configuration, ReadConfigError> {
         let config = fs::read_to_string(path)?;
-        let config = validate_configuration(&config)?;
-
-        Ok(config)
+        config.parse().map_err(ReadConfigError::Validation)
     }
 }
 

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -390,7 +390,7 @@ mod test {
 
     #[tokio::test]
     async fn test_yaml_no_extras() {
-        let config = Configuration::builder().build();
+        let config = Configuration::builder().build().unwrap();
         let service = create_service(config).await;
         assert!(service.is_ok())
     }

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -498,7 +498,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 vec![
-                    UpdateConfiguration(Configuration::builder().build().boxed()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().boxed()),
                     UpdateSchema(example_schema()),
                     Shutdown
                 ],
@@ -519,7 +519,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 vec![
-                    UpdateConfiguration(Configuration::builder().build().boxed()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().boxed()),
                     UpdateSchema(minimal_schema.to_owned()),
                     UpdateSchema(example_schema()),
                     Shutdown
@@ -541,7 +541,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 vec![
-                    UpdateConfiguration(Configuration::builder().build().boxed()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().boxed()),
                     UpdateSchema(example_schema()),
                     UpdateConfiguration(
                         Configuration::builder()
@@ -551,6 +551,7 @@ mod tests {
                                     .build()
                             )
                             .build()
+                            .unwrap()
                             .boxed()
                     ),
                     Shutdown
@@ -572,7 +573,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 vec![
-                    UpdateConfiguration(Configuration::builder().build().boxed()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().boxed()),
                     UpdateSchema(example_schema()),
                     Shutdown
                 ],
@@ -598,7 +599,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 vec![
-                    UpdateConfiguration(Configuration::builder().build().boxed()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().boxed()),
                     UpdateSchema(example_schema()),
                 ],
             )
@@ -635,7 +636,7 @@ mod tests {
                 server_factory,
                 router_factory,
                 vec![
-                    UpdateConfiguration(Configuration::builder().build().boxed()),
+                    UpdateConfiguration(Configuration::builder().build().unwrap().boxed()),
                     UpdateSchema(example_schema()),
                     UpdateSchema(example_schema()),
                     Shutdown


### PR DESCRIPTION
Fixes #1791

There were three ways one could instantiate a Configuration, and (YAML) validation would only happen if explicitly invoked.

No Business rule validation was applied, and yml configuration could be easily bypassed because Configuration derives Deserialize.

This PR coerces Configuration instanciation to go through our yml validation when applicable, and allows us to enforce business requirements by making build() functions fallible.
