### PR TITLE
make argument parsing optional in Executable

### DIFF
--- a/.changesets/fix_lasso_howl_conductor_crop.md
+++ b/.changesets/fix_lasso_howl_conductor_crop.md
@@ -1,0 +1,5 @@
+### make argument parsing optional in the `Executable` builder ([PR #2666](https://github.com/apollographql/router/pull/2666))
+
+The `Executable` builder was parsing command line arguments, which was causing issues when used as part of a larger application with its own set of flags, that would not be recognized by the router. This allows parsing the arguments separately, then passing the required ones to the `Executable` builder directly. The default behaviour is still parsing from inside the builder.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2666

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -129,7 +129,7 @@ enum ConfigSubcommand {
 #[derive(Parser, Debug)]
 #[clap(name = "router", about = "Apollo federation router")]
 #[command(disable_version_flag(true))]
-pub(crate) struct Opt {
+pub struct Opt {
     /// Log level (off|error|warn|info|debug|trace).
     #[clap(
         long = "log",
@@ -340,8 +340,9 @@ impl Executable {
         schema: Option<SchemaSource>,
         entitlement: Option<EntitlementSource>,
         config: Option<ConfigurationSource>,
+        cli_args: Option<Opt>,
     ) -> Result<()> {
-        let opt = Opt::parse();
+        let opt = cli_args.unwrap_or_else(Opt::parse);
 
         if opt.version {
             println!("{}", std::env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
if the Executable builder is used, it should not try to parse command line arguments itself, because the wrapping application may come with its own set of arguments.
With this change, it is possible to parse command line arguments before building the Executable, passing the required parameters to the builder. And the default behaviour is still to parse them directly so this is not a breaking change.
The main API change here is exposing the `Opt` struct, and adding a method to the builder
