### PR TITLE
Expand many glob imports

### DIFF
--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -67,6 +67,7 @@ use crate::services::layers::static_page::sandbox_page_content;
 use crate::services::new_service::ServiceFactory;
 use crate::services::router;
 use crate::services::router_service;
+use crate::services::supergraph;
 use crate::services::RouterRequest;
 use crate::services::RouterResponse;
 use crate::services::SupergraphResponse;
@@ -1994,7 +1995,7 @@ Accept: application/json\r
 #[tokio::test]
 async fn test_health_check() {
     let router_service = router_service::from_supergraph_mock_callback(|_| {
-        Ok(crate::supergraph::Response::builder()
+        Ok(supergraph::Response::builder()
             .data(json!({ "__typename": "Query"}))
             .context(Context::new())
             .build()

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -15,14 +15,9 @@ use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::str::FromStr;
 
-use cors::*;
 use derivative::Derivative;
 use displaydoc::Display;
-use expansion::*;
-pub(crate) use experimental::print_all_experimental_conf;
 use itertools::Itertools;
-pub(crate) use schema::generate_config_schema;
-pub(crate) use schema::generate_upgrade;
 use schemars::gen::SchemaGenerator;
 use schemars::schema::ObjectValidation;
 use schemars::schema::Schema;
@@ -35,6 +30,11 @@ use serde_json::Map;
 use serde_json::Value;
 use thiserror::Error;
 
+use self::cors::Cors;
+use self::expansion::Expansion;
+pub(crate) use self::experimental::print_all_experimental_conf;
+pub(crate) use self::schema::generate_config_schema;
+pub(crate) use self::schema::generate_upgrade;
 use crate::cache::DEFAULT_CACHE_CAPACITY;
 use crate::configuration::schema::Mode;
 use crate::executable::APOLLO_ROUTER_DEV_ENV;

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -53,7 +53,7 @@ fn routing_url_in_schema() {
           REVIEWS @join__graph(name: "reviews" url: "http://localhost:4004/graphql")
         }
         "#;
-    let schema = crate::Schema::parse(schema, &Default::default()).unwrap();
+    let schema = crate::spec::Schema::parse(schema, &Default::default()).unwrap();
 
     let subgraphs: HashMap<&String, &Uri> = schema.subgraphs().collect();
 
@@ -105,7 +105,7 @@ fn missing_subgraph_url() {
           PRODUCTS @join__graph(name: "products" url: "http://localhost:4003/graphql")
           REVIEWS @join__graph(name: "reviews" url: "")
         }"#;
-    let schema_error = crate::Schema::parse(schema_error, &Default::default())
+    let schema_error = crate::spec::Schema::parse(schema_error, &Default::default())
         .expect_err("Must have an error because we have one missing subgraph routing url");
 
     if let SchemaError::MissingSubgraphUrl(subgraph) = schema_error {

--- a/apollo-router/src/context.rs
+++ b/apollo-router/src/context.rs
@@ -25,7 +25,8 @@ pub(crate) type Entries = Arc<DashMap<String, Value>>;
 /// for usability but could lead to surprises when updates are highly contested.
 ///
 /// Within the router, contention is likely to be highest within plugins which
-/// provide [`crate::SubgraphRequest`] or [`crate::SubgraphResponse`] processing. At such times,
+/// provide [`crate::services::SubgraphRequest`] or
+/// [`crate::services::SubgraphResponse`] processing. At such times,
 /// plugins should restrict themselves to the [`Context::get`] and [`Context::upsert`]
 /// functions to minimise the possibility of mis-sequenced updates.
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/apollo-router/src/layers/async_checkpoint.rs
+++ b/apollo-router/src/layers/async_checkpoint.rs
@@ -147,8 +147,8 @@ mod async_checkpoint_tests {
     use super::*;
     use crate::layers::ServiceBuilderExt;
     use crate::plugin::test::MockExecutionService;
-    use crate::ExecutionRequest;
-    use crate::ExecutionResponse;
+    use crate::services::ExecutionRequest;
+    use crate::services::ExecutionResponse;
 
     #[tokio::test]
     async fn test_service_builder() {
@@ -157,23 +157,22 @@ mod async_checkpoint_tests {
         let mut execution_service = MockExecutionService::new();
         execution_service.expect_clone().return_once(move || {
             let mut execution_service = MockExecutionService::new();
-            execution_service.expect_call().times(1).returning(
-                move |req: crate::ExecutionRequest| {
+            execution_service
+                .expect_call()
+                .times(1)
+                .returning(move |req: ExecutionRequest| {
                     Ok(ExecutionResponse::fake_builder()
                         .label(expected_label.to_string())
                         .context(req.context)
                         .build()
                         .unwrap())
-                },
-            );
+                });
 
             execution_service
         });
 
         let service_stack = ServiceBuilder::new()
-            .checkpoint_async(|req: crate::ExecutionRequest| async {
-                Ok(ControlFlow::Continue(req))
-            })
+            .checkpoint_async(|req: ExecutionRequest| async { Ok(ControlFlow::Continue(req)) })
             .service(execution_service);
 
         let request = ExecutionRequest::fake_builder().build();

--- a/apollo-router/src/layers/map_future_with_request_data.rs
+++ b/apollo-router/src/layers/map_future_with_request_data.rs
@@ -89,8 +89,8 @@ mod test {
 
     use crate::layers::ServiceBuilderExt;
     use crate::plugin::test::MockSupergraphService;
-    use crate::SupergraphRequest;
-    use crate::SupergraphResponse;
+    use crate::services::SupergraphRequest;
+    use crate::services::SupergraphResponse;
 
     #[tokio::test]
     async fn test_layer() -> Result<(), BoxError> {

--- a/apollo-router/src/layers/sync_checkpoint.rs
+++ b/apollo-router/src/layers/sync_checkpoint.rs
@@ -176,8 +176,8 @@ mod checkpoint_tests {
     use super::*;
     use crate::layers::ServiceBuilderExt;
     use crate::plugin::test::MockExecutionService;
-    use crate::ExecutionRequest;
-    use crate::ExecutionResponse;
+    use crate::services::ExecutionRequest;
+    use crate::services::ExecutionResponse;
 
     #[tokio::test]
     async fn test_service_builder() {
@@ -188,7 +188,7 @@ mod checkpoint_tests {
         execution_service
             .expect_call()
             .times(1)
-            .returning(move |req: crate::ExecutionRequest| {
+            .returning(move |req: ExecutionRequest| {
                 Ok(ExecutionResponse::fake_builder()
                     .label(expected_label.to_string())
                     .context(req.context)
@@ -197,7 +197,7 @@ mod checkpoint_tests {
             });
 
         let service_stack = ServiceBuilder::new()
-            .checkpoint(|req: crate::ExecutionRequest| Ok(ControlFlow::Continue(req)))
+            .checkpoint(|req: ExecutionRequest| Ok(ControlFlow::Continue(req)))
             .service(execution_service);
 
         let request = ExecutionRequest::fake_builder().build();

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -101,7 +101,3 @@ pub mod _private {
     pub use crate::plugins::telemetry::Telemetry as TelemetryPlugin;
     pub use crate::router_factory::create_test_service_factory_from_yaml;
 }
-
-// TODO: clean these up and import from relevant modules instead
-pub(crate) use crate::services::*;
-pub(crate) use crate::spec::*;

--- a/apollo-router/src/plugin/test/mock/subgraph.rs
+++ b/apollo-router/src/plugin/test/mock/subgraph.rs
@@ -14,8 +14,8 @@ use tower::Service;
 use crate::graphql::Request;
 use crate::graphql::Response;
 use crate::json_ext::Object;
-use crate::SubgraphRequest;
-use crate::SubgraphResponse;
+use crate::services::SubgraphRequest;
+use crate::services::SubgraphResponse;
 
 type MockResponses = HashMap<Request, Response>;
 

--- a/apollo-router/src/plugin/test/mod.rs
+++ b/apollo-router/src/plugin/test/mod.rs
@@ -20,6 +20,7 @@ use crate::services::subgraph_service::SubgraphServiceFactory;
 use crate::services::MakeSubgraphService;
 use crate::services::Plugins;
 use crate::services::SubgraphRequest;
+use crate::services::SubgraphResponse;
 
 #[derive(Clone)]
 pub(crate) struct MockSubgraphFactory {
@@ -28,12 +29,11 @@ pub(crate) struct MockSubgraphFactory {
 }
 
 impl SubgraphServiceFactory for MockSubgraphFactory {
-    type SubgraphService = BoxService<crate::SubgraphRequest, crate::SubgraphResponse, BoxError>;
+    type SubgraphService = BoxService<SubgraphRequest, SubgraphResponse, BoxError>;
 
-    type Future =
-        <BoxService<crate::SubgraphRequest, crate::SubgraphResponse, BoxError> as Service<
-            SubgraphRequest,
-        >>::Future;
+    type Future = <BoxService<SubgraphRequest, SubgraphResponse, BoxError> as Service<
+        SubgraphRequest,
+    >>::Future;
 
     fn create(&self, name: &str) -> Option<Self::SubgraphService> {
         self.subgraphs.get(name).map(|service| {

--- a/apollo-router/src/plugin/test/service.rs
+++ b/apollo-router/src/plugin/test/service.rs
@@ -1,12 +1,12 @@
 #![allow(dead_code, unreachable_pub)]
 #![allow(missing_docs)] // FIXME
 
-use crate::ExecutionRequest;
-use crate::ExecutionResponse;
-use crate::SubgraphRequest;
-use crate::SubgraphResponse;
-use crate::SupergraphRequest;
-use crate::SupergraphResponse;
+use crate::services::ExecutionRequest;
+use crate::services::ExecutionResponse;
+use crate::services::SubgraphRequest;
+use crate::services::SubgraphResponse;
+use crate::services::SupergraphRequest;
+use crate::services::SupergraphResponse;
 
 /// Build a mock service handler for the router pipeline.
 macro_rules! mock_service {

--- a/apollo-router/src/plugins/csrf.rs
+++ b/apollo-router/src/plugins/csrf.rs
@@ -15,7 +15,7 @@ use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::register_plugin;
 use crate::services::supergraph;
-use crate::SupergraphResponse;
+use crate::services::SupergraphResponse;
 
 /// CSRF Configuration.
 #[derive(Deserialize, Debug, Clone, JsonSchema)]

--- a/apollo-router/src/plugins/expose_query_plan.rs
+++ b/apollo-router/src/plugins/expose_query_plan.rs
@@ -124,7 +124,7 @@ mod tests {
     use crate::plugin::test::MockSubgraph;
     use crate::plugin::DynPlugin;
     use crate::services::PluggableSupergraphServiceBuilder;
-    use crate::Schema;
+    use crate::spec::Schema;
 
     static EXPECTED_RESPONSE_WITH_QUERY_PLAN: Lazy<Response> = Lazy::new(|| {
         serde_json::from_str(include_str!(

--- a/apollo-router/src/plugins/external.rs
+++ b/apollo-router/src/plugins/external.rs
@@ -24,14 +24,14 @@ use tower::ServiceBuilder;
 use tower::ServiceExt;
 
 use crate::error::Error;
-use crate::external::Externalizable;
-use crate::external::PipelineStep;
 use crate::layers::async_checkpoint::AsyncCheckpointLayer;
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::register_plugin;
 use crate::services::external::Control;
+use crate::services::external::Externalizable;
+use crate::services::external::PipelineStep;
 use crate::services::router;
 use crate::Context;
 

--- a/apollo-router/src/plugins/forbid_mutations.rs
+++ b/apollo-router/src/plugins/forbid_mutations.rs
@@ -11,8 +11,8 @@ use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::register_plugin;
 use crate::services::execution;
-use crate::ExecutionRequest;
-use crate::ExecutionResponse;
+use crate::services::ExecutionRequest;
+use crate::services::ExecutionResponse;
 
 #[derive(Debug, Clone)]
 struct ForbidMutations {
@@ -147,7 +147,7 @@ mod forbid_http_get_mutations_tests {
         assert_eq!(&response.errors[0], expected_error);
     }
 
-    fn create_request(method: Method, operation_kind: OperationKind) -> crate::ExecutionRequest {
+    fn create_request(method: Method, operation_kind: OperationKind) -> ExecutionRequest {
         let root: PlanNode = if operation_kind == OperationKind::Mutation {
             serde_json::from_value(json!({
                 "kind": "Sequence",

--- a/apollo-router/src/plugins/headers.rs
+++ b/apollo-router/src/plugins/headers.rs
@@ -36,7 +36,7 @@ use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::register_plugin;
 use crate::services::subgraph;
-use crate::SubgraphRequest;
+use crate::services::SubgraphRequest;
 
 register_plugin!("apollo", "headers", Headers);
 
@@ -373,9 +373,9 @@ mod test {
     use crate::plugins::headers::Config;
     use crate::plugins::headers::HeadersLayer;
     use crate::query_planner::fetch::OperationKind;
+    use crate::services::SubgraphRequest;
+    use crate::services::SubgraphResponse;
     use crate::Context;
-    use crate::SubgraphRequest;
-    use crate::SubgraphResponse;
 
     #[test]
     fn test_subgraph_config() {

--- a/apollo-router/src/plugins/include_subgraph_errors.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors.rs
@@ -10,7 +10,7 @@ use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::register_plugin;
 use crate::services::subgraph;
-use crate::SubgraphResponse;
+use crate::services::SubgraphResponse;
 
 static REDACTED_ERROR_MESSAGE: &str = "Subgraph errors redacted";
 
@@ -90,10 +90,10 @@ mod test {
     use crate::router_factory::create_plugins;
     use crate::services::router;
     use crate::services::router_service::RouterCreator;
+    use crate::services::PluggableSupergraphServiceBuilder;
+    use crate::services::SupergraphRequest;
+    use crate::spec::Schema;
     use crate::Configuration;
-    use crate::PluggableSupergraphServiceBuilder;
-    use crate::Schema;
-    use crate::SupergraphRequest;
 
     static UNREDACTED_PRODUCT_RESPONSE: Lazy<Bytes> = Lazy::new(|| {
         Bytes::from_static(r#"{"data":{"topProducts":null},"errors":[{"message":"couldn't find mock for query {\"query\":\"query ErrorTopProducts__products__0($first:Int){topProducts(first:$first){__typename upc name}}\",\"operationName\":\"ErrorTopProducts__products__0\",\"variables\":{\"first\":2}}","extensions":{"test":"value","code":"FETCH_ERROR"}}]}"#.as_bytes())

--- a/apollo-router/src/plugins/override_url.rs
+++ b/apollo-router/src/plugins/override_url.rs
@@ -11,7 +11,7 @@ use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::register_plugin;
 use crate::services::subgraph;
-use crate::SubgraphRequest;
+use crate::services::SubgraphRequest;
 
 #[derive(Debug, Clone)]
 struct OverrideSubgraphUrl {
@@ -64,9 +64,9 @@ mod tests {
 
     use crate::plugin::test::MockSubgraphService;
     use crate::plugin::DynPlugin;
+    use crate::services::SubgraphRequest;
+    use crate::services::SubgraphResponse;
     use crate::Context;
-    use crate::SubgraphRequest;
-    use crate::SubgraphResponse;
 
     #[tokio::test]
     async fn plugin_registered() {

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -63,12 +63,12 @@ use crate::layers::ServiceBuilderExt;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
 use crate::register_plugin;
+use crate::services::ExecutionRequest;
+use crate::services::ExecutionResponse;
+use crate::services::SupergraphRequest;
+use crate::services::SupergraphResponse;
 use crate::tracer::TraceId;
 use crate::Context;
-use crate::ExecutionRequest;
-use crate::ExecutionResponse;
-use crate::SupergraphRequest;
-use crate::SupergraphResponse;
 
 trait OptionDance<T> {
     fn with_mut<R>(&self, f: impl FnOnce(&mut T) -> R) -> R;
@@ -1652,7 +1652,7 @@ mod tests {
     use crate::plugin::test::MockExecutionService;
     use crate::plugin::test::MockSupergraphService;
     use crate::plugin::DynPlugin;
-    use crate::SubgraphRequest;
+    use crate::services::SubgraphRequest;
 
     #[tokio::test]
     async fn rhai_plugin_router_service() -> Result<(), BoxError> {

--- a/apollo-router/src/plugins/telemetry/metrics/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo.rs
@@ -75,8 +75,8 @@ mod test {
     use crate::plugins::telemetry::apollo_exporter::Sender;
     use crate::plugins::telemetry::Telemetry;
     use crate::plugins::telemetry::STUDIO_EXCLUDE;
+    use crate::services::SupergraphRequest;
     use crate::Context;
-    use crate::SupergraphRequest;
     use crate::TestHarness;
 
     #[tokio::test]

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -102,17 +102,17 @@ use crate::router_factory::Endpoint;
 use crate::services::execution;
 use crate::services::router;
 use crate::services::subgraph;
+use crate::services::subgraph::Request;
+use crate::services::subgraph::Response;
 use crate::services::supergraph;
-use crate::subgraph::Request;
-use crate::subgraph::Response;
+use crate::services::ExecutionRequest;
+use crate::services::SubgraphRequest;
+use crate::services::SubgraphResponse;
+use crate::services::SupergraphRequest;
+use crate::services::SupergraphResponse;
 use crate::tracer::TraceId;
 use crate::Context;
-use crate::ExecutionRequest;
 use crate::ListenAddr;
-use crate::SubgraphRequest;
-use crate::SubgraphResponse;
-use crate::SupergraphRequest;
-use crate::SupergraphResponse;
 pub(crate) mod apollo;
 pub(crate) mod apollo_exporter;
 pub(crate) mod config;
@@ -1457,8 +1457,8 @@ mod tests {
     use crate::plugin::DynPlugin;
     use crate::services::SubgraphRequest;
     use crate::services::SubgraphResponse;
-    use crate::SupergraphRequest;
-    use crate::SupergraphResponse;
+    use crate::services::SupergraphRequest;
+    use crate::services::SupergraphResponse;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn plugin_registered() {

--- a/apollo-router/src/plugins/traffic_shaping/deduplication.rs
+++ b/apollo-router/src/plugins/traffic_shaping/deduplication.rs
@@ -18,8 +18,8 @@ use tower::ServiceExt;
 use crate::graphql::Request;
 use crate::http_ext;
 use crate::query_planner::fetch::OperationKind;
-use crate::SubgraphRequest;
-use crate::SubgraphResponse;
+use crate::services::SubgraphRequest;
+use crate::services::SubgraphResponse;
 
 #[derive(Default)]
 pub(crate) struct QueryDeduplicationLayer;

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -44,8 +44,8 @@ use crate::register_plugin;
 use crate::services::subgraph;
 use crate::services::subgraph_service::Compression;
 use crate::services::supergraph;
+use crate::services::SubgraphRequest;
 use crate::Configuration;
-use crate::SubgraphRequest;
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 pub(crate) const APOLLO_TRAFFIC_SHAPING: &str = "apollo.traffic_shaping";
@@ -388,11 +388,11 @@ mod test {
     use crate::router_factory::create_plugins;
     use crate::services::router;
     use crate::services::router_service::RouterCreator;
+    use crate::services::PluggableSupergraphServiceBuilder;
+    use crate::services::SupergraphRequest;
+    use crate::services::SupergraphResponse;
+    use crate::spec::Schema;
     use crate::Configuration;
-    use crate::PluggableSupergraphServiceBuilder;
-    use crate::Schema;
-    use crate::SupergraphRequest;
-    use crate::SupergraphResponse;
 
     static EXPECTED_RESPONSE: Lazy<Bytes> = Lazy::new(|| {
         Bytes::from_static(r#"{"data":{"topProducts":[{"upc":"1","name":"Table","reviews":[{"id":"1","product":{"name":"Table"},"author":{"id":"1","name":"Ada Lovelace"}},{"id":"4","product":{"name":"Table"},"author":{"id":"2","name":"Alan Turing"}}]},{"upc":"2","name":"Couch","reviews":[{"id":"2","product":{"name":"Couch"},"author":{"id":"1","name":"Ada Lovelace"}}]}]}}"#.as_bytes())

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -18,12 +18,17 @@ use tracing::Instrument;
 use super::PlanNode;
 use super::QueryKey;
 use super::QueryPlanOptions;
-use super::TYPENAME;
 use crate::error::QueryPlannerError;
+use crate::graphql;
 use crate::introspection::Introspection;
 use crate::plugins::traffic_shaping::TrafficShaping;
 use crate::services::QueryPlannerContent;
-use crate::*;
+use crate::services::QueryPlannerRequest;
+use crate::services::QueryPlannerResponse;
+use crate::spec::query::TYPENAME;
+use crate::spec::Query;
+use crate::spec::Schema;
+use crate::Configuration;
 
 pub(crate) static USAGE_REPORTING: &str = "apollo_telemetry::usage_reporting";
 
@@ -124,7 +129,7 @@ impl BridgeQueryPlanner {
                 let subselections = node.parse_subselections(&self.schema)?;
                 selections.subselections = subselections;
                 Ok(QueryPlannerContent::Plan {
-                    plan: Arc::new(query_planner::QueryPlan {
+                    plan: Arc::new(super::QueryPlan {
                         usage_reporting,
                         root: node,
                         formatted_query_plan,

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -17,7 +17,9 @@ use crate::cache::DeduplicatingCache;
 use crate::error::CacheResolverError;
 use crate::error::QueryPlannerError;
 use crate::services::QueryPlannerContent;
-use crate::*;
+use crate::services::QueryPlannerRequest;
+use crate::services::QueryPlannerResponse;
+use crate::Context;
 
 /// A query planner wrapper that caches results.
 ///
@@ -279,14 +281,15 @@ impl std::fmt::Display for CachingQueryKey {
 mod tests {
     use mockall::mock;
     use mockall::predicate::*;
-    use query_planner::QueryPlan;
     use router_bridge::planner::UsageReporting;
     use test_log::test;
     use tower::Service;
 
     use super::*;
     use crate::error::PlanErrors;
+    use crate::query_planner::QueryPlan;
     use crate::query_planner::QueryPlanOptions;
+    use crate::spec::Query;
 
     mock! {
         #[derive(Debug)]

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -31,7 +31,9 @@ use crate::query_planner::FLATTEN_SPAN_NAME;
 use crate::query_planner::PARALLEL_SPAN_NAME;
 use crate::query_planner::SEQUENCE_SPAN_NAME;
 use crate::services::subgraph_service::SubgraphServiceFactory;
-use crate::*;
+use crate::spec::Query;
+use crate::spec::Schema;
+use crate::Context;
 
 impl QueryPlan {
     /// Execute the plan and return a [`Response`].

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -14,13 +14,17 @@ use super::selection::select_object;
 use super::selection::Selection;
 use crate::error::Error;
 use crate::error::FetchError;
+use crate::graphql;
 use crate::graphql::Request;
+use crate::http_ext;
+use crate::json_ext;
 use crate::json_ext::Object;
 use crate::json_ext::Path;
 use crate::json_ext::Value;
 use crate::json_ext::ValueExt;
 use crate::services::subgraph_service::SubgraphServiceFactory;
-use crate::*;
+use crate::services::SubgraphRequest;
+use crate::spec::Schema;
 
 /// GraphQL operation type.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -6,7 +6,6 @@ pub(crate) use bridge_query_planner::*;
 pub(crate) use caching_query_planner::*;
 
 pub(crate) use self::fetch::OperationKind;
-use crate::*;
 
 mod bridge_query_planner;
 mod caching_query_planner;

--- a/apollo-router/src/query_planner/plan.rs
+++ b/apollo-router/src/query_planner/plan.rs
@@ -9,11 +9,13 @@ use serde::Serialize;
 pub(crate) use self::fetch::OperationKind;
 use super::fetch;
 use crate::error::QueryPlannerError;
+use crate::json_ext;
 use crate::json_ext::Object;
 use crate::json_ext::Path;
 use crate::json_ext::Value;
 use crate::spec::query::SubSelection;
-use crate::*;
+use crate::spec::Query;
+use crate::spec::Schema;
 
 /// Query planning options.
 #[derive(Clone, Eq, Hash, PartialEq, Debug, Default, Serialize, Deserialize)]

--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -6,7 +6,7 @@ use crate::error::FetchError;
 use crate::json_ext::Object;
 use crate::json_ext::Value;
 use crate::json_ext::ValueExt;
-use crate::*;
+use crate::spec::Schema;
 
 /// A selection that is part of a fetch.
 /// Selections are used to propagate data to subgraph fetches.

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -8,13 +8,28 @@ use http::Method;
 use router_bridge::planner::UsageReporting;
 use serde_json_bytes::json;
 
-use super::*;
+use super::DeferredNode;
+use super::Depends;
+use super::FlattenNode;
+use super::OperationKind;
+use super::PlanNode;
+use super::Primary;
+use super::QueryPlan;
+use super::QueryPlanOptions;
 use crate::json_ext::Path;
 use crate::json_ext::PathElement;
+use crate::plugin;
 use crate::plugin::test::MockSubgraph;
 use crate::plugin::test::MockSubgraphFactory;
+use crate::query_planner;
 use crate::query_planner::fetch::FetchNode;
+use crate::request;
 use crate::services::subgraph_service::MakeSubgraphService;
+use crate::services::SubgraphResponse;
+use crate::spec::Query;
+use crate::spec::Schema;
+use crate::Configuration;
+use crate::Context;
 
 macro_rules! test_query_plan {
     () => {

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -25,11 +25,11 @@ use crate::services::new_service::ServiceFactory;
 use crate::services::router;
 use crate::services::router_service::RouterCreator;
 use crate::services::transport;
+use crate::services::PluggableSupergraphServiceBuilder;
 use crate::services::SubgraphService;
 use crate::services::SupergraphCreator;
+use crate::spec::Schema;
 use crate::ListenAddr;
-use crate::PluggableSupergraphServiceBuilder;
-use crate::Schema;
 
 #[derive(Clone)]
 /// A path and a handler to be exposed as a web_endpoint for plugins
@@ -115,7 +115,7 @@ pub(crate) trait RouterSuperServiceFactory: Send + Sync + 'static {
     async fn create<'a>(
         &'a mut self,
         configuration: Arc<Configuration>,
-        schema: Arc<crate::Schema>,
+        schema: Arc<Schema>,
         previous_router: Option<&'a Self::RouterFactory>,
         extra_plugins: Option<Vec<(String, Box<dyn DynPlugin>)>>,
     ) -> Result<Self::RouterFactory, BoxError>;
@@ -412,7 +412,7 @@ mod test {
     use crate::router_factory::inject_schema_id;
     use crate::router_factory::RouterSuperServiceFactory;
     use crate::router_factory::YamlRouterFactory;
-    use crate::Schema;
+    use crate::spec::Schema;
 
     #[derive(Debug)]
     struct PluginError;

--- a/apollo-router/src/services/execution_service.rs
+++ b/apollo-router/src/services/execution_service.rs
@@ -29,9 +29,9 @@ use crate::json_ext::Path;
 use crate::json_ext::PathElement;
 use crate::json_ext::ValueExt;
 use crate::services::execution;
-use crate::ExecutionRequest;
-use crate::ExecutionResponse;
-use crate::Schema;
+use crate::services::ExecutionRequest;
+use crate::services::ExecutionResponse;
+use crate::spec::Schema;
 
 /// [`Service`] for query execution.
 #[derive(Clone)]

--- a/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
+++ b/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
@@ -15,8 +15,8 @@ use tower::Service;
 use crate::graphql::Error;
 use crate::json_ext::Object;
 use crate::layers::sync_checkpoint::CheckpointService;
-use crate::ExecutionRequest;
-use crate::ExecutionResponse;
+use crate::services::ExecutionRequest;
+use crate::services::ExecutionResponse;
 
 #[derive(Default)]
 pub(crate) struct AllowOnlyHttpPostMutationsLayer {}
@@ -192,7 +192,7 @@ mod forbid_http_get_mutations_tests {
         assert_eq!(&response.errors[0], expected_error);
     }
 
-    fn create_request(method: Method, operation_kind: OperationKind) -> crate::ExecutionRequest {
+    fn create_request(method: Method, operation_kind: OperationKind) -> ExecutionRequest {
         let root: PlanNode = if operation_kind == OperationKind::Mutation {
             serde_json::from_value(json!({
                 "kind": "Sequence",

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -12,8 +12,8 @@ use sha2::Digest;
 use sha2::Sha256;
 
 use crate::cache::DeduplicatingCache;
-use crate::SupergraphRequest;
-use crate::SupergraphResponse;
+use crate::services::SupergraphRequest;
+use crate::services::SupergraphResponse;
 
 /// A persisted query.
 #[derive(Deserialize, Clone, Debug)]

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -21,9 +21,9 @@ use super::supergraph;
 use super::MULTIPART_DEFER_CONTENT_TYPE;
 use crate::graphql;
 use crate::json_ext::Path;
+use crate::services::TryIntoHeaderName;
+use crate::services::TryIntoHeaderValue;
 use crate::Context;
-use crate::TryIntoHeaderName;
-use crate::TryIntoHeaderValue;
 
 pub type BoxService = tower::util::BoxService<Request, Response, BoxError>;
 pub type BoxCloneService = tower::util::BoxCloneService<Request, Response, BoxError>;

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -47,13 +47,13 @@ use crate::graphql;
 use crate::plugin::test::MockSupergraphService;
 use crate::router_factory::RouterFactory;
 use crate::services::layers::content_negociation::GRAPHQL_JSON_RESPONSE_HEADER_VALUE;
+use crate::services::RouterRequest;
+use crate::services::RouterResponse;
+use crate::services::SupergraphRequest;
+use crate::services::SupergraphResponse;
 use crate::Configuration;
 use crate::Endpoint;
 use crate::ListenAddr;
-use crate::RouterRequest;
-use crate::RouterResponse;
-use crate::SupergraphRequest;
-use crate::SupergraphResponse;
 
 /// Containing [`Service`] in the request lifecyle.
 #[derive(Clone)]

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -39,6 +39,8 @@ use crate::error::FetchError;
 use crate::graphql;
 use crate::plugins::telemetry::LOGGING_DISPLAY_BODY;
 use crate::plugins::telemetry::LOGGING_DISPLAY_HEADERS;
+use crate::services::SubgraphRequest;
+use crate::services::SubgraphResponse;
 
 #[derive(PartialEq, Debug, Clone, Deserialize, JsonSchema, Copy)]
 #[serde(rename_all = "lowercase")]
@@ -93,8 +95,8 @@ impl SubgraphService {
     }
 }
 
-impl tower::Service<crate::SubgraphRequest> for SubgraphService {
-    type Response = crate::SubgraphResponse;
+impl tower::Service<SubgraphRequest> for SubgraphService {
+    type Response = SubgraphResponse;
     type Error = BoxError;
     type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
 
@@ -104,8 +106,8 @@ impl tower::Service<crate::SubgraphRequest> for SubgraphService {
             .map(|res| res.map_err(|e| Box::new(e) as BoxError))
     }
 
-    fn call(&mut self, request: crate::SubgraphRequest) -> Self::Future {
-        let crate::SubgraphRequest {
+    fn call(&mut self, request: SubgraphRequest) -> Self::Future {
+        let SubgraphRequest {
             subgraph_request,
             context,
             ..
@@ -256,7 +258,7 @@ impl tower::Service<crate::SubgraphRequest> for SubgraphService {
 
             let resp = http::Response::from_parts(parts, graphql);
 
-            Ok(crate::SubgraphResponse::new_from_response(resp, context))
+            Ok(SubgraphResponse::new_from_response(resp, context))
         })
     }
 }
@@ -301,8 +303,8 @@ pub(crate) async fn compress(body: String, headers: &HeaderMap) -> Result<Vec<u8
 
 pub(crate) trait SubgraphServiceFactory: Clone + Send + Sync + 'static {
     type SubgraphService: Service<
-            crate::SubgraphRequest,
-            Response = crate::SubgraphResponse,
+            SubgraphRequest,
+            Response = SubgraphResponse,
             Error = BoxError,
             Future = Self::Future,
         > + Send
@@ -335,29 +337,28 @@ impl SubgraphCreator {
 ///
 /// there can be multiple instances of that service executing at any given time
 pub(crate) trait MakeSubgraphService: Send + Sync + 'static {
-    fn make(&self) -> BoxService<crate::SubgraphRequest, crate::SubgraphResponse, BoxError>;
+    fn make(&self) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError>;
 }
 
 impl<S> MakeSubgraphService for S
 where
-    S: Service<crate::SubgraphRequest, Response = crate::SubgraphResponse, Error = BoxError>
+    S: Service<SubgraphRequest, Response = SubgraphResponse, Error = BoxError>
         + Clone
         + Send
         + Sync
         + 'static,
-    <S as Service<crate::SubgraphRequest>>::Future: Send,
+    <S as Service<SubgraphRequest>>::Future: Send,
 {
-    fn make(&self) -> BoxService<crate::SubgraphRequest, crate::SubgraphResponse, BoxError> {
+    fn make(&self) -> BoxService<SubgraphRequest, SubgraphResponse, BoxError> {
         self.clone().boxed()
     }
 }
 
 impl SubgraphServiceFactory for SubgraphCreator {
-    type SubgraphService = BoxService<crate::SubgraphRequest, crate::SubgraphResponse, BoxError>;
-    type Future =
-        <BoxService<crate::SubgraphRequest, crate::SubgraphResponse, BoxError> as Service<
-            crate::SubgraphRequest,
-        >>::Future;
+    type SubgraphService = BoxService<SubgraphRequest, SubgraphResponse, BoxError>;
+    type Future = <BoxService<SubgraphRequest, SubgraphResponse, BoxError> as Service<
+        SubgraphRequest,
+    >>::Future;
 
     fn create(&self, name: &str) -> Option<Self::SubgraphService> {
         self.services.get(name).map(|service| {
@@ -386,6 +387,7 @@ mod tests {
     use serde_json_bytes::Value;
     use tower::service_fn;
     use tower::ServiceExt;
+    use SubgraphRequest;
 
     use super::*;
     use crate::graphql::Error;
@@ -393,7 +395,6 @@ mod tests {
     use crate::graphql::Response;
     use crate::query_planner::fetch::OperationKind;
     use crate::Context;
-    use crate::SubgraphRequest;
 
     // starts a local server emulating a subgraph returning status code 400
     async fn emulate_subgraph_bad_request(socket_addr: SocketAddr) {

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -36,18 +36,18 @@ use crate::plugins::traffic_shaping::TrafficShaping;
 use crate::plugins::traffic_shaping::APOLLO_TRAFFIC_SHAPING;
 use crate::query_planner::BridgeQueryPlanner;
 use crate::query_planner::CachingQueryPlanner;
-use crate::supergraph;
+use crate::services::supergraph;
+use crate::services::ExecutionRequest;
+use crate::services::ExecutionResponse;
+use crate::services::QueryPlannerRequest;
+use crate::services::QueryPlannerResponse;
+use crate::services::SupergraphRequest;
+use crate::services::SupergraphResponse;
+use crate::spec::Schema;
 use crate::Configuration;
 use crate::Context;
 use crate::Endpoint;
-use crate::ExecutionRequest;
-use crate::ExecutionResponse;
 use crate::ListenAddr;
-use crate::QueryPlannerRequest;
-use crate::QueryPlannerResponse;
-use crate::Schema;
-use crate::SupergraphRequest;
-use crate::SupergraphResponse;
 
 pub(crate) const QUERY_PLANNING_SPAN_NAME: &str = "query_planning";
 

--- a/apollo-router/src/spec/field_type.rs
+++ b/apollo-router/src/spec/field_type.rs
@@ -4,7 +4,8 @@ use serde::Serialize;
 
 use crate::json_ext::Value;
 use crate::json_ext::ValueExt;
-use crate::*;
+use crate::spec::Schema;
+use crate::spec::SpecError;
 
 #[derive(Debug)]
 pub(crate) struct InvalidValue;

--- a/apollo-router/src/spec/fragments.rs
+++ b/apollo-router/src/spec/fragments.rs
@@ -4,7 +4,14 @@ use apollo_parser::ast;
 use serde::Deserialize;
 use serde::Serialize;
 
-use crate::*;
+use crate::spec::parse_include;
+use crate::spec::parse_skip;
+use crate::spec::FieldType;
+use crate::spec::Include;
+use crate::spec::Schema;
+use crate::spec::Selection;
+use crate::spec::Skip;
+use crate::spec::SpecError;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub(crate) struct Fragments {

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -9,7 +9,6 @@ use std::collections::HashSet;
 use apollo_parser::ast;
 use apollo_parser::ast::AstNode;
 use derivative::Derivative;
-use graphql::Error;
 use serde::de::Visitor;
 use serde::Deserialize;
 use serde::Serialize;
@@ -17,6 +16,7 @@ use serde_json_bytes::ByteString;
 use tracing::level_filters::LevelFilter;
 
 use crate::error::FetchError;
+use crate::graphql::Error;
 use crate::graphql::Request;
 use crate::graphql::Response;
 use crate::json_ext::Object;
@@ -24,7 +24,13 @@ use crate::json_ext::Path;
 use crate::json_ext::PathElement;
 use crate::json_ext::Value;
 use crate::query_planner::fetch::OperationKind;
-use crate::*;
+use crate::spec::FieldType;
+use crate::spec::Fragments;
+use crate::spec::InvalidValue;
+use crate::spec::Schema;
+use crate::spec::Selection;
+use crate::spec::SpecError;
+use crate::Configuration;
 
 pub(crate) const TYPENAME: &str = "__typename";
 

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -18,7 +18,9 @@ use crate::json_ext::Object;
 use crate::json_ext::Value;
 use crate::query_planner::OperationKind;
 use crate::spec::query::parse_value;
-use crate::*;
+use crate::spec::FieldType;
+use crate::spec::SpecError;
+use crate::Configuration;
 
 /// A GraphQL schema.
 #[derive(Debug, Default, Clone)]

--- a/apollo-router/src/spec/selection.rs
+++ b/apollo-router/src/spec/selection.rs
@@ -7,10 +7,10 @@ use serde_json_bytes::ByteString;
 use super::Fragments;
 use crate::json_ext::Object;
 use crate::json_ext::PathElement;
+use crate::spec::FieldType;
+use crate::spec::Schema;
+use crate::spec::SpecError;
 use crate::spec::TYPENAME;
-use crate::FieldType;
-use crate::Schema;
-use crate::SpecError;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub(crate) enum Selection {

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -25,7 +25,7 @@ use crate::configuration::Configuration;
 use crate::configuration::ListenAddr;
 use crate::router_factory::RouterFactory;
 use crate::router_factory::RouterSuperServiceFactory;
-use crate::Schema;
+use crate::spec::Schema;
 
 /// This state maintains private information that is not exposed to the user via state listener.
 #[derive(derivative::Derivative)]
@@ -657,7 +657,7 @@ mod tests {
             async fn create<'a>(
                 &'a mut self,
                 configuration: Arc<Configuration>,
-                schema: Arc<crate::Schema>,
+                schema: Arc<Schema>,
                 previous_router: Option<&'a MockMyRouterFactory>,
                 extra_plugins: Option<Vec<(String, Box<dyn DynPlugin>)>>,
             ) -> Result<MockMyRouterFactory, BoxError>;

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -21,7 +21,7 @@ use crate::services::router_service::RouterCreator;
 use crate::services::subgraph;
 use crate::services::supergraph;
 use crate::services::SupergraphCreator;
-use crate::Schema;
+use crate::spec::Schema;
 
 #[cfg(test)]
 pub(crate) mod http_client;


### PR DESCRIPTION
No behavior or public API should change, only internal imports

For apollo-complier integration I might need to move many things around in the `spec` module. This will allow more easily finding its users.

---
name: Checklist
about: PR Acceptance Checklist.
title: ''
labels: []
assignees: ''

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible<sup>1</sup>
- [ ] Documentation<sup>2</sup> completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing<sup>3</sup>
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

Nothing new to test or document. Perf should be unaffected.

**Notes**

1. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
2. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
3. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
