### PR TITLE
apply traffic shaping on subgraph directly

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -78,4 +78,13 @@ The file is becoming large and hard to modify.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/1996
 
+### Apply traffic shaping on supergraph and subgraph directly [PR #2034](https://github.com/apollographql/router/issues/2034))
+
+The plugin infrastructure works on `BoxService` instances, and makes no guarantee on plugin ordering.
+The traffic shaping plugin needs a clonable inner service, and should run right before calling
+the underlying service. So this changes the traffic plugin application so it can work directly
+on the underlying service. It is still a plugin though, so it keeps the same configuration.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2034
+
 ## 📚 Documentation

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -256,7 +256,6 @@ pub(crate) trait DynPlugin: Send + Sync + 'static {
     /// Return one or several `Endpoint`s and `ListenAddr` and the router will serve your custom web Endpoint(s).
     fn web_endpoints(&self) -> MultiMap<ListenAddr, Endpoint>;
 
-    #[cfg(test)]
     fn as_any(&self) -> &dyn std::any::Any;
 }
 
@@ -287,9 +286,8 @@ where
         self.web_endpoints()
     }
 
-    #[cfg(test)]
     fn as_any(&self) -> &dyn std::any::Any {
-        self.as_any()
+        self
     }
 }
 

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -45,6 +45,8 @@ use crate::Configuration;
 use crate::SubgraphRequest;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+pub const APOLLO_TRAFFIC_SHAPING: &str = "apollo.traffic_shaping";
+
 trait Merge {
     fn merge(&self, fallback: Option<&Self>) -> Self;
 }
