### PR TITLE
chore(renovate): Improve Rust version bumping grouping logic

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -38,6 +38,15 @@
     }
   ],
   "packageRules": [
+    // Don't do `rust` image updates on Dockerfiles since they'll we want them
+    // managed/grouped into the package rule directly after this one.  This
+    // prevents multiple PRs for the same bump, and puts all our Rust version
+    // bumps together.
+    {
+      "matchPackageNames": ["rust"],
+      "matchManagers": ["dockerfile"],
+      "enabled": false
+    },
     {
       // This "rust" name maps to the Docker Hub "rust" image above on account
       // of the `regexManagers[0]` defined above being `datasourceTemplate` = `docker`.

--- a/renovate.json5
+++ b/renovate.json5
@@ -26,7 +26,7 @@
     {
       "fileMatch": [
         "^\\.tool-versions$",
-        "^dockerfiles/diy/dockerfiles/Dockerfile\\.repo$",
+        "(^|/)Dockerfile[^/]*$",
         "^rust-toolchain\\.toml$",
         "^docs/.*?\\.mdx$"
       ],


### PR DESCRIPTION
This follows up on the original https://github.com/apollographql/router/pull/1336 by trying to fix the case of the two Renovate PRs:

* #2588
* #2589

We'll ignore `rust` images for [the `dockerfile` manager](https://docs.renovatebot.com/modules/manager/) since they'll be covered by the annotations that group these together in our Dockerfiles and Docs, etc.