### PR TITLE
fix(docs): correct cookie forwarding rhai example

### DIFF
--- a/docs/source/configuration/header-propagation.mdx
+++ b/docs/source/configuration/header-propagation.mdx
@@ -241,7 +241,7 @@ fn supergraph_service(service) {
 
 fn subgraph_service(service, subgraph) {
     let store_cookies_from_subgraphs = |response| {
-      if response.headers["set-cookie"] != () {
+      if "set-cookie" in response.headers {
         if response.context["set_cookie_headers"] == () {
           response.context.set_cookie_headers = []
         }

--- a/docs/source/configuration/header-propagation.mdx
+++ b/docs/source/configuration/header-propagation.mdx
@@ -225,7 +225,7 @@ rhai:
 Example Rhai script that collects `set-cookie` headers from subgraphs and merges them into a single client response header.
 
 ```rhai title="./rhai/main.rhai"
-fn router_service(service) {
+fn supergraph_service(service) {
   let add_cookies_to_response = |response| {
     if response.context["set_cookie_headers"]?.len > 0 {
       let cookie = "";
@@ -246,7 +246,7 @@ fn subgraph_service(service, subgraph) {
           response.context.set_cookie_headers = []
         }
 
-        response.context.set_cookie_headers += response.headers["set-cookie"]
+        response.context.set_cookie_headers += response.headers["set-cookie"];
       }
     };
 

--- a/docs/source/configuration/header-propagation.mdx
+++ b/docs/source/configuration/header-propagation.mdx
@@ -228,11 +228,7 @@ Example Rhai script that collects `set-cookie` headers from subgraphs and merges
 fn supergraph_service(service) {
   let add_cookies_to_response = |response| {
     if response.context["set_cookie_headers"]?.len > 0 {
-      let cookie = "";
-      for header in response.context["set_cookie_headers"] {
-        cookie += header + "; ";
-      }
-      response.headers["set-cookie"] = cookie;
+      response.headers["set-cookie"] = response.context["set_cookie_headers"];
     }
   };
 
@@ -240,17 +236,17 @@ fn supergraph_service(service) {
 }
 
 fn subgraph_service(service, subgraph) {
-    let store_cookies_from_subgraphs = |response| {
-      if "set-cookie" in response.headers {
-        if response.context["set_cookie_headers"] == () {
-          response.context.set_cookie_headers = []
-        }
-
-        response.context.set_cookie_headers += response.headers["set-cookie"];
+  let store_cookies_from_subgraphs = |response| {
+    if "set-cookie" in response.headers {
+      if response.context["set_cookie_headers"] == () {
+        response.context.set_cookie_headers = []
       }
-    };
 
-    service.map_response(store_cookies_from_subgraphs);
+      response.context.set_cookie_headers += response.headers.values("set-cookie");
+    }
+  };
+
+  service.map_response(store_cookies_from_subgraphs);
 }
 ```
 


### PR DESCRIPTION
This was previously written for an old version of the router that used `router_service` instead of `subgraph_service`.
