### PR TITLE
CI fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -400,12 +400,9 @@ jobs:
       - checkout
       - linux_amd_install_baseline
       - run:
-          name: Use latest Rust Nightly and update all Rust dependencies
+          name: Update all Rust dependencies
           command: |
-            sed -i '/channel/d' rust-toolchain.toml
-            echo 'channel = "nightly"' >> rust-toolchain.toml
             rm Cargo.lock
-            cargo fetch
       - test_workspace:
           os: linux_amd
           # schema_generation test skipped because schemars changed its representation of enums:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,10 +231,10 @@ commands:
             - rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>-{{ checksum "Cargo.lock" }}-{{ checksum "xtask/Cargo.lock" }}
             - rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>
       - run:
-        name: Install xtask
-        command: |
-            set -e -o pipefail
-            xtask help || cd xtask && cargo install --path . && cd ..
+          name: Install xtask
+          command: |
+              set -e -o pipefail
+              xtask help || cd xtask && cargo install --path . && cd ..
       - run: xtask lint
       - save_cache:
           name: Save .cargo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,6 +273,10 @@ commands:
       cargo_test_args:
         type: string
         default: "--"
+      # additional cache key to have a cache for test_updated
+      cache_key:
+        type: string
+        default: ""
     steps:
       - run:
           name: Start jaeger
@@ -281,8 +285,8 @@ commands:
       - restore_cache:
           name: Restore .cargo
           keys:
-            - rust-cargo-<< pipeline.parameters.cache_version >>-test-<< parameters.os >>-{{ checksum "Cargo.lock" }}
-            - rust-cargo-<< pipeline.parameters.cache_version >>-test-<< parameters.os >>
+            - rust-cargo-<< pipeline.parameters.cache_version >>-test-<< parameters.os >><<parameters.cache_key>>-{{ checksum "Cargo.lock" }}
+            - rust-cargo-<< pipeline.parameters.cache_version >>-test-<< parameters.os >><<parameters.cache_key>>
 
       # As of rustc 1.61.0, must limit the number of linux jobs or we run out of memory (large executor/8GB)
       - when:
@@ -397,6 +401,7 @@ jobs:
           # schema_generation test skipped because schemars changed its representation of enums:
           # https://github.com/GREsau/schemars/blob/master/CHANGELOG.md#086---2021-09-26
           cargo_test_args: --no-fail-fast -- --skip schema_generation
+          cache_key: .test_updated
 
   build_release:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -403,6 +403,7 @@ jobs:
           name: Update all Rust dependencies
           command: |
             rm Cargo.lock
+            cargo fetch
       - test_workspace:
           os: linux_amd
           # schema_generation test skipped because schemars changed its representation of enums:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -228,9 +228,14 @@ commands:
       - restore_cache:
           name: Restore .cargo
           keys:
-            - rust-cargo-<< pipeline.parameters.cache_version >>-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
-            - rust-cargo-<< pipeline.parameters.cache_version >>-build-<< parameters.os >>
+            - rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+            - rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>
       - run: cargo xtask lint
+       - save_cache:
+          name: Save .cargo
+          key: rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+          paths:
+            - ~/.cargo
 
   xtask_check_compliance:
     parameters:
@@ -240,8 +245,8 @@ commands:
       - restore_cache:
           name: Restore .cargo
           keys:
-            - rust-cargo-<< pipeline.parameters.cache_version >>-build-<< parameters.os >>-{{ checksum "Cargo.lock" }}
-            - rust-cargo-<< pipeline.parameters.cache_version >>-build-<< parameters.os >>
+            - rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+            - rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>
       - install_extra_tools:
           os: << parameters.os >>
       # cargo-deny fetches a rustsec advisory DB, which has to happen on github.com over https

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ parameters:
   cache_version:
     type: string
     # increment this to invalidate all the caches
-    default: v11.{{ arch}}-{{ checksum "rust-toolchain.toml" }}
+    default: v12.{{ arch}}-{{ checksum "rust-toolchain.toml" }}
   jaeger_version:
     type: string
     # update this as new versions of jaeger become available
@@ -228,12 +228,17 @@ commands:
       - restore_cache:
           name: Restore .cargo
           keys:
-            - rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+            - rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>-{{ checksum "Cargo.lock" }}-{{ checksum "xtask/Cargo.lock" }}
             - rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>
-      - run: cargo xtask lint
+      - run:
+        name: Install xtask
+        command: |
+            set -e -o pipefail
+            xtask help || cd xtask && cargo install --path . && cd ..
+      - run: xtask lint
       - save_cache:
           name: Save .cargo
