### PR TITLE
Make Configuration::default() go through centralised parse validation and expansion logic.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -163,7 +163,7 @@ By [@Meemaw](https://github.com/Meemaw) in https://github.com/apollographql/rout
 The env variable `APOLLO_USAGE_REPORTING_INGRESS_URL` was not being applied correctly when the router was being run without a configuration file.
 In addition, defaulting of env variables now directly injects the variable rather than injecting an expansion expression. This means that `APOLLO_ROUTER_CONFIG_ENV_PREFIX` doesn't affect injected defaults.
 
-By [@bryncooke](https://github.com/bryncopoke) in https://github.com/apollographql/router/pull/2432
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/2432
 
 ## 🛠 Maintenance
 

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -158,6 +158,12 @@ When receiving requests with invalid content-type/accept header missmatch (e.g m
 
 By [@Meemaw](https://github.com/Meemaw) in https://github.com/apollographql/router/pull/2370
 
+### Fix `APOLLO_USAGE_REPORTING_INGRESS_URL` application when router is run without a configuration file
+
+The env variable `APOLLO_USAGE_REPORTING_INGRESS_URL` was not being applied correctly when the router was being run without a configuration file.
+In addition, defaulting of env variables now directly injects the variable rather than injecting an expansion expression. This means that `APOLLO_ROUTER_CONFIG_ENV_PREFIX` doesn't affect injected defaults.
+
+By [@bryncooke](https://github.com/bryncopoke) in https://github.com/apollographql/router/pull/2432
 
 ## 🛠 Maintenance
 

--- a/apollo-router/src/configuration/expansion.rs
+++ b/apollo-router/src/configuration/expansion.rs
@@ -15,6 +15,14 @@ use super::ConfigurationError;
 pub(crate) struct Expansion {
     prefix: Option<String>,
     supported_modes: Vec<String>,
+    defaults: Vec<ConfigDefault>,
+}
+
+#[derive(buildstructor::Builder)]
+pub(crate) struct ConfigDefault {
+    config_path: String,
+    env_name: String,
+    default: String,
 }
 
 impl Expansion {
@@ -35,10 +43,17 @@ impl Expansion {
             .split(',')
             .map(|mode| mode.trim().to_string())
             .collect::<Vec<String>>();
-        Ok(Expansion {
-            prefix,
-            supported_modes,
-        })
+        Ok(Expansion::builder()
+            .and_prefix(prefix)
+            .supported_modes(supported_modes)
+            .default(
+                ConfigDefault::builder()
+                    .config_path("telemetry.apollo.endpoint")
+                    .env_name("APOLLO_USAGE_REPORTING_INGRESS_URL")
+                    .default("https://usage-reporting.api.apollographql.com/api/ingress/traces")
+                    .build(),
+            )
+            .build())
     }
 }
 
@@ -82,73 +97,78 @@ impl Expansion {
             Err(ConfigurationError::InvalidExpansionModeConfig)
         }
     }
-}
 
-pub(crate) fn expand_env_variables(
-    configuration: &serde_json::Value,
-    expansion: &Expansion,
-) -> Result<serde_json::Value, ConfigurationError> {
-    let mut configuration = configuration.clone();
-    #[cfg(not(test))]
-    env_defaults(&mut configuration);
-    visit(&mut configuration, expansion)?;
-    Ok(configuration)
-}
+    pub(crate) fn expand_env_variables(
+        &self,
+        configuration: &serde_json::Value,
+    ) -> Result<serde_json::Value, ConfigurationError> {
+        let mut configuration = configuration.clone();
+        self.env_defaults(&mut configuration)?;
+        self.visit(&mut configuration)?;
+        Ok(configuration)
+    }
 
-fn env_defaults(config: &mut Value) {
-    // Anything that needs expanding via env variable should be placed here. Don't pollute the codebase with calls to std::env.
-    let defaults = vec![(
-        "telemetry.apollo.endpoint",
-        "${env.APOLLO_USAGE_REPORTING_INGRESS_URL:-https://usage-reporting.api.apollographql.com/api/ingress/traces}",
-    )];
-    let mut transformer_builder = TransformBuilder::default();
-    transformer_builder =
-        transformer_builder.add_action(Parser::parse("", "").expect("migration must be valid"));
-    for (path, value) in defaults {
-        if jsonpath_lib::select(config, &format!("$.{}", path))
-            .unwrap_or_default()
-            .is_empty()
-        {
-            transformer_builder = transformer_builder.add_action(
-                Parser::parse(&format!("const(\"{}\")", value), path)
+    fn env_defaults(&self, config: &mut Value) -> Result<(), ConfigurationError> {
+        // Anything that needs expanding via env variable should be placed here. Don't pollute the codebase with calls to std::env.
+        // For testing we have the one fixed expansion. We don't actually want to expand env variables during tests
+        let mut transformer_builder = TransformBuilder::default();
+        transformer_builder =
+            transformer_builder.add_action(Parser::parse("", "").expect("migration must be valid"));
+        for default in &self.defaults {
+            let env_variable =
+                std::env::var(&default.env_name).unwrap_or_else(|_| default.default.clone());
+            if jsonpath_lib::select(config, &format!("$.{}", default.config_path))
+                .unwrap_or_default()
+                .is_empty()
+            {
+                transformer_builder = transformer_builder.add_action(
+                    Parser::parse(
+                        &format!("const(\"{}\")", env_variable),
+                        &default.config_path,
+                    )
                     .expect("migration must be valid"),
-            );
+                );
+            }
         }
+        *config = transformer_builder
+            .build()
+            .expect("failed to build config default transformer")
+            .apply(config)
+            .map_err(|e| ConfigurationError::InvalidConfiguration {
+                message: "could not set configuration defaults as the source configuration had an invalid structure",
+                error: e.to_string(),
+            })?;
+        Ok(())
     }
-    *config = transformer_builder
-        .build()
-        .expect("failed to build config default transformer")
-        .apply(config)
-        .expect("failed to set config defaults");
-}
 
-fn visit(value: &mut Value, expansion: &Expansion) -> Result<(), ConfigurationError> {
-    let mut expanded: Option<String> = None;
-    match value {
-        Value::String(value) => {
-            let new_value = shellexpand::env_with_context(value, expansion.context_fn())
-                .map_err(|e| e.cause)?;
-            if &new_value != value {
-                expanded = Some(new_value.to_string());
+    fn visit(&self, value: &mut Value) -> Result<(), ConfigurationError> {
+        let mut expanded: Option<String> = None;
+        match value {
+            Value::String(value) => {
+                let new_value =
+                    shellexpand::env_with_context(value, self.context_fn()).map_err(|e| e.cause)?;
+                if &new_value != value {
+                    expanded = Some(new_value.to_string());
+                }
             }
-        }
-        Value::Array(a) => {
-            for v in a {
-                visit(v, expansion)?
+            Value::Array(a) => {
+                for v in a {
+                    self.visit(v)?
+                }
             }
-        }
-        Value::Object(o) => {
-            for v in o.values_mut() {
-                visit(v, expansion)?
+            Value::Object(o) => {
+                for v in o.values_mut() {
+                    self.visit(v)?
+                }
             }
+            _ => {}
         }
-        _ => {}
+        // The expansion may have resulted in a primitive, reparse and replace
+        if let Some(expanded) = expanded {
+            *value = coerce(&expanded)
+        }
+        Ok(())
     }
-    // The expansion may have resulted in a primitive, reparse and replace
-    if let Some(expanded) = expanded {
-        *value = coerce(&expanded)
-    }
-    Ok(())
 }
 
 pub(crate) fn coerce(expanded: &str) -> Value {
@@ -165,12 +185,69 @@ mod test {
     use insta::assert_yaml_snapshot;
     use serde_json::json;
 
-    use crate::configuration::expansion::env_defaults;
+    use crate::configuration::expansion::ConfigDefault;
+    use crate::configuration::Expansion;
 
     #[test]
-    fn test_env_defaults() {
-        let mut value = json!({"hi": "there"});
-        env_defaults(&mut value);
+    fn test_unprefixed() {
+        std::env::set_var("TEST_EXPANSION_VAR", "expanded");
+        std::env::set_var("TEST_DEFAULTED_VAR", "defaulted");
+
+        let expansion = Expansion::builder()
+            .supported_mode("env")
+            .default(
+                ConfigDefault::builder()
+                    .config_path("defaulted")
+                    .env_name("TEST_DEFAULTED_VAR")
+                    .default("defaulted")
+                    .build(),
+            )
+            .default(
+                ConfigDefault::builder()
+                    .config_path("overridden")
+                    .env_name("TEST_DEFAULTED_VAR")
+                    .default("defaulted")
+                    .build(),
+            )
+            .build();
+        let mut value =
+            json!({"expanded": "${env.TEST_EXPANSION_VAR}", "overridden": "overridden"});
+        value = expansion
+            .expand_env_variables(&value)
+            .expect("expansion must succeed");
+        insta::with_settings!({sort_maps => true}, {
+            assert_yaml_snapshot!(value);
+        })
+    }
+
+    #[test]
+    fn test_prefixed() {
+        std::env::set_var("TEST_PREFIX_TEST_EXPANSION_VAR", "expanded");
+        std::env::set_var("TEST_DEFAULTED_VAR", "defaulted");
+
+        let expansion = Expansion::builder()
+            .prefix("TEST_PREFIX")
+            .supported_mode("env")
+            .default(
+                ConfigDefault::builder()
+                    .config_path("defaulted")
+                    .env_name("TEST_DEFAULTED_VAR")
+                    .default("defaulted")
+                    .build(),
+            )
+            .default(
+                ConfigDefault::builder()
+                    .config_path("overridden")
+                    .env_name("TEST_DEFAULTED_VAR")
+                    .default("defaulted")
+                    .build(),
+            )
+            .build();
+        let mut value =
+            json!({"expanded": "${env.TEST_EXPANSION_VAR}", "overridden": "overridden"});
+        value = expansion
+            .expand_env_variables(&value)
+            .expect("expansion must succeed");
         insta::with_settings!({sort_maps => true}, {
             assert_yaml_snapshot!(value);
         })

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -314,9 +314,8 @@ impl Configuration {
 
 impl Default for Configuration {
     fn default() -> Self {
-        Configuration::builder()
-            .build()
-            .expect("default configuration must be valid")
+        // We want to trigger all defaulting logic so don't use the raw builder.
+        Configuration::from_str("").expect("default configuration must be valid")
     }
 }
 

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -14,7 +14,6 @@ use schemars::schema::RootSchema;
 use yaml_rust::scanner::Marker;
 
 use super::expansion::coerce;
-use super::expansion::expand_env_variables;
 use super::expansion::Expansion;
 use super::experimental::log_used_experimental_conf;
 use super::plugins;
@@ -101,7 +100,7 @@ pub(crate) fn validate_yaml_configuration(
 
     if migration == Mode::Upgrade {
         let upgraded = upgrade_configuration(&yaml, true)?;
-        let expanded_yaml = expand_env_variables(&upgraded, &expansion)?;
+        let expanded_yaml = expansion.expand_env_variables(&upgraded)?;
         if schema.validate(&expanded_yaml).is_ok() {
             yaml = upgraded;
         } else {
@@ -109,7 +108,7 @@ pub(crate) fn validate_yaml_configuration(
         }
     }
     log_used_experimental_conf(&yaml);
-    let expanded_yaml = expand_env_variables(&yaml, &expansion)?;
+    let expanded_yaml = expansion.expand_env_variables(&yaml)?;
     let parsed_yaml = super::yaml::parse(raw_yaml)?;
     if let Err(errors_it) = schema.validate(&expanded_yaml) {
         // Validation failed, translate the errors into something nice for the user

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__expansion__test__env_defaults.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__expansion__test__env_defaults.snap
@@ -1,9 +1,0 @@
----
-source: apollo-router/src/configuration/expansion.rs
-expression: value
----
-hi: there
-telemetry:
-  apollo:
-    endpoint: "${env.APOLLO_USAGE_REPORTING_INGRESS_URL:-https://usage-reporting.api.apollographql.com/api/ingress/traces}"
-

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__expansion__test__prefixed.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__expansion__test__prefixed.snap
@@ -1,0 +1,8 @@
+---
+source: apollo-router/src/configuration/expansion.rs
+expression: value
+---
+defaulted: defaulted
+expanded: expanded
+overridden: overridden
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__expansion__test__unprefixed.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__expansion__test__unprefixed.snap
@@ -1,0 +1,8 @@
+---
+source: apollo-router/src/configuration/expansion.rs
+expression: value
+---
+defaulted: defaulted
+expanded: expanded
+overridden: overridden
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__default_config_has_defaults.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__default_config_has_defaults.snap
@@ -1,0 +1,9 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: "Configuration::default().validated_yaml"
+---
+plugins: ~
+telemetry:
+  apollo:
+    endpoint: "https://usage-reporting.api.apollographql.com/api/ingress/traces"
+

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -652,6 +652,11 @@ fn all_properties_are_documented() {
     }
 }
 
+#[test]
+fn default_config_has_defaults() {
+    insta::assert_yaml_snapshot!(Configuration::default().validated_yaml);
+}
+
 fn visit_schema(path: &str, schema: &Value, errors: &mut Vec<String>) {
     match schema {
         Value::Array(arr) => {

--- a/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__create_report.snap
+++ b/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__create_report.snap
@@ -20,6 +20,7 @@ usage:
   configuration.headers.subgraphs.<redacted>.request.remove.named.<redacted>: 1
   configuration.override_subgraph_url.len: 1
   configuration.plugins.len: 0
+  configuration.telemetry.apollo.endpoint.<redacted>: 1
   configuration.telemetry.apollo.send_headers.len: 1
   configuration.telemetry.tracing.otlp.endpoint.<redacted>: 1
   configuration.telemetry.tracing.otlp.grpc.metadata.len: 2

--- a/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__visit_config.snap
+++ b/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__visit_config.snap
@@ -13,6 +13,7 @@ configuration.headers.subgraphs.<redacted>.request.insert.value.<redacted>: 1
 configuration.headers.subgraphs.<redacted>.request.remove.len: 1
 configuration.headers.subgraphs.<redacted>.request.remove.named.<redacted>: 1
 configuration.override_subgraph_url.len: 1
+configuration.telemetry.apollo.endpoint.<redacted>: 1
 configuration.telemetry.apollo.send_headers.len: 1
 configuration.telemetry.tracing.otlp.endpoint.<redacted>: 1
 configuration.telemetry.tracing.otlp.grpc.metadata.len: 2

--- a/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__visit_config_that_needed_upgrade.snap
+++ b/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__visit_config_that_needed_upgrade.snap
@@ -3,4 +3,5 @@ source: apollo-router/src/orbiter/mod.rs
 expression: usage
 ---
 configuration.supergraph.defer_support.true: 1
+configuration.telemetry.apollo.endpoint.<redacted>: 1
 


### PR DESCRIPTION
- Fix #2429

There are lots of steps in producing final validated configuration, this is handled when configuration is hydrated from a string. Previously Configuration::default() was using the builder rather than the parse logic.

In addition the defaulting mechanism now works directly against config with the env variables, so prefixing no longer interferes.

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] ~~Documentation[^2] completed~~
- [ ] ~~Performance impact assessed and acceptable~~
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] ~~Integration Tests~~
    - [x] Manual Tests

**Exceptions**

No docs needed as this is not a change or new  in functionality.

*Note any exceptions here*

**Notes**

In future we should consider removing the `Configuration::builder()`. We can leave the fake one. Goal would be that we have a single way of creating Configuration rather than the multiple that we have right now.

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
