### PR TITLE
Fix: Propagate errors across inline fragments.

### DIFF
--- a/apollo-router/src/spec/selection.rs
+++ b/apollo-router/src/spec/selection.rs
@@ -390,7 +390,7 @@ impl Selection {
             (Some(PathElement::Key(_)), Selection::InlineFragment { selection_set, .. }) => {
                 selection_set
                     .iter()
-                    .any(|selection| selection.contains_error_path(&path[1..], fragments))
+                    .any(|selection| selection.contains_error_path(&path, fragments))
             }
             (Some(PathElement::Fragment(_)), Selection::Field { .. }) => false,
         }


### PR DESCRIPTION
An off by one error lead the router to fail to propagate errors correctly across inline fragments. This fixes it, andd adds a unit test.