### PR TITLE
Extensible Subgraph Authentication (Starting with AWS SigV4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,6 +172,8 @@ dependencies = [
  "async-compression",
  "async-trait",
  "atty",
+ "aws-sigv4",
+ "aws-types",
  "axum",
  "backtrace",
  "base64 0.13.1",
@@ -473,6 +475,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "aws-sigv4"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ff4cff8c4a101962d593ba94e72cd83891aecd423f0c6e3146bff6fb92c9e3"
+dependencies = [
+ "aws-smithy-http",
+ "form_urlencoded",
+ "hex",
+ "http",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "ring",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b3442b4c5d3fc39891a2e5e625735fba6b24694887d49c6518460fde98247a9"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "aws-smithy-client"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff28d553714f8f54cd921227934fc13a536a1c03f106e56b362fd57e16d450ad"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf58ed4fefa61dbf038e5421a521cbc2c448ef69deff0ab1d915d8a10eda5664"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-tower"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c96d7bd35e7cf96aca1134b2f81b1b59ffe493f7c6539c051791cbbf7a42d3"
+dependencies = [
+ "aws-smithy-http",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b02e06ea63498c43bc0217ea4d16605d4e58d85c12fc23f6572ff6d0a840c61"
+dependencies = [
+ "itoa 1.0.4",
+ "num-integer",
+ "ryu",
+ "time",
+]
+
+[[package]]
+name = "aws-types"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05701d32da168b44f7ee63147781aed8723e792cc131cb9b18363b5393f17f70"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "http",
+ "rustc_version 0.4.0",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
 name = "axum"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +807,16 @@ name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d3a8076e283f3acd27400535992edb3ba4b5bb72f8891ad8fbe7932a7d4b9"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cache-padded"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -50,6 +50,8 @@ async-compression = { version = "0.3.15", features = [
 ] }
 async-trait = "0.1.59"
 atty = "0.2.14"
+aws-sigv4 = "0.51.0"
+aws-types = "0.51.0"
 axum = { version = "0.5.17", features = ["headers", "json", "original-uri"] }
 backtrace = "0.3.66"
 base64 = "0.13.1"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -599,6 +599,90 @@ expression: "&schema"
       },
       "additionalProperties": false
     },
+    "subgraph_auth": {
+      "type": "object",
+      "properties": {
+        "all": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "aws_sig_v4"
+              ],
+              "properties": {
+                "aws_sig_v4": {
+                  "type": "object",
+                  "required": [
+                    "access_key_id",
+                    "region",
+                    "secret_access_key",
+                    "service"
+                  ],
+                  "properties": {
+                    "access_key_id": {
+                      "type": "string"
+                    },
+                    "region": {
+                      "type": "string"
+                    },
+                    "secret_access_key": {
+                      "type": "string"
+                    },
+                    "service": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            }
+          ],
+          "nullable": true
+        },
+        "subgraphs": {
+          "type": "object",
+          "additionalProperties": {
+            "oneOf": [
+              {
+                "type": "object",
+                "required": [
+                  "aws_sig_v4"
+                ],
+                "properties": {
+                  "aws_sig_v4": {
+                    "type": "object",
+                    "required": [
+                      "access_key_id",
+                      "region",
+                      "secret_access_key",
+                      "service"
+                    ],
+                    "properties": {
+                      "access_key_id": {
+                        "type": "string"
+                      },
+                      "region": {
+                        "type": "string"
+                      },
+                      "secret_access_key": {
+                        "type": "string"
+                      },
+                      "service": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  }
+                },
+                "additionalProperties": false
+              }
+            ]
+          }
+        }
+      },
+      "additionalProperties": false
+    },
     "supergraph": {
       "description": "Configuration options pertaining to the supergraph server component.",
       "default": {

--- a/apollo-router/src/plugins/mod.rs
+++ b/apollo-router/src/plugins/mod.rs
@@ -9,5 +9,6 @@ mod headers;
 mod include_subgraph_errors;
 pub(crate) mod override_url;
 pub(crate) mod rhai;
+mod subgraph_auth;
 pub(crate) mod telemetry;
 pub(crate) mod traffic_shaping;

--- a/apollo-router/src/plugins/subgraph_auth.rs
+++ b/apollo-router/src/plugins/subgraph_auth.rs
@@ -3,9 +3,12 @@ use std::task::Context;
 use std::task::Poll;
 use std::time::SystemTime;
 
-use aws_sigv4::http_request::{
-    sign, PayloadChecksumKind, SignableBody, SignableRequest, SigningParams, SigningSettings,
-};
+use aws_sigv4::http_request::sign;
+use aws_sigv4::http_request::PayloadChecksumKind;
+use aws_sigv4::http_request::SignableBody;
+use aws_sigv4::http_request::SignableRequest;
+use aws_sigv4::http_request::SigningParams;
+use aws_sigv4::http_request::SigningSettings;
 use aws_types::Credentials;
 use schemars::JsonSchema;
 use serde::Deserialize;

--- a/apollo-router/src/plugins/subgraph_auth.rs
+++ b/apollo-router/src/plugins/subgraph_auth.rs
@@ -1,0 +1,296 @@
+use std::collections::HashMap;
+use std::task::Context;
+use std::task::Poll;
+use std::time::SystemTime;
+
+use aws_sigv4::http_request::{
+    sign, PayloadChecksumKind, SignableBody, SignableRequest, SigningParams, SigningSettings,
+};
+use aws_types::Credentials;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower::BoxError;
+use tower::Layer;
+use tower::ServiceBuilder;
+use tower::ServiceExt;
+use tower_service::Service;
+
+use crate::plugin::Plugin;
+use crate::plugin::PluginInit;
+use crate::register_plugin;
+use crate::services::subgraph;
+use crate::SubgraphRequest;
+
+register_plugin!("apollo", "subgraph_auth", SubgraphAuth);
+
+#[derive(Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+struct AWSSigV4Config {
+    access_key_id: String,
+    secret_access_key: String,
+    region: String,
+    service: String,
+}
+
+#[derive(Clone, JsonSchema, Deserialize)]
+#[serde(deny_unknown_fields)]
+enum AuthConfig {
+    #[serde(rename = "aws_sig_v4")]
+    AWSSigV4(AWSSigV4Config),
+}
+
+#[derive(Clone, JsonSchema, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+struct Config {
+    #[serde(default)]
+    all: Option<AuthConfig>,
+    #[serde(default)]
+    subgraphs: HashMap<String, AuthConfig>,
+}
+
+struct SubgraphAuth {
+    config: Config,
+}
+
+#[async_trait::async_trait]
+impl Plugin for SubgraphAuth {
+    type Config = Config;
+    async fn new(init: PluginInit<Self::Config>) -> Result<Self, BoxError> {
+        Ok(SubgraphAuth {
+            config: init.config,
+        })
+    }
+
+    fn subgraph_service(&self, name: &str, service: subgraph::BoxService) -> subgraph::BoxService {
+        let mut auth = self.config.all.as_ref();
+        if let Some(subgraph) = self.config.subgraphs.get(name) {
+            auth = Some(subgraph);
+        }
+        match auth {
+            Some(auth) => ServiceBuilder::new()
+                .layer(AuthLayer::new(auth.to_owned()))
+                .service(service)
+                .boxed(),
+            None => service,
+        }
+    }
+}
+
+struct AuthLayer {
+    auth: AuthConfig,
+}
+
+impl AuthLayer {
+    fn new(auth: AuthConfig) -> Self {
+        Self { auth }
+    }
+}
+
+impl<S> Layer<S> for AuthLayer {
+    type Service = AuthLayerService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AuthLayerService {
+            inner,
+            auth: self.auth.clone(),
+        }
+    }
+}
+
+struct AuthLayerService<S> {
+    inner: S,
+    auth: AuthConfig,
+}
+
+impl<S> Service<SubgraphRequest> for AuthLayerService<S>
+where
+    S: Service<SubgraphRequest>,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = S::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: SubgraphRequest) -> Self::Future {
+        match &self.auth {
+            AuthConfig::AWSSigV4(config) => {
+                let credentials = Credentials::new(
+                    config.access_key_id.clone(),
+                    config.secret_access_key.clone(),
+                    None,
+                    None,
+                    "config",
+                );
+
+                let mut settings = SigningSettings::default();
+                settings.payload_checksum_kind = PayloadChecksumKind::XAmzSha256;
+
+                let mut builder = SigningParams::builder()
+                    .access_key(credentials.access_key_id())
+                    .secret_key(credentials.secret_access_key())
+                    .region(config.region.as_ref())
+                    .service_name(config.service.as_ref())
+                    .time(SystemTime::now())
+                    .settings(settings);
+
+                builder.set_security_token(credentials.session_token());
+                let signing_params = builder.build().expect("all required fields set");
+
+                let body_bytes = match serde_json::to_string(&req.subgraph_request.body()) {
+                    Ok(body_str) => body_str.as_bytes().to_owned(),
+                    Err(err) => {
+                        tracing::error!("Failed to serialize GraphQL body for AWS SigV4 signing, skipping signing. Error: {}", err);
+                        return self.inner.call(req);
+                    }
+                };
+
+                let signable_request = SignableRequest::new(
+                    req.subgraph_request.method(),
+                    req.subgraph_request.uri(),
+                    req.subgraph_request.headers(),
+                    SignableBody::Bytes(&body_bytes),
+                );
+                let (signing_instructions, _signature) = match sign(signable_request, &signing_params) {
+                    Ok(output) => output,
+                    Err(err) => {
+                        tracing::error!("Failed to sign GraphQL request for AWS SigV4, skipping signing. Error: {}", err);
+                        return self.inner.call(req);
+                    }
+                }.into_parts();
+
+                signing_instructions.apply_to_request(&mut req.subgraph_request);
+
+                self.inner.call(req)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::graphql::Request;
+    use crate::plugin::test::MockSubgraphService;
+    use crate::plugins::subgraph_auth::AuthConfig;
+    use crate::plugins::subgraph_auth::AuthLayer;
+    use crate::query_planner::fetch::OperationKind;
+    use crate::Context;
+    use crate::SubgraphRequest;
+    use crate::SubgraphResponse;
+
+    use http::header::CONTENT_LENGTH;
+    use http::header::CONTENT_TYPE;
+    use http::header::HOST;
+
+    use regex::Regex;
+
+    #[test]
+    fn test_all_aws_sig_v4_config() {
+        serde_yaml::from_str::<Config>(
+            r#"
+        all:
+          aws_sig_v4:
+            access_key_id: "test"
+            secret_access_key: "test"
+            region: "us-east-1"
+            service: "lambda"
+        "#,
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn test_subgraph_aws_sig_v4_config() {
+        serde_yaml::from_str::<Config>(
+            r#"
+        subgraphs:
+          products:
+            aws_sig_v4:
+              access_key_id: "test"
+              secret_access_key: "test"
+              region: "us-east-1"
+              service: "lambda"
+        "#,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_aws_sig_v4_headers() -> Result<(), BoxError> {
+        let subgraph_request = example_request();
+
+        let mut mock = MockSubgraphService::new();
+        mock.expect_call()
+            .times(1)
+            .withf(|request| {
+                let authorization_regex = Regex::new(r"AWS4-HMAC-SHA256 Credential=id/\d{8}/us-east-1/lambda/aws4_request, SignedHeaders=content-length;content-type;host;x-amz-content-sha256;x-amz-date, Signature=[a-f0-9]{64}").unwrap();
+                let authorization_header_str = request.subgraph_request.headers().get("authorization").unwrap().to_str().unwrap();
+                assert_eq!(match authorization_regex.find(authorization_header_str) {
+                    Some(m) => m.as_str(),
+                    None => "no match"
+                }, authorization_header_str);
+
+                let x_amz_date_regex = Regex::new(r"\d{8}T\d{6}Z").unwrap();
+                let x_amz_date_header_str = request.subgraph_request.headers().get("x-amz-date").unwrap().to_str().unwrap();
+                assert_eq!(match x_amz_date_regex.find(x_amz_date_header_str) {
+                    Some(m) => m.as_str(),
+                    None => "no match"
+                }, x_amz_date_header_str);
+
+                assert_eq!(request.subgraph_request.headers().get("x-amz-content-sha256").unwrap(), "255959b4c6e11c1080f61ce0d75eb1b565c1772173335a7828ba9c13c25c0d8c");
+
+                true
+            })
+            .returning(example_response);
+
+        let mut service = AuthLayer::new(AuthConfig::AWSSigV4(AWSSigV4Config {
+            access_key_id: "id".to_string(),
+            secret_access_key: "secret".to_string(),
+            region: "us-east-1".to_string(),
+            service: "lambda".to_string(),
+        }))
+        .layer(mock);
+
+        service.ready().await?.call(subgraph_request).await?;
+        Ok(())
+    }
+
+    fn example_response(_: SubgraphRequest) -> Result<SubgraphResponse, BoxError> {
+        Ok(SubgraphResponse::new_from_response(
+            http::Response::default(),
+            Context::new(),
+        ))
+    }
+
+    fn example_request() -> SubgraphRequest {
+        let ctx = Context::new();
+        SubgraphRequest {
+            supergraph_request: Arc::new(
+                http::Request::builder()
+                    .header(HOST, "host")
+                    .header(CONTENT_LENGTH, "2")
+                    .header(CONTENT_TYPE, "graphql")
+                    .body(
+                        Request::builder()
+                            .query("query")
+                            .operation_name("my_operation_name")
+                            .build(),
+                    )
+                    .expect("expecting valid request"),
+            ),
+            subgraph_request: http::Request::builder()
+                .header(HOST, "rhost")
+                .header(CONTENT_LENGTH, "22")
+                .header(CONTENT_TYPE, "graphql")
+                .body(Request::builder().query("query").build())
+                .expect("expecting valid request"),
+            operation_kind: OperationKind::Query,
+            context: ctx,
+        }
+    }
+}

--- a/apollo-router/src/plugins/subgraph_auth.rs
+++ b/apollo-router/src/plugins/subgraph_auth.rs
@@ -173,6 +173,11 @@ where
 mod test {
     use std::sync::Arc;
 
+    use http::header::CONTENT_LENGTH;
+    use http::header::CONTENT_TYPE;
+    use http::header::HOST;
+    use regex::Regex;
+
     use super::*;
     use crate::graphql::Request;
     use crate::plugin::test::MockSubgraphService;
@@ -182,12 +187,6 @@ mod test {
     use crate::Context;
     use crate::SubgraphRequest;
     use crate::SubgraphResponse;
-
-    use http::header::CONTENT_LENGTH;
-    use http::header::CONTENT_TYPE;
-    use http::header::HOST;
-
-    use regex::Regex;
 
     #[test]
     fn test_all_aws_sig_v4_config() {


### PR DESCRIPTION
I started working on this as a standalone plugin, but realized it might have some serious customer value in the cloud router. If you don't think this fits in the main router repo, or it doesn't fit into the roadmap, my feelings won't be hurt 😄 Just figured I'd share what I have worked on for my other projects.

## Why?

Most medium-sized companies I've built infrastructure for host their GraphQL endpoint on AWS Lambda through API Gateway. With the work that has been put into the AS4 Lambda Integration, and the recent(ish) release of [Lambda Function URLs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-urls.html), I figure a perfect way to secure the connection between the Cloud Router and the Lambda Subgraph would be to use the existing `AWS_IAM` authorization type.

One of the major benefits of this is that the authorization and security is pushed into the AWS side of the shared responsibility model. With a pre-shared key, an attacker with knowledge of my lambda endpoint could rack up quite the bill by attempting different authorization patterns. With authorization set to `AWS_IAM`, Amazon takes on the burden of validating the request and the customer _isn't charged anything_ for unauthorized requests.

This authorization model is also work with existing API Gateway deployments (as opposed to the newer Function URLs)

## Why merge into the main router instead of a plugin?

I think that AWS SigV4 authorization is most important on the cloud router where the subgraphs must be internet facing. If I were to implement this as a plugin, I would need to run my own router, and at that point I would just use an internal API Gateway. This authorization model is already proven out for public-facing secure services, as almost all AWS services are accessed over the public internet unless the developer has went out of their way to implement VPC Endpoints. The plugin is written in such a way that other authorization methods could be implemented in the future without deprecating or moving fields.
