### PR TITLE
Fix handling of root query operation not named `Query`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -38,4 +38,12 @@ is given the the error reporting library `miette`.
 Instead, the Router now parses introspection types separately
 and “concatenates” definitions at the AST level.
 
-By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/issues/2448
+By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/2448
+
+### Fix handling of root query operation not named `Query`
+
+With such a schema, some parsing code in the Router would incorrectly
+return an error because it was assuming the default name.
+Similarly with a root mutation operation not named `Mutation`.
+
+By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/2459

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -1073,11 +1073,10 @@ impl Operation {
             })
             .unwrap_or(OperationKind::Query);
 
-        let current_field_type = match kind {
-            OperationKind::Query => FieldType::Named("Query".to_string()),
-            OperationKind::Mutation => FieldType::Named("Mutation".to_string()),
-            OperationKind::Subscription => return Err(SpecError::SubscriptionNotSupported),
-        };
+        if kind == OperationKind::Subscription {
+            return Err(SpecError::SubscriptionNotSupported);
+        }
+        let current_field_type = FieldType::Named(schema.root_operation_name(kind).to_owned());
 
         let selection_set = operation
             .selection_set()


### PR DESCRIPTION
With such a schema, some parsing code in the Router would incorrectly return an error because it was assuming the default name. Similarly with a root mutation operation not named `Mutation`.

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
