### PR TITLE
chore(deps): Bump `apollo-server-core` versions in `tracing` Dockerfiles

### DIFF
--- a/dockerfiles/tracing/datadog-subgraph/package-lock.json
+++ b/dockerfiles/tracing/datadog-subgraph/package-lock.json
@@ -493,9 +493,9 @@
       }
     },
     "node_modules/apollo-server-core": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.0.tgz",
-      "integrity": "sha512-ln5drIk3oW/ycYhcYL9TvM7vRf7OZwJrgHWlnjnMakozBQIBSumdMi4pN001DhU9mVBWTfnmBv3CdcxJdGXIvA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.2.tgz",
+      "integrity": "sha512-/1o9KPoAMgcjJJ9Y0IH1665wf9d02L/m/mcfBOHiFmRgeGkNgrhTy59BxQTBK241USAWMhwMpp171cv/hM5Dng==",
       "dependencies": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "@apollo/utils.logger": "^1.0.0",
@@ -2249,9 +2249,9 @@
       }
     },
     "apollo-server-core": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.0.tgz",
-      "integrity": "sha512-ln5drIk3oW/ycYhcYL9TvM7vRf7OZwJrgHWlnjnMakozBQIBSumdMi4pN001DhU9mVBWTfnmBv3CdcxJdGXIvA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.2.tgz",
+      "integrity": "sha512-/1o9KPoAMgcjJJ9Y0IH1665wf9d02L/m/mcfBOHiFmRgeGkNgrhTy59BxQTBK241USAWMhwMpp171cv/hM5Dng==",
       "requires": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "@apollo/utils.logger": "^1.0.0",

--- a/dockerfiles/tracing/jaeger-subgraph/package-lock.json
+++ b/dockerfiles/tracing/jaeger-subgraph/package-lock.json
@@ -428,9 +428,9 @@
       }
     },
     "node_modules/apollo-server-core": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.0.tgz",
-      "integrity": "sha512-ln5drIk3oW/ycYhcYL9TvM7vRf7OZwJrgHWlnjnMakozBQIBSumdMi4pN001DhU9mVBWTfnmBv3CdcxJdGXIvA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.2.tgz",
+      "integrity": "sha512-/1o9KPoAMgcjJJ9Y0IH1665wf9d02L/m/mcfBOHiFmRgeGkNgrhTy59BxQTBK241USAWMhwMpp171cv/hM5Dng==",
       "dependencies": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "@apollo/utils.logger": "^1.0.0",
@@ -1783,9 +1783,9 @@
       }
     },
     "apollo-server-core": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.0.tgz",
-      "integrity": "sha512-ln5drIk3oW/ycYhcYL9TvM7vRf7OZwJrgHWlnjnMakozBQIBSumdMi4pN001DhU9mVBWTfnmBv3CdcxJdGXIvA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.2.tgz",
+      "integrity": "sha512-/1o9KPoAMgcjJJ9Y0IH1665wf9d02L/m/mcfBOHiFmRgeGkNgrhTy59BxQTBK241USAWMhwMpp171cv/hM5Dng==",
       "requires": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "@apollo/utils.logger": "^1.0.0",

--- a/dockerfiles/tracing/zipkin-subgraph/package-lock.json
+++ b/dockerfiles/tracing/zipkin-subgraph/package-lock.json
@@ -429,9 +429,9 @@
       }
     },
     "node_modules/apollo-server-core": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.0.tgz",
-      "integrity": "sha512-ln5drIk3oW/ycYhcYL9TvM7vRf7OZwJrgHWlnjnMakozBQIBSumdMi4pN001DhU9mVBWTfnmBv3CdcxJdGXIvA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.2.tgz",
+      "integrity": "sha512-/1o9KPoAMgcjJJ9Y0IH1665wf9d02L/m/mcfBOHiFmRgeGkNgrhTy59BxQTBK241USAWMhwMpp171cv/hM5Dng==",
       "dependencies": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "@apollo/utils.logger": "^1.0.0",
@@ -1842,9 +1842,9 @@
       }
     },
     "apollo-server-core": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.0.tgz",
-      "integrity": "sha512-ln5drIk3oW/ycYhcYL9TvM7vRf7OZwJrgHWlnjnMakozBQIBSumdMi4pN001DhU9mVBWTfnmBv3CdcxJdGXIvA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-3.10.2.tgz",
+      "integrity": "sha512-/1o9KPoAMgcjJJ9Y0IH1665wf9d02L/m/mcfBOHiFmRgeGkNgrhTy59BxQTBK241USAWMhwMpp171cv/hM5Dng==",
       "requires": {
         "@apollo/utils.keyvaluecache": "^1.0.1",
         "@apollo/utils.logger": "^1.0.0",


### PR DESCRIPTION
Just a depenency bump on the packages we rely on internally for testing tracing
