### PR TITLE
apollo-parser@0.2.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,9 @@ checksum = "344a1afec31ce0273dc2061105b04e5c4ab620fe0748a76244338aa893db42f3"
 
 [[package]]
 name = "apollo-parser"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bcfad5b20c7edffbfe4425828152f6f1575ea44b959031456ade138ccd732f0"
+checksum = "c12416e40e4a1883da10af9238c3dec2fd2573015df79a969ec947c8683e2f65"
 dependencies = [
  "rowan",
 ]

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -28,6 +28,11 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 ## ❗ BREAKING ❗
 ## 🚀 Features
 ## 🐛 Fixes
+### update apollo-parser to 0.2.11
+
+Fixes error creation for missing selection sets in named operation definitions.
+
+By [@lrlna](https://github.com/lrlna) in https://github.com/apollographql/router/pull/1841
 
 ### Fix router scaffold version ([Issue #1836](https://github.com/apollographql/router/issues/1836))
 

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -26,7 +26,7 @@ console = ["tokio/tracing", "console-subscriber"]
 [dependencies]
 access-json = "0.1.0"
 anyhow = "1.0.64"
-apollo-parser = "0.2.10"
+apollo-parser = "0.2.11"
 async-compression = { version = "0.3.14", features = [
     "tokio",
     "brotli",
@@ -157,7 +157,7 @@ tower-http = { version = "0.3.4", features = [
     "decompression-br",
     "decompression-deflate",
     "decompression-gzip",
-    "timeout"
+    "timeout",
 ] }
 tower-service = "0.3.2"
 
@@ -188,7 +188,7 @@ uname = "0.1.1"
 uname = "0.1.1"
 
 [dev-dependencies]
-insta = { version = "1.19.1", features = [ "json", "redactions" ] }
+insta = { version = "1.19.1", features = ["json", "redactions"] }
 jsonpath_lib = "0.3.0"
 maplit = "1.0.2"
 memchr = { version = "2.5.0", default-features = false }


### PR DESCRIPTION
Creates errors for missing selection sets in named operation definitions.
