### PR TITLE
Fix grpc otlp tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,7 +2193,7 @@ dependencies = [
  "hyper",
  "log",
  "rustls 0.20.4",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.2",
  "tokio",
  "tokio-rustls 0.23.3",
 ]
@@ -3828,7 +3828,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.20.4",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.2",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -4099,6 +4099,18 @@ dependencies = [
  "ring",
  "sct 0.7.0",
  "webpki 0.22.0",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls 0.19.1",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -5123,6 +5135,7 @@ dependencies = [
  "pin-project",
  "prost 0.9.0",
  "prost-derive 0.9.0",
+ "rustls-native-certs 0.5.0",
  "tokio",
  "tokio-rustls 0.22.0",
  "tokio-stream",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -31,6 +31,15 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 ## 🚀 Features
 ## 🐛 Fixes
 
+### Fix OTLP GRPC ([Issue #1976](https://github.com/apollographql/router/issues/1976))
+
+OTLP GRPC has been fixed and confirmed to work against external APMs.
+
+* TLS root certificates needed to be enabled in tonic.
+* TLS domain needs to be set for GRPC over HTTP(S). THis is now defaulted.
+
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/#1977
+
 ### Prefix the prometheus metrics with `router_` ([Issue #1915](https://github.com/apollographql/router/issues/1915))
 
 Adopt the prefix naming convention for prometheus metrics.

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -157,7 +157,7 @@ thiserror = "1.0.34"
 tokio = { version = "1.21.0", features = ["full"] }
 tokio-stream = { version = "0.1.10", features = ["sync", "net"] }
 tokio-util = { version = "0.7.4", features = ["net", "codec"] }
-tonic = { version = "0.6.2", features = ["transport", "tls"] }
+tonic = { version = "0.6.2", features = ["transport", "tls", "tls-roots"] }
 tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.3.4", features = [
     "trace",

--- a/licenses.html
+++ b/licenses.html
@@ -6162,6 +6162,7 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/Kimundi/rustc-version-rs ">rustc_version</a></li>
                     <li><a href=" https://github.com/rustls/rustls ">rustls</a></li>
                     <li><a href=" https://github.com/ctz/rustls-native-certs ">rustls-native-certs</a></li>
+                    <li><a href=" https://github.com/ctz/rustls-native-certs ">rustls-native-certs</a></li>
                     <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile</a></li>
                     <li><a href=" https://github.com/dtolnay/rustversion ">rustversion</a></li>
                     <li><a href=" https://github.com/salsa-rs/salsa ">salsa</a></li>


### PR DESCRIPTION
Fixes #1976 

TLS domain must be set. This is now defaulted for the user based on endpoint

Root certificates must be loaded. This is a feature of tonic.
