### PR TITLE
show multiple validation errors

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -99,3 +99,10 @@ Moving APQ from the axum level to the supergraph service reintroduced a `Buffer`
 Now the APQ and`EnsureQueryPresence ` layers are part of the router service, to remove that `Buffer`.
 
 By [@Geal](https://github.com/geal) in https://github.com/apollographql/router/pull/2296
+
+### Refactor yaml validation error reports ([Issue #2180](https://github.com/apollographql/router/issues/2180))
+
+YAML configuration file validation prints a report of the errors it encountered, but that report was missing some
+information, and had small mistakes around alignment and pointing out the right line.
+
+By [@Geal](https://github.com/geal) in https://github.com/apollographql/router/pull/2347

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -136,7 +136,7 @@ pub(crate) fn validate_yaml_configuration(
                         // This guarantees that if the env variable contained a secret it won't be leaked.
                         e.instance = Cow::Owned(coerce(value));
 
-                        write!(
+                        let _ = write!(
                             &mut errors,
                             "{}. {}\n\n{}\n{}^----- {}\n\n",
                             idx + 1,
@@ -151,7 +151,7 @@ pub(crate) fn validate_yaml_configuration(
 
                         let lines = context_lines(&yaml_split_by_lines, start_marker, end_marker);
 
-                        write!(
+                        let _ = write!(
                             &mut errors,
                             "{}. {}\n\n{}\n└-----> {}\n\n",
                             idx + 1,
@@ -174,7 +174,6 @@ pub(crate) fn validate_yaml_configuration(
                                 if let Some((label, value)) =
                                     map.iter().find(|(label, _)| label.name == key)
                                 {
-                                    println!("key {key} => {label:?}");
                                     let (start_marker, end_marker) = (
                                         label.marker.as_ref().unwrap_or(marker),
                                         value.end_marker(),
@@ -190,7 +189,7 @@ pub(crate) fn validate_yaml_configuration(
                                         unexpected: vec![key.clone()],
                                     };
 
-                                    write!(
+                                    let _ = write!(
                                         &mut errors,
                                         "{}. {}\n\n{}\n└-----> {}\n\n",
                                         idx + 1,

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -118,12 +118,15 @@ pub(crate) fn validate_yaml_configuration(
                     const NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY: usize = 5;
                     match element {
                         yaml::Value::String(value, marker) => {
-                            let lines = yaml_split_by_lines[0.max(
-                                marker
+                            let start_marker = marker;
+                            let end_marker = marker;
+                            let offset = 0.max(
+                                start_marker
                                     .line()
                                     .saturating_sub(NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY),
-                            )
-                                ..marker.line()]
+                            );
+
+                            let lines = yaml_split_by_lines[offset..end_marker.line()]
                                 .iter()
                                 .join("\n");
 

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -223,8 +223,6 @@ pub(crate) fn validate_yaml_configuration(
                         }
                     }
                 }
-            } else {
-                //None
             }
         }
 

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -130,6 +130,7 @@ pub(crate) fn validate_yaml_configuration(
 
                         let lines = yaml_split_by_lines[offset..end_marker.line()]
                             .iter()
+                            .map(|line| format!("  {line}"))
                             .join("\n");
 
                         // Replace the value in the error message with the one from the raw config.
@@ -142,7 +143,7 @@ pub(crate) fn validate_yaml_configuration(
                             idx + 1,
                             e.instance_path,
                             lines,
-                            " ".repeat(0.max(marker.col())),
+                            " ".repeat(2 + marker.col()),
                             e
                         );
                     }
@@ -211,7 +212,7 @@ pub(crate) fn validate_yaml_configuration(
                             let lines =
                                 context_lines(&yaml_split_by_lines, start_marker, end_marker);
 
-                            write!(
+                            let _ = write!(
                                 &mut errors,
                                 "{}. {}\n\n{}\n└-----> {}\n\n",
                                 idx + 1,

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -285,7 +285,7 @@ fn context_lines(
             match real_line.cmp(&start_marker.line()) {
                 Ordering::Equal => format!("┌ {line}"),
                 Ordering::Greater => format!("| {line}"),
-                Ordering::Less => line.to_string(),
+                Ordering::Less => format!("  {line}"),
             }
         })
         .join("\n")

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -123,11 +123,9 @@ pub(crate) fn validate_yaml_configuration(
                     yaml::Value::String(value, marker) => {
                         let start_marker = marker;
                         let end_marker = marker;
-                        let offset = 0.max(
-                            start_marker
-                                .line()
-                                .saturating_sub(NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY),
-                        );
+                        let offset = start_marker
+                            .line()
+                            .saturating_sub(NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY);
 
                         let lines = yaml_split_by_lines[offset..end_marker.line()]
                             .iter()
@@ -232,16 +230,15 @@ fn context_lines(
     start_marker: &Marker,
     end_marker: &Marker,
 ) -> String {
-    let offset = 0.max(
-        start_marker
-            .line()
-            .saturating_sub(NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY),
-    );
+    let offset = start_marker
+        .line()
+        .saturating_sub(NUMBER_OF_PREVIOUS_LINES_TO_DISPLAY);
+
     yaml_split_by_lines[offset..end_marker.line()]
         .iter()
         .enumerate()
         .map(|(idx, line)| {
-            let real_line = idx + offset;
+            let real_line = idx + offset + 1;
             match real_line.cmp(&start_marker.line()) {
                 Ordering::Equal => format!("┌ {line}"),
                 Ordering::Greater => format!("| {line}"),

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -139,9 +139,9 @@ pub(crate) fn validate_yaml_configuration(
 
                         let _ = write!(
                             &mut errors,
-                            "{}. {}\n\n{}\n{}^----- {}\n\n",
+                            "{}. at line {}\n\n{}\n{}^----- {}\n\n",
                             idx + 1,
-                            e.instance_path,
+                            start_marker.line(),
                             lines,
                             " ".repeat(2 + marker.col()),
                             e
@@ -154,9 +154,9 @@ pub(crate) fn validate_yaml_configuration(
 
                         let _ = write!(
                             &mut errors,
-                            "{}. {}\n\n{}\n└-----> {}\n\n",
+                            "{}. at line {}\n\n{}\n└-----> {}\n\n",
                             idx + 1,
-                            e.instance_path,
+                            start_marker.line(),
                             lines,
                             e
                         );
@@ -192,9 +192,9 @@ pub(crate) fn validate_yaml_configuration(
 
                                     let _ = write!(
                                         &mut errors,
-                                        "{}. {}\n\n{}\n└-----> {}\n\n",
+                                        "{}. at line {}\n\n{}\n└-----> {}\n\n",
                                         idx + 1,
-                                        e.instance_path,
+                                        start_marker.line(),
                                         lines,
                                         e
                                     );
@@ -214,9 +214,9 @@ pub(crate) fn validate_yaml_configuration(
 
                             let _ = write!(
                                 &mut errors,
-                                "{}. {}\n\n{}\n└-----> {}\n\n",
+                                "{}. at line {}\n\n{}\n└-----> {}\n\n",
                                 idx + 1,
-                                e.instance_path,
+                                start_marker.line(),
                                 lines,
                                 e
                             );

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__it_does_not_leak_env_variable_values.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__it_does_not_leak_env_variable_values.snap
@@ -3,7 +3,7 @@ source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
-1. /supergraph/introspection
+1. at line 3
 
   
   supergraph:

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__it_does_not_leak_env_variable_values.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__it_does_not_leak_env_variable_values.snap
@@ -1,11 +1,13 @@
 ---
-source: apollo-router/src/configuration/mod.rs
+source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
 1. /supergraph/introspection
 
+  
+  supergraph:
+    introspection: ${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}
+                   ^----- "${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}" is not of type "boolean"
 
-supergraph:
-  introspection: ${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}
-                 ^----- "${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}" is not of type "boolean"
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors.snap
@@ -1,13 +1,13 @@
 ---
-source: apollo-router/src/configuration/mod.rs
+source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
 1. /plugins
 
 
-plugins:
-┌   non_existant:
+┌ plugins:
+|   non_existant:
 |     foo: "bar"
 └-----> Additional properties are not allowed ('non_existant' was unexpected)
 
@@ -17,6 +17,8 @@ plugins:
   non_existant:
     foo: "bar"
 
-telemetry:
-┌   another_non_existant: 3
+┌ telemetry:
+|   another_non_existant: 3
 └-----> Additional properties are not allowed ('another_non_existant' was unexpected)
+
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors.snap
@@ -6,19 +6,18 @@ configuration had errors:
 1. /plugins
 
 
-┌ plugins:
-|   non_existant:
+plugins:
+┌   non_existant:
 |     foo: "bar"
 └-----> Additional properties are not allowed ('non_existant' was unexpected)
 
 2. /telemetry
 
-plugins:
   non_existant:
     foo: "bar"
 
-┌ telemetry:
-|   another_non_existant: 3
+telemetry:
+┌   another_non_existant: 3
 └-----> Additional properties are not allowed ('another_non_existant' was unexpected)
 
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors.snap
@@ -5,18 +5,18 @@ expression: error.to_string()
 configuration had errors: 
 1. /plugins
 
-
-plugins:
+  
+  plugins:
 ┌   non_existant:
 |     foo: "bar"
 └-----> Additional properties are not allowed ('non_existant' was unexpected)
 
 2. /telemetry
 
-  non_existant:
-    foo: "bar"
-
-telemetry:
+    non_existant:
+      foo: "bar"
+  
+  telemetry:
 ┌   another_non_existant: 3
 └-----> Additional properties are not allowed ('another_non_existant' was unexpected)
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors.snap
@@ -3,7 +3,7 @@ source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
-1. /plugins
+1. at line 3
 
   
   plugins:
@@ -11,7 +11,7 @@ configuration had errors:
 |     foo: "bar"
 └-----> Additional properties are not allowed ('non_existant' was unexpected)
 
-2. /telemetry
+2. at line 7
 
     non_existant:
       foo: "bar"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_bad_type.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_bad_type.snap
@@ -3,7 +3,7 @@ source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
-1. /supergraph/listen
+1. at line 5
 
   
   supergraph:

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_bad_type.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_bad_type.snap
@@ -1,13 +1,15 @@
 ---
-source: apollo-router/src/configuration/mod.rs
+source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
 1. /supergraph/listen
 
+  
+  supergraph:
+    # The socket address and port to listen on
+    # Defaults to 127.0.0.1:4000
+    listen: true
+            ^----- true is not valid under any of the given schemas
 
-supergraph:
-  # The socket address and port to listen on
-  # Defaults to 127.0.0.1:4000
-  listen: true
-          ^----- true is not valid under any of the given schemas
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field.snap
@@ -3,7 +3,7 @@ source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
-1. /supergraph
+1. at line 6
 
   supergraph:
     # The socket address and port to listen on
@@ -12,7 +12,7 @@ configuration had errors:
 ┌   bad: "donotwork"
 └-----> Additional properties are not allowed ('bad' was unexpected)
 
-1. /supergraph
+1. at line 7
 
     # The socket address and port to listen on
     # Defaults to 127.0.0.1:4000

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field.snap
@@ -1,15 +1,17 @@
 ---
-source: apollo-router/src/configuration/mod.rs
+source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
 1. /supergraph
 
 
-supergraph:
-┌   # The socket address and port to listen on
+┌ supergraph:
+|   # The socket address and port to listen on
 |   # Defaults to 127.0.0.1:4000
 |   listen: 127.0.0.1:4000
 |   bad: "donotwork"
 |   another_one: true
 └-----> Additional properties are not allowed ('bad', 'another_one' were unexpected)
+
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field.snap
@@ -5,19 +5,19 @@ expression: error.to_string()
 configuration had errors: 
 1. /supergraph
 
-supergraph:
-  # The socket address and port to listen on
-  # Defaults to 127.0.0.1:4000
-  listen: 127.0.0.1:4000
+  supergraph:
+    # The socket address and port to listen on
+    # Defaults to 127.0.0.1:4000
+    listen: 127.0.0.1:4000
 ┌   bad: "donotwork"
 └-----> Additional properties are not allowed ('bad' was unexpected)
 
 1. /supergraph
 
-  # The socket address and port to listen on
-  # Defaults to 127.0.0.1:4000
-  listen: 127.0.0.1:4000
-  bad: "donotwork"
+    # The socket address and port to listen on
+    # Defaults to 127.0.0.1:4000
+    listen: 127.0.0.1:4000
+    bad: "donotwork"
 ┌   another_one: true
 └-----> Additional properties are not allowed ('another_one' was unexpected)
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field.snap
@@ -5,13 +5,20 @@ expression: error.to_string()
 configuration had errors: 
 1. /supergraph
 
+supergraph:
+  # The socket address and port to listen on
+  # Defaults to 127.0.0.1:4000
+  listen: 127.0.0.1:4000
+┌   bad: "donotwork"
+└-----> Additional properties are not allowed ('bad' was unexpected)
 
-┌ supergraph:
-|   # The socket address and port to listen on
-|   # Defaults to 127.0.0.1:4000
-|   listen: 127.0.0.1:4000
-|   bad: "donotwork"
-|   another_one: true
-└-----> Additional properties are not allowed ('bad', 'another_one' were unexpected)
+1. /supergraph
+
+  # The socket address and port to listen on
+  # Defaults to 127.0.0.1:4000
+  listen: 127.0.0.1:4000
+  bad: "donotwork"
+┌   another_one: true
+└-----> Additional properties are not allowed ('another_one' was unexpected)
 
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field_env_expansion.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field_env_expansion.snap
@@ -3,7 +3,7 @@ source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
-1. /supergraph
+1. at line 6
 
   supergraph:
     # The socket address and port to listen on
@@ -12,7 +12,7 @@ configuration had errors:
 ┌   ${TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}: 5
 └-----> Additional properties are not allowed ('${TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}' was unexpected)
 
-1. /supergraph
+1. at line 7
 
     # The socket address and port to listen on
     # Defaults to 127.0.0.1:4000

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field_env_expansion.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field_env_expansion.snap
@@ -5,13 +5,20 @@ expression: error.to_string()
 configuration had errors: 
 1. /supergraph
 
+supergraph:
+  # The socket address and port to listen on
+  # Defaults to 127.0.0.1:4000
+  listen: 127.0.0.1:4000
+┌   ${TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}: 5
+└-----> Additional properties are not allowed ('${TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}' was unexpected)
 
-┌ supergraph:
-|   # The socket address and port to listen on
-|   # Defaults to 127.0.0.1:4000
-|   listen: 127.0.0.1:4000
-|   ${TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}: 5
-|   another_one: foo
-└-----> Additional properties are not allowed ('${TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}', 'another_one' were unexpected)
+1. /supergraph
+
+  # The socket address and port to listen on
+  # Defaults to 127.0.0.1:4000
+  listen: 127.0.0.1:4000
+  ${TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}: 5
+┌   another_one: foo
+└-----> Additional properties are not allowed ('another_one' was unexpected)
 
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field_env_expansion.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field_env_expansion.snap
@@ -5,19 +5,19 @@ expression: error.to_string()
 configuration had errors: 
 1. /supergraph
 
-supergraph:
-  # The socket address and port to listen on
-  # Defaults to 127.0.0.1:4000
-  listen: 127.0.0.1:4000
+  supergraph:
+    # The socket address and port to listen on
+    # Defaults to 127.0.0.1:4000
+    listen: 127.0.0.1:4000
 ┌   ${TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}: 5
 └-----> Additional properties are not allowed ('${TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}' was unexpected)
 
 1. /supergraph
 
-  # The socket address and port to listen on
-  # Defaults to 127.0.0.1:4000
-  listen: 127.0.0.1:4000
-  ${TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}: 5
+    # The socket address and port to listen on
+    # Defaults to 127.0.0.1:4000
+    listen: 127.0.0.1:4000
+    ${TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}: 5
 ┌   another_one: foo
 └-----> Additional properties are not allowed ('another_one' was unexpected)
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field_env_expansion.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_errors_after_first_field_env_expansion.snap
@@ -1,15 +1,17 @@
 ---
-source: apollo-router/src/configuration/mod.rs
+source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
 1. /supergraph
 
 
-supergraph:
-┌   # The socket address and port to listen on
+┌ supergraph:
+|   # The socket address and port to listen on
 |   # Defaults to 127.0.0.1:4000
 |   listen: 127.0.0.1:4000
 |   ${TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}: 5
 |   another_one: foo
 └-----> Additional properties are not allowed ('${TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}', 'another_one' were unexpected)
+
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_inline_sequence.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_inline_sequence.snap
@@ -3,7 +3,7 @@ source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
-1. /cors/allow_headers/1
+1. at line 7
 
     # The socket address and port to listen on
     # Defaults to 127.0.0.1:4000

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_inline_sequence.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_inline_sequence.snap
@@ -1,13 +1,15 @@
 ---
-source: apollo-router/src/configuration/mod.rs
+source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
 1. /cors/allow_headers/1
 
-  # The socket address and port to listen on
-  # Defaults to 127.0.0.1:4000
-  listen: 127.0.0.1:4000
-cors:
-  allow_headers: [ Content-Type, 5 ]
-                                 ^----- 5 is not of type "string"
+    # The socket address and port to listen on
+    # Defaults to 127.0.0.1:4000
+    listen: 127.0.0.1:4000
+  cors:
+    allow_headers: [ Content-Type, 5 ]
+                                   ^----- 5 is not of type "string"
+
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_inline_sequence_env_expansion.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_inline_sequence_env_expansion.snap
@@ -3,7 +3,7 @@ source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
-1. /cors/allow_headers/1
+1. at line 7
 
     # The socket address and port to listen on
     # Defaults to 127.0.0.1:4000

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_inline_sequence_env_expansion.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_inline_sequence_env_expansion.snap
@@ -1,13 +1,15 @@
 ---
-source: apollo-router/src/configuration/mod.rs
+source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
 1. /cors/allow_headers/1
 
-  # The socket address and port to listen on
-  # Defaults to 127.0.0.1:4000
-  listen: 127.0.0.1:4000
-cors:
-  allow_headers: [ Content-Type, "${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE}" ]
-                                 ^----- "${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE}" is not of type "string"
+    # The socket address and port to listen on
+    # Defaults to 127.0.0.1:4000
+    listen: 127.0.0.1:4000
+  cors:
+    allow_headers: [ Content-Type, "${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE}" ]
+                                   ^----- "${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE}" is not of type "string"
+
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_sequence.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_sequence.snap
@@ -3,7 +3,7 @@ source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
-1. /cors/allow_headers/1
+1. at line 9
 
     listen: 127.0.0.1:4000
   cors:

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_sequence.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_sequence.snap
@@ -1,13 +1,15 @@
 ---
-source: apollo-router/src/configuration/mod.rs
+source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
 1. /cors/allow_headers/1
 
-  listen: 127.0.0.1:4000
-cors:
-  allow_headers:
-    - Content-Type
-    - 5
-      ^----- 5 is not of type "string"
+    listen: 127.0.0.1:4000
+  cors:
+    allow_headers:
+      - Content-Type
+      - 5
+        ^----- 5 is not of type "string"
+
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_sequence_env_expansion.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_sequence_env_expansion.snap
@@ -3,7 +3,7 @@ source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
-1. /cors/allow_headers/1
+1. at line 9
 
     listen: 127.0.0.1:4000
   cors:

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_sequence_env_expansion.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_with_sequence_env_expansion.snap
@@ -1,13 +1,15 @@
 ---
-source: apollo-router/src/configuration/mod.rs
+source: apollo-router/src/configuration/tests.rs
 expression: error.to_string()
 ---
 configuration had errors: 
 1. /cors/allow_headers/1
 
-  listen: 127.0.0.1:4000
-cors:
-  allow_headers:
-    - Content-Type
-    - "${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}"
-      ^----- "${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}" is not of type "string"
+    listen: 127.0.0.1:4000
+  cors:
+    allow_headers:
+      - Content-Type
+      - "${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}"
+        ^----- "${env.TEST_CONFIG_NUMERIC_ENV_UNIQUE:-true}" is not of type "string"
+
+

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -174,7 +174,7 @@ subgraphs:
         error.to_string(),
         String::from(
             r#"configuration had errors: 
-1. 
+1. at line 4
 
   
   supergraph:
@@ -203,7 +203,7 @@ unknown:
         error.to_string(),
         String::from(
             r#"configuration had errors: 
-1. 
+1. at line 2
 
   
 ┌ unknown:

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -176,7 +176,7 @@ subgraphs:
             r#"configuration had errors: 
 1. 
 
-
+  
   supergraph:
     path: /
 ┌ subgraphs:

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -170,7 +170,22 @@ subgraphs:
         Mode::NoUpgrade,
     )
     .expect_err("should have resulted in an error");
-    assert_eq!(error.to_string(), String::from("unknown fields: additional properties are not allowed ('subgraphs' was/were unexpected)"));
+    assert_eq!(
+        error.to_string(),
+        String::from(
+            r#"configuration had errors: 
+1. 
+
+
+  supergraph:
+    path: /
+┌ subgraphs:
+|   account: true
+└-----> Additional properties are not allowed ('subgraphs' was unexpected)
+
+"#
+        )
+    );
 }
 
 #[test]
@@ -187,7 +202,15 @@ unknown:
     assert_eq!(
         error.to_string(),
         String::from(
-            "unknown fields: additional properties are not allowed ('unknown' was/were unexpected)"
+            r#"configuration had errors: 
+1. 
+
+  
+┌ unknown:
+|   foo: true
+└-----> Additional properties are not allowed ('unknown' was unexpected)
+
+"#
         )
     );
 }


### PR DESCRIPTION
Fix #2180

When starting the router with this configuration file, that contains errors due to invalid data and fields that are not recognized:

```yaml
supergraph:
    listen: 127.0.0.1:4000
    introspection: "a"
    query_planning:
      experimental_cache:
        redis:
          urls: ["rediss://:router@127.0.0.1:4101"]
sandbox:
  enabled: true

tls:
  subgraphs:
    certificate_authorities: "${file./home/geal/dev/test/tls-proxy/server.crt}"

include_subgraph_errors:
  all: true
```

The router will print this:

```
2023-01-05T10:57:42.878484Z ERROR configuration had errors: 
1. /supergraph/introspection

supergraph:
    listen: 127.0.0.1:4000
    introspection: "a"
                   ^----- "a" is not of type "boolean"

2. /supergraph/query_planning/experimental_cache

supergraph:
    listen: 127.0.0.1:4000
    introspection: "a"
    query_planning:
      experimental_cache:
┌         redis:
|           urls: ["rediss://:router@127.0.0.1:4101"]
└-----> "in_memory" is a required property

3. /supergraph/query_planning/experimental_cache

supergraph:
    listen: 127.0.0.1:4000
    introspection: "a"
    query_planning:
      experimental_cache:
┌         redis:
|           urls: ["rediss://:router@127.0.0.1:4101"]
└-----> Additional properties are not allowed ('redis' was unexpected)
2023-01-05T10:57:42.879601Z ERROR no valid configuration was supplied
```

There are multiple issues with that log:
- `in_memory` is a required property of `experimental_cache` but the arrow starts at `redis`
- when the arrow is printed, it shifts elements of that line by 2 spaces, but not the other lines
- the top level `tls` field is invalid (it comes from a PR that is not merged yet), but we do not see any error pointing it out
- each error indicates the path in the JSON file, but it is not very actionable information
- if there are multiple unknown properties under a map, we only show one error (not displayed here)

Here's the version from this PR:

```
2023-01-05T11:02:37.071102Z ERROR configuration had errors: 
1. at line 3

  supergraph:
      listen: 127.0.0.1:4000
      introspection: "a"
                     ^----- "a" is not of type "boolean"

2. at line 5

  supergraph:
      listen: 127.0.0.1:4000
      introspection: "a"
      query_planning:
┌       experimental_cache:
|         redis:
|           urls: ["rediss://:router@127.0.0.1:4101"]
└-----> "in_memory" is a required property

3. at line 6

      listen: 127.0.0.1:4000
      introspection: "a"
      query_planning:
        experimental_cache:
┌         redis:
|           urls: ["rediss://:router@127.0.0.1:4101"]
└-----> Additional properties are not allowed ('redis' was unexpected)

4. at line 11

            urls: ["rediss://:router@127.0.0.1:4101"]
  sandbox:
    enabled: true
  
┌ tls:
|   subgraphs:
|     certificate_authorities: "${file./home/geal/dev/test/tls-proxy/server.crt}"
└-----> Additional properties are not allowed ('tls' was unexpected)


2023-01-05T11:02:37.071775Z ERROR no valid configuration was supplied
```

All errors are now displayed, all the file lines have proper indentation, aligned the same way for all error types, the arrows start from the right line and we show the line number