### PR TITLE
Fix default value parsing of integer fields of input types

### DIFF
--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 use apollo_parser::ast;
-use apollo_parser::ast::AstNode;
 use derivative::Derivative;
 use serde::de::Visitor;
 use serde::Deserialize;
@@ -1197,7 +1196,8 @@ pub(crate) fn parse_value(value: &ast::Value) -> Option<Value> {
         ast::Value::StringValue(s) => String::try_from(s).ok().map(Into::into),
         ast::Value::FloatValue(f) => f64::try_from(f).ok().map(Into::into),
         ast::Value::IntValue(i) => {
-            let s = i.source_string();
+            let token = i.int_token()?;
+            let s = token.text();
             s.parse::<i64>()
                 .ok()
                 .map(Into::into)

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -2913,7 +2913,10 @@ fn it_parses_default_floats() {
         "#,
     );
 
-    Schema::parse(&schema, &Default::default()).unwrap();
+    let schema = Schema::parse(&schema, &Default::default()).unwrap();
+    let (_field_type, value) =
+        &schema.input_types["WithAllKindsOfFloats"].fields["a_float_that_doesnt_fit_an_int"];
+    assert_eq!(value.as_ref().unwrap().as_i64().unwrap(), 9876543210);
 }
 
 #[test]

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -619,7 +619,7 @@ macro_rules! implement_input_object_type_or_interface {
         #[derive(Debug, Clone)]
         $visibility struct $name {
             name: String,
-            fields: HashMap<String, (FieldType, Option<Value>)>,
+            pub(crate) fields: HashMap<String, (FieldType, Option<Value>)>,
         }
 
         impl $name {


### PR DESCRIPTION
`IntValue::source_string()` can include whitespace, which causes `i64::from_str` to fail.

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

- Compat: I’m not sure what the macro-consequences are of the router incorrectly thinking there is no default value, so I don’t know if anyone could (accidentally) rely on this bug
- Docs: Is such a bugfix changelog-worthy?
- Perf: I expect (but have not measured) impact, if any, to be indistinguishable from noise

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
