### PR TITLE
fix(deps): update all non-major packages >= 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.64"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a8f622bcf6ff3df478e9deba3e03e4e04b300f8e6a139e192c05fa3490afc7"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
 name = "apollo-compiler"
@@ -151,7 +151,7 @@ dependencies = [
  "base64 0.13.0",
  "buildstructor 0.5.0",
  "bytes",
- "clap 3.2.21",
+ "clap 3.2.22",
  "console-subscriber",
  "ctor",
  "dashmap 5.4.0",
@@ -265,7 +265,7 @@ version = "1.1.0"
 dependencies = [
  "anyhow",
  "cargo-scaffold",
- "clap 3.2.21",
+ "clap 3.2.22",
  "copy_dir",
  "regex",
  "str_inflector",
@@ -812,9 +812,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.21"
+version = "3.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed5341b2301a26ab80be5cbdced622e80ed808483c52e45e3310a877d3b37d7"
+checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
@@ -824,7 +824,7 @@ dependencies = [
  "once_cell",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.15.0",
+ "textwrap 0.15.1",
 ]
 
 [[package]]
@@ -931,15 +931,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847"
+checksum = "c050367d967ced717c04b65d8c619d863ef9292ce0c5760028655a2fb298718c"
 dependencies = [
  "encode_unicode",
+ "lazy_static",
  "libc",
- "once_cell",
  "terminal_size",
- "unicode-width",
  "winapi 0.3.9",
 ]
 
@@ -2307,7 +2306,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
 dependencies = [
- "console 0.15.1",
+ "console 0.12.0",
  "lazy_static",
  "number_prefix",
  "regex",
@@ -2335,13 +2334,13 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.19.1"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc61e98be01e89296f3343a878e9f8ca75a494cb5aaf29df65ef55734aeb85f5"
+checksum = "581d4e3314cae4536e5d22ffd23189d4a374696c5ef733eadafae0ed273fd303"
 dependencies = [
- "console 0.15.1",
+ "console 0.15.2",
+ "lazy_static",
  "linked-hash-map",
- "once_cell",
  "pest",
  "pest_derive",
  "serde",
@@ -2734,7 +2733,7 @@ dependencies = [
  "supports-hyperlinks",
  "supports-unicode",
  "terminal_size",
- "textwrap 0.15.0",
+ "textwrap 0.15.1",
  "thiserror",
  "unicode-width",
 ]
@@ -2754,7 +2753,7 @@ dependencies = [
  "supports-hyperlinks",
  "supports-unicode",
  "terminal_size",
- "textwrap 0.15.0",
+ "textwrap 0.15.1",
  "thiserror",
  "unicode-width",
 ]
@@ -3104,9 +3103,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "oorandom"
@@ -3967,9 +3966,9 @@ dependencies = [
 
 [[package]]
 name = "rhai"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "863c895db914cfbef71203b027f6336c00c9aed51c985c484584c37dd0375c51"
+checksum = "6eec3a3db30f591ece18c66b3db4c9fa26f3bce20bc821c50550968361f84333"
 dependencies = [
  "ahash 0.8.0",
  "bitflags",
@@ -4397,9 +4396,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
+checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 dependencies = [
  "serde_derive",
 ]
@@ -4416,9 +4415,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.144"
+version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
+checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4965,9 +4964,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 dependencies = [
  "smawk",
  "unicode-linebreak",
@@ -4976,18 +4975,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.34"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.34"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5069,9 +5068,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.0"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg 1.1.0",
  "bytes",
@@ -5079,7 +5078,6 @@ dependencies = [
  "memchr",
  "mio 0.8.4",
  "num_cpus",
- "once_cell",
  "parking_lot 0.12.0",
  "pin-project-lite",
  "signal-hook-registry",

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -7,8 +7,8 @@ license = "LicenseRef-ELv2"
 publish = false
 
 [dependencies]
-anyhow = "1.0.64"
-clap = { version = "3.2.21", features = ["derive"] }
+anyhow = "1.0.65"
+clap = { version = "3.2.22", features = ["derive"] }
 cargo-scaffold = { version = "0.8.5", default-features = false }
 regex = "1"
 str_inflector = "0.12.0"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -34,7 +34,7 @@ features = ["docs_rs"]
 
 [dependencies]
 access-json = "0.1.0"
-anyhow = "1.0.64"
+anyhow = "1.0.65"
 ansi_term = "0.12"
 apollo-parser = "0.2.12"
 async-compression = { version = "0.3.14", features = [
@@ -50,7 +50,7 @@ backtrace = "0.3.66"
 base64 = "0.13.0"
 buildstructor = "0.5.0"
 bytes = "1.2.1"
-clap = { version = "3.2.21", default-features = false, features = [
+clap = { version = "3.2.22", default-features = false, features = [
     "env",
     "derive",
     "std",
@@ -88,7 +88,7 @@ mockall = "0.11.2"
 miette = { version = "5.3.0", features = ["fancy"] }
 mime = "0.3.16"
 multimap = "0.8.3"
-once_cell = "1.14.0"
+once_cell = "1.15.0"
 
 # Any package that starts with `opentelemetry` needs to be updated with care
 # because it is tightly intertwined with the `tracing` packages on account of
@@ -134,7 +134,7 @@ prometheus = "0.13"
 prost = "0.9.0"
 prost-types = "0.9.0"
 rand = "0.8.5"
-rhai = { version = "1.10.0", features = ["sync", "serde", "internals"] }
+rhai = { version = "1.10.1", features = ["sync", "serde", "internals"] }
 regex = "1.6.0"
 reqwest = { version = "0.11.12", default-features = false, features = [
     "rustls-tls",
@@ -145,15 +145,15 @@ router-bridge = "0.1.9"
 schemars = { version = "0.8.10", features = ["url"] }
 shellexpand = "2.1.2"
 sha2 = "0.10.6"
-serde = { version = "1.0.144", features = ["derive", "rc"] }
+serde = { version = "1.0.145", features = ["derive", "rc"] }
 serde_json_bytes = { version = "0.2.0", features = ["preserve_order"] }
 serde_json = { version = "1.0.85", features = ["preserve_order"] }
 serde_urlencoded = "0.7.1"
 serde_yaml = "0.8.26"
 static_assertions = "1.1.0"
 sys-info = "0.9.1"
-thiserror = "1.0.34"
-tokio = { version = "1.21.0", features = ["full"] }
+thiserror = "1.0.37"
+tokio = { version = "1.21.2", features = ["full"] }
 tokio-stream = { version = "0.1.10", features = ["sync", "net"] }
 tokio-util = { version = "0.7.4", features = ["net", "codec"] }
 tonic = { version = "0.6.2", features = ["transport", "tls"] }
@@ -198,13 +198,13 @@ uname = "0.1.1"
 uname = "0.1.1"
 
 [dev-dependencies]
-insta = { version = "1.19.1", features = ["json", "redactions"] }
+insta = { version = "1.21.0", features = ["json", "redactions"] }
 introspector-gadget = "0.1.0"
 jsonpath_lib = "0.3.0"
 maplit = "1.0.2"
 memchr = { version = "2.5.0", default-features = false }
 mockall = "0.11.2"
-once_cell = "1.14.0"
+once_cell = "1.15.0"
 reqwest = { version = "0.11.12", default-features = false, features = [
     "json",
     "stream",

--- a/dockerfiles/tracing/datadog-subgraph/package-lock.json
+++ b/dockerfiles/tracing/datadog-subgraph/package-lock.json
@@ -17,7 +17,7 @@
         "graphql": "^16.5.0"
       },
       "devDependencies": {
-        "typescript": "4.8.3"
+        "typescript": "4.8.4"
       }
     },
     "node_modules/@apollo/cache-control-types": {
@@ -1767,9 +1767,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3207,9 +3207,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "unpipe": {

--- a/dockerfiles/tracing/datadog-subgraph/package.json
+++ b/dockerfiles/tracing/datadog-subgraph/package.json
@@ -18,6 +18,6 @@
     "graphql": "^16.5.0"
   },
   "devDependencies": {
-    "typescript": "4.8.3"
+    "typescript": "4.8.4"
   }
 }

--- a/dockerfiles/tracing/jaeger-subgraph/package-lock.json
+++ b/dockerfiles/tracing/jaeger-subgraph/package-lock.json
@@ -18,7 +18,7 @@
         "opentracing": "^0.14.7"
       },
       "devDependencies": {
-        "typescript": "4.8.3"
+        "typescript": "4.8.4"
       }
     },
     "node_modules/@apollo/cache-control-types": {
@@ -1354,9 +1354,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2477,9 +2477,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "unpipe": {

--- a/dockerfiles/tracing/jaeger-subgraph/package.json
+++ b/dockerfiles/tracing/jaeger-subgraph/package.json
@@ -19,6 +19,6 @@
     "opentracing": "^0.14.7"
   },
   "devDependencies": {
-    "typescript": "4.8.3"
+    "typescript": "4.8.4"
   }
 }

--- a/dockerfiles/tracing/zipkin-subgraph/package-lock.json
+++ b/dockerfiles/tracing/zipkin-subgraph/package-lock.json
@@ -19,7 +19,7 @@
         "zipkin-javascript-opentracing": "^3.0.0"
       },
       "devDependencies": {
-        "typescript": "4.8.3"
+        "typescript": "4.8.4"
       }
     },
     "node_modules/@apollo/cache-control-types": {
@@ -1381,9 +1381,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2548,9 +2548,9 @@
       }
     },
     "typescript": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.3.tgz",
-      "integrity": "sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "unpipe": {

--- a/dockerfiles/tracing/zipkin-subgraph/package.json
+++ b/dockerfiles/tracing/zipkin-subgraph/package.json
@@ -20,6 +20,6 @@
     "zipkin-javascript-opentracing": "^3.0.0"
   },
   "devDependencies": {
-    "typescript": "4.8.3"
+    "typescript": "4.8.4"
   }
 }


### PR DESCRIPTION
I'm opening this PR as a copy of https://github.com/apollographql/router/pull/1767 that brings the bumps as of 783206a93718c65d0a25ca7c930f0f64ec59df70, when the tests on ARM were at least passing.  It looks like there has been a panic that started showing up with some version bumps after that.