### PR TITLE
fix missing condition on default value for APQ

### DIFF
--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -180,12 +180,12 @@ impl RouterSuperServiceFactory for YamlRouterFactory {
                                 .subgraphs
                                 .get(name)
                                 .map(|apq| apq.enabled)
-                                .or(Some(configuration.supergraph.apq.subgraph.all.enabled)),
+                                .unwrap_or(configuration.supergraph.apq.subgraph.all.enabled),
                             subgraph_root_store,
                         ),
                     ),
                 ),
-                None => Either::B(SubgraphService::new(name, None, subgraph_root_store)),
+                None => Either::B(SubgraphService::new(name, false, subgraph_root_store)),
             };
             builder = builder.with_subgraph_service(name, subgraph_service);
         }
@@ -267,12 +267,12 @@ impl YamlRouterFactory {
                                 .subgraphs
                                 .get(name)
                                 .map(|apq| apq.enabled)
-                                .or(Some(configuration.supergraph.apq.subgraph.all.enabled)),
+                                .unwrap_or(configuration.supergraph.apq.subgraph.all.enabled),
                             subgraph_root_store,
                         ),
                     ),
                 ),
-                None => Either::B(SubgraphService::new(name, None, subgraph_root_store)),
+                None => Either::B(SubgraphService::new(name, false, subgraph_root_store)),
             };
             builder = builder.with_subgraph_service(name, subgraph_service);
         }

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -107,7 +107,7 @@ pub(crate) struct SubgraphService {
 impl SubgraphService {
     pub(crate) fn new(
         service: impl Into<String>,
-        apq_enabled: Option<bool>,
+        apq_enabled: bool,
         tls_cert_store: Option<RootCertStore>,
     ) -> Self {
         let mut http_connector = HttpConnector::new();
@@ -136,7 +136,7 @@ impl SubgraphService {
                 .layer(DecompressionLayer::new())
                 .service(hyper::Client::builder().build(connector)),
             service: Arc::new(service.into()),
-            apq: Arc::new(<AtomicBool>::new(apq_enabled.unwrap_or(true))),
+            apq: Arc::new(<AtomicBool>::new(apq_enabled)),
         }
     }
 }

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -963,7 +963,7 @@ mod tests {
     async fn test_bad_status_code_should_not_fail() {
         let socket_addr = SocketAddr::from_str("127.0.0.1:2626").unwrap();
         tokio::task::spawn(emulate_subgraph_bad_request(socket_addr));
-        let subgraph_service = SubgraphService::new("test", Some(true), None);
+        let subgraph_service = SubgraphService::new("test", true, None);
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let response = subgraph_service
@@ -997,7 +997,7 @@ mod tests {
         let socket_addr = SocketAddr::from_str("127.0.0.1:2525").unwrap();
         tokio::task::spawn(emulate_subgraph_bad_response_format(socket_addr));
 
-        let subgraph_service = SubgraphService::new("test", Some(true), None);
+        let subgraph_service = SubgraphService::new("test", true, None);
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let err = subgraph_service
@@ -1030,7 +1030,7 @@ mod tests {
     async fn test_compressed_request_response_body() {
         let socket_addr = SocketAddr::from_str("127.0.0.1:2727").unwrap();
         tokio::task::spawn(emulate_subgraph_compressed_response(socket_addr));
-        let subgraph_service = SubgraphService::new("test", Some(false), None);
+        let subgraph_service = SubgraphService::new("test", false, None);
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let resp = subgraph_service
@@ -1067,7 +1067,7 @@ mod tests {
     async fn test_unauthorized() {
         let socket_addr = SocketAddr::from_str("127.0.0.1:2828").unwrap();
         tokio::task::spawn(emulate_subgraph_unauthorized(socket_addr));
-        let subgraph_service = SubgraphService::new("test", Some(true), None);
+        let subgraph_service = SubgraphService::new("test", true, None);
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let err = subgraph_service
@@ -1100,7 +1100,7 @@ mod tests {
     async fn test_persisted_query_not_supported_message() {
         let socket_addr = SocketAddr::from_str("127.0.0.1:2929").unwrap();
         tokio::task::spawn(emulate_persisted_query_not_supported_message(socket_addr));
-        let subgraph_service = SubgraphService::new("test", Some(true), None);
+        let subgraph_service = SubgraphService::new("test", true, None);
 
         assert!(subgraph_service.clone().apq.as_ref().load(Relaxed));
 
@@ -1142,7 +1142,7 @@ mod tests {
         tokio::task::spawn(emulate_persisted_query_not_supported_extension_code(
             socket_addr,
         ));
-        let subgraph_service = SubgraphService::new("test", Some(true), None);
+        let subgraph_service = SubgraphService::new("test", true, None);
 
         assert!(subgraph_service.clone().apq.as_ref().load(Relaxed));
 
@@ -1182,7 +1182,7 @@ mod tests {
     async fn test_persisted_query_not_found_message() {
         let socket_addr = SocketAddr::from_str("127.0.0.1:3131").unwrap();
         tokio::task::spawn(emulate_persisted_query_not_found_message(socket_addr));
-        let subgraph_service = SubgraphService::new("test", Some(true), None);
+        let subgraph_service = SubgraphService::new("test", true, None);
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let resp = subgraph_service
@@ -1221,7 +1221,7 @@ mod tests {
         tokio::task::spawn(emulate_persisted_query_not_found_extension_code(
             socket_addr,
         ));
-        let subgraph_service = SubgraphService::new("test", Some(true), None);
+        let subgraph_service = SubgraphService::new("test", true, None);
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let resp = subgraph_service
@@ -1258,7 +1258,7 @@ mod tests {
     async fn test_apq_enabled_subgraph_configuration() {
         let socket_addr = SocketAddr::from_str("127.0.0.1:3333").unwrap();
         tokio::task::spawn(emulate_expected_apq_enabled_configuration(socket_addr));
-        let subgraph_service = SubgraphService::new("test", Some(true), None);
+        let subgraph_service = SubgraphService::new("test", true, None);
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let resp = subgraph_service
@@ -1295,7 +1295,7 @@ mod tests {
     async fn test_apq_disabled_subgraph_configuration() {
         let socket_addr = SocketAddr::from_str("127.0.0.1:3434").unwrap();
         tokio::task::spawn(emulate_expected_apq_disabled_configuration(socket_addr));
-        let subgraph_service = SubgraphService::new("test", Some(false), None);
+        let subgraph_service = SubgraphService::new("test", false, None);
 
         let url = Uri::from_str(&format!("http://{socket_addr}")).unwrap();
         let resp = subgraph_service


### PR DESCRIPTION
Subgraph APQ was still enabed by default, but not in the configuration