### PR TITLE
Exports `Endpoint` struct

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -55,6 +55,11 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 A recent change to the way we provide the SDL to plugins broke the rhai SDL print. This fixes it.
 
 By [@fernando-apollo](https://github.com/fernando-apollo) in https://github.com/apollographql/router/pull/2007
+
+### Exports a missing strut (`router_factory::Endpoint`) that was preventing the `web_endpoints` trait from being implemented by Plugins
+
+By [@scottdouglas1989](https://github.com/scottdouglas1989) in https://github.com/apollographql/router/pull/2007
+
 ## 🛠 Maintenance
 
 ### Split the configuration file management in multiple modules [Issue #1790](https://github.com/apollographql/router/issues/1790))

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -83,6 +83,7 @@ pub use crate::router::ConfigurationSource;
 pub use crate::router::RouterHttpServer;
 pub use crate::router::SchemaSource;
 pub use crate::router::ShutdownSource;
+pub use crate::router_factory::Endpoint;
 pub use crate::test_harness::MockedSubgraphs;
 pub use crate::test_harness::TestHarness;
 

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -30,6 +30,7 @@ use crate::PluggableSupergraphServiceBuilder;
 use crate::Schema;
 
 #[derive(Clone)]
+/// A path and a handler to be exposed as a web_endpoint for plugins
 pub struct Endpoint {
     pub(crate) path: String,
     // Plugins need to be Send + Sync
@@ -46,6 +47,7 @@ impl std::fmt::Debug for Endpoint {
 }
 
 impl Endpoint {
+    /// Creates an Endpoint given a path and a Boxed Service
     pub fn new(path: String, handler: transport::BoxService) -> Self {
         Self {
             path,


### PR DESCRIPTION
Allows router plugins to utilize `web_endpoints`

🕷 At the moment, the `web_endpoints` function on the `Plugin` trait is not usable because the `Endpoint` struct is not exported, see a simple example plugin attempting to use `web_endpoints`:

```
#[derive(Debug)]
struct HelloWorld {
    #[allow(dead_code)]
    configuration: Conf,
}

#[derive(Debug, Default, Deserialize, JsonSchema)]
struct Conf {
    message: String,
}

#[async_trait::async_trait]
impl Plugin for HelloWorld {
    type Config = Conf;

    async fn new(init: PluginInit<Self::Config>) -> Result<Self, BoxError> {
        tracing::info!("{}", init.config.message);
        Ok(HelloWorld {
            configuration: init.config,
        })
    }

    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
        service
    }

    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
        service
    }

    fn subgraph_service(&self, _name: &str, service: subgraph::BoxService) -> subgraph::BoxService {
        service
    }

    fn web_endpoints(&self) -> MultiMap<ListenAddr, apollo_router::router_factory::Endpoint> {
        MultiMap::new()
    }
}

register_plugin!("router", "hello_world", HelloWorld);
```

It seems like this is probably just a mistake, since `ListenAddr` is exported and available outside the crate. It feels like the intention was to allow Plugins to implement this trait.