### PR TITLE
replace lrucache with hashmap

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -136,6 +136,12 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 
 ## 🛠 Maintenance
 
+### replace lrucache with hashmap in telemetry ([PR #1934](https://github.com/apollographql/router/pull/1934))
+
+I didn't see this figure go past 10 entries in my testing, so there doesn't appear to be a requirement for an lrucache. I've left the configuration element, but reduced it to 64 (from 10,000).
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1934
+
 ### Fix hpa yaml for appropriate kubernetes versions ([#1908](https://github.com/apollographql/router/pull/1908))
 
 Correct schema for autoscaling/v2beta2 and autoscaling/v2 api versions of the

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -648,7 +648,7 @@ expression: "&schema"
           "properties": {
             "buffer_size": {
               "description": "The buffer size for sending traces to Apollo. Increase this if you are experiencing lost traces.",
-              "default": 10000,
+              "default": 64,
               "type": "integer",
               "format": "uint",
               "minimum": 0.0

--- a/apollo-router/src/plugins/telemetry/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/apollo.rs
@@ -106,7 +106,7 @@ const fn client_version_header_default() -> HeaderName {
 }
 
 pub(crate) const fn default_buffer_size() -> usize {
-    10000
+    64
 }
 
 impl Default for Config {


### PR DESCRIPTION
I was searching for memory issues in the router and noted that we used lru cache where we probably only needed a hashmap.

The cache is loaded and emptied over a fairly tight iteration in the export function, so I don't know why this is using a long lived cache. I also noted that the API complained about the fact it had to do a double lookup, which isn't required with hashmap.

In my testing I never found more than 10 entries in the map, so I've configured it to accept 64.
