### PR TITLE
Make Orbiter code gracefully handle invalid validated_yaml

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -28,7 +28,7 @@ By [@USERNAME](https://github.com/USERNAME) in https://github.com/apollographql/
 # [1.8.1] (unreleased) - 2022-mm-dd
 
 ## 🚀 Features
-### Anonymous product usage analytics ([Issue #2124](https://github.com/apollographql/router/issues/2124), [Issue #2397](https://github.com/apollographql/router/issues/2397))
+### Anonymous product usage analytics ([Issue #2124](https://github.com/apollographql/router/issues/2124), [Issue #2397](https://github.com/apollographql/router/issues/2397), [Issue #2412](https://github.com/apollographql/router/issues/2412))
 
 Following up on https://github.com/apollographql/router/pull/1630, the Router transmits anonymous usage telemetry about configurable feature usage which helps guide Router product development.  No information is transmitted in our usage collection that includes any request-specific information.  Knowing what features and configuration our users are depending on allows us to evaluate opportunity to reduce complexity and remain diligent about the surface area of the Router.  The privacy of your and your user's data is of critical importantance to the core Router team and we handle it in accordance with our [privacy policy](https://www.apollographql.com/docs/router/privacy/), which clearly states which data we collect and transmit and offers information on how to opt-out.
 Note that strings are output as `<redacted>` so that we do not leak confidential or sensitive information.
@@ -61,7 +61,7 @@ For example:
 
 Users can disable the sending this data by using the command line flag `--anonymous-telemetry-disabled` or setting the environment variable `APOLLO_TELEMETRY_DISABLED=true`
 
-By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/2173, https://github.com/apollographql/router/issues/2398
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/2173, https://github.com/apollographql/router/issues/2398, https://github.com/apollographql/router/pull/2413
 
 
 ## 🐛 Fixes

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -4,7 +4,6 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::fmt::Write;
-use std::sync::Arc;
 
 use itertools::Itertools;
 use jsonschema::error::ValidationErrorKind;
@@ -263,7 +262,7 @@ pub(crate) fn validate_yaml_configuration(
             ),
         });
     }
-    config.validated_yaml = Arc::new(expanded_yaml);
+    config.validated_yaml = Some(expanded_yaml);
     Ok(config)
 }
 

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -26,7 +26,6 @@ use url::Url;
 use crate::configuration;
 use crate::configuration::generate_config_schema;
 use crate::configuration::generate_upgrade;
-use crate::configuration::Configuration;
 use crate::configuration::ConfigurationError;
 use crate::router::ConfigurationSource;
 use crate::router::RouterHttpServer;
@@ -432,9 +431,7 @@ impl Executable {
                 }
             }) {
                 Some(configuration) => configuration,
-                None => Configuration::builder()
-                    .build()
-                    .map(std::convert::Into::into)?,
+                None => Default::default(),
             },
         };
 

--- a/apollo-router/src/orbiter/mod.rs
+++ b/apollo-router/src/orbiter/mod.rs
@@ -125,7 +125,10 @@ impl<T: RouterSuperServiceFactory> RouterSuperServiceFactory
 }
 
 fn create_report(configuration: Arc<Configuration>, _schema: Arc<Schema>) -> UsageReport {
-    let mut configuration: Value = (*configuration.validated_yaml).clone();
+    let mut configuration: Value = configuration
+        .validated_yaml
+        .clone()
+        .unwrap_or_else(|| Value::Object(Default::default()));
     let os = get_os();
     let mut usage = HashMap::new();
 
@@ -138,6 +141,11 @@ fn create_report(configuration: Arc<Configuration>, _schema: Arc<Schema>) -> Usa
             .map(|plugins| plugins.len())
             .unwrap_or_default() as u64,
     );
+
+    // Make sure the config is an object, but don't fail if it wasn't
+    if !configuration.is_object() {
+        configuration = Value::Object(Default::default());
+    }
 
     // Delete the plugins block so that we don't report on it.
     // A custom plugin may have configuration that is sensitive.
@@ -295,8 +303,6 @@ fn visit_config(usage: &mut HashMap<String, u64>, config: &Value) {
                 _ => {}
             }
         }
-    } else {
-        panic!("config should have been valid");
     }
 }
 
