### PR TITLE
Fix helm values command

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -51,3 +51,9 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 
 ## 🛠 Maintenance
 ## 📚 Documentation
+
+### Fix example `helm show values` command ([PR #2088](https://github.com/apollographql/router/pull/2088))
+
+The `helm show vaues` command needs to use the correct Helm chart reference `oci://ghcr.io/apollographql/helm-charts/router`.
+
+By [@col](https://github.com/col) in https://github.com/apollographql/router/pull/2088

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -29,7 +29,7 @@ _See [configuration](#configuration) below._
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-helm show values apollographql/router
+helm show values oci://ghcr.io/apollographql/helm-charts/router
 ```
 
 ## Values

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -29,7 +29,7 @@ _See [configuration](#configuration) below._
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-helm show values oci://ghcr.io/apollographql/helm-charts/router
+helm show values apollographql/router
 ```
 
 ## Values

--- a/helm/chart/router/README.md.gotmpl
+++ b/helm/chart/router/README.md.gotmpl
@@ -28,7 +28,7 @@ _See [configuration](#configuration) below._
 See [Customizing the Chart Before Installing](https://helm.sh/docs/intro/using_helm/#customizing-the-chart-before-installing). To see all configurable options with detailed comments, visit the chart's [values.yaml](./values.yaml), or run these configuration commands:
 
 ```console
-helm show values apollographql/router
+helm show values oci://ghcr.io/apollographql/helm-charts/router
 ```
 
 {{ template "chart.requirementsSection" . }}


### PR DESCRIPTION
This is a tiny PR but I think it's a valid fix. 

When I tried to run `helm show values apollographql/router` as suggested in the README I got the error `Error: repo apollographql not found`. 

I believe the command should actually be `helm show values oci://ghcr.io/apollographql/helm-charts/router` which works as expected for me. 
