### PR TITLE
Fix default tracing service name.

### DIFF
--- a/.changesets/fix_bryn_service_name_default.md
+++ b/.changesets/fix_bryn_service_name_default.md
@@ -1,0 +1,9 @@
+### Fix tracing default service name ([Issue #2641](https://github.com/apollographql/router/issues/2641))
+
+The default tracing service name should be `router`. At some point expansion by defaults was changed, which has lead to the default being `${env.OTEL_SERVICE_NAME:-router}`.
+
+This new default was expanded, and the resulting service name in tracing tools is unpleasant.
+
+`telemetry.tracing.trace_config.service_name` is now defaulted to `router` again.
+
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/2642

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -4153,7 +4153,7 @@ expression: "&schema"
                 },
                 "service_name": {
                   "description": "The trace service name",
-                  "default": "${env.OTEL_SERVICE_NAME:-router}",
+                  "default": "router",
                   "type": "string"
                 },
                 "service_namespace": {

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -340,8 +340,8 @@ fn default_sampler() -> SamplerOption {
 impl Default for Trace {
     fn default() -> Self {
         Self {
-            service_name: default_service_name(),
-            service_namespace: default_service_namespace(),
+            service_name: "router".to_string(),
+            service_namespace: Default::default(),
             sampler: default_sampler(),
             parent_based_sampler: default_parent_based_sampler(),
             max_events_per_span: default_max_events_per_span(),
@@ -354,12 +354,6 @@ impl Default for Trace {
     }
 }
 
-fn default_service_name() -> String {
-    "${env.OTEL_SERVICE_NAME:-router}".to_string()
-}
-fn default_service_namespace() -> String {
-    "".to_string()
-}
 fn default_max_events_per_span() -> u32 {
     SpanLimits::default().max_events_per_span
 }


### PR DESCRIPTION
Fixes #2641

The default tracing service name should be `router`. At some point expansion by defaults was changed, which has lead to the default being `${env.OTEL_SERVICE_NAME:-router}`.

This new default was expanded, and the resulting service name in tracing tools is unpleasant.

`telemetry.tracing.trace_config.service_name` is now defaulted to `router` again.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] ~~Documentation[^2] completed~~
- [ ] ~~Performance impact assessed and acceptable~~
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] ~~Integration Tests~~
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
