### PR TITLE
Try to make rate limiting tests more reliable

### DIFF
--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -498,9 +498,9 @@ mod test {
             .oneshot(SubgraphRequest::fake_builder().build())
             .await
             .unwrap();
-        // Note: use `timeout` to guarantee 300ms has elapsed
+        // Note: use `timeout` to guarantee 400ms has elapsed
         let big_sleep = tokio::time::sleep(Duration::from_secs(10));
-        assert!(tokio::time::timeout(Duration::from_millis(300), big_sleep)
+        assert!(tokio::time::timeout(Duration::from_millis(400), big_sleep)
             .await
             .is_err());
         let _response = plugin
@@ -551,9 +551,9 @@ mod test {
             .oneshot(SupergraphRequest::fake_builder().build().unwrap())
             .await
             .is_err());
-        // Note: use `timeout` to guarantee 300ms has elapsed
+        // Note: use `timeout` to guarantee 400ms has elapsed
         let big_sleep = tokio::time::sleep(Duration::from_secs(10));
-        assert!(tokio::time::timeout(Duration::from_millis(300), big_sleep)
+        assert!(tokio::time::timeout(Duration::from_millis(400), big_sleep)
             .await
             .is_err());
         let _response = plugin


### PR DESCRIPTION
These tests sometimes fail on CI, presumably when CPU load is high:

https://app.circleci.com/pipelines/github/apollographql/router/7565/workflows/2df8a225-a968-4267-8598-0afe59214878/jobs/57269

Before this commit, they sleep for exactly the duration of the rate limit interval. This adds some margin.