### PR TITLE
attempt at fixing FTV1 sampling

### DIFF
--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -243,22 +243,26 @@ impl Plugin for Telemetry {
         let ftv1_activated = self
             .config
             .apollo
+            .as_ref()
             .map(|c| c.field_level_instrumentation_sampler.is_some())
             .unwrap_or(false);
         let studio_activated = self
             .config
             .apollo
+            .as_ref()
             .map(|c| c.apollo_key.is_some())
             .unwrap_or(false);
         let send_headers = self
             .config
             .apollo
-            .map(|c| c.send_headers)
+            .as_ref()
+            .map(|c| c.send_headers.clone())
             .unwrap_or_default();
         let send_variable_values = self
             .config
             .apollo
-            .map(|c| c.send_variable_values)
+            .as_ref()
+            .map(|c| c.send_variable_values.clone())
             .unwrap_or_default();
 
         ServiceBuilder::new()

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -23,6 +23,7 @@ use crate::plugins::telemetry::config::Sampler;
 use crate::plugins::telemetry::config::SamplerOption;
 use crate::plugins::telemetry::tracing::apollo::TracesReport;
 use crate::plugins::telemetry::BoxError;
+use crate::plugins::telemetry::EXECUTION_SPAN_NAME;
 use crate::plugins::telemetry::REQUEST_SPAN_NAME;
 use crate::plugins::telemetry::SUBGRAPH_SPAN_NAME;
 use crate::plugins::telemetry::SUPERGRAPH_SPAN_NAME;

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -333,7 +333,7 @@ impl Exporter {
             SUBGRAPH_SPAN_NAME => {
                 vec![TreeData::Trace(self.find_ftv1_trace(span))]
             }
-            SUPERGRAPH_SPAN_NAME => {
+            EXECUTION_SPAN_NAME => {
                 //Currently some data is in the supergraph span as we don't have the a request hook in plugin.
                 child_nodes.push(TreeData::Supergraph {
                     http: self.extract_http_data(span),

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -372,7 +372,7 @@ impl PlanNode {
         SF: SubgraphServiceFactory,
     {
         Box::pin(async move {
-            tracing::info!("executing plan:\n");
+            tracing::trace!("executing plan:\n{:#?}", self);
             let mut value;
             let mut errors;
             let mut subselection = None;

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -372,7 +372,7 @@ impl PlanNode {
         SF: SubgraphServiceFactory,
     {
         Box::pin(async move {
-            tracing::trace!("executing plan:\n{:#?}", self);
+            tracing::info!("executing plan:\n");
             let mut value;
             let mut errors;
             let mut subselection = None;


### PR DESCRIPTION
request headers and variables are currently always added to spans, even if ftv1 or studio reporting are not active