### PR TITLE
Disregard APOLLO_TELEMETRY_DISABLED env variable in unit test.

### DIFF
--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -237,3 +237,10 @@ Parsing behavior has been tested to be identical on a large corpus
 of production schemas and queries.
 
 By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/2466
+
+
+### Disregard APOLLO_TELEMETRY_DISABLED in orbiter unit test ([Issue #2487](https://github.com/apollographql/router/issues/2487))
+
+`orbiter::test::test_visit_args` failed if APOLLO_TELEMETRY_DISABLED was set.
+
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/2488

--- a/apollo-router/src/orbiter/mod.rs
+++ b/apollo-router/src/orbiter/mod.rs
@@ -332,6 +332,7 @@ mod test {
                 .map(|a| a.to_string())
                 .collect(),
         );
+        usage.remove("args.anonymous_telemetry_disabled.true");
         usage.remove("args.apollo_graph_ref.<redacted>");
         usage.remove("args.apollo_key.<redacted>");
         insta::with_settings!({sort_maps => true}, {


### PR DESCRIPTION
Fix #2487

The test would output would change if the env variable `APOLLO_TELEMETRY_DISABLED` was set.
Remove `args.anonymous_telemetry_disabled.true` from the test.

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] ~~Documentation[^2] completed~~
- [ ] ~~Performance impact assessed and acceptable~~
- Tests added and passing[^3]
    - [ ] ~~Unit Tests~~
    - [ ] ~~Integration Tests~~
    - [ ] ~~Manual Tests~~

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
