### PR TITLE
split circleci machine types into build/test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,7 +320,7 @@ jobs:
             - xtask_lint:
                 os: linux_amd
       - persist_to_workspace:
-          root: workspace
+          root: .
           paths:
             - .
   check_compliance:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ parameters:
   cache_version:
     type: string
     # increment this to invalidate all the caches
-    default: v11.{{ arch}}-{{ checksum "rust-toolchain.toml" }}
+    default: v12-lean.{{ arch}}-{{ checksum "rust-toolchain.toml" }}
   jaeger_version:
     type: string
     # update this as new versions of jaeger become available

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,6 +310,7 @@ jobs:
       platform:
         type: executor
     executor: << parameters.platform >>
+    working_directory: ~/project/<< parameters.platform >>
     steps:
       - checkout
       # - when:
@@ -326,6 +327,7 @@ jobs:
       platform:
         type: executor
     executor: << parameters.platform >>
+    working_directory: ~/project/<< parameters.platform >>
     steps:
       - when:
           condition:
@@ -341,6 +343,7 @@ jobs:
       platform:
         type: executor
     executor: << parameters.platform >>
+    working_directory: ~/project/<< parameters.platform >>
     steps:
       - checkout
       - when:
@@ -372,7 +375,7 @@ jobs:
             - build_workspace:
                 os: macos
       - persist_to_workspace:
-          root: .
+          root: ~/project/<< parameters.platform >>
           paths:
             - target
   test:
@@ -382,10 +385,11 @@ jobs:
       platform:
         type: executor
     executor: << parameters.platform >>
+    working_directory: ~/project/<< parameters.platform >>
     steps:
       - checkout
       - attach_workspace:
