### PR TITLE
improve the deduplication logic

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -50,11 +50,18 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 
 ## 🐛 Fixes
 
+### Fix the deduplication logic in deduplication caching [Issue #1984](https://github.com/apollographql/router/issues/1984))
+
+Under load, it is possible to break the router deduplication logic and leave orphaned entries in the waiter map. This fixes the logic to prevent this from occurring.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/2014
+
 ### Fix the rhai SDL print function [Issue #2005](https://github.com/apollographql/router/issues/2005))
 
 A recent change to the way we provide the SDL to plugins broke the rhai SDL print. This fixes it.
 
 By [@fernando-apollo](https://github.com/fernando-apollo) in https://github.com/apollographql/router/pull/2007
+
 ## 🛠 Maintenance
 
 ### Split the configuration file management in multiple modules [Issue #1790](https://github.com/apollographql/router/issues/1790))

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -105,7 +105,6 @@ where
     async fn send(&self, sender: broadcast::Sender<V>, key: K, value: V) {
         // Lock the wait map to prevent more subscribers racing with our send
         // notification
-        // let _locked_wait_map = self.wait_map.lock().await;
         let mut locked_wait_map = self.wait_map.lock().await;
         let _ = locked_wait_map.remove(&key);
         let _ = sender.send(value);

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -55,23 +55,6 @@ where
             None => {
                 let (sender, _receiver) = broadcast::channel(1);
 
-                locked_wait_map.insert(key.clone(), sender.clone());
-
-                // we must not hold a lock over the wait map while we are waiting for a value from the
-                // cache. This way, other tasks can come and register interest in the same key, or
-                // request other keys independently
-                drop(locked_wait_map);
-
-                if let Some(value) = self.storage.get(key).await {
-                    let mut locked_wait_map = self.wait_map.lock().await;
-                    let _ = locked_wait_map.remove(key);
-                    let _ = sender.send(value.clone());
-
-                    return Entry {
-                        inner: EntryInner::Value(value),
-                    };
-                }
-
                 let k = key.clone();
                 // when _drop_signal is dropped, either by getting out of the block, returning
                 // the error from ready_oneshot or by cancellation, the drop_sentinel future will
@@ -83,6 +66,25 @@ where
                     let mut locked_wait_map = wait_map.lock().await;
                     let _ = locked_wait_map.remove(&k);
                 });
+
+                locked_wait_map.insert(key.clone(), sender.clone());
+
+                // we must not hold a lock over the wait map while we are waiting for a value from the
+                // cache. This way, other tasks can come and register interest in the same key, or
+                // request other keys independently
+                drop(locked_wait_map);
+
+                if let Some(value) = self.storage.get(key).await {
+                    // Lock the wait map to prevent more subscribers racing with our send
+                    // notification
+                    let mut locked_wait_map = self.wait_map.lock().await;
+                    let _ = locked_wait_map.remove(key);
+                    let _ = sender.send(value.clone());
+
+                    return Entry {
+                        inner: EntryInner::Value(value),
+                    };
+                }
 
                 Entry {
                     inner: EntryInner::First {
@@ -100,9 +102,13 @@ where
         self.storage.insert(key, value.clone()).await;
     }
 
-    pub(crate) async fn remove_wait(&self, key: &K) {
+    async fn send(&self, sender: broadcast::Sender<V>, key: K, value: V) {
+        // Lock the wait map to prevent more subscribers racing with our send
+        // notification
+        // let _locked_wait_map = self.wait_map.lock().await;
         let mut locked_wait_map = self.wait_map.lock().await;
-        let _ = locked_wait_map.remove(key);
+        let _ = locked_wait_map.remove(&key);
+        let _ = sender.send(value);
     }
 }
 
@@ -157,8 +163,7 @@ where
         } = self.inner
         {
             cache.insert(key.clone(), value.clone()).await;
-            cache.remove_wait(&key).await;
-            let _ = sender.send(value);
+            cache.send(sender, key, value).await;
         }
     }
 
@@ -169,8 +174,7 @@ where
             sender, cache, key, ..
         } = self.inner
         {
-            let _ = sender.send(value);
-            cache.remove_wait(&key).await;
+            cache.send(sender, key, value).await;
         }
     }
 }


### PR DESCRIPTION
Close examination revealed that some judicious tweaking of the locking and spawning would improve the behaviour.

In performance testing this performs the same as current (dev) or using the deduplicate crate. I can't reproduce the hanging problem with dev with this set of changes.

The rationale for the changes are as follows:

 - We need to spawn the sentinel **before** we insert the waiter entry or failure after inserting, but before spawning a sentinel, will cause issues.
 - Notification of waiters from the "first" entry **must be synchronised** under the "wait_map" lock, or else that becomes racy and subscribers may be missed. That notification must be immediately preceded by the removal of the wait_map entry.

fixes: #1984 