### PR TITLE
replace notify recommended watcher with poll watcher

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -47,7 +47,7 @@ By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollo
 
 We noticed that we kept receiving issues about hot reload. We tried to fix this a while back by moving from HotWatch to Notify, but there are still issues. The problem appears to be caused by having different mechanisms on different platforms. Switching to the PollWatcher, which offers less sophisticated functionality but is the same on all platforms, should solve these issues at the expense of slightly worse reactiveness.
 
-By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/XXXX
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/2276
 
 ## 🛠 Maintenance
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -41,6 +41,14 @@ It defaults to 30 seconds.
 
 By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/2271
 
+## 🐛 Fixes
+
+### Replace notify recommended watcher with PollWatcher ([Issue #2245](https://github.com/apollographql/router/issues/2245))
+
+We noticed that we kept receiving issues about hot reload. We tried to fix this a while back by moving from HotWatch to Notify, but there are still issues. The problem appears to be caused by having different mechanisms on different platforms. Switching to the PollWatcher, which offers less sophisticated functionality but is the same on all platforms, should solve these issues at the expense of slightly worse reactiveness.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/XXXX
+
 ## 🛠 Maintenance
 
 ### Return more consistent errors ([Issue #2101](https://github.com/apollographql/router/issues/2101))

--- a/apollo-router/src/files.rs
+++ b/apollo-router/src/files.rs
@@ -69,7 +69,6 @@ fn watch_with_duration(path: &Path, duration: Duration) -> impl Stream<Item = ()
                             }
                         }
                     }
-                    // }
                 }
             }
             Err(e) => tracing::error!("event error: {:?}", e),
@@ -77,17 +76,6 @@ fn watch_with_duration(path: &Path, duration: Duration) -> impl Stream<Item = ()
         config,
     )
     .unwrap_or_else(|_| panic!("could not create watch on: {:?}", directory));
-    /*
-    tracing::info!(
-        "Default config: interval: {:?}, compare: {}",
-        Config::default().poll_interval(),
-        Config::default().compare_contents()
-    );
-    let config = Config::default()
-        .with_poll_interval(Duration::from_secs(3))
-        .with_compare_contents(true);
-    watcher.configure(config).expect("configuring watcher");
-    */
     watcher
         .watch(&directory, RecursiveMode::NonRecursive)
         .unwrap_or_else(|_| panic!("could not watch: {:?}", directory));

--- a/apollo-router/src/files.rs
+++ b/apollo-router/src/files.rs
@@ -13,6 +13,12 @@ use notify::PollWatcher;
 use notify::RecursiveMode;
 use notify::Watcher;
 
+#[cfg(not(test))]
+const DEFAULT_WATCH_DURATION: Duration = Duration::from_secs(3);
+
+#[cfg(test)]
+const DEFAULT_WATCH_DURATION: Duration = Duration::from_millis(100);
+
 /// Creates a stream events whenever the file at the path has changes. The stream never terminates
 /// and must be dropped to finish watching.
 ///
@@ -23,7 +29,7 @@ use notify::Watcher;
 /// returns: impl Stream<Item=()>
 ///
 pub(crate) fn watch(path: &Path) -> impl Stream<Item = ()> {
-    watch_with_duration(path, Duration::from_secs(3))
+    watch_with_duration(path, DEFAULT_WATCH_DURATION)
 }
 
 fn watch_with_duration(path: &Path, duration: Duration) -> impl Stream<Item = ()> {

--- a/apollo-router/src/files.rs
+++ b/apollo-router/src/files.rs
@@ -128,19 +128,17 @@ pub(crate) mod tests {
         assert!(futures::poll!(watch.next()).is_ready())
     }
 
-    #[cfg(test)]
     pub(crate) fn create_temp_file() -> (PathBuf, File) {
         let path = temp_dir().join(format!("{}", uuid::Uuid::new_v4()));
         let file = std::fs::File::create(&path).unwrap();
         (path, file)
     }
 
-    #[cfg(test)]
     pub(crate) async fn write_and_flush(file: &mut File, contents: &str) {
         file.seek(SeekFrom::Start(0)).unwrap();
         file.set_len(0).unwrap();
         file.write_all(contents.as_bytes()).unwrap();
         file.flush().unwrap();
-        tokio::time::sleep(Duration::from_millis(200)).await;
+        tokio::time::sleep(Duration::from_millis(500)).await;
     }
 }

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -8,6 +8,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::time::Duration;
 
 use arc_swap::ArcSwap;
 use futures::future::ready;
