### PR TITLE
expose the TraceId functionality to rhai

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -113,7 +113,7 @@ By [@garypen](https://github.com/garypen) in https://github.com/apollographql/ro
 
 ### Expose the TraceId functionality to rhai ([Issue #1935](https://github.com/apollographql/router/issues/1935))
     
-A new function, traceid(), is exposed to rhai scripts which may be used to retrieve a unique trace id for a request. The trace id is an opentelemetry span id.     
+A new function, traceid(), is exposed to rhai scripts which may be used to retrieve a unique trace id for a request. The trace id is an opentelemetry span id.  
 
 ```
 fn supergraph_service(service) {

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -110,9 +110,30 @@ This will mount the confimap created above in the `/dist/rhai` directory with tw
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1917
 
 ## 🚀 Features
+
+### Expose the TraceId functionality to rhai ([Issue #1935](https://github.com/apollographql/router/issues/1935))
+    
+A new function, traceid(), is exposed to rhai scripts which may be used to retrieve a unique trace id for a request. The trace id is an opentelemetry span id.     
+
+```
+fn supergraph_service(service) {
+    try {
+        let id = traceid();
+        print(`id: ${id}`);
+    }
+    catch(err)
+    {
+        // log any errors
+        log_error(`span id error: ${err}`);
+    }
+}
+```
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1937
+
 ## 🐛 Fixes
 
-### Fix studio reporting failures ([Issue #1903](https://github.com/apollographql/router/issues/1903))
+### Fix studio reporting failures ([Issue #1903](https://github.com/apollographql/router/issues/1937))
 
 The root cause of the issue was letting the server component of spaceport close silently during a re-configuration or schema reload. This fixes the issue by keeping the server component alive as long as the client remains connected.
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -133,7 +133,7 @@ By [@garypen](https://github.com/garypen) in https://github.com/apollographql/ro
 
 ## 🐛 Fixes
 
-### Fix studio reporting failures ([Issue #1903](https://github.com/apollographql/router/issues/1937))
+### Fix studio reporting failures ([Issue #1903](https://github.com/apollographql/router/issues/1903))
 
 The root cause of the issue was letting the server component of spaceport close silently during a re-configuration or schema reload. This fixes the issue by keeping the server component alive as long as the client remains connected.
 

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -50,6 +50,7 @@ use crate::layers::ServiceBuilderExt;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::register_plugin;
+use crate::tracer::TraceId;
 use crate::Context;
 use crate::ExecutionRequest;
 use crate::ExecutionResponse;
@@ -1050,6 +1051,7 @@ impl Rhai {
             .register_type::<Value>()
             .register_type::<Error>()
             .register_type::<Uri>()
+            .register_type::<TraceId>()
             // Register HeaderMap as an iterator so we can loop over contents
             .register_iterator::<HeaderMap>()
             // Register a contains function for HeaderMap so that "in" works
@@ -1239,6 +1241,11 @@ impl Rhai {
                 x.extensions = from_dynamic(&om.into())?;
                 Ok(())
             })
+            // TraceId support
+            .register_fn("traceid", || -> Result<TraceId, Box<EvalAltResult>> {
+                TraceId::maybe_new().ok_or_else(|| "trace unavailable".into())
+            })
+            .register_fn("to_string", |id: &mut TraceId| -> String { id.to_string() })
             // Register a series of logging functions
             .register_fn("log_trace", |out: Dynamic| {
                 tracing::trace!(%out, "rhai_trace");

--- a/apollo-router/src/tracer.rs
+++ b/apollo-router/src/tracer.rs
@@ -39,7 +39,7 @@ impl TraceId {
 
 impl fmt::Display for TraceId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.to_u128())
+        write!(f, "{:032x}", self.to_u128())
     }
 }
 

--- a/apollo-router/src/tracer.rs
+++ b/apollo-router/src/tracer.rs
@@ -5,11 +5,12 @@ use std::fmt;
 
 use opentelemetry::trace::TraceContextExt;
 use opentelemetry::trace::TraceId as OtelTraceId;
+use serde::Serialize;
 use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 /// Trace ID
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 pub struct TraceId([u8; 16]);
 
 impl TraceId {

--- a/docs/source/customizations/rhai-api.mdx
+++ b/docs/source/customizations/rhai-api.mdx
@@ -102,6 +102,24 @@ fn supergraph_service(service) {
 }
 ```
 
+## Accessing a TraceId
+
+Your Rhai customization can use the function `traceid()` to retrieve an opentelemetry span id. This will throw an exception if a span is not available, so always handle exceptions when using this function.
+
+```rhai
+fn supergraph_service(service) {
+    try {
+        let id = traceid();
+        print(`id: ${id}`);
+    }
+    catch(err)
+    {
+        // log any errors
+        log_error(`span id error: ${err}`);
+    }
+}
+```
+
 ## `Request` interface
 
 All callback functions registered via `map_request` are passed a `request` object that represents the request sent by the client. This object provides the following fields, any of which a callback can modify in-place:

--- a/examples/rhai-surrogate-cache-key/src/rhai_surrogate_cache_key.rhai
+++ b/examples/rhai-surrogate-cache-key/src/rhai_surrogate_cache_key.rhai
@@ -24,7 +24,7 @@ fn supergraph_service(service) {
         catch(err)
         {
             // log any errors
-            error_log(`surrogate-cache-key not created: ${err}`);
+            log_error(`surrogate-cache-key not created: ${err}`);
         }
     };
     // Map our response using our closure


### PR DESCRIPTION
issue: #1935 suggested exposing a span's trace id via the Context. I think it's better to avoid further use of the context and provide direct acccess to the traceid from `rhai`. (Note: In case it isn't obvious the `TraceId` is the opentelemetry Span Id.)

If you ran code like the docs example, you'd see something like:
```
2022-10-10T11:37:58.404084Z  INFO apollo_router::plugins::rhai: id: 338600282987103915558890515230971876324
```

fixes: #1935

also: drive by fix of the `log_error` in the surrogate example.