### PR TITLE
Add `limits.selection_set_depth` configuration

### DIFF
--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -619,6 +619,20 @@ expression: "&schema"
       },
       "additionalProperties": false
     },
+    "limits": {
+      "description": "Requests that exceed a configured limit are rejected with a GraphQL error",
+      "type": "object",
+      "properties": {
+        "selection_set_depth": {
+          "description": "Limit query nesting level",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        }
+      },
+      "additionalProperties": false
+    },
     "override_subgraph_url": {
       "description": "Subgraph URL mappings",
       "anyOf": [

--- a/apollo-router/src/plugin/test/mock/canned.rs
+++ b/apollo-router/src/plugin/test/mock/canned.rs
@@ -36,6 +36,20 @@ pub(crate) fn accounts_subgraph() -> MockSubgraph {
                         ]
                     }
                 }}
+        ),
+        (
+            json!({
+                "query": "{me{__typename id}}", 
+                "operationName": null, 
+                "variables": {}, 
+                "extensions": {}
+            }),
+            json!({
+                "data": {
+                    "__typename": "User",
+                    "id": "1"
+                }
+            })
         )
     ].into_iter().map(|(query, response)| (serde_json::from_value(query).unwrap(), serde_json::from_value(response).unwrap())).collect();
     MockSubgraph::new(account_mocks)

--- a/apollo-router/src/plugins/limits.rs
+++ b/apollo-router/src/plugins/limits.rs
@@ -1,0 +1,161 @@
+//! Configurable complexity limiting
+
+use std::ops::ControlFlow;
+
+use apollo_compiler::hir;
+use http::StatusCode;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use tower::BoxError;
+use tower::ServiceBuilder;
+use tower::ServiceExt;
+
+use crate::graphql::Error;
+use crate::layers::ServiceBuilderExt;
+use crate::plugin::Plugin;
+use crate::plugin::PluginInit;
+use crate::register_plugin;
+use crate::services::execution;
+
+struct Limits {
+    conf: Conf,
+}
+
+/// Requests that exceed a configured limit are rejected with a GraphQL error
+#[derive(Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+struct Conf {
+    /// Limit query nesting level
+    selection_set_depth: Option<u32>,
+}
+
+impl Conf {
+    // Returns whether this plugin does anything
+    fn any(&self) -> bool {
+        let Self {
+            selection_set_depth,
+        } = self;
+        selection_set_depth.is_some()
+    }
+}
+
+#[async_trait::async_trait]
+impl Plugin for Limits {
+    type Config = Conf;
+
+    async fn new(init: PluginInit<Self::Config>) -> Result<Self, BoxError> {
+        Ok(Self { conf: init.config })
+    }
+
+    fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+        if !self.conf.any() {
+            return service;
+        }
+        let conf = self.conf.clone();
+        ServiceBuilder::new()
+            .checkpoint(move |req: execution::Request| {
+                let operation = req.operation_definition();
+                if let Some(limit) = conf.selection_set_depth {
+                    let depth = selection_set_depth(&req.compiler, operation.selection_set());
+                    if depth > limit {
+                        let error = Error::builder()
+                            .message("Operation exceeds configured depth limit")
+                            .extension_code("SELECTION_SET_DEPTH_LIMIT_EXCEEDED")
+                            .build();
+                        let res = execution::Response::builder()
+                            .error(error)
+                            .status_code(StatusCode::BAD_REQUEST)
+                            .context(req.context)
+                            .build()?;
+                        return Ok(ControlFlow::Break(res));
+                    }
+                }
+                Ok(ControlFlow::Continue(req))
+            })
+            .service(service)
+            .boxed()
+    }
+}
+
+register_plugin!("apollo", "limits", Limits);
+
+fn selection_set_depth(db: &apollo_compiler::Snapshot, selection_set: &hir::SelectionSet) -> u32 {
+    selection_set
+        .selection()
+        .iter()
+        .map(|selection| match selection {
+            hir::Selection::Field(field) => 1 + selection_set_depth(db, field.selection_set()),
+            hir::Selection::InlineFragment(inline) => {
+                selection_set_depth(db, inline.selection_set())
+            }
+            hir::Selection::FragmentSpread(spread) => spread
+                .fragment(&**db)
+                .map(|frag| selection_set_depth(db, frag.selection_set()))
+                .unwrap_or(0),
+        })
+        .max()
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use tower::Service;
+    use tower::ServiceExt;
+
+    use crate::graphql;
+    use crate::services::supergraph;
+    use crate::TestHarness;
+
+    #[tokio::test]
+    async fn test_just_under_and_just_above_selection_set_depth_limit() {
+        let harness = &mut TestHarness::builder()
+            .configuration_json(serde_json::json!({
+                "limits": {
+                    "selection_set_depth" : 5,
+                },
+                "include_subgraph_errors": {
+                    "all": true
+                }
+            }))
+            .unwrap()
+            .build_supergraph()
+            .await
+            .unwrap();
+
+        let query = "{ me { reviews { product { reviews { body } }}}}";
+        let response = call(harness, query).await;
+        assert!(response.data.is_some());
+        assert!(response.errors.is_empty());
+
+        let query = "{ me { reviews { product { reviews { author { name } } }}}}";
+        let response = call(harness, query).await;
+        assert!(response.data.is_none());
+        assert_eq!(response.errors.len(), 1);
+        assert_eq!(
+            response.errors[0].extensions["code"].as_str().unwrap(),
+            "SELECTION_SET_DEPTH_LIMIT_EXCEEDED"
+        );
+    }
+
+    #[track_caller]
+    async fn call(
+        test_harness: &mut supergraph::BoxCloneService,
+        query: &str,
+    ) -> graphql::Response {
+        let request = supergraph::Request::fake_builder()
+            .query(query)
+            .build()
+            .unwrap();
+        test_harness
+            .ready()
+            .await
+            .unwrap()
+            .call(request)
+            .await
+            .unwrap()
+            .next_response()
+            .await
+            .unwrap()
+    }
+}

--- a/apollo-router/src/plugins/mod.rs
+++ b/apollo-router/src/plugins/mod.rs
@@ -27,6 +27,7 @@ mod external;
 mod forbid_mutations;
 mod headers;
 mod include_subgraph_errors;
+mod limits;
 pub(crate) mod override_url;
 pub(crate) mod rhai;
 pub(crate) mod telemetry;


### PR DESCRIPTION
Using the new apollo-compiler integration, this returns an error on queries that go over the configured limit (if any). The default is no limit.

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

Docs pending on decision whether we actually want this as a Router feature.

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
