### PR TITLE
apply tower best practices to services when cloning inner services

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -28,11 +28,11 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 ## ❗ BREAKING ❗
 ## 🚀 Features
 
-### Add support for dhat based heap profiling [PR #XXXX](https://github.com/apollographql/router/pull/XXXX))
+### Add support for dhat based heap profiling [PR #1829](https://github.com/apollographql/router/pull/1829))
 
 [dhat-rs](https://github.com/nnethercote/dhat-rs) provides [DHAT](https://www.valgrind.org/docs/manual/dh-manual.html) style heap profiling. We have added two compile features, dhat-heap and dhat-ad-hoc, which leverage this ability.
 
-By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/XXXX
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/1829
 
 ### Add `trace_id` in logs to identify all logs related to a specific request [Issue #1981](https://github.com/apollographql/router/issues/1981))
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -78,6 +78,12 @@ By [@fernando-apollo](https://github.com/fernando-apollo) in https://github.com/
 
 ## 🛠 Maintenance
 
+### Apply tower best practice to inner service cloning [PR #2030](https://github.com/apollographql/router/pull/2030))
+
+Our service readiness checking can be improved by following tower project recommendations for cloning inner services.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/2030
+
 ### Split the configuration file management in multiple modules [Issue #1790](https://github.com/apollographql/router/issues/1790))
 
 The file is becoming large and hard to modify.

--- a/apollo-router/src/services/execution_service.rs
+++ b/apollo-router/src/services/execution_service.rs
@@ -56,7 +56,10 @@ where
     }
 
     fn call(&mut self, req: ExecutionRequest) -> Self::Future {
-        let this = self.clone();
+        let clone = self.clone();
+
+        let this = std::mem::replace(self, clone);
+
         let fut = async move {
             let context = req.context;
             let ctx = context.clone();

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -108,7 +108,9 @@ impl tower::Service<crate::SubgraphRequest> for SubgraphService {
             ..
         } = request;
 
-        let mut client = self.client.clone();
+        let clone = self.client.clone();
+
+        let mut client = std::mem::replace(&mut self.client, clone);
         let service_name = (*self.service).to_owned();
 
         Box::pin(async move {

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -57,7 +57,6 @@ pub(crate) type Plugins = IndexMap<String, Box<dyn DynPlugin>>;
 pub(crate) struct SupergraphService<ExecutionFactory> {
     execution_service_factory: ExecutionFactory,
     query_planner_service: CachingQueryPlanner<BridgeQueryPlanner>,
-    ready_query_planner_service: Option<CachingQueryPlanner<BridgeQueryPlanner>>,
     schema: Arc<Schema>,
 }
 
@@ -72,7 +71,6 @@ impl<ExecutionFactory> SupergraphService<ExecutionFactory> {
         SupergraphService {
             query_planner_service,
             execution_service_factory,
-            ready_query_planner_service: None,
             schema,
         }
     }
@@ -87,19 +85,16 @@ where
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        // We need to obtain references to two hot services for use in call.
-        // The reason for us to clone here is that the async block needs to own the hot services,
-        // and cloning will produce a cold service. Therefore cloning in `SupergraphService#call` is not
-        // a valid course of action.
-        self.ready_query_planner_service
-            .get_or_insert_with(|| self.query_planner_service.clone())
+        self.query_planner_service
             .poll_ready(cx)
             .map_err(|err| err.into())
     }
 
     fn call(&mut self, req: SupergraphRequest) -> Self::Future {
         // Consume our cloned services and allow ownership to be transferred to the async block.
-        let planning = self.ready_query_planner_service.take().unwrap();
+        let clone = self.query_planner_service.clone();
+
+        let planning = std::mem::replace(&mut self.query_planner_service, clone);
         let execution = self.execution_service_factory.new_service();
 
         let schema = self.schema.clone();


### PR DESCRIPTION
When I was investigating connection resets I noted that we weren't following tower documentation with respect to [cloning inner services](https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services). 

This PR addresses that. The change to the supergraph seems to be most invasive. I have run the tests manually many times and the change seems good, but probably worth closer examination.
