### PR TITLE
Don’t install the rustc-docs component on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ commands:
             echo "Downloading rustup"
             (New-Object System.Net.WebClient).DownloadFile("https://win.rustup.rs/x86_64", "$installer_dir\rustup-init.exe")
             echo "Installing rustup"
-            & $installer_dir\rustup-init.exe --profile minimal --component rustfmt,clippy -y
+            & $installer_dir\rustup-init.exe -y --default-toolchain none --profile minimal
             exit $LASTEXITCODE
       - run:
           name: Special case for Windows because of ssh-agent
@@ -115,7 +115,7 @@ commands:
           command: |
             curl https://sh.rustup.rs -sSf -o rustup.sh
             chmod 755 ./rustup.sh
-            ./rustup.sh -y --default-toolchain none
+            ./rustup.sh -y --default-toolchain none --profile minimal
             echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"
 
   install_extra_tools:


### PR DESCRIPTION
See https://rust-lang.github.io/rustup/concepts/profiles.html

Compared to the default profile, the minimal profile removes rust-docs, rustfmt, and clippy. However we still request rustfmt and clippy through rust-toolchain.toml.

Also apply https://github.com/apollographql/router/pull/1877 (not installing a redundant toolchain) for Windows CI.