### PR TITLE
prepare header propagation configuration for #1284

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -27,7 +27,7 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 
 ## ❗ BREAKING ❗
 
-### Respect supergraph path for kubernetes deployment probes [PR #1795](https://github.com/apollographql/router/pull/1795)
+### Change header propagation configuration [PR #1795](https://github.com/apollographql/router/pull/1795)
 
 Adds `request` subsection into header propagation configuration to prepare for #1284 coming post 1.0
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -26,6 +26,22 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 # [x.x.x] (unreleased) - 2022-mm-dd
 
 ## ❗ BREAKING ❗
+
+### Respect supergraph path for kubernetes deployment probes [PR #1795](https://github.com/apollographql/router/pull/1795)
+
+Adds `request` subsection into header propagation configuration to prepare for #1284 coming post 1.0
+
+```patch
+headers:
+    all:
++     request:
+          - remove:
+              named: "test"
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1795
+
+
 ## 🚀 Features
 ## 🐛 Fixes
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -118,234 +118,255 @@ expression: "&schema"
       "type": "object",
       "properties": {
         "all": {
-          "type": "array",
-          "items": {
-            "oneOf": [
-              {
-                "type": "object",
-                "required": [
-                  "insert"
-                ],
-                "properties": {
-                  "insert": {
+          "type": "object",
+          "required": [
+            "request"
+          ],
+          "properties": {
+            "request": {
+              "description": "Propagate/Insert/Remove headers from request",
+              "type": "array",
+              "items": {
+                "oneOf": [
+                  {
                     "type": "object",
                     "required": [
-                      "name",
-                      "value"
+                      "insert"
                     ],
                     "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "value": {
-                        "type": "string"
+                      "insert": {
+                        "type": "object",
+                        "required": [
+                          "name",
+                          "value"
+                        ],
+                        "properties": {
+                          "name": {
+                            "type": "string"
+                          },
+                          "value": {
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "remove"
+                    ],
+                    "properties": {
+                      "remove": {
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "required": [
+                              "named"
+                            ],
+                            "properties": {
+                              "named": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "matching"
+                            ],
+                            "properties": {
+                              "matching": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "required": [
+                      "propagate"
+                    ],
+                    "properties": {
+                      "propagate": {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "required": [
+                              "named"
+                            ],
+                            "properties": {
+                              "default": {
+                                "type": "string",
+                                "nullable": true
+                              },
+                              "named": {
+                                "type": "string"
+                              },
+                              "rename": {
+                                "type": "string",
+                                "nullable": true
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "matching"
+                            ],
+                            "properties": {
+                              "matching": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        ]
                       }
                     },
                     "additionalProperties": false
                   }
-                },
-                "additionalProperties": false
-              },
-              {
-                "type": "object",
-                "required": [
-                  "remove"
-                ],
-                "properties": {
-                  "remove": {
-                    "oneOf": [
-                      {
-                        "type": "object",
-                        "required": [
-                          "named"
-                        ],
-                        "properties": {
-                          "named": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false
-                      },
-                      {
-                        "type": "object",
-                        "required": [
-                          "matching"
-                        ],
-                        "properties": {
-                          "matching": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    ]
-                  }
-                },
-                "additionalProperties": false
-              },
-              {
-                "type": "object",
-                "required": [
-                  "propagate"
-                ],
-                "properties": {
-                  "propagate": {
-                    "anyOf": [
-                      {
-                        "type": "object",
-                        "required": [
-                          "named"
-                        ],
-                        "properties": {
-                          "default": {
-                            "type": "string",
-                            "nullable": true
-                          },
-                          "named": {
-                            "type": "string"
-                          },
-                          "rename": {
-                            "type": "string",
-                            "nullable": true
-                          }
-                        },
-                        "additionalProperties": false
-                      },
-                      {
-                        "type": "object",
-                        "required": [
-                          "matching"
-                        ],
-                        "properties": {
-                          "matching": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false
-                      }
-                    ]
-                  }
-                },
-                "additionalProperties": false
+                ]
               }
-            ]
-          }
+            }
+          },
+          "additionalProperties": false,
+          "nullable": true
         },
         "subgraphs": {
           "type": "object",
           "additionalProperties": {
-            "type": "array",
-            "items": {
-              "oneOf": [
-                {
-                  "type": "object",
-                  "required": [
-                    "insert"
-                  ],
-                  "properties": {
-                    "insert": {
+            "type": "object",
+            "required": [
+              "request"
+            ],
+            "properties": {
+              "request": {
+                "description": "Propagate/Insert/Remove headers from request",
+                "type": "array",
+                "items": {
+                  "oneOf": [
+                    {
                       "type": "object",
                       "required": [
-                        "name",
-                        "value"
+                        "insert"
                       ],
                       "properties": {
-                        "name": {
-                          "type": "string"
-                        },
-                        "value": {
-                          "type": "string"
+                        "insert": {
+                          "type": "object",
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "properties": {
+                            "name": {
+                              "type": "string"
+                            },
+                            "value": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "remove"
+                      ],
+                      "properties": {
+                        "remove": {
+                          "oneOf": [
+                            {
+                              "type": "object",
+                              "required": [
+                                "named"
+                              ],
+                              "properties": {
+                                "named": {
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "required": [
+                                "matching"
+                              ],
+                              "properties": {
+                                "matching": {
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          ]
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "required": [
+                        "propagate"
+                      ],
+                      "properties": {
+                        "propagate": {
+                          "anyOf": [
+                            {
+                              "type": "object",
+                              "required": [
+                                "named"
+                              ],
+                              "properties": {
+                                "default": {
+                                  "type": "string",
+                                  "nullable": true
+                                },
+                                "named": {
+                                  "type": "string"
+                                },
+                                "rename": {
+                                  "type": "string",
+                                  "nullable": true
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            {
+                              "type": "object",
+                              "required": [
+                                "matching"
+                              ],
+                              "properties": {
+                                "matching": {
+                                  "type": "string"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          ]
                         }
                       },
                       "additionalProperties": false
                     }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "required": [
-                    "remove"
-                  ],
-                  "properties": {
-                    "remove": {
-                      "oneOf": [
-                        {
-                          "type": "object",
-                          "required": [
-                            "named"
-                          ],
-                          "properties": {
-                            "named": {
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "required": [
-                            "matching"
-                          ],
-                          "properties": {
-                            "matching": {
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "required": [
-                    "propagate"
-                  ],
-                  "properties": {
-                    "propagate": {
-                      "anyOf": [
-                        {
-                          "type": "object",
-                          "required": [
-                            "named"
-                          ],
-                          "properties": {
-                            "default": {
-                              "type": "string",
-                              "nullable": true
-                            },
-                            "named": {
-                              "type": "string"
-                            },
-                            "rename": {
-                              "type": "string",
-                              "nullable": true
-                            }
-                          },
-                          "additionalProperties": false
-                        },
-                        {
-                          "type": "object",
-                          "required": [
-                            "matching"
-                          ],
-                          "properties": {
-                            "matching": {
-                              "type": "string"
-                            }
-                          },
-                          "additionalProperties": false
-                        }
-                      ]
-                    }
-                  },
-                  "additionalProperties": false
+                  ]
                 }
-              ]
-            }
+              }
+            },
+            "additionalProperties": false
           }
         }
       },

--- a/docs/source/configuration/header-propagation.mdx
+++ b/docs/source/configuration/header-propagation.mdx
@@ -11,16 +11,17 @@ You define header rules in your [YAML configuration file](./overview/#yaml-confi
 # ...other configuration...
 headers:
   all: # Header rules for all subgraphs
-    - propagate:
-        matching: ^upstream-header-.*
-    - remove:
-        named: "x-legacy-account-id"
+    request:
+      - propagate:
+          matching: ^upstream-header-.*
+      - remove:
+          named: "x-legacy-account-id"
   subgraphs:
     products: # Header rules for just the products subgraph
-    - insert:
-        name: "router-subgraph-name"
-        value: "products"
-
+      request:
+        - insert:
+            name: "router-subgraph-name"
+            value: "products"
 ```
 
 ## Supported header rules
