### PR TITLE
Parse schemas and queries with `apollo-compiler`

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -122,3 +122,16 @@ supergraph:
 
 By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/2440
 
+## 🛠 Maintenance
+
+### Parse schemas and queries with `apollo-compiler`
+
+The Router now uses the higher-level representation from `apollo-compiler`
+instead of using the AST from `apollo-parser` directly.
+This is a first step towards replacing a bunch of code that grew organically
+during the Router’s early days, with a general-purpose library with intentional design.
+Internal data structures are unchanged for now.
+Parsing behavior has been tested to be identical on a large corpus
+of production schemas and queries.
+
+By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/2466

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -291,7 +291,7 @@ impl Query {
         schema: &Schema,
         configuration: &Configuration,
     ) -> Result<Self, SpecError> {
-        Self::parse_with_ast(query, schema, configuration)
+        Self::parse_with_hir(query, schema, configuration)
     }
 
     pub(crate) fn parse_with_hir(

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -146,7 +146,7 @@ fn make_api_schema(schema: &str) -> Result<String, SchemaError> {
 
 impl Schema {
     pub(crate) fn parse(s: &str, configuration: &Configuration) -> Result<Self, SchemaError> {
-        Self::parse_with_ast(s, configuration)
+        Self::parse_with_hir(s, configuration)
     }
 
     pub(crate) fn parse_with_hir(


### PR DESCRIPTION
This enables the new parsing code added in https://github.com/apollographql/router/pull/2401 and https://github.com/apollographql/router/pull/2411.

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

Perf: data structures are unchanged so no increase in long-lived memory consumption is expected: Salsa databases and caches are dropped when `parse()` returns.

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
