### PR TITLE
Deny panic, unwrap and expect in the spec module

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -67,4 +67,21 @@ Add more gates (for `console` feature) to not have warnings when using `--all-fe
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1830
 
+
+### Deny unwrap and expect in the spec module ([Issue #1844](https://github.com/apollographql/router/pull/1844))
+
+As we are progressing towards 1.0, we are progressively banning `unwrap()` and `expect()` from the critical parts of the codebase.
+
+This codepath is exercised after Parsing has happened, so invariants expressed by `expect`s would always have been enforced or checked before. However we decided to tighten the router even further, by raising errors instead, which will provide users with even more stability guarantees.
+
+The spec module now has gates that prevent its content from using code that explicitly panics.
+
+```rust
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+```
+
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1844
+
 ## 📚 Documentation

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -68,7 +68,7 @@ Add more gates (for `console` feature) to not have warnings when using `--all-fe
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1830
 
 
-### Deny unwrap and expect in the spec module ([Issue #1844](https://github.com/apollographql/router/pull/1844))
+### Deny panic, unwrap and expect in the spec module ([Issue #1844](https://github.com/apollographql/router/pull/1844))
 
 As we are progressing towards 1.0, we are progressively banning `unwrap()` and `expect()` from the critical parts of the codebase.
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -79,6 +79,7 @@ The spec module now has gates that prevent its content from using code that expl
 ```rust
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]
+#![deny(clippy::panic)]
 ```
 
 

