### PR TITLE
deps: Update `apollo-parser` to `v0.3.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-parser"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8f6cc3fa1313e045538ed2ce72ba916d52b501cd81e636a0bd5cdc703a0c73"
+checksum = "d640c8fb7f9ab98a78a8086bb413d8ecf3ee44849976e1636e27265f09e9e544"
 dependencies = [
  "rowan",
 ]

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -125,6 +125,12 @@ Rather than persist with this complexity, we've concluded that it would be bette
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/2085
 
+### Update `apollo-parser` to `v0.3.2` ([PR #TODO](https://github.com/apollographql/router/pull/TODO))
+
+This updates our dependency on our `apollo-parser` package which brings a few improvements, including more defensive parsing of some operations.  See its CHANGELOG in [the `apollo-rs` repository](https://github.com/apollographql/apollo-rs/blob/main/crates/apollo-parser/CHANGELOG.md#032---2022-11-15) for more details.
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/TODO
+
 ## 📚 Documentation
 
 ### Fix example `helm show values` command ([PR #2088](https://github.com/apollographql/router/pull/2088))

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -125,11 +125,11 @@ Rather than persist with this complexity, we've concluded that it would be bette
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/2085
 
-### Update `apollo-parser` to `v0.3.2` ([PR #TODO](https://github.com/apollographql/router/pull/TODO))
+### Update `apollo-parser` to `v0.3.2` ([PR #2103](https://github.com/apollographql/router/pull/2103))
 
 This updates our dependency on our `apollo-parser` package which brings a few improvements, including more defensive parsing of some operations.  See its CHANGELOG in [the `apollo-rs` repository](https://github.com/apollographql/apollo-rs/blob/main/crates/apollo-parser/CHANGELOG.md#032---2022-11-15) for more details.
 
-By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/TODO
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/2103
 
 ## 📚 Documentation
 

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -41,7 +41,7 @@ features = ["docs_rs"]
 access-json = "0.1.0"
 anyhow = "1.0.66"
 ansi_term = "0.12"
-apollo-parser = "0.3.1"
+apollo-parser = "0.3.2"
 async-compression = { version = "0.3.15", features = [
     "tokio",
     "brotli",

--- a/examples/supergraph-sdl/rust/Cargo.toml
+++ b/examples/supergraph-sdl/rust/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 apollo-compiler = "0.3.0"
-apollo-parser = "0.3.0"
+apollo-parser = "0.3.2"
 apollo-router = { path = "../../../apollo-router" }
 async-trait = "0.1"
 futures = "0.3"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 apollo-smith = { version = "0.2.0", features = ["parser-impl"] }
-apollo-parser = "0.3.1"
+apollo-parser = "0.3.2"
 env_logger = "0.9.3"
 log = "0.4"
 reqwest = { version = "0.11", features = ["json", "blocking"] }


### PR DESCRIPTION
This updates our dependency on our `apollo-parser` package which brings a few improvements, including more defensive parsing of some operations.  See its CHANGELOG in [the `apollo-rs` repository](https://github.com/apollographql/apollo-rs/blob/main/crates/apollo-parser/CHANGELOG.md#032---2022-11-15) for more details on what's included in the v0.3.2 release.

