### PR TITLE
stabilize Redis caching for APQ and query plan

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -259,6 +259,14 @@ to validate the data sent back to the client. Those query shapes were invalid fo
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2102
 
+### *Experimental* 🥼 APQ and query planner Redis caching fixes ([PR #2176](https://github.com/apollographql/router/pull/2176))
+
+* use a null byte as separator in Redis keys
+* handle Redis connection errors
+* mark APQ and query plan caching as license key functionality
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2176
+
 ## 🛠 Maintenance
 
 

--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -166,6 +166,7 @@ impl HttpServerFactory for AxumHttpServerFactory {
             let apq = APQLayer::with_cache(
                 DeduplicatingCache::from_configuration(
                     &configuration.supergraph.apq.experimental_cache,
+                    "APQ",
                 )
                 .await,
             );

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -26,6 +26,7 @@ where
     K: KeyType + 'static,
     V: ValueType + 'static,
 {
+    #[cfg(test)]
     pub(crate) async fn new() -> Self {
         Self::with_capacity(DEFAULT_CACHE_CAPACITY, None).await
     }

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -28,23 +28,31 @@ where
 {
     #[cfg(test)]
     pub(crate) async fn new() -> Self {
-        Self::with_capacity(DEFAULT_CACHE_CAPACITY, None).await
+        Self::with_capacity(DEFAULT_CACHE_CAPACITY, None, "test").await
     }
 
-    pub(crate) async fn with_capacity(capacity: usize, redis_urls: Option<Vec<String>>) -> Self {
+    pub(crate) async fn with_capacity(
+        capacity: usize,
+        redis_urls: Option<Vec<String>>,
+        caller: &str,
+    ) -> Self {
         Self {
             wait_map: Arc::new(Mutex::new(HashMap::new())),
-            storage: CacheStorage::new(capacity, redis_urls).await,
+            storage: CacheStorage::new(capacity, redis_urls, caller).await,
         }
     }
 
-    pub(crate) async fn from_configuration(config: &crate::configuration::Cache) -> Self {
+    pub(crate) async fn from_configuration(
+        config: &crate::configuration::Cache,
+        caller: &str,
+    ) -> Self {
         Self::with_capacity(
             config.in_memory.limit,
             #[cfg(feature = "experimental_cache")]
             config.redis.as_ref().map(|c| c.urls.clone()),
             #[cfg(not(feature = "experimental_cache"))]
             None,
+            caller,
         )
         .await
     }
@@ -199,7 +207,7 @@ mod tests {
     #[tokio::test]
     async fn example_cache_usage() {
         let k = "key".to_string();
-        let cache = DeduplicatingCache::with_capacity(1, None).await;
+        let cache = DeduplicatingCache::with_capacity(1, None, "test").await;
 
         let entry = cache.get(&k).await;
 
@@ -216,7 +224,7 @@ mod tests {
     #[test(tokio::test)]
     async fn it_should_enforce_cache_limits() {
         let cache: DeduplicatingCache<usize, usize> =
-            DeduplicatingCache::with_capacity(13, None).await;
+            DeduplicatingCache::with_capacity(13, None, "test").await;
 
         for i in 0..14 {
             let entry = cache.get(&i).await;
@@ -239,7 +247,7 @@ mod tests {
         mock.expect_retrieve().times(1).return_const(1usize);
 
         let cache: DeduplicatingCache<usize, usize> =
-            DeduplicatingCache::with_capacity(10, None).await;
+            DeduplicatingCache::with_capacity(10, None, "test").await;
 
         // Let's trigger 100 concurrent gets of the same value and ensure only
         // one delegated retrieve is made

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -9,6 +9,8 @@ use self::storage::CacheStorage;
 use self::storage::KeyType;
 use self::storage::ValueType;
 
+#[cfg(feature = "experimental_cache")]
+mod redis;
 pub(crate) mod storage;
 
 type WaitMap<K, V> = Arc<Mutex<HashMap<K, broadcast::Sender<V>>>>;

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -1,0 +1,144 @@
+// This entire file is license key functionality
+
+use std::fmt;
+use std::sync::Arc;
+
+use redis::AsyncCommands;
+use redis::FromRedisValue;
+use redis::RedisResult;
+use redis::RedisWrite;
+use redis::ToRedisArgs;
+use redis_cluster_async::Client;
+use redis_cluster_async::Connection;
+use tokio::sync::Mutex;
+
+use super::KeyType;
+use super::ValueType;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct RedisKey<K>(pub(crate) K)
+where
+    K: KeyType;
+
+#[derive(Clone, Debug)]
+pub(crate) struct RedisValue<V>(pub(crate) V)
+where
+    V: ValueType;
+
+#[derive(Clone)]
+pub(crate) struct RedisCacheStorage {
+    inner: Arc<Mutex<Connection>>,
+}
+
+fn get_type_of<T>(_: &T) -> &'static str {
+    std::any::type_name::<T>()
+}
+
+impl<K> fmt::Display for RedisKey<K>
+where
+    K: KeyType,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<K> ToRedisArgs for RedisKey<K>
+where
+    K: KeyType,
+{
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        out.write_arg_fmt(self);
+    }
+}
+
+impl<V> fmt::Display for RedisValue<V>
+where
+    V: ValueType,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}|{:?}", get_type_of(&self.0), self.0)
+    }
+}
+
+impl<V> ToRedisArgs for RedisValue<V>
+where
+    V: ValueType,
+{
+    fn write_redis_args<W>(&self, out: &mut W)
+    where
+        W: ?Sized + RedisWrite,
+    {
+        let v = serde_json::to_vec(&self.0)
+            .expect("JSON serialization should not fail for redis values");
+        out.write_arg(&v);
+    }
+}
+
+impl<V> FromRedisValue for RedisValue<V>
+where
+    V: ValueType,
+{
+    fn from_redis_value(v: &redis::Value) -> RedisResult<Self> {
+        match v {
+            redis::Value::Bulk(bulk_data) => {
+                for entry in bulk_data {
+                    tracing::trace!("entry: {:?}", entry);
+                }
+                Err(redis::RedisError::from((
+                    redis::ErrorKind::TypeError,
+                    "the data is the wrong type",
+                )))
+            }
+            redis::Value::Data(v) => serde_json::from_slice(v).map(RedisValue).map_err(|e| {
+                redis::RedisError::from((
+                    redis::ErrorKind::TypeError,
+                    "can't deserialize from JSON",
+                    e.to_string(),
+                ))
+            }),
+            res => Err(redis::RedisError::from((
+                redis::ErrorKind::TypeError,
+                "the data is the wrong type",
+                format!("{:?}", res),
+            ))),
+        }
+    }
+}
+
+impl RedisCacheStorage {
+    pub(crate) async fn new(urls: Vec<String>) -> Result<Self, redis::RedisError> {
+        let client = Client::open(urls)?;
+        let connection = client.get_connection().await?;
+
+        tracing::trace!("redis connection established");
+        Ok(Self {
+            inner: Arc::new(Mutex::new(connection)),
+        })
+    }
+
+    pub(crate) async fn get<K: KeyType, V: ValueType>(
+        &self,
+        key: RedisKey<K>,
+    ) -> Option<RedisValue<V>> {
+        tracing::trace!("getting from redis: {:?}", key);
+        let mut guard = self.inner.lock().await;
+        guard.get(key).await.ok()
+    }
+
+    pub(crate) async fn insert<K: KeyType, V: ValueType>(
+        &self,
+        key: RedisKey<K>,
+        value: RedisValue<V>,
+    ) {
+        tracing::trace!("inserting into redis: {:?}, {:?}", key, value);
+        let mut guard = self.inner.lock().await;
+        let r = guard
+            .set::<RedisKey<K>, RedisValue<V>, redis::Value>(key, value)
+            .await;
+        tracing::trace!("insert result {:?}", r);
+    }
+}

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -1,3 +1,5 @@
+// This entire file is license key functionality
+
 use std::fmt;
 use std::hash::Hash;
 use std::sync::Arc;
@@ -6,6 +8,9 @@ use lru::LruCache;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio::sync::Mutex;
+
+#[cfg(feature = "experimental_cache")]
+use super::redis::*;
 
 pub(crate) trait KeyType:
     Clone + fmt::Debug + fmt::Display + Hash + Eq + Send + Sync
@@ -33,9 +38,6 @@ where
     // Nothing to implement, since V already supports the other traits.
     // It has the functions it needs already
 }
-
-#[cfg(feature = "experimental_cache")]
-use redis_storage::*;
 
 // placeholder storage module
 //
@@ -115,151 +117,5 @@ where
     #[cfg(test)]
     pub(crate) async fn len(&self) -> usize {
         self.inner.lock().await.len()
-    }
-}
-
-#[cfg(feature = "experimental_cache")]
-mod redis_storage {
-    use std::fmt;
-    use std::sync::Arc;
-
-    use redis::AsyncCommands;
-    use redis::FromRedisValue;
-    use redis::RedisResult;
-    use redis::RedisWrite;
-    use redis::ToRedisArgs;
-    use redis_cluster_async::Client;
-    use redis_cluster_async::Connection;
-    use tokio::sync::Mutex;
-
-    use super::KeyType;
-    use super::ValueType;
-
-    #[derive(Clone, Debug, Eq, Hash, PartialEq)]
-    pub(crate) struct RedisKey<K>(pub(crate) K)
-    where
-        K: KeyType;
-
-    #[derive(Clone, Debug)]
-    pub(crate) struct RedisValue<V>(pub(crate) V)
-    where
-        V: ValueType;
-
-    #[derive(Clone)]
-    pub(crate) struct RedisCacheStorage {
-        inner: Arc<Mutex<Connection>>,
-    }
-
-    fn get_type_of<T>(_: &T) -> &'static str {
-        std::any::type_name::<T>()
-    }
-
-    impl<K> fmt::Display for RedisKey<K>
-    where
-        K: KeyType,
-    {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "{}", self.0)
-        }
-    }
-
-    impl<K> ToRedisArgs for RedisKey<K>
-    where
-        K: KeyType,
-    {
-        fn write_redis_args<W>(&self, out: &mut W)
-        where
-            W: ?Sized + RedisWrite,
-        {
-            out.write_arg_fmt(self);
-        }
-    }
-
-    impl<V> fmt::Display for RedisValue<V>
-    where
-        V: ValueType,
-    {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            write!(f, "{}|{:?}", get_type_of(&self.0), self.0)
-        }
-    }
-
-    impl<V> ToRedisArgs for RedisValue<V>
-    where
-        V: ValueType,
-    {
-        fn write_redis_args<W>(&self, out: &mut W)
-        where
-            W: ?Sized + RedisWrite,
-        {
-            let v = serde_json::to_vec(&self.0)
-                .expect("JSON serialization should not fail for redis values");
-            out.write_arg(&v);
-        }
-    }
-
-    impl<V> FromRedisValue for RedisValue<V>
-    where
-        V: ValueType,
-    {
-        fn from_redis_value(v: &redis::Value) -> RedisResult<Self> {
-            match v {
-                redis::Value::Bulk(bulk_data) => {
-                    for entry in bulk_data {
-                        tracing::trace!("entry: {:?}", entry);
-                    }
-                    Err(redis::RedisError::from((
-                        redis::ErrorKind::TypeError,
-                        "the data is the wrong type",
-                    )))
-                }
-                redis::Value::Data(v) => serde_json::from_slice(v).map(RedisValue).map_err(|e| {
-                    redis::RedisError::from((
-                        redis::ErrorKind::TypeError,
-                        "can't deserialize from JSON",
-                        e.to_string(),
-                    ))
-                }),
-                res => Err(redis::RedisError::from((
-                    redis::ErrorKind::TypeError,
-                    "the data is the wrong type",
-                    format!("{:?}", res),
-                ))),
-            }
-        }
-    }
-
-    impl RedisCacheStorage {
-        pub(crate) async fn new(urls: Vec<String>) -> Result<Self, redis::RedisError> {
-            let client = Client::open(urls)?;
-            let connection = client.get_connection().await?;
-
-            tracing::trace!("redis connection established");
-            Ok(Self {
-                inner: Arc::new(Mutex::new(connection)),
-            })
-        }
-
-        pub(crate) async fn get<K: KeyType, V: ValueType>(
-            &self,
-            key: RedisKey<K>,
-        ) -> Option<RedisValue<V>> {
-            tracing::trace!("getting from redis: {:?}", key);
-            let mut guard = self.inner.lock().await;
-            guard.get(key).await.ok()
-        }
-
-        pub(crate) async fn insert<K: KeyType, V: ValueType>(
-            &self,
-            key: RedisKey<K>,
-            value: RedisValue<V>,
-        ) {
-            tracing::trace!("inserting into redis: {:?}, {:?}", key, value);
-            let mut guard = self.inner.lock().await;
-            let r = guard
-                .set::<RedisKey<K>, RedisValue<V>, redis::Value>(key, value)
-                .await;
-            tracing::trace!("insert result {:?}", r);
-        }
     }
 }

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -374,6 +374,7 @@ impl Configuration {
                 },
             );
         }
