### PR TITLE
allow router installer to install aarch64 binaries

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -105,15 +105,6 @@ get_architecture() {
     fi
 
 
-    # If we are building a linux container on an M1 chip, let's
-    # download a86_64 binaries and assume the docker image is
-    # for amd64. We do this because we don't have router binaries
-    # for aarch64 for any OS right now. If this changes in the
-    # future, we'll need to re-visit this hack.
-    if [ "$_ostype" = "Linux" ] && [ "$_cputype" = "aarch64" ]; then
-        _cputype="x86_64"
-    fi
-
     case "$_ostype" in
         Linux)
             _ostype=unknown-linux-gnu
@@ -133,7 +124,7 @@ get_architecture() {
     esac
 
     case "$_cputype" in
-        x86_64 | x86-64 | x64 | amd64)
+        x86_64 | x86-64 | x64 | amd64 | aarch64)
             ;;
         *)
             err "no precompiled binaries available for CPU architecture: $_cputype"


### PR DESCRIPTION
In the past, we didn't have aarch64 binaries. We hacked our install script so that we downloaded x86_64 binaries and relied on magic (aka chip emulation) to run the binary.

We build aarch64 binaries now, so we need to update the installer to install them and give a performance boost to our linux on aarch64 user base.

I manually tested the change by running a debian docker image on my M1 laptop and using the modified script to install a router into it.