### PR TITLE
also update the rust build crate for diy dockerfiles

### DIFF
--- a/dockerfiles/diy/dockerfiles/Dockerfile.repo
+++ b/dockerfiles/diy/dockerfiles/Dockerfile.repo
@@ -1,6 +1,6 @@
 # Use the rust build image from docker as our base
 # renovate-automation: rustc version
-FROM rust:1.61.0 as build
+FROM rust:1.63.0 as build
 
 # Set our working directory for the build
 WORKDIR /usr/src/router


### PR DESCRIPTION
This was missed in the fix for #1721. It should have been included in PR: #1722 