### PR TITLE
Docs: Update cors match regex example:

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -145,6 +145,13 @@ By [@col](https://github.com/col) in https://github.com/apollographql/router/pul
 ## 🛠 Maintenance
 ## 📚 Documentation
 
+### Docs: Update cors match regex example ([Issue #2151](https://github.com/apollographql/router/issues/2151))
+
+The docs CORS regex example now displays a working and safe way to allow `HTTPS` subdomains of `api.example.com`.
+
+By [@col](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/2152
+
+
 ### update documentation to reflect new examples structure ([Issue #2095](https://github.com/apollographql/router/pull/2133))
 
 We recently updated the examples directory structure. This fixes the documentation links to the examples. It also makes clear that rhai subgraph fields are read-only, since they are shared resources.

--- a/docs/source/configuration/cors.mdx
+++ b/docs/source/configuration/cors.mdx
@@ -40,7 +40,7 @@ cors:
     - https://www.your-app.example.com
     - https://studio.apollographql.com # Keep this so Apollo Studio can run queries against your router
   match_origins:
-    - "https://([a-z0-9]+[.])*api[.]example[.]com" # any host that uses https and ends with .api.example.com
+    - "^https://([a-z0-9]+[.])*api[.]example[.]com$" # any host that uses https and ends with .api.example.com
 ```
 
 You can also disable CORS entirely by setting `origins` to an empty list:


### PR DESCRIPTION
fixes #2151

The docs match regex example was wrong, it was missing ^ at the beginning and $ at the end. `$` marks the end of a string, which could be a safety issue.
