### PR TITLE
chore(deps): update `libgit2-sys`, again.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.4+1.4.2"
+version = "0.13.5+1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+checksum = "51e5ea06c26926f1002dd553fded6cfcdc9784c1f60feeb58368b4d9b07b6dba"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
This follows up https://github.com/apollographql/router/pull/2457 and https://github.com/apollographql/router/pull/2497 which both attempted to update `libgit2-sys`.

The changeset of https://github.com/apollographql/router/pull/2503 inadvertently resulted in a reversion of that version bump, which brought back the offending version and upset our compliance check.

Thankfully, we have tooling that catches this stuff (even if it wasn't on the PR itself).
