### PR TITLE
chore(deps): Update to router-bridge@0.1.11 (Federation v2.1.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3983,9 +3983,9 @@ dependencies = [
 
 [[package]]
 name = "router-bridge"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ed5e5dac99281772c0705b7544f783407e749847f66e0912272da713d84116"
+checksum = "74d2434deb0c39a41b7b68f968c78517c59b1032894c2e013244ba18d9fb49b4"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -82,6 +82,12 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 
 ## 🛠 Maintenance
 
+### Update to Federation v2.1.4 ([PR #1994](https://github.com/apollographql/router/pull/1994))
+
+In addition to general Federation bug-fixes, this update should resolve a case ([seen in Issue #1962](https://github.com/apollographql/router/issues/1962)) where a `@defer` directives which had been previously present in a Supergraph were causing a startup failure in the Router when we were trying to generate an API schema in the Router with `@defer`.
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/1994
+
 ### Improve the stability of some flaky tests ([PR #1972](https://github.com/apollographql/router/pull/1972))
 
 The trace and rate limiting tests have been failing in our ci environment. The root cause is racyness in the tests, so the tests have been made more resilient to reduce the number of failures.

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -142,7 +142,7 @@ reqwest = { version = "0.11.12", default-features = false, features = [
     "json",
     "stream",
 ] }
-router-bridge = "0.1.10"
+router-bridge = "0.1.11"
 schemars = { version = "0.8.10", features = ["url"] }
 shellexpand = "2.1.2"
 sha2 = "0.10.6"


### PR DESCRIPTION
This updates to a version of the Router Bridge that packages Federaiton
2.1.4 as found in the referenced/related PRs.

Ref: https://github.com/apollographql/federation/pull/2215
Ref: https://github.com/apollographql/federation-rs/pull/204

Fixes https://github.com/apollographql/router/issues/1962