### PR TITLE
As we are now using metrics for all requests we should not set operation count

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -54,7 +54,7 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 Previously if a request was sampled for tracing it was not contributing to metrics correctly. This was a particular problem for users with a high sampling rate.
 Now metrics and traces have been separated so that metrics are always comprehensive and traces are ancillary.
 
-By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/2277
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/2277 and https://github.com/apollographql/router/pull/2286
 
 ### Replace notify recommended watcher with PollWatcher ([Issue #2245](https://github.com/apollographql/router/issues/2245))
 

--- a/apollo-router/src/plugins/telemetry/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/apollo.rs
@@ -246,7 +246,7 @@ impl AddAssign<SingleReport> for Report {
 
 impl AddAssign<TracesReport> for Report {
     fn add_assign(&mut self, report: TracesReport) {
-        self.operation_count += report.traces.len() as u64;
+        // Note that operation count is dealt with in metrics so we don't increment this.
         for (operation_signature, trace) in report.traces {
             self.traces_per_query
                 .entry(operation_signature)

--- a/apollo-router/src/plugins/telemetry/apollo_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/apollo_exporter.rs
@@ -163,7 +163,7 @@ impl ApolloExporter {
     }
 
     pub(crate) async fn submit_report(&self, report: Report) -> Result<(), ApolloExportError> {
-        // We may be sending traces but with no operation countr
+        // We may be sending traces but with no operation count
         if report.operation_count == 0 && report.traces_per_query.is_empty() {
             return Ok(());
         }

--- a/apollo-router/src/plugins/telemetry/apollo_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/apollo_exporter.rs
@@ -163,7 +163,8 @@ impl ApolloExporter {
     }
 
     pub(crate) async fn submit_report(&self, report: Report) -> Result<(), ApolloExportError> {
-        if report.operation_count == 0 {
+        // We may be sending traces but with no operation countr
+        if report.operation_count == 0 && report.traces_per_query.is_empty() {
             return Ok(());
         }
         tracing::debug!("submitting report: {:?}", report);

--- a/apollo-router/tests/snapshots/apollo_reports__client_name.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__client_name.snap
@@ -588,6 +588,6 @@ traces_per_query:
     referenced_fields_by_type: {}
     internal_traces_contributing_to_stats: []
 end_time: "[end_time]"
-operation_count: 1
+operation_count: 0
 traces_pre_aggregated: true
 

--- a/apollo-router/tests/snapshots/apollo_reports__client_version.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__client_version.snap
@@ -588,6 +588,6 @@ traces_per_query:
     referenced_fields_by_type: {}
     internal_traces_contributing_to_stats: []
 end_time: "[end_time]"
-operation_count: 1
+operation_count: 0
 traces_pre_aggregated: true
 

--- a/apollo-router/tests/snapshots/apollo_reports__condition_else.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__condition_else.snap
@@ -594,6 +594,6 @@ traces_per_query:
     referenced_fields_by_type: {}
     internal_traces_contributing_to_stats: []
 end_time: "[end_time]"
-operation_count: 1
+operation_count: 0
 traces_pre_aggregated: true
 

--- a/apollo-router/tests/snapshots/apollo_reports__condition_if.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__condition_if.snap
@@ -607,6 +607,6 @@ traces_per_query:
     referenced_fields_by_type: {}
     internal_traces_contributing_to_stats: []
 end_time: "[end_time]"
-operation_count: 1
+operation_count: 0
 traces_pre_aggregated: true
 

--- a/apollo-router/tests/snapshots/apollo_reports__non_defer.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__non_defer.snap
@@ -585,6 +585,6 @@ traces_per_query:
     referenced_fields_by_type: {}
     internal_traces_contributing_to_stats: []
 end_time: "[end_time]"
-operation_count: 1
+operation_count: 0
 traces_pre_aggregated: true
 

--- a/apollo-router/tests/snapshots/apollo_reports__send_header.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__send_header.snap
@@ -591,6 +591,6 @@ traces_per_query:
     referenced_fields_by_type: {}
     internal_traces_contributing_to_stats: []
 end_time: "[end_time]"
-operation_count: 1
+operation_count: 0
 traces_pre_aggregated: true
 

--- a/apollo-router/tests/snapshots/apollo_reports__send_variable_value.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__send_variable_value.snap
@@ -587,6 +587,6 @@ traces_per_query:
     referenced_fields_by_type: {}
     internal_traces_contributing_to_stats: []
 end_time: "[end_time]"
-operation_count: 1
+operation_count: 0
 traces_pre_aggregated: true
 

--- a/apollo-router/tests/snapshots/apollo_reports__trace_id.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__trace_id.snap
@@ -585,6 +585,6 @@ traces_per_query:
     referenced_fields_by_type: {}
     internal_traces_contributing_to_stats: []
 end_time: "[end_time]"
-operation_count: 1
+operation_count: 0
 traces_pre_aggregated: true
 


### PR DESCRIPTION
This change has not been released but the issue was introduced in #2277 Fixes #2267
Metrics will always have the definitive operation count.