### PR TITLE
Use `with_current_subscriber` on a spawned task, not a `JoinHandle`

### DIFF
--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -59,7 +59,7 @@ pub(crate) fn stream_supergraph(
     timeout: Duration,
 ) -> impl Stream<Item = Result<Schema, String>> {
     let (sender, receiver) = channel(2);
-    let _ = tokio::task::spawn(async move {
+    let task = async move {
         let mut composition_id = None;
         let mut current_url_idx = 0;
 
@@ -71,7 +71,7 @@ pub(crate) fn stream_supergraph(
                 graph_ref.to_string(),
                 composition_id.clone(),
                 urls.as_ref().map(|u| &u[current_url_idx]),
-                timeout
+                timeout,
             )
             .await
             {
@@ -91,7 +91,8 @@ pub(crate) fn stream_supergraph(
                         }
                         // this will truncate the number of seconds to under u64::MAX, which should be
                         // a large enough delay anyway
-                        interval = Duration::from_secs(schema_config.min_delay_seconds.round() as u64);
+                        interval =
+                            Duration::from_secs(schema_config.min_delay_seconds.round() as u64);
                     }
                     supergraph_sdl::SupergraphSdlRouterConfig::Unchanged => {
                         tracing::trace!("schema did not change");
@@ -105,12 +106,14 @@ pub(crate) fn stream_supergraph(
                             }
 
                             if sender
-                            .send(Err(format!("error downloading the schema from Uplink: {message}")))
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
+                                .send(Err(format!(
+                                    "error downloading the schema from Uplink: {message}"
+                                )))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
                         } else {
                             if sender
                             .send(Err(format!("{code:?} error downloading the schema from Uplink, the router will not try again: {message}")))
@@ -133,8 +136,8 @@ pub(crate) fn stream_supergraph(
 
             tokio::time::sleep(interval).await;
         }
-    })
-    .with_current_subscriber();
+    };
+    let _ = tokio::task::spawn(task).with_current_subscriber();
 
     ReceiverStream::new(receiver)
 }

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -137,7 +137,7 @@ pub(crate) fn stream_supergraph(
             tokio::time::sleep(interval).await;
         }
     };
-    let _ = tokio::task::spawn(task).with_current_subscriber();
+    let _ = tokio::task::spawn(task.with_current_subscriber());
 
     ReceiverStream::new(receiver)
 }


### PR DESCRIPTION
The first commit extracts a sub-expression into a variable in order to make the second commit have a diff easier to read.

This change matches the example in docs for `with_current_subscriber`, so I assume this was intended. `JoinHandle` is also a future which is why the previous code compiled, but it is never polled.

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

I don’t really understand this, it just looked suspicious.

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