-          at: target
+          at: ~/project/<< parameters.platform >>/target
       - when:
           condition:
             equal: [*rust_amd_linux_test_executor, << parameters.platform >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,12 +258,12 @@ commands:
       - persist_to_workspace:
           root: .
           paths:
-            - target
+            - project\target
 
   windows_test_workspace:
     steps:
       - attach_workspace:
-          at: target
+          at: project\target
       - run:
           name: Start jaeger
           background: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,13 +373,13 @@ jobs:
             - linux_arm_install_baseline
             - build_workspace:
                 os: linux_arm
-      - when:
-          condition:
-            equal: [*rust_windows_build_executor, << parameters.platform >>]
-          steps:
-            - windows_install_baseline
-            - windows_prepare_env
-            - windows_build_workspace
+                # - when:
+                  # condition:
+                    # equal: [*rust_windows_build_executor, << parameters.platform >>]
+                    # steps:
+                      # - windows_install_baseline
+                      # - windows_prepare_env
+                      # - windows_build_workspace
       - when:
           condition:
             equal: [*rust_macos_executor, << parameters.platform >>]
@@ -411,13 +411,13 @@ jobs:
             - linux_arm_install_baseline
             - test_workspace:
                 os: linux_arm
-      - when:
-          condition:
-            equal: [*rust_windows_test_executor, << parameters.platform >>]
-          steps:
-            - windows_install_baseline
-            - windows_prepare_env
-            - windows_test_workspace
+                # - when:
+                  # condition:
+                    # equal: [*rust_windows_test_executor, << parameters.platform >>]
+                    # steps:
+                      # - windows_install_baseline
+                      # - windows_prepare_env
+                      # - windows_test_workspace
       - when:
           condition:
             equal: [*rust_macos_executor, << parameters.platform >>]
@@ -439,9 +439,6 @@ jobs:
       MACOS_PRIMARY_BUNDLE_ID: com.apollographql.router
     steps:
       - checkout
-      - run:
-          name: Initialize submodules
-          command: git submodule update --recursive --init
       - when:
           condition:
             equal: [*rust_macos_executor, << parameters.platform >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,7 +347,7 @@ jobs:
     executor: << parameters.platform >>
     steps:
       - attach_workspace:
-          at: project
+          at: .
       - when:
           condition:
             equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
@@ -385,7 +385,7 @@ jobs:
     executor: << parameters.platform >>
     steps:
       - attach_workspace:
-          at: project
+          at: .
       - when:
           condition:
             equal: [*rust_amd_linux_test_executor, << parameters.platform >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,9 @@ parameters:
     type: string
     # update this as new versions of jaeger become available
     default: "1.33.0"
+  target_dir:
+    type: string
+    default: "~/project/target"
 
 # These are common environment variables that we want to set on on all jobs.
 # While these could conceivably be set on the CircleCI project settings'
@@ -222,8 +225,6 @@ commands:
     parameters:
       os:
         type: string
-      target_dir:
-        type: string
     steps:
       - restore_cache:
           name: Restore .cargo
@@ -239,7 +240,7 @@ commands:
       - persist_to_workspace:
           root: .
           paths:
-            - target.<< parameters.target_dir >>
+            - << pipeline.parameters.target_dir >>
 
   windows_build_workspace:
     steps:
@@ -283,11 +284,9 @@ commands:
     parameters:
       os:
         type: string
-      target_dir:
-        type: string
     steps:
       - attach_workspace:
-          at: target.<< parameters.target_dir >>
+          at: << pipeline.parameters.target_dir >>
       - run:
           name: Start jaeger
           background: true
@@ -353,7 +352,7 @@ jobs:
   build:
     environment:
       <<: *common_job_environment
-      CARGO_TARGET_DIR: ~/project/target.<< parameters.platform >>
+      CARGO_TARGET_DIR: << pipeline.parameters.target_dir >>
     parameters:
       platform:
         type: executor
@@ -367,7 +366,6 @@ jobs:
             - linux_amd_install_baseline
             - build_workspace:
                 os: linux_amd
-                target_dir: ~/project/target.<< parameters.platform>>
       - when:
           condition:
             equal: [*rust_arm_linux_build_executor, << parameters.platform >>]
@@ -375,7 +373,6 @@ jobs:
             - linux_arm_install_baseline
             - build_workspace:
                 os: linux_arm
-                target_dir: ~/project/target.<< parameters.platform>>
       - when:
           condition:
             equal: [*rust_windows_build_executor, << parameters.platform >>]
@@ -390,7 +387,6 @@ jobs:
             - macos_install_baseline
             - build_workspace:
                 os: macos
-                target_dir: ~/project/target.<< parameters.platform>>
   test:
     environment:
       <<: *common_job_environment
@@ -408,7 +404,6 @@ jobs:
             - linux_amd_install_baseline
             - test_workspace:
                 os: linux_amd
-                target_dir: ~/project/target.<< parameters.platform>>
       - when:
           condition:
             equal: [*rust_arm_linux_test_executor, << parameters.platform >>]
@@ -416,7 +411,6 @@ jobs:
             - linux_arm_install_baseline
             - test_workspace:
                 os: linux_arm
-                target_dir: ~/project/target.<< parameters.platform>>
       - when:
           condition:
             equal: [*rust_windows_test_executor, << parameters.platform >>]
@@ -431,7 +425,6 @@ jobs:
             - macos_install_baseline
             - test_workspace:
                 os: macos
-                target_dir: ~/project/target.<< parameters.platform>>
 
   build_release:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - .
+            - project
   check_compliance:
     environment:
       <<: *common_job_environment
@@ -347,7 +347,7 @@ jobs:
     executor: << parameters.platform >>
     steps:
       - attach_workspace:
-          at: .
+          at: project
       - when:
           condition:
             equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
@@ -385,7 +385,7 @@ jobs:
     executor: << parameters.platform >>
     steps:
       - attach_workspace:
-          at: .
+          at: project
       - when:
           condition:
             equal: [*rust_amd_linux_test_executor, << parameters.platform >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,15 +312,15 @@ jobs:
     executor: << parameters.platform >>
     steps:
       - checkout
-      - when:
-          condition:
-            equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
-          steps:
-            - linux_amd_install_baseline
-            - xtask_lint:
-                os: linux_amd
+      # - when:
+        # condition:
+          # equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
+          # steps:
+            # - linux_amd_install_baseline
+            # - xtask_lint:
+              # os: linux_amd
       - persist_to_workspace:
-          root: .
+          root: project
           paths:
             - "*"
   check_compliance:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,6 @@ commands:
           key: rust-cargo-<< pipeline.parameters.cache_version >>-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo
-            - ~/project
 
   windows_build_workspace:
     steps:
@@ -249,7 +248,6 @@ commands:
           key: rust-cargo-<< pipeline.parameters.cache_version >>-build-windows-{{ checksum "Cargo.lock" }}
           paths:
             - C:\\Users\\circleci\.cargo
-            - C:\\Users\\circleci\project
 
   windows_test_workspace:
     steps:
@@ -268,7 +266,6 @@ commands:
           key: rust-cargo-<< pipeline.parameters.cache_version >>-test-windows-{{ checksum "Cargo.lock" }}
           paths:
             - C:\\Users\\circleci\.cargo
-            - C:\\Users\\circleci\project
 
   test_workspace:
     parameters:
@@ -304,7 +301,6 @@ commands:
           key: rust-cargo-<< pipeline.parameters.cache_version >>-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo
-            - ~/project
 
 jobs:
   lint:
@@ -323,12 +319,10 @@ jobs:
             - linux_amd_install_baseline
             - xtask_lint:
                 os: linux_amd
-      - save_cache:
-          name: Save .cargo
-          key: rust-cargo-<< pipeline.parameters.cache_version >>-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+      - persist_to_workspace:
+          root: workspace
           paths:
-            - ~/.cargo
-            - ~/project
+            - project
   check_compliance:
     environment:
       <<: *common_job_environment
@@ -352,6 +346,8 @@ jobs:
         type: executor
     executor: << parameters.platform >>
     steps:
+      - attach_workspace:
+          at: project
       - when:
           condition:
             equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
@@ -388,6 +384,8 @@ jobs:
         type: executor
     executor: << parameters.platform >>
     steps:
+      - attach_workspace:
+          at: project
       - when:
           condition:
             equal: [*rust_amd_linux_test_executor, << parameters.platform >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,7 +320,7 @@ jobs:
             # - xtask_lint:
               # os: linux_amd
       - persist_to_workspace:
-          root: project
+          root: .
           paths:
             - "*"
   check_compliance:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ parameters:
     default: "1.33.0"
   target_dir:
     type: string
-    default: "~/project/target"
+    default: "project/target"
 
 # These are common environment variables that we want to set on on all jobs.
 # While these could conceivably be set on the CircleCI project settings'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ parameters:
     default: "1.33.0"
   target_dir:
     type: string
-    default: target-{{ arch }}
+    default: target-{{ arch}}
 
 # These are common environment variables that we want to set on on all jobs.
 # While these could conceivably be set on the CircleCI project settings'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ parameters:
   cache_version:
     type: string
     # increment this to invalidate all the caches
-    default: v12-lean.{{ arch }}-{{ checksum "rust-toolchain.toml" }}
+    default: v11.{{ arch}}-{{ checksum "rust-toolchain.toml" }}
   jaeger_version:
     type: string
     # update this as new versions of jaeger become available
@@ -234,10 +234,6 @@ commands:
           key: rust-cargo-<< pipeline.parameters.cache_version >>-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo
-      - persist_to_workspace:
-          root: .
-          paths:
-            - target-{{ arch }}
 
   windows_build_workspace:
     steps:
@@ -252,15 +248,9 @@ commands:
           key: rust-cargo-<< pipeline.parameters.cache_version >>-build-windows-{{ checksum "Cargo.lock" }}
           paths:
             - C:\\Users\\circleci\.cargo
-      - persist_to_workspace:
-          root: .
-          paths:
-            - target
 
   windows_test_workspace:
     steps:
-      - attach_workspace:
-          at: project\target
       - run:
           name: Start jaeger
           background: true
@@ -282,8 +272,6 @@ commands:
       os:
         type: string
     steps:
-      - attach_workspace:
-          at: target-{{ arch }}
       - run:
           name: Start jaeger
           background: true
@@ -324,13 +312,13 @@ jobs:
     executor: << parameters.platform >>
     steps:
       - checkout
-      # - when:
-        # condition:
-          # equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
-          # steps:
-            # - linux_amd_install_baseline
-            # - xtask_lint:
-              # os: linux_amd
+      - when:
+          condition:
+            equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
+          steps:
+            - linux_amd_install_baseline
+            - xtask_lint:
+                os: linux_amd
   check_compliance:
     environment:
       <<: *common_job_environment
@@ -339,6 +327,7 @@ jobs:
         type: executor
     executor: << parameters.platform >>
     steps:
+      - checkout
       - when:
           condition:
             equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
@@ -349,7 +338,6 @@ jobs:
   build:
     environment:
       <<: *common_job_environment
-      CARGO_TARGET_DIR: target-{{ arch }}
     parameters:
       platform:
         type: executor
@@ -370,13 +358,13 @@ jobs:
             - linux_arm_install_baseline
             - build_workspace:
                 os: linux_arm
-                # - when:
-                  # condition:
-                    # equal: [*rust_windows_build_executor, << parameters.platform >>]
-                    # steps:
-                      # - windows_install_baseline
-                      # - windows_prepare_env
-                      # - windows_build_workspace
+      - when:
+          condition:
+            equal: [*rust_windows_build_executor, << parameters.platform >>]
+          steps:
+            - windows_install_baseline
+            - windows_prepare_env
+            - windows_build_workspace
       - when:
           condition:
             equal: [*rust_macos_executor, << parameters.platform >>]
@@ -387,7 +375,6 @@ jobs:
   test:
     environment:
       <<: *common_job_environment
-      CARGO_TARGET_DIR: target-{{ arch }}
     parameters:
       platform:
         type: executor
@@ -408,13 +395,13 @@ jobs:
             - linux_arm_install_baseline
             - test_workspace:
                 os: linux_arm
-                # - when:
-                  # condition:
-                    # equal: [*rust_windows_test_executor, << parameters.platform >>]
-                    # steps:
-                      # - windows_install_baseline
-                      # - windows_prepare_env
-                      # - windows_test_workspace
+      - when:
+          condition:
+            equal: [*rust_windows_test_executor, << parameters.platform >>]
+          steps:
+            - windows_install_baseline
+            - windows_prepare_env
+            - windows_test_workspace
       - when:
           condition:
             equal: [*rust_macos_executor, << parameters.platform >>]
@@ -436,6 +423,9 @@ jobs:
       MACOS_PRIMARY_BUNDLE_ID: com.apollographql.router
     steps:
       - checkout
+      - run:
+          name: Initialize submodules
+          command: git submodule update --recursive --init
       - when:
           condition:
             equal: [*rust_macos_executor, << parameters.platform >>]
@@ -572,13 +562,12 @@ jobs:
             helm push ${CHART} oci://ghcr.io/apollographql/helm-charts
 
 workflows:
-  version: 2
   ci_checks:
     jobs:
       - lint:
           matrix:
             parameters:
-              platform: [rust_macos, rust_windows_build, rust_amd_linux_build, rust_arm_linux_build]
+              platform: [rust_amd_linux_build]
 
       # check-compliance is disabled for now because it is flaky
       # `cargo about` seems to be non-deterministic and sometimes
@@ -586,21 +575,15 @@ workflows:
       # For now, we’ll re-generate it for each release instead. (See RELEASE_CHECKLIST.md)
 
       # - check_compliance:
-      #     requires:
-      #       - lint
       #     matrix:
       #       parameters:
       #         platform: [rust_linux]
 
       - build:
-          requires:
-            - lint
           matrix:
             parameters:
               platform: [rust_macos, rust_windows_build, rust_amd_linux_build, rust_arm_linux_build]
       - test:
-          requires:
-            - build
           matrix:
             parameters:
               platform: [rust_macos, rust_windows_test, rust_amd_linux_test, rust_arm_linux_test]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - project
+            - "*"
   check_compliance:
     environment:
       <<: *common_job_environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,10 +319,6 @@ jobs:
             # - linux_amd_install_baseline
             # - xtask_lint:
               # os: linux_amd
-      - persist_to_workspace:
-          root: .
-          paths:
-            - "*"
   check_compliance:
     environment:
       <<: *common_job_environment
@@ -346,8 +342,7 @@ jobs:
         type: executor
     executor: << parameters.platform >>
     steps:
-      - attach_workspace:
-          at: .
+      - checkout
       - when:
           condition:
             equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
@@ -376,6 +371,10 @@ jobs:
             - macos_install_baseline
             - build_workspace:
                 os: macos
+      - persist_to_workspace:
+          root: .
+          paths:
+            - target
   test:
     environment:
       <<: *common_job_environment
@@ -384,8 +383,9 @@ jobs:
         type: executor
     executor: << parameters.platform >>
     steps:
+      - checkout
       - attach_workspace:
-          at: .
+          at: target
       - when:
           condition:
             equal: [*rust_amd_linux_test_executor, << parameters.platform >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,6 +323,12 @@ jobs:
             - linux_amd_install_baseline
             - xtask_lint:
                 os: linux_amd
+      - save_cache:
+          name: Save .cargo
+          key: rust-cargo-<< pipeline.parameters.cache_version >>-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+          paths:
+            - ~/.cargo
+            - ~/project
   check_compliance:
     environment:
       <<: *common_job_environment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,14 @@ executors:
     machine:
       image: ubuntu-2004:2022.04.1
     resource_class: arm.large
-  rust_macos: &rust_macos_executor
+  rust_macos_build: &rust_macos_build_executor
+    macos:
+      # See https://circleci.com/docs/xcode-policy along with the support matrix
+      # at https://circleci.com/docs/using-macos#supported-xcode-versions.
+      # We use the major.minor notation to bring in compatible patches.
+      xcode: 13.4
+    resource_class: macos.x86.medium.gen2
+  rust_macos_test: &rust_macos_test_executor
     macos:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
@@ -367,7 +374,7 @@ jobs:
             - windows_build_workspace
       - when:
           condition:
-            equal: [*rust_macos_executor, << parameters.platform >>]
+            equal: [*rust_macos_build_executor, << parameters.platform >>]
           steps:
             - macos_install_baseline
             - build_workspace:
@@ -404,7 +411,7 @@ jobs:
             - windows_test_workspace
       - when:
           condition:
-            equal: [*rust_macos_executor, << parameters.platform >>]
+            equal: [*rust_macos_test_executor, << parameters.platform >>]
           steps:
             - macos_install_baseline
             - test_workspace:
@@ -428,7 +435,7 @@ jobs:
           command: git submodule update --recursive --init
       - when:
           condition:
-            equal: [*rust_macos_executor, << parameters.platform >>]
+            equal: [*rust_macos_build_executor, << parameters.platform >>]
           steps:
             - install_minimal_rust
             - run:
@@ -582,17 +589,17 @@ workflows:
       - build:
           matrix:
             parameters:
-              platform: [rust_macos, rust_windows_build, rust_amd_linux_build, rust_arm_linux_build]
+              platform: [rust_macos_build, rust_windows_build, rust_amd_linux_build, rust_arm_linux_build]
       - test:
           matrix:
             parameters:
-              platform: [rust_macos, rust_windows_test, rust_amd_linux_test, rust_arm_linux_test]
+              platform: [rust_macos_test, rust_windows_test, rust_amd_linux_test, rust_arm_linux_test]
   release:
     jobs:
       - build_release:
           matrix:
             parameters:
-              platform: [rust_macos, rust_windows_build, rust_amd_linux_build, rust_arm_linux_build]
+              platform: [rust_macos_build, rust_windows_build, rust_amd_linux_build, rust_arm_linux_build]
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,19 +6,19 @@ orbs:
   gh: circleci/github-cli@2.1.1
 
 executors:
-  rust_amd_linux_build: &rust_amd_linux_executor
+  rust_amd_linux_build: &rust_amd_linux_build_executor
     docker:
       - image: cimg/base:stable
     resource_class: medium
-  rust_amd_linux_test: &rust_amd_linux_executor
+  rust_amd_linux_test: &rust_amd_linux_test_executor
     docker:
       - image: cimg/base:stable
     resource_class: xlarge
-  rust_arm_linux_build: &rust_arm_linux_executor
+  rust_arm_linux_build: &rust_arm_linux_build_executor
     machine:
       image: ubuntu-2004:2022.04.1
     resource_class: arm.medium
-  rust_arm_linux_test: &rust_arm_linux_executor
+  rust_arm_linux_test: &rust_arm_linux_test_executor
     machine:
       image: ubuntu-2004:2022.04.1
     resource_class: arm.large
@@ -29,12 +29,12 @@ executors:
       # We use the major.minor notation to bring in compatible patches.
       xcode: 13.4
     resource_class: macos.x86.medium.gen2
-  rust_windows_build: &rust_windows_executor
+  rust_windows_build: &rust_windows_build_executor
     machine:
       image: "windows-server-2019-vs2019:stable"
     resource_class: windows.medium
     shell: powershell.exe -ExecutionPolicy Bypass
-  rust_windows_test: &rust_windows_executor
+  rust_windows_test: &rust_windows_test_executor
     machine:
       image: "windows-server-2019-vs2019:stable"
     resource_class: windows.xlarge
@@ -314,7 +314,7 @@ jobs:
       - checkout
       - when:
           condition:
-            equal: [*rust_amd_linux_executor, << parameters.platform >>]
+            equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
           steps:
             - linux_amd_install_baseline
             - xtask_lint:
@@ -330,7 +330,7 @@ jobs:
       - checkout
       - when:
           condition:
-            equal: [*rust_amd_linux_executor, << parameters.platform >>]
+            equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
           steps:
             - linux_amd_install_baseline
             - xtask_check_compliance:
@@ -346,21 +346,21 @@ jobs:
       - checkout
       - when:
           condition:
-            equal: [*rust_amd_linux_executor, << parameters.platform >>]
+            equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
           steps:
             - linux_amd_install_baseline
             - build_workspace:
                 os: linux_amd
       - when:
           condition:
-            equal: [*rust_arm_linux_executor, << parameters.platform >>]
+            equal: [*rust_arm_linux_build_executor, << parameters.platform >>]
           steps:
             - linux_arm_install_baseline
             - build_workspace:
                 os: linux_arm
       - when:
           condition:
-            equal: [*rust_windows_executor, << parameters.platform >>]
+            equal: [*rust_windows_build_executor, << parameters.platform >>]
           steps:
             - windows_install_baseline
             - windows_prepare_env
@@ -383,21 +383,21 @@ jobs:
       - checkout
       - when:
           condition:
-            equal: [*rust_amd_linux_executor, << parameters.platform >>]
+            equal: [*rust_amd_linux_test_executor, << parameters.platform >>]
           steps:
             - linux_amd_install_baseline
             - test_workspace:
                 os: linux_amd
       - when:
           condition:
-            equal: [*rust_arm_linux_executor, << parameters.platform >>]
+            equal: [*rust_arm_linux_test_executor, << parameters.platform >>]
           steps:
             - linux_arm_install_baseline
             - test_workspace:
                 os: linux_arm
       - when:
           condition:
-            equal: [*rust_windows_executor, << parameters.platform >>]
+            equal: [*rust_windows_test_executor, << parameters.platform >>]
           steps:
             - windows_install_baseline
             - windows_prepare_env
@@ -451,8 +451,8 @@ jobs:
       - when:
           condition:
             or:
-              - equal: [*rust_amd_linux_executor, << parameters.platform >>]
-              - equal: [*rust_arm_linux_executor, << parameters.platform >>]
+              - equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
+              - equal: [*rust_arm_linux_build_executor, << parameters.platform >>]
           steps:
             - run:
                 name: Update and install dependencies
@@ -470,7 +470,7 @@ jobs:
                   cargo xtask package --output artifacts/
       - when:
           condition:
-            equal: [*rust_windows_executor, << parameters.platform >>]
+            equal: [*rust_windows_build_executor, << parameters.platform >>]
           steps:
             - run:
                 name: Install rustup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ parameters:
     default: "1.33.0"
   target_dir:
     type: string
-    default: "project/target"
+    default: target-{{ arch }}
 
 # These are common environment variables that we want to set on on all jobs.
 # While these could conceivably be set on the CircleCI project settings'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,14 +45,11 @@ parameters:
   cache_version:
     type: string
     # increment this to invalidate all the caches
-    default: v12-lean.{{ arch}}-{{ checksum "rust-toolchain.toml" }}
+    default: v12-lean.{{ arch }}-{{ checksum "rust-toolchain.toml" }}
   jaeger_version:
     type: string
     # update this as new versions of jaeger become available
     default: "1.33.0"
-  target_dir:
-    type: string
-    default: target-{{ arch}}
 
 # These are common environment variables that we want to set on on all jobs.
 # While these could conceivably be set on the CircleCI project settings'
@@ -240,7 +237,7 @@ commands:
       - persist_to_workspace:
           root: .
           paths:
-            - << pipeline.parameters.target_dir >>
+            - target-{{ arch }}
 
   windows_build_workspace:
     steps:
@@ -286,7 +283,7 @@ commands:
         type: string
     steps:
       - attach_workspace:
-          at: << pipeline.parameters.target_dir >>
+          at: target-{{ arch }}
       - run:
           name: Start jaeger
           background: true
@@ -352,7 +349,7 @@ jobs:
   build:
     environment:
       <<: *common_job_environment
-      CARGO_TARGET_DIR: << pipeline.parameters.target_dir >>
+      CARGO_TARGET_DIR: target-{{ arch }}
     parameters:
       platform:
         type: executor
@@ -390,7 +387,7 @@ jobs:
   test:
     environment:
       <<: *common_job_environment
-      CARGO_TARGET_DIR: << pipeline.parameters.target_dir >>
+      CARGO_TARGET_DIR: target-{{ arch }}
     parameters:
       platform:
         type: executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,19 @@ orbs:
   gh: circleci/github-cli@2.1.1
 
 executors:
-  rust_amd_linux: &rust_amd_linux_executor
+  rust_amd_linux_build: &rust_amd_linux_executor
+    docker:
+      - image: cimg/base:stable
+    resource_class: medium
+  rust_amd_linux_test: &rust_amd_linux_executor
     docker:
       - image: cimg/base:stable
     resource_class: xlarge
-  rust_arm_linux: &rust_arm_linux_executor
+  rust_arm_linux_build: &rust_arm_linux_executor
+    machine:
+      image: ubuntu-2004:2022.04.1
+    resource_class: arm.medium
+  rust_arm_linux_test: &rust_arm_linux_executor
     machine:
       image: ubuntu-2004:2022.04.1
     resource_class: arm.large
@@ -21,11 +29,17 @@ executors:
       # We use the major.minor notation to bring in compatible patches.
       xcode: 13.4
     resource_class: macos.x86.medium.gen2
-  rust_windows: &rust_windows_executor
+  rust_windows_build: &rust_windows_executor
+    machine:
+      image: "windows-server-2019-vs2019:stable"
+    resource_class: windows.medium
+    shell: powershell.exe -ExecutionPolicy Bypass
+  rust_windows_test: &rust_windows_executor
     machine:
       image: "windows-server-2019-vs2019:stable"
     resource_class: windows.xlarge
     shell: powershell.exe -ExecutionPolicy Bypass
+
 
 parameters:
   cache_version:
@@ -553,7 +567,7 @@ workflows:
       - lint:
           matrix:
             parameters:
-              platform: [rust_amd_linux]
+              platform: [rust_amd_linux_build]
 
       # check-compliance is disabled for now because it is flaky
       # `cargo about` seems to be non-deterministic and sometimes
@@ -568,17 +582,17 @@ workflows:
       - build:
           matrix:
             parameters:
-              platform: [rust_macos, rust_windows, rust_amd_linux, rust_arm_linux]
+              platform: [rust_macos, rust_windows_build, rust_amd_linux_build, rust_arm_linux_build]
       - test:
           matrix:
             parameters:
-              platform: [rust_macos, rust_windows, rust_amd_linux, rust_arm_linux]
+              platform: [rust_macos, rust_windows_test, rust_amd_linux_test, rust_arm_linux_test]
   release:
     jobs:
       - build_release:
           matrix:
             parameters:
-              platform: [rust_macos, rust_windows, rust_amd_linux, rust_arm_linux]
+              platform: [rust_macos, rust_windows_build, rust_amd_linux_build, rust_arm_linux_build]
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ commands:
       - persist_to_workspace:
           root: .
           paths:
-            - project\target
+            - target
 
   windows_test_workspace:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,8 @@ commands:
     parameters:
       os:
         type: string
+      target_dir:
+        type: string
     steps:
       - restore_cache:
           name: Restore .cargo
@@ -234,6 +236,10 @@ commands:
           key: rust-cargo-<< pipeline.parameters.cache_version >>-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - target.<< parameters.target_dir >>
 
   windows_build_workspace:
     steps:
@@ -271,7 +277,11 @@ commands:
     parameters:
       os:
         type: string
+      target_dir:
+        type: string
     steps:
+      - attach_workspace:
+          at: ~/project/target.<< parameters.target_dir >>
       - run:
           name: Start jaeger
           background: true
@@ -310,7 +320,6 @@ jobs:
       platform:
         type: executor
     executor: << parameters.platform >>
-    working_directory: ~/project/<< parameters.platform >>
     steps:
       - checkout
       # - when:
@@ -327,7 +336,6 @@ jobs:
       platform:
         type: executor
     executor: << parameters.platform >>
-    working_directory: ~/project/<< parameters.platform >>
     steps:
       - when:
           condition:
@@ -339,11 +347,11 @@ jobs:
   build:
     environment:
       <<: *common_job_environment
+      CARGO_TARGET_DIR: ~/project/target.<< parameters.platform >>
     parameters:
       platform:
         type: executor
     executor: << parameters.platform >>
-    working_directory: ~/project/<< parameters.platform >>
     steps:
       - checkout
       - when:
@@ -353,6 +361,7 @@ jobs:
             - linux_amd_install_baseline
             - build_workspace:
                 os: linux_amd
+                target_dir: ~/project/target.<< parameters.platform>>
       - when:
           condition:
             equal: [*rust_arm_linux_build_executor, << parameters.platform >>]
@@ -360,6 +369,7 @@ jobs:
             - linux_arm_install_baseline
             - build_workspace:
                 os: linux_arm
+                target_dir: ~/project/target.<< parameters.platform>>
       - when:
           condition:
             equal: [*rust_windows_build_executor, << parameters.platform >>]
@@ -374,22 +384,17 @@ jobs:
             - macos_install_baseline
             - build_workspace:
                 os: macos
-      - persist_to_workspace:
-          root: ~/project/<< parameters.platform >>
-          paths:
-            - target
+                target_dir: ~/project/target.<< parameters.platform>>
   test:
     environment:
       <<: *common_job_environment
+      CARGO_TARGET_DIR: ~/project/target.<< parameters.platform >>
     parameters:
       platform:
         type: executor
     executor: << parameters.platform >>
-    working_directory: ~/project/<< parameters.platform >>
     steps:
       - checkout
-      - attach_workspace:
-          at: ~/project/<< parameters.platform >>/target
       - when:
           condition:
             equal: [*rust_amd_linux_test_executor, << parameters.platform >>]
@@ -397,6 +402,7 @@ jobs:
             - linux_amd_install_baseline
             - test_workspace:
                 os: linux_amd
+                target_dir: ~/project/target.<< parameters.platform>>
       - when:
           condition:
             equal: [*rust_arm_linux_test_executor, << parameters.platform >>]
@@ -404,6 +410,7 @@ jobs:
             - linux_arm_install_baseline
             - test_workspace:
                 os: linux_arm
+                target_dir: ~/project/target.<< parameters.platform>>
       - when:
           condition:
             equal: [*rust_windows_test_executor, << parameters.platform >>]
@@ -418,6 +425,7 @@ jobs:
             - macos_install_baseline
             - test_workspace:
                 os: macos
+                target_dir: ~/project/target.<< parameters.platform>>
 
   build_release:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -390,7 +390,7 @@ jobs:
   test:
     environment:
       <<: *common_job_environment
-      CARGO_TARGET_DIR: ~/project/target.<< parameters.platform >>
+      CARGO_TARGET_DIR: << pipeline.parameters.target_dir >>
     parameters:
       platform:
         type: executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,6 +234,7 @@ commands:
           key: rust-cargo-<< pipeline.parameters.cache_version >>-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo
+            - ~/project
 
   windows_build_workspace:
     steps:
@@ -248,6 +249,7 @@ commands:
           key: rust-cargo-<< pipeline.parameters.cache_version >>-build-windows-{{ checksum "Cargo.lock" }}
           paths:
             - C:\\Users\\circleci\.cargo
+            - C:\\Users\\circleci\project
 
   windows_test_workspace:
     steps:
@@ -266,6 +268,7 @@ commands:
           key: rust-cargo-<< pipeline.parameters.cache_version >>-test-windows-{{ checksum "Cargo.lock" }}
           paths:
             - C:\\Users\\circleci\.cargo
+            - C:\\Users\\circleci\project
 
   test_workspace:
     parameters:
@@ -301,6 +304,7 @@ commands:
           key: rust-cargo-<< pipeline.parameters.cache_version >>-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo
+            - ~/project
 
 jobs:
   lint:
@@ -327,7 +331,6 @@ jobs:
         type: executor
     executor: << parameters.platform >>
     steps:
-      - checkout
       - when:
           condition:
             equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
@@ -343,7 +346,6 @@ jobs:
         type: executor
     executor: << parameters.platform >>
     steps:
-      - checkout
       - when:
           condition:
             equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
@@ -380,7 +382,6 @@ jobs:
         type: executor
     executor: << parameters.platform >>
     steps:
-      - checkout
       - when:
           condition:
             equal: [*rust_amd_linux_test_executor, << parameters.platform >>]
@@ -562,12 +563,13 @@ jobs:
             helm push ${CHART} oci://ghcr.io/apollographql/helm-charts
 
 workflows:
+  version: 2
   ci_checks:
     jobs:
       - lint:
           matrix:
             parameters:
-              platform: [rust_amd_linux_build]
+              platform: [rust_macos, rust_windows_build, rust_amd_linux_build, rust_arm_linux_build]
 
       # check-compliance is disabled for now because it is flaky
       # `cargo about` seems to be non-deterministic and sometimes
@@ -575,15 +577,21 @@ workflows:
       # For now, we’ll re-generate it for each release instead. (See RELEASE_CHECKLIST.md)
 
       # - check_compliance:
+      #     requires:
+      #       - lint
       #     matrix:
       #       parameters:
       #         platform: [rust_linux]
 
       - build:
+          requires:
+            - lint
           matrix:
             parameters:
               platform: [rust_macos, rust_windows_build, rust_amd_linux_build, rust_arm_linux_build]
       - test:
+          requires:
+            - build
           matrix:
             parameters:
               platform: [rust_macos, rust_windows_test, rust_amd_linux_test, rust_arm_linux_test]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,7 +237,7 @@ commands:
           paths:
             - ~/.cargo
       - persist_to_workspace:
-          root: ~/project
+          root: .
           paths:
             - target.<< parameters.target_dir >>
 
@@ -254,9 +254,15 @@ commands:
           key: rust-cargo-<< pipeline.parameters.cache_version >>-build-windows-{{ checksum "Cargo.lock" }}
           paths:
             - C:\\Users\\circleci\.cargo
+      - persist_to_workspace:
+          root: .
+          paths:
+            - target
 
   windows_test_workspace:
     steps:
+      - attach_workspace:
+          at: target
       - run:
           name: Start jaeger
           background: true
@@ -281,7 +287,7 @@ commands:
         type: string
     steps:
       - attach_workspace:
-          at: ~/project/target.<< parameters.target_dir >>
+          at: target.<< parameters.target_dir >>
       - run:
           name: Start jaeger
           background: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,7 +322,7 @@ jobs:
       - persist_to_workspace:
           root: workspace
           paths:
-            - project
+            - .
   check_compliance:
     environment:
       <<: *common_job_environment
@@ -347,7 +347,7 @@ jobs:
     executor: << parameters.platform >>
     steps:
       - attach_workspace:
-          at: project
+          at: .
       - when:
           condition:
             equal: [*rust_amd_linux_build_executor, << parameters.platform >>]
@@ -385,7 +385,7 @@ jobs:
     executor: << parameters.platform >>
     steps:
       - attach_workspace:
-          at: project
+          at: .
       - when:
           condition:
             equal: [*rust_amd_linux_test_executor, << parameters.platform >>]


### PR DESCRIPTION
circleci now makes resource consumption data available for all platforms.

A quick examination of our usage on a recent dev build shows peak memory consumption of approx:

Windows
 build: 12% 1/8
 test: 51% 1/2

Amd
 build: 15% 1/7
 test: 85% 7/8

Arm
 build: 8% 1/12
 test: 61% 3/5

Macos
 build: 46% 1/2
 test: 56% 1/2

Clearly, there are significant variations between build and test (except on Macos). We should try to rightsize all of them, but step 1 is splitting the machine types for platform further into by platform and by build or test. We can already make the build machines smaller (apart from on Macos) and see how that affects performance and billing.

With less memory, you get less CPU, but because we run everything in parallel, the now slower build jobs don't affect the overall time because they are still faster than the test jobs. We could differentiate by platform and with the money we save by having smaller AMD and Windows build machines, we could have bigger ARM test machines and speed up the overall pipeline.

I compared the cost of the most recent successful build of dev with this branch and found that:

Full Dev Cost:
 windows: 13 mins 13 x 210 = 2730
 arm: 25 mins 25 x 20 = 500
 amd: 19 mins 19 x 40 = 760
 mac: 15 * 75 = 1125
total: 5115 credits

Full Lean Cost:
 windows: 6 x 40 + 10 * 210 = 2340
 arm: 9 * 10 + 18 * 20 = 450
 amd: 9 * 10 +  13 * 40 = 610
 mac: 15 * 75 = 1125
total: 4525 credits

(12% saving in cost) This branch completed in 18:15, latest dev completed in 18:33 (which is basically the same)


