### PR TITLE
nit: Cosmetic capitalization/grammatical tweaks

### DIFF
--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -86,7 +86,7 @@ where
 
     if configuration.health_check.enabled {
         tracing::info!(
-            "healthcheck endpoint exposed at {}/health",
+            "Health check endpoint exposed at {}/health",
             configuration.health_check.listen
         );
         endpoints.insert(

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -89,7 +89,7 @@ pub struct Configuration {
     #[serde(default)]
     pub(crate) server: Server,
 
-    /// Healthcheck configuration
+    /// Health check configuration
     #[serde(default)]
     #[serde(rename = "health-check")]
     pub(crate) health_check: HealthCheck,
@@ -805,7 +805,7 @@ pub(crate) struct HealthCheck {
     #[serde(default = "default_health_check_listen")]
     pub(crate) listen: ListenAddr,
 
-    /// Set to false to disable the healthcheck endpoint
+    /// Set to false to disable the health check endpoint
     #[serde(default = "default_health_check")]
     pub(crate) enabled: bool,
 }

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -549,7 +549,7 @@ expression: "&schema"
       "additionalProperties": false
     },
     "health-check": {
-      "description": "Healthcheck configuration",
+      "description": "Health check configuration",
       "default": {
         "listen": "127.0.0.1:8088",
         "enabled": true
@@ -557,7 +557,7 @@ expression: "&schema"
       "type": "object",
       "properties": {
         "enabled": {
-          "description": "Set to false to disable the healthcheck endpoint",
+          "description": "Set to false to disable the health check endpoint",
           "default": true,
           "type": "boolean"
         },

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -436,9 +436,9 @@ impl Executable {
         };
 
         let apollo_telemetry_msg = if opt.anonymous_telemetry_disabled {
-            "anonymous usage data was disabled".to_string()
+            "Anonymous usage data collection is disabled.".to_string()
         } else {
-            "anonymous usage data is gathered to inform Apollo product development.  See https://go.apollo.dev/o/privacy for more info".to_string()
+            "Anonymous usage data is gathered to inform Apollo product development.  See https://go.apollo.dev/o/privacy for details.".to_string()
         };
 
         let apollo_router_msg = format!("Apollo Router v{} // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)", std::env!("CARGO_PKG_VERSION"));

--- a/docs/source/configuration/health-checks.mdx
+++ b/docs/source/configuration/health-checks.mdx
@@ -39,8 +39,8 @@ $ curl -v "http://127.0.0.1:8088/health"
 
 ## Using in a containers environment
 
-The health-check listens to 127.0.0.1 by default, which won't allow connections issued from a network.
-While this is a safe default, *other containers won't be able to perform healthchecks*, which will prevent the router pod from switching to a healthy state.
+The health check listens to 127.0.0.1 by default, which won't allow connections issued from a network.
+While this is a safe default, *other containers won't be able to perform health checks*, which will prevent the router pod from switching to a healthy state.
 
 You can change this by setting `health-check`:
 ```yaml title="router.yaml"

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -41,7 +41,7 @@ helm show values oci://ghcr.io/apollographql/helm-charts/router
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| containerPorts.health | int | `8088` | For exposing the healthcheck endpoint |
+| containerPorts.health | int | `8088` | For exposing the health check endpoint |
 | containerPorts.http | int | `80` | If you override the port in `router.configuration.server.listen` then make sure to match the listen port here |
 | containerPorts.metrics | int | `9090` | For exposing the metrics port when running a serviceMonitor for example |
 | extraEnvVars | list | `[]` |  |

--- a/helm/chart/router/values.yaml
+++ b/helm/chart/router/values.yaml
@@ -74,7 +74,7 @@ containerPorts:
   http: 80
   # -- For exposing the metrics port when running a serviceMonitor for example
   metrics: 9090
-  # -- For exposing the healthcheck endpoint
+  # -- For exposing the health check endpoint
   health: 8088
 
 imagePullSecrets: []


### PR DESCRIPTION
This doesn't attempt to bring full consistency (which should have a more principled pass done at some point), but this starts by:

- In human-readable references to the Router's health check, they are now referred to as "Health check" to match the treatment in our documentation.
- Reverts a cosmetic change that was included in #2173 (e137df2b4) which changed the captialization of some console message output.
- Capitalizes another lower-case log message about the "healthcheck" which was immediately followed by a capitalized line about "GraphQL".

  Before:

  ```
  Apollo Router v1.8.0 // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)
  anonymous usage data is gathered to inform Apollo product development.  See https://go.apollo.dev/o/privacy for more info
  healthcheck endpoint exposed at http://127.0.0.1:8088/health
  GraphQL endpoint exposed at http://127.0.0.1:4000/ 🚀
  ```

  After:

  ```
  Apollo Router v1.8.0 // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)
  Anonymous usage data is gathered to inform Apollo product development.  See https://go.apollo.dev/o/privacy for details.
  Health check endpoint exposed at http://127.0.0.1:8088/health
  GraphQL endpoint exposed at http://127.0.0.1:4000/ 🚀
  ```

Follows-up: https://github.com/apollographql/router/pull/2173
