### PR TITLE
Removed `Request::from_bytes()` from public API

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -26,6 +26,17 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 # [x.x.x] (unreleased) - 2022-mm-dd
 
 ## ❗ BREAKING ❗
+
+### Removed unused `Request::from_bytes()` from public API ([Issue #1855](https://github.com/apollographql/router/issues/1855))
+
+We've removed `Request::from_bytes()` from the public API.  We were no longer using it and we don't expect anyone external to have been relying on it.
+
+We discovered this function during an exercise of documenting our entire public API.  While we considered keeping it, it didn't necessarily meet our requirements for shipping it in the public API.  It's internal usage was removed in [`d147f97d`](https://github.com/apollographql/router/commit/d147f97d as part of [PR #429](https://github.com/apollographql/router/pull/429).
+
+We're happy to consider re-introducing this in the future (it even has a matching `Response::from_bytes()` which it composes against nicely!), but we thought it was best to remove it for the time-being.
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/TODO
+
 ## 🚀 Features
 ## 🐛 Fixes
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -35,7 +35,7 @@ We discovered this function during an exercise of documenting our entire public 
 
 We're happy to consider re-introducing this in the future (it even has a matching `Response::from_bytes()` which it composes against nicely!), but we thought it was best to remove it for the time-being.
 
-By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/TODO
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/1858
 
 ## 🚀 Features
 ## 🐛 Fixes

--- a/apollo-router/src/request.rs
+++ b/apollo-router/src/request.rs
@@ -1,4 +1,3 @@
-use bytes::Bytes;
 use derivative::Derivative;
 use serde::de::Error;
 use serde::Deserialize;

--- a/apollo-router/src/request.rs
+++ b/apollo-router/src/request.rs
@@ -180,36 +180,6 @@ impl Request {
 
         Ok(request)
     }
-
-    /// Create a [`Request`] from the supplied [`Bytes`].
-    ///
-    /// This will return an error if the input is invalid.
-    pub fn from_bytes(b: Bytes) -> Result<Request, serde_json::error::Error> {
-        let value = Value::from_bytes(b)?;
-        let mut object = ensure_object!(value).map_err(serde::de::Error::custom)?;
-
-        let variables = extract_key_value_from_object!(object, "variables", Value::Object(o) => o)
-            .map_err(serde::de::Error::custom)?
-            .unwrap_or_default();
-        let extensions =
-            extract_key_value_from_object!(object, "extensions", Value::Object(o) => o)
-                .map_err(serde::de::Error::custom)?
-                .unwrap_or_default();
-        let query = extract_key_value_from_object!(object, "query", Value::String(s) => s)
-            .map_err(serde::de::Error::custom)?
-            .map(|s| s.as_str().to_string());
-        let operation_name =
-            extract_key_value_from_object!(object, "operation_name", Value::String(s) => s)
-                .map_err(serde::de::Error::custom)?
-                .map(|s| s.as_str().to_string());
-
-        Ok(Request {
-            query,
-            operation_name,
-            variables,
-            extensions,
-        })
-    }
 }
 
 fn get_from_urldecoded<'a, T: Deserialize<'a>>(


### PR DESCRIPTION
This removes `Request::from_bytes()` from the public API.  We were no longer using it and we don't expect anyone external to have been relying on it.

This was discovered this function during an exercise of documenting our entire public API.  We considered keeping it briefly, but it doesn't necessarily meet our requirements for shipping it in the public API.  It's internal usage was removed in [`d147f97d`](https://github.com/apollographql/router/commit/d147f97d) as part of [PR #429](https://github.com/apollographql/router/pull/429).

We can consider re-introducing this in the future (it even has a matching `Response::from_bytes()` which it composes against nicely!), but it seemed worth remove it for the time-being until the use-cases are here.  (We can already see the use-cases, but we want to actually design them first.)

Closes https://github.com/apollographql/router/issues/1855
