### PR TITLE
add a fuzz target to generate invalid queries

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -26,6 +26,12 @@ test = false
 doc = false
 
 [[bin]]
+name = "router_errors"
+path = "fuzz_targets/router_errors.rs"
+test = false
+doc = false
+
+[[bin]]
 name = "federation"
 path = "fuzz_targets/federation.rs"
 test = false


### PR DESCRIPTION
To not keep it only on my laptop, here is another fuzz target I use when I want to check if when giving an invalid query it will throw an error on both the gateway and the router.