@@ -37,8 +38,8 @@ You can specify which headers to propagate based on a matching [regex pattern](h
 - propagate:
     matching: .*
 ```
-> **Note:** The Apollo Router _never_ propagates so-called [hop-by-hop headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers) (such as `Content-Length`) when propagating by pattern.
 
+> **Note:** The Apollo Router _never_ propagates so-called [hop-by-hop headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers#hop-by-hop_headers) (such as `Content-Length`) when propagating by pattern.
 
 Alternatively, you can provide a static string via the `named` option. These `named` configurations have additional flexibility, because they support the following options:
 
@@ -47,9 +48,9 @@ Alternatively, you can provide a static string via the `named` option. These `na
 
 ```yaml
 - propagate:
-      named: "x-user-id"
-      default: "abc123"
-      rename: "account-id"
+    named: "x-user-id"
+    default: "abc123"
+    rename: "account-id"
 ```
 
 ### `remove`
@@ -83,11 +84,12 @@ Header rules are applied in the same order they're declared, and later rules can
 
 ```yaml title="bad_configuration.yaml"
 headers:
-all:
-  - remove:
-    named: "test"
-  - propagate:
-    matching: .*
+  all:
+    request:
+      - remove:
+        named: "test"
+      - propagate:
+        matching: .*
 ```
 
 In this example, first any header named `test` is removed from the list of headers to propagate. However, _the list of headers to propagate is currently empty!_ Next, the `propagate` rule adds _all_ headers to the propagation list, _including_ `test`.
@@ -98,11 +100,12 @@ To correctly remove a header from the propagation list, make sure to define your
 
 ```yaml title="good_configuration.yaml"
 headers:
-all:
-  - propagate:
-    matching: .*
-  - remove:
-    named: "test"
+  all:
+    request:
+      - propagate:
+        matching: .*
+      - remove:
+        named: "test"
 ```
 
 With this ordering, first all headers are added to the propagation list, then the `test` header is removed.
@@ -115,34 +118,37 @@ Here's a complete example showing all the possible configuration options in use:
 headers:
   # Header rules for all subgraphs
   all:
-  # Propagate matching headers
-  - propagate:
-      matching: ^upstream-header-.*
-  # Propagate matching headers
-  - propagate:
-      named: "some-header"
-      default: "default-value"
-      rename: "destination-header"
-  # Remove the "x-legacy-account-id" header
-  - remove:
-      named: "x-legacy-account-id"
-  # Remove matching headers
-  - remove:
-      matching: ^x-deprecated-.*
-  # Insert the 'my-company' header
-  - insert:
-      name: "my-company"
-      value: "acme"
+    request:
+      # Propagate matching headers
+      - propagate:
+          matching: ^upstream-header-.*
+      # Propagate matching headers
+      - propagate:
+          named: "some-header"
+          default: "default-value"
+          rename: "destination-header"
+      # Remove the "x-legacy-account-id" header
+      - remove:
+          named: "x-legacy-account-id"
+      # Remove matching headers
+      - remove:
+          matching: ^x-deprecated-.*
+      # Insert the 'my-company' header
+      - insert:
+          name: "my-company"
+          value: "acme"
   # Subgraph-specific header rules
   subgraphs:
     products:
-      # Calls to the products subgraph have the "router-subgraph-name" header set to `products`.
-      - insert:
-          name: "router-subgraph-name"
-          value: "products"
+      request:
+        # Calls to the products subgraph have the "router-subgraph-name" header set to `products`.
+        - insert:
+            name: "router-subgraph-name"
+            value: "products"
     accounts:
-      # Calls to the accounts subgraph have the "router-subgraph-name" header set to `accounts`.
-      - insert:
-          name: "router-subgraph-name"
-          value: "accounts"
+      request:
+        # Calls to the accounts subgraph have the "router-subgraph-name" header set to `accounts`.
+        - insert:
+            name: "router-subgraph-name"
+            value: "accounts"
 ```

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -397,11 +397,13 @@ You can reuse parts of your configuration file in multiple places using standard
 headers:
   subgraphs:
     products:
-      - insert: &insert_custom_header
-          name: "custom-header"
-          value: "something"
+      request:
+        - insert: &insert_custom_header
+            name: "custom-header"
+            value: "something"
     reviews:
-      - insert: *insert_custom_header
+      request:
+        - insert: *insert_custom_header
 ```
 
 Here, the `name` and `value` entries under `&insert_custom_header` are reused under `*insert_custom_header`.

--- a/examples/header-manipulation/router.yaml
+++ b/examples/header-manipulation/router.yaml
@@ -3,50 +3,52 @@
 headers:
   # The following section is applied to all subgraphs.
   all:
-    # Propagate headers matching name but do nothing if the client header did not exist.
-    - propagate:
-        named: "Propagate"
+    request:
+        # Propagate headers matching name but do nothing if the client header did not exist.
+        - propagate:
+            named: "Propagate"
 
-    # Propagate headers matching name and default if the client header did not exist.
-    - propagate:
-        named: "PropagateAndDefault"
-        default: "DefaultValue"
+        # Propagate headers matching name and default if the client header did not exist.
+        - propagate:
+            named: "PropagateAndDefault"
+            default: "DefaultValue"
 
-    # Propagate headers matching name and rename on the subgraph request.
-    - propagate:
-        named: "PropagateAndRename"
-        rename: "NewHeaderName"
+        # Propagate headers matching name and rename on the subgraph request.
+        - propagate:
+            named: "PropagateAndRename"
+            rename: "NewHeaderName"
 
-    # Propagate headers matching name and rename on the subgraph request. Default if the client header did not exist.
-    - propagate:
-        named: "PropagateAndDefaultAndRename"
-        default: "DefaultValue"
-        rename: "NewHeaderName"
+        # Propagate headers matching name and rename on the subgraph request. Default if the client header did not exist.
+        - propagate:
+            named: "PropagateAndDefaultAndRename"
+            default: "DefaultValue"
+            rename: "NewHeaderName"
 
-    # Propagate headers matching a regex
-    - propagate:
-        matching: "PropagateMatching-.*"
+        # Propagate headers matching a regex
+        - propagate:
+            matching: "PropagateMatching-.*"
 
-    # Remove a named header
-    - remove:
-        named: "Remove"
+        # Remove a named header
+        - remove:
+            named: "Remove"
 
-    # Remove headers matching a regex
-    - remove:
-        matching: "RemoveMatching-.*"
+        # Remove headers matching a regex
+        - remove:
+            matching: "RemoveMatching-.*"
 
-    # Insert a header value
-    - insert:
-        name: "Insert"
-        value: "Value"
+        # Insert a header value
+        - insert:
+            name: "Insert"
+            value: "Value"
 
   # The following section is applied to all subgraphs.
   subgraphs:
     # Anything shown in the above `all` section can be specified on a subgraph specific basis.
     products:
-      # Insert a header value
-      - insert:
-          name: "InsertSubgraph"
-          value: "Value"
+        request:
+            # Insert a header value
+            - insert:
+                name: "InsertSubgraph"
+                value: "Value"
 
 


### PR DESCRIPTION
Adds `request` subsection into header propagation configuration to prepare for #1284 coming post 1.0

```patch
all:
+     request:
        - remove:
            named: "test"
```