### PR TITLE
docs: Update federation version support table (for `main`)

### DIFF
--- a/docs/source/federation-version-support.mdx
+++ b/docs/source/federation-version-support.mdx
@@ -11,7 +11,9 @@ Apollo Federation is an evolving project, and its composition algorithm regularl
 
 ## Support table
 
-The table below shows which version of federation each router release is compiled against. You might encounter issues if your router uses an earlier version of federation than the version that was used to compose its supergraph schema.
+The table below shows which version of federation each router release is compiled against. Make sure that your router's federation version is _at least_ as recent as the version used to compose your supergraph schema.
+
+> **Avoid router versions marked with ⚠️.** These versions include bugs described in the [changelog](https://github.com/apollographql/router/blob/main/CHANGELOG.md).
 
 <table>
     <thead>
@@ -23,7 +25,31 @@ The table below shows which version of federation each router release is compile
     <tbody>
     <tr>
         <td>
-            v1.6.0 and later (<a href="https://github.com/apollographql/router/releases">see latest releases</a>)
+            v1.10.2 and later (<a href="https://github.com/apollographql/router/releases">see latest releases</a>)
+        </td>
+        <td>
+            2.3.1
+        </td>
+    </tr>
+    <tr>
+        <td>
+            ⚠️ v1.10.1
+        </td>
+        <td>
+            2.3.1
+        </td>
+    </tr>
+    <tr>
+        <td>
+            ⚠️ v1.10.0
+        </td>
+        <td>
+            2.3.0
+        </td>
+    </tr>
+    <tr>
+        <td>
+            v1.6.0 - v1.9.0
         </td>
         <td>
             2.2.2
@@ -45,7 +71,20 @@ The table below shows which version of federation each router release is compile
             2.1.3
         </td>
     </tr>
+    </tbody>
+</table>
+
+<ExpansionPanel title="See pre-1.0 versions">
+
+<table>
+    <thead>
     <tr>
+        <th>Router version</th>
+        <th>Federation version</th>
+    </tr>
+    </thead>
+    <tbody>
+          <tr>
         <td>
             v1.0.0-rc.1 and v1.0.0
         </td>
@@ -113,8 +152,10 @@ The table below shows which version of federation each router release is compile
             2.0.0-preview.7
         </td>
     </tr>
-    </tbody>
+  </tbody>
 </table>
+
+</ExpansionPanel>
 
 ## Federation 1 support
 


### PR DESCRIPTION
This applies the same commit from https://github.com/apollographql/router/pull/2618 but directly to `main` so it gets out prior to the next release.