+
         Ok(self)
     }
 }

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -21,7 +21,7 @@ pub(crate) struct Introspection {
 impl Introspection {
     pub(crate) async fn with_capacity(configuration: &Configuration, capacity: usize) -> Self {
         Self {
-            cache: CacheStorage::new(capacity, None).await,
+            cache: CacheStorage::new(capacity, None, "introspection").await,
             defer_support: configuration.supergraph.preview_defer_support,
         }
     }

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -1,3 +1,5 @@
+// This entire file is license key functionality
+
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::Arc;

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -38,8 +38,10 @@ where
         schema_id: Option<String>,
         config: &crate::configuration::QueryPlanning,
     ) -> CachingQueryPlanner<T> {
-        let cache =
-            Arc::new(DeduplicatingCache::from_configuration(&config.experimental_cache).await);
+        let cache = Arc::new(
+            DeduplicatingCache::from_configuration(&config.experimental_cache, "query planner")
+                .await,
+        );
         Self {
             cache,
             delegate,

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -190,7 +190,7 @@ impl std::fmt::Display for CachingQueryKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "plan|{}|{}|{}",
+            "plan\0{}\0{}\0{}",
             self.schema_id.as_deref().unwrap_or("-"),
             self.query,
             self.operation.as_deref().unwrap_or("-")

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -36,6 +36,7 @@ use self::Event::UpdateSchema;
 use crate::axum_factory::make_axum_router;
 use crate::axum_factory::AxumHttpServerFactory;
 use crate::axum_factory::ListenAddrAndRouter;
+use crate::cache::DeduplicatingCache;
 use crate::configuration::Configuration;
 use crate::configuration::ListenAddr;
 use crate::plugin::DynPlugin;
@@ -64,7 +65,10 @@ async fn make_transport_service<RF>(
         .create(configuration.clone(), schema, None, Some(extra_plugins))
         .await?;
 
-    let apq = APQLayer::new().await;
+    let apq = APQLayer::with_cache(
+        DeduplicatingCache::from_configuration(&configuration.supergraph.apq.experimental_cache)
+            .await,
+    );
     let web_endpoints = service_factory.web_endpoints();
     let routers = make_axum_router(service_factory, &configuration, web_endpoints, apq)?;
     // FIXME: how should

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -66,8 +66,11 @@ async fn make_transport_service<RF>(
         .await?;
 
     let apq = APQLayer::with_cache(
-        DeduplicatingCache::from_configuration(&configuration.supergraph.apq.experimental_cache)
-            .await,
+        DeduplicatingCache::from_configuration(
+            &configuration.supergraph.apq.experimental_cache,
+            "APQ",
+        )
+        .await,
     );
     let web_endpoints = service_factory.web_endpoints();
     let routers = make_axum_router(service_factory, &configuration, web_endpoints, apq)?;

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -3,6 +3,8 @@
 //!  For more information on APQ see:
 //!  <https://www.apollographql.com/docs/apollo-server/performance/apq/>
 
+// This entire file is license key functionality
+
 use std::ops::ControlFlow;
 
 use futures::future::BoxFuture;

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -38,12 +38,6 @@ pub(crate) struct APQLayer {
 }
 
 impl APQLayer {
-    pub(crate) async fn new() -> Self {
-        Self {
-            cache: DeduplicatingCache::new().await,
-        }
-    }
-
     pub(crate) fn with_cache(cache: DeduplicatingCache<String, String>) -> Self {
         Self { cache }
     }

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -215,6 +215,7 @@ impl<'a> TestHarness<'a> {
         let apq = APQLayer::with_cache(
             DeduplicatingCache::from_configuration(
                 &configuration.supergraph.apq.experimental_cache,
+                "APQ",
             )
             .await,
         );
@@ -237,7 +238,11 @@ impl<'a> TestHarness<'a> {
         let (config, router_creator) = self.build_common().await?;
         let web_endpoints = router_creator.web_endpoints();
         let apq = APQLayer::with_cache(
-            DeduplicatingCache::from_configuration(&config.supergraph.apq.experimental_cache).await,
+            DeduplicatingCache::from_configuration(
+                &config.supergraph.apq.experimental_cache,
+                "APQ",
+            )
+            .await,
         );
 
         let routers = make_axum_router(router_creator, &config, web_endpoints, apq)?;

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -5,6 +5,7 @@ use tower::BoxError;
 use tower::Layer;
 use tower::ServiceExt;
 
+use crate::cache::DeduplicatingCache;
 use crate::configuration::Configuration;
 use crate::plugin::test::canned;
 use crate::plugin::test::MockSubgraph;
@@ -210,8 +211,13 @@ impl<'a> TestHarness<'a> {
 
     /// Builds the GraphQL service
     pub async fn build(self) -> Result<supergraph::BoxCloneService, BoxError> {
-        let (_config, router_creator) = self.build_common().await?;
-        let apq = APQLayer::new().await;
+        let (configuration, router_creator) = self.build_common().await?;
+        let apq = APQLayer::with_cache(
+            DeduplicatingCache::from_configuration(
+                &configuration.supergraph.apq.experimental_cache,
+            )
+            .await,
+        );
 
         Ok(tower::service_fn(move |request| {
             // APQ must be added here because it is implemented in the HTTP server
@@ -230,7 +236,9 @@ impl<'a> TestHarness<'a> {
 
         let (config, router_creator) = self.build_common().await?;
         let web_endpoints = router_creator.web_endpoints();
-        let apq = APQLayer::new().await;
+        let apq = APQLayer::with_cache(
+            DeduplicatingCache::from_configuration(&config.supergraph.apq.experimental_cache).await,
+        );
 
         let routers = make_axum_router(router_creator, &config, web_endpoints, apq)?;
         let ListenAddrAndRouter(_listener, router) = routers.main;


### PR DESCRIPTION
* check for Redis connection issues
* use a null byte as separator for Redis key to prevent potential injections in the future
* mark all of Redis caching as license key functionality under Elastic License v2
