### PR TITLE
APQ: Add cache-control header on PERSISTED_QUERY_NOT_FOUND

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2705,9 +2705,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.5+1.4.5"
+version = "0.13.4+1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e5ea06c26926f1002dd553fded6cfcdc9784c1f60feeb58368b4d9b07b6dba"
+checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
 dependencies = [
  "cc",
  "libc",

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -44,10 +44,11 @@ By [@osamra-rbi](https://github.com/osamra-rbi) in https://github.com/apollograp
 
 ## 🐛 Fixes
 
-### APQ: Add cache-control header on PERSISTED_QUERY_NOT_FOUND ([Issue #2502](https://github.com/apollographql/router/issues/2502))
+### Forbid caching `PERSISTED_QUERY_NOT_FOUND` responses ([Issue #2502](https://github.com/apollographql/router/issues/2502))
 
-The router now sends `cache-control: private, no-cache, must-revalidate` when a persisted query hash was not found.
+The router now sends a `cache-control: private, no-cache, must-revalidate` response header to clients, in addition to the existing `PERSISTED_QUERY_NOT_FOUND` error code on the response which was being sent previously.  This expanded behaviour occurs when when a persisted query hash could not be found and is important since such responses should **not** be cached by intermediary proxies/CDNs since the client will need to be able to send the full query directly to the Router on a subsequent request.
 
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/2503
 ### Listen on root URL when `/*` is set in `supergraph.path` configuration ([Issue #2471](https://github.com/apollographql/router/issues/2471))
 
 If you provided this configuration:

--- a/NEXT_CHANGELOG.md
+++ b/NEXT_CHANGELOG.md
@@ -44,6 +44,10 @@ By [@osamra-rbi](https://github.com/osamra-rbi) in https://github.com/apollograp
 
 ## 🐛 Fixes
 
+### APQ: Add cache-control header on PERSISTED_QUERY_NOT_FOUND ([Issue #2502](https://github.com/apollographql/router/issues/2502))
+
+The router now sends `cache-control: private, no-cache, must-revalidate` when a persisted query hash was not found.
+
 ### Listen on root URL when `/*` is set in `supergraph.path` configuration ([Issue #2471](https://github.com/apollographql/router/issues/2471))
 
 If you provided this configuration:

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -113,10 +113,6 @@ where
     }
 
     pub(crate) async fn insert(&self, key: K, value: V) {
-        // Let's see if we can help waiters make progress.
-        // if let Some(sender) = self.wait_map.lock().await.remove(&key) {
-        //     let _ = sender.send(value.clone());
-        // }
         self.storage.insert(key, value).await;
     }
 

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -114,9 +114,9 @@ where
 
     pub(crate) async fn insert(&self, key: K, value: V) {
         // Let's see if we can help waiters make progress.
-        if let Some(sender) = self.wait_map.lock().await.remove(&key) {
-            let _ = sender.send(value.clone());
-        }
+        // if let Some(sender) = self.wait_map.lock().await.remove(&key) {
+        //     let _ = sender.send(value.clone());
+        // }
         self.storage.insert(key, value).await;
     }
 

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -113,7 +113,11 @@ where
     }
 
     pub(crate) async fn insert(&self, key: K, value: V) {
-        self.storage.insert(key, value.clone()).await;
+        // Let's see if we can help waiters make progress.
+        if let Some(sender) = self.wait_map.lock().await.remove(&key) {
+            let _ = sender.send(value.clone());
+        }
+        self.storage.insert(key, value).await;
     }
 
     async fn send(&self, sender: broadcast::Sender<V>, key: &K, value: V) {

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -98,7 +98,7 @@ async fn apq_request(
             if let Ok(cached_query) = cache.get(&redis_key(&apq_hash)).await.get().await {
                 let _ = request.context.insert("persisted_query_hit", true);
                 tracing::trace!("apq: cache hit");
-                request.supergraph_request.body_mut().query = Some(cached_query.to_string());
+                request.supergraph_request.body_mut().query = Some(cached_query);
                 Ok(request)
             } else {
                 let _ = request.context.insert("persisted_query_miss", true);

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -69,7 +69,7 @@ async fn apq_request(
         (Some((query_hash, query_hash_bytes)), Some(query)) => {
             if query_matches_hash(query.as_str(), query_hash_bytes.as_slice()) {
                 tracing::trace!("apq: cache insert");
-                let _ = request.context.insert("persisted_query_hit", false);
+                let _ = request.context.insert("persisted_query_register", true);
                 cache.insert(redis_key(&query_hash), query).await;
             } else {
                 tracing::warn!("apq: graphql request doesn't match provided sha256Hash");
@@ -83,7 +83,7 @@ async fn apq_request(
                 request.supergraph_request.body_mut().query = Some(cached_query);
                 Ok(request)
             } else {
-                let _ = request.context.insert("persisted_query_miss", true);
+                let _ = request.context.insert("persisted_query_hit", false);
                 tracing::trace!("apq: cache miss");
                 let errors = vec![crate::error::Error {
                     message: "PersistedQueryNotFound".to_string(),

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -52,6 +52,9 @@ impl APQLayer {
     }
 }
 
+/// Persisted query errors (especially "not found") need to be uncached, because
+/// hopefully we're about to fill in the APQ cache and the same request will
+/// succeed next time.
 fn set_cache_control_headers(mut response: RouterResponse) -> RouterResponse {
     if let Ok(Some(true)) = &response.context.get::<_, bool>("persisted_query_miss") {
         response.response.headers_mut().insert(

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -212,7 +212,7 @@ where
                     })
             };
 
-            match graphql_request {
+            let router_response = match graphql_request {
                 Ok(graphql_request) => {
                     let request = SupergraphRequest {
                         supergraph_request: http::Request::from_parts(parts, graphql_request),
@@ -221,7 +221,7 @@ where
 
                     let request_res = match apq {
                         None => Ok(request),
-                        Some(apq) => apq.request(request).await,
+                        Some(apq) => apq.supergraph_request(request).await,
                     };
 
                     let SupergraphResponse { response, context } =
@@ -414,7 +414,8 @@ where
                         context,
                     })
                 }
-            }
+            };
+            router_response.map(|r| apq.router_response(r))
         };
         Box::pin(fut)
     }

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -174,6 +174,7 @@ where
 
         let supergraph_creator = self.supergraph_creator.clone();
         let apq = self.apq_layer.clone();
+        let apq2 = apq.clone();
 
         let fut = async move {
             let graphql_request: Result<graphql::Request, (&str, String)> = if parts.method
@@ -415,7 +416,11 @@ where
                     })
                 }
             };
-            router_response.map(|r| apq.router_response(r))
+            if let Some(apq) = apq2 {
+                router_response.map(|r| apq.router_response(r))
+            } else {
+                router_response
+            }
         };
         Box::pin(fut)
     }


### PR DESCRIPTION
Fixes #2502 

The router now sends `cache-control: private, no-cache, must-revalidate` when a persisted query hash was not found.