### PR TITLE
Do not erase errors when missing  _entities

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -46,6 +46,14 @@ Several of the dockerfiles in the router repository were out of date with respec
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1857
 
+### Do not erase errors when missing `_entities` ([Issue #1863](https://github.com/apollographql/router/issues/1863))
+
+in a federated query, if the subgraph returned a response with errors and a null or absent data field, the router
+was ignoring the subgraph error and instead returning an error complaining about the missing` _entities` field.
+This will now aggregate the subgraph error and the missing `_entities` error.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1870
+
 ## 🛠 Maintenance
 
 ### Disable Deno snapshotting on docs.rs

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -3048,12 +3048,11 @@ Content-Type: application/json\r
                     },
                     "errors": [
                         {
-                            "message": "invalid content: Missing key `_entities`!",
-                            "path": ["topProducts", "@"],
-                            "extensions": {
-                                "type": "ExecutionInvalidContent",
-                                "reason": "Missing key `_entities`!"
-                            }
+                            "message": "couldn't find mock for query {\"query\":\"query TopProducts__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on Product{reviews{__typename id product{__typename upc}}}}}\",\"operationName\":\"TopProducts__reviews__1\",\"variables\":{\"representations\":[{\"__typename\":\"Product\",\"upc\":\"1\"},{\"__typename\":\"Product\",\"upc\":\"2\"}]}}"
+                        },
+                        {
+                            "message": "Missing key `_entities`!",
+                            "path": [ "topProducts", "@" ]
                         }],
                     "hasNext": true,
                 },

--- a/apollo-router/src/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_http_server_factory.rs
@@ -3224,7 +3224,7 @@ Content-Type: application/json\r
                             "message": "couldn't find mock for query {\"query\":\"query TopProducts__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on Product{reviews{__typename id product{__typename upc}}}}}\",\"operationName\":\"TopProducts__reviews__1\",\"variables\":{\"representations\":[{\"__typename\":\"Product\",\"upc\":\"1\"},{\"__typename\":\"Product\",\"upc\":\"2\"}]}}"
                         },
                         {
-                            "message": "Missing key `_entities`!",
+                            "message": "Subgraph response from 'reviews' was missing key `_entities`",
                             "path": [ "topProducts", "@" ]
                         }],
                     "hasNext": true,

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -1124,7 +1124,10 @@ pub(crate) mod fetch {
                 errors.push(
                     Error::builder()
                         .path(current_dir.clone())
-                        .message("Missing key `_entities`!".to_string())
+                        .message(format!(
+                            "Subgraph response from '{}' was missing key `_entities`",
+                            self.service_name
+                        ))
                         .build(),
                 );
 

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -1111,18 +1111,6 @@ pub(crate) mod fetch {
                         if let Value::Array(array) = entities {
                             let mut value = Value::default();
 
-                            if paths.len() != array.len() {
-                                errors.push(
-                                    Error::builder()
-                                        .path(current_dir.clone())
-                                        .message(format!(
-                                            "Expected \"data._entities\" to contain {} elements",
-                                            paths.len()
-                                        ))
-                                        .build(),
-                                );
-                            }
-
                             for (path, entity_idx) in paths {
                                 if let Some(entity) = array.get(entity_idx) {
                                     let _ = value.insert(&path, entity.clone());


### PR DESCRIPTION
fix #1863

in a federated query, if the subgraph returns a response with errors and a null or absent data field, the router was ignoring the subgraph error and instead returning an error complaining about the missing `_entities` field. This will now aggregate the subgraph error and the missing `_entities` error