### PR TITLE
docs: fix rhai example for import modules

### DIFF
--- a/docs/source/customizations/rhai.mdx
+++ b/docs/source/customizations/rhai.mdx
@@ -118,9 +118,13 @@ fn process_request(request) {
 
 import "my_module" as my_mod;
 
+fn process_request(request) {
+  my_mod::process_request(request)
+}
+
 fn supergraph_service(service) {
   // Rhai convention for creating a function pointer
-  const request_callback = Fn("my_mod::process_request"); 
+  const request_callback = Fn("process_request"); 
   
   service.map_request(request_callback);
 }


### PR DESCRIPTION
I was running into issues when copying the example from the initial docs due to function pointers in Rhai can't be referred to imported modules, so reworked the example per the [rhai docs](https://rhai.rs/book/language/fn-ptr.html?highlight=fn%20pointer#warning--global-namespace-only).