### PR TITLE
docs: Docker overrides for CLI arguments, config

### DIFF
--- a/docs/source/containerization/docker.mdx
+++ b/docs/source/containerization/docker.mdx
@@ -15,31 +15,36 @@ Note: The exact image version to use is your choice depending on which release y
 
 ## Override the configuration
 
-If you wish to override the default configuration, then you need to provide the new configuration:
+Our default Docker images include a basic configuration which can be seen [in our repository](https://github.com/apollographql/router/blob/main/dockerfiles/router.yaml).  Inside the container, this file is located at `/dist/config/router.yaml`.
 
-```bash
+If you wish to override the default configuration, it is important to consider and preserve aspects of the default configuration.  In particular, it is generally important for the Router to bind to the special "listening address" of `0.0.0.0` (i.e., "all interfaces") to ensure the Router is exposed on a the network inferface accessible outside of the local container; without this configuration, the Router will only listen on `localhost`.
+
+You can provide your own configuration from the host environment to the Router by mounting your configuration to `/dist/config/router.yaml`, as follows:
+
+```bash {4}
 docker run -p 4000:4000 \
   --env APOLLO_GRAPH_REF="<your graph>" \
   --env APOLLO_KEY="<your key>" \
-  --mount "type=bind,source=/router.yaml,target=/dist/config/router.yaml" \
+  --mount "type=bind,source=/home/user/router.yaml,target=/dist/config/router.yaml" \
   --rm \
   ghcr.io/apollographql/router:<image version>
 ```
 
-In this case we are mounting a file from our local system's root directory (Note: that path must be absolute) over the top of the default configuration in the image.
+> Note: Both local and container paths must be specified as absolute paths.
 
-If, for whatever reason, we wish to specify a different location for our configuration, we can:
+In this case we are mounting a file from the host system (`/home/user/router.yaml`) in place of the default configuration provided in the image at `/dist/config/router.yaml`.
 
-```bash
+## Passing command-line arguments to the Router binary
+
+By default, the `router` command invoked inside the published container does run not set any of the [available command-line arguments](../configuration/overview#command-arguments).  If you want to set any of the available options, pass the desired options at end of the `docker run` command.  For example, to start the Router using the `--dev` argument, you can use the following `docker run` command:
+
+```bash {5}
 docker run -p 4000:4000 \
   --env APOLLO_GRAPH_REF="<your graph>" \
   --env APOLLO_KEY="<your key>" \
-  --mount "type=bind,source=/router.yaml,target=/tmp/router.yaml" \
   --rm \
-  ghcr.io/apollographql/router:<image version> -c /tmp/router.yaml
+  ghcr.io/apollographql/router:<image version> --dev
 ```
-
-Here, we are mounting our configuration into the /tmp directory and changing the router startup to let it know that it can find configuration in /tmp/router.yaml.
 
 ## Debugging your container
 

--- a/docs/source/containerization/docker.mdx
+++ b/docs/source/containerization/docker.mdx
@@ -36,14 +36,14 @@ In this case we are mounting a file from the host system (`/home/user/router.yam
 
 ## Passing command-line arguments to the Router binary
 
-By default, the `router` command invoked inside the published container does run not set any of the [available command-line arguments](../configuration/overview#command-arguments).  If you want to set any of the available options, pass the desired options at end of the `docker run` command.  For example, to start the Router using the `--dev` argument, you can use the following `docker run` command:
+By default, the `router` command invoked inside the published container does run not set any of the [available command-line arguments](../configuration/overview#command-arguments).  If you want to set any of the available options, pass the desired options at end of the `docker run` command.  For example, to start the Router using the `--log debug` argument, you can use the following `docker run` command:
 
 ```bash {5}
 docker run -p 4000:4000 \
   --env APOLLO_GRAPH_REF="<your graph>" \
   --env APOLLO_KEY="<your key>" \
   --rm \
-  ghcr.io/apollographql/router:<image version> --dev
+  ghcr.io/apollographql/router:<image version> --log debug
 ```
 
 ## Debugging your container


### PR DESCRIPTION
This includes an attempt at fixing an outstanding concern around our containerization documentation, in addition to adding clarity on how to pass arbitrary [supported CLI flags] to the Router.

Fixes: https://github.com/apollographql/router/issues/1127

[supported CLI flags]: https://apollographql.com/docs/router/configuration/overview#command-arguments
