### PR TITLE
CORS: Give a more meaningful message for users who misconfigured allow_any_origin

### DIFF
--- a/.changesets/maint_scuba_dictionary_gem_rooftop.md
+++ b/.changesets/maint_scuba_dictionary_gem_rooftop.md
@@ -1,0 +1,28 @@
+### CORS: Give a more meaningful message for users who missconfigured allow_any_origin ([PR #2634](https://github.com/apollographql/router/pull/2634))
+
+Allowing any origins in the router configuration is done this way:
+```yaml
+cors:
+  allow_any_origin: true
+```
+
+It is however intuitive for users to try to set it up like so:
+```yaml
+cors:
+  origins:
+    - "*"
+```
+
+Unfortunately, this won't work and the error message was neither comprehensive nor actionnable:
+
+```
+ERROR panicked at 'Wildcard origin (`*`) cannot be passed to `AllowOrigin::list`. Use `AllowOrigin::any()` instead'
+```
+
+This change adds a meaningful error message which will help you successfully set up the router:
+
+```
+Invalid CORS configuration: use `allow_any_origin: true` to set `Access-Control-Allow-Origin: *`
+```
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/2634

--- a/.changesets/maint_scuba_dictionary_gem_rooftop.md
+++ b/.changesets/maint_scuba_dictionary_gem_rooftop.md
@@ -1,4 +1,4 @@
-### CORS: Give a more meaningful message for users who missconfigured allow_any_origin ([PR #2634](https://github.com/apollographql/router/pull/2634))
+### CORS: Give a more meaningful message for users who misconfigured allow_any_origin ([PR #2634](https://github.com/apollographql/router/pull/2634))
 
 Allowing any origins in the router configuration is done this way:
 ```yaml

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -371,6 +371,25 @@ cors:
 }
 
 #[test]
+fn it_doesnt_allow_origins_wildcard() {
+    let cfg = validate_yaml_configuration(
+        r#"
+cors:
+  origins:
+    - "*"
+        "#,
+        Expansion::default().unwrap(),
+        Mode::NoUpgrade,
+    )
+    .expect("should not have resulted in an error");
+    let error = cfg
+        .cors
+        .into_layer()
+        .expect_err("should have resulted in an error");
+    assert_eq!(error, "Invalid CORS configuration: use `allow_any_origin: true` to set `Access-Control-Allow-Origin: *`");
+}
+
+#[test]
 fn validate_project_config_files() {
     std::env::set_var("JAEGER_USERNAME", "username");
     std::env::set_var("JAEGER_PASSWORD", "pass");

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -367,7 +367,7 @@ cors:
         .cors
         .into_layer()
         .expect_err("should have resulted in an error");
-    assert_eq!(error, "Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `Access-Control-Allow-Origin: *`");
+    assert_eq!(error, "Invalid CORS configuration: Cannot combine `Access-Control-Allow-Credentials: true` with `allow_any_origin: true`");
 }
 
 #[test]


### PR DESCRIPTION
Allowing any origins in the router configuration is done this way:

```yaml
cors:
  allow_any_origin: true
```

It is however intuitive for users to try to set it up like so:
```yaml
cors:
  origins:
    - "*"
```

Unfortunately, this won't work and the error message was neither comprehensive nor actionnable:

```
ERROR panicked at 'Wildcard origin (`*`) cannot be passed to `AllowOrigin::list`. Use `AllowOrigin::any()` instead'
```

This change adds a meaningful error message which will help you successfully set up the router:

```
Invalid CORS configuration: use `allow_any_origin: true` to set `Access-Control-Allow-Origin: *`
```
