### PR TITLE
fix: correctly set content-type on request with invalid content-type/…

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -63,6 +63,16 @@ Users can disable the sending this data by using the command line flag `--anonym
 
 By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/2173, https://github.com/apollographql/router/issues/2398
 
+
+## 🐛 Fixes
+
+### Specify content type to `application/json` on requests with content-type/accept header missmatch ([Issue #2334](https://github.com/apollographql/router/issues/2334))
+
+When receiving requests with invalid content-type/accept header missmatch (e.g multipart requests) , it now specifies the right `content-type` header.
+
+By [@Meemaw](https://github.com/Meemaw) in https://github.com/apollographql/router/pull/2370
+
+
 ## 🛠 Maintenance
 
 ### Remove unused factory traits ([Issue #2180](https://github.com/apollographql/router/pull/2372))

--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -1009,6 +1009,14 @@ async fn it_send_bad_content_type() -> Result<(), ApolloRouterError> {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE,);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE),
+        Some(&HeaderValue::from_static(APPLICATION_JSON.essence_str()))
+    );
+    assert_eq!(
+        response.text().await.unwrap(),
+        r#"{"message":"'content-type' header can't be different from \"application/json\" or \"application/graphql-response+json\"","extensions":{"code":"INVALID_ACCEPT_HEADER"}}"#
+    );
 
     server.shutdown().await
 }
@@ -1040,6 +1048,14 @@ async fn it_sends_bad_accept_header() -> Result<(), ApolloRouterError> {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::NOT_ACCEPTABLE);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE),
+        Some(&HeaderValue::from_static(APPLICATION_JSON.essence_str()))
+    );
+    assert_eq!(
+        response.text().await.unwrap(),
+        r#"{"message":"'accept' header can't be different from \\\"*/*\\\", \"application/json\", \"application/graphql-response+json\" or \"multipart/mixed;boundary=\\\"graphql\\\";deferSpec=20220824\"","extensions":{"code":"INVALID_ACCEPT_HEADER"}}"#
+    );
 
     server.shutdown().await
 }

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -363,15 +363,23 @@ where
                                 Ok(router::Response {
                                 response: http::Response::builder()
                                     .status(StatusCode::NOT_ACCEPTABLE)
-                                    .body(Body::from(
-                                        format!(
-                                            r#"'accept' header can't be different from \"*/*\", {:?}, {:?} or {:?}"#,
-                                            APPLICATION_JSON.essence_str(),
-                                            GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
-                                            MULTIPART_DEFER_CONTENT_TYPE
+                                    .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                                    .body(
+                                    Body::from(
+                                        serde_json::to_string(
+                                            &graphql::Error::builder()
+                                                .message(format!(
+                                                    r#"'accept' header can't be different from \"*/*\", {:?}, {:?} or {:?}"#,
+                                                    APPLICATION_JSON.essence_str(),
+                                                    GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
+                                                    MULTIPART_DEFER_CONTENT_TYPE
+                                                ))
+                                                .extension_code("INVALID_ACCEPT_HEADER")
+                                                .build(),
                                         )
-                                    ))
-                                    .expect("cannot fail"),
+                                        .unwrap_or_else(|_| String::from("Invalid request"))
+                                    )
+                                ).expect("cannot fail"),
                                 context,
                             })
                             }


### PR DESCRIPTION
Fix content type for requests with invalid content-type.

Fixes https://github.com/apollographql/router/issues/2334

---
name: Checklist
about: PR Acceptance Checklist.
title: ''
labels: []
assignees: ''

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible<sup>1</sup>
- [ ] Documentation<sup>2</sup> completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing<sup>3</sup>
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

1. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
2. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
3. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
