### PR TITLE
debug_assert identical schema parsing with apollo-compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,12 +114,13 @@ checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "apollo-compiler"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1466d86c8bec27cd5c28c80538a298729cf57ab3127389741336ac586634ec8"
+checksum = "3af79860291cff25966e4d35fa1b67b271043c5cfc6433e7a155b3fc800d926a"
 dependencies = [
  "apollo-parser 0.4.1",
- "miette 4.7.1",
+ "indexmap",
+ "miette",
  "ordered-float 2.10.0",
  "rowan",
  "salsa",
@@ -219,7 +220,7 @@ dependencies = [
  "maplit",
  "mediatype",
  "memchr",
- "miette 5.5.0",
+ "miette",
  "mime",
  "mockall",
  "multer",
@@ -2769,33 +2770,13 @@ dependencies = [
 
 [[package]]
 name = "miette"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c90329e44f9208b55f45711f9558cec15d7ef8295cc65ecd6d4188ae8edc58c"
-dependencies = [
- "atty",
- "backtrace",
- "miette-derive 4.7.1",
- "once_cell",
- "owo-colors",
- "supports-color",
- "supports-hyperlinks",
- "supports-unicode",
- "terminal_size",
- "textwrap 0.15.2",
- "thiserror",
- "unicode-width",
-]
-
-[[package]]
-name = "miette"
 version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4afd9b301defa984bbdbe112b4763e093ed191750a0d914a78c1106b2d0fe703"
 dependencies = [
  "atty",
  "backtrace",
- "miette-derive 5.5.0",
+ "miette-derive",
  "once_cell",
  "owo-colors",
  "supports-color",
@@ -2805,17 +2786,6 @@ dependencies = [
  "textwrap 0.15.2",
  "thiserror",
  "unicode-width",
-]
-
-[[package]]
-name = "miette-derive"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b5bc45b761bcf1b5e6e6c4128cd93b84c218721a8d9b894aa0aff4ed180174c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,6 +173,7 @@ dependencies = [
  "access-json",
  "ansi_term",
  "anyhow",
+ "apollo-compiler",
  "apollo-encoder 0.4.0",
  "apollo-parser 0.4.1",
  "arc-swap",
@@ -255,6 +256,7 @@ dependencies = [
  "serde_yaml",
  "sha2",
  "shellexpand",
+ "similar-asserts",
  "static_assertions",
  "strum_macros",
  "sys-info",
@@ -658,7 +660,9 @@ version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
 dependencies = [
+ "lazy_static",
  "memchr",
+ "regex-automata",
 ]
 
 [[package]]
@@ -4685,6 +4689,20 @@ name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
+dependencies = [
+ "bstr",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "similar-asserts"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf644ad016b75129f01a34a355dcb8d66a5bc803e417c7a77cc5d5ee9fa0f18"
+dependencies = [
+ "console 0.15.4",
+ "similar",
+]
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ incremental = false
 inherits = "release"
 debug = 1
 
+[patch.crates-io]
 # TODO: to delete
-# [patch.crates-io]
 # opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "e5ef3552efab2bdbf2f838023c37461cd799ab2c"}
 # opentelemetry-http = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "e5ef3552efab2bdbf2f838023c37461cd799ab2c"}
 # opentelemetry-jaeger = { git = "https://github.com/open-telemetry/opentelemetry-rust.git", rev = "e5ef3552efab2bdbf2f838023c37461cd799ab2c"}

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -41,6 +41,7 @@ features = ["docs_rs"]
 access-json = "0.1.0"
 anyhow = "1.0.68"
 ansi_term = "0.12"
+apollo-compiler = "0.4.1"
 apollo-parser = "0.4.1"
 arc-swap = "1.6.0"
 async-compression = { version = "0.3.15", features = [
@@ -163,6 +164,7 @@ serde_json_bytes = { version = "0.2.0", features = ["preserve_order"] }
 serde_json = { version = "1.0.91", features = ["preserve_order"] }
 serde_urlencoded = "0.7.1"
 serde_yaml = "0.8.26"
+similar-asserts = "1.4.2" # Only cfg(debug_assertions), but not a dev-dependency so it runs in other crates’s tests
 static_assertions = "1.1.0"
 strum_macros = "0.24.3"
 sys-info = "0.9.1"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -41,7 +41,7 @@ features = ["docs_rs"]
 access-json = "0.1.0"
 anyhow = "1.0.68"
 ansi_term = "0.12"
-apollo-compiler = "0.4.1"
+apollo-compiler = "0.5.0"
 apollo-parser = "0.4.1"
 arc-swap = "1.6.0"
 async-compression = { version = "0.3.15", features = [

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -398,6 +398,8 @@ pub(crate) enum SchemaError {
     MissingSubgraphUrl(String),
     /// Parsing error(s).
     Parse(ParseErrors),
+    /// Validation error(s) from apollo-compiler.
+    Validation(Vec<apollo_compiler::ApolloDiagnostic>),
     /// Api error(s): {0}
     Api(String),
 }

--- a/apollo-router/src/spec/field_type.rs
+++ b/apollo-router/src/spec/field_type.rs
@@ -1,3 +1,4 @@
+use apollo_compiler::hir;
 use apollo_parser::ast;
 use serde::Deserialize;
 use serde::Serialize;
@@ -157,6 +158,23 @@ impl FieldType {
 
     pub(crate) fn is_non_null(&self) -> bool {
         matches!(self, FieldType::NonNull(_))
+    }
+}
+
+impl From<&'_ hir::Type> for FieldType {
+    fn from(ty: &'_ hir::Type) -> Self {
+        match ty {
+            hir::Type::NonNull { ty, .. } => Self::NonNull(Box::new((&**ty).into())),
+            hir::Type::List { ty, .. } => Self::List(Box::new((&**ty).into())),
+            hir::Type::Named { name, .. } => match name.as_str() {
+                "String" => Self::String,
+                "Int" => Self::Int,
+                "Float" => Self::Float,
+                "ID" => Self::Id,
+                "Boolean" => Self::Boolean,
+                _ => Self::Named(name.clone()),
+            },
+        }
     }
 }
 

--- a/examples/supergraph-sdl/rust/Cargo.toml
+++ b/examples/supergraph-sdl/rust/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 anyhow = "1"
-apollo-compiler = "0.4.0"
+apollo-compiler = "0.5.0"
 apollo-parser = "0.4.0"
 apollo-router = { path = "../../../apollo-router" }
 async-trait = "0.1"

--- a/examples/supergraph-sdl/rust/src/supergraph_sdl.rs
+++ b/examples/supergraph-sdl/rust/src/supergraph_sdl.rs
@@ -39,7 +39,8 @@ impl Plugin for SupergraphSDL {
                 if let Some(query) = &req.supergraph_request.body().query {
                     // Compile our supergraph_sdl and query
                     let input = format!("{}\n{}", supergraph_sdl, query);
-                    let ctx = ApolloCompiler::new(&input);
+                    let mut ctx = ApolloCompiler::new();
+                    ctx.create_schema(&input, "supergraph.sdl");
                     // Do we have any diagnostics we'd like to print?
                     let diagnostics = ctx.validate();
                     for diagnostic in diagnostics {


### PR DESCRIPTION
Add a new code path for parsing schemas base on making queries to apollo-compiler’s database instead of traversing apollo-parser’s AST. This involves much less logic, leaving mostly type conversions. Eventually the router could use the compiler’s HIR types directly, reducing even that.

For now this new path only runs when debug assertions are enabled (so in debug mode or in tests) to assert that it returns results identical to the AST one.