### PR TITLE
Just use a `--notes-file` of `/dev/null` to get the release out

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -612,7 +612,7 @@ jobs:
             cd artifacts && sha1sum *.tar.gz > sha1sums.txt
       - run:
           command: >
-            gh release create $VERSION --notes-file NEXT_CHANGELOG.md --title $VERSION artifacts/*
+            gh release create $VERSION --notes-file /dev/null --title $VERSION artifacts/*
       - setup_remote_docker:
           version: 20.10.11
           docker_layer_caching: true


### PR DESCRIPTION
This merges a change from `main` to the `dev` branch that temporarily disables the use of `NEXT_CHANGELOG.md` for the `gh release create` command that was inadvertently left in `.circleci/config.yml` during the work that occurred in #2534.

The work to track follow-up is captured in https://github.com/apollographql/router/issues/2566.