### PR TITLE
Improve errors when subgraph service returns a non-2xx status code

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -115,9 +115,9 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2096
 
-### Improve errors when subgraph returns non-2xx status code ([Issue #2117](https://github.com/apollographql/router/issues/2117))
+### Improve errors when subgraph returns non-GraphQL response with a non-2xx status code ([Issue #2117](https://github.com/apollographql/router/issues/2117))
 
-The error response will now contain the status code and status name.
+The error response will now contain the status code and status name. Example: `HTTP fetch failed from 'my-service': 401 Unauthorized`
 
 By [@col](https://github.com/col) in https://github.com/apollographql/router/pull/2118
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -117,7 +117,7 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 
 ### Improve errors when subgraph returns non-2xx status code ([Issue #2117](https://github.com/apollographql/router/issues/2117))
 
-The error response will no contain the status code and status name.
+The error response will now contain the status code and status name.
 
 By [@col](https://github.com/col) in https://github.com/apollographql/router/pull/2118
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -115,6 +115,12 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2096
 
+### Improve errors when subgraph returns non-2xx status code ([Issue #2117](https://github.com/apollographql/router/issues/2117))
+
+The error response will no contain the status code and status name.
+
+By [@col](https://github.com/col) in https://github.com/apollographql/router/pull/2118
+
 ## 🛠 Maintenance
 
 ### Use `debian:bullseye-slim` as our base Docker image ([PR #2085](https://github.com/apollographql/router/pull/2085))

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -189,14 +189,18 @@ impl tower::Service<crate::SubgraphRequest> for SubgraphService {
                         return if !parts.status.is_success() {
                             Err(BoxError::from(FetchError::SubrequestHttpError {
                                 service: service_name.clone(),
-                                reason: format!("{}: {}", parts.status.as_str(), parts.status.canonical_reason().unwrap_or("Unknown")),
+                                reason: format!(
+                                    "{}: {}",
+                                    parts.status.as_str(),
+                                    parts.status.canonical_reason().unwrap_or("Unknown")
+                                ),
                             }))
                         } else {
                             Err(BoxError::from(FetchError::SubrequestHttpError {
                                 service: service_name.clone(),
                                 reason: format!("subgraph didn't return JSON (expected content-type: application/json or content-type: application/graphql+json; found content-type: {content_type:?})"),
                             }))
-                        }
+                        };
                     }
                 }
             }

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -186,16 +186,16 @@ impl tower::Service<crate::SubgraphRequest> for SubgraphService {
                     if !content_type_str.contains(APPLICATION_JSON_HEADER_VALUE)
                         && !content_type_str.contains(GRAPHQL_JSON_RESPONSE_HEADER_VALUE)
                     {
-                        if !parts.status.is_success() {
-                            return Err(BoxError::from(FetchError::SubrequestHttpError {
+                        return if !parts.status.is_success() {
+                            Err(BoxError::from(FetchError::SubrequestHttpError {
                                 service: service_name.clone(),
                                 reason: format!("{}: {}", parts.status.as_str(), parts.status.canonical_reason().unwrap_or("Unknown")),
-                            }));
+                            }))
                         } else {
-                            return Err(BoxError::from(FetchError::SubrequestHttpError {
+                            Err(BoxError::from(FetchError::SubrequestHttpError {
                                 service: service_name.clone(),
                                 reason: format!("subgraph didn't return JSON (expected content-type: application/json or content-type: application/graphql+json; found content-type: {content_type:?})"),
-                            }));
+                            }))
                         }
                     }
                 }

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -387,9 +387,7 @@ mod tests {
 
         let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle)) });
         let server = Server::bind(&socket_addr).serve(make_svc);
-        if let Err(e) = server.await {
-            eprintln!("server error: {}", e);
-        }
+        server.await.unwrap();
     }
 
     // starts a local server emulating a subgraph returning status code 401
@@ -404,9 +402,7 @@ mod tests {
 
         let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle)) });
         let server = Server::bind(&socket_addr).serve(make_svc);
-        if let Err(e) = server.await {
-            eprintln!("server error: {}", e);
-        }
+        server.await.unwrap();
     }
 
     // starts a local server emulating a subgraph returning bad response format
@@ -421,9 +417,7 @@ mod tests {
 
         let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle)) });
         let server = Server::bind(&socket_addr).serve(make_svc);
-        if let Err(e) = server.await {
-            eprintln!("server error: {}", e);
-        }
+        server.await.unwrap();
     }
 
     // starts a local server emulating a subgraph returning compressed response
@@ -470,9 +464,7 @@ mod tests {
 
         let make_svc = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle)) });
         let server = Server::bind(&socket_addr).serve(make_svc);
-        if let Err(e) = server.await {
-            eprintln!("server error: {}", e);
-        }
+        server.await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
This PR tries to address Issue #2117

Here's an example of how the Router would now respond when a subgraph service returns a non-2xx status code and content-type not set to `application/json`.
```
{
  "data": null,
  "errors": [
    {
      "message": "HTTP fetch failed from 'my-service': 401 Unauthorized",
      "path": [],
      "extensions": {
        "type": "SubrequestHttpError",
        "service": "my-service",
        "reason": "HTTP fetch failed from 'my-service': 401 Unauthorized"
      }
    }
  ]
}
```

