### PR TITLE
feat(helm): make terminationGracePeriodSeconds configurable

### DIFF
--- a/.changesets/feat_make_terminationgraceperiodseconds_configurable_in_helm.md
+++ b/.changesets/feat_make_terminationgraceperiodseconds_configurable_in_helm.md
@@ -1,0 +1,7 @@
+### Make terminationGracePeriodSeconds property configurable in the Helm chart
+
+`terminationGracePeriodSeconds` is now configurable on the Deployment object in Helm chart.
+
+This is useful & recommended to adjust if you are changing the default timeout on the router, and should always be a value slightly bigger than the timeout in order to ensure no requests are closed prematurely on shutdown.
+
+By [@Meemaw](https://github.com/Meemaw) in https://github.com/apollographql/router/pull/2582

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -69,6 +69,7 @@ helm show values oci://ghcr.io/apollographql/helm-charts/router
 | podAnnotations | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | priorityClassName | string | `""` |  |
+| terminationGracePeriodSeconds | int | `30` | Sets the [termination grace period](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#hook-handler-execution) for Deployment pods |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | router | object | `{"args":["--hot-reload"],"configuration":{"health_check":{"listen":"0.0.0.0:8088"},"supergraph":{"listen":"0.0.0.0:80"},"telemetry":{"metrics":{"prometheus":{"enabled":false,"listen":"0.0.0.0:9090","path":"/metrics"}}}}}` | See https://www.apollographql.com/docs/router/configuration/overview#configuration-file for yaml structure |

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -144,3 +144,6 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}


### PR DESCRIPTION
*Description here*

Makes the `terminationGracePeriodSeconds` configurable.

This is related to https://github.com/apollographql/router/issues/2539, and is needed to properly shutdown the router without dropping any of the requests.

For example, if router supergraph timeout is 45, then the `terminationGracePeriodSeconds` should be modified accordingly.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
