### PR TITLE
Add (unused) query parsing based on apollo-compiler

### DIFF
--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -114,4 +114,25 @@ pub mod _private {
             format!("{:?}", Schema::parse_with_hir(schema, &conf)),
         )
     }
+
+    /// Retuns the `Debug` fomatting of two `Result<Query, SpecError>`,
+    /// from `parse_with_ast` and `parse_with_hir` respectively.
+    ///
+    /// The two strings are expected to be equal.
+    pub fn compare_query_parsing(query: &str) -> (String, String) {
+        use once_cell::sync::OnceCell;
+
+        use crate::spec::Query;
+        use crate::spec::Schema;
+
+        static DUMMY_SCHEMA: OnceCell<Schema> = OnceCell::new();
+        let conf = Default::default();
+        let schema = DUMMY_SCHEMA.get_or_init(|| {
+            Schema::parse(include_str!("testdata/minimal_supergraph.graphql"), &conf).unwrap()
+        });
+        (
+            format!("{:?}", Query::parse_with_ast(query, schema, &conf)),
+            format!("{:?}", Query::parse_with_hir(query, schema, &conf)),
+        )
+    }
 }

--- a/apollo-router/src/spec/fragments.rs
+++ b/apollo-router/src/spec/fragments.rs
@@ -1,9 +1,13 @@
 use std::collections::HashMap;
 
+use apollo_compiler::ApolloCompiler;
+use apollo_compiler::HirDatabase;
 use apollo_parser::ast;
 use serde::Deserialize;
 use serde::Serialize;
 
+use super::parse_include_hir;
+use super::parse_skip_hir;
 use crate::spec::parse_include;
 use crate::spec::parse_skip;
 use crate::spec::FieldType;
