### PR TITLE
Turn off FTV1 for default integration test

### DIFF
--- a/.changesets/maint_pixel_the_cat.md
+++ b/.changesets/maint_pixel_the_cat.md
@@ -1,0 +1,7 @@
+### Fix flaky tracing integration test ([Issue #2548](https://github.com/apollographql/router/issues/2548))
+
+Disable FTV1 from test so that consistent results are generated.
+
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/2549
+
+

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -881,7 +881,17 @@ async fn http_query_rust(
 async fn query_rust(
     request: supergraph::Request,
 ) -> (apollo_router::graphql::Response, CountingServiceRegistry) {
-    query_rust_with_config(request, serde_json::json!({})).await
+    query_rust_with_config(
+        request,
+        serde_json::json!({
+            "telemetry":{
+              "apollo": {
+                    "field_level_instrumentation_sampler": "always_off"
+                }
+            }
+        }),
+    )
+    .await
 }
 
 async fn http_query_rust_with_config(


### PR DESCRIPTION
- Fix #2548

As FTV1 is only requested a certain percentage of times this was causing sporadic failures in CI.
Disable FTV1 in this test.

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] ~~Documentation[^2] completed~~
- [ ] ~~Performance impact assessed and acceptable~~
- Tests added and passing[^3]
    - [ ] ~~Unit Tests~~
    - [ ] ~~Integration Tests~~
    - [ ] ~~Manual Tests~~

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
