### PR TITLE
Add entitlements uplink integration

### DIFF
--- a/.changesets/maint_on_a_dark_desert_highway.md
+++ b/.changesets/maint_on_a_dark_desert_highway.md
@@ -1,0 +1,9 @@
+### Uplink refactor ([Issue #2547](https://github.com/apollographql/router/issues/2547)
+
+Uplink code is pulled out into a reusable component so that it can be used for schema and entitlements.
+Generally improved code quality and added tests.
+
+Round-robin behaviour is now changed. Previously on failure there would be a delay before trying the next round-robin URL.
+Now all URLs will be tried in sequence until exhausted. If all URLs fail then the usual delay is applied before trying again.
+
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/2537

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "once_cell",
  "version_check",
 ]
@@ -61,7 +61,7 @@ checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
  "const-random",
- "getrandom",
+ "getrandom 0.2.8",
  "once_cell",
  "serde",
  "version_check",
@@ -244,7 +244,7 @@ dependencies = [
  "prost",
  "prost-types",
  "proteus",
- "rand",
+ "rand 0.8.5",
  "redis",
  "redis_cluster_async",
  "regex",
@@ -291,6 +291,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "walkdir 2.3.2",
+ "wiremock",
  "wsl",
  "yaml-rust",
 ]
@@ -409,6 +410,16 @@ dependencies = [
  "serde",
  "syn",
  "toml",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -559,9 +570,9 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "instant",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -894,7 +905,7 @@ checksum = "454038500439e141804c655b4cd1bc6a70bcb95cd2bc9463af5661b6956f0e46"
 dependencies = [
  "libc",
  "once_cell",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1057,7 +1068,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d7d6ab3c3a2282db210df5f02c4dab6e0a7057af0fb7ebd4070f30fe05c0ddb"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "once_cell",
  "proc-macro-hack",
  "tiny-keccak",
@@ -1254,7 +1265,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -1308,6 +1319,25 @@ dependencies = [
  "parking_lot_core 0.9.5",
  "serde",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "retain_mut",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaa37046cc0f6c3cc6090fbdbf73ef0b8ef4cfcc37f6befc0020f63e8cf121e1"
 
 [[package]]
 name = "deduplicate"
@@ -1547,7 +1577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e18997d4604542d0736fae2c5ad6de987f0a50530cbcc14a7ce5a685328a252d"
 dependencies = [
  "ct-codecs",
- "getrandom",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -1572,7 +1602,7 @@ dependencies = [
  "hkdf",
  "pem-rfc7468 0.6.0",
  "pkcs8 0.9.0",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -1677,7 +1707,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -1861,6 +1891,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfb8371b6fb2aeb2d280374607aeabfc99d95c72edfe51692e42d3d7f0d08531"
 
 [[package]]
+name = "futures-lite"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,6 +1927,12 @@ name = "futures-task"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
+
+[[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
@@ -1913,6 +1964,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
@@ -1920,7 +1982,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2034,7 +2096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -2259,6 +2321,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
+name = "http-types"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
+dependencies = [
+ "anyhow",
+ "async-channel",
+ "base64 0.13.1",
+ "futures-lite",
+ "http",
+ "infer",
+ "pin-project-lite",
+ "rand 0.7.3",
+ "serde",
+ "serde_json",
+ "serde_qs",
+ "serde_urlencoded",
+ "url",
+]
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2394,6 +2477,12 @@ dependencies = [
  "number_prefix",
  "regex",
 ]
+
+[[package]]
+name = "infer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
 name = "inotify"
@@ -2651,7 +2740,7 @@ dependencies = [
  "k256",
  "p256",
  "p384",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "serde_json",
@@ -2993,7 +3082,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.42.0",
 ]
 
@@ -3148,7 +3237,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -3477,7 +3566,7 @@ dependencies = [
  "once_cell",
  "opentelemetry_api",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3540,6 +3629,12 @@ dependencies = [
  "elliptic-curve",
  "sha2",
 ]
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -4006,13 +4101,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -4022,7 +4140,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -4031,7 +4158,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -4088,7 +4224,7 @@ dependencies = [
  "futures",
  "log",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "redis",
  "tokio",
 ]
@@ -4108,7 +4244,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "redox_syscall",
  "thiserror",
 ]
@@ -4192,6 +4328,12 @@ dependencies = [
  "webpki-roots",
  "winreg",
 ]
+
+[[package]]
+name = "retain_mut"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "rfc6979"
@@ -4381,7 +4523,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8 0.8.0",
- "rand_core",
+ "rand_core 0.6.4",
  "smallvec",
  "subtle",
  "zeroize",
@@ -4740,6 +4882,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_qs"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
+dependencies = [
+ "percent-encoding",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4854,7 +5007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5546,7 +5699,7 @@ dependencies = [
  "indexmap",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -5909,7 +6062,7 @@ version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
  "serde",
  "wasm-bindgen",
 ]
@@ -5957,6 +6110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
 name = "walkdir"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5986,6 +6145,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -6262,6 +6427,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12316b50eb725e22b2f6b9c4cbede5b7b89984274d113a7440c86e5c3fc6f99b"
+dependencies = [
+ "assert-json-diff",
+ "async-trait",
+ "base64 0.13.1",
+ "deadpool",
+ "futures",
+ "futures-timer",
+ "http-types",
+ "hyper",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -238,6 +238,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 ] }
 tracing-test = "0.2.2"
 walkdir = "2.3.2"
+wiremock = "0.5.12"
 
 [build-dependencies]
 tonic-build = "0.8.4"

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -51,9 +51,11 @@ use crate::services::router;
 use crate::spec::Schema;
 use crate::state_machine::ListenAddresses;
 use crate::state_machine::StateMachine;
-use crate::uplink::entitlement::stream_entitlement;
 use crate::uplink::entitlement::Entitlement;
-use crate::uplink::schema::stream_supergraph;
+use crate::uplink::entitlement::EntitlementRequest;
+use crate::uplink::schema::SupergraphSdlQuery;
+use crate::uplink::stream_from_uplink;
+use crate::uplink::Endpoints;
 
 // For now this is unused:
 // TODO: Check with simon once the refactor is complete
@@ -239,17 +241,23 @@ impl SchemaSource {
             } => {
                 // With regards to ELv2 licensing, the code inside this block
                 // is license key functionality
-                stream_supergraph(apollo_key, apollo_graph_ref, urls, poll_interval, timeout)
-                    .filter_map(|res| {
-                        future::ready(match res {
-                            Ok(schema_result) => Some(UpdateSchema(schema_result.schema)),
-                            Err(e) => {
-                                tracing::error!("{}", e);
-                                None
-                            }
-                        })
+                stream_from_uplink::<SupergraphSdlQuery, String>(
+                    apollo_key,
+                    apollo_graph_ref,
+                    urls.map(Endpoints::round_robin),
+                    poll_interval,
+                    timeout,
+                )
+                .filter_map(|res| {
+                    future::ready(match res {
+                        Ok(schema) => Some(UpdateSchema(schema)),
+                        Err(e) => {
+                            tracing::error!("{}", e);
+                            None
+                        }
                     })
-                    .boxed()
+                })
+                .boxed()
             }
         }
         .chain(stream::iter(vec![NoMoreSchema]))
@@ -493,17 +501,23 @@ impl EntitlementSource {
                 urls,
                 poll_interval,
                 timeout,
-            } => stream_entitlement(apollo_key, apollo_graph_ref, urls, poll_interval, timeout)
-                .filter_map(|res| {
-                    future::ready(match res {
-                        Ok(entitlement) => Some(UpdateEntitlement(entitlement)),
-                        Err(e) => {
-                            tracing::error!("{}", e);
-                            None
-                        }
-                    })
+            } => stream_from_uplink::<EntitlementRequest, Entitlement>(
+                apollo_key,
+                apollo_graph_ref,
+                urls.map(Endpoints::round_robin),
+                poll_interval,
+                timeout,
+            )
+            .filter_map(|res| {
+                future::ready(match res {
+                    Ok(entitlement) => Some(UpdateEntitlement(entitlement)),
+                    Err(e) => {
+                        tracing::error!("{}", e);
+                        None
+                    }
                 })
-                .boxed(),
+            })
+            .boxed(),
             EntitlementSource::Env => {
                 match std::env::var("APOLLO_ROUTER_ENTITLEMENT").map(|e| Entitlement::from_str(&e))
                 {

--- a/apollo-router/src/uplink/entitlement_query.graphql
+++ b/apollo-router/src/uplink/entitlement_query.graphql
@@ -1,0 +1,21 @@
+query EntitlementRequest($apiKey: String!, $graph_ref: String!, $unlessId: ID) {
+
+    routerEntitlements(unlessId: $unlessId, apiKey: $apiKey, ref: $graph_ref) {
+        __typename
+        ... on RouterEntitlementsResult {
+            id
+            minDelaySeconds
+            entitlement {
+                jwt
+            }
+        }
+        ... on Unchanged {
+            id
+            minDelaySeconds
+        }
+        ... on FetchError {
+            code
+            message
+        }
+    }
+}

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -209,14 +209,15 @@ where
     Query: graphql_client::GraphQLQuery,
 {
     for url in urls {
-        return match http_request::<Query>(url.as_str(), request_body, timeout).await {
-            Ok(response) => match response.data {
-                None => Err(Error::EmptyResponse),
-                Some(response_data) => Ok(response_data),
-            },
+        match http_request::<Query>(url.as_str(), request_body, timeout).await {
+            Ok(response) => {
+                return match response.data {
+                    None => Err(Error::EmptyResponse),
+                    Some(response_data) => Ok(response_data),
+                }
+            }
             Err(e) => {
                 tracing::warn!("failed to fetch from Uplink endpoint {}: {}", url, e);
-                continue;
             }
         };
     }

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -594,7 +594,7 @@ mod test {
             mock_server: &'a MockServer,
             endpoint: &'a Url,
             responses: Vec<ResponseTemplate>,
-        ) -> () {
+        ) {
             let len = responses.len() as u64;
             Mock::given(method("POST"))
                 .and(path(endpoint.path()))

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -1,6 +1,684 @@
 // With regards to ELv2 licensing, this entire file is license key functionality
 
+use std::time::Duration;
+
+use futures::Stream;
+use graphql_client::QueryBody;
+use thiserror::Error;
+use tokio::sync::mpsc::channel;
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::instrument::WithSubscriber;
+use url::Url;
+
 //TODO Remove once everything is hooked up
 #[allow(dead_code)]
 pub(crate) mod entitlement;
 pub(crate) mod schema;
+
+const GCP_URL: &str = "https://uplink.api.apollographql.com/graphql";
+const AWS_URL: &str = "https://aws.uplink.api.apollographql.com/graphql";
+
+#[derive(Debug, Error)]
+pub(crate) enum Error {
+    #[error("http error")]
+    Http(#[from] reqwest::Error),
+
+    #[error("empty response")]
+    EmptyResponse,
+
+    #[error("fetch failed from all endpoints")]
+    FetchFailed,
+
+    #[error("uplink error: code={code} message={message}")]
+    UplinkError { code: String, message: String },
+
+    #[error("uplink error, the request will not be retried: code={code} message={message}")]
+    UplinkErrorNoRetry { code: String, message: String },
+}
+
+pub(crate) struct UplinkRequest {
+    api_key: String,
+    graph_ref: String,
+    id: Option<String>,
+}
+
+pub(crate) enum UplinkResponse<Response> {
+    Result {
+        response: Response,
+        id: String,
+        delay: u64,
+    },
+    Unchanged {
+        id: Option<String>,
+        delay: Option<u64>,
+    },
+    Error {
+        retry_later: bool,
+        code: String,
+        message: String,
+    },
+}
+
+pub(crate) enum Endpoints {
+    Fallback { urls: Vec<Url> },
+    RoundRobin { urls: Vec<Url>, current: usize },
+}
+
+impl Default for Endpoints {
+    fn default() -> Self {
+        Self::fallback(
+            vec![GCP_URL, AWS_URL]
+                .iter()
+                .map(|url| Url::parse(url).expect("default urls must be valid"))
+                .collect(),
+        )
+    }
+}
+
+impl Endpoints {
+    pub(crate) fn fallback(urls: Vec<Url>) -> Self {
+        Endpoints::Fallback { urls }
+    }
+    pub(crate) fn round_robin(urls: Vec<Url>) -> Self {
+        Endpoints::RoundRobin { urls, current: 0 }
+    }
+
+    fn iter<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a Url> + Send + 'a> {
+        match self {
+            Endpoints::Fallback { urls } => Box::new(urls.iter()),
+            Endpoints::RoundRobin { urls, current } => Box::new(
+                urls.iter()
+                    .cycle()
+                    .skip(*current)
+                    .map(|url| {
+                        *current += 1;
+                        url
+                    })
+                    .take(urls.len()),
+            ),
+        }
+    }
+}
+
+/// Regularly fetch from Uplink
+/// If urls are supplied then they will be called round robin  
+pub(crate) fn stream_from_uplink<Query, Response>(
+    api_key: String,
+    graph_ref: String,
+    endpoints: Option<Endpoints>,
+    mut interval: Duration,
+    timeout: Duration,
+) -> impl Stream<Item = Result<Response, Error>>
+where
+    Query: graphql_client::GraphQLQuery,
+    <Query as graphql_client::GraphQLQuery>::ResponseData: Into<UplinkResponse<Response>> + Send,
+    <Query as graphql_client::GraphQLQuery>::Variables: From<UplinkRequest> + Send + Sync,
+    Response: Send + 'static,
+{
+    let (sender, receiver) = channel(2);
+    let task = async move {
+        let mut last_id = None;
+        let mut endpoints = endpoints.unwrap_or_default();
+        loop {
+            let query_body = Query::build_query(
+                UplinkRequest {
+                    graph_ref: graph_ref.to_string(),
+                    api_key: api_key.to_string(),
+                    id: last_id.clone(),
+                }
+                .into(),
+            );
+            // Prevent the situation where repeated UplinkResponse::Unchanged could prevent shutdown.
+            if sender.is_closed() {
+                break;
+            }
+            match fetch::<Query>(&query_body, &mut endpoints.iter(), timeout).await {
+                Ok(value) => {
+                    let response: UplinkResponse<Response> = value.into();
+                    match response {
+                        UplinkResponse::Result {
+                            id,
+                            response,
+                            delay,
+                        } => {
+                            last_id = Some(id);
+                            if sender.send(Ok(response)).await.is_err() {
+                                break;
+                            }
+
+                            interval = Duration::from_secs(delay);
+                        }
+                        UplinkResponse::Unchanged { id, delay } => {
+                            tracing::trace!("uplink response did not change");
+                            // Preserve behavior for schema uplink errors where id and delay are not reset if they are not provided on error.
+                            if let Some(id) = id {
+                                last_id = Some(id);
+                            }
+                            if let Some(delay) = delay {
+                                interval = Duration::from_secs(delay);
+                            }
+                        }
+                        UplinkResponse::Error {
+                            retry_later,
+                            message,
+                            code,
+                        } => {
+                            let err = if retry_later {
+                                Err(Error::UplinkError { code, message })
+                            } else {
+                                Err(Error::UplinkErrorNoRetry { code, message })
+                            };
+                            if sender.send(err).await.is_err() {
+                                break;
+                            }
+                            if !retry_later {
+                                break;
+                            }
+                        }
+                    }
+                }
+                Err(err) => {
+                    if sender.send(Err(err)).await.is_err() {
+                        break;
+                    }
+                }
+            }
+
+            // This could potentially cause a perceived hang on shutdown as it has no knowledge if the sender is closed.
+            // In particular interval could be set to something large for some reason.
+            tokio::time::sleep(interval).await;
+        }
+    };
+    drop(tokio::task::spawn(task.with_current_subscriber()));
+
+    ReceiverStream::new(receiver)
+}
+
+pub(crate) async fn fetch<Query>(
+    request_body: &QueryBody<Query::Variables>,
+    urls: &mut impl Iterator<Item = &Url>,
+    timeout: Duration,
+) -> Result<Query::ResponseData, Error>
+where
+    Query: graphql_client::GraphQLQuery,
+{
+    for url in urls {
+        return match http_request::<Query>(url.as_str(), request_body, timeout).await {
+            Ok(response) => match response.data {
+                None => Err(Error::EmptyResponse),
+                Some(response_data) => Ok(response_data),
+            },
+            Err(e) => {
+                tracing::warn!("failed to fetch from Uplink endpoint {}: {}", url, e);
+                continue;
+            }
+        };
+    }
+    Err(Error::FetchFailed)
+}
+
+async fn http_request<Query>(
+    url: &str,
+    request_body: &QueryBody<Query::Variables>,
+    timeout: Duration,
+) -> Result<graphql_client::Response<Query::ResponseData>, reqwest::Error>
+where
+    Query: graphql_client::GraphQLQuery,
+{
+    let client = reqwest::Client::builder().timeout(timeout).build()?;
+    let res = client.post(url).json(request_body).send().await?;
+    let response_body: graphql_client::Response<Query::ResponseData> = res.json().await?;
+    Ok(response_body)
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    use buildstructor::buildstructor;
+    use futures::StreamExt;
+    use http::StatusCode;
+    use insta::assert_yaml_snapshot;
+    use serde_json::json;
+    use url::Url;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::Request;
+    use wiremock::Respond;
+    use wiremock::ResponseTemplate;
+
+    use crate::uplink::entitlement::Entitlement;
+    use crate::uplink::entitlement::EntitlementRequest;
+    use crate::uplink::stream_from_uplink;
+    use crate::uplink::Endpoints;
+    use crate::uplink::Error;
+
+    #[test]
+    #[cfg(not(windows))] // Don’t bother with line ending differences
+    fn test_uplink_schema_is_up_to_date() {
+        use std::path::PathBuf;
+
+        use introspector_gadget::blocking::GraphQLClient;
+        use introspector_gadget::introspect;
+        use introspector_gadget::introspect::GraphIntrospectInput;
+
+        let client = GraphQLClient::new(
+            "https://uplink.api.apollographql.com/",
+            reqwest::blocking::Client::new(),
+        );
+
+        let should_retry = true;
+        let introspection_response = introspect::run(
+            GraphIntrospectInput {
+                headers: Default::default(),
+            },
+            &client,
+            should_retry,
+        )
+        .unwrap();
+        if introspection_response.schema_sdl != include_str!("uplink.graphql") {
+            let path = PathBuf::from(std::env::var_os("OUT_DIR").unwrap()).join("uplink.graphql");
+            std::fs::write(&path, introspection_response.schema_sdl).unwrap();
+            panic!(
+                "\n\nUplink schema is out of date. Run this command to update it:\n\n    \
+                mv {} apollo-router/src/uplink/uplink.graphql\n\n",
+                path.to_str().unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn test_round_robin_endpoints() {
+        let url1 = Url::parse("http://example1.com").expect("url must be valid");
+        let url2 = Url::parse("http://example2.com").expect("url must be valid");
+        let mut endpoints = Endpoints::round_robin(vec![url1.clone(), url2.clone()]);
+        assert_eq!(endpoints.iter().collect::<Vec<_>>(), vec![&url1, &url2]);
+        assert_eq!(endpoints.iter().next(), Some(&url1));
+        assert_eq!(endpoints.iter().collect::<Vec<_>>(), vec![&url2, &url1]);
+    }
+
+    #[test]
+    fn test_fallback_endpoints() {
+        let url1 = Url::parse("http://example1.com").expect("url must be valid");
+        let url2 = Url::parse("http://example2.com").expect("url must be valid");
+        let mut endpoints = Endpoints::fallback(vec![url1.clone(), url2.clone()]);
+        assert_eq!(endpoints.iter().collect::<Vec<_>>(), vec![&url1, &url2]);
+        assert_eq!(endpoints.iter().next(), Some(&url1));
+        assert_eq!(endpoints.iter().collect::<Vec<_>>(), vec![&url1, &url2]);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_from_uplink_fallback() {
+        let (mock_server, url1, url2, _url3) = init_mock_server().await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url1)
+            .response(response_ok())
+            .response(response_ok())
+            .build()
+            .await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url2)
+            .build()
+            .await;
+
+        let results = stream_from_uplink::<EntitlementRequest, Entitlement>(
+            "dummy_key".to_string(),
+            "dummy_graph_ref".to_string(),
+            Some(Endpoints::fallback(vec![url1, url2])),
+            Duration::from_secs(0),
+            Duration::from_secs(1),
+        )
+        .take(2)
+        .collect::<Vec<_>>()
+        .await;
+        assert_yaml_snapshot!(results.into_iter().map(to_friendly).collect::<Vec<_>>());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_from_uplink_round_robin() {
+        let (mock_server, url1, url2, _url3) = init_mock_server().await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url1)
+            .response(response_ok())
+            .build()
+            .await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .response(response_ok())
+            .endpoint(&url2)
+            .build()
+            .await;
+
+        let results = stream_from_uplink::<EntitlementRequest, Entitlement>(
+            "dummy_key".to_string(),
+            "dummy_graph_ref".to_string(),
+            Some(Endpoints::round_robin(vec![url1, url2])),
+            Duration::from_secs(0),
+            Duration::from_secs(1),
+        )
+        .take(2)
+        .collect::<Vec<_>>()
+        .await;
+        assert_yaml_snapshot!(results.into_iter().map(to_friendly).collect::<Vec<_>>());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_from_uplink_error_retry() {
+        let (mock_server, url1, url2, _url3) = init_mock_server().await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url1)
+            .response(response_fetch_error_retry())
+            .response(response_ok())
+            .build()
+            .await;
+        let results = stream_from_uplink::<EntitlementRequest, Entitlement>(
+            "dummy_key".to_string(),
+            "dummy_graph_ref".to_string(),
+            Some(Endpoints::fallback(vec![url1, url2])),
+            Duration::from_secs(0),
+            Duration::from_secs(1),
+        )
+        .take(2)
+        .collect::<Vec<_>>()
+        .await;
+        assert_yaml_snapshot!(results.into_iter().map(to_friendly).collect::<Vec<_>>());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_from_uplink_error_no_retry() {
+        let (mock_server, url1, url2, _url3) = init_mock_server().await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url1)
+            .response(response_fetch_error_no_retry())
+            .build()
+            .await;
+        let results = stream_from_uplink::<EntitlementRequest, Entitlement>(
+            "dummy_key".to_string(),
+            "dummy_graph_ref".to_string(),
+            Some(Endpoints::fallback(vec![url1, url2])),
+            Duration::from_secs(0),
+            Duration::from_secs(1),
+        )
+        .collect::<Vec<_>>()
+        .await;
+        assert_yaml_snapshot!(results.into_iter().map(to_friendly).collect::<Vec<_>>());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_from_uplink_error_http_fallback() {
+        let (mock_server, url1, url2, url3) = init_mock_server().await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url1)
+            .response(response_fetch_error_http())
+            .response(response_fetch_error_http())
+            .build()
+            .await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url2)
+            .response(response_ok())
+            .response(response_ok())
+            .build()
+            .await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url3)
+            .build()
+            .await;
+        let results = stream_from_uplink::<EntitlementRequest, Entitlement>(
+            "dummy_key".to_string(),
+            "dummy_graph_ref".to_string(),
+            Some(Endpoints::fallback(vec![url1, url2, url3])),
+            Duration::from_secs(0),
+            Duration::from_secs(1),
+        )
+        .take(2)
+        .collect::<Vec<_>>()
+        .await;
+        assert_yaml_snapshot!(results.into_iter().map(to_friendly).collect::<Vec<_>>());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_from_uplink_error_http_round_robin() {
+        let (mock_server, url1, url2, url3) = init_mock_server().await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url1)
+            .response(response_fetch_error_http())
+            .build()
+            .await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url2)
+            .response(response_ok())
+            .build()
+            .await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url3)
+            .response(response_ok())
+            .build()
+            .await;
+        let results = stream_from_uplink::<EntitlementRequest, Entitlement>(
+            "dummy_key".to_string(),
+            "dummy_graph_ref".to_string(),
+            Some(Endpoints::round_robin(vec![url1, url2, url3])),
+            Duration::from_secs(0),
+            Duration::from_secs(1),
+        )
+        .take(2)
+        .collect::<Vec<_>>()
+        .await;
+        assert_yaml_snapshot!(results.into_iter().map(to_friendly).collect::<Vec<_>>());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_from_uplink_invalid() {
+        let (mock_server, url1, url2, url3) = init_mock_server().await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url1)
+            .response(response_invalid_entitlement())
+            .build()
+            .await;
+        let results = stream_from_uplink::<EntitlementRequest, Entitlement>(
+            "dummy_key".to_string(),
+            "dummy_graph_ref".to_string(),
+            Some(Endpoints::round_robin(vec![url1, url2, url3])),
+            Duration::from_secs(0),
+            Duration::from_secs(1),
+        )
+        .take(1)
+        .collect::<Vec<_>>()
+        .await;
+        assert_yaml_snapshot!(results.into_iter().map(to_friendly).collect::<Vec<_>>());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_from_uplink_unchanged() {
+        let (mock_server, url1, url2, url3) = init_mock_server().await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url1)
+            .response(response_ok())
+            .response(response_unchanged())
+            .response(response_ok())
+            .build()
+            .await;
+        let results = stream_from_uplink::<EntitlementRequest, Entitlement>(
+            "dummy_key".to_string(),
+            "dummy_graph_ref".to_string(),
+            Some(Endpoints::round_robin(vec![url1, url2, url3])),
+            Duration::from_secs(0),
+            Duration::from_secs(1),
+        )
+        .take(2)
+        .collect::<Vec<_>>()
+        .await;
+        assert_yaml_snapshot!(results.into_iter().map(to_friendly).collect::<Vec<_>>());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_from_uplink_failed_from_all() {
+        let (mock_server, url1, url2, _url3) = init_mock_server().await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url1)
+            .response(response_fetch_error_http())
+            .build()
+            .await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url2)
+            .response(response_fetch_error_http())
+            .build()
+            .await;
+        let results = stream_from_uplink::<EntitlementRequest, Entitlement>(
+            "dummy_key".to_string(),
+            "dummy_graph_ref".to_string(),
+            Some(Endpoints::round_robin(vec![url1, url2])),
+            Duration::from_secs(0),
+            Duration::from_secs(1),
+        )
+        .take(1)
+        .collect::<Vec<_>>()
+        .await;
+        assert_yaml_snapshot!(results.into_iter().map(to_friendly).collect::<Vec<_>>());
+    }
+
+    fn to_friendly(r: Result<Entitlement, Error>) -> Result<String, String> {
+        match r {
+            Ok(_) => Ok("response".to_string()),
+            Err(e) => Err(e.to_string()),
+        }
+    }
+    async fn init_mock_server() -> (MockServer, Url, Url, Url) {
+        let mock_server = MockServer::start().await;
+        let url1 =
+            Url::parse(&format!("{}/endpoint1", mock_server.uri())).expect("url must be valid");
+        let url2 =
+            Url::parse(&format!("{}/endpoint2", mock_server.uri())).expect("url must be valid");
+        let url3 =
+            Url::parse(&format!("{}/endpoint3", mock_server.uri())).expect("url must be valid");
+        (mock_server, url1, url2, url3)
+    }
+
+    struct MockResponses {
+        responses: Mutex<VecDeque<ResponseTemplate>>,
+    }
+
+    impl Respond for MockResponses {
+        fn respond(&self, _request: &Request) -> ResponseTemplate {
+            self.responses
+                .lock()
+                .expect("lock poisoned")
+                .pop_front()
+                .unwrap_or_else(response_fetch_error_no_retry)
+        }
+    }
+
+    #[buildstructor]
+    impl MockResponses {
+        #[builder(entry = "builder")]
+        async fn setup<'a>(
+            mock_server: &'a MockServer,
+            endpoint: &'a Url,
+            responses: Vec<ResponseTemplate>,
+        ) -> () {
+            let len = responses.len() as u64;
+            Mock::given(method("POST"))
+                .and(path(endpoint.path()))
+                .respond_with(Self {
+                    responses: Mutex::new(responses.into()),
+                })
+                .expect(len..len + 2)
+                .mount(mock_server)
+                .await;
+        }
+    }
+
+    fn response_ok() -> ResponseTemplate {
+        ResponseTemplate::new(StatusCode::OK).set_body_json(json!(
+            {
+                "data":{
+                    "routerEntitlements": {
+                    "__typename": "RouterEntitlementsResult",
+                    "id": "1",
+                    "minDelaySeconds": 0,
+                    "entitlement": {
+                        "jwt": "eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJodHRwczovL3d3dy5hcG9sbG9ncmFwaHFsLmNvbS8iLCJzdWIiOiJhcG9sbG8iLCJhdWQiOiJTRUxGX0hPU1RFRCIsIndhcm5BdCI6MTY3NjgwODAwMCwiaGFsdEF0IjoxNjc4MDE3NjAwfQ.tXexfjZ2SQeqSwkWQ7zD4XBoxS_Hc5x7tSNJ3ln-BCL_GH7i3U9hsIgdRQTczCAjA_jjk34w39DeSV0nTc5WBw"
+                        }
+                    }
+                }
+            }))
+    }
+
+    fn response_invalid_entitlement() -> ResponseTemplate {
+        ResponseTemplate::new(StatusCode::OK).set_body_json(json!(
+        {
+            "data":{
+                "routerEntitlements": {
+                    "__typename": "RouterEntitlementsResult",
+                    "id": "1",
+                    "minDelaySeconds": 0,
+                    "entitlement": {
+                        "jwt": "invalid"
+                        }
+                    }
+                }
+        }))
+    }
+
+    fn response_unchanged() -> ResponseTemplate {
+        ResponseTemplate::new(StatusCode::OK).set_body_json(json!(
+        {
+            "data":{
+                "routerEntitlements": {
+                    "__typename": "Unchanged",
+                    "id": "2",
+                    "minDelaySeconds": 0,
+                }
+            }
+        }))
+    }
+
+    fn response_fetch_error_retry() -> ResponseTemplate {
+        ResponseTemplate::new(StatusCode::OK).set_body_json(json!(
+        {
+            "data":{
+                "routerEntitlements": {
+                    "__typename": "FetchError",
+                    "code": "RETRY_LATER",
+                    "message": "error message",
+                }
+            }
+        }))
+    }
+
+    fn response_fetch_error_no_retry() -> ResponseTemplate {
+        ResponseTemplate::new(StatusCode::OK).set_body_json(json!(
+        {
+            "data":{
+                "routerEntitlements": {
+                    "__typename": "FetchError",
+                    "code": "NO_RETRY",
+                    "message": "error message",
+                }
+            }
+        }))
+    }
+
+    fn response_fetch_error_http() -> ResponseTemplate {
+        ResponseTemplate::new(StatusCode::INTERNAL_SERVER_ERROR)
+    }
+}

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -128,10 +128,7 @@ where
                 }
                 .into(),
             );
-            // Prevent the situation where repeated UplinkResponse::Unchanged could prevent shutdown.
-            if sender.is_closed() {
-                break;
-            }
+
             match fetch::<Query>(&query_body, &mut endpoints.iter(), timeout).await {
                 Ok(value) => {
                     let response: UplinkResponse<Response> = value.into();

--- a/apollo-router/src/uplink/schema.rs
+++ b/apollo-router/src/uplink/schema.rs
@@ -5,229 +5,95 @@
 // Read more: https://github.com/hyperium/tonic/issues/1056
 #![allow(clippy::derive_partial_eq_without_eq)]
 
-use std::time::Duration;
-
-use futures::Stream;
 use graphql_client::GraphQLQuery;
-use graphql_client::QueryBody;
-use graphql_client::Response;
-use supergraph_sdl::FetchErrorCode;
-use tokio::sync::mpsc::channel;
-use tokio_stream::wrappers::ReceiverStream;
-use tracing::instrument::WithSubscriber;
-use url::Url;
 
-use self::supergraph_sdl::SupergraphSdlRouterConfigOnFetchError;
-
-const GCP_URL: &str = "https://uplink.api.apollographql.com/graphql";
-const AWS_URL: &str = "https://aws.uplink.api.apollographql.com/graphql";
+use crate::uplink::schema::supergraph_sdl_query::FetchErrorCode;
+use crate::uplink::schema::supergraph_sdl_query::SupergraphSdlQueryRouterConfig;
+use crate::uplink::UplinkRequest;
+use crate::uplink::UplinkResponse;
 
 #[derive(GraphQLQuery)]
 #[graphql(
-    query_path = "src/uplink/query.graphql",
+    query_path = "src/uplink/schema_query.graphql",
     schema_path = "src/uplink/uplink.graphql",
     request_derives = "Debug",
     response_derives = "PartialEq, Debug, Deserialize",
     deprecated = "warn"
 )]
 
-pub(crate) struct SupergraphSdl;
+pub(crate) struct SupergraphSdlQuery;
 
-#[derive(Debug)]
-pub(crate) enum Error {
-    Reqwest(reqwest::Error),
-    EmptyResponse,
-}
-
-impl From<reqwest::Error> for Error {
-    fn from(e: reqwest::Error) -> Self {
-        Error::Reqwest(e)
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct Schema {
-    pub(crate) schema: String,
-}
-
-/// regularly download a schema from Uplink
-pub(crate) fn stream_supergraph(
-    api_key: String,
-    graph_ref: String,
-    urls: Option<Vec<Url>>,
-    mut interval: Duration,
-    timeout: Duration,
-) -> impl Stream<Item = Result<Schema, String>> {
-    let (sender, receiver) = channel(2);
-    let task = async move {
-        let mut composition_id = None;
-        let mut current_url_idx = 0;
-
-        loop {
-            let mut nb_errors = 0usize;
-            match fetch_supergraph(
-                &mut nb_errors,
-                api_key.to_string(),
-                graph_ref.to_string(),
-                composition_id.clone(),
-                urls.as_ref().map(|u| &u[current_url_idx]),
-                timeout,
-            )
-            .await
-            {
-                Ok(value) => match value.router_config {
-                    supergraph_sdl::SupergraphSdlRouterConfig::RouterConfigResult(
-                        schema_config,
-                    ) => {
-                        composition_id = Some(schema_config.id.clone());
-                        if sender
-                            .send(Ok(Schema {
-                                schema: schema_config.supergraph_sdl,
-                            }))
-                            .await
-                            .is_err()
-                        {
-                            break;
-                        }
-                        // this will truncate the number of seconds to under u64::MAX, which should be
-                        // a large enough delay anyway
-                        interval =
-                            Duration::from_secs(schema_config.min_delay_seconds.round() as u64);
-                    }
-                    supergraph_sdl::SupergraphSdlRouterConfig::Unchanged => {
-                        tracing::trace!("schema did not change");
-                    }
-                    supergraph_sdl::SupergraphSdlRouterConfig::FetchError(
-                        SupergraphSdlRouterConfigOnFetchError { code, message },
-                    ) => {
-                        if code == FetchErrorCode::RETRY_LATER {
-                            if let Some(urls) = &urls {
-                                current_url_idx = (current_url_idx + 1) % urls.len();
-                            }
-
-                            if sender
-                                .send(Err(format!(
-                                    "error downloading the schema from Uplink: {message}"
-                                )))
-                                .await
-                                .is_err()
-                            {
-                                break;
-                            }
-                        } else {
-                            if sender
-                                .send(Err(format!("{code:?} error downloading the schema from Uplink, the router will not try again: {message}")))
-                                .await
-                                .is_err()
-                            {
-                                break;
-                            }
-                            break;
-                        }
-                    }
-                },
-                Err(err) => {
-                    if let Some(urls) = &urls {
-                        current_url_idx = (current_url_idx + 1) % urls.len();
-                    }
-                    tracing::error!("error downloading the schema from Uplink: {:?}", err);
-                }
-            }
-
-            tokio::time::sleep(interval).await;
+impl From<UplinkRequest> for supergraph_sdl_query::Variables {
+    fn from(req: UplinkRequest) -> Self {
+        supergraph_sdl_query::Variables {
+            api_key: req.api_key,
+            graph_ref: req.graph_ref,
+            if_after_id: req.id,
         }
-    };
-    drop(tokio::task::spawn(task.with_current_subscriber()));
-
-    ReceiverStream::new(receiver)
-}
-
-pub(crate) async fn fetch_supergraph(
-    nb_errors: &mut usize,
-    api_key: String,
-    graph_ref: String,
-    composition_id: Option<String>,
-    url: Option<&Url>,
-    timeout: Duration,
-) -> Result<supergraph_sdl::ResponseData, Error> {
-    let variables = supergraph_sdl::Variables {
-        api_key,
-        graph_ref,
-        if_after_id: composition_id,
-    };
-    let request_body = SupergraphSdl::build_query(variables);
-
-    let response = match url {
-        Some(url) => http_request(url.as_str(), &request_body, timeout).await?,
-        None => match http_request(GCP_URL, &request_body, timeout).await {
-            Ok(response) => {
-                if *nb_errors > 0 {
-                    *nb_errors = 0;
-                    tracing::info!("successfully retrieved the schema from GCP");
-                }
-                response
-            }
-            Err(e) => {
-                if *nb_errors == 3 {
-                    tracing::error!("could not get schema from GCP, trying AWS: {:?}", e);
-                } else {
-                    tracing::debug!("could not get schema from GCP, trying AWS: {:?}", e);
-                }
-                *nb_errors += 1;
-                http_request(AWS_URL, &request_body, timeout).await?
-            }
-        },
-    };
-
-    match response.data {
-        None => Err(Error::EmptyResponse),
-        Some(response_data) => Ok(response_data),
     }
 }
 
-async fn http_request(
-    url: &str,
-    request_body: &QueryBody<supergraph_sdl::Variables>,
-    timeout: Duration,
-) -> Result<Response<supergraph_sdl::ResponseData>, reqwest::Error> {
-    let client = reqwest::Client::builder().timeout(timeout).build()?;
-
-    let res = client.post(url).json(request_body).send().await?;
-    let response_body: Response<supergraph_sdl::ResponseData> = res.json().await?;
-    Ok(response_body)
+impl From<supergraph_sdl_query::ResponseData> for UplinkResponse<String> {
+    fn from(response: supergraph_sdl_query::ResponseData) -> Self {
+        match response.router_config {
+            SupergraphSdlQueryRouterConfig::RouterConfigResult(result) => UplinkResponse::Result {
+                response: result.supergraph_sdl,
+                id: result.id,
+                // this will truncate the number of seconds to under u64::MAX, which should be
+                // a large enough delay anyway
+                delay: result.min_delay_seconds as u64,
+            },
+            SupergraphSdlQueryRouterConfig::Unchanged => UplinkResponse::Unchanged {
+                id: None,
+                delay: None,
+            },
+            SupergraphSdlQueryRouterConfig::FetchError(err) => UplinkResponse::Error {
+                retry_later: err.code == FetchErrorCode::RETRY_LATER,
+                code: match err.code {
+                    FetchErrorCode::AUTHENTICATION_FAILED => "AUTHENTICATION_FAILED".to_string(),
+                    FetchErrorCode::ACCESS_DENIED => "ACCESS_DENIED".to_string(),
+                    FetchErrorCode::UNKNOWN_REF => "UNKNOWN_REF".to_string(),
+                    FetchErrorCode::RETRY_LATER => "RETRY_LATER".to_string(),
+                    FetchErrorCode::Other(other) => other,
+                },
+                message: err.message,
+            },
+        }
+    }
 }
 
-#[test]
-#[cfg(not(windows))] // Don’t bother with line ending differences
-fn test_uplink_schema_is_up_to_date() {
-    use std::path::PathBuf;
+#[cfg(test)]
+mod test {
+    use std::time::Duration;
 
-    use introspector_gadget::blocking::GraphQLClient;
-    use introspector_gadget::introspect;
-    use introspector_gadget::introspect::GraphIntrospectInput;
+    use futures::stream::StreamExt;
 
-    let client = GraphQLClient::new(
-        "https://uplink.api.apollographql.com/",
-        reqwest::blocking::Client::new(),
-    );
+    use crate::uplink::schema::SupergraphSdlQuery;
+    use crate::uplink::stream_from_uplink;
 
-    let should_retry = true;
-    let introspection_response = introspect::run(
-        GraphIntrospectInput {
-            headers: Default::default(),
-        },
-        &client,
-        should_retry,
-    )
-    .unwrap();
+    #[tokio::test]
+    async fn integration_test() {
+        if let (Ok(apollo_key), Ok(apollo_graph_ref)) = (
+            std::env::var("TEST_APOLLO_KEY"),
+            std::env::var("TEST_APOLLO_GRAPH_REF"),
+        ) {
+            let results = stream_from_uplink::<SupergraphSdlQuery, String>(
+                apollo_key,
+                apollo_graph_ref,
+                None,
+                Duration::from_secs(1),
+                Duration::from_secs(5),
+            )
+            .take(1)
+            .collect::<Vec<_>>()
+            .await;
 
-    if introspection_response.schema_sdl != include_str!("uplink.graphql") {
-        let path = PathBuf::from(std::env::var_os("OUT_DIR").unwrap()).join("uplink.graphql");
-        std::fs::write(&path, introspection_response.schema_sdl).unwrap();
-        panic!(
-            "\n\nUplink schema is out of date. Run this command to update it:\n\n    \
-                mv {} apollo-router/src/uplink/uplink.graphql\n\n",
-            path.to_str().unwrap()
-        );
+            assert!(!results
+                .get(0)
+                .expect("expected one result")
+                .as_ref()
+                .expect("schema should be OK")
+                .is_empty())
+        }
     }
 }

--- a/apollo-router/src/uplink/schema_query.graphql
+++ b/apollo-router/src/uplink/schema_query.graphql
@@ -1,4 +1,4 @@
-query SupergraphSdl($apiKey: String!, $graph_ref: String!, $ifAfterId: ID) {
+query SupergraphSdlQuery($apiKey: String!, $graph_ref: String!, $ifAfterId: ID) {
     routerConfig(ref: $graph_ref, apiKey: $apiKey, ifAfterId: $ifAfterId) {
         __typename
         ... on RouterConfigResult {

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_error_http_fallback.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_error_http_fallback.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/uplink/mod.rs
+expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
+---
+- Ok: response
+- Ok: response
+

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_error_http_round_robin.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_error_http_round_robin.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/uplink/mod.rs
+expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
+---
+- Ok: response
+- Ok: response
+

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_error_no_retry.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_error_no_retry.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-router/src/uplink/mod.rs
+expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
+---
+- Err: "uplink error, the request will not be retried: code=NO_RETRY message=error message"
+

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_error_retry.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_error_retry.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/uplink/mod.rs
+expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
+---
+- Err: "uplink error: code=RETRY_LATER message=error message"
+- Ok: response
+

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_failed_from_all.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_failed_from_all.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-router/src/uplink/mod.rs
+expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
+---
+- Err: fetch failed from all endpoints
+

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_fallback.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_fallback.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/uplink/mod.rs
+expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
+---
+- Ok: response
+- Ok: response
+

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_invalid.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_invalid.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-router/src/uplink/mod.rs
+expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
+---
+- Err: "uplink error: code=INVALID_ENTITLEMENT message=invalid entitlement: InvalidToken"
+

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_round_robin.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_round_robin.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/uplink/mod.rs
+expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
+---
+- Ok: response
+- Ok: response
+

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_unchanged.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_unchanged.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/uplink/mod.rs
+expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
+---
+- Ok: response
+- Ok: response
+


### PR DESCRIPTION
Added entitlements uplink logic.
Common uplink code has been pulled out into the module. And some reasonably comprehensive tests have been added.

Code that handles round robin and fallback has been cleaned up, however there is a slight difference in behaviour now.
Previously in round robin mode if a failure occurred the next URL would not be checked until the next loop. Now all urls are tried consecutively.

~~In addition there may have been a potential hang on shutdown if uplink only ever reported `UNCHANGED` as the sender was never checked to see if it had been closed.~~ This is not an issue as it will stop if the main thread is exited.

This work may warrant entering the changelog, so will create an issue etc for this next week.
- Fix #2547

*description here*

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] ~~Documentation[^2] completed~~
- [ ] ~~Performance impact assessed and acceptable~~
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
