### PR TITLE
reduce CI bill and improve build speed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ commands:
           condition:
             equal: [linux_amd, << parameters.os >>]
           steps:
-            - run: cargo test --jobs 8 --workspace --locked << parameters.cargo_test_args >> --test-threads=8
+            - run: cargo test --jobs 4 --workspace --locked << parameters.cargo_test_args >> --test-threads=8
       - when:
           condition:
             equal: [linux_arm, << parameters.os >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,11 +248,14 @@ commands:
       # As of rustc 1.61.0, must limit the number of linux jobs or we run out of memory (large executor/8GB)
       - when:
           condition:
-            or:
-              - equal: [linux_amd, << parameters.os >>]
-              - equal: [linux_arm, << parameters.os >>]
+            equal: [linux_amd, << parameters.os >>]
           steps:
             - run: cargo test --jobs 4 --workspace --locked << parameters.cargo_test_args >> --test-threads=4
+      - when:
+          condition:
+            equal: [linux_arm, << parameters.os >>]
+          steps:
+            - run: cargo test --jobs 8 --workspace --locked << parameters.cargo_test_args >> --test-threads=4
       - when:
           condition:
             equal: [macos, << parameters.os >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,7 +525,9 @@ workflows:
       #       parameters:
       #         platform: [linux]
 
-      - test_updated
+      - test_updated:
+          requires:
+            - lint
       - test:
           requires:
             - lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ commands:
           condition:
             equal: [linux_amd, << parameters.os >>]
           steps:
-            - run: cargo test --jobs 4 --workspace --locked << parameters.cargo_test_args >> --test-threads=8
+            - run: cargo test --jobs 4 --workspace --locked << parameters.cargo_test_args >> --test-threads=6
       - when:
           condition:
             equal: [linux_arm, << parameters.os >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,8 +527,8 @@ workflows:
 
       - test_updated
       - test:
-        requires:
-          - lint
+          requires:
+            - lint
           matrix:
             parameters:
               platform:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,12 +250,12 @@ commands:
           condition:
             equal: [linux_amd, << parameters.os >>]
           steps:
-            - run: cargo test --jobs 4 --workspace --locked << parameters.cargo_test_args >> --test-threads=4
+            - run: cargo test --jobs 8 --workspace --locked << parameters.cargo_test_args >> --test-threads=8
       - when:
           condition:
             equal: [linux_arm, << parameters.os >>]
           steps:
-            - run: cargo test --jobs 8 --workspace --locked << parameters.cargo_test_args >> --test-threads=4
+            - run: cargo test --jobs 8 --workspace --locked << parameters.cargo_test_args >> --test-threads=8
       - when:
           condition:
             equal: [macos, << parameters.os >>]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,11 @@ executors:
   arm_linux_build: &arm_linux_build_executor
     machine:
       image: ubuntu-2004:2022.04.1
-    resource_class: arm.medium
+    resource_class: arm.large
   arm_linux_test: &arm_linux_test_executor
     machine:
       image: ubuntu-2004:2022.04.1
-    resource_class: arm.large
+    resource_class: arm.xlarge
   macos_build: &macos_build_executor
     macos:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
@@ -527,6 +527,8 @@ workflows:
 
       - test_updated
       - test:
+        requires:
+          - lint
           matrix:
             parameters:
               platform:


### PR DESCRIPTION
The long pole on our build is the arm build/test step. Also, running everything in parallel is expensive.

Let's address both of those problems:

 - require lint to succeed before starting build/test jobs
 - give more resources to arm jobs to allow them to complete faster
 - tweak the build setting for both arm and amd to use resources more effectively

Result:
 - total build time is reduced by ~15% in my test runs (even with waiting for lint first)
 - billing should be reduced by less renovate waste-fullness when lint fails