--- a/apollo-router/src/spec/field_type.rs
+++ b/apollo-router/src/spec/field_type.rs
@@ -105,11 +105,15 @@ impl FieldType {
             {
                 Ok(())
             }
-            (FieldType::Named(name), value) if value.is_object() => {
-                if let Some(object_ty) = schema.input_types.get(name) {
-                    object_ty
-                        .validate_object(value.as_object().unwrap(), schema)
-                        .map_err(|_| InvalidValue)
+            (FieldType::Named(name), value) => {
+                if let Some(value) = value.as_object() {
+                    if let Some(object_ty) = schema.input_types.get(name) {
+                        object_ty
+                            .validate_object(value, schema)
+                            .map_err(|_| InvalidValue)
+                    } else {
+                        Err(InvalidValue)
+                    }
                 } else {
                     Err(InvalidValue)
                 }
@@ -154,58 +158,68 @@ impl FieldType {
     }
 }
 
-impl From<ast::Type> for FieldType {
+impl TryFrom<ast::Type> for FieldType {
+    type Error = SpecError;
     // Spec: https://spec.graphql.org/draft/#sec-Type-References
-    fn from(ty: ast::Type) -> Self {
+    fn try_from(ty: ast::Type) -> Result<Self, Self::Error> {
         match ty {
-            ast::Type::NamedType(named) => named.into(),
-            ast::Type::ListType(list) => list.into(),
-            ast::Type::NonNullType(non_null) => non_null.into(),
+            ast::Type::NamedType(named) => named.try_into(),
+            ast::Type::ListType(list) => list.try_into(),
+            ast::Type::NonNullType(non_null) => non_null.try_into(),
         }
     }
 }
 
-impl From<ast::NamedType> for FieldType {
+impl TryFrom<ast::NamedType> for FieldType {
+    type Error = SpecError;
     // Spec: https://spec.graphql.org/draft/#NamedType
-    fn from(named: ast::NamedType) -> Self {
+    fn try_from(named: ast::NamedType) -> Result<Self, Self::Error> {
         let name = named
             .name()
-            .expect("the node Name is not optional in the spec; qed")
+            .ok_or_else(|| {
+                SpecError::InvalidType("the node Name is not optional in the spec; qed".to_string())
+            })?
             .text()
             .to_string();
-        match name.as_str() {
+        Ok(match name.as_str() {
             "String" => Self::String,
             "Int" => Self::Int,
             "Float" => Self::Float,
             "ID" => Self::Id,
             "Boolean" => Self::Boolean,
             _ => Self::Named(name),
-        }
+        })
     }
 }
 
-impl From<ast::ListType> for FieldType {
+impl TryFrom<ast::ListType> for FieldType {
+    type Error = SpecError;
+
     // Spec: https://spec.graphql.org/draft/#ListType
-    fn from(list: ast::ListType) -> Self {
-        Self::List(Box::new(
+    fn try_from(list: ast::ListType) -> Result<Self, Self::Error> {
+        Ok(Self::List(Box::new(
             list.ty()
-                .expect("the node Type is not optional in the spec; qed")
-                .into(),
-        ))
+                .ok_or_else(|| {
+                    SpecError::InvalidType("node Type is not optional in the spec; qed".to_string())
+                })?
+                .try_into()?,
+        )))
     }
 }
 
-impl From<ast::NonNullType> for FieldType {
+impl TryFrom<ast::NonNullType> for FieldType {
+    type Error = SpecError;
+
     // Spec: https://spec.graphql.org/draft/#NonNullType
-    fn from(non_null: ast::NonNullType) -> Self {
+    fn try_from(non_null: ast::NonNullType) -> Result<Self, Self::Error> {
         if let Some(list) = non_null.list_type() {
-            Self::NonNull(Box::new(list.into()))
+            Ok(Self::NonNull(Box::new(list.try_into()?)))
         } else if let Some(named) = non_null.named_type() {
-            Self::NonNull(Box::new(named.into()))
+            Ok(Self::NonNull(Box::new(named.try_into()?)))
         } else {
-            eprintln!("{:?}", non_null);
-            eprintln!("{:?}", non_null.to_string());
-            unreachable!("either the NamedType node is provided, either the ListType node; qed")
+            Err(SpecError::InvalidType(
+                "either the NamedType node is provided, either the ListType node; qed".to_string(),
+            ))
         }
     }
 }

--- a/apollo-router/src/spec/field_type.rs
+++ b/apollo-router/src/spec/field_type.rs
@@ -105,6 +105,8 @@ impl FieldType {
             {
                 Ok(())
             }
+            // NOTE: graphql's types are all optional by default
+            (_, Value::Null) => Ok(()),
             (FieldType::Named(name), value) => {
                 if let Some(value) = value.as_object() {
                     if let Some(object_ty) = schema.input_types.get(name) {
@@ -118,8 +120,6 @@ impl FieldType {
                     Err(InvalidValue)
                 }
             }
-            // NOTE: graphql's types are all optional by default
-            (_, Value::Null) => Ok(()),
             _ => Err(InvalidValue),
         }
     }

--- a/apollo-router/src/spec/fragments.rs
+++ b/apollo-router/src/spec/fragments.rs
@@ -23,25 +23,49 @@ impl Fragments {
             .map(|fragment_definition| {
                 let name = fragment_definition
                     .fragment_name()
-                    .expect("the node FragmentName is not optional in the spec; qed")
+                    .ok_or_else(|| {
+                        SpecError::ParsingError(
+                            "the node FragmentName is not optional in the spec".to_string(),
+                        )
+                    })?
                     .name()
-                    .unwrap()
+                    .ok_or_else(|| {
+                        SpecError::ParsingError(
+                            "the node FragmentName is not optional in the spec".to_string(),
+                        )
+                    })?
                     .text()
                     .to_string();
 
                 let type_condition = fragment_definition
                     .type_condition()
-                    .expect("Fragments must specify the type they apply to; qed")
+                    .ok_or_else(|| {
+                        SpecError::ParsingError(
+                            "Fragments must specify the type they apply to".to_string(),
+                        )
+                    })?
                     .named_type()
-                    .expect("Fragments must specify the type they apply to; qed")
+                    .ok_or_else(|| {
+                        SpecError::ParsingError(
+                            "Fragments must specify the type they apply to".to_string(),
+                        )
+                    })?
                     .name()
-                    .expect("the node Name is not optional in the spec; qed")
+                    .ok_or_else(|| {
+                        SpecError::ParsingError(
+                            "Fragments must specify the type they apply to".to_string(),
+                        )
+                    })?
                     .text()
                     .to_string();
 
                 let selection_set = fragment_definition
                     .selection_set()
-                    .expect("the node SelectionSet is not optional in the spec; qed")
+                    .ok_or_else(|| {
+                        SpecError::ParsingError(
+                            "the node SelectionSet is not optional in the spec".to_string(),
+                        )
+                    })?
                     .selections()
                     .map(|selection| {
                         Selection::from_ast(

--- a/apollo-router/src/spec/mod.rs
+++ b/apollo-router/src/spec/mod.rs
@@ -1,5 +1,5 @@
-#![deny(clippy::unwrap_used)]
-#![deny(clippy::expect_used)]
+#![cfg_attr(not(test), deny(clippy::unwrap_used))]
+#![cfg_attr(not(test), deny(clippy::expect_used))]
 
 mod field_type;
 mod fragments;

--- a/apollo-router/src/spec/mod.rs
+++ b/apollo-router/src/spec/mod.rs
@@ -1,3 +1,6 @@
+#![deny(clippy::unwrap_used)]
+#![deny(clippy::expect_used)]
+
 mod field_type;
 mod fragments;
 mod query;

--- a/apollo-router/src/spec/mod.rs
+++ b/apollo-router/src/spec/mod.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(test), deny(clippy::unwrap_used))]
 #![cfg_attr(not(test), deny(clippy::expect_used))]
+#![cfg_attr(not(test), deny(clippy::panic))]
 
 mod field_type;
 mod fragments;


### PR DESCRIPTION
### Deny unwrap and expect in the spec module ([Issue #1844](https://github.com/apollographql/router/pull/1844))

As we are progressing towards 1.0, we are progressively banning `unwrap()` and `expect()` from the critical parts of the codebase.

This codepath is exercised after Parsing has happened, so invariants expressed by `expect`s would always have been enforced or checked before. However we decided to tighten the router even further, by raising errors instead, which will provide users with even more stability guarantees.

The spec module now has gates that prevent its content from using code that explicitly panics.

```rust
#![deny(clippy::unwrap_used)]
#![deny(clippy::expect_used)]
#![deny(clippy::panic)]
```