### PR TITLE
remove requirement for Clone from AsyncCheckpoint

### DIFF
--- a/apollo-router/src/layers/mod.rs
+++ b/apollo-router/src/layers/mod.rs
@@ -138,7 +138,7 @@ pub trait ServiceBuilderExt<L>: Sized {
         async_checkpoint_fn: F,
     ) -> ServiceBuilder<Stack<AsyncCheckpointLayer<S, Fut, Request>, L>>
     where
-        S: Service<Request, Error = BoxError> + Clone + Send + 'static,
+        S: Service<Request, Error = BoxError> + Send + 'static,
         Fut: Future<
             Output = Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>,
         >,

--- a/apollo-router/src/plugins/authentication.rs
+++ b/apollo-router/src/plugins/authentication.rs
@@ -698,7 +698,7 @@ impl Plugin for AuthenticationPlugin {
                     }
                 }
             })
-            .buffered()
+            // .buffered()
             .service(service)
         .boxed()
     }


### PR DESCRIPTION
DRAFT PR. WHAT DO PEOPLE THINK ABOUT THE BROAD APPROACH?

A REAL PR WOULD BE NEATER. I'M JUST DOING SOME QUICK TO ILLUSTRATE THE APPROACH.

I was thinking about things a bit overnight in particular, about the fact that Geoffroy had re-engineered the router plugin pipeline some time ago so that we create the service fresh for each request.

That made me then think, why do we need Clone (and hence buffers) in AsyncCheckpoint?

This commit is a basically working (two layer tests fail and would need to be addressed) removal of Clone from AsyncCheckpoint. We could probably do this to other services which currently require Clone and maybe no longer do. If we do that we can probably completely remove the need for "Buffer" from the plugin codebase.

The really nice feature is that I think AsynCheckpoint is a popular piece of functionality in customer  plugins, so this could be a really nice way of improving reliability (by avoiding Buffer).

Fixes #issue_number

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
