### PR TITLE
docs: Retroactively update `federation-version-support.mdx` for v1.6.0.

### DIFF
--- a/docs/source/federation-version-support.mdx
+++ b/docs/source/federation-version-support.mdx
@@ -23,7 +23,15 @@ The table below shows which version of federation each router release is compile
     <tbody>
     <tr>
         <td>
-            v1.2.1 and later (<a href="https://github.com/apollographql/router/releases">see latest releases</a>)
+            v1.6.0 and later (<a href="https://github.com/apollographql/router/releases">see latest releases</a>)
+        </td>
+        <td>
+            2.2.2
+        </td>
+    </tr>
+    <tr>
+        <td>
+            v1.2.1 - v1.5.0
         </td>
         <td>
             2.1.4


### PR DESCRIPTION
This should have been updated as part of the release process for the 1.6.0
release to indicate that Federation v2.2.2 was the active version as of that
release.  Apologies to the folks who rely on this information being accurate
to do their job correctly.

In the future, we will introduce automation to eliminate the human factor of
this, and that work is being tracked in https://github.com/apollographql/router/issues/2261.
