### PR TITLE
fix: float coercion rules should validate i64s

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -25,3 +25,10 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 
 # [x.x.x] (unreleased) - 2022-mm-dd
 
+## 🐛 Fixes
+
+### Fix a coercion rule that failed to validate 64 bit integers ([PR #1951](https://github.com/apollographql/router/pull/1951))
+
+Queries that passed 64 bit integers for Float values would (incorrectly) fail to validate.
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/1951

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -352,10 +352,10 @@ impl ValueExt for Value {
         match self {
             // When expected as an input type, both integer and float input values are accepted.
             Value::Number(n) if n.is_f64() => true,
-            // The Int scalar type represents a signed 32-bit numeric non-fractional value.
+            // Integer input values are coerced to Float by adding an empty fractional part, for example 1.0 for the integer input value 1.
             Value::Number(n) => n
                 .as_i64()
-                .map(|as_number| i32::try_from(as_number).is_ok())
+                .map(|as_number| i64::try_from(as_number).is_ok())
                 .unwrap_or_default(),
             // All other input values, including strings with numeric content, must raise a request error indicating an incorrect type.
             _ => false,

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -353,10 +353,7 @@ impl ValueExt for Value {
             // When expected as an input type, both integer and float input values are accepted.
             Value::Number(n) if n.is_f64() => true,
             // Integer input values are coerced to Float by adding an empty fractional part, for example 1.0 for the integer input value 1.
-            Value::Number(n) => n
-                .as_i64()
-                .map(|as_number| i64::try_from(as_number).is_ok())
-                .unwrap_or_default(),
+            Value::Number(n) => n.is_i64(),
             // All other input values, including strings with numeric content, must raise a request error indicating an incorrect type.
             _ => false,
         }

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -1053,6 +1053,17 @@ fn variable_validation() {
     // When expected as an input type, both integer and float input values are accepted.
     assert_validation!(schema, "query($foo:Float){x}", json!({"foo":2}));
     assert_validation!(schema, "query($foo:Float){x}", json!({"foo":2.0}));
+    // double precision floats are valid
+    assert_validation!(
+        schema,
+        "query($foo:Float){x}",
+        json!({"foo":1600341978193i64})
+    );
+    assert_validation!(
+        schema,
+        "query($foo:Float){x}",
+        json!({"foo":1600341978193f64})
+    );
     // All other input values, including strings with numeric content,
     // must raise a request error indicating an incorrect type.
     assert_validation_error!(schema, "query($foo:Float){x}", json!({"foo":"2.0"}));


### PR DESCRIPTION
### Fix a coercion rule that failed to validate 64 bit integers ([PR #1951](https://github.com/apollographql/router/pull/1951))

Queries that passed 64 bit integers for Float values would (incorrectly) fail to validate.
