### PR TITLE
Remove last mentions of `preview` for `@defer` support.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## ❗ BREAKING ❗
 ## 🚀 Features
 ## 🐛 Fixes
+## 📃 Configuration
 ## 🛠 Maintenance
 ## 📚 Documentation
 ## 🥼 Experimental
@@ -26,7 +27,29 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 
 # [1.8.0] (unreleased) - 2022-mm-dd
 
-## ❗ BREAKING ❗
+## 📃 Configuration
+
+Configuration will be [automatically migrated on load](https://www.apollographql.com/docs/router/configuration/overview#upgrading-your-router-configuration). However you should update your source configuration files.
+
+### Defer support GA docs and config ([Issue #2368](https://github.com/apollographql/router/issues/2368))
+
+`@defer` has reached GA, however there were still mentions of it being in preview. These have now been removed.
+
+If you had disabled defer support via config then you will need to update your router.yaml
+
+Before:
+```yaml
+supergraph:
+  preview_defer_support: true
+```
+
+After:
+```yaml
+supergraph:
+  defer_support: true
+```
+
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/2378
 
 ### Remove timeout from otlp exporter ([Issue #2337](https://github.com/apollographql/router/issues/2337))
 

--- a/apollo-router/src/configuration/migrations/0004-defer_support_ga.yaml
+++ b/apollo-router/src/configuration/migrations/0004-defer_support_ga.yaml
@@ -1,0 +1,6 @@
+description: supergraph.preview_defer_support moved to supergraph.defer_support
+actions:
+  - type: move
+    from: supergraph.preview_defer_support
+    to: supergraph.defer_support
+

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -483,8 +483,9 @@ pub(crate) struct Supergraph {
     #[serde(default = "default_graphql_introspection")]
     pub(crate) introspection: bool,
 
+    /// Enable defer support
     #[serde(default = "default_defer_support")]
-    pub(crate) preview_defer_support: bool,
+    pub(crate) defer_support: bool,
 
     /// Configures automatic persisted queries
     #[serde(default)]
@@ -506,7 +507,7 @@ impl Supergraph {
         listen: Option<ListenAddr>,
         path: Option<String>,
         introspection: Option<bool>,
-        preview_defer_support: Option<bool>,
+        defer_support: Option<bool>,
         apq: Option<Apq>,
         query_planning: Option<QueryPlanning>,
     ) -> Self {
@@ -514,7 +515,7 @@ impl Supergraph {
             listen: listen.unwrap_or_else(default_graphql_listen),
             path: path.unwrap_or_else(default_graphql_path),
             introspection: introspection.unwrap_or_else(default_graphql_introspection),
-            preview_defer_support: preview_defer_support.unwrap_or_else(default_defer_support),
+            defer_support: defer_support.unwrap_or_else(default_defer_support),
             apq: apq.unwrap_or_default(),
             query_planning: query_planning.unwrap_or_default(),
         }
@@ -529,7 +530,7 @@ impl Supergraph {
         listen: Option<ListenAddr>,
         path: Option<String>,
         introspection: Option<bool>,
-        preview_defer_support: Option<bool>,
+        defer_support: Option<bool>,
         apq: Option<Apq>,
         query_planning: Option<QueryPlanning>,
     ) -> Self {
@@ -537,7 +538,7 @@ impl Supergraph {
             listen: listen.unwrap_or_else(test_listen),
             path: path.unwrap_or_else(default_graphql_path),
             introspection: introspection.unwrap_or_else(default_graphql_introspection),
-            preview_defer_support: preview_defer_support.unwrap_or_else(default_defer_support),
+            defer_support: defer_support.unwrap_or_else(default_defer_support),
             apq: apq.unwrap_or_default(),
             query_planning: query_planning.unwrap_or_default(),
         }

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -680,7 +680,7 @@ expression: "&schema"
         "listen": "127.0.0.1:4000",
         "path": "/",
         "introspection": false,
-        "preview_defer_support": true,
+        "defer_support": true,
         "apq": {
           "experimental_cache": {
             "in_memory": {
@@ -741,6 +741,11 @@ expression: "&schema"
           },
           "additionalProperties": false
         },
+        "defer_support": {
+          "description": "Enable defer support",
+          "default": true,
+          "type": "boolean"
+        },
         "introspection": {
           "description": "Enable introspection Default: false",
           "default": false,
@@ -764,10 +769,6 @@ expression: "&schema"
           "description": "The HTTP path on which GraphQL requests will be served. default: \"/\"",
           "default": "/",
           "type": "string"
-        },
-        "preview_defer_support": {
-          "default": true,
-          "type": "boolean"
         },
         "query_planning": {
           "description": "Query planning options",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@defer_support_ga.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@defer_support_ga.router.yaml.snap
@@ -1,0 +1,8 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+---
+---
+supergraph:
+  defer_support: true
+

--- a/apollo-router/src/configuration/testdata/migrations/defer_support_ga.router.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/defer_support_ga.router.yaml
@@ -1,0 +1,2 @@
+supergraph:
+  defer_support: true

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -27,7 +27,7 @@ impl Introspection {
     ) -> Self {
         Self {
             cache: CacheStorage::new(capacity, None, "introspection").await,
-            defer_support: configuration.supergraph.preview_defer_support,
+            defer_support: configuration.supergraph.defer_support,
         }
     }
 

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -59,7 +59,7 @@ impl BridgeQueryPlanner {
                     schema.as_string().to_string(),
                     QueryPlannerConfig {
                         incremental_delivery: Some(IncrementalDeliverySupport {
-                            enable_defer: Some(configuration.supergraph.preview_defer_support),
+                            enable_defer: Some(configuration.supergraph.defer_support),
                         }),
                     },
                 )

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -614,7 +614,7 @@ async fn normal_query_with_defer_accept_header() {
 async fn defer_path_with_disabled_config() {
     let config = serde_json::json!({
         "supergraph": {
-            "preview_defer_support": false,
+            "defer_support": false,
         },
         "plugins": {
             "apollo.include_subgraph_errors": {

--- a/docs/source/executing-operations/defer-support.mdx
+++ b/docs/source/executing-operations/defer-support.mdx
@@ -3,7 +3,7 @@ title: Apollo Router support for @defer
 description: Improve performance by delivering entity fields incrementally
 ---
 
-> This feature is currently in **preview**, available in Apollo Router v1.0 and later. [Learn about launch stages.](/resources/product-launch-stages)
+> Available in Apollo Router v1.0 and later. [Learn about launch stages.](/resources/product-launch-stages)
 
 Queries sent to the Apollo Router can use the `@defer` directive to enable the incremental delivery of response data. By deferring data for some fields, the router can resolve and return data for the query's _other_ fields more quickly, improving responsiveness.
 
@@ -204,4 +204,11 @@ The `@defer` directive is currently part of a draft-stage RFC for the GraphQL sp
 
 The Apollo Router supports the `@defer` directive as it's documented in [these edits to the RFC](https://github.com/graphql/graphql-spec/pull/742), according to the state of those edits on 2022-08-24.
 
-Entity-based `@defer` support in the Apollo Router is currently [preview functionality](/resources/product-launch-stages/#preview). We'd love your feedback on this preview! Feedback will help inform improvements to the functionality prior to its general availability. It will _also_ help inform any changes to the `@defer` RFC as it proceeds through remaining contribution stages.
+## Disabling defer
+
+Defer is enabled by default. If you wish to disable `@defer`, you can do so via router.yaml:
+
+```yaml title="router.yaml"
+supergraph:
+  defer_support: false
+```


### PR DESCRIPTION
Fixes #2368

Removes last mentions of `preview` now that `@defer` has reached GA.

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

~~- [ ] Changes are compatible[^1]~~
- [x] Documentation[^2] completed
~~- [ ] Performance impact assessed and acceptable~~
- Tests added and passing[^3]
    - [x] Unit Tests
~~- [ ] Integration Tests~~
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
