### PR TITLE
Warn and halt entitlements events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5625,6 +5625,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "pin-project-lite",
+ "slab",
  "tokio",
  "tracing",
 ]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -178,7 +178,7 @@ sys-info = "0.9.1"
 thiserror = "1.0.38"
 tokio = { version = "1.25.0", features = ["full"] }
 tokio-stream = { version = "0.1.11", features = ["sync", "net"] }
-tokio-util = { version = "0.7.4", features = ["net", "codec"] }
+tokio-util = { version = "0.7.4", features = ["net", "codec", "time"] }
 tonic = { version = "0.8.3", features = ["transport", "tls", "tls-roots", "gzip"] }
 tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.3.5", features = [

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -52,8 +52,8 @@ use crate::spec::Schema;
 use crate::state_machine::ListenAddresses;
 use crate::state_machine::StateMachine;
 use crate::uplink::entitlement::Entitlement;
-use crate::uplink::entitlement::EntitlementRequest;
-use crate::uplink::schema::SupergraphSdlQuery;
+use crate::uplink::entitlement_stream::EntitlementRequest;
+use crate::uplink::schema_stream::SupergraphSdlQuery;
 use crate::uplink::stream_from_uplink;
 use crate::uplink::Endpoints;
 
@@ -781,6 +781,12 @@ pub(crate) enum Event {
 
     /// Update entitlement.
     UpdateEntitlement(Entitlement),
+
+    /// The entitlement has entered warn_at has passed.
+    WarnEntitlement,
+
+    /// The entitlement has halt_at has passed.
+    HaltEntitlement,
 
     /// There were no more updates to entitlement.
     NoMoreEntitlement,

--- a/apollo-router/src/uplink/entitlement.rs
+++ b/apollo-router/src/uplink/entitlement.rs
@@ -12,7 +12,6 @@ use std::time::SystemTime;
 
 use buildstructor::Builder;
 use displaydoc::Display;
-use graphql_client::GraphQLQuery;
 use itertools::Itertools;
 use jsonwebtoken::decode;
 use jsonwebtoken::jwk::JwkSet;
@@ -26,83 +25,9 @@ use serde_json::Value;
 use thiserror::Error;
 
 use crate::spec::Schema;
-use crate::uplink::entitlement::entitlement_request::EntitlementRequestRouterEntitlements;
-use crate::uplink::entitlement::entitlement_request::FetchErrorCode;
-use crate::uplink::UplinkRequest;
-use crate::uplink::UplinkResponse;
 use crate::Configuration;
 
 static JWKS: OnceCell<JwkSet> = OnceCell::new();
-
-#[derive(GraphQLQuery)]
-#[graphql(
-    query_path = "src/uplink/entitlement_query.graphql",
-    schema_path = "src/uplink/uplink.graphql",
-    request_derives = "Debug",
-    response_derives = "PartialEq, Debug, Deserialize",
-    deprecated = "warn"
-)]
-pub(crate) struct EntitlementRequest {}
-
-impl From<UplinkRequest> for entitlement_request::Variables {
-    fn from(req: UplinkRequest) -> Self {
-        entitlement_request::Variables {
-            api_key: req.api_key,
-            graph_ref: req.graph_ref,
-            unless_id: req.id,
-        }
-    }
-}
-
-impl From<entitlement_request::ResponseData> for UplinkResponse<Entitlement> {
-    fn from(response: entitlement_request::ResponseData) -> Self {
-        match response.router_entitlements {
-            EntitlementRequestRouterEntitlements::RouterEntitlementsResult(result) => {
-                if let Some(entitlement) = result.entitlement {
-                    match Entitlement::from_str(&entitlement.jwt) {
-                        Ok(entitlement) => UplinkResponse::Result {
-                            response: entitlement,
-                            id: result.id,
-                            // this will truncate the number of seconds to under u64::MAX, which should be
-                            // a large enough delay anyway
-                            delay: result.min_delay_seconds as u64,
-                        },
-                        Err(error) => UplinkResponse::Error {
-                            retry_later: true,
-                            code: "INVALID_ENTITLEMENT".to_string(),
-                            message: error.to_string(),
-                        },
-                    }
-                } else {
-                    UplinkResponse::Result {
-                        response: Entitlement::default(),
-                        id: result.id,
-                        // this will truncate the number of seconds to under u64::MAX, which should be
-                        // a large enough delay anyway
-                        delay: result.min_delay_seconds as u64,
-                    }
-                }
-            }
-            EntitlementRequestRouterEntitlements::Unchanged(response) => {
-                UplinkResponse::Unchanged {
-                    id: Some(response.id),
-                    delay: Some(response.min_delay_seconds as u64),
-                }
-            }
-            EntitlementRequestRouterEntitlements::FetchError(error) => UplinkResponse::Error {
-                retry_later: error.code == FetchErrorCode::RETRY_LATER,
-                code: match error.code {
-                    FetchErrorCode::AUTHENTICATION_FAILED => "AUTHENTICATION_FAILED".to_string(),
-                    FetchErrorCode::ACCESS_DENIED => "ACCESS_DENIED".to_string(),
-                    FetchErrorCode::UNKNOWN_REF => "UNKNOWN_REF".to_string(),
-                    FetchErrorCode::RETRY_LATER => "RETRY_LATER".to_string(),
-                    FetchErrorCode::Other(other) => other,
-                },
-                message: error.message,
-            },
-        }
-    }
-}
 
 #[derive(Error, Display, Debug)]
 pub enum Error {
@@ -114,13 +39,13 @@ pub enum Error {
 }
 
 #[derive(Eq, PartialEq)]
-enum RouterState {
+pub(crate) enum RouterState {
     Startup,
     Running,
 }
 
 #[derive(Debug, Eq, PartialEq)]
-enum EntitlementState {
+pub(crate) enum EntitlementState {
     Oss,
     Entitled,
     Warning,
@@ -128,7 +53,7 @@ enum EntitlementState {
 }
 
 #[derive(Eq, PartialEq)]
-enum Action {
+pub(crate) enum Action {
     PreventStartup,
     PreventReload,
     Warn,
@@ -137,27 +62,27 @@ enum Action {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-enum Audience {
+pub(crate) enum Audience {
     SelfHosted,
     Cloud,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(untagged)]
-enum OneOrMany<T> {
+pub(crate) enum OneOrMany<T> {
     One(T),
     Many(Vec<T>),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub(crate) struct Claims {
-    iss: String,
-    sub: String,
-    aud: OneOrMany<Audience>,
+    pub(crate) iss: String,
+    pub(crate) sub: String,
+    pub(crate) aud: OneOrMany<Audience>,
     #[serde(with = "serde_millis", rename = "warnAt")]
-    warn_at: SystemTime,
+    pub(crate) warn_at: SystemTime,
     #[serde(with = "serde_millis", rename = "haltAt")]
-    halt_at: SystemTime,
+    pub(crate) halt_at: SystemTime,
 }
 
 impl Claims {
@@ -211,10 +136,10 @@ impl EntitlementReport {
 
 /// Entitlement controls availability of certain features of the Router. It must be constructed from a base64 encoded JWT
 /// This API experimental and is subject to change outside of semver.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct Entitlement {
     pub(crate) claims: Option<Claims>,
-    configuration_restrictions: Vec<ConfigurationRestriction>,
+    pub(crate) configuration_restrictions: Vec<ConfigurationRestriction>,
 }
 
 impl Display for Entitlement {
@@ -271,7 +196,7 @@ impl FromStr for Entitlement {
 
 /// An individual check for the router.yaml.
 #[derive(Builder, Clone, Debug, Serialize, Deserialize)]
-struct ConfigurationRestriction {
+pub(crate) struct ConfigurationRestriction {
     name: String,
     path: String,
     value: Value,
@@ -346,7 +271,6 @@ mod test {
     use std::time::SystemTime;
     use std::time::UNIX_EPOCH;
 
-    use futures::stream::StreamExt;
     use insta::assert_snapshot;
     use serde_json::json;
 
@@ -357,10 +281,8 @@ mod test {
     use crate::uplink::entitlement::ConfigurationRestriction;
     use crate::uplink::entitlement::Entitlement;
     use crate::uplink::entitlement::EntitlementReport;
-    use crate::uplink::entitlement::EntitlementRequest;
     use crate::uplink::entitlement::OneOrMany;
     use crate::uplink::entitlement::RouterState;
-    use crate::uplink::stream_from_uplink;
     use crate::Configuration;
 
     // For testing we restrict healthcheck
@@ -528,32 +450,5 @@ mod test {
             "haltAt": 123,
         }))
         .expect("json must deserialize");
-    }
-
-    #[tokio::test]
-    async fn integration_test() {
-        if let (Ok(apollo_key), Ok(apollo_graph_ref)) = (
-            std::env::var("TEST_APOLLO_KEY"),
-            std::env::var("TEST_APOLLO_GRAPH_REF"),
-        ) {
-            let results = stream_from_uplink::<EntitlementRequest, Entitlement>(
-                apollo_key,
-                apollo_graph_ref,
-                None,
-                Duration::from_secs(1),
-                Duration::from_secs(5),
-            )
-            .take(1)
-            .collect::<Vec<_>>()
-            .await;
-
-            assert!(results
-                .get(0)
-                .expect("expected one result")
-                .as_ref()
-                .expect("entitlement should be OK")
-                .claims
-                .is_some())
-        }
     }
 }

--- a/apollo-router/src/uplink/entitlement_stream.rs
+++ b/apollo-router/src/uplink/entitlement_stream.rs
@@ -172,15 +172,21 @@ where
     }
 }
 
+/// This function exists to generate an approximate Instant from a `SystemTime`. We have externally generated unix timestamps that need to be scheduled, but anything time related to scheduling must be an `Instant`.
+/// The generated instant is only approximate.
 fn to_instant(system_time: SystemTime) -> Instant {
     // This is approximate as there is no real conversion between SystemTime and Instant
     let now_instant = Instant::now();
     let now_system_time = SystemTime::now();
-    match now_system_time.duration_since(system_time) {
-        Ok(duration) => now_instant
-            .checked_sub(duration)
+    // system_time is likely to be a time in the future, but may be in the past.
+    match system_time.duration_since(now_system_time) {
+        // system_time was in the future.
+        Ok(duration) => now_instant + duration,
+
+        // system_time was in the past.
+        Err(e) => now_instant
+            .checked_sub(e.duration())
             .expect("system time can always be converted into an instant"),
-        Err(e) => now_instant + e.duration(),
     }
 }
 
@@ -202,6 +208,7 @@ impl<T: Stream<Item = Event>> EventStreamExt for T {}
 mod test {
 
     use std::time::Duration;
+    use std::time::Instant;
     use std::time::SystemTime;
 
     use futures::SinkExt;
@@ -212,6 +219,7 @@ mod test {
     use crate::uplink::entitlement::Claims;
     use crate::uplink::entitlement::Entitlement;
     use crate::uplink::entitlement::OneOrMany;
+    use crate::uplink::entitlement_stream::to_instant;
     use crate::uplink::entitlement_stream::EntitlementRequest;
     use crate::uplink::entitlement_stream::EventStreamExt;
     use crate::uplink::stream_from_uplink;
@@ -241,6 +249,21 @@ mod test {
                 .claims
                 .is_some())
         }
+    }
+
+    #[test]
+    fn test_to_instant() {
+        let now_system_time = SystemTime::now();
+        let now_instant = Instant::now();
+        let future_system_time = now_system_time + Duration::from_secs(1024);
+        let future_instant = to_instant(future_system_time);
+        assert!(future_instant < now_instant + Duration::from_secs(1025));
+        assert!(future_instant > now_instant + Duration::from_secs(1023));
+
+        let past_system_time = now_system_time - Duration::from_secs(1024);
+        let past_instant = to_instant(past_system_time);
+        assert!(past_instant < now_instant - Duration::from_secs(1023));
+        assert!(past_instant > now_instant - Duration::from_secs(1025));
     }
 
     #[tokio::test]

--- a/apollo-router/src/uplink/entitlement_stream.rs
+++ b/apollo-router/src/uplink/entitlement_stream.rs
@@ -262,8 +262,18 @@ mod test {
 
         let past_system_time = now_system_time - Duration::from_secs(1024);
         let past_instant = to_instant(past_system_time);
-        assert!(past_instant < now_instant - Duration::from_secs(1023));
-        assert!(past_instant > now_instant - Duration::from_secs(1025));
+        assert!(
+            past_instant
+                < now_instant
+                    .checked_sub(Duration::from_secs(1023))
+                    .expect("must be able to create instant")
+        );
+        assert!(
+            past_instant
+                > now_instant
+                    .checked_sub(Duration::from_secs(1025))
+                    .expect("must be able to create instant")
+        );
     }
 
     #[tokio::test]

--- a/apollo-router/src/uplink/entitlement_stream.rs
+++ b/apollo-router/src/uplink/entitlement_stream.rs
@@ -1,0 +1,386 @@
+// With regards to ELv2 licensing, this entire file is license key functionality
+
+// tonic does not derive `Eq` for the gRPC message types, which causes a warning from Clippy. The
+// current suggestion is to explicitly allow the lint in the module that imports the protos.
+// Read more: https://github.com/hyperium/tonic/issues/1056
+#![allow(clippy::derive_partial_eq_without_eq)]
+
+use std::pin::Pin;
+use std::str::FromStr;
+use std::task::Context;
+use std::task::Poll;
+use std::time::Instant;
+use std::time::SystemTime;
+
+use displaydoc::Display;
+use futures::Stream;
+use graphql_client::GraphQLQuery;
+use pin_project_lite::pin_project;
+use thiserror::Error;
+use tokio_util::time::DelayQueue;
+
+use crate::router::Event;
+use crate::uplink::entitlement::Entitlement;
+use crate::uplink::entitlement::EntitlementReport;
+use crate::uplink::entitlement_stream::entitlement_request::EntitlementRequestRouterEntitlements;
+use crate::uplink::entitlement_stream::entitlement_request::FetchErrorCode;
+use crate::uplink::UplinkRequest;
+use crate::uplink::UplinkResponse;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    query_path = "src/uplink/entitlement_query.graphql",
+    schema_path = "src/uplink/uplink.graphql",
+    request_derives = "Debug",
+    response_derives = "PartialEq, Debug, Deserialize",
+    deprecated = "warn"
+)]
+pub(crate) struct EntitlementRequest {}
+
+impl From<UplinkRequest> for entitlement_request::Variables {
+    fn from(req: UplinkRequest) -> Self {
+        entitlement_request::Variables {
+            api_key: req.api_key,
+            graph_ref: req.graph_ref,
+            unless_id: req.id,
+        }
+    }
+}
+
+impl From<entitlement_request::ResponseData> for UplinkResponse<Entitlement> {
+    fn from(response: entitlement_request::ResponseData) -> Self {
+        match response.router_entitlements {
+            EntitlementRequestRouterEntitlements::RouterEntitlementsResult(result) => {
+                if let Some(entitlement) = result.entitlement {
+                    match Entitlement::from_str(&entitlement.jwt) {
+                        Ok(entitlement) => UplinkResponse::Result {
+                            response: entitlement,
+                            id: result.id,
+                            // this will truncate the number of seconds to under u64::MAX, which should be
+                            // a large enough delay anyway
+                            delay: result.min_delay_seconds as u64,
+                        },
+                        Err(error) => UplinkResponse::Error {
+                            retry_later: true,
+                            code: "INVALID_ENTITLEMENT".to_string(),
+                            message: error.to_string(),
+                        },
+                    }
+                } else {
+                    UplinkResponse::Result {
+                        response: Entitlement::default(),
+                        id: result.id,
+                        // this will truncate the number of seconds to under u64::MAX, which should be
+                        // a large enough delay anyway
+                        delay: result.min_delay_seconds as u64,
+                    }
+                }
+            }
+            EntitlementRequestRouterEntitlements::Unchanged(response) => {
+                UplinkResponse::Unchanged {
+                    id: Some(response.id),
+                    delay: Some(response.min_delay_seconds as u64),
+                }
+            }
+            EntitlementRequestRouterEntitlements::FetchError(error) => UplinkResponse::Error {
+                retry_later: error.code == FetchErrorCode::RETRY_LATER,
+                code: match error.code {
+                    FetchErrorCode::AUTHENTICATION_FAILED => "AUTHENTICATION_FAILED".to_string(),
+                    FetchErrorCode::ACCESS_DENIED => "ACCESS_DENIED".to_string(),
+                    FetchErrorCode::UNKNOWN_REF => "UNKNOWN_REF".to_string(),
+                    FetchErrorCode::RETRY_LATER => "RETRY_LATER".to_string(),
+                    FetchErrorCode::Other(other) => other,
+                },
+                message: error.message,
+            },
+        }
+    }
+}
+
+#[derive(Error, Display, Debug)]
+pub(crate) enum Error {
+    /// invalid entitlement: {0}
+    InvalidEntitlement(jsonwebtoken::errors::Error),
+
+    /// entitlement violations: {0}
+    EntitlementViolations(EntitlementReport),
+}
+
+pin_project! {
+    /// This stream wrapper will cause check the current entitlement at the point of warn_at or halt_at.
+    /// This means that the state machine can be kept clean, and not have to deal with setting it's own timers and also avoids lots of racy scenarios as entitlement checks are guaranteed to happen after an entitlement update even if they were in the past.
+    struct EntitlementExpander<Upstream>
+    where
+        Upstream: Stream<Item = Event>,
+    {
+        #[pin]
+        checks: DelayQueue<Event>,
+        #[pin]
+        upstream: Upstream,
+    }
+}
+
+impl<Upstream> Stream for EntitlementExpander<Upstream>
+where
+    Upstream: Stream<Item = Event>,
+{
+    type Item = Event;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+        let active_checks = !this.checks.is_empty();
+        match this.checks.poll_expired(cx) {
+            // We have an expired claim that needs checking
+            Poll::Ready(Some(item)) => Poll::Ready(Some(item.into_inner())),
+
+            // No expired claim is ready so go for upstream
+            Poll::Pending | Poll::Ready(None) => {
+                let next = this.upstream.poll_next(cx);
+                match (&next, active_checks) {
+                    // Upstream has a new event with a claim
+                    (
+                        Poll::Ready(Some(Event::UpdateEntitlement(Entitlement {
+                            claims: Some(claim),
+                            ..
+                        }))),
+                        _,
+                    ) => {
+                        // We got a new claim, so clear the previous checks.
+                        this.checks.clear();
+                        // Insert the new checks.
+                        this.checks
+                            .insert_at(Event::WarnEntitlement, (to_instant(claim.warn_at)).into());
+                        this.checks
+                            .insert_at(Event::HaltEntitlement, (to_instant(claim.halt_at)).into());
+                        next
+                    }
+                    // Upstream has a new event with no claim
+                    (Poll::Ready(Some(_)), _) => {
+                        // As we have no claim clear the checks
+                        this.checks.clear();
+                        next
+                    }
+                    // There were still active checks, so go for pending
+                    (Poll::Ready(None), true) => Poll::Pending,
+                    // Upstream is exhausted and there are no checks left
+                    (Poll::Ready(None), false) => Poll::Ready(None),
+                    // Upstream not exhausted
+                    (Poll::Pending, _) => Poll::Pending,
+                }
+            }
+        }
+    }
+}
+
+fn to_instant(system_time: SystemTime) -> Instant {
+    // This is approximate as there is no real conversion between SystemTime and Instant
+    let now_instant = Instant::now();
+    let now_system_time = SystemTime::now();
+    match now_system_time.duration_since(system_time) {
+        Ok(duration) => now_instant
+            .checked_sub(duration)
+            .expect("system time can always be converted into an instant"),
+        Err(e) => now_instant + e.duration(),
+    }
+}
+
+trait EventStreamExt: Stream<Item = Event> {
+    fn expand_entitlements(self) -> EntitlementExpander<Self>
+    where
+        Self: Sized,
+    {
+        EntitlementExpander {
+            checks: Default::default(),
+            upstream: self,
+        }
+    }
+}
+
+impl<T: Stream<Item = Event>> EventStreamExt for T {}
+
+#[cfg(test)]
+mod test {
+
+    use std::time::Duration;
+    use std::time::SystemTime;
+
+    use futures::SinkExt;
+    use futures::StreamExt;
+
+    use crate::router::Event;
+    use crate::uplink::entitlement::Audience;
+    use crate::uplink::entitlement::Claims;
+    use crate::uplink::entitlement::Entitlement;
+    use crate::uplink::entitlement::OneOrMany;
+    use crate::uplink::entitlement_stream::EntitlementRequest;
+    use crate::uplink::entitlement_stream::EventStreamExt;
+    use crate::uplink::stream_from_uplink;
+
+    #[tokio::test]
+    async fn integration_test() {
+        if let (Ok(apollo_key), Ok(apollo_graph_ref)) = (
+            std::env::var("TEST_APOLLO_KEY"),
+            std::env::var("TEST_APOLLO_GRAPH_REF"),
+        ) {
+            let results = stream_from_uplink::<EntitlementRequest, Entitlement>(
+                apollo_key,
+                apollo_graph_ref,
+                None,
+                Duration::from_secs(1),
+                Duration::from_secs(5),
+            )
+            .take(1)
+            .collect::<Vec<_>>()
+            .await;
+
+            assert!(results
+                .get(0)
+                .expect("expected one result")
+                .as_ref()
+                .expect("entitlement should be OK")
+                .claims
+                .is_some())
+        }
+    }
+
+    #[tokio::test]
+    async fn entitlement_expander_claim() {
+        let events_stream = futures::stream::iter(vec![entitlement_with_claim(0, 15)])
+            .expand_entitlements()
+            .map(SimpleEvent::from);
+
+        let events = events_stream.collect::<Vec<_>>().await;
+        assert_eq!(
+            events,
+            &[
+                SimpleEvent::UpdateEntitlement,
+                SimpleEvent::WarnEntitlement,
+                SimpleEvent::HaltEntitlement
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn entitlement_expander_no_claim() {
+        let events_stream = futures::stream::iter(vec![entitlement_with_no_claim()])
+            .expand_entitlements()
+            .map(SimpleEvent::from);
+
+        let events = events_stream.collect::<Vec<_>>().await;
+        assert_eq!(events, &[SimpleEvent::UpdateEntitlement]);
+    }
+
+    #[tokio::test]
+    async fn entitlement_expander_claim_no_claim() {
+        let events_stream = futures::stream::iter(vec![
+            entitlement_with_claim(10, 10),
+            entitlement_with_no_claim(),
+        ])
+        .expand_entitlements()
+        .map(SimpleEvent::from);
+
+        let events = events_stream.collect::<Vec<_>>().await;
+        assert_eq!(
+            events,
+            &[
+                SimpleEvent::UpdateEntitlement,
+                SimpleEvent::UpdateEntitlement
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn entitlement_expander_no_claim_claim() {
+        let events_stream = futures::stream::iter(vec![
+            entitlement_with_no_claim(),
+            entitlement_with_claim(0, 15),
+        ])
+        .expand_entitlements()
+        .map(SimpleEvent::from);
+
+        let events = events_stream.collect::<Vec<_>>().await;
+        assert_eq!(
+            events,
+            &[
+                SimpleEvent::UpdateEntitlement,
+                SimpleEvent::UpdateEntitlement,
+                SimpleEvent::WarnEntitlement,
+                SimpleEvent::HaltEntitlement
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn entitlement_expander_claim_pause_claim() {
+        let (mut tx, rx) = futures::channel::mpsc::channel(10);
+        let events_stream = rx.expand_entitlements().map(SimpleEvent::from);
+
+        tokio::task::spawn(async move {
+            // This simulates a new claim coming in before in between the warning and halt
+            let _ = tx.send(entitlement_with_claim(0, 30)).await;
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            let _ = tx.send(entitlement_with_claim(0, 30)).await;
+        });
+        let events = events_stream.collect::<Vec<_>>().await;
+        assert_eq!(
+            events,
+            &[
+                SimpleEvent::UpdateEntitlement,
+                SimpleEvent::WarnEntitlement,
+                SimpleEvent::UpdateEntitlement,
+                SimpleEvent::WarnEntitlement,
+                SimpleEvent::HaltEntitlement
+            ]
+        );
+    }
+
+    fn entitlement_with_claim(warn_delta: u64, halt_delta: u64) -> Event {
+        let now = SystemTime::now();
+        Event::UpdateEntitlement(Entitlement {
+            claims: Some(Claims {
+                iss: "".to_string(),
+                sub: "".to_string(),
+                aud: OneOrMany::One(Audience::SelfHosted),
+                warn_at: now + Duration::from_millis(warn_delta),
+                halt_at: now + Duration::from_millis(halt_delta),
+            }),
+            configuration_restrictions: vec![],
+        })
+    }
+
+    fn entitlement_with_no_claim() -> Event {
+        Event::UpdateEntitlement(Entitlement {
+            claims: None,
+            configuration_restrictions: vec![],
+        })
+    }
+
+    #[derive(Eq, PartialEq, Debug)]
+    enum SimpleEvent {
+        UpdateConfiguration,
+        NoMoreConfiguration,
+        UpdateSchema,
+        NoMoreSchema,
+        UpdateEntitlement,
+        HaltEntitlement,
+        WarnEntitlement,
+        NoMoreEntitlement,
+        Shutdown,
+    }
+
+    impl From<Event> for SimpleEvent {
+        fn from(value: Event) -> Self {
+            match value {
+                Event::UpdateConfiguration(_) => SimpleEvent::UpdateConfiguration,
+                Event::NoMoreConfiguration => SimpleEvent::NoMoreConfiguration,
+                Event::UpdateSchema(_) => SimpleEvent::UpdateSchema,
+                Event::NoMoreSchema => SimpleEvent::NoMoreSchema,
+                Event::UpdateEntitlement(_) => SimpleEvent::UpdateEntitlement,
+                Event::WarnEntitlement => SimpleEvent::WarnEntitlement,
+                Event::HaltEntitlement => SimpleEvent::HaltEntitlement,
+                Event::NoMoreEntitlement => SimpleEvent::NoMoreEntitlement,
+                Event::Shutdown => SimpleEvent::Shutdown,
+            }
+        }
+    }
+}

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -13,7 +13,9 @@ use url::Url;
 //TODO Remove once everything is hooked up
 #[allow(dead_code)]
 pub(crate) mod entitlement;
-pub(crate) mod schema;
+#[allow(dead_code)]
+pub(crate) mod entitlement_stream;
+pub(crate) mod schema_stream;
 
 const GCP_URL: &str = "https://uplink.api.apollographql.com/graphql";
 const AWS_URL: &str = "https://aws.uplink.api.apollographql.com/graphql";
@@ -259,7 +261,7 @@ mod test {
     use wiremock::ResponseTemplate;
 
     use crate::uplink::entitlement::Entitlement;
-    use crate::uplink::entitlement::EntitlementRequest;
+    use crate::uplink::entitlement_stream::EntitlementRequest;
     use crate::uplink::stream_from_uplink;
     use crate::uplink::Endpoints;
     use crate::uplink::Error;

--- a/apollo-router/src/uplink/schema_stream.rs
+++ b/apollo-router/src/uplink/schema_stream.rs
@@ -7,8 +7,8 @@
 
 use graphql_client::GraphQLQuery;
 
-use crate::uplink::schema::supergraph_sdl_query::FetchErrorCode;
-use crate::uplink::schema::supergraph_sdl_query::SupergraphSdlQueryRouterConfig;
+use crate::uplink::schema_stream::supergraph_sdl_query::FetchErrorCode;
+use crate::uplink::schema_stream::supergraph_sdl_query::SupergraphSdlQueryRouterConfig;
 use crate::uplink::UplinkRequest;
 use crate::uplink::UplinkResponse;
 
@@ -68,7 +68,7 @@ mod test {
 
     use futures::stream::StreamExt;
 
-    use crate::uplink::schema::SupergraphSdlQuery;
+    use crate::uplink::schema_stream::SupergraphSdlQuery;
     use crate::uplink::stream_from_uplink;
 
     #[tokio::test]


### PR DESCRIPTION
Add WarnEntitlement and HaltEntitlement events and EntitlementExpander stream combinator.

When an entitlement event is detected in the stream it registers the warn_at and halt_at times to also generate WarnEntitlement and HaltEntitlement events.

If a subsequent entitlement is detected then existing checks cleared and new checks created if needed.


For reviewers.
* Some code has been moved around, but is unchanged. The body of what needs reviewing is: https://github.com/apollographql/router/pull/2568/files#diff-5f0172e9051bdb6e7cf11dc4b51bdbf1dc516ba0d188f6bdaed117012af8db82R109-R386
<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] ~~Documentation[^2] completed~~
- [ ] ~~Performance impact assessed and acceptable~~
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] ~~Integration Tests~~
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
