### PR TITLE
redact `apollo_private` fields

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -40,6 +40,12 @@ By [@abernix](https://github.com/abernix) in https://github.com/apollographql/ro
 ## 🚀 Features
 ## 🐛 Fixes
 
+### remove apollo_private and otel entries from log ([Issue #1862](https://github.com/apollographql/router/issues/1862))
+
+This change removes some apollo_private and otel fields from the logs.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1868
+
 ### update and validate configuration files ([Issue #1854](https://github.com/apollographql/router/issues/1854))
 
 Several of the dockerfiles in the router repository were out of date with respect to recent configuration changes. This fix extends our configuration testing range and updates the configuration files.

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -1026,7 +1026,7 @@ impl<B> MakeSpan<B> for PropagatingMakeSpan {
                 uri = %request.uri(),
                 version = ?request.version(),
                 "otel.kind" = %SpanKind::Server,
-                "otel.status_code" = %opentelemetry::trace::StatusCode::Unset.as_str(),
+                "otel.status_code" = tracing::field::Empty,
                 "apollo_private.duration_ns" = tracing::field::Empty
             )
         } else {
@@ -1038,7 +1038,7 @@ impl<B> MakeSpan<B> for PropagatingMakeSpan {
                 uri = %request.uri(),
                 version = ?request.version(),
                 "otel.kind" = %SpanKind::Server,
-                "otel.status_code" = %opentelemetry::trace::StatusCode::Unset.as_str(),
+                "otel.status_code" =  tracing::field::Empty,
                 "apollo_private.duration_ns" = tracing::field::Empty
             )
         }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -446,12 +446,10 @@ impl Telemetry {
                         || field.name().starts_with("otel")
                     {
                         write!(writer, "")
+                    } else if field.name() == "message" {
+                        write!(writer, "{:?}", value)
                     } else {
-                        if field.name() == "message" {
-                            write!(writer, "{:?}", value)
-                        } else {
-                            write!(writer, "{}={:?}", field, value)
-                        }
+                        write!(writer, "{}={:?}", field, value)
                     }
                 })
                 .delimited(" ")

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -443,10 +443,9 @@ impl Telemetry {
 
                 let formatter = debug_fn(|writer, field, value| {
                     if field.name().starts_with("apollo_private") {
-                        // XXX: Are these being correctly delimited?
-                        write!(writer, "{}: null", field)
+                        write!(writer, "")
                     } else {
-                        write!(writer, "{}: {:?}", field, value)
+                        write!(writer, "{}={:?}", field, value)
                     }
                 })
                 .delimited(", ")
@@ -1330,15 +1329,9 @@ impl<'a> FormatFields<'a> for RouterJsonFields {
 
         current_map.extend(new_map);
 
-        for (key, value) in current_map.iter_mut() {
-            if key.starts_with("apollo_private") {
-                // XXX: WHY DOES THIS NOT WORK?
-                // *value = serde_json::from_str("REDACTED").map_err(|_| fmt::Error)?;
-                *value = serde_json::Value::Null;
-            }
-        }
+        current_map.retain(|k, _v| !k.starts_with("apollo_private"));
 
-        // Finally serialize our merged, redacted output to be our set of fields.
+        // Serialize our merged, redacted output to be our set of fields.
         current.fields = serde_json::to_string(&current_map).map_err(|_| fmt::Error)?;
 
         Ok(())

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -442,8 +442,8 @@ impl Telemetry {
                     .unwrap_or("info");
 
                 let formatter = debug_fn(|writer, field, value| {
-                    if field.name().starts_with("apollo_private")
-                        || field.name().starts_with("otel")
+                    if field.name().starts_with("apollo_private.")
+                        || field.name().starts_with("otel.")
                     {
                         write!(writer, "")
                     } else if field.name() == "message" {
@@ -1317,9 +1317,10 @@ impl<'a> FormatFields<'a> for RouterJsonFields {
         //
         // We do this by converting our existing formatted string into a
         // map and creating a new visitor to record the new fields, which
-        // we then convert into a map.
+        // we also convert into a map.
         //
-        // We merge the maps and then remove the apollo_private keys.
+        // We merge the maps and finally remove the apollo_private and otel
+        // keys.
 
         let mut new = String::new();
         let mut v = JsonVisitor::new(&mut new);
@@ -1333,7 +1334,7 @@ impl<'a> FormatFields<'a> for RouterJsonFields {
 
         current_map.extend(new_map);
 
-        current_map.retain(|k, _v| !k.starts_with("apollo_private") && !k.starts_with("otel"));
+        current_map.retain(|k, _v| !k.starts_with("apollo_private.") && !k.starts_with("otel."));
 
         // Serialize our merged, redacted output to be our set of fields.
         current.fields = serde_json::to_string(&current_map).map_err(|_| fmt::Error)?;

--- a/licenses.html
+++ b/licenses.html
@@ -44,7 +44,7 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#MIT">MIT License</a> (81)</li>
+            <li><a href="#MIT">MIT License</a> (80)</li>
             <li><a href="#Apache-2.0">Apache License 2.0</a> (54)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (8)</li>
             <li><a href="#ISC">ISC License</a> (8)</li>
@@ -6697,7 +6697,6 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/dtolnay/async-trait ">async-trait</a></li>
                     <li><a href=" https://github.com/cuviper/autocfg ">autocfg</a></li>
                     <li><a href=" https://github.com/cuviper/autocfg ">autocfg</a></li>
-                    <li><a href=" https://github.com/ihrwein/backoff ">backoff</a></li>
                     <li><a href=" https://github.com/rust-lang/backtrace-rs ">backtrace</a></li>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64</a></li>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64</a></li>
@@ -12490,35 +12489,6 @@ SOFTWARE.
                 <pre class="license-text">MIT License
 
 Copyright (c) 2021 MarcusGrass
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/apollographql/introspector-gadget ">introspector-gadget</a></li>
-                </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2022 Apollo GraphQL
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal


### PR DESCRIPTION
The JSON bit is a bit finicky but so is the code in the `tracing_subscriber` crate which I've mainly just lifted here.

fixes: #1862
fixes: #1869 