### PR TITLE
chore: Remove `triage` labels from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ['triage', 'raised by user']
+labels: ['raised by user']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: ['triage', 'raised by user']
+labels: ['raised by user']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/improvement.md
+++ b/.github/ISSUE_TEMPLATE/improvement.md
@@ -2,7 +2,7 @@
 name: Improvement
 about: Improve the project without adding new features
 title: ''
-labels: ['triage', 'raised by user']
+labels: ['raised by user']
 assignees: ''
 
 ---


### PR DESCRIPTION
Removes the default `triage` label applied to the issues that are opened on this repo.

No changelog for this one, but this doesn't seem like necessary labeling anymore, to me.

Thoughts?