### PR TITLE
chore: Phase 2 of changelog project, now w/ optionally prepopulated CHANGELOG

### DIFF
--- a/.changesets/README.md
+++ b/.changesets/README.md
@@ -10,10 +10,19 @@ This directory keeps files which individually represent entries that will repres
 >
 > The aforementioned **tooling doesn't exist yet** but will be created soon. 😺
 
-Create a file **by hand** in this directory for each individual changelog entry by using the required convention.  That convention is:
+### How to create a Changelog entry
+
+1. Push the change you are writing a changeset for up to GitHub.
+2. Open a pull request for it.  Note that your PR title and body will be used to pre-populate the changeset.
+3. On your local checkout, **run `cargo xtask changeset create` from the root of the repository** and follow the prompts.
+4. Add, commit and push the changeset file that is created and push it up to GitHub.
+
+### Conventions used in this `.changesets/` directory
+
+The convention used in this directory and obeyed by the `cargo xtask changeset create` command is:
 
 1. Files in this directory must use the `.md` file extension.
-2. Do not put multiple changelog entries in a single file.
+2. There must not be multiple changelog entries in a single file.
 3. Files *must start with a prefix* that indicates the classification of the changeset.  The prefixes are as follows:
    - **Breaking**: `breaking_`
    - **Feature**: `feat_`

