### PR TITLE
fix(telemetry): don't send header names on Studio if send_headers is None

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -108,6 +108,13 @@ By [@Geal](https://github.com/geal) in https://github.com/apollographql/router/p
 
 ## 🐛 Fixes
 
+### Don't send header names on Studio if `send_headers` is `none` ([Issue #2403](https://github.com/apollographql/router/issues/2403))
+
+Before when `send_headers` was set to `none` we sent header names with empty header values. Now we don't send anything to Studio.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/2425
+
+
 ### Specify content type to `application/json` on requests with content-type/accept header missmatch ([Issue #2334](https://github.com/apollographql/router/issues/2334))
 
 When receiving requests with invalid content-type/accept header missmatch (e.g multipart requests) , it now specifies the right `content-type` header.

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -115,9 +115,15 @@ By [@Geal](https://github.com/geal) in https://github.com/apollographql/router/p
 
 ## 🐛 Fixes
 
-### Don't send header names on Studio if `send_headers` is `none` ([Issue #2403](https://github.com/apollographql/router/issues/2403))
+### Don't send header names to Studio if `send_headers` is `none` ([Issue #2403](https://github.com/apollographql/router/issues/2403))
 
-Before when `send_headers` was set to `none` we sent header names with empty header values. Now we don't send anything to Studio.
+Before when `send_headers` was set to `none` (like in the following example of configuration) we sent header names with empty header values. Now we don't send anything to Studio.
+
+```yaml
+telemetry:
+  apollo:
+    send_headers: none
+```
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/2425
 

--- a/apollo-router/tests/snapshots/apollo_reports__client_name.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__client_name.snap
@@ -32,13 +32,7 @@ traces_per_query:
         client_version: ""
         http:
           method: 4
-          request_headers:
-            apollographql-client-name:
-              value:
-                - ""
-            content-type:
-              value:
-                - ""
+          request_headers: {}
           response_headers:
             my_trace_id: "[my_trace_id]"
           status_code: 0

--- a/apollo-router/tests/snapshots/apollo_reports__client_version.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__client_version.snap
@@ -32,13 +32,7 @@ traces_per_query:
         client_version: my client version
         http:
           method: 4
-          request_headers:
-            apollographql-client-version:
-              value:
-                - ""
-            content-type:
-              value:
-                - ""
+          request_headers: {}
           response_headers:
             my_trace_id: "[my_trace_id]"
           status_code: 0

--- a/apollo-router/tests/snapshots/apollo_reports__condition_else.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__condition_else.snap
@@ -33,13 +33,7 @@ traces_per_query:
         client_version: ""
         http:
           method: 4
-          request_headers:
-            accept:
-              value:
-                - ""
-            content-type:
-              value:
-                - ""
+          request_headers: {}
           response_headers:
             my_trace_id: "[my_trace_id]"
           status_code: 0

--- a/apollo-router/tests/snapshots/apollo_reports__condition_if.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__condition_if.snap
@@ -33,13 +33,7 @@ traces_per_query:
         client_version: ""
         http:
           method: 4
-          request_headers:
-            accept:
-              value:
-                - ""
-            content-type:
-              value:
-                - ""
+          request_headers: {}
           response_headers:
             my_trace_id: "[my_trace_id]"
           status_code: 0

--- a/apollo-router/tests/snapshots/apollo_reports__non_defer.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__non_defer.snap
@@ -32,10 +32,7 @@ traces_per_query:
         client_version: ""
         http:
           method: 4
-          request_headers:
-            content-type:
-              value:
-                - ""
+          request_headers: {}
           response_headers:
             my_trace_id: "[my_trace_id]"
           status_code: 0

--- a/apollo-router/tests/snapshots/apollo_reports__send_header.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__send_header.snap
@@ -33,12 +33,6 @@ traces_per_query:
         http:
           method: 4
           request_headers:
-            content-type:
-              value:
-                - ""
-            dont-send-header:
-              value:
-                - ""
             send-header:
               value:
                 - Header value

--- a/apollo-router/tests/snapshots/apollo_reports__send_variable_value.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__send_variable_value.snap
@@ -34,10 +34,7 @@ traces_per_query:
         client_version: ""
         http:
           method: 4
-          request_headers:
-            content-type:
-              value:
-                - ""
+          request_headers: {}
           response_headers:
             my_trace_id: "[my_trace_id]"
           status_code: 0

--- a/apollo-router/tests/snapshots/apollo_reports__trace_id.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__trace_id.snap
@@ -32,10 +32,7 @@ traces_per_query:
         client_version: ""
         http:
           method: 4
-          request_headers:
-            content-type:
-              value:
-                - ""
+          request_headers: {}
           response_headers:
             my_trace_id: "[my_trace_id]"
           status_code: 0

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_composition.snap
@@ -88,7 +88,7 @@ expression: get_spans()
               ],
               [
                 "apollo_private.http.request_headers",
-                "{\"content-type\":[\"\"]}"
+                "{}"
               ],
               [
                 "apollo_private.duration_ns",

--- a/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
+++ b/apollo-router/tests/snapshots/integration_tests__traced_basic_request.snap
@@ -88,7 +88,7 @@ expression: get_spans()
               ],
               [
                 "apollo_private.http.request_headers",
-                "{\"content-type\":[\"\"]}"
+                "{}"
               ],
               [
                 "apollo_private.duration_ns",


### PR DESCRIPTION
- Fix #2403

Before this PR is `send_headers`  was set to `none` we sent header names with empty header values. Now we don't send anything

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
