### PR TITLE
Update `router-bridge` to `0.1.14+v2.3.0`

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -159,7 +159,7 @@ reqwest = { version = "0.11.14", default-features = false, features = [
     "json",
     "stream",
 ] }
-router-bridge = "0.1.13-beta.0+v2.3.0-beta.3"
+router-bridge = "0.1.14+v2.3.0"
 rust-embed="6.4.2"
 rustls = "0.20.8"
 rustls-pemfile = "1.0.2"


### PR DESCRIPTION
Note that the merge from `dev` on the PR this merges into (#2464) already brought this in its `Cargo.lock`, so this just
corrects the `apollo-router`'s `Cargo.toml`.
