### PR TITLE
Run rustfmt on xtask too

### DIFF
--- a/.changesets/maint_simon_xtask_fmt.md
+++ b/.changesets/maint_simon_xtask_fmt.md
@@ -1,0 +1,7 @@
+### Run rustfmt on xtask too ([Issue #2557](https://github.com/apollographql/router/issues/2557))
+
+`xtask` which runs `cargo fmt --all` which reformats of Rust code in all crates of the workspace. However the code of xtask itself is a separate workspace. In order for it to be formatted with the same configuration, running a second `cargo` command is required. This adds that second command, and applies the corresponding formatting.
+
+Fixes https://github.com/apollographql/router/issues/2557
+
+By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/2561

--- a/xtask/src/commands/changeset/matching_pull_request.rs
+++ b/xtask/src/commands/changeset/matching_pull_request.rs
@@ -17,8 +17,10 @@ pub mod matching_pull_request {
     use std::result::Result;
     pub const OPERATION_NAME: &str = "MatchingPullRequest";
     pub const QUERY : & str = "# This operation is used to generate Rust code which lives in a file directly\n# next to this with the same name but a `.rs` extension.  For instructions on\n# how to generate the code, see the top of `./mod.rs`.\nfragment PrInfo on PullRequest {\n  url\n  number\n  author {\n    __typename\n    login\n  }\n  title\n  closingIssuesReferences(last: 4) {\n    nodes {\n      url\n      number\n      repository {\n        nameWithOwner\n      }\n    }\n  }\n  body\n}\nfragment PrSearchResult on SearchResultItemConnection {\n  issueCount\n  nodes {\n    __typename\n    ...PrInfo\n  }\n }\n\nquery MatchingPullRequest($search: String!) {\n  search(\n    type: ISSUE\n    query: $search\n    first: 1\n  ) {\n    ...PrSearchResult\n  }\n}\n" ;
+    use serde::Deserialize;
+    use serde::Serialize;
+
     use super::*;
-    use serde::{Deserialize, Serialize};
     #[allow(dead_code)]
     type Boolean = bool;
     #[allow(dead_code)]

--- a/xtask/src/commands/changeset/mod.rs
+++ b/xtask/src/commands/changeset/mod.rs
@@ -23,19 +23,30 @@
 mod matching_pull_request;
 mod scalars;
 
+use std::fmt;
+use std::fs;
+use std::path::PathBuf;
+use std::str::FromStr;
+
 use ::reqwest::Client;
 use anyhow::Result;
 use console::style;
-use dialoguer::{console::Term, theme::ColorfulTheme, Confirm, Editor, Input, Select};
+use dialoguer::console::Term;
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::Confirm;
+use dialoguer::Editor;
+use dialoguer::Input;
+use dialoguer::Select;
 use git2;
 use itertools::Itertools;
-use matching_pull_request::matching_pull_request::{ResponseData,Variables};
+use matching_pull_request::matching_pull_request::ResponseData;
+use matching_pull_request::matching_pull_request::Variables;
 use matching_pull_request::MatchingPullRequest;
 use memorable_wordlist;
 use serde::Serialize;
-use std::{fmt, fs, path::PathBuf, str::FromStr};
 use structopt::StructOpt;
-use tinytemplate::{format_unescaped, TinyTemplate};
+use tinytemplate::format_unescaped;
+use tinytemplate::TinyTemplate;
 use xtask::PKG_PROJECT_ROOT;
 
 #[derive(Serialize)]
@@ -109,13 +120,13 @@ impl Classification {
     /// Defines the ordering that eventually appears in the emitted CHANGELOG
     /// and the order options appear in the TUI.
     const ORDERED_ALL: &'static [Self] = &[
-            Classification::Breaking,
-            Classification::Feature,
-            Classification::Fix,
-            Classification::Configuration,
-            Classification::Maintenance,
-            Classification::Documentation,
-            Classification::Experimental,
+        Classification::Breaking,
+        Classification::Feature,
+        Classification::Fix,
+        Classification::Configuration,
+        Classification::Maintenance,
+        Classification::Documentation,
+        Classification::Experimental,
     ];
 }
 

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -17,8 +17,11 @@ const RUSTFMT_CONFIG: &[&str] = &["imports_granularity=Item", "group_imports=Std
 impl Lint {
     pub fn run(&self) -> Result<()> {
         if self.fmt {
-            let status = Self::fmt_command()?.status()?;
-            ensure!(status.success(), "cargo fmt check failed");
+            let [mut command_1, mut command_2] = Self::fmt_commands()?;
+            let status = command_1.status()?;
+            ensure!(status.success(), "cargo fmt failed");
+            let status = command_2.status()?;
+            ensure!(status.success(), "cargo fmt failed");
             Ok(())
         } else {
             self.run_common(Self::check_fmt)
@@ -30,7 +33,10 @@ impl Lint {
             if Self::check_fmt().is_err() {
                 // cargo fmt check failed, this means there is some formatting to do
                 // given this task is running locally, let's do it and let our user know
-                let status = Self::fmt_command()?.status()?;
+                let [mut command_1, mut command_2] = Self::fmt_commands()?;
+                let status = command_1.status()?;
+                ensure!(status.success(), "cargo fmt failed");
+                let status = command_2.status()?;
                 ensure!(status.success(), "cargo fmt failed");
                 eprintln!(
                     "🧹 cargo fmt job is complete 🧹\n\
@@ -49,20 +55,22 @@ impl Lint {
     }
 
     fn check_fmt() -> Result<()> {
-        let status = Self::fmt_command()?.arg("--check").status()?;
+        let [mut command_1, mut command_2] = Self::fmt_commands()?;
+        let status = command_1.arg("--check").status()?;
+        ensure!(status.success(), "cargo fmt check failed");
+        let status = command_2.arg("--check").status()?;
         ensure!(status.success(), "cargo fmt check failed");
         Ok(())
     }
 
-    fn fmt_command() -> Result<Command> {
-        let mut command = Command::new(which::which("cargo")?);
-        command.current_dir(&*PKG_PROJECT_ROOT).args([
-            "fmt",
-            "--all",
-            "--",
-            "--config",
-            &RUSTFMT_CONFIG.join(","),
-        ]);
-        Ok(command)
+    fn fmt_commands() -> Result<[Command; 2]> {
+        let cargo = which::which("cargo")?;
+        let args = ["fmt", "--all", "--", "--config", &RUSTFMT_CONFIG.join(",")];
+        let mut command_1 = Command::new(&cargo);
+        let mut command_2 = Command::new(&cargo);
+        let root = &*PKG_PROJECT_ROOT;
+        command_1.args(args).current_dir(root);
+        command_2.args(args).current_dir(root.join("xtask"));
+        Ok([command_1, command_2])
     }
 }

--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -1,10 +1,13 @@
-use anyhow::{anyhow, Error, Result};
+use std::str::FromStr;
+
+use anyhow::anyhow;
+use anyhow::Error;
+use anyhow::Result;
 use cargo_metadata::MetadataCommand;
 use chrono::prelude::Utc;
 use git2::Repository;
 use octorust::types::PullsCreateRequest;
 use octorust::Client;
-use std::str::FromStr;
 use structopt::StructOpt;
 use tap::TapFallible;
 use walkdir::WalkDir;


### PR DESCRIPTION
`xtask` which runs `cargo fmt --all` which reformats of Rust code in all crates of the workspace. However the code of xtask itself is a separate workspace. In order for it to be formatted with the same configuration, running a second `cargo` command is required. This adds that second command, and applies the corresponding formatting.

Fixes https://github.com/apollographql/router/issues/2557

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
