### PR TITLE
change the default value for `apollo.field_level_instrumentation_sampler`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -166,11 +166,6 @@ Before this fix, `_0___typename` was set to `null`. Thanks to this fix it return
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/2357
 
-### Change the default value of `apollo.field_level_instrumentation_sampler` ([Issue #2339](https://github.com/apollographql/router/issues/2339))
-
-Change the default value of `apollo.field_level_instrumentation_sampler` to `always_off` instead of `0.01`
-
-By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/2356
 
 ### `subgraph_request` span is set as the parent of traces coming from subgraphs ([Issue #2344](https://github.com/apollographql/router/issues/2344))
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -910,7 +910,7 @@ expression: "&schema"
               "type": "string"
             },
             "field_level_instrumentation_sampler": {
-              "description": "Enable field level instrumentation for subgraphs via ftv1. ftv1 tracing can cause performance issues as it is transmitted in band with subgraph responses. 0.0 will result in no field level instrumentation. 1.0 will result in always instrumentation. Value MUST be less than global sampling rate Default: always_off",
+              "description": "Enable field level instrumentation for subgraphs via ftv1. ftv1 tracing can cause performance issues as it is transmitted in band with subgraph responses. 0.0 will result in no field level instrumentation. 1.0 will result in always instrumentation. Value MUST be less than global sampling rate",
               "anyOf": [
                 {
                   "description": "Sample a given fraction. Fractions >= 1 will always sample.",

--- a/apollo-router/src/plugins/telemetry/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/apollo.rs
@@ -13,7 +13,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use url::Url;
 
-use super::config::Sampler;
 use super::metrics::apollo::studio::ContextualizedStats;
 use super::metrics::apollo::studio::SingleStats;
 use super::metrics::apollo::studio::SingleStatsReport;
@@ -75,7 +74,6 @@ pub(crate) struct Config {
     /// Enable field level instrumentation for subgraphs via ftv1. ftv1 tracing can cause performance issues as it is transmitted in band with subgraph responses.
     /// 0.0 will result in no field level instrumentation. 1.0 will result in always instrumentation.
     /// Value MUST be less than global sampling rate
-    /// Default: always_off
     #[serde(default = "default_field_level_instrumentation_sampler")]
     pub(crate) field_level_instrumentation_sampler: SamplerOption,
 
@@ -97,7 +95,7 @@ pub(crate) struct Config {
 }
 
 fn default_field_level_instrumentation_sampler() -> SamplerOption {
-    SamplerOption::Always(Sampler::AlwaysOff)
+    SamplerOption::TraceIdRatioBased(0.01)
 }
 
 fn endpoint_default() -> Url {

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
@@ -144,7 +144,7 @@ expression: get_spans()
                   ],
                   [
                     "apollo_private.field_level_instrumentation_ratio",
-                    0.0
+                    0.01
                   ],
                   [
                     "apollo_private.graphql.variables",

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
@@ -144,7 +144,7 @@ expression: get_spans()
                   ],
                   [
                     "apollo_private.field_level_instrumentation_ratio",
-                    0.0
+                    0.01
                   ],
                   [
                     "apollo_private.graphql.variables",

--- a/docs/source/configuration/apollo-telemetry.mdx
+++ b/docs/source/configuration/apollo-telemetry.mdx
@@ -17,7 +17,13 @@ More information on usage reporting is available in the [Studio documentation](/
 
 ## Enabling field-level instrumentation
 
-Field-level instrumentation (also known as FTV1 tracing) is set to `0.01` by default. To enable it, add the following to your router configuration:
+[Apollo field-level instrumentation](https://www.apollographql.com/docs/federation/metrics) (also known as FTV1 tracing) is set to a sampling rate of `0.01` by default, which means it will request traces for 1% of traffic.  To change it to a higher rate, set the `field_level_instrumentation_sampler` value to a rate higher than `0.1`. To completely disable it, set it to `always_off`.
+
+> **Note**
+> Since field-level instrumentation is _dependent_ OpenTelemetry tracing, it is necessary to set the `sampler` value for traces to a value the _same or higher_ than the `field_level_instrumentation_sampler` value.
+
+The following example sets both Apollo field-level tracing and OpenTelemetry tracing to attempt to sample 50% of requests:
+
 
 ```yaml
 telemetry:

--- a/docs/source/configuration/apollo-telemetry.mdx
+++ b/docs/source/configuration/apollo-telemetry.mdx
@@ -17,7 +17,7 @@ More information on usage reporting is available in the [Studio documentation](/
 
 ## Enabling field-level instrumentation
 
-Field-level instrumentation (also known as FTV1 tracing) is disabled by default. To enable it, add the following to your router configuration:
+Field-level instrumentation (also known as FTV1 tracing) is set to `0.01` by default. To enable it, add the following to your router configuration:
 
 ```yaml
 telemetry:


### PR DESCRIPTION
This PR reverses the choice made in https://github.com/apollographql/router/pull/2356 which came up originally in https://github.com/apollographql/router/issues/2339.  By default, we would like the user experience to be that Apollo Studio tracing works at a low sampling rate when you've provided an Apollo Studio API key.  To disable field level tracing (FTV1) entirely, the rate can be set to `0.0`.