### PR TITLE
Faster scaffold test: share `target` and `Cargo.lock` with main workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,9 @@ commands:
     parameters:
       os:
         type: string
+      cargo_test_args:
+        type: string
+        default: "--"
     steps:
       - run:
           name: Start jaeger
@@ -249,7 +252,7 @@ commands:
               - equal: [linux_amd, << parameters.os >>]
               - equal: [linux_arm, << parameters.os >>]
           steps:
-            - run: cargo test --jobs 4 --workspace --locked -- --test-threads=4
+            - run: cargo test --jobs 4 --workspace --locked << parameters.cargo_test_args >> --test-threads=4
       - when:
           condition:
             equal: [macos, << parameters.os >>]
@@ -332,6 +335,26 @@ jobs:
             - macos_install_baseline
             - test_workspace:
                 os: macos
+
+  test_updated:
+    environment:
+      <<: *common_job_environment
+    executor: amd_linux_test
+    steps:
+      - checkout
+      - linux_amd_install_baseline
+      - run:
+          name: Use latest Rust Nightly and update all Rust dependencies
+          command: |
+            sed -i '/channel/d' rust-toolchain.toml
+            echo 'channel = "nightly"' >> rust-toolchain.toml
+            rm Cargo.lock
+            cargo fetch
+      - test_workspace:
+          os: linux_amd
+          # schema_generation test skipped because schemars changed its representation of enums:
+          # https://github.com/GREsau/schemars/blob/master/CHANGELOG.md#086---2021-09-26
+          cargo_test_args: --no-fail-fast -- --skip schema_generation
 
   build_release:
     parameters:
@@ -502,6 +525,7 @@ workflows:
       #       parameters:
       #         platform: [linux]
 
+      - test_updated
       - test:
           matrix:
             parameters:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-scaffold"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88d8273d7d4d94345d5da1e4a77c91d266e0fe5637230f7dc96219ffe10f6a4"
+checksum = "29870394429099fd98f0a518aff593310b5c9fe25178a17949219a15ae3882eb"
 dependencies = [
  "anyhow",
  "buildstructor 0.3.2",

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 clap = { version = "3.2.23", features = ["derive"] }
-cargo-scaffold = { version = "0.8.5", default-features = false }
+cargo-scaffold = { version = "0.8.6", default-features = false }
 regex = "1"
 str_inflector = "0.12.0"
 toml = "0.5.9"

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -33,3 +33,8 @@ serde_json = "1.0.79"
 tokio = { version = "1.17.0", features = ["full"] }
 tower = { version = "0.4.12", features = ["full"] }
 tracing = "=0.1.34"
+
+# this makes build scripts and proc macros faster to compile
+[profile.dev.build-override]
+strip = "debuginfo"
+incremental = false


### PR DESCRIPTION
Since this test is typically run together with other tests, the apollo-router and its dependencies will be already built. This sharing avoids recompiling some of the dependencies, but unfortunately not all because of some differences in feature selection.

For local development however, repeated runs of the test will be much faster since the target directory is preserved across runs.

RUSTFLAGS is replaced with a crate attribute so that it doesn’t affected dependencies (which then don’t all need to be recompiled)