### PR TITLE
Make apollo-compiler available in execution::Request (router crate-private)

### DIFF
--- a/apollo-router/src/services/execution.rs
+++ b/apollo-router/src/services/execution.rs
@@ -57,13 +57,14 @@ impl Request {
     }
 
     #[builder(visibility = "pub(crate)")]
+    #[allow(clippy::needless_lifetimes)] // needed by buildstructor-generated code
     async fn internal_new<'a>(
         supergraph_request: http::Request<graphql::Request>,
         query_plan: Arc<QueryPlan>,
         schema: &'a Schema,
         context: Context,
     ) -> Request {
-        let compiler = query_plan.query.compiler(Some(&schema)).await.snapshot();
+        let compiler = query_plan.query.compiler(Some(schema)).await.snapshot();
         Self {
             supergraph_request,
             query_plan,

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -207,11 +207,13 @@ where
             } else {
                 let execution_response = execution
                     .oneshot(
-                        ExecutionRequest::builder()
+                        ExecutionRequest::internal_builder()
                             .supergraph_request(req.supergraph_request)
                             .query_plan(plan.clone())
+                            .schema(&schema)
                             .context(context)
-                            .build(),
+                            .build()
+                            .await,
                     )
                     .await?;
 

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -30,6 +30,7 @@ use crate::Configuration;
 /// A GraphQL schema.
 pub(crate) struct Schema {
     pub(crate) raw_sdl: Arc<String>,
+    pub(crate) type_system: Arc<apollo_compiler::hir::TypeSystem>,
     subtype_map: Arc<HashMap<String, HashSet<String>>>,
     subgraphs: HashMap<String, Uri>,
     pub(crate) object_types: HashMap<String, ObjectType>,
@@ -79,6 +80,7 @@ impl std::fmt::Debug for Schema {
 
         // Make sure we consider all fields
         let Schema {
+            type_system: _,
             raw_sdl,
             subtype_map,
             subgraphs,
@@ -290,6 +292,7 @@ impl Schema {
 
             Ok(Schema {
                 raw_sdl: Arc::new(schema.into()),
+                type_system: compiler.db.type_system(),
                 subtype_map: compiler.db.subtype_map(),
                 subgraphs,
                 object_types,
@@ -313,10 +316,14 @@ impl Schema {
         return Ok(schema);
 
         fn parse(schema: &str, _configuration: &Configuration) -> Result<Schema, SchemaError> {
-            let parser = apollo_parser::Parser::new(include_str!("introspection_types.graphql"));
-            let introspection_tree = parser.parse();
-            let parser = apollo_parser::Parser::new(schema);
-            let tree = parser.parse();
+            let mut compiler = ApolloCompiler::new();
+            let id = compiler.add_type_system(
+                include_str!("introspection_types.graphql"),
+                "introspection_types.graphql",
+            );
+            let introspection_tree = compiler.db.ast(id);
+            let id = compiler.add_type_system(schema, "schema.graphql");
+            let tree = compiler.db.ast(id);
 
             // Trace log recursion limit data
             let recursion_limit = tree.recursion_limit();
@@ -714,8 +721,9 @@ impl Schema {
             let schema_id = Some(format!("{:x}", hasher.finalize()));
 
             Ok(Schema {
-                subtype_map: Arc::new(subtype_map),
                 raw_sdl: Arc::new(schema.to_owned()),
+                type_system: compiler.db.type_system(),
+                subtype_map: Arc::new(subtype_map),
                 subgraphs,
                 object_types,
                 input_types,


### PR DESCRIPTION
Compilers are kept with hot Salsa memoization database in the in-memory query plan cache, and lazily-initialized for queries from the Redis cache.

We would expect some increase in memory use, but the impact is smaller than noise level (variation between runs) in `cargo bench -p apollo-router-benchmarks --bench memory_use`, which measures physical (resident) memory of a Router process after processing each of 100 queries.

![chart3](https://user-images.githubusercontent.com/291359/214831387-d0a53db1-0e27-43a8-8205-f3419862e2b5.png)


<details>

Tab-separated results, in MiB:

```
Queries	dev, run #1	dev, run #2	dev, run #3	dev, run #4	PR, run #1	PR, run
#2	PR, run #3	PR, run #4
0	65.39	61.34	60.92	65.47	60.98	65.28	60.84	61.89
1	67.75	63.5	63.17	67.64	63.3	67.5	63.08	64.11
2	69.47	63.83	63.78	67.98	63.73	67.92	64.02	64.66
3	70.97	65.06	65.25	69.36	65.05	69.08	65.44	66.25
4	71	65.11	65.31	69.42	65.11	69.12	65.47	66.28
5	71.06	65.16	65.36	69.48	65.17	69.2	65.55	66.34
6	71.2	65.72	65.41	69.53	65.25	69.27	65.61	66.39
7	71.34	66.25	65.53	69.62	65.39	69.38	65.75	66.5
8	71.34	66.25	65.53	69.62	65.41	69.38	65.77	66.52
9	71.39	66.3	65.58	69.67	65.48	69.47	65.83	66.59
10	71.42	66.34	65.61	69.7	65.55	69.53	65.88	66.64
11	71.42	66.34	65.61	69.7	65.58	69.55	65.89	66.66
12	71.45	66.36	65.64	69.73	65.64	69.58	65.94	66.72
13	71.47	66.39	65.66	69.75	65.69	69.61	65.97	66.77
14	71.5	66.42	65.7	69.78	65.75	69.67	66.05	66.83
15	71.5	66.42	65.72	69.8	65.81	69.75	66.08	66.86
16	71.56	66.45	65.78	69.86	65.91	69.83	66.16	66.94
17	71.61	66.52	65.83	69.91	66	69.92	66.27	67.03
18	71.62	66.55	65.84	69.92	66.03	69.97	66.3	67.05
19	71.75	67.48	66.92	70.88	67.09	70.34	67.52	67.5
20	72.23	67.59	67.28	72.88	67.17	71.19	69.61	69.22
21	72.25	68.28	67.47	72.92	67.78	71.2	69.66	69.28
22	72.34	68.41	67.59	72.98	67.95	71.31	69.72	69.36
23	72.34	68.41	67.61	72.98	68	71.33	69.75	69.39
24	72.34	68.41	67.61	73	68.02	71.36	69.78	69.44
25	72.39	68.42	67.64	73.05	68.08	71.42	69.88	69.48
26	72.39	68.44	67.66	73.05	68.09	71.45	69.91	69.52
27	72.39	68.44	67.66	73.06	68.09	71.48	69.94	69.58
28	72.41	68.44	67.66	73.06	68.12	71.48	69.95	69.59
29	72.44	68.48	67.67	73.08	68.16	71.55	70	69.62
30	72.44	68.5	67.67	73.08	68.2	71.56	70.02	69.64
31	72.47	68.53	67.72	73.11	68.39	71.59	70.06	69.7
32	72.5	68.55	67.73	73.14	68.48	71.64	70.11	69.73
33	72.53	68.56	67.83	73.17	68.53	71.66	70.16	69.77
34	72.53	68.59	67.84	73.17	68.55	71.7	70.17	69.78
35	72.59	68.67	67.92	73.27	68.66	71.83	70.38	69.86
36	72.64	68.72	67.98	73.3	68.72	71.91	70.44	69.94
37	72.64	68.72	67.98	73.3	68.73	71.92	70.45	69.97
38	72.66	68.72	68	73.33	68.78	71.98	70.5	70
39	72.67	68.73	68.55	73.34	68.81	72.02	70.55	70.05
40	72.7	68.78	68.58	73.55	68.83	72.09	70.59	70.08
41	72.7	68.78	68.61	73.55	68.88	72.11	70.7	70.16
42	72.75	68.8	68.67	74.3	68.94	73.06	70.78	70.39
43	73.06	69.81	69.64	74.59	69.03	73.47	70.83	71.3
44	73.56	69.86	69.69	74.61	69.09	73.48	70.86	71.33
45	73.59	69.88	69.7	74.64	69.14	73.55	70.89	71.38
46	73.62	69.89	69.72	74.66	69.19	73.58	70.94	71.42
47	73.77	70.05	69.89	74.88	69.33	74.28	71.36	71.69
48	73.97	70.31	69.95	74.91	69.44	74.31	71.42	71.77
49	74.75	70.38	70	74.97	69.81	74.41	71.56	72.33
50	74.83	70.41	70.03	75.02	69.91	74.47	72.23	73.41
51	74.83	70.73	70.03	75.42	70.03	74.91	72.33	73.45
52	74.84	71.38	70.08	75.48	71.11	75.33	72.39	73.53
53	75.59	71.94	70.83	75.5	71.44	75.34	72.44	73.56
54	75.66	72.02	70.92	75.53	71.5	75.41	72.5	73.61
55	75.66	72.02	70.94	75.53	71.5	75.42	72.5	73.64
56	75.67	72.03	70.95	75.53	71.53	75.45	72.53	73.67
57	75.69	72.03	70.95	75.56	71.59	75.48	72.58	73.69
58	75.7	72.03	70.95	75.56	71.61	75.5	72.59	73.7
59	76.14	72.08	71.03	75.67	71.72	75.53	72.67	73.75
60	77.48	72.09	71.03	75.8	71.8	75.64	72.81	73.86
61	77.98	72.22	71.11	75.81	71.94	75.7	72.84	73.88
62	78.03	72.27	71.12	75.83	71.95	75.75	72.88	73.89
63	78.05	72.28	71.14	75.86	72	75.81	72.94	73.95
64	78.06	72.3	71.14	75.86	72.02	75.83	72.98	73.97
65	78.09	72.33	71.16	75.89	72.08	75.88	73.02	74.03
66	78.14	72.36	71.2	75.91	72.14	75.91	73.08	74.09
67	78.16	72.39	71.22	75.97	72.17	76.02	73.62	74.19
68	78.27	72.42	71.23	76.03	72.22	76.11	73.97	74.27
69	78.31	72.5	71.3	76.06	72.36	76.16	74.02	74.3
70	78.44	72.61	71.38	76.14	72.53	76.3	74.14	74.47
71	78.44	72.61	71.38	76.16	72.53	76.33	74.17	74.5
72	78.45	72.64	71.41	76.2	72.56	76.41	74.22	74.58
73	78.55	72.69	71.45	76.2	72.64	76.48	74.27	74.64
74	78.55	72.69	71.45	76.44	72.66	76.53	74.39	74.78
75	79.23	72.7	71.8	76.8	72.84	76.91	74.55	74.86
76	79.28	72.75	71.91	76.83	72.97	76.98	74.61	74.89
77	79.3	72.78	71.92	76.83	72.98	77.02	74.64	74.91
78	79.36	72.8	71.94	76.84	73.03	77.03	74.7	74.97
79	79.36	72.84	71.95	76.86	73.03	77.14	74.72	75.39
80	79.44	72.89	72.05	77.33	73.83	77.58	75.16	75.95
81	79.56	73	72.12	77.45	73.97	77.69	75.28	76.08
82	79.66	73.11	72.19	77.59	74.17	77.94	75.45	76.25
83	79.67	73.12	72.22	77.59	74.2	77.94	75.45	76.31
84	79.69	73.12	72.22	77.59	74.25	78	75.52	76.34
85	79.77	73.19	72.31	77.66	74.31	78.11	75.64	76.42
86	79.77	73.2	72.31	77.67	74.36	78.14	75.66	76.48
87	79.78	73.22	72.31	77.69	74.44	78.19	75.69	76.5
88	79.8	73.23	72.34	77.7	74.47	78.25	75.73	76.56
89	79.8	73.23	72.36	77.72	74.48	78.28	75.77	76.59
90	79.81	73.25	72.38	77.73	74.52	78.3	75.8	76.62
91	79.83	73.25	72.38	77.73	74.55	78.31	75.81	76.64
92	79.83	73.27	72.38	77.73	74.61	78.38	75.83	76.66
93	79.83	73.27	72.39	77.75	74.61	78.39	75.84	76.67
94	80	73.36	72.5	77.84	74.73	78.52	76.05	76.8
95	80.05	73.41	72.55	77.91	74.83	78.59	76.11	76.88
96	80.08	73.44	72.58	77.94	74.91	78.62	76.16	76.91
97	80.08	73.44	72.58	77.95	74.94	78.64	76.17	76.91
98	80.09	73.48	72.58	77.95	74.98	78.66	76.22	76.94
99	80.11	73.55	72.61	78	75.05	78.7	76.39	76.97
100	80.14	73.67	72.62	78.02	75.11	78.73	76.42	77.02
```

</details>

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

No behavior change

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