-          key: rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+          key: rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>-{{ checksum "Cargo.lock" }}-{{ checksum "xtask/Cargo.lock" }}
           paths:
             - ~/.cargo
 
@@ -245,7 +250,7 @@ commands:
       - restore_cache:
           name: Restore .cargo
           keys:
-            - rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>-{{ checksum "Cargo.lock" }}
+            - rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>-{{ checksum "Cargo.lock" }}-{{ checksum "xtask/Cargo.lock" }}
             - rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>
       - install_extra_tools:
           os: << parameters.os >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ commands:
           name: Install xtask
           command: |
               set -e -o pipefail
-              xtask help || cd xtask && cargo install --path . && cd ..
+              xtask help || { cd xtask && cargo install --path . && cd ..; }
       - run: xtask lint
       - save_cache:
           name: Save .cargo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,7 +231,7 @@ commands:
             - rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>-{{ checksum "Cargo.lock" }}
             - rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>
       - run: cargo xtask lint
-       - save_cache:
+      - save_cache:
           name: Save .cargo
           key: rust-cargo-<< pipeline.parameters.cache_version >>-xtask-<< parameters.os >>-{{ checksum "Cargo.lock" }}
           paths:

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -1,5 +1,4 @@
 use std::process::Command;
-use std::process::Stdio;
 
 use anyhow::ensure;
 use anyhow::Result;

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -9,8 +9,6 @@ use xtask::*;
 #[derive(Debug, StructOpt)]
 pub struct Lint {}
 
-const RUSTFMT_TOOLCHAIN: &str = "nightly-2022-06-26";
-
 const RUSTFMT_CONFIG: &[&str] = &["imports_granularity=Item", "group_imports=StdExternalCrate"];
 
 impl Lint {
@@ -35,30 +33,9 @@ impl Lint {
     }
 
     fn run_common(&self, fmt: impl FnOnce() -> Result<()>) -> Result<()> {
-        Self::install_rustfmt()?;
         fmt()?;
-        cargo!(["clippy", "--all", "--all-targets", "--", "-D", "warnings"]);
+        cargo!(["clippy", "--all", "--all-targets", "--", "-D", "warnings",]);
         cargo!(["doc", "--all", "--no-deps"], env = { "RUSTDOCFLAGS" => "-Dwarnings" });
-        Ok(())
-    }
-
-    fn install_rustfmt() -> Result<()> {
-        let nightly = RUSTFMT_TOOLCHAIN;
-        if !output("rustup", &["toolchain", "list"])?
-            .lines()
-            .any(|line| line.starts_with(nightly))
-        {
-            let args = ["toolchain", "install", nightly, "--profile", "minimal"];
-            run("rustup", &args)?
-        }
-        let args = ["component", "list", "--installed", "--toolchain", nightly];
-        if !output("rustup", &args)?
-            .lines()
-            .any(|line| line.starts_with("rustfmt"))
-        {
-            let args = ["component", "add", "rustfmt", "--toolchain", nightly];
-            run("rustup", &args)?
-        }
         Ok(())
     }
 
@@ -69,32 +46,15 @@ impl Lint {
     }
 
     fn fmt_command() -> Result<Command> {
-        let mut command = Command::new(which::which("rustup")?);
+        let mut command = Command::new(which::which("cargo")?);
         command.current_dir(&*PKG_PROJECT_ROOT).args([
-            "run",
-            RUSTFMT_TOOLCHAIN,
-            "cargo",
             "fmt",
             "--all",
             "--",
             "--config",
             &RUSTFMT_CONFIG.join(","),
+            "-v",
         ]);
         Ok(command)
     }
-}
-
-fn run(program: &str, args: &[&str]) -> Result<()> {
-    let status = Command::new(which::which(program)?).args(args).status()?;
-    ensure!(status.success(), "{} failed", program);
-    Ok(())
-}
-
-fn output(program: &str, args: &[&str]) -> Result<String> {
-    let output = Command::new(which::which(program)?)
-        .args(args)
-        .stderr(Stdio::piped())
-        .output()?;
-    ensure!(output.status.success(), "{} failed", program);
-    Ok(String::from_utf8(output.stdout)?)
 }

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -52,7 +52,6 @@ impl Lint {
             "--",
             "--config",
             &RUSTFMT_CONFIG.join(","),
-            "-v",
         ]);
         Ok(command)
     }


### PR DESCRIPTION
* set up a cache for the `xtask lint` task do not rebuild xtask on each CI run (-2mn on the total run)
* fix the cache for the `test_updated` task (-4mn on the total run)
* the rustfmt command from `xtask lint` can now run on stable rust
* `test_updated` runs on stable now (running it on nightly did not make sens as it is not supported)