### PR TITLE
fix the recently added servicemonitor features

### DIFF
--- a/helm/chart/router/templates/service.yaml
+++ b/helm/chart/router/templates/service.yaml
@@ -20,7 +20,7 @@ spec:
       protocol: TCP
       name: health
     {{- if .Values.serviceMonitor.enabled }}
-    - port: {{ .Values.serviceMonitor.port }}
+    - port: {{ (splitList ":" .Values.router.configuration.telemetry.metrics.prometheus.listen | last) | default "9090" }}
       targetPort: metrics
       protocol: TCP
       name: metrics

--- a/helm/chart/router/templates/servicemonitor.yaml
+++ b/helm/chart/router/templates/servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   endpoints:
   - path: {{ include "router.prometheusMetricsPath" . }}
-    port: metrics
+    port: {{ (splitList ":" .Values.router.configuration.telemetry.metrics.prometheus.listen | last) | default "9090" | quote }}
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/helm/chart/router/templates/servicemonitor.yaml
+++ b/helm/chart/router/templates/servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   endpoints:
   - path: {{ include "router.prometheusMetricsPath" . }}
-    port: {{ (splitList ":" .Values.router.configuration.telemetry.metrics.prometheus.listen | last) | default "9090" | quote }}
+    port: metrics
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}


### PR DESCRIPTION
The recently added serviceMonitor functionality isn't quite correct:

 - There is no .Values.serviceMonitor.port

This PR fixes this problem.