@@ -15,10 +19,45 @@ use crate::spec::SpecError;
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub(crate) struct Fragments {
-    map: HashMap<String, Fragment>,
+    pub(crate) map: HashMap<String, Fragment>,
 }
 
 impl Fragments {
+    pub(crate) fn from_hir(compiler: &ApolloCompiler, schema: &Schema) -> Result<Self, SpecError> {
+        let map = compiler
+            .db
+            .all_fragments()
+            .iter()
+            .map(|(name, fragment)| {
+                let type_condition = fragment.type_condition().to_owned();
+                let current_type = FieldType::Named(type_condition.clone());
+                let fragment = Fragment {
+                    type_condition,
+                    selection_set: fragment
+                        .selection_set()
+                        .selection()
+                        .iter()
+                        .filter_map(|selection| {
+                            Selection::from_hir(selection, &current_type, schema, 0).transpose()
+                        })
+                        .collect::<Result<Vec<_>, _>>()?,
+                    skip: fragment
+                        .directives()
+                        .iter()
+                        .find_map(parse_skip_hir)
+                        .unwrap_or(Skip::No),
+                    include: fragment
+                        .directives()
+                        .iter()
+                        .find_map(parse_include_hir)
+                        .unwrap_or(Include::Yes),
+                };
+                Ok((name.clone(), fragment))
+            })
+            .collect::<Result<_, _>>()?;
+        Ok(Fragments { map })
+    }
+
     pub(crate) fn from_ast(document: &ast::Document, schema: &Schema) -> Result<Self, SpecError> {
         let map = document
             .definitions()

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -1144,11 +1144,10 @@ impl Operation {
     fn from_hir(operation: &hir::OperationDefinition, schema: &Schema) -> Result<Self, SpecError> {
         let name = operation.name().map(|s| s.to_owned());
         let kind = operation.operation_ty().into();
-        let current_field_type = match kind {
-            OperationKind::Query => FieldType::Named("Query".to_string()),
-            OperationKind::Mutation => FieldType::Named("Mutation".to_string()),
-            OperationKind::Subscription => return Err(SpecError::SubscriptionNotSupported),
-        };
+        if kind == OperationKind::Subscription {
+            return Err(SpecError::SubscriptionNotSupported);
+        }
+        let current_field_type = FieldType::Named(schema.root_operation_name(kind).to_owned());
         let selection_set = operation
             .selection_set()
             .selection()

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -1161,7 +1161,7 @@ impl Operation {
             .variables()
             .iter()
             .map(|variable| {
-                let name = ByteString::from(variable.name());
+                let name = variable.name().into();
                 let variable = Variable {
                     field_type: variable.ty().into(),
                     default_value: variable.default_value().and_then(parse_hir_value),
@@ -1239,7 +1239,7 @@ impl Operation {
                 })?)?;
 
                 Ok((
-                    ByteString::from(name),
+                    name.into(),
                     Variable {
                         field_type: ty,
                         default_value: parse_default_value(&definition),

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -7,6 +7,9 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 use apollo_compiler::hir;
+use apollo_compiler::ApolloCompiler;
+use apollo_compiler::AstDatabase;
+use apollo_compiler::HirDatabase;
 use apollo_parser::ast;
 use derivative::Derivative;
 use serde::de::Visitor;
@@ -35,7 +38,7 @@ use crate::Configuration;
 pub(crate) const TYPENAME: &str = "__typename";
 
 /// A GraphQL query.
-#[derive(Debug, Derivative, Default, Serialize, Deserialize)]
+#[derive(Derivative, Default, Serialize, Deserialize)]
 #[derivative(PartialEq, Hash, Eq)]
 pub(crate) struct Query {
     string: String,
@@ -45,6 +48,36 @@ pub(crate) struct Query {
     pub(crate) operations: Vec<Operation>,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub(crate) subselections: HashMap<SubSelection, Query>,
+}
+
+impl std::fmt::Debug for Query {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use super::schema::sorted_map;
+        let Query {
+            string,
+            fragments,
+            operations,
+            subselections,
+        } = self;
+        writeln!(f, "Query:")?;
+        writeln!(f, "  string: {string:?}")?;
+        sorted_map(f, "  ", "fragments", &fragments.map)?;
+        writeln!(f, "  operations:")?;
+        for operation in operations {
+            let Operation {
+                name,
+                kind,
+                selection_set,
+                variables,
+            } = operation;
+            writeln!(f, "    - name: {name:?}")?;
+            writeln!(f, "      kind: {kind:?}")?;
+            writeln!(f, "      selection_set: {selection_set:#?}")?;
+            sorted_map(f, "      ", "variables", variables)?;
+        }
+        writeln!(f, "  subselections: {subselections:#?}")?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Derivative, Default)]
@@ -254,6 +287,58 @@ impl Query {
     }
 
     pub(crate) fn parse(
+        query: impl Into<String>,
+        schema: &Schema,
+        configuration: &Configuration,
+    ) -> Result<Self, SpecError> {
+        Self::parse_with_ast(query, schema, configuration)
+    }
+
+    pub(crate) fn parse_with_hir(
+        query: impl Into<String>,
+        schema: &Schema,
+        configuration: &Configuration,
+    ) -> Result<Self, SpecError> {
+        let query = query.into();
+        let mut compiler = ApolloCompiler::with_recursion_limit(
+            configuration.server.experimental_parser_recursion_limit,
+        );
+        let id = compiler.add_executable(&query, "query");
+        let ast = compiler.db.ast(id);
+
+        // Trace log recursion limit data
+        let recursion_limit = ast.recursion_limit();
+        tracing::trace!(?recursion_limit, "recursion limit data");
+
+        let errors = ast
+            .errors()
+            .map(|err| format!("{:?}", err))
+            .collect::<Vec<_>>();
+
+        if !errors.is_empty() {
+            let errors = errors.join(", ");
+            failfast_debug!("parsing error(s): {}", errors);
+            return Err(SpecError::ParsingError(errors));
+        }
+
+        let fragments = Fragments::from_hir(&compiler, schema)?;
+
+        let operations = compiler
+            .db
+            .all_operations()
+            .iter()
+            .map(|operation| Operation::from_hir(operation, schema))
+            .collect::<Result<Vec<_>, SpecError>>()?;
+
+        Ok(Query {
+            string: query,
+            fragments,
+            operations,
+            subselections: HashMap::new(),
+        })
+    }
+
+    pub(crate) fn parse_with_ast(
         query: impl Into<String>,
         schema: &Schema,
         configuration: &Configuration,
@@ -1056,6 +1141,42 @@ pub(crate) struct Variable {
 }
 
 impl Operation {
+    fn from_hir(operation: &hir::OperationDefinition, schema: &Schema) -> Result<Self, SpecError> {
+        let name = operation.name().map(|s| s.to_owned());
+        let kind = operation.operation_ty().into();
+        let current_field_type = match kind {
+            OperationKind::Query => FieldType::Named("Query".to_string()),
+            OperationKind::Mutation => FieldType::Named("Mutation".to_string()),
+            OperationKind::Subscription => return Err(SpecError::SubscriptionNotSupported),
+        };
+        let selection_set = operation
+            .selection_set()
+            .selection()
+            .iter()
+            .filter_map(|selection| {
+                Selection::from_hir(selection, &current_field_type, schema, 0).transpose()
+            })
+            .collect::<Result<_, _>>()?;
+        let variables = operation
+            .variables()
+            .iter()
+            .map(|variable| {
+                let name = ByteString::from(variable.name());
+                let variable = Variable {
+                    field_type: variable.ty().into(),
+                    default_value: variable.default_value().and_then(parse_hir_value),
+                };
+                Ok((name, variable))
+            })
+            .collect::<Result<_, _>>()?;
+        Ok(Operation {
+            selection_set,
+            name,
+            variables,
+            kind,
+        })
+    }
+
     // clippy false positive due to the bytes crate
     // ref: https://rust-lang.github.io/rust-clippy/master/index.html#mutable_key_type
     #[allow(clippy::mutable_key_type)]

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -42,29 +42,33 @@ pub(crate) struct Schema {
     root_operations: HashMap<OperationKind, String>,
 }
 
+pub(crate) fn sorted_map<K, V>(
+    f: &mut std::fmt::Formatter<'_>,
+    indent: &str,
+    name: &str,
+    map: &HashMap<K, V>,
+) -> std::fmt::Result
+where
+    K: std::fmt::Debug + Ord,
+    V: std::fmt::Debug,
+{
+    writeln!(f, "{indent}{name}:")?;
+    for (k, v) in map.iter().sorted_by_key(|&(k, _v)| k) {
+        writeln!(f, "{indent}  {k:?}: {v:#?}")?;
+    }
+    Ok(())
+}
+
 /// YAML-like representation with sorted hashmap/sets, more amenable to diffing
 impl std::fmt::Debug for Schema {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        fn sorted_map<V: std::fmt::Debug>(
-            f: &mut std::fmt::Formatter<'_>,
-            indent: &str,
-            name: &str,
-            map: &HashMap<String, V>,
-        ) -> std::fmt::Result {
-            writeln!(f, "{indent}{name}:")?;
-            for (k, v) in map.iter().sorted_by_key(|&(k, _v)| k.clone()) {
-                writeln!(f, "{indent}  {k:?}: {v:?}")?;
-            }
-            Ok(())
-        }
-
         fn sorted_map_of_sets(
             f: &mut std::fmt::Formatter<'_>,
             name: &str,
             map: &HashMap<String, HashSet<String>>,
         ) -> std::fmt::Result {
             writeln!(f, "  {name}:")?;
-            for (k, set) in map.iter().sorted_by_key(|&(k, _set)| k.clone()) {
+            for (k, set) in map.iter().sorted_by_key(|&(k, _set)| k) {
                 writeln!(f, "    {k:?}:")?;
                 for v in set.iter().sorted() {
                     writeln!(f, "      {v:?}")?;
@@ -95,7 +99,7 @@ impl std::fmt::Debug for Schema {
             .collect();
         sorted_map(f, "  ", "root_operations", &root)?;
         writeln!(f, "  object_types:")?;
-        for (k, v) in object_types.iter().sorted_by_key(|&(k, _v)| k.clone()) {
+        for (k, v) in object_types.iter().sorted_by_key(|&(k, _v)| k) {
             let ObjectType {
                 name: _,
                 fields,
@@ -106,7 +110,7 @@ impl std::fmt::Debug for Schema {
             sorted_map(f, "      ", "fields", fields)?
         }
         writeln!(f, "  interfaces:")?;
-        for (k, v) in interfaces.iter().sorted_by_key(|&(k, _v)| k.clone()) {
+        for (k, v) in interfaces.iter().sorted_by_key(|&(k, _v)| k) {
             let Interface {
                 name: _,
                 fields,
@@ -117,7 +121,7 @@ impl std::fmt::Debug for Schema {
             sorted_map(f, "      ", "fields", fields)?
         }
         writeln!(f, "  input_types:")?;
-        for (k, v) in input_types.iter().sorted_by_key(|&(k, _v)| k.clone()) {
+        for (k, v) in input_types.iter().sorted_by_key(|&(k, _v)| k) {
             let InputObjectType { name: _, fields } = v;
             writeln!(f, "    {k:?}:")?;
             sorted_map(f, "      ", "fields", fields)?

--- a/apollo-router/src/spec/selection.rs
+++ b/apollo-router/src/spec/selection.rs
@@ -104,7 +104,7 @@ impl Selection {
                     }
                 };
 
-                let alias = field.alias().map(|x| ByteString::from(&*x.0));
+                let alias = field.alias().map(|x| x.0.as_str().into());
 
                 let selection_set = if field_type.is_builtin_scalar() {
                     None

--- a/apollo-router/tests/compiler_integration.rs
+++ b/apollo-router/tests/compiler_integration.rs
@@ -1,10 +1,32 @@
 /// Just a "smoke test",
-/// `fuzz_schema_parsing` is expected to be used with a wide variety of inputs,
+/// `compare_schema_parsing` is expected to be used with a wide variety of inputs,
 /// such as fuzzing or a corpus production schemas.
 #[test]
-fn compare_schema_parsing() {
+fn test_compare_schema_parsing() {
     let (with_ast, with_hir) = apollo_router::_private::compare_schema_parsing(include_str!(
         "../src/query_planner/testdata/schema.graphql"
     ));
+    similar_asserts::assert_eq!(with_ast, with_hir)
+}
+
+/// Just a "smoke test",
+/// `compare_query_parsing` is expected to be used with a wide variety of inputs,
+/// such as fuzzing or a corpus production queries.
+#[test]
+fn test_compare_query_parsing() {
+    let query = "
+    query TopProducts($first: Int) { 
+        topProducts(first: $first) { 
+            upc 
+            name 
+            reviews { 
+                id 
+                product { name } 
+                author { id name } 
+            } 
+        } 
+    }
+    ";
+    let (with_ast, with_hir) = apollo_router::_private::compare_query_parsing(query);
     similar_asserts::assert_eq!(with_ast, with_hir)
 }


### PR DESCRIPTION
Continuation of https://github.com/apollographql/router/pull/2401

Similar to there, the new `Query::parse_with_hir` constructor is not used yet during normal Router operation.
The two implementations return identical results
for all of a corpus of ~1.2 million production queries.

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

- Compat: expect identical behavior (which is supported by testing)
- Docs: no user-visible change
- Perf: expect increase of memory use during query parsing, but unknown how significant. And parsing is short, and its results cached.
- Manual testing with https://github.com/apollographql/harness-vs-apollo-rs/pull/1

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
