### PR TITLE
nit: Adjust messaging for dev mode and remove conditional `APOLLO_ROVER` check

### DIFF
--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -263,11 +263,7 @@ impl Configuration {
 
     /// This should be executed after normal configuration processing
     pub(crate) fn enable_dev_mode(&mut self) {
-        if std::env::var("APOLLO_ROVER").ok().as_deref() == Some("true") {
-            tracing::info!("Development mode has been enabled. This mode of operation is only meant for development!");
-        } else {
-            tracing::warn!("Development mode has been enabled and has not been started by `rover dev`. This mode of operation is only meant for development!");
-        }
+        tracing::info!("Running with *development* mode settings which facilitate development experience (e.g., introspection enabled)");
 
         if self.plugins.plugins.is_none() {
             self.plugins.plugins = Some(Map::new());


### PR DESCRIPTION
I think a follow-up could replace this message with a link to our documentation with more details.  I've removed the `APOLLO_ROVER` conditional for now since we will release before `rover dev` is fully GA and part of our development story.
