### PR TITLE
Support for UUID and Unix timestamp functions in Rhai

### DIFF
--- a/.changesets/feat_uuid_unix_timestamp_rhai_functions.md
+++ b/.changesets/feat_uuid_unix_timestamp_rhai_functions.md
@@ -1,0 +1,11 @@
+### Support for UUID and Unix timestamp functions in Rhai 
+
+*Description*
+
+When building Rhai scripts, it's often that you'll need to add headers that either uniquely identify a request, or append timestamp information for processing information later, such as crafting a trace header or otherwise. 
+
+While the default `timestamp()` and similar functions (e.g. `apollo_start`) can be used for a somewhat similar function, it also isn't able to be translated into an epoch. As a result, it doesn't acutely address the asks we've heard from users.
+
+This adds a `uuid()` and `unix_now()` function to obtain a UUID and Unix timestamp, respectively.
+
+By [@lleadbet](https://github.com/lleadbet) in https://github.com/apollographql/router/pull/2617

--- a/.changesets/feat_uuid_unix_timestamp_rhai_functions.md
+++ b/.changesets/feat_uuid_unix_timestamp_rhai_functions.md
@@ -6,6 +6,6 @@ When building Rhai scripts, it's often that you'll need to add headers that eith
 
 While the default `timestamp()` and similar functions (e.g. `apollo_start`) can be used for a somewhat similar function, it also isn't able to be translated into an epoch. As a result, it doesn't acutely address the asks we've heard from users.
 
-This adds a `uuid()` and `unix_now()` function to obtain a UUID and Unix timestamp, respectively.
+This adds a `uuid_v4()` and `unix_now()` function to obtain a UUID and Unix timestamp, respectively.
 
 By [@lleadbet](https://github.com/lleadbet) in https://github.com/apollographql/router/pull/2617

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -2237,4 +2237,29 @@ mod tests {
             panic!("error processed incorrectly");
         }
     }
+    #[test]
+    fn it_can_create_unix_now() {
+        let engine = Rhai::new_rhai_engine(None);
+        let st = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("can get system time")
+            .as_secs();
+        let unix_now: u64 = engine
+            .eval(r#"unix_now()"#)
+            .expect("can get unix_now() timestamp");
+        // Always difficult to do timing tests. unix_now() should execute within a second of st,
+        // so...
+        assert!(st <= unix_now && unix_now <= st + 1);
+    }
+
+    #[test]
+    fn it_can_generate_uuid() {
+        let engine = Rhai::new_rhai_engine(None);
+        let uuid_v4_rhai: String = engine.eval(r#"uuid_v4()"#).expect("can get uuid");
+        // attempt to parse back to UUID..
+        let uuid_parsed =
+            Uuid::parse_str(uuid_v4_rhai.as_str()).expect("can parse uuid from string");
+        // finally validate that parsed string equals the returned value
+        assert_eq!(uuid_v4_rhai, uuid_parsed.to_string());
+    }
 }

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
+use std::time::SystemTime;
 
 use arc_swap::ArcSwap;
 use futures::future::ready;
@@ -52,6 +53,7 @@ use tower::util::BoxService;
 use tower::BoxError;
 use tower::ServiceBuilder;
 use tower::ServiceExt;
+use uuid::Uuid;
 
 use crate::error::Error;
 use crate::graphql::Request;
@@ -1607,6 +1609,15 @@ impl Rhai {
             })
             .register_fn("to_string", |x: &mut Value| -> String {
                 format!("{x:?}")
+            })
+            .register_fn("uuid", || -> String {
+                Uuid::new_v4().to_string()
+            })
+            .register_fn("now", ||-> u64 {
+                match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
+                    Ok(v)=> v.as_secs(),
+                    Err(_)=>0
+                }
             })
             .register_fn("to_string", |x: &mut Uri| -> String { format!("{x:?}") })
             // Add query plan getter to execution request

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -1610,6 +1610,7 @@ impl Rhai {
             .register_fn("to_string", |x: &mut Value| -> String {
                 format!("{x:?}")
             })
+            .register_fn("to_string", |x: &mut Uri| -> String { format!("{x:?}") })
             .register_fn("uuid", || -> String {
                 Uuid::new_v4().to_string()
             })
@@ -1619,7 +1620,6 @@ impl Rhai {
                     Err(_)=>0
                 }
             })
-            .register_fn("to_string", |x: &mut Uri| -> String { format!("{x:?}") })
             // Add query plan getter to execution request
             .register_get(
                 "query_plan",

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -1611,7 +1611,7 @@ impl Rhai {
                 format!("{x:?}")
             })
             .register_fn("to_string", |x: &mut Uri| -> String { format!("{x:?}") })
-            .register_fn("uuid", || -> String {
+            .register_fn("uuid_v4", || -> String {
                 Uuid::new_v4().to_string()
             })
             .register_fn("unix_now", ||-> u64 {

--- a/apollo-router/src/plugins/rhai.rs
+++ b/apollo-router/src/plugins/rhai.rs
@@ -1613,7 +1613,7 @@ impl Rhai {
             .register_fn("uuid", || -> String {
                 Uuid::new_v4().to_string()
             })
-            .register_fn("now", ||-> u64 {
+            .register_fn("unix_now", ||-> u64 {
                 match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
                     Ok(v)=> v.as_secs(),
                     Err(_)=>0

--- a/docs/source/customizations/rhai-api.mdx
+++ b/docs/source/customizations/rhai-api.mdx
@@ -208,11 +208,11 @@ fn supergraph_service(service) {
 
 ## Unique IDs (UUID)
 
-Your Rhai customization can use the function `uuid()` to obtain a UUIDv4 ID.
+Your Rhai customization can use the function `uuid_v4()` to obtain a UUIDv4 ID.
  
 ```rhai
 fn supergraph_service(service) {
-    let id = uuid();
+    let id = uuid_v4();
 }
 ```
 

--- a/docs/source/customizations/rhai-api.mdx
+++ b/docs/source/customizations/rhai-api.mdx
@@ -196,6 +196,26 @@ If you wish to get multiple values for a header key, then you must use the `valu
 
 Look at the examples to see how this works in practice.
 
+## Unix timestamp
+
+Your Rhai customization can use the function `unix_now()` to obtain the current Unix timestamp in seconds since the Unix epoch. 
+
+```rhai
+fn supergraph_service(service) {
+    let now = unix_now();
+}
+```
+
+## Unique IDs (UUID)
+
+Your Rhai customization can use the function `uuid()` to obtain a UUIDv4 ID.
+ 
+```rhai
+fn supergraph_service(service) {
+    let id = uuid();
+}
+```
+
 ## `Request` interface
 
 All callback functions registered via `map_request` are passed a `request` object that represents the request sent by the client. This object provides the following fields, any of which a callback can modify in-place (read-write):


### PR DESCRIPTION
*Description*

When building Rhai scripts, it's often that you'll need to add headers that either uniquely identify a request, or append timestamp information for processing information later, such as crafting a trace header or otherwise. 

While the default `timestamp()` and associated functions (e.g. `apollo_start`) can be used for a somewhat similar function, it also isn't able to be translated into an epoch. As a result, it doesn't acutely address the asks we've heard from customers. 

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible
- [x] Documentation completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Notes**

* Unsure on how to measure performance impact; would be happy with information and I can add it
* Unsure how new functions in Rhai are tested, as the existing tests don't seem to have specific unit tests against it. 
* Manually tested locally using a simple Rhai script: 

```rhai
fn supergraph_service(service) {
    print(uuid());
    print(unix_now());
}
```