@@ -22,8 +23,12 @@ use http::uri::PathAndQuery;
 use http::HeaderMap;
 use http::StatusCode;
 use http::Uri;
+use notify::event::DataChange;
+use notify::event::MetadataKind;
 use notify::event::ModifyKind;
+use notify::Config;
 use notify::EventKind;
+use notify::PollWatcher;
 use notify::RecursiveMode;
 use notify::Watcher;
 use rhai::module_resolvers::FileModuleResolver;
@@ -445,8 +450,11 @@ impl Plugin for Rhai {
 
         let watcher_handle = std::thread::spawn(move || {
             let watching_path = watched_path.clone();
-            let mut watcher =
-                notify::recommended_watcher(move |res: Result<notify::Event, notify::Error>| {
+            let config = Config::default()
+                .with_poll_interval(Duration::from_secs(3))
+                .with_compare_contents(true);
+            let mut watcher = PollWatcher::new(
+                move |res: Result<notify::Event, notify::Error>| {
                     match res {
                         Ok(event) => {
                             // Let's limit the events we are interested in to:
@@ -455,7 +463,8 @@ impl Plugin for Rhai {
                             //  - with suffix "rhai"
                             if matches!(
                                 event.kind,
-                                EventKind::Modify(ModifyKind::Data(_))
+                                EventKind::Modify(ModifyKind::Metadata(MetadataKind::WriteTime))
+                                    | EventKind::Modify(ModifyKind::Data(DataChange::Any))
                                     | EventKind::Create(_)
                                     | EventKind::Remove(_)
                             ) {
@@ -489,8 +498,10 @@ impl Plugin for Rhai {
                         }
                         Err(e) => tracing::error!("rhai watching event error: {:?}", e),
                     }
-                })
-                .unwrap_or_else(|_| panic!("could not create watch on: {:?}", watched_path));
+                },
+                config,
+            )
+            .unwrap_or_else(|_| panic!("could not create watch on: {:?}", watched_path));
             watcher
                 .watch(&watched_path, RecursiveMode::Recursive)
                 .unwrap_or_else(|_| panic!("could not watch: {:?}", watched_path));

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -744,8 +744,10 @@ mod tests {
             UpdateConfiguration(_)
         ));
 
+        // Need different contents, since we won't get an event if content is the same
+        let contents_datadog = include_str!("testdata/datadog.router.yaml");
         // Modify the file and try again
-        write_and_flush(&mut file, contents).await;
+        write_and_flush(&mut file, contents_datadog).await;
         assert!(matches!(
             stream.next().await.unwrap(),
             UpdateConfiguration(_)
@@ -853,15 +855,17 @@ mod tests {
         // First update is guaranteed
         assert!(matches!(stream.next().await.unwrap(), UpdateSchema(_)));
 
+        // Need different contents, since we won't get an event if content is the same
+        let schema_minimal = include_str!("testdata/minimal_supergraph.graphql");
         // Modify the file and try again
-        write_and_flush(&mut file, schema).await;
+        write_and_flush(&mut file, schema_minimal).await;
         assert!(matches!(stream.next().await.unwrap(), UpdateSchema(_)));
     }
 
     #[test(tokio::test)]
     async fn schema_by_file_missing() {
         let mut stream = SchemaSource::File {
-            path: temp_dir().join("does_not_exit"),
+            path: temp_dir().join("does_not_exist"),
             watch: true,
             delay: None,
         }


### PR DESCRIPTION
To get consistent behaviour across multiple platforms and file systems.

fixes: #2245
  
The watcher may not be as reactive, but I think it's reactive enough for things which shouldn't change frequently.

As a bonus, we no longer get events if the content is the same, so less spurious reloads, which is good. That means I had to modify the tests though to use different contents.

The rhai file watching appeared to be working fine, but to be safe I converted it to the PollWatcher as well.