### PR TITLE
fix: specify content type to application/json when it throws an invalid graphql request error

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -33,3 +33,11 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 For `experimental_cache` with redis caching it now works with only a single Redis instance if you provide only one URL.
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/2310
+
+## 🛠 Maintenance
+
+### Specify content type to `application/json` when it throws an invalid GraphQL request error ([Issue #2320](https://github.com/apollographql/router/issues/2320))
+
+When throwing a `INVALID_GRAPHQL_REQUEST` error, it nows specify the right content-type header.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/2321

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -38,6 +38,6 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 
 ### Specify content type to `application/json` when it throws an invalid GraphQL request error ([Issue #2320](https://github.com/apollographql/router/issues/2320))
 
-When throwing a `INVALID_GRAPHQL_REQUEST` error, it nows specify the right `content-type` header.
+When throwing a `INVALID_GRAPHQL_REQUEST` error, it now specifies the right `content-type` header.
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/2321

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -38,6 +38,6 @@ By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router
 
 ### Specify content type to `application/json` when it throws an invalid GraphQL request error ([Issue #2320](https://github.com/apollographql/router/issues/2320))
 
-When throwing a `INVALID_GRAPHQL_REQUEST` error, it nows specify the right content-type header.
+When throwing a `INVALID_GRAPHQL_REQUEST` error, it nows specify the right `content-type` header.
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/2321

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -349,6 +349,7 @@ where
                     Ok(router::Response {
                         response: http::Response::builder()
                             .status(StatusCode::BAD_REQUEST)
+                            .header(CONTENT_TYPE, APPLICATION_JSON.to_string())
                             .body(Body::from(
                                 serde_json::to_string(
                                     &graphql::Error::builder()


### PR DESCRIPTION
close #2320 