### PR TITLE
fix(telemetry): add missing status attribute

### DIFF
--- a/.changesets/fix_lot_skid_monster_communicate.md
+++ b/.changesets/fix_lot_skid_monster_communicate.md
@@ -1,0 +1,5 @@
+### Add missing `status` attribute on some metrics ([PR #2593](https://github.com/apollographql/router/pull/2593))
+
+When it created a status code 500 we didn't provide the `status` attribute in metrics. Instead of having an empty `status` attribute on your metrics you'll have `status="500"`.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/2593

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -749,7 +749,11 @@ impl Telemetry {
 
                 Ok(SupergraphResponse { context, response })
             }
-            Err(err) => Err(err),
+            Err(err) => {
+                metric_attrs.push(KeyValue::new("status", "500"));
+
+                Err(err)
+            }
         };
 
         // http_requests_total - the total number of HTTP requests received
@@ -982,6 +986,7 @@ impl Telemetry {
                 );
             }
             Err(err) => {
+                metric_attrs.push(KeyValue::new("status", "500"));
                 // Fill attributes from error
                 if let Some(subgraph_attributes_conf) = &*attribute_forward_config {
                     metric_attrs.extend(

--- a/apollo-router/src/plugins/telemetry/snapshots/apollo_router__plugins__telemetry__tests__it_test_prometheus_metrics.snap
+++ b/apollo-router/src/plugins/telemetry/snapshots/apollo_router__plugins__telemetry__tests__it_test_prometheus_metrics.snap
@@ -5,4 +5,4 @@ expression: prom_metrics
 apollo_router_http_request_duration_seconds_count{another_test="my_default_value",error="400 Bad Request",myname="label_value",renamed_value="my_value_set",service_name="apollo-router",status="400"} 1
 apollo_router_http_request_duration_seconds_count{another_test="my_default_value",my_value="2",myname="label_value",renamed_value="my_value_set",service_name="apollo-router",status="200",x_custom="coming_from_header"} 1
 apollo_router_http_request_duration_seconds_count{error="INTERNAL_SERVER_ERROR",my_key="my_custom_attribute_from_context",query_from_request="query { test }",service_name="apollo-router",status="200",subgraph="my_subgraph_name",unknown_data="default_value"} 1
-apollo_router_http_request_duration_seconds_count{message="cannot contact the subgraph",service_name="apollo-router",subgraph="my_subgraph_name_error",subgraph_error_extended_code="SUBREQUEST_HTTP_ERROR"} 1
+apollo_router_http_request_duration_seconds_count{message="cannot contact the subgraph",service_name="apollo-router",status="500",subgraph="my_subgraph_name_error",subgraph_error_extended_code="SUBREQUEST_HTTP_ERROR"} 1


### PR DESCRIPTION
When it created a status code 500 we didn't provide the `status` attribute in metrics. Instead of having an empty `status` attribute on your metrics you'll have `status="500"`.
