### PR TITLE
add badge to crates.io and docs.rs in apollo-router readme

### DIFF
--- a/apollo-router/README.md
+++ b/apollo-router/README.md
@@ -1,3 +1,6 @@
+[![Version](https://img.shields.io/crates/v/apollo-router.svg)](https://crates.io/crates/apollo-router)
+[![Docs.rs](https://docs.rs/apollo-router/badge.svg)](https://docs.rs/apollo-router)
+
 # Apollo Router
 
 [<img alt="Apollo Router" src="https://raw.githubusercontent.com/apollographql/space-kit/main/src/illustrations/svgs/satellite1.svg" height="144">](https://www.apollographql.com/docs/router/)


### PR DESCRIPTION
Always useful to know what's the last version published on crates.io and a link to docs.rs