### PR TITLE
Unfeature Rust as a first impression of the router

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -20,8 +20,6 @@ flowchart BT;
   clients -.- gateway;
   class clients secondary;
 ```
-
- The Apollo Router is [implemented in Rust](https://github.com/apollographql/router), which provides [performance benefits](https://www.apollographql.com/blog/announcement/backend/apollo-router-our-graphql-federation-runtime-in-rust/) over the Node.js `@apollo/gateway` library.
  
 If you have an existing supergraph that currently uses `@apollo/gateway`, you can move to the Apollo Router without changing any other part of your supergraph.
 


### PR DESCRIPTION
Docs-only change to remove talking about Rust at the top of router docs. 

The router can now be talked about as a first-class way to operationalize supergraph runtime -- we no longer need to compare it to the legacy Gateway. We also don't need people worrying about what language the router is implemented in as part of their initial exploration.
