### PR TITLE
missing `@skip` and `@include` implementation for root operations

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -63,6 +63,12 @@ the `Accept` header means `*/*` when it is absent.
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/2078
 
+### Missing `@skip` and `@include` implementation for root operations ([Issue #2072](https://github.com/apollographql/router/issues/2072))
+
+`@skip` and `@include` were not implemented for inline fratgments and fragment spreads on top level operations.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2096
+
 ## 🛠 Maintenance
 ## 📚 Documentation
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -65,7 +65,7 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 
 ### Missing `@skip` and `@include` implementation for root operations ([Issue #2072](https://github.com/apollographql/router/issues/2072))
 
-`@skip` and `@include` were not implemented for inline fratgments and fragment spreads on top level operations.
+`@skip` and `@include` were not implemented for inline fragments and fragment spreads on top level operations.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2096
 

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -735,6 +735,8 @@ impl Query {
                 Selection::InlineFragment {
                     type_condition,
                     selection_set,
+                    skip,
+                    include,
                     ..
                 } => {
                     // top level objects will not provide a __typename field
@@ -742,6 +744,14 @@ impl Query {
                         != parameters.schema.root_operation_name(operation.kind)
                     {
                         return Err(InvalidValue);
+                    }
+
+                    if skip.should_skip(parameters.variables).unwrap_or(false) {
+                        continue;
+                    }
+
+                    if !include.should_include(parameters.variables).unwrap_or(true) {
+                        continue;
                     }
 
                     self.apply_selection_set(
@@ -756,10 +766,33 @@ impl Query {
                 Selection::FragmentSpread {
                     name,
                     known_type: _,
-                    skip: _,
-                    include: _,
+                    skip,
+                    include,
                 } => {
+                    if skip.should_skip(parameters.variables).unwrap_or(false) {
+                        continue;
+                    }
+
+                    if !include.should_include(parameters.variables).unwrap_or(true) {
+                        continue;
+                    }
+
                     if let Some(fragment) = self.fragments.get(name) {
+                        if fragment
+                            .skip
+                            .should_skip(parameters.variables)
+                            .unwrap_or(false)
+                        {
+                            continue;
+                        }
+                        if !fragment
+                            .include
+                            .should_include(parameters.variables)
+                            .unwrap_or(true)
+                        {
+                            continue;
+                        }
+
                         let operation_type_name =
                             parameters.schema.root_operation_name(operation.kind);
                         let is_apply = {

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -4102,6 +4102,120 @@ fn include() {
             },
         }})
         .test();
+
+    FormatTest::builder()
+        .schema(schema)
+        .query(
+            "query Example($shouldInclude: Boolean) {
+            get {
+                name
+            }
+            ...test @include(if: $shouldInclude)
+        }
+
+        fragment test on Query {
+            get {
+                id
+            }
+        }",
+        )
+        .response(json! {{
+            "get": {
+                "name": "a",
+            },
+        }})
+        .operation("Example")
+        .variables(json! {{
+            "shouldInclude": false
+        }})
+        .expected(json! {{
+            "get": {
+               "name": "a",
+            },
+        }})
+        .test();
+
+    FormatTest::builder()
+        .schema(schema)
+        .query(
+            "query Example($shouldInclude: Boolean) {
+            get {
+                name
+            }
+            ...test @include(if: $shouldInclude)
+        }
+
+        fragment test on Query {
+            get {
+                id
+            }
+        }",
+        )
+        .response(json! {{
+            "get": {
+                "name": "a",
+            },
+        }})
+        .operation("Example")
+        .expected(json! {{
+            "get": null,
+        }})
+        .test();
+
+    FormatTest::builder()
+        .schema(schema)
+        .query(
+            "query Example($shouldInclude: Boolean) {
+            get {
+                name
+            }
+            ... @include(if: $shouldInclude) {
+                get {
+                    id
+                }
+            }
+        }",
+        )
+        .response(json! {{
+            "get": {
+                "name": "a",
+            },
+        }})
+        .operation("Example")
+        .variables(json! {{
+            "shouldInclude": false
+        }})
+        .expected(json! {{
+            "get": {
+               "name": "a",
+            },
+        }})
+        .test();
+
+    FormatTest::builder()
+        .schema(schema)
+        .query(
+            "query Example($shouldInclude: Boolean) {
+            get {
+                name
+            }
+            ... @include(if: $shouldInclude) {
+                get {
+                    id
+                }
+            }
+        }",
+        )
+        .response(json! {{
+            "get": {
+                "name": "a",
+            },
+        }})
+        .operation("Example")
+        .expected(json! {{
+            "get": null,
+        }})
+        .test();
 }
 
 #[test]


### PR DESCRIPTION
Fix #2072

`@skip` and `@include` were not implemented for inline fragments and fragment spreads on top level operations