@@ -308,6 +314,7 @@ mod test {
     use std::sync::Arc;
 
     use insta::assert_yaml_snapshot;
+    use serde_json::json;
     use serde_json::Value;
 
     use crate::orbiter::create_report;
@@ -334,10 +341,16 @@ mod test {
 
     #[test]
     fn test_visit_config() {
-        let config = serde_yaml::from_str(include_str!("testdata/redaction.router.yaml"))
+        let config = Configuration::from_str(include_str!("testdata/redaction.router.yaml"))
             .expect("yaml must be valid");
         let mut usage = HashMap::new();
-        visit_config(&mut usage, &config);
+        visit_config(
+            &mut usage,
+            config
+                .validated_yaml
+                .as_ref()
+                .expect("config should have had validated_yaml"),
+        );
         insta::with_settings!({sort_maps => true}, {
             assert_yaml_snapshot!(usage);
         });
@@ -349,7 +362,13 @@ mod test {
             Configuration::from_str("supergraph:\n  preview_defer_support: true")
                 .expect("config must be valid");
         let mut usage = HashMap::new();
-        visit_config(&mut usage, &config.validated_yaml);
+        visit_config(
+            &mut usage,
+            config
+                .validated_yaml
+                .as_ref()
+                .expect("config should have had validated_yaml"),
+        );
         insta::with_settings!({sort_maps => true}, {
             assert_yaml_snapshot!(usage);
         });
@@ -357,12 +376,44 @@ mod test {
 
     #[test]
     fn test_create_report() {
-        let config_yaml: Value =
-            serde_yaml::from_str(include_str!("testdata/redaction.router.yaml"))
-                .expect("test yaml must parse");
-        let mut config: Configuration =
-            serde_json::from_value(config_yaml.clone()).expect("yaml must be valid");
-        config.validated_yaml = Arc::new(config_yaml);
+        let config = Configuration::from_str(include_str!("testdata/redaction.router.yaml"))
+            .expect("config must be valid");
+        let schema_string = include_str!("../testdata/minimal_supergraph.graphql");
+        let schema = crate::spec::Schema::parse(schema_string, &config).unwrap();
+        let report = create_report(Arc::new(config), Arc::new(schema));
+        insta::with_settings!({sort_maps => true}, {
+                    assert_yaml_snapshot!(report, {
+                ".version" => "[version]",
+                ".session_id" => "[session_id]",
+                ".platform.os" => "[os]",
+                ".platform.continuous_integration" => "[ci]",
+            });
+        });
+    }
+
+    #[test]
+    fn test_create_report_incorrect_type_validated_yaml() {
+        let mut config = Configuration::from_str(include_str!("testdata/redaction.router.yaml"))
+            .expect("config must be valid");
+        config.validated_yaml = Some(Value::Null);
+        let schema_string = include_str!("../testdata/minimal_supergraph.graphql");
+        let schema = crate::spec::Schema::parse(schema_string, &config).unwrap();
+        let report = create_report(Arc::new(config), Arc::new(schema));
+        insta::with_settings!({sort_maps => true}, {
+                    assert_yaml_snapshot!(report, {
+                ".version" => "[version]",
+                ".session_id" => "[session_id]",
+                ".platform.os" => "[os]",
+                ".platform.continuous_integration" => "[ci]",
+            });
+        });
+    }
+
+    #[test]
+    fn test_create_report_invalid_validated_yaml() {
+        let mut config = Configuration::from_str(include_str!("testdata/redaction.router.yaml"))
+            .expect("config must be valid");
+        config.validated_yaml = Some(json!({"garbage": "garbage"}));
         let schema_string = include_str!("../testdata/minimal_supergraph.graphql");
         let schema = crate::spec::Schema::parse(schema_string, &config).unwrap();
         let report = create_report(Arc::new(config), Arc::new(schema));

--- a/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__create_report_incorrect_type_validated_yaml.snap
+++ b/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__create_report_incorrect_type_validated_yaml.snap
@@ -1,0 +1,12 @@
+---
+source: apollo-router/src/orbiter/mod.rs
+expression: report
+---
+session_id: "[session_id]"
+version: "[version]"
+platform:
+  os: "[os]"
+  continuous_integration: "[ci]"
+usage:
+  configuration.plugins.len: 0
+

--- a/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__create_report_invalid_validated_yaml.snap
+++ b/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__create_report_invalid_validated_yaml.snap
@@ -1,0 +1,12 @@
+---
+source: apollo-router/src/orbiter/mod.rs
+expression: report
+---
+session_id: "[session_id]"
+version: "[version]"
+platform:
+  os: "[os]"
+  continuous_integration: "[ci]"
+usage:
+  configuration.plugins.len: 0
+


### PR DESCRIPTION
- Fix #2412

Make the orbiter code gracefully degrade if there are issues rather than panic.
Cleaned up configuration creation code.
Put validated schema in an option rather than an Arc.

Note that there are still expects in the code, but these should remain as they would point to actual bugs.


**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

This doesn't affect perf or need new docs.
An integration test could have been written, but I feel this is better covered by the unit tests.

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
