### PR TITLE
improve our rhai unit testing story

### DIFF
--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -769,21 +769,25 @@ macro_rules! gen_map_deferred_response {
     };
 }
 
+#[derive(Default)]
 pub(crate) struct RhaiExecutionResponse {
     context: Context,
     response: http_ext::Response<Response>,
 }
 
+#[derive(Default)]
 pub(crate) struct RhaiExecutionDeferredResponse {
     context: Context,
     response: Response,
 }
 
+#[derive(Default)]
 pub(crate) struct RhaiSupergraphResponse {
     context: Context,
     response: http_ext::Response<Response>,
 }
 
+#[derive(Default)]
 pub(crate) struct RhaiSupergraphDeferredResponse {
     context: Context,
     response: Response,
@@ -1061,6 +1065,10 @@ impl Rhai {
                     Err(_e) => false,
                 }
             })
+            // Register a contains function for Context so that "in" works
+            .register_fn("contains", |x: &mut Context, key: &str| -> bool {
+                x.get(key).map_or(false, |v: Option<Dynamic>| v.is_some())
+            })
             .register_fn(
                 "headers_are_available",
                 |_: &mut SharedMut<supergraph::Response>| -> bool { true },
@@ -1325,11 +1333,21 @@ impl Rhai {
             .register_fn("to_string", |x: &mut Value| -> String {
                 format!("{:?}", x)
             })
-            .register_fn("to_string", |x: &mut Uri| -> String { format!("{:?}", x) });
-
-        register_rhai_interface!(engine, supergraph, execution, subgraph);
-
-        engine
+            .register_fn("to_string", |x: &mut Uri| -> String { format!("{:?}", x) })
+            // Add query plan getter to execution request
+            .register_get(
+                "query_plan",
+                |obj: &mut SharedMut<execution::Request>| -> String {
+                    obj.with_mut(|request| {
+                        request
+                            .query_plan
+                            .formatted_query_plan
+                            .clone()
+                            .unwrap_or_default()
+                    })
+                },
+            )
+            // Add context getter/setters for deferred responses
             .register_get(
                 "context",
                 |obj: &mut SharedMut<supergraph::DeferredResponse>| -> Result<Context, Box<EvalAltResult>> {
@@ -1342,9 +1360,7 @@ impl Rhai {
                     obj.with_mut(|response| response.context = context);
                     Ok(())
                 },
-            );
-
-        engine
+            )
             .register_get(
                 "context",
                 |obj: &mut SharedMut<execution::DeferredResponse>| -> Result<Context, Box<EvalAltResult>> {
@@ -1358,6 +1374,8 @@ impl Rhai {
                     Ok(())
                 },
             );
+        // Add common getter/setters for different types
+        register_rhai_interface!(engine, supergraph, execution, subgraph);
 
         engine
     }
@@ -1373,6 +1391,7 @@ register_plugin!("apollo", "rhai", Rhai);
 mod tests {
     use std::str::FromStr;
 
+    use rhai::EvalAltResult;
     use serde_json::Value;
     use tower::util::BoxService;
     use tower::Service;
@@ -1383,9 +1402,7 @@ mod tests {
     use crate::plugin::test::MockExecutionService;
     use crate::plugin::test::MockSupergraphService;
     use crate::plugin::DynPlugin;
-    use crate::Context;
-    use crate::SupergraphRequest;
-    use crate::SupergraphResponse;
+    use crate::SubgraphRequest;
 
     #[tokio::test]
     async fn rhai_plugin_router_service() -> Result<(), BoxError> {
@@ -1594,5 +1611,211 @@ mod tests {
             .call_fn(&mut guard, &rhai_instance.ast, "get_sdl", ())
             .expect("can get sdl");
         assert_eq!(sdl.as_str(), "");
+    }
+
+    #[test]
+    fn it_provides_helpful_headermap_errors() {
+        let mut engine = Rhai::new_rhai_engine(None);
+        engine.register_fn("new_hm", HeaderMap::new);
+
+        let result = engine.eval::<HeaderMap>(
+            r#"
+    let map = new_hm();
+    map["ümlaut"] = "will fail";
+    map
+"#,
+        );
+        assert!(result.is_err());
+        assert!(matches!(
+            *result.unwrap_err(),
+            EvalAltResult::ErrorRuntime(..)
+        ));
+    }
+
+    // There is a lot of repetition in these tests, so I've tried to reduce that with these two
+    // macros. The repetition could probably be reduced further, but ...
+
+    macro_rules! gen_request_test {
+        ($base: ident, $fn_name: literal) => {
+            let dyn_plugin: Box<dyn DynPlugin> = crate::plugin::plugins()
+                .get("apollo.rhai")
+                .expect("Plugin not found")
+                .create_instance_without_schema(
+                    &Value::from_str(
+                        r#"{"scripts":"tests/fixtures", "main":"request_response_test.rhai"}"#,
+                    )
+                    .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            // Downcast our generic plugin. We know it must be Rhai
+            let it: &dyn std::any::Any = dyn_plugin.as_any();
+            let rhai_instance: &Rhai = it.downcast_ref::<Rhai>().expect("downcast");
+
+            // Get a scope to use for our test
+            let scope = rhai_instance.scope.clone();
+
+            let mut guard = scope.lock().unwrap();
+
+            // We must wrap our canned request in Arc<Mutex<Option<>>> to keep the rhai runtime
+            // happy
+            let request = Arc::new(Mutex::new(Some($base::fake_builder().build())));
+
+            // Call our rhai test function. If it return an error, the test failed.
+            let result: Result<(), Box<rhai::EvalAltResult>> =
+                rhai_instance
+                    .engine
+                    .call_fn(&mut guard, &rhai_instance.ast, $fn_name, (request,));
+            result.expect("test failed");
+        };
+    }
+
+    macro_rules! gen_response_test {
+        ($base: ident, $fn_name: literal) => {
+            let dyn_plugin: Box<dyn DynPlugin> = crate::plugin::plugins()
+                .get("apollo.rhai")
+                .expect("Plugin not found")
+                .create_instance_without_schema(
+                    &Value::from_str(
+                        r#"{"scripts":"tests/fixtures", "main":"request_response_test.rhai"}"#,
+                    )
+                    .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            // Downcast our generic plugin. We know it must be Rhai
+            let it: &dyn std::any::Any = dyn_plugin.as_any();
+            let rhai_instance: &Rhai = it.downcast_ref::<Rhai>().expect("downcast");
+
+            // Get a scope to use for our test
+            let scope = rhai_instance.scope.clone();
+
+            let mut guard = scope.lock().unwrap();
+
+            // We must wrap our canned response in Arc<Mutex<Option<>>> to keep the rhai runtime
+            // happy
+            let response = Arc::new(Mutex::new(Some($base::default())));
+
+            // Call our rhai test function. If it return an error, the test failed.
+            let result: Result<(), Box<rhai::EvalAltResult>> =
+                rhai_instance
+                    .engine
+                    .call_fn(&mut guard, &rhai_instance.ast, $fn_name, (response,));
+            result.expect("test failed");
+        };
+    }
+
+    #[tokio::test]
+    async fn it_can_process_supergraph_request() {
+        let dyn_plugin: Box<dyn DynPlugin> = crate::plugin::plugins()
+            .get("apollo.rhai")
+            .expect("Plugin not found")
+            .create_instance_without_schema(
+                &Value::from_str(
+                    r#"{"scripts":"tests/fixtures", "main":"request_response_test.rhai"}"#,
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Downcast our generic plugin. We know it must be Rhai
+        let it: &dyn std::any::Any = dyn_plugin.as_any();
+        let rhai_instance: &Rhai = it.downcast_ref::<Rhai>().expect("downcast");
+
+        // Get a scope to use for our test
+        let scope = rhai_instance.scope.clone();
+
+        let mut guard = scope.lock().unwrap();
+
+        // We must wrap our canned request in Arc<Mutex<Option<>>> to keep the rhai runtime
+        // happy
+        let request = Arc::new(Mutex::new(Some(
+            SupergraphRequest::canned_builder()
+                .operation_name("canned")
+                .build()
+                .expect("build canned supergraph request"),
+        )));
+
+        // Call our rhai test function. If it return an error, the test failed.
+        let result: Result<(), Box<rhai::EvalAltResult>> = rhai_instance.engine.call_fn(
+            &mut guard,
+            &rhai_instance.ast,
+            "process_supergraph_request",
+            (request,),
+        );
+        result.expect("test failed");
+    }
+
+    #[tokio::test]
+    async fn it_can_process_execution_request() {
+        gen_request_test!(ExecutionRequest, "process_execution_request");
+    }
+
+    #[tokio::test]
+    async fn it_can_process_subgraph_request() {
+        gen_request_test!(SubgraphRequest, "process_subgraph_request");
+    }
+
+    #[tokio::test]
+    async fn it_can_process_supergraph_response() {
+        gen_response_test!(RhaiSupergraphResponse, "process_supergraph_response");
+    }
+
+    #[tokio::test]
+    async fn it_can_process_supergraph_deferred_response() {
+        gen_response_test!(
+            RhaiSupergraphDeferredResponse,
+            "process_supergraph_response"
+        );
+    }
+
+    #[tokio::test]
+    async fn it_can_process_execution_response() {
+        gen_response_test!(RhaiExecutionResponse, "process_execution_response");
+    }
+
+    #[tokio::test]
+    async fn it_can_process_execution_deferred_response() {
+        gen_response_test!(RhaiExecutionDeferredResponse, "process_execution_response");
+    }
+
+    #[tokio::test]
+    async fn it_can_process_subgraph_response() {
+        let dyn_plugin: Box<dyn DynPlugin> = crate::plugin::plugins()
+            .get("apollo.rhai")
+            .expect("Plugin not found")
+            .create_instance_without_schema(
+                &Value::from_str(
+                    r#"{"scripts":"tests/fixtures", "main":"request_response_test.rhai"}"#,
+                )
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Downcast our generic plugin. We know it must be Rhai
+        let it: &dyn std::any::Any = dyn_plugin.as_any();
+        let rhai_instance: &Rhai = it.downcast_ref::<Rhai>().expect("downcast");
+
+        // Get a scope to use for our test
+        let scope = rhai_instance.scope.clone();
+
+        let mut guard = scope.lock().unwrap();
+
+        // We must wrap our canned response in Arc<Mutex<Option<>>> to keep the rhai runtime
+        // happy
+        let response = Arc::new(Mutex::new(Some(subgraph::Response::fake_builder().build())));
+
+        // Call our rhai test function. If it return an error, the test failed.
+        let result: Result<(), Box<rhai::EvalAltResult>> = rhai_instance.engine.call_fn(
+            &mut guard,
+            &rhai_instance.ast,
+            "process_subgraph_response",
+            (response,),
+        );
+        result.expect("test failed");
     }
 }

--- a/apollo-router/tests/fixtures/request_response_test.rhai
+++ b/apollo-router/tests/fixtures/request_response_test.rhai
@@ -1,0 +1,114 @@
+// These tests ensure that we can process request/responses and that we are receiving the
+// correct values provided in the rust layer.
+// If any of the tests fail, the thrown error will cause the respective rust
+// unit test to fail.
+
+fn process_common_request(check_context, request) {
+    if check_context {
+        if request.context.entries != () {
+            throw(`context entries: expected: (), actual: ${request.context.entries}`);
+        }
+    }
+    if request.body.operation_name != () {
+        throw(`operation name: expected: canned, actual: ${request.body.operation_name}`);
+    }
+    if request.body.query != () {
+        throw(`query: expected: (), actual: ${request.body.query}`);
+    }
+    if request.body.variables != #{} {
+        throw(`query: expected: #{}, actual: ${request.body.variables}`);
+    }
+    if request.body.extensions != #{} {
+        throw(`query: expected: #{}, actual: ${request.body.extensions}`);
+    }
+    if request.uri.host != () {
+        throw(`query: expected: (), actual: ${request.uri.host}`);
+    }
+    if request.uri.path != "/" {
+        throw(`query: expected: "/", actual: ${request.uri.path}`);
+    }
+}
+
+fn process_supergraph_request(request) {
+    if request.context.entries != () {
+        throw(`context entries: expected: (), actual: ${request.context.entries}`);
+    }
+    if request.headers["content-type"] != "application/json" {
+        throw(`header["content-type"]: expected: "application/json", actual: ${request.headers.content-type}`);
+    }
+    if request.body.operation_name != "canned" {
+        throw(`operation name: expected: canned, actual: ${request.body.operation_name}`);
+    }
+    let expected_query = `
+
+            query TopProducts($first: Int) { 
+                topProducts(first: $first) { 
+                    upc 
+                    name 
+                    reviews { 
+                        id 
+                        product { name } 
+                        author { id name } 
+                    } 
+                } 
+            }
+        `;
+    if request.body.query != expected_query {
+        throw(`query: expected: ${expected_query}, actual: ${request.body.query}`);
+    }
+    if request.body.variables != #{"first": 2} {
+        throw(`query: expected: #{"first": 2}, actual: ${request.body.variables}`);
+    }
+    if request.body.extensions != #{} {
+        throw(`query: expected: #{}, actual: ${request.body.extensions}`);
+    }
+    if request.uri.host != "default" {
+        throw(`query: expected: "default", actual: ${request.uri.host}`);
+    }
+    if request.uri.path != "/" {
+        throw(`query: expected: "/", actual: ${request.uri.path}`);
+    }
+}
+
+fn process_execution_request(request) {
+    process_common_request(true, request);
+    if request.query_plan != "" {
+        throw(`query: expected: (), actual: ${request.query_plan}`);
+    }
+}
+
+fn process_subgraph_request(request) {
+    process_common_request(true, request);
+    // subgraph doesn't have a context member
+    process_common_request(false, request.subgraph);
+}
+
+fn process_common_response(response) {
+    if response.context.entries != () {
+        throw(`context entries: expected: (), actual: ${response.context.entries}`);
+    }
+    if response.body.label != () {
+        throw(`label: expected: (), actual: ${response.body.label}`);
+    }
+    if response.body.data != () {
+        throw(`query: expected: (), actual: ${response.body.data}`);
+    }
+    if response.body.errors != [] {
+        throw(`query: expected: [], actual: ${response.body.errors}`);
+    }
+    if response.body.extensions != #{} {
+        throw(`query: expected: #{}, actual: ${response.body.extensions}`);
+    }
+}
+
+fn process_supergraph_response(response) {
+    process_common_response(response);
+}
+
+fn process_execution_response(response) {
+    process_common_response(response);
+}
+
+fn process_subgraph_response(response) {
+    process_common_response(response);
+}


### PR DESCRIPTION
Add unit tests for all rhai `request` and `response` accessors.

If a test fails, you'll see something like:

thread 'plugins::rhai::tests::it_can_process_supergraph_request' panicked at 'test failed: ErrorInFunctionCall("process_supergraph_request", "", ErrorRuntime("query: expected: #{\"first\": 1}, actual: #{\"first\": 2}", 60:9), none)', apollo-router/src/plugins/rhai.rs:1749:16

Which is telling you why the rhai script failed (expected != actual) and where it failed: functiona name, line number character offset. That should be enough to figure out what the problem is.

also:
 - add support for reading the query_plan from an ExecutionRequest
 - add contains function for context