@@ -311,7 +313,7 @@ impl TrafficShaping {
 impl TrafficShaping {
     pub(crate) fn get_configuration_deduplicate_variables(configuration: &Configuration) -> bool {
         configuration
-            .plugin_configuration("apollo.traffic_shaping")
+            .plugin_configuration(APOLLO_TRAFFIC_SHAPING)
             .map(|conf| conf.get("deduplicate_variables") == Some(&serde_json::Value::Bool(true)))
             .unwrap_or_default()
     }
@@ -424,7 +426,7 @@ mod test {
             .with_configuration(Arc::new(config));
 
         let builder = builder
-            .with_dyn_plugin("apollo.traffic_shaping".to_string(), plugin)
+            .with_dyn_plugin(APOLLO_TRAFFIC_SHAPING.to_string(), plugin)
             .with_subgraph_service("accounts", account_service.clone())
             .with_subgraph_service("reviews", review_service.clone())
             .with_subgraph_service("products", product_service.clone());
@@ -435,7 +437,7 @@ mod test {
     async fn get_traffic_shaping_plugin(config: &serde_json::Value) -> Box<dyn DynPlugin> {
         // Build a traffic shaping plugin
         crate::plugin::plugins()
-            .get("apollo.traffic_shaping")
+            .get(APOLLO_TRAFFIC_SHAPING)
             .expect("Plugin not found")
             .create_instance_without_schema(config)
             .await

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -606,7 +606,6 @@ mod test {
         mock_service.expect_clone().returning(|| {
             let mut mock_service = MockSupergraphService::new();
 
-            println!("cloning the supergraph");
             mock_service.expect_clone().returning(|| {
                 let mut mock_service = MockSupergraphService::new();
                 mock_service.expect_call().times(0..2).returning(move |_| {

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -490,7 +490,10 @@ mod test {
         });
 
         let _response = plugin
-            .subgraph_service("test", test_service.boxed())
+            .as_any()
+            .downcast_ref::<TrafficShaping>()
+            .unwrap()
+            .subgraph_service_internal("test", test_service)
             .oneshot(request)
             .await
             .unwrap();
@@ -545,17 +548,26 @@ mod test {
         let test_service = MockSubgraph::new(HashMap::new());
 
         let _response = plugin
-            .subgraph_service("test", test_service.clone().boxed())
+            .as_any()
+            .downcast_ref::<TrafficShaping>()
+            .unwrap()
+            .subgraph_service_internal("test", test_service.clone())
             .oneshot(SubgraphRequest::fake_builder().build())
             .await
             .unwrap();
         let _response = plugin
-            .subgraph_service("test", test_service.clone().boxed())
+            .as_any()
+            .downcast_ref::<TrafficShaping>()
+            .unwrap()
+            .subgraph_service_internal("test", test_service.clone())
             .oneshot(SubgraphRequest::fake_builder().build())
             .await
             .expect_err("should be in error due to a timeout and rate limit");
         let _response = plugin
-            .subgraph_service("another", test_service.clone().boxed())
+            .as_any()
+            .downcast_ref::<TrafficShaping>()
+            .unwrap()
+            .subgraph_service_internal("another", test_service.clone())
             .oneshot(SubgraphRequest::fake_builder().build())
             .await
             .unwrap();
@@ -565,7 +577,10 @@ mod test {
             .await
             .is_err());
         let _response = plugin
-            .subgraph_service("test", test_service.boxed())
+            .as_any()
+            .downcast_ref::<TrafficShaping>()
+            .unwrap()
+            .subgraph_service_internal("test", test_service.clone())
             .oneshot(SubgraphRequest::fake_builder().build())
             .await
             .unwrap();
@@ -589,17 +604,25 @@ mod test {
         mock_service.expect_clone().returning(|| {
             let mut mock_service = MockSupergraphService::new();
 
-            mock_service.expect_call().times(0..2).returning(move |_| {
-                Ok(SupergraphResponse::fake_builder()
-                    .data(json!({ "test": 1234_u32 }))
-                    .build()
-                    .unwrap())
+            println!("cloning the supergraph");
+            mock_service.expect_clone().returning(|| {
+                let mut mock_service = MockSupergraphService::new();
+                mock_service.expect_call().times(0..2).returning(move |_| {
+                    Ok(SupergraphResponse::fake_builder()
+                        .data(json!({ "test": 1234_u32 }))
+                        .build()
+                        .unwrap())
+                });
+                mock_service
             });
             mock_service
         });
 
         let _response = plugin
-            .supergraph_service(mock_service.clone().boxed())
+            .as_any()
+            .downcast_ref::<TrafficShaping>()
+            .unwrap()
+            .supergraph_service_internal(mock_service.clone())
             .oneshot(SupergraphRequest::fake_builder().build().unwrap())
             .await
             .unwrap()
@@ -608,7 +631,10 @@ mod test {
             .unwrap();
 
         assert!(plugin
-            .supergraph_service(mock_service.clone().boxed())
+            .as_any()
+            .downcast_ref::<TrafficShaping>()
+            .unwrap()
+            .supergraph_service_internal(mock_service.clone())
             .oneshot(SupergraphRequest::fake_builder().build().unwrap())
             .await
             .is_err());
@@ -618,7 +644,10 @@ mod test {
             .await
             .is_err());
         let _response = plugin
-            .supergraph_service(mock_service.clone().boxed())
+            .as_any()
+            .downcast_ref::<TrafficShaping>()
+            .unwrap()
+            .supergraph_service_internal(mock_service.clone())
             .oneshot(SupergraphRequest::fake_builder().build().unwrap())
             .await
             .unwrap()

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -45,7 +45,7 @@ use crate::Configuration;
 use crate::SubgraphRequest;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
-pub const APOLLO_TRAFFIC_SHAPING: &str = "apollo.traffic_shaping";
+pub(crate) const APOLLO_TRAFFIC_SHAPING: &str = "apollo.traffic_shaping";
 
 trait Merge {
     fn merge(&self, fallback: Option<&Self>) -> Self;

--- a/apollo-router/src/plugins/traffic_shaping/rate/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/rate/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod future;
 mod layer;
 #[allow(clippy::module_inception)]
 mod rate;
-mod service;
+pub(crate) mod service;
 
 pub(crate) use self::error::RateLimited;
 pub(crate) use self::layer::RateLimitLayer;

--- a/apollo-router/src/plugins/traffic_shaping/rate/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/rate/mod.rs
@@ -1,7 +1,7 @@
 //! Limit the rate at which requests are processed.
 
 mod error;
-mod future;
+pub(crate) mod future;
 mod layer;
 #[allow(clippy::module_inception)]
 mod rate;

--- a/apollo-router/src/plugins/traffic_shaping/rate/service.rs
+++ b/apollo-router/src/plugins/traffic_shaping/rate/service.rs
@@ -14,7 +14,7 @@ use super::future::ResponseFuture;
 use super::Rate;
 use crate::plugins::traffic_shaping::rate::error::RateLimited;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct RateLimit<T> {
     pub(crate) inner: T,
     pub(crate) rate: Rate,

--- a/apollo-router/src/plugins/traffic_shaping/timeout/layer.rs
+++ b/apollo-router/src/plugins/traffic_shaping/timeout/layer.rs
@@ -17,7 +17,7 @@ impl TimeoutLayer {
     }
 }
 
-impl<S> Layer<S> for TimeoutLayer {
+impl<S: Clone> Layer<S> for TimeoutLayer {
     type Service = Timeout<S>;
 
     fn layer(&self, service: S) -> Self::Service {

--- a/apollo-router/src/plugins/traffic_shaping/timeout/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/timeout/mod.rs
@@ -9,85 +9,52 @@ pub(crate) mod error;
 pub(crate) mod future;
 mod layer;
 
-use std::pin::Pin;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
 
-use futures::Future;
-use tokio::time::Sleep;
+use tower::util::Oneshot;
 use tower::Service;
+use tower::ServiceExt;
 
 use self::future::ResponseFuture;
 pub(crate) use self::layer::TimeoutLayer;
 pub(crate) use crate::plugins::traffic_shaping::timeout::error::Elapsed;
 
 /// Applies a timeout to requests.
-#[derive(Debug)]
-pub(crate) struct Timeout<T> {
+#[derive(Debug, Clone)]
+pub(crate) struct Timeout<T: Clone> {
     inner: T,
     timeout: Duration,
-    sleep: Option<Pin<Box<Sleep>>>,
 }
 
 // ===== impl Timeout =====
 
-impl<T> Timeout<T> {
+impl<T: Clone> Timeout<T> {
     /// Creates a new [`Timeout`]
     pub(crate) fn new(inner: T, timeout: Duration) -> Self {
-        Timeout {
-            inner,
-            timeout,
-            sleep: None,
-        }
+        Timeout { inner, timeout }
     }
 }
 
 impl<S, Request> Service<Request> for Timeout<S>
 where
-    S: Service<Request>,
+    S: Service<Request> + Clone,
     S::Error: Into<tower::BoxError>,
 {
     type Response = S::Response;
     type Error = tower::BoxError;
-    type Future = ResponseFuture<S::Future>;
+    type Future = ResponseFuture<Oneshot<S, Request>>;
 
-    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        if self.sleep.is_none() {
-            self.sleep = Some(Box::pin(tokio::time::sleep(self.timeout)));
-        }
-        match self.inner.poll_ready(cx) {
-            Poll::Pending => {}
-            Poll::Ready(r) => return Poll::Ready(r.map_err(Into::into)),
-        };
-
-        // Checking if we don't timeout on `poll_ready`
-        if Pin::new(
-            &mut self
-                .sleep
-                .as_mut()
-                .expect("we can unwrap because we set it just before"),
-        )
-        .poll(cx)
-        .is_ready()
-        {
-            tracing::trace!("timeout exceeded.");
-            self.sleep = None;
-
-            return Poll::Ready(Err(Elapsed::new().into()));
-        }
-
-        Poll::Pending
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        return Poll::Ready(Ok(()));
     }
 
     fn call(&mut self, request: Request) -> Self::Future {
-        let response = self.inner.call(request);
+        let service = self.inner.clone();
 
-        ResponseFuture::new(
-            response,
-            self.sleep
-                .take()
-                .expect("poll_ready must been called before"),
-        )
+        let response = service.oneshot(request);
+
+        ResponseFuture::new(response, Box::pin(tokio::time::sleep(self.timeout)))
     }
 }

--- a/apollo-router/src/plugins/traffic_shaping/timeout/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/timeout/mod.rs
@@ -47,7 +47,7 @@ where
     type Future = ResponseFuture<Oneshot<S, Request>>;
 
     fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        return Poll::Ready(Ok(()));
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, request: Request) -> Self::Future {

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -17,6 +17,7 @@ use crate::configuration::ConfigurationError;
 use crate::plugin::DynPlugin;
 use crate::plugin::Handler;
 use crate::plugins::traffic_shaping::TrafficShaping;
+use crate::plugins::traffic_shaping::APOLLO_TRAFFIC_SHAPING;
 use crate::services::new_service::NewService;
 use crate::services::RouterCreator;
 use crate::services::SubgraphService;
@@ -130,7 +131,7 @@ impl SupergraphServiceConfigurator for YamlSupergraphServiceFactory {
         for (name, _) in schema.subgraphs() {
             let subgraph_service = match plugins
                 .iter()
-                .find(|i| i.0.as_str() == "apollo.traffic_shaping")
+                .find(|i| i.0.as_str() == APOLLO_TRAFFIC_SHAPING)
                 .and_then(|plugin| (&*plugin.1).as_any().downcast_ref::<TrafficShaping>())
             {
                 Some(shaping) => {

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-use std::any::TypeId;
 // With regards to ELv2 licensing, this entire file is license key functionality
 use std::sync::Arc;
 

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -123,11 +123,6 @@ impl SupergraphServiceConfigurator for YamlSupergraphServiceFactory {
         let mut builder = PluggableSupergraphServiceBuilder::new(schema.clone());
         builder = builder.with_configuration(configuration);
 
-        println!(
-            "plugins list: {:?}",
-            plugins.iter().map(|i| i.0.as_str()).collect::<Vec<_>>()
-        );
-
         for (name, _) in schema.subgraphs() {
             let subgraph_service = match plugins
                 .iter()

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -423,7 +423,7 @@ impl RouterCreator {
         let supergraph_service = match self
             .plugins
             .iter()
-            .find(|i| i.0.as_str() == "apollo.traffic_shaping")
+            .find(|i| i.0.as_str() == APOLLO_TRAFFIC_SHAPING)
             .and_then(|plugin| plugin.1.as_any().downcast_ref::<TrafficShaping>())
         {
             Some(shaping) => Either::A(shaping.supergraph_service_internal(supergraph_service)),

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -424,7 +424,7 @@ impl RouterCreator {
             .plugins
             .iter()
             .find(|i| i.0.as_str() == "apollo.traffic_shaping")
-            .and_then(|plugin| (&*plugin.1).as_any().downcast_ref::<TrafficShaping>())
+            .and_then(|plugin| plugin.1.as_any().downcast_ref::<TrafficShaping>())
         {
             Some(shaping) => Either::A(shaping.supergraph_service_internal(supergraph_service)),
             None => Either::B(supergraph_service),

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -13,6 +13,7 @@ use indexmap::IndexMap;
 use multimap::MultiMap;
 use opentelemetry::trace::SpanKind;
 use tower::util::BoxService;
+use tower::util::Either;
 use tower::BoxError;
 use tower::ServiceBuilder;
 use tower::ServiceExt;
@@ -32,6 +33,7 @@ use crate::graphql;
 use crate::graphql::IntoGraphQLErrors;
 use crate::introspection::Introspection;
 use crate::plugin::DynPlugin;
+use crate::plugins::traffic_shaping::TrafficShaping;
 use crate::query_planner::BridgeQueryPlanner;
 use crate::query_planner::CachingQueryPlanner;
 use crate::router_factory::Endpoint;
@@ -408,23 +410,35 @@ impl RouterCreator {
         Error = BoxError,
         Future = BoxFuture<'static, Result<SupergraphResponse, BoxError>>,
     > + Send {
+        let supergraph_service = SupergraphService::builder()
+            .query_planner_service(self.query_planner_service.clone())
+            .execution_service_factory(ExecutionCreator {
+                schema: self.schema.clone(),
+                plugins: self.plugins.clone(),
+                subgraph_creator: self.subgraph_creator.clone(),
+            })
+            .schema(self.schema.clone())
+            .build();
+
+        let supergraph_service = match self
+            .plugins
+            .iter()
+            .find(|i| i.0.as_str() == "apollo.traffic_shaping")
+            .and_then(|plugin| (&*plugin.1).as_any().downcast_ref::<TrafficShaping>())
+        {
+            Some(shaping) => Either::A(shaping.supergraph_service_internal(supergraph_service)),
+            None => Either::B(supergraph_service),
+        };
+
         ServiceBuilder::new()
             .layer(EnsureQueryPresence::default())
             .service(
-                self.plugins.iter().rev().fold(
-                    BoxService::new(
-                        SupergraphService::builder()
-                            .query_planner_service(self.query_planner_service.clone())
-                            .execution_service_factory(ExecutionCreator {
-                                schema: self.schema.clone(),
-                                plugins: self.plugins.clone(),
-                                subgraph_creator: self.subgraph_creator.clone(),
-                            })
-                            .schema(self.schema.clone())
-                            .build(),
-                    ),
-                    |acc, (_, e)| e.supergraph_service(acc),
-                ),
+                self.plugins
+                    .iter()
+                    .rev()
+                    .fold(BoxService::new(supergraph_service), |acc, (_, e)| {
+                        e.supergraph_service(acc)
+                    }),
             )
     }
 

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -34,6 +34,7 @@ use crate::graphql::IntoGraphQLErrors;
 use crate::introspection::Introspection;
 use crate::plugin::DynPlugin;
 use crate::plugins::traffic_shaping::TrafficShaping;
+use crate::plugins::traffic_shaping::APOLLO_TRAFFIC_SHAPING;
 use crate::query_planner::BridgeQueryPlanner;
 use crate::query_planner::CachingQueryPlanner;
 use crate::router_factory::Endpoint;


### PR DESCRIPTION
The plugin infrastructure works on `BoxService` instances, and makes no guarantee on plugin ordering.
The traffic shaping plugin needs a clonable inner service, and should run right before calling
the underlying service. So this changes the traffic plugin application so it can work directly
on the underlying service. It is still a plugin though, so it keeps the same configuration.