### PR TITLE
return PERSISTED_QUERY_NOT_SUPPORTED when APQ is disabled

### DIFF
--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -189,14 +189,15 @@ mod apq_tests {
     use tower::Service;
 
     use super::*;
-    use crate::configuration::{Apq, Supergraph};
+    use crate::configuration::Apq;
+    use crate::configuration::Supergraph;
     use crate::error::Error;
     use crate::graphql::Response;
     use crate::services::layers::content_negociation::ACCEPTS_JSON_CONTEXT_KEY;
-    use crate::services::router_service::{
-        from_supergraph_mock_callback, from_supergraph_mock_callback_and_configuration,
-    };
-    use crate::{Configuration, Context};
+    use crate::services::router_service::from_supergraph_mock_callback;
+    use crate::services::router_service::from_supergraph_mock_callback_and_configuration;
+    use crate::Configuration;
+    use crate::Context;
 
     #[tokio::test]
     async fn it_works() {

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -62,14 +62,14 @@ where
     SF: ServiceFactory<supergraph::Request> + Clone + Send + Sync + 'static,
 {
     supergraph_creator: Arc<SF>,
-    apq_layer: Option<APQLayer>,
+    apq_layer: APQLayer,
 }
 
 impl<SF> RouterService<SF>
 where
     SF: ServiceFactory<supergraph::Request> + Clone + Send + Sync + 'static,
 {
-    pub(crate) fn new(supergraph_creator: Arc<SF>, apq_layer: Option<APQLayer>) -> Self {
+    pub(crate) fn new(supergraph_creator: Arc<SF>, apq_layer: APQLayer) -> Self {
         RouterService {
             supergraph_creator,
             apq_layer,
@@ -219,10 +219,7 @@ where
                         context,
                     };
 
-                    let request_res = match &apq {
-                        None => Ok(request),
-                        Some(apq) => apq.supergraph_request(request).await,
-                    };
+                    let request_res = apq.supergraph_request(request).await;
 
                     let SupergraphResponse { response, context } =
                         match request_res.and_then(|request| {
@@ -433,7 +430,7 @@ where
 {
     supergraph_creator: Arc<SF>,
     static_page: StaticPageLayer,
-    apq_layer: Option<APQLayer>,
+    apq_layer: APQLayer,
 }
 
 impl<SF> ServiceFactory<router::Request> for RouterCreator<SF>
@@ -485,15 +482,15 @@ where
     pub(crate) async fn new(supergraph_creator: Arc<SF>, configuration: &Configuration) -> Self {
         let static_page = StaticPageLayer::new(configuration);
         let apq_layer = if configuration.supergraph.apq.enabled {
-            Some(APQLayer::with_cache(
+            APQLayer::with_cache(
                 DeduplicatingCache::from_configuration(
                     &configuration.supergraph.apq.experimental_cache,
                     "APQ",
                 )
                 .await,
-            ))
+            )
         } else {
-            None
+            APQLayer::disabled()
         };
 
         Self {


### PR DESCRIPTION
When Automatic Persisted Queries are disabled, there's a specific error code that we should use to signal it. That error response can be cached because when APQ is not supported, we can reasonably assume it will still not be supported on the next call.

- Fix #2436

*description here*

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
