### PR TITLE
reload the configuration when receiving the SIGHUP signal

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -48,6 +48,13 @@ Example of logs in JSON:
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/1982
 
+### Reload the configuration when receiving the SIGHUP signal [Issue #35](https://github.com/apollographql/router/issues/35))
+
+This adds support for reloading configuration when receiving the SIGHUP signal. This only works on unix-like platforms,
+and only with the configuration file.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2015
+
 ## 🐛 Fixes
 
 ### Fix the rhai SDL print function [Issue #2005](https://github.com/apollographql/router/issues/2005))

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -335,7 +335,7 @@ impl ConfigurationSource {
                                 let mut sighup_stream = tokio::signal::unix::signal(
                                     tokio::signal::unix::SignalKind::hangup(),
                                 )
-                                .expect("Failed to install SIGTERM signal handler");
+                                .expect("Failed to install SIGHUP signal handler");
 
                                 let (mut tx, rx) = futures::channel::mpsc::channel(1);
                                 tokio::task::spawn(async move {

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -319,7 +319,7 @@ impl ConfigurationSource {
                 } else {
                     match ConfigurationSource::read_config(&path) {
                         Ok(configuration) => {
-                            #[cfg(not(unix))]
+                            #[cfg(any(test, not(unix)))]
                             {
                                 stream::once(future::ready(UpdateConfiguration(Box::new(
                                     configuration,
@@ -327,7 +327,7 @@ impl ConfigurationSource {
                                 .boxed()
                             }
 
-                            #[cfg(unix)]
+                            #[cfg(all(not(test), unix))]
                             {
                                 let mut sighup_stream = tokio::signal::unix::signal(
                                     tokio::signal::unix::SignalKind::hangup(),

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -339,11 +339,8 @@ impl ConfigurationSource {
 
                                 let (mut tx, rx) = futures::channel::mpsc::channel(1);
                                 tokio::task::spawn(async move {
-                                    loop {
-                                        match sighup_stream.recv().await {
-                                            Some(()) => tx.send(()).await.unwrap(),
-                                            None => break,
-                                        }
+                                    while let Some(()) = sighup_stream.recv().await {
+                                        tx.send(()).await.unwrap();
                                     }
                                 });
                                 futures::stream::select(


### PR DESCRIPTION
Fix #35 

This adds support for reloading configuration when receiving the SIGHUP signal. This only works on unix-like platforms, and only with the configuration file