### PR TITLE
Remove note about Apollo Server docs from homepage

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -108,6 +108,12 @@ execution service returning a stream of invalid responses, so the execution plug
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1771
 
+### Hide footer from "homepage" landing page ([PR #1900](https://github.com/apollographql/router/pull/1900))
+
+Hides some incorrect language about customization on the landing page.  Currently to customize the landing page it requires additional support.
+
+By [@glasser](https://github.com/glasser) in https://github.com/apollographql/router/pull/1900
+
 ## 🛠 Maintenance
 
 ### Change span attribute names in otel to be more consistent ([PR #1876](https://github.com/apollographql/router/pull/1876))

--- a/apollo-router/templates/homepage_index.html
+++ b/apollo-router/templates/homepage_index.html
@@ -41,7 +41,7 @@
                 <h1>Welcome to the Apollo Router</h1>
                 <p>It appears that you might be offline. POST to this endpoint to query your graph:</p>
             </div>
-            <script>window.landingPage = `{ "isProd": true }`;</script>
+            <script>window.landingPage = `{ "isProd": true, "footer": false }`;</script>
             <script src="https://apollo-server-landing-page.cdn.apollographql.com/_latest/static/js/main.js"></script>
         </div>
     </body>


### PR DESCRIPTION
The 'homepage' option displays the studio landing page (https://github.com/apollographql/studio-landing-page/blob/main/src/App.tsx). If you don't pass `footer: false`, it adds a footer that says "This page can be customized or hidden. Learn more in the Apollo Server Docs" which is inappropriate for Router (because it is not Apollo Server, and because the page can't be customized other than by replacing it with a different page.)