### PR TITLE
Orbiter integration runs on expanded validated config rather than raw

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -28,7 +28,7 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 # [1.8.1] (unreleased) - 2022-mm-dd
 
 ## 🚀 Features
-### Anonymous product usage analytics ([Issue #2124](https://github.com/apollographql/router/issues/2124))
+### Anonymous product usage analytics ([Issue #2124](https://github.com/apollographql/router/issues/2124), [Issue #2397](https://github.com/apollographql/router/issues/2397))
 
 Following up on https://github.com/apollographql/router/pull/1630, the Router transmits anonymous usage telemetry about configurable feature usage which helps guide Router product development.  No information is transmitted in our usage collection that includes any request-specific information.  Knowing what features and configuration our users are depending on allows us to evaluate opportunity to reduce complexity and remain diligent about the surface area of the Router.  The privacy of your and your user's data is of critical importantance to the core Router team and we handle it in accordance with our [privacy policy](https://www.apollographql.com/docs/router/privacy/), which clearly states which data we collect and transmit and offers information on how to opt-out.
 Note that strings are output as `<redacted>` so that we do not leak confidential or sensitive information.
@@ -61,7 +61,7 @@ For example:
 
 Users can disable the sending this data by using the command line flag `--anonymous-telemetry-disabled` or setting the environment variable `APOLLO_TELEMETRY_DISABLED=true`
 
-By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/2173
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/2173, https://github.com/apollographql/router/issues/2398
 
 ## 🛠 Maintenance
 

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -80,7 +80,7 @@ pub enum ConfigurationError {
 pub struct Configuration {
     /// The raw configuration string.
     #[serde(skip)]
-    pub(crate) raw_yaml: Arc<String>,
+    pub(crate) validated_yaml: Arc<Value>,
 
     /// Configuration options pertaining to the http server component.
     #[serde(default)]
@@ -178,7 +178,7 @@ fn test_listen() -> ListenAddr {
 impl Configuration {
     #[builder]
     pub(crate) fn new(
-        raw_yaml: Option<String>,
+        validated_yaml: Option<Value>,
         server: Option<Server>,
         supergraph: Option<Supergraph>,
         health_check: Option<HealthCheck>,
@@ -190,7 +190,7 @@ impl Configuration {
         dev: Option<bool>,
     ) -> Result<Self, ConfigurationError> {
         let mut conf = Self {
-            raw_yaml: Arc::new(raw_yaml.unwrap_or_default()),
+            validated_yaml: Arc::new(validated_yaml.unwrap_or_default()),
             server: server.unwrap_or_default(),
             supergraph: supergraph.unwrap_or_default(),
             health_check: health_check.unwrap_or_default(),
@@ -318,7 +318,7 @@ impl Configuration {
         dev: Option<bool>,
     ) -> Result<Self, ConfigurationError> {
         let mut configuration = Self {
-            raw_yaml: Default::default(),
+            validated_yaml: Default::default(),
             server: server.unwrap_or_default(),
             supergraph: supergraph.unwrap_or_else(|| Supergraph::fake_builder().build()),
             health_check: health_check.unwrap_or_else(|| HealthCheck::fake_builder().build()),

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -235,7 +235,7 @@ pub(crate) fn validate_yaml_configuration(
         }
     }
 
-    let mut config: Configuration = serde_json::from_value(expanded_yaml)
+    let mut config: Configuration = serde_json::from_value(expanded_yaml.clone())
         .map_err(ConfigurationError::DeserializeConfigError)?;
 
     // ------------- Check for unknown fields at runtime ----------------
@@ -263,7 +263,7 @@ pub(crate) fn validate_yaml_configuration(
             ),
         });
     }
-    config.raw_yaml = Arc::new(raw_yaml.to_string());
+    config.validated_yaml = Arc::new(expanded_yaml);
     Ok(config)
 }
 

--- a/apollo-router/src/orbiter/mod.rs
+++ b/apollo-router/src/orbiter/mod.rs
@@ -304,6 +304,7 @@ fn visit_config(usage: &mut HashMap<String, u64>, config: &Value) {
 mod test {
     use std::collections::HashMap;
     use std::env;
+    use std::str::FromStr;
     use std::sync::Arc;
 
     use insta::assert_yaml_snapshot;
@@ -337,6 +338,18 @@ mod test {
             .expect("yaml must be valid");
         let mut usage = HashMap::new();
         visit_config(&mut usage, &config);
+        insta::with_settings!({sort_maps => true}, {
+            assert_yaml_snapshot!(usage);
+        });
+    }
+
+    #[test]
+    fn test_visit_config_that_needed_upgrade() {
+        let config: Configuration =
+            Configuration::from_str("supergraph:\n  preview_defer_support: true")
+                .expect("config must be valid");
+        let mut usage = HashMap::new();
+        visit_config(&mut usage, &config.validated_yaml);
         insta::with_settings!({sort_maps => true}, {
             assert_yaml_snapshot!(usage);
         });

--- a/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__visit_config_that_needed_upgrade.snap
+++ b/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__visit_config_that_needed_upgrade.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-router/src/orbiter/mod.rs
+expression: usage
+---
+configuration.supergraph.defer_support.true: 1
+


### PR DESCRIPTION
Fixes #2397

When we reach orbiter integration we should have a valid configuration. This change stashes the validated and expanded config rather than the raw config so that we don't have to worry about doing this stuff again within the orbiter code.

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- ~~[ ] Documentation[^2] completed~~
- ~~[ ] Performance impact assessed and acceptable~~
- Tests added and passing[^3]
    - [x] Unit Tests
    - ~~[ ] Integration Tests~~
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
