### PR TITLE
Allow for priorityClassName to be set on the Deployment to control pod preemption by the scheduler

### DIFF
--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -141,3 +141,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}

--- a/helm/chart/router/values.yaml
+++ b/helm/chart/router/values.yaml
@@ -25,7 +25,7 @@ managedFederation:
   # -- If using managed federation, the graph API key to identify router to Studio
   apiKey:
   # -- If using managed federation, use existing Secret which stores the graph API key instead of creating a new one.
-  # If set along `managedFederation.apiKey`, a secret with the graph API key will be created using this parameter as name 
+  # If set along `managedFederation.apiKey`, a secret with the graph API key will be created using this parameter as name
   existingSecret:
   # -- If using managed federation, the variant of which graph to use
   graphRef: ""
@@ -183,3 +183,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# set to existing PriorityClass name to control pod preemption by the scheduler
+priorityClassName: ""


### PR DESCRIPTION
- Fix #2543

*This leverages https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/ to enable the setting of a `priorityClassName` value which can then be set of the `Deployment` such that pod priority and preemption can be controlled.*

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
