### PR TITLE
Remove semver metadata from version requirement

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -159,7 +159,7 @@ reqwest = { version = "0.11.14", default-features = false, features = [
     "json",
     "stream",
 ] }
-router-bridge = "0.1.15+v2.3.1"
+router-bridge = "0.1.15"
 rust-embed="6.4.2"
 rustls = "0.20.8"
 rustls-pemfile = "1.0.2"


### PR DESCRIPTION
Fixes the warning:

> version requirement `0.1.15+v2.3.1` for dependency `router-bridge` includes semver metadata which will be ignored, removing the metadata is recommended to avoid confusion

A version requirement in `[dependencies]` is not a version number. `0.1.15+v2.3.1` is interpreted as `>=0.1.15, <0.2.0`, same as `0.1.15` would since semver metadata (starting at `+`) is ignored for the purpose of version ordering.

See also https://doc.rust-lang.org/cargo/reference/resolver.html#version-metadata

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
