### PR TITLE
Only rebuild protos if proto source changes

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -42,6 +42,11 @@ It defaults to 30 seconds.
 By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/2271
 
 ## 🐛 Fixes
+
+### Only rebuild protos if proto source changes
+
+By [@scottdouglas1989](https://github.com/scottdouglas1989) in https://github.com/apollographql/router/pull/2283
+
 ### Traces won't cause missing field-stats ([Issue #2267](https://github.com/apollographql/router/issues/2267))
 
 Previously if a request was sampled for tracing it was not contributing to metrics correctly. This was a particular problem for users with a high sampling rate.

--- a/apollo-router/build/studio.rs
+++ b/apollo-router/build/studio.rs
@@ -8,8 +8,6 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     let reports_src = proto_dir.join("reports.proto");
     let reports_out = out_dir.join("reports.proto");
 
-    println!("cargo:rerun-if-changed={}", reports_src.to_str().unwrap());
-
     // Process the retrieved content to:
     //  - Insert a package Report; line after the import lines (currently only one) and before the first message definition
     //  - Remove the Apollo TS extensions [(js_use_toArray)=true] and [(js_preEncoded)=true] from the file
@@ -23,6 +21,8 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     content = content.replace("[(js_use_toArray)=true]", "");
     content = content.replace("[(js_preEncoded)=true]", "");
     std::fs::write(&reports_out, &content)?;
+
+    println!("cargo:rerun-if-changed={}", reports_src.to_str().unwrap());
 
     // Process the proto files
 
@@ -49,6 +49,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
         )
         .type_attribute(".", "#[derive(serde::Serialize)]")
         .type_attribute("StatsContext", "#[derive(Eq, Hash)]")
+        .emit_rerun_if_changed(false)
         .compile(&[reports_out],  &[&out_dir])?;
 
     Ok(())


### PR DESCRIPTION
`tonic_build` changes timestamps by a few nanos.

Router only needs to re-run `tonic_build` if `reports.proto` changes, and that's managed by the build.rs file already via `println!("cargo:rerun-if-changed={}", reports_src.to_str().unwrap());`

This just disables `tonic_build`'s rerun emits so it's fully managed by `apollo-router`