### PR TITLE
Attempt to speed up builds by introducing sccache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ commands:
           command: |
             sudo apt-get update
             sudo apt-get install -y libssl-dev cmake
+
       - install_minimal_rust
   linux_amd_install_baseline:
     steps:
@@ -85,6 +86,24 @@ commands:
             curl -L https://github.com/jaegertracing/jaeger/releases/download/v<< pipeline.parameters.jaeger_version >>/jaeger-<< pipeline.parameters.jaeger_version >>-linux-amd64.tar.gz --output jaeger.tar.gz
             tar -xf jaeger.tar.gz
             mv jaeger-<< pipeline.parameters.jaeger_version >>-linux-amd64 jaeger
+      - run:
+          name: Download sccache
+          command: |
+            curl -L https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz --output /tmp/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz
+            tar -xzf /tmp/sccache-v0.3.0-x86_64-unknown-linux-musl.tar.gz -C /tmp/
+            chmod ugo+x /tmp/sccache-v0.3.0-x86_64-unknown-linux-musl/sccache
+            sudo mv /tmp/sccache-v0.3.0-x86_64-unknown-linux-musl/sccache /usr/local/bin/sccache
+            mkdir -p ~/.cache/sccache
+            # This configures Rust to use sccache.
+            echo 'export RUSTC_WRAPPER="sccache"' >> $BASH_ENV
+            # This is the maximum space sccache cache will use on disk.
+            echo 'export SCCACHE_CACHE_SIZE="1G"' >> $BASH_ENV
+            sccache --version
+      - restore_cache:
+          keys:
+            - sccache-<< parameters.manifest-directory >>-{{ .Environment.CIRCLE_JOB }}-linux-amd
+          paths:
+            - ~/.cache/sccache
   linux_arm_install_baseline:
     steps:
       - linux_install_baseline
@@ -264,7 +283,14 @@ commands:
           key: rust-cargo-<< pipeline.parameters.cache_version >>-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}
           paths:
             - ~/.cargo
-
+      - when:
+          condition:
+            or:
+              - equal: [linux_amd, << parameters.os >>]
+          steps:
+            - save_cache:
+              name: Save sccache
+              key: sccache-<< parameters.manifest-directory >>-{{ .Environment.CIRCLE_JOB }}-linux-amd
 jobs:
   lint:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -292,6 +292,9 @@ commands:
                 key: sccache-{{ .Environment.CIRCLE_JOB }}-linux-amd
                 paths:
                   - ~/.cache/sccache
+            - run:
+                name: sccache timings
+                command: sccache --show-stats
 jobs:
   lint:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ commands:
             sccache --version
       - restore_cache:
           keys:
-            - sccache-<< parameters.manifest-directory >>-{{ .Environment.CIRCLE_JOB }}-linux-amd
+            - sccache-{{ .Environment.CIRCLE_JOB }}-linux-amd
           paths:
             - ~/.cache/sccache
   linux_arm_install_baseline:
@@ -289,7 +289,9 @@ commands:
           steps:
             - save_cache:
                 name: Save sccache
-                key: sccache-<< parameters.manifest-directory >>-{{ .Environment.CIRCLE_JOB }}-linux-amd
+                key: sccache-{{ .Environment.CIRCLE_JOB }}-linux-amd
+                paths:
+                  - ~/.cache/sccache
 jobs:
   lint:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,12 +285,11 @@ commands:
             - ~/.cargo
       - when:
           condition:
-            or:
-              - equal: [linux_amd, << parameters.os >>]
+            equal: [linux_amd, << parameters.os >>]
           steps:
             - save_cache:
-              name: Save sccache
-              key: sccache-<< parameters.manifest-directory >>-{{ .Environment.CIRCLE_JOB }}-linux-amd
+                name: Save sccache
+                key: sccache-<< parameters.manifest-directory >>-{{ .Environment.CIRCLE_JOB }}-linux-amd
 jobs:
   lint:
     environment:


### PR DESCRIPTION
IF I get good results from this PR I'll discuss it with members of this team, to ensure I'm doing the right thing.

For now I'm opening this PR as a way to make Circle build my thing....

# Purpose

This PR introduces [sccache](https://github.com/mozilla/sccache), a shared compilation cache for Rust and C/C++ projects.

My - totally unfamiliar with Rust! - belief is that sccache is some kind of intermediate shared cache where ?? objects are looked up and written to before being sent to the compiler ?? (I've seen similar things back in my C++ days, so the concept isn't super new to me).

As sccache creates (and garbage collects?) this shared cache it can be cached in Circle and restored. In my experimentation (about half an hour to set up, based on some other code I had laying around, then another half hour waiting for builds to finish) I was able to shave about 2 minutes off the Circle job I experimented with (linux_amd64).

(Previous runs of  `test-amd_linux_test` took 11m 20ish seconds. In this PR running that job took 9m 40ish seconds)

If this looks awesome to all you Rusticans I will do the other os+arch combinations too (sccache is available for seemingly all the architectures we target)

