### PR TITLE
chore: Follow-ups to release tooling

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -24,8 +24,6 @@ Description! And a link to a [reference](http://url)
 By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/router/pull/PULL_NUMBER
 -->
 
-# [1.8.0] (unreleased) - 2022-mm-dd
-
 ## 🚀 Features
 
 ### Add support for single instance Redis ([Issue #2300](https://github.com/apollographql/router/issues/2300))

--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -98,6 +98,7 @@ impl Prepare {
 
     async fn prepare_release(&self) -> Result<(), Error> {
         self.ensure_pristine_checkout()?;
+        self.ensure_prereqs()?;
         let version = self.update_cargo_tomls(&self.version)?;
         let github = octorust::Client::new(
             "router-release".to_string(),
@@ -133,6 +134,35 @@ impl Prepare {
                 "git workspace was not clean and requires 'git stash' before releasing"
             ));
         }
+        Ok(())
+    }
+
+    fn ensure_prereqs(&self) -> Result<()> {
+        if which::which("git").is_err() {
+            return Err(anyhow!(
+                "the 'git' executable could not be found in your PATH"
+            ));
+        }
+
+        if which::which("helm").is_err() {
+            return Err(anyhow!("the 'helm' executable could not be found in your PATH.  Install it using the instructions at https://helm.sh/docs/intro/install/ and try again."));
+        }
+
+        if which::which("helm-docs").is_err() {
+            return Err(anyhow!("the 'helm-docs' executable could not be found in your PATH.  Install it using the instructions at https://github.com/norwoodj/helm-docs#installation and try again."));
+        }
+
+        if which::which("cargo-about").is_err() {
+            return Err(anyhow!("the 'cargo-about' executable could not be found in your PATH.  Install it by running `cargo install --locked cargo-about"));
+        }
+
+        if which::which("cargo-deny").is_err() {
+            return Err(anyhow!("the 'cargo-deny' executable could not be found in your PATH.  Install it by running `cargo install --locked cargo-deny"));
+        }
+
+        // if std::env::var("GITHUB_TOKEN").is_err() {
+        //     return Err(anyhow!("it is required to set GITHUB_TOKEN in your"))
+        // }
         Ok(())
     }
 

--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -93,13 +93,7 @@ impl Prepare {
             .enable_all()
             .build()
             .unwrap()
-            .block_on(async {
-                let result = self.prepare_release().await;
-                if self.dry_run {
-                    git!("reset", "--hard");
-                }
-                result
-            })
+            .block_on(async { self.prepare_release().await })
     }
 
     async fn prepare_release(&self) -> Result<(), Error> {

--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -474,9 +474,9 @@ impl Prepare {
                     "--set",
                     "router.configuration.telemetry.metrics.prometheus.enabled=true",
                     "--set",
-                    "managedFederation.apiKey=\"REDACTED\"",
+                    "managedFederation.apiKey=REDACTED",
                     "--set",
-                    "managedFederation.graphRef=\"REDACTED\"",
+                    "managedFederation.graphRef=REDACTED",
                     "--debug",
                     ".",
                 ])

--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -110,8 +110,8 @@ impl Prepare {
         }
         self.assign_issues_to_milestone(&github, &version).await?;
         self.update_install_script(&version)?;
-        self.update_docs(&version)?;
         self.update_helm_charts(&version)?;
+        self.update_docs(&version)?;
         self.docker_files(&version)?;
         self.finalize_changelog(&version)?;
         self.update_lock()?;
@@ -467,6 +467,12 @@ impl Prepare {
     ///   (If not installed, you should [install `helm-docs`](https://github.com/norwoodj/helm-docs))
     fn update_helm_charts(&self, version: &str) -> Result<()> {
         println!("updating helm charts");
+        replace_in_file!(
+            "./helm/chart/router/Chart.yaml",
+            "appVersion: \"v\\d+.\\d+.\\d+\"",
+            format!("appVersion: \"v{}\"", version)
+        );
+
         if !std::process::Command::new(which::which("helm-docs")?)
             .current_dir("./helm/chart")
             .args(["helm-docs", "router"])
@@ -475,12 +481,6 @@ impl Prepare {
         {
             return Err(anyhow!("failed to generate helm docs"));
         }
-
-        replace_in_file!(
-            "./helm/chart/router/Chart.yaml",
-            "appVersion: \"v\\d+.\\d+.\\d+\"",
-            format!("appVersion: \"v{}\"", version)
-        );
 
         Ok(())
     }

--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -425,13 +425,13 @@ impl Prepare {
         }
         replace_in_file!(
             "./apollo-router-scaffold/templates/base/Cargo.toml",
-            "^apollo-router\\s*=\\s*\"\\d+.\\d+.\\d+\"",
+            "^apollo-router\\s*=\\s*\"[^\"]+\"",
             format!("apollo-router = \"{}\"", version)
         );
         replace_in_file!(
             "./apollo-router-scaffold/templates/base/xtask/Cargo.toml",
-            "^apollo-router-scaffold = \\{ git=\"https://github.com/apollographql/router.git\", tag\\s*=\\s*\"v\\d+.\\d+.\\d+\"\\s*\\}",
-            format!("apollo-router-scaffold = {{ git=\"https://github.com/apollographql/router.git\", tag = \"v{}\" }}", version)
+            r#"^apollo-router-scaffold = \{\s*git\s*=\s*"https://github.com/apollographql/router.git",\s*tag\s*=\s*"v[^"]+"\s*\}$"#,
+            format!(r#"apollo-router-scaffold = {{ git = "https://github.com/apollographql/router.git", tag = "v{}" }}"#, version)
         );
 
         Ok(version)
@@ -458,13 +458,13 @@ impl Prepare {
         println!("updating docs");
         replace_in_file!(
             "./docs/source/containerization/docker.mdx",
-            "with your chosen version. e.g.: `v\\d+.\\d+.\\d+`",
+            "with your chosen version. e.g.: `v[^`]+`",
             format!("with your chosen version. e.g.: `v{}`", version)
         );
         replace_in_file!(
             "./docs/source/containerization/kubernetes.mdx",
-            "router/tree/v\\d+.\\d+.\\d+",
-            format!("router/tree/v{}", version)
+            "https://github.com/apollographql/router/tree/[^/]+/helm/chart/router",
+            format!("https://github.com/apollographql/router/tree/v{}/helm/chart/router", version)
         );
         let helm_chart = String::from_utf8(
             std::process::Command::new(which::which("helm")?)
@@ -499,7 +499,7 @@ impl Prepare {
         println!("updating helm charts");
         replace_in_file!(
             "./helm/chart/router/Chart.yaml",
-            "appVersion: \"v\\d+.\\d+.\\d+\"",
+            "appVersion: \"v[^\"]+\"",
             format!("appVersion: \"v{}\"", version)
         );
 
@@ -526,8 +526,8 @@ impl Prepare {
             {
                 replace_in_file!(
                     entry.path(),
-                    r"ghcr.io/apollographql/router:v\d+.\d+.\d+",
-                    format!("ghcr.io/apollographql/router:v{}", version)
+                    r#"^(?P<indentation>\s+)image:\s*ghcr.io/apollographql/router:v.*$"#,
+                    format!("${{indentation}}image: ghcr.io/apollographql/router:v{}", version)
                 );
             }
         }


### PR DESCRIPTION
This PR follows-up #2202 and it consists of several commits which can stand alone, if necessary.  Each of those commits has their own message and while I suggest reviewing the totality of the PR, it's worth considering the text of the individual commit messages for additional context on the changes.

As a summary of those commits:

- Remove destructive `git reset --hard` command which destroyed my local changes
- Require a pristine Git checkout of known files prior to releasing
- Update Helm Chart version BEFORE `helm-docs` and `helm template` commands.
- Do a pre-flight check which asserts availabilty of necessary tools
- Remove pre-determined version heading from `NEXT_CHANGELOG.md`
- Repair logic which migrates `NEXT_CHANGELOG.md` entries to `CHANGELOG.md`
- Support ANY version string rather than just digits-dot-digits-dot-digits.
- Remove quotes around invocation of `helm template`'s `--set` flags