--- a/.changesets/maint_abernix_changeset_part_2.md
+++ b/.changesets/maint_abernix_changeset_part_2.md
@@ -1,0 +1,11 @@
+### Improve Changelog management through conventions and tooling ([PR #2545](https://github.com/apollographql/router/pull/2545), [PR #2534](https://github.com/apollographql/router/pull/2534))
+
+New tooling and conventions adjust our "incoming changelog in the next release" mechanism to no longer rely on a single file, but instead leverage a "file per feature" pattern in conjunction with tooling to create that file.
+
+This stubbing takes place through the use of a new command:
+
+    cargo xtask changeset create
+
+For more information on the process, read the [README in the `./.changesets` directory](https://github.com/apollographql/router/blob/HEAD/.changesets/README.md) or consult the referenced Pull Requests below.
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/2545 and https://github.com/apollographql/router/pull/2534

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
-- Fix #issue_number
+*Description here*
 
-*description here*
+Fixes #issue_number
+
+<!-- start metadata -->
 
 **Checklist**
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,4 +12,4 @@ jobs:
         uses: mskelton/changelog-reminder-action@v3.0.0
         with:
           changelogRegex: '\.changesets/(breaking|feat|fix|config|maint|docs|exp)_.*\.md'
-          message: "@${{ github.actor }}, please create a file in `/.changesets/` following [these instructions](https://github.com/apollographql/router/blob/HEAD/.changesets/README.md)."
+          message: "@${{ github.actor }}, please consider creating a changeset entry in `/.changesets/`. [These instructions](https://github.com/apollographql/router/blob/HEAD/.changesets/README.md) describe the process and tooling."

--- a/xtask/Cargo.lock
+++ b/xtask/Cargo.lock
@@ -42,6 +42,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 
 [[package]]
+name = "ascii"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
+
+[[package]]
 name = "async-recursion"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +205,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "combine"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+dependencies = [
+ "ascii",
+ "byteorder",
+ "either",
+ "memchr",
+ "unreachable",
+]
+
+[[package]]
+name = "console"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "unicode-width",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +338,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af3c796f3b0b408d9fd581611b47fa850821fcb84aa640b83a3c1a5be2d691f2"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +370,12 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -499,6 +549,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
@@ -521,6 +582,65 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "url",
+]
+
+[[package]]
+name = "graphql-introspection-query"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f2a4732cf5140bd6c082434494f785a19cfb566ab07d1382c3671f5812fed6d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "graphql-parser"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
+dependencies = [
+ "combine",
+ "thiserror",
+]
+
+[[package]]
+name = "graphql_client"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa61bb9dc6d373a8b465a5da17b62809483e8527a34b0e9034dc0915b09e160a"
+dependencies = [
+ "graphql_query_derive",
+ "reqwest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "graphql_client_codegen"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e55df64cc702c4ad6647f8df13a799ad11688a3781fadf5045f7ba12733fa9b"
+dependencies = [
+ "graphql-introspection-query",
+ "graphql-parser",
+ "heck 0.4.1",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
+name = "graphql_query_derive"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52fc9cde811f44b15ec0692b31e56a3067f6f431c5ace712f286e47c1dacc98"
+dependencies = [
+ "graphql_client_codegen",
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -556,6 +676,12 @@ checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -873,6 +999,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memorable-wordlist"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673c6a442e72f0bca457afb369a8130596eeeb51c80a38b1dd39b6c490ed36c1"
+dependencies = [
+ "rand 0.7.3",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,7 +1198,7 @@ dependencies = [
  "lazy_static",
  "percent-encoding",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "thiserror",
 ]
 
@@ -1193,13 +1328,36 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1209,7 +1367,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -1218,7 +1385,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.8",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1371,7 +1547,7 @@ checksum = "e09bbcb5003282bcb688f0bae741b278e9c7e8f378f561522c9806c58e075d9b"
 dependencies = [
  "anyhow",
  "chrono",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1519,18 +1695,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.150"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.150"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1596,6 +1772,12 @@ checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1666,7 +1848,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
 dependencies = [
- "heck",
+ "heck 0.3.3",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -1807,6 +1989,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d967f99f534ca7e495c575c62638eebc2898a8c84c119b89e250477bc4ba16b2"
 dependencies = [
  "time-core",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2020,6 +2212,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+dependencies = [
+ "void",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2062,6 +2263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,6 +2288,12 @@ dependencies = [
  "log",
  "try-lock",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.9.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -2359,14 +2572,19 @@ dependencies = [
  "camino",
  "cargo_metadata",
  "chrono",
+ "console",
+ "dialoguer",
  "flate2",
  "git2",
+ "graphql_client",
  "itertools",
  "libc",
+ "memorable-wordlist",
  "octorust",
  "once_cell",
  "regex",
  "reqwest",
+ "serde",
  "serde_json",
  "serde_json_traversal",
  "sha2",
@@ -2374,11 +2592,18 @@ dependencies = [
  "tap",
  "tar",
  "tempfile",
+ "tinytemplate",
  "tokio",
  "walkdir",
  "which",
  "zip",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 
 [[package]]
 name = "zip"

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -15,10 +15,14 @@ base64 = "0.20"
 camino = "1"
 cargo_metadata = "0.15"
 chrono = "0.4.23"
+console = "0.15.5"
+dialoguer = "0.10.3"
 flate2 = "1"
+graphql_client = { version = "0.12.0", features = ["reqwest"] }
 git2 = "0.16.1"
 itertools = "0.10.5"
 libc = "0.2"
+memorable-wordlist = "0.1.7"
 octorust = "0.2.1"
 once_cell = "1"
 regex="1.7.1"
@@ -26,12 +30,14 @@ reqwest = { version = "0.11", default-features = false, features = [
     "blocking",
     "native-tls",
 ] }
+serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1"
 serde_json_traversal = "0.2"
 structopt = { version = "0.3", default-features = false }
 tar = "0.4"
 tempfile = "3"
 tap = "1.0.1"
+tinytemplate = "1.2.1"
 tokio = "1.25.0"
 which = "4"
 zip = { version = "0.6", default-features = false }

--- a/xtask/src/commands/all.rs
+++ b/xtask/src/commands/all.rs
@@ -10,7 +10,6 @@ use super::Test;
 pub struct All {
     #[structopt(flatten)]
     compliance: Compliance,
-
     #[structopt(flatten)]
     licenses: Licenses,
     #[structopt(flatten)]

--- a/xtask/src/commands/all.rs
+++ b/xtask/src/commands/all.rs
@@ -9,6 +9,7 @@ use super::Test;
 pub struct All {
     #[structopt(flatten)]
     compliance: Compliance,
+
     #[structopt(flatten)]
     lint: Lint,
     #[structopt(flatten)]

--- a/xtask/src/commands/changeset/matching_pull_request.graphql
+++ b/xtask/src/commands/changeset/matching_pull_request.graphql
@@ -1,3 +1,6 @@
+# This operation is used to generate Rust code which lives in a file directly
+# next to this with the same name but a `.rs` extension.  For instructions on
+# how to generate the code, see the top of `./mod.rs`.
 fragment PrInfo on PullRequest {
   url
   number

--- a/xtask/src/commands/changeset/matching_pull_request.graphql
+++ b/xtask/src/commands/changeset/matching_pull_request.graphql
@@ -1,0 +1,36 @@
+fragment PrInfo on PullRequest {
+  url
+  number
+  author {
+    __typename
+    login
+  }
+  title
+  closingIssuesReferences(last: 4) {
+    nodes {
+      url
+      number
+      repository {
+        nameWithOwner
+      }
+    }
+  }
+  body
+}
+fragment PrSearchResult on SearchResultItemConnection {
+  issueCount
+  nodes {
+    __typename
+    ...PrInfo
+  }
+ }
+
+query MatchingPullRequest($search: String!) {
+  search(
+    type: ISSUE
+    query: $search
+    first: 1
+  ) {
+    ...PrSearchResult
+  }
+}

--- a/xtask/src/commands/changeset/matching_pull_request.rs
+++ b/xtask/src/commands/changeset/matching_pull_request.rs
@@ -4,7 +4,7 @@ pub mod matching_pull_request {
     #![allow(dead_code)]
     use std::result::Result;
     pub const OPERATION_NAME: &str = "MatchingPullRequest";
-    pub const QUERY : & str = "fragment PrInfo on PullRequest {\n  url\n  number\n  author {\n    __typename\n    login\n  }\n  title\n  closingIssuesReferences(last: 4) {\n    nodes {\n      url\n      number\n      repository {\n        nameWithOwner\n      }\n    }\n  }\n  body\n}\nfragment PrSearchResult on SearchResultItemConnection {\n  issueCount\n  nodes {\n    __typename\n    ...PrInfo\n  }\n }\n\nquery MatchingPullRequest($search: String!) {\n  search(\n    type: ISSUE\n    query: $search\n    first: 1\n  ) {\n    ...PrSearchResult\n  }\n}\n" ;
+    pub const QUERY : & str = "# This operation is used to generate Rust code which lives in a file directly\n# next to this with the same name but a `.rs` extension.  For instructions on\n# how to generate the code, see the top of `./mod.rs`.\nfragment PrInfo on PullRequest {\n  url\n  number\n  author {\n    __typename\n    login\n  }\n  title\n  closingIssuesReferences(last: 4) {\n    nodes {\n      url\n      number\n      repository {\n        nameWithOwner\n      }\n    }\n  }\n  body\n}\nfragment PrSearchResult on SearchResultItemConnection {\n  issueCount\n  nodes {\n    __typename\n    ...PrInfo\n  }\n }\n\nquery MatchingPullRequest($search: String!) {\n  search(\n    type: ISSUE\n    query: $search\n    first: 1\n  ) {\n    ...PrSearchResult\n  }\n}\n" ;
     use super::*;
     use serde::{Deserialize, Serialize};
     #[allow(dead_code)]

--- a/xtask/src/commands/changeset/matching_pull_request.rs
+++ b/xtask/src/commands/changeset/matching_pull_request.rs
@@ -1,3 +1,15 @@
+// THIS FILE IS GENERATED
+// THIS FILE IS GENERATED
+// THIS FILE IS GENERATED
+// See the instructions in `./mod.rs` for how to regenerate it.  It is
+// generated based on the operation that sits alongside it in this same file.
+// Unfortunately, this comment will not be preserved and needs to be manually
+// preserved if it's desired to keep it around.  Luckily, I don't think this
+// operation will change very often.
+// THIS FILE IS GENERATED
+// THIS FILE IS GENERATED
+// THIS FILE IS GENERATED
+
 #![allow(clippy::all, warnings)]
 pub struct MatchingPullRequest;
 pub mod matching_pull_request {

--- a/xtask/src/commands/changeset/matching_pull_request.rs
+++ b/xtask/src/commands/changeset/matching_pull_request.rs
@@ -1,0 +1,99 @@
+#![allow(clippy::all, warnings)]
+pub struct MatchingPullRequest;
+pub mod matching_pull_request {
+    #![allow(dead_code)]
+    use std::result::Result;
+    pub const OPERATION_NAME: &str = "MatchingPullRequest";
+    pub const QUERY : & str = "fragment PrInfo on PullRequest {\n  url\n  number\n  author {\n    __typename\n    login\n  }\n  title\n  closingIssuesReferences(last: 4) {\n    nodes {\n      url\n      number\n      repository {\n        nameWithOwner\n      }\n    }\n  }\n  body\n}\nfragment PrSearchResult on SearchResultItemConnection {\n  issueCount\n  nodes {\n    __typename\n    ...PrInfo\n  }\n }\n\nquery MatchingPullRequest($search: String!) {\n  search(\n    type: ISSUE\n    query: $search\n    first: 1\n  ) {\n    ...PrSearchResult\n  }\n}\n" ;
+    use super::*;
+    use serde::{Deserialize, Serialize};
+    #[allow(dead_code)]
+    type Boolean = bool;
+    #[allow(dead_code)]
+    type Float = f64;
+    #[allow(dead_code)]
+    type Int = i64;
+    #[allow(dead_code)]
+    type ID = String;
+    type URI = crate::commands::changeset::scalars::URI;
+    #[derive(Serialize)]
+    pub struct Variables {
+        pub search: String,
+    }
+    impl Variables {}
+    #[derive(Deserialize, Debug)]
+    pub struct PrInfo {
+        pub url: URI,
+        pub number: Int,
+        pub author: Option<PrInfoAuthor>,
+        pub title: String,
+        #[serde(rename = "closingIssuesReferences")]
+        pub closing_issues_references: Option<PrInfoClosingIssuesReferences>,
+        pub body: String,
+    }
+    #[derive(Deserialize, Debug)]
+    pub struct PrInfoAuthor {
+        pub login: String,
+        #[serde(flatten)]
+        pub on: PrInfoAuthorOn,
+    }
+    #[derive(Deserialize, Debug)]
+    #[serde(tag = "__typename")]
+    pub enum PrInfoAuthorOn {
+        Bot,
+        EnterpriseUserAccount,
+        Mannequin,
+        Organization,
+        User,
+    }
+    #[derive(Deserialize, Debug)]
+    pub struct PrInfoClosingIssuesReferences {
+        pub nodes: Option<Vec<Option<PrInfoClosingIssuesReferencesNodes>>>,
+    }
+    #[derive(Deserialize, Debug)]
+    pub struct PrInfoClosingIssuesReferencesNodes {
+        pub url: URI,
+        pub number: Int,
+        pub repository: PrInfoClosingIssuesReferencesNodesRepository,
+    }
+    #[derive(Deserialize, Debug)]
+    pub struct PrInfoClosingIssuesReferencesNodesRepository {
+        #[serde(rename = "nameWithOwner")]
+        pub name_with_owner: String,
+    }
+    #[derive(Deserialize, Debug)]
+    pub struct PrSearchResult {
+        #[serde(rename = "issueCount")]
+        pub issue_count: Int,
+        pub nodes: Option<Vec<Option<PrSearchResultNodes>>>,
+    }
+    #[derive(Deserialize, Debug)]
+    #[serde(tag = "__typename")]
+    pub enum PrSearchResultNodes {
+        App,
+        Discussion,
+        Issue,
+        MarketplaceListing,
+        Organization,
+        PullRequest(PrSearchResultNodesOnPullRequest),
+        Repository,
+        User,
+    }
+    pub type PrSearchResultNodesOnPullRequest = PrInfo;
+    #[derive(Deserialize, Debug)]
+    pub struct ResponseData {
+        pub search: MatchingPullRequestSearch,
+    }
+    pub type MatchingPullRequestSearch = PrSearchResult;
+}
+impl graphql_client::GraphQLQuery for MatchingPullRequest {
+    type Variables = matching_pull_request::Variables;
+    type ResponseData = matching_pull_request::ResponseData;
+    fn build_query(variables: Self::Variables) -> ::graphql_client::QueryBody<Self::Variables> {
+        graphql_client::QueryBody {
+            variables,
+            query: matching_pull_request::QUERY,
+            operation_name: matching_pull_request::OPERATION_NAME,
+        }
+    }
+}

--- a/xtask/src/commands/changeset/mod.rs
+++ b/xtask/src/commands/changeset/mod.rs
@@ -33,7 +33,7 @@ use matching_pull_request::matching_pull_request::{ResponseData,Variables};
 use matching_pull_request::MatchingPullRequest;
 use memorable_wordlist;
 use serde::Serialize;
-use std::{fmt, fs, path::PathBuf, slice::Iter, str::FromStr};
+use std::{fmt, fs, path::PathBuf, str::FromStr};
 use structopt::StructOpt;
 use tinytemplate::{format_unescaped, TinyTemplate};
 use xtask::PKG_PROJECT_ROOT;
@@ -106,11 +106,9 @@ impl Classification {
         }
     }
 
-    /// This definition of how to iterate over classifications is responsible
-    /// for the ordering that eventually appears in the emitted CHANGELOG. It's
-    /// also the order options are displayed in the TUI.
-    pub fn iterator() -> Iter<'static, Classification> {
-        static CLASSIFICATIONS: [Classification; 7] = [
+    /// Defines the ordering that eventually appears in the emitted CHANGELOG
+    /// and the order options appear in the TUI.
+    const ORDERED_ALL: &'static [Self] = &[
             Classification::Breaking,
             Classification::Feature,
             Classification::Fix,
@@ -118,9 +116,7 @@ impl Classification {
             Classification::Maintenance,
             Classification::Documentation,
             Classification::Experimental,
-        ];
-        CLASSIFICATIONS.iter()
-    }
+    ];
 }
 
 type ParseError = &'static str;
@@ -195,7 +191,7 @@ impl Create {
             .build()
             .unwrap()
             .block_on(async {
-                let items = Classification::iterator().collect_vec();
+                let items = Classification::ORDERED_ALL;
 
                 let selected_classification: Classification = if self.classification.is_some() {
                     println!(

--- a/xtask/src/commands/changeset/mod.rs
+++ b/xtask/src/commands/changeset/mod.rs
@@ -169,9 +169,7 @@ pub struct Create {
 async fn github_graphql_post_request(
     token: &str,
     url: &str,
-    request_body: &graphql_client::QueryBody<
-        matching_pull_request::matching_pull_request::Variables,
-    >,
+    request_body: &graphql_client::QueryBody<Variables>,
 ) -> Result<
     graphql_client::Response<matching_pull_request::matching_pull_request::ResponseData>,
     ::reqwest::Error,

--- a/xtask/src/commands/changeset/mod.rs
+++ b/xtask/src/commands/changeset/mod.rs
@@ -29,7 +29,7 @@ use console::style;
 use dialoguer::{console::Term, theme::ColorfulTheme, Confirm, Editor, Input, Select};
 use git2;
 use itertools::Itertools;
-use matching_pull_request::matching_pull_request::Variables;
+use matching_pull_request::matching_pull_request::{ResponseData,Variables};
 use matching_pull_request::MatchingPullRequest;
 use memorable_wordlist;
 use serde::Serialize;
@@ -170,10 +170,7 @@ async fn github_graphql_post_request(
     token: &str,
     url: &str,
     request_body: &graphql_client::QueryBody<Variables>,
-) -> Result<
-    graphql_client::Response<matching_pull_request::matching_pull_request::ResponseData>,
-    ::reqwest::Error,
-> {
+) -> Result<graphql_client::Response<ResponseData>, ::reqwest::Error> {
     let client = Client::builder().build()?;
 
     let res = client
@@ -186,9 +183,7 @@ async fn github_graphql_post_request(
         .json(request_body)
         .send()
         .await?;
-    let response_body: graphql_client::Response<
-        matching_pull_request::matching_pull_request::ResponseData,
-    > = res.json().await?;
+    let response_body: graphql_client::Response<ResponseData> = res.json().await?;
     Ok(response_body)
 }
 
@@ -479,7 +474,7 @@ fn get_token_from_gh_cli(gh_cli_path: PathBuf) -> Result<String, &'static str> {
 }
 
 fn pr_info_from_response(
-    response_data: matching_pull_request::matching_pull_request::ResponseData,
+    response_data: ResponseData,
 ) -> Vec<matching_pull_request::matching_pull_request::PrInfo> {
     response_data.search.nodes.map(|node| {
         let maybe_prs = node.into_iter().map(|p| {

--- a/xtask/src/commands/changeset/mod.rs
+++ b/xtask/src/commands/changeset/mod.rs
@@ -1,0 +1,499 @@
+/// This module is generated:
+///   1. Only if you actually change the `matching_pull_request.graphql` query.
+///   1. By installing `graphql_client_cli`
+///
+///          cargo install graphql_client_cli
+///
+///   1. By running:
+///      1. A command that downloads the GitHub Schema.  It's large so we don't
+///         need to check it in.  Make sure to download it INTO the
+///         `src/commands/changeset/` directory.
+///
+///             wget https://docs.github.com/public/schema.docs.graphql`
+///
+///      2. Generate against this downloaded schema.  Run this from inside the
+///         `src/commands/changeset/` directory.
+///
+///             graphql-client generate \
+///               --schema-path ./schema.docs.graphql \
+///               --response-derives='Debug' \
+///               --custom-scalars-module='crate::commands::changeset::scalars' \
+///               ./matching_pull_request.graphql
+///
+mod matching_pull_request;
+mod scalars;
+
+use ::reqwest::Client;
+use anyhow::Result;
+use console::style;
+use dialoguer::{console::Term, theme::ColorfulTheme, Confirm, Editor, Input, Select};
+use git2;
+use itertools::Itertools;
+use matching_pull_request::matching_pull_request::Variables;
+use matching_pull_request::MatchingPullRequest;
+use memorable_wordlist;
+use serde::Serialize;
+use std::{fmt, fs, path::PathBuf, slice::Iter, str::FromStr};
+use structopt::StructOpt;
+use tinytemplate::{format_unescaped, TinyTemplate};
+use xtask::*;
+
+#[derive(Serialize)]
+struct TemplateResource {
+    number: String,
+    url: String,
+}
+
+#[derive(Serialize)]
+struct TemplateContext {
+    pulls: Vec<TemplateResource>,
+    issues: Vec<TemplateResource>,
+    title: String,
+    body: String,
+    author: String,
+}
+
+const REPO_WITH_OWNER: &'static str = "apollographql/router";
+
+const EXAMPLE_TEMPLATE: &'static str = "### {title} {{ for issue in issues -}}
+([Issue #{issue.number}]({issue.url})){{ if not @last }}, {{ endif }}
+{{- endfor }}
+
+{body}
+
+By [@{author}](https://github.com/{author}) in {{ for pull in pulls -}}
+{pull.url}{{ if not @last }}, {{ endif }}
+{{- endfor }}
+";
+
+impl Command {
+    pub fn run(&self) -> Result<()> {
+        match self {
+            Command::Create(command) => command.run(),
+        }
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub enum Command {
+    /// Add a new changeset
+    Create(Create),
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+enum Classification {
+    Breaking,
+    Feature,
+    Fix,
+    Configuration,
+    Maintenance,
+    Documentation,
+    Experimental,
+}
+
+impl Classification {
+    /// These "short names" are the prefixes that are used on the files
+    /// themselves and also for the `--class` flag for the CLI.
+    fn as_short_name(&self) -> &'static str {
+        match self {
+            Classification::Breaking => "breaking",
+            Classification::Feature => "feat",
+            Classification::Fix => "fix",
+            Classification::Configuration => "config",
+            Classification::Maintenance => "maint",
+            Classification::Documentation => "docs",
+            Classification::Experimental => "exp",
+        }
+    }
+
+    /// This definition of how to iterate over classifications is responsible
+    /// for the ordering that eventually appears in the emitted CHANGELOG. It's
+    /// also the order options are displayed in the TUI.
+    pub fn iterator() -> Iter<'static, Classification> {
+        static CLASSIFICATIONS: [Classification; 7] = [
+            Classification::Breaking,
+            Classification::Feature,
+            Classification::Fix,
+            Classification::Configuration,
+            Classification::Maintenance,
+            Classification::Documentation,
+            Classification::Experimental,
+        ];
+        CLASSIFICATIONS.iter()
+    }
+}
+
+type ParseError = &'static str;
+impl FromStr for Classification {
+    type Err = ParseError;
+    fn from_str(classification: &str) -> Result<Self, Self::Err> {
+        match classification {
+            "break" => Ok(Classification::Breaking),
+            "feat" => Ok(Classification::Feature),
+            "fix" => Ok(Classification::Fix),
+            "config" => Ok(Classification::Configuration),
+            "maint" => Ok(Classification::Maintenance),
+            "docs" => Ok(Classification::Documentation),
+            "exp" => Ok(Classification::Experimental),
+            &_ => Err("unknown classification"),
+        }
+    }
+}
+
+impl fmt::Display for Classification {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let pretty = match self {
+            Classification::Breaking => "❗ BREAKING ❗",
+            Classification::Feature => "🚀 Features",
+            Classification::Fix => "🐛 Fixes",
+            Classification::Configuration => "📃 Configuration",
+            Classification::Maintenance => "🛠 Maintenance",
+            Classification::Documentation => "📚 Documentation",
+            Classification::Experimental => "🧪 Experimental",
+        };
+        write!(f, "{}", pretty)
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Create {
+    /// Use the current branch as the file name
+    #[structopt(short = "b", long = "--with-branch-name")]
+    with_branch_name: bool,
+
+    /// The classification of the changeset
+    #[structopt(short = "c", long = "--class")]
+    classification: Option<Classification>,
+}
+
+async fn github_graphql_post_request(
+    token: &str,
+    url: &str,
+    request_body: &graphql_client::QueryBody<
+        matching_pull_request::matching_pull_request::Variables,
+    >,
+) -> Result<
+    graphql_client::Response<matching_pull_request::matching_pull_request::ResponseData>,
+    ::reqwest::Error,
+> {
+    let client = Client::builder().build()?;
+
+    let res = client
+        .post(url)
+        .header(
+            "User-Agent",
+            format!("github {} releasing", REPO_WITH_OWNER),
+        )
+        .header("Authorization", format!("Bearer {}", token))
+        .json(request_body)
+        .send()
+        .await?;
+    let response_body: graphql_client::Response<
+        matching_pull_request::matching_pull_request::ResponseData,
+    > = res.json().await?;
+    Ok(response_body)
+}
+
+impl Create {
+    pub fn run(&self) -> Result<()> {
+        let changesets_dir_path = PKG_PROJECT_ROOT.join(".changesets");
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let items = Classification::iterator().collect_vec();
+
+                let selected_classification: Classification = if self.classification.is_some() {
+                    println!(
+                        "{} {} {}",
+                        style("Using").yellow(),
+                        style(self.classification.unwrap()).cyan(),
+                        style("classification from CLI arguments").yellow()
+                    );
+                    self.classification.unwrap()
+                } else {
+                    let selection = Select::with_theme(&ColorfulTheme::default())
+                        .with_prompt("What is the classification?")
+                        .items(&items)
+                        .interact_on_opt(&Term::stderr())?
+                        .expect("no classification was selected");
+                    items[selection].clone()
+                };
+
+                let gh_cli_path = which::which("gh");
+                let use_gh_cli = if gh_cli_path.is_err() {
+                    println!("{}", style("If you install and authorize the GitHub CLI, we can use information from the PR!").underlined().on_blue().yellow().bright().bold());
+                    println!("  Find more details at: {}", style("https://cli.github.com/").bold());
+                    false
+                } else {
+                    if Confirm::new()
+                        .default(true)
+                        .with_prompt(format!(
+                            "{}",
+                            style("You have the GitHub CLI installed!  Can we use it to access the API and pre-populate values for the changelog?").yellow(),
+                        ))
+                        .interact()?
+                    {
+                      println!("{}", style("Great! That'll make your life easier.").yellow());
+                      true
+                    } else {
+                        println!("Ok! We won't talk to GitHub, so you'll be on your own.");
+                        false
+                    }
+                };
+
+                // TODO: Get existing files somewhere.  This does the trick.
+                // let changeset_files = fs::read_dir(&changesets_dir_path).unwrap();
+                // for path in changeset_files {
+                //     println!("Name: {}", path.unwrap().path().display())
+                // }
+
+                let use_branch_name = if self.with_branch_name {
+                    true
+                } else {
+                    let selection = Select::with_theme(&ColorfulTheme::default())
+                        .default(0)
+                        .with_prompt("How do you want to name it?")
+                        .items(&["Branch Name", "Random Name"])
+                        .interact_on_opt(&Term::stderr())?
+                        .expect("no naming convention was selected");
+                    if selection == 0 {
+                        true
+                    } else {
+                        false
+                    }
+                };
+
+                let branch_name: Option<String> = match git2::Repository::open_from_env() {
+                    Ok(repo) => {
+                        let refr = repo.head().unwrap();
+                        if refr.is_branch() {
+                            Some(refr.shorthand()
+                            .expect("no shorthand Git branch name available").to_string())
+                        } else {
+                            None
+                        }
+                    }
+                    Err(e) => panic!("failed to open: {e}"),
+                };
+
+                // If the branch name worked out, we'll use that, otherwise, random.
+                let initial_text = if use_branch_name && branch_name.is_some() {
+                    let branch_regex = regex::Regex::new(r"[^a-z0-9]")?;
+                    branch_regex.replace_all(
+                        &branch_name
+                        .clone()
+                        .unwrap()
+                        .to_lowercase()
+                        .as_str(), "_"
+                        ).to_string()
+                } else {
+                    memorable_wordlist::snake_case(48)
+                };
+
+                let input: String = Input::new()
+                    .with_prompt(format!(
+                        "{} {} {}",
+                        style("Any edits to the slug for the").yellow(),
+                        style(selected_classification.to_string()).cyan(),
+                        style("changeset?").yellow(),
+                    ))
+                    .with_initial_text(initial_text)
+                    .interact_text()?;
+
+                let new_changeset_path = changesets_dir_path.join(format!(
+                    "{}_{}.md",
+                    selected_classification.as_short_name(),
+                    input
+                ));
+
+                let mut tt = TinyTemplate::new();
+                tt.add_template("message", EXAMPLE_TEMPLATE)?;
+
+                let default_context = TemplateContext {
+                    title: String::from("Brief but complete sentence that stands on its own"),
+                    issues: vec!(TemplateResource {
+                        url: format!("https://github.com/{}/issues/ISSUE_NUMBER", REPO_WITH_OWNER),
+                        number: String::from("ISSUE_NUMBER"),
+                    }),
+                    pulls: vec!(TemplateResource {
+                        url: format!("https://github.com/{}/pull/PULL_NUMBER", REPO_WITH_OWNER),
+                        number: String::from("PULL_NUMBER"),
+                    }),
+                    author: String::from("AUTHOR"),
+                    body: String::from("A description of the fix which stands on its own separate from the title.  It should embrace the use of Markdown to stylize the commentary so it looks great on the GitHub Releases, when shared on social cards, etc."),
+                };
+
+                let context: TemplateContext = if use_gh_cli && branch_name.is_some() {
+                    match get_token_from_gh_cli(gh_cli_path.unwrap()) {
+                        Err(_) => default_context,
+                        Ok(gh_token) => {
+                            // Good for testing. ;)
+                            // let search = format!("repo:{} is:open is:pr head:{}", REPO_WITH_OWNER, "garypen/stricter-jwt-authentication");
+                            let search = format!("repo:{} is:open is:pr head:{}", REPO_WITH_OWNER, &branch_name.as_ref().unwrap());
+                            let query = <MatchingPullRequest as graphql_client::GraphQLQuery>::build_query(Variables { search });
+                            let response = github_graphql_post_request(&gh_token, "https://api.github.com/graphql", &query).await?;
+
+                            // There's only ever one query because the operation only asks for the `first: 1`.
+                            let all_prs_info = pr_info_from_response(response.data.expect("no data"));
+
+                            let pr_info = all_prs_info.first();
+
+                            if pr_info.is_some() {
+                                let pr_info = pr_info.expect("some PR info expected");
+                                let issues= pr_info.closing_issues_references.as_ref().map(|i| {
+                                    i.nodes.as_ref().unwrap().into_iter().map(|j| {
+                                        j.as_ref().unwrap()
+                                    })
+                                }).unwrap().filter(|p| {
+                                    p.repository.name_with_owner == REPO_WITH_OWNER
+                                }).map(|p| {
+                                    TemplateResource {
+                                        number: p.number.to_string(),
+                                        url: p.url.to_string(),
+                                    }
+                                });
+
+                                let pr_body = pr_info.body.clone().replace("\r\n", "\n");
+
+                                // Remove the trailing part of the checklist from the PR body.
+                                // In the future, we will use the "start metadata" HTML tag, but for now,
+                                // we support both.
+                                let pr_body_trailer_regex = regex::Regex::new(
+                                r"(?ms)(^<!-- start metadata -->\n$\n)?^\*\*Checklist\*\*$[\s\S]*",
+                                )?;
+
+                                // Remove all the "Fixes" references, since we're already going to reference
+                                // those in the course of generating the template.
+                                let pr_body_fixes_regex = regex::Regex::new(
+                                    r"(?m)^(- )?Fix(es)? #.*$",
+                                )?;
+
+                                // Run the above Regexes and trim the blurb.
+                                let clean_pr_body = pr_body_fixes_regex
+                                    .replace_all(pr_body_trailer_regex
+                                    .replace(&pr_body, "")
+                                    .trim(), "")
+                                    .trim()
+                                    .to_string();
+
+                                TemplateContext {
+                                    title: pr_info.title.clone(),
+                                    issues: issues.collect_vec(),
+                                    pulls: vec!(TemplateResource {
+                                        number: pr_info.number.to_string(),
+                                        url: pr_info.url.to_string(),
+                                    }),
+                                    body: clean_pr_body,
+                                    author: pr_info.author.as_ref().unwrap().login.to_string(),
+                                }
+                            } else {
+                                // TODO In a follow-up we should figure out how forks work with the GitHub API.
+                                println!(
+                                    "{} {} {} {} {}",
+                                    style("The changeset will be").magenta(),
+                                    style("generic").red().bold(),
+                                    style("as we didn't find any PRs on GitHub for").magenta(),
+                                    style(&branch_name.as_ref().unwrap()).green(),
+                                    style("! (We don't support forks right now.)")
+                                );
+                                default_context
+                            }
+                        },
+                    }
+                } else {
+                    default_context
+                };
+
+                tt.set_default_formatter(&format_unescaped);
+                let rendered_template = tt.render("message", &context).unwrap().replace('\r', "");
+
+                if new_changeset_path.exists() {
+                    panic!("The desired changeset name already exists and proceeding would clobber it.  Edit or delete the existing changeset with the same name.");
+                }
+
+                fs::write(&new_changeset_path, &rendered_template)?;
+                println!(
+                    "{} {} {} {}",
+                    style("Created new").yellow(),
+                    style(selected_classification.to_string()).cyan(),
+                    style("changeset named").yellow(),
+                    style(&new_changeset_path).cyan(),
+                );
+
+                if Confirm::new()
+                    .default(true)
+                    .with_prompt(format!(
+                        "{} {} {} {}?",
+                        style("Do you want to open").yellow(),
+                        style(&new_changeset_path).cyan(),
+                        style("in").yellow(),
+                        style("$EDITOR").green(),
+                    ))
+                    .interact()?
+                {
+                    if let Some(rv) = Editor::new()
+                        .extension(".md")
+                        .trim_newlines(true)
+                        .edit(&rendered_template)
+                        .unwrap()
+                    {
+                        fs::write(&new_changeset_path, rv)?;
+                    } else {
+                        println!(
+                            "{}",
+                            style("Editing was aborted and changes were not saved.")
+                                .red()
+                                .on_yellow()
+                        );
+                    }
+                }
+
+                println!(
+                    "{}",
+                    style("Be sure to finalize the changeset, commit it and push it to Git.")
+                        .magenta()
+                );
+
+                Ok(())
+            })
+    }
+}
+
+fn get_token_from_gh_cli(gh_cli_path: PathBuf) -> Result<String, &'static str> {
+    let result = std::process::Command::new(gh_cli_path)
+        .args(["auth", "token"])
+        .output()
+        .expect("this didn't go well");
+    if !result.status.success() {
+        Err("We couldn't run `gh auth token`.  Perhaps run `gh auth login`.")
+    } else {
+        let gh_token_with_nl =
+            String::from_utf8(result.stdout).expect("should have had newline token");
+        let gh_token = gh_token_with_nl.trim().to_string();
+        if gh_token.is_empty() {
+            Err("Doesn't look like you have a valid token. Run `gh auth login`.")
+        } else {
+            Ok(gh_token)
+        }
+    }
+}
+
+fn pr_info_from_response(
+    response_data: matching_pull_request::matching_pull_request::ResponseData,
+) -> Vec<matching_pull_request::matching_pull_request::PrInfo> {
+    response_data.search.nodes.map(|node| {
+        let maybe_prs = node.into_iter().map(|p| {
+            p.unwrap()
+        });
+
+        maybe_prs.filter_map(|maybe_pr| {
+            if let matching_pull_request::matching_pull_request::PrSearchResultNodes::PullRequest(info) = maybe_pr {
+                Some(info)
+            } else {
+                None
+            }
+        }).collect()
+    }).unwrap_or_default()
+}

--- a/xtask/src/commands/changeset/mod.rs
+++ b/xtask/src/commands/changeset/mod.rs
@@ -36,7 +36,7 @@ use serde::Serialize;
 use std::{fmt, fs, path::PathBuf, slice::Iter, str::FromStr};
 use structopt::StructOpt;
 use tinytemplate::{format_unescaped, TinyTemplate};
-use xtask::*;
+use xtask::PKG_PROJECT_ROOT;
 
 #[derive(Serialize)]
 struct TemplateResource {

--- a/xtask/src/commands/changeset/mod.rs
+++ b/xtask/src/commands/changeset/mod.rs
@@ -251,11 +251,9 @@ impl Create {
                         .items(&["Branch Name", "Random Name"])
                         .interact_on_opt(&Term::stderr())?
                         .expect("no naming convention was selected");
-                    if selection == 0 {
-                        true
-                    } else {
-                        false
-                    }
+
+                    // Match if the first index was "Branch Name" (from `items`)
+                    selection == 0
                 };
 
                 let branch_name: Option<String> = match git2::Repository::open_from_env() {

--- a/xtask/src/commands/changeset/scalars.rs
+++ b/xtask/src/commands/changeset/scalars.rs
@@ -1,0 +1,3 @@
+/// The GitHub API uses a Scalar called URI.  I promise it's still
+/// just a String.
+pub(crate) type URI = String;

--- a/xtask/src/commands/mod.rs
+++ b/xtask/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod all;
+pub(crate) mod changeset;
 pub(crate) mod compliance;
 pub(crate) mod dist;
 pub(crate) mod lint;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -23,6 +23,10 @@ struct Xtask {
 pub enum Command {
     /// Locally run all the checks the CI will perform.
     All(commands::All),
+
+    /// Produce or consume changesets
+    Changeset(commands::changeset::Command),
+
     /// Check the code for licence and security compliance.
     CheckCompliance(commands::Compliance),
 
@@ -46,6 +50,7 @@ impl Xtask {
     pub fn run(&self) -> Result<()> {
         match &self.command {
             Command::All(command) => command.run(),
+            Command::Changeset(command) => command.run(),
             Command::CheckCompliance(command) => command.run(),
             Command::Dist(command) => command.run(),
             Command::Lint(command) => command.run(),


### PR DESCRIPTION
This follows up on Phase 1 of the project I started in #2534 by bringing along a tool that lets one stub out the nessary changeset file.

This stubbing takes place through the use of a new command:

    cargo xtask changeset create

There are no required arguments to pass, though it's possible to specify some arguments that will shortcut interactive prompts.  For example, the use of the `--class <class>` (where `<class>` is one of `feat`, `maint`, etc.) will skip the interactive prompt asking for precisely that.

In most cases, the prompt has sensible defaults.  Additionally, the tool will attempt to pre-populate the changeset entry with information by matching the branch name the developer is currently working on against any PRs from that branch on GitHub which have a pull request open already.

This means that a very practical work-flow for using this command is to:

- Develop a change
- Push up a PR _without_ a changeset
- Run `cargo xtask changeset create` and follow the prompts
- Add and commit the resulting file in the `.changesets/` directory.
- Push that up to GitHub on the same branch
