### PR TITLE
recent changes to add support for local repos broke the script

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -215,6 +215,12 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 
 ## 🐛 Fixes
 
+### fix build_docker_image.sh script when using default repo ([PR #2163](https://github.com/apollographql/router/pull/2163))
+
+Adding the `-r` flag recently broke the existing functionality to build from the default repo using `-b`. This fixes that.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/2163
+
 ### Improve errors when subgraph returns non-GraphQL response with a non-2xx status code ([Issue #2117](https://github.com/apollographql/router/issues/2117))
 
 The error response will now contain the status code and status name. Example: `HTTP fetch failed from 'my-service': 401 Unauthorized`
@@ -247,7 +253,7 @@ The docs CORS regex example now displays a working and safe way to allow `HTTPS`
 By [@col](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/2152
 
 
-### update documentation to reflect new examples structure ([Issue #2095](https://github.com/apollographql/router/pull/2133))
+### update documentation to reflect new examples structure ([Issue #2095](https://github.com/apollographql/router/issues/2095))
 
 We recently updated the examples directory structure. This fixes the documentation links to the examples. It also makes clear that rhai subgraph fields are read-only, since they are shared resources.
 

--- a/dockerfiles/diy/build_docker_image.sh
+++ b/dockerfiles/diy/build_docker_image.sh
@@ -118,11 +118,11 @@ else
     if [ "${BUILD_IMAGE}" = false ]; then
         usage
     fi
-    if [ -z "${GIT_REPO}" ]; then
-        GIT_REPO="${DEFAULT_REPO}"
-    fi
 fi
 
+if [ -z "${GIT_REPO}" ]; then
+    GIT_REPO="${DEFAULT_REPO}"
+fi
 
 # We need a place to build
 if ! BUILD_DIR=$(mktemp -d -t "router-build.XXXXXXXXXX"); then
@@ -150,7 +150,7 @@ if [ "${BUILD_IMAGE}" = true ]; then
         ROUTER_VERSION=$(git rev-parse HEAD)
     fi
     # Let the user know what we are going to do
-    echo "Building image: ${ROUTER_VERSION}" from repo""
+    echo "Building image: ${ROUTER_VERSION}" from repo: ${GIT_REPO}""
     git checkout "${ROUTER_VERSION}" > /dev/null 2>&1 || terminate "Couldn't checkout ${ROUTER_VERSION}"
     # Build our docker images
     docker build -q -t "router:${ROUTER_VERSION}" \


### PR DESCRIPTION
The addition of the `-r` flag broke the existing logic for processing the `-b` flag with non `-r` repos.

This fixes the logic and prints additional information about which repo is being used to build the image.
