### PR TITLE
try to reduce the flakiness of rate limiting test in ci

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -51,6 +51,15 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 
 ## 🛠 Maintenance
 
+### Improve the stability of some flaky tests ([PR #1972](https://github.com/apollographql/router/pull/1972))
+
+The trace and rate limiting tests have been failing in our ci environment. The root cause is racyness in the tests, so the tests have been made more resilient to reduce the number of failures.
+
+Two PRs are represented by this single changelog.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1972
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1974
+
 ### Update docker-compose and Dockerfiles now that the submodules have been removed ([PR #1950](https://github.com/apollographql/router/pull/1950))
 
 We recently removed git submodules dependency, but we didn't update the global and the fuzzer `docker-compose.yml`.

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -372,7 +372,7 @@ mod test {
     }
 
     async fn get_traffic_shaping_plugin(config: &serde_json::Value) -> Box<dyn DynPlugin> {
-        // Build a redacting plugin
+        // Build a traffic shaping plugin
         crate::plugin::plugins()
             .get("apollo.traffic_shaping")
             .expect("Plugin not found")
@@ -389,7 +389,7 @@ mod test {
         "#,
         )
         .unwrap();
-        // Build a redacting plugin
+        // Build a traffic shaping plugin
         let plugin = get_traffic_shaping_plugin(&config).await;
         let router = build_mock_router_with_variable_dedup_optimization(plugin).await;
         execute_router_test(VALID_QUERY, &*EXPECTED_RESPONSE, router).await;
@@ -498,7 +498,9 @@ mod test {
             .oneshot(SubgraphRequest::fake_builder().build())
             .await
             .unwrap();
-        tokio::time::sleep(Duration::from_millis(300)).await;
+        // Note: 300ms should be long enough for this test to succeed, but it seems to be flaky in
+        // ci, so bump it to 301ms to see if that makes it less flaky.
+        tokio::time::sleep(Duration::from_millis(301)).await;
         let _response = plugin
             .subgraph_service("test", test_service.boxed())
             .oneshot(SubgraphRequest::fake_builder().build())
@@ -547,7 +549,11 @@ mod test {
             .oneshot(SupergraphRequest::fake_builder().build().unwrap())
             .await
             .is_err());
-        tokio::time::sleep(Duration::from_millis(300)).await;
+        // Note: 300ms should be long enough for this test to succeed, but its sibling (subgraph)
+        // seems to be flaky at that figure in ci. So, let's bump this one as well to be
+        // consistent.
+        // ci, so bump it to 301ms to see if that makes it less flaky.
+        tokio::time::sleep(Duration::from_millis(301)).await;
         let _response = plugin
             .supergraph_service(mock_service.clone().boxed())
             .oneshot(SupergraphRequest::fake_builder().build().unwrap())

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -498,9 +498,11 @@ mod test {
             .oneshot(SubgraphRequest::fake_builder().build())
             .await
             .unwrap();
-        // Note: 300ms should be long enough for this test to succeed, but it seems to be flaky in
-        // ci, so bump it to 301ms to see if that makes it less flaky.
-        tokio::time::sleep(Duration::from_millis(301)).await;
+        // Note: use `timeout` to guarantee 300ms has elapsed
+        let big_sleep = tokio::time::sleep(Duration::from_secs(10));
+        assert!(tokio::time::timeout(Duration::from_millis(300), big_sleep)
+            .await
+            .is_err());
         let _response = plugin
             .subgraph_service("test", test_service.boxed())
             .oneshot(SubgraphRequest::fake_builder().build())
@@ -549,11 +551,11 @@ mod test {
             .oneshot(SupergraphRequest::fake_builder().build().unwrap())
             .await
             .is_err());
-        // Note: 300ms should be long enough for this test to succeed, but its sibling (subgraph)
-        // seems to be flaky at that figure in ci. So, let's bump this one as well to be
-        // consistent.
-        // ci, so bump it to 301ms to see if that makes it less flaky.
-        tokio::time::sleep(Duration::from_millis(301)).await;
+        // Note: use `timeout` to guarantee 300ms has elapsed
+        let big_sleep = tokio::time::sleep(Duration::from_secs(10));
+        assert!(tokio::time::timeout(Duration::from_millis(300), big_sleep)
+            .await
+            .is_err());
         let _response = plugin
             .supergraph_service(mock_service.clone().boxed())
             .oneshot(SupergraphRequest::fake_builder().build().unwrap())


### PR DESCRIPTION
The modified tests have a high random fail rate in ci, so try to reduce that to improve the reliability of the ci pipeline.