### PR TITLE
chore(deps): update git2 and corresponding license file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2705,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.4+1.4.2"
+version = "0.13.5+1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+checksum = "51e5ea06c26926f1002dd553fded6cfcdc9784c1f60feeb58368b4d9b07b6dba"
 dependencies = [
  "cc",
  "libc",

--- a/licenses.html
+++ b/licenses.html
@@ -2943,6 +2943,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
                     <li><a href=" https://github.com/dtolnay/async-trait ">async-trait</a></li>
                     <li><a href=" https://github.com/rust-lang/libc ">libc</a></li>
                     <li><a href=" https://github.com/nox/serde_urlencoded ">serde_urlencoded</a></li>
+                    <li><a href=" https://github.com/MattiasBuelens/wasm-streams/ ">wasm-streams</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -5864,6 +5865,7 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/Nemo157/async-compression ">async-compression</a></li>
                     <li><a href=" https://github.com/cuviper/autocfg ">autocfg</a></li>
                     <li><a href=" https://github.com/rust-lang/backtrace-rs ">backtrace</a></li>
+                    <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64</a></li>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64</a></li>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64</a></li>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64</a></li>
@@ -9169,7 +9171,6 @@ additional terms or conditions.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-encoder</a></li>
                     <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
-                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-smith</a></li>
                 </ul>
                 <pre class="license-text">../../LICENSE-APACHE</pre>
             </li>
@@ -9820,6 +9821,7 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-compiler</a></li>
+                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-smith</a></li>
                     <li><a href=" https://github.com/djc/askama ">askama_shared</a></li>
                     <li><a href=" https://github.com/graphql-rust/graphql-client ">graphql-introspection-query</a></li>
                     <li><a href=" https://github.com/graphql-rust/graphql-client ">graphql_client</a></li>


### PR DESCRIPTION
This follows up https://github.com/apollographql/router/pull/2457 which updated `git2`.  In particular, this also updates the impacted transitive dependency of `libgit2-sys ` which wasn't previously updated and had been triggering our vulnerability alert.  It's also causing our nightly builds to fail right now.

This also updates the license file accordingly.
