### PR TITLE
Use the fred Redis client

### DIFF
--- a/.changesets/maint_geal_redis_fred.md
+++ b/.changesets/maint_geal_redis_fred.md
@@ -1,5 +1,5 @@
 ### Use the `fred` Redis client ([Issue #2623](https://github.com/apollographql/router/issues/2623))
 
-A description of the fix which stands on its own separate from the title.  It should embrace the use of Markdown to stylize the commentary so it looks great on the GitHub Releases, when shared on social cards, etc.
+Use the `fred` Redis client instead of the `redis` and `redis-cluster-async` crates. This simplifies the code, adds support for TLS in cluster mode, and removes OpenSSL usage.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2689

--- a/.changesets/maint_geal_redis_fred.md
+++ b/.changesets/maint_geal_redis_fred.md
@@ -1,0 +1,5 @@
+### Use the `fred` Redis client ([Issue #2623](https://github.com/apollographql/router/issues/2623))
+
+A description of the fix which stands on its own separate from the title.  It should embrace the use of Markdown to stylize the commentary so it looks great on the GitHub Releases, when shared on social cards, etc.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2689

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -385,6 +385,9 @@ jobs:
           command: |
             rm Cargo.lock
             cargo fetch
+      - run:
+          name: Wait for Redis server
+          command: dockerize -wait tcp://localhost:6379 -timeout 1m
       - test_workspace:
           os: linux_amd
           # schema_generation test skipped because schemars changed its representation of enums:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,7 @@ dependencies = [
  "directories",
  "displaydoc",
  "flate2",
+ "fred",
  "futures",
  "futures-test",
  "graphql_client",
@@ -203,7 +204,7 @@ dependencies = [
  "hex",
  "http",
  "http-body",
- "humantime",
+ "humantime 2.1.0",
  "humantime-serde",
  "hyper",
  "hyper-rustls",
@@ -243,8 +244,6 @@ dependencies = [
  "prost-types",
  "proteus",
  "rand 0.8.5",
- "redis",
- "redis_cluster_async",
  "regex",
  "reqwest",
  "rhai",
@@ -352,6 +351,12 @@ name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
+name = "arcstr"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f907281554a3d0312bb7aab855a8e0ef6cbf1614d06de54105039ca8b34460e"
 
 [[package]]
 name = "ascii"
@@ -737,6 +742,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d3a8076e283f3acd27400535992edb3ba4b5bb72f8891ad8fbe7932a7d4b9"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "cargo-scaffold"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -917,20 +932,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "combine"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
-dependencies = [
- "bytes",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
 name = "compose-your-graphql-router"
 version = "0.1.0"
 dependencies = [
@@ -1018,7 +1019,7 @@ dependencies = [
  "crossbeam-utils",
  "futures",
  "hdrhistogram",
- "humantime",
+ "humantime 2.1.0",
  "prost-types",
  "serde",
  "serde_json",
@@ -1082,6 +1083,12 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
 
 [[package]]
 name = "cookies-to-headers"
@@ -1535,7 +1542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef0ed82b765c2ab79fb48e4bf2c95bd583202f4078a702bc714cc6e6f3ca80c3"
 dependencies = [
  "dw-sys",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -1622,11 +1629,24 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "humantime",
+ "humantime 2.1.0",
  "is-terminal",
  "log",
  "regex",
@@ -1779,21 +1799,12 @@ dependencies = [
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1806,12 +1817,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1843,6 +1848,36 @@ name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+
+[[package]]
+name = "fred"
+version = "6.0.0-beta.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d201dfcc95110c0d555fbc91086d5efe5c00b1bf9137e1972274dddd8c97c730"
+dependencies = [
+ "arc-swap",
+ "arcstr",
+ "async-trait",
+ "bytes",
+ "bytes-utils",
+ "cfg-if",
+ "float-cmp",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "pretty_env_logger",
+ "rand 0.8.5",
+ "redis-protocol",
+ "rustls-native-certs",
+ "semver 1.0.16",
+ "sha-1",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+]
 
 [[package]]
 name = "fsio"
@@ -2085,7 +2120,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
 dependencies = [
- "combine 3.8.1",
+ "combine",
  "thiserror",
 ]
 
@@ -2213,7 +2248,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha1 0.10.5",
+ "sha1",
 ]
 
 [[package]]
@@ -2390,6 +2425,15 @@ checksum = "02296996cb8796d7c6e3bc2d9211b7802812d36999a51bb754123ead7d37d026"
 
 [[package]]
 name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
+name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
@@ -2400,7 +2444,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
- "humantime",
+ "humantime 2.1.0",
  "serde",
 ]
 
@@ -3146,24 +3190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
-dependencies = [
- "lazy_static",
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nom"
 version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3352,32 +3378,6 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -3768,7 +3768,7 @@ checksum = "984298b75898e30a843e278a9f2452c31e349a073a0ce6fd950a12a74464e065"
 dependencies = [
  "once_cell",
  "pest",
- "sha1 0.10.5",
+ "sha1",
 ]
 
 [[package]]
@@ -3926,6 +3926,16 @@ checksum = "54ff541861505aabf6ea722d2131ee980b8276e10a1297b94e896dd8b621850d"
 dependencies = [
  "predicates-core",
  "termtree",
+]
+
+[[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger 0.7.1",
+ "log",
 ]
 
 [[package]]
@@ -4093,6 +4103,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4195,40 +4211,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "redis"
-version = "0.21.7"
+name = "redis-protocol"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152f3863635cbb76b73bc247845781098302c6c9ad2060e1a9a7de56840346b6"
+checksum = "9c31deddf734dc0a39d3112e73490e88b61a05e83e074d211f348404cee4d2c6"
 dependencies = [
- "async-trait",
  "bytes",
- "combine 4.6.6",
- "futures-util",
- "itoa",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "ryu",
- "sha1 0.6.1",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "url",
-]
-
-[[package]]
-name = "redis_cluster_async"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee1556d15936b948e248d5fce3b540c96194fbda59ef11d8fa7a48571fa5ddd"
-dependencies = [
+ "bytes-utils",
+ "cookie-factory",
  "crc16",
- "futures",
  "log",
- "pin-project-lite",
- "rand 0.8.5",
- "redis",
- "tokio",
+ "nom",
 ]
 
 [[package]]
@@ -4483,7 +4476,7 @@ version = "0.0.0"
 dependencies = [
  "apollo-parser 0.4.1",
  "apollo-smith",
- "env_logger",
+ "env_logger 0.10.0",
  "libfuzzer-sys",
  "log",
  "reqwest",
@@ -4929,12 +4922,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.6.1"
+name = "sha-1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
- "sha1_smol",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -4947,12 +4942,6 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -5561,16 +5550,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "prost-types",
  "proteus",
  "rand 0.8.5",
+ "redis",
  "regex",
  "reqwest",
  "rhai",
@@ -929,6 +930,20 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2120,7 +2135,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
 dependencies = [
- "combine",
+ "combine 3.8.1",
  "thiserror",
 ]
 
@@ -2248,7 +2263,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.5",
 ]
 
 [[package]]
@@ -3768,7 +3783,7 @@ checksum = "984298b75898e30a843e278a9f2452c31e349a073a0ce6fd950a12a74464e065"
 dependencies = [
  "once_cell",
  "pest",
- "sha1",
+ "sha1 0.10.5",
 ]
 
 [[package]]
@@ -4208,6 +4223,26 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
  "num_cpus",
+]
+
+[[package]]
+name = "redis"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152f3863635cbb76b73bc247845781098302c6c9ad2060e1a9a7de56840346b6"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "combine 4.6.6",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1 0.6.1",
+ "tokio",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -4934,6 +4969,15 @@ dependencies = [
 
 [[package]]
 name = "sha1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
+]
+
+[[package]]
+name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
@@ -4942,6 +4986,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -76,6 +76,7 @@ diff = "0.1.13"
 directories = "4.0.1"
 displaydoc = "0.2"
 flate2 = "1.0.25"
+fred = { version = "6.0.0-beta.2", features = ["enable-rustls"] }
 futures = { version = "0.3.26", features = ["thread-pool"] }
 graphql_client = "0.11.0"
 hex = "0.4.3"
@@ -201,7 +202,6 @@ uuid = { version = "1.2.2", features = ["serde", "v4"] }
 yaml-rust = "0.4.5"
 wsl = "0.1.0"
 tokio-rustls = "0.23.4"
-fred = { version = "6.0.0-beta.2", features = ["enable-rustls"] }
 
 [target.'cfg(macos)'.dependencies]
 uname = "0.1.1"
@@ -210,6 +210,7 @@ uname = "0.1.1"
 uname = "0.1.1"
 
 [dev-dependencies]
+fred = "6.0.0-beta.2"
 futures-test = "0.3.26"
 insta = { version = "1.26.0", features = ["json", "redactions", "yaml"] }
 introspector-gadget = "0.2.0"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -211,6 +211,7 @@ uname = "0.1.1"
 
 [dev-dependencies]
 fred = "6.0.0-beta.2"
+redis = { version = "0.21.7", features = ["tokio-comp"] }
 futures-test = "0.3.26"
 insta = { version = "1.26.0", features = ["json", "redactions", "yaml"] }
 introspector-gadget = "0.2.0"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -149,8 +149,6 @@ prost-types = "0.11.7"
 proteus = "0.5.0"
 rand = "0.8.5"
 rhai = { version = "1.12.0", features = ["sync", "serde", "internals"] }
-redis = { version = "0.21.7", features = ["tokio-comp", "tls", "tokio-native-tls-comp"] }
-redis_cluster_async = { version = "0.7.2", features = [ "tls" ] }
 regex = "1.6.0"
 reqwest = { version = "0.11.14", default-features = false, features = [
     "rustls-tls",
@@ -203,6 +201,7 @@ uuid = { version = "1.2.2", features = ["serde", "v4"] }
 yaml-rust = "0.4.5"
 wsl = "0.1.0"
 tokio-rustls = "0.23.4"
+fred = { version = "6.0.0-beta.2", features = ["enable-rustls"] }
 
 [target.'cfg(macos)'.dependencies]
 uname = "0.1.1"

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -33,7 +33,7 @@ where
 {
     pub(crate) async fn with_capacity(
         capacity: NonZeroUsize,
-        redis_urls: Option<Vec<String>>,
+        redis_urls: Option<Vec<url::Url>>,
         caller: &str,
     ) -> Self {
         Self {

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -59,7 +59,7 @@ where
 {
     pub(crate) async fn new(
         max_capacity: NonZeroUsize,
-        _redis_urls: Option<Vec<String>>,
+        _redis_urls: Option<Vec<url::Url>>,
         caller: &str,
     ) -> Self {
         Self {

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -627,7 +627,7 @@ impl Default for InMemoryCache {
 /// Redis cache configuration
 pub(crate) struct RedisCache {
     /// List of URLs to the Redis cluster
-    pub(crate) urls: Vec<String>,
+    pub(crate) urls: Vec<url::Url>,
 }
 
 /// TLS related configuration options.

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -904,7 +904,8 @@ expression: "&schema"
                       "description": "List of URLs to the Redis cluster",
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uri"
                       }
                     }
                   },
@@ -1041,7 +1042,8 @@ expression: "&schema"
                       "description": "List of URLs to the Redis cluster",
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "type": "string",
+                        "format": "uri"
                       }
                     }
                   },
@@ -4514,7 +4516,8 @@ expression: "&schema"
               "description": "List of URLs to the Redis cluster",
               "type": "array",
               "items": {
-                "type": "string"
+                "type": "string",
+                "format": "uri"
               }
             }
           },

--- a/apollo-router/tests/redis_test.rs
+++ b/apollo-router/tests/redis_test.rs
@@ -3,6 +3,8 @@ mod test {
     use apollo_router::services::execution::QueryPlan;
     use apollo_router::services::router;
     use apollo_router::services::supergraph;
+    use fred::prelude::ClientLike;
+    use fred::prelude::KeysInterface;
     use futures::StreamExt;
     use http::Method;
     use redis::AsyncCommands;
@@ -15,16 +17,36 @@ mod test {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn query_planner() -> Result<(), BoxError> {
-        let client = Client::open("redis://127.0.0.1:6379").expect("opening ClusterClient");
-        let mut connection = client
-            .get_async_connection()
-            .await
-            .expect("got redis connection");
+        let client = fred::prelude::RedisClient::new(
+            fred::types::RedisConfig::from_url("redis://redis:6379").unwrap(),
+            None,
+            None,
+        );
+        // spawn tasks that listen for connection close or reconnect events
+        let mut error_rx = client.on_error();
+        let mut reconnect_rx = client.on_reconnect();
+        tokio::spawn(async move {
+            while let Ok(error) = error_rx.recv().await {
+                println!("Client disconnected with error: {:?}", error);
+            }
+        });
+        tokio::spawn(async move {
+            while reconnect_rx.recv().await.is_ok() {
+                println!("Redis client reconnected.");
+            }
+        });
 
-        connection
-        .del::<&'static str, ()>("plan\x005abb5fecf7df056396fb90fdf38d430b8c1fec55ec132fde878161608af18b76\x00{ topProducts { name name2:name } }\x00-")
-          .await
-          .unwrap();
+        println!("qp redis wait for connect");
+        tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            client.wait_for_connect(),
+        )
+        .await
+        .unwrap()
+        .expect("opening redis client");
+
+        client
+        .del::<(), &'static str>("plan\x005abb5fecf7df056396fb90fdf38d430b8c1fec55ec132fde878161608af18b76\x00{ topProducts { name name2:name } }\x00-").await.unwrap();
 
         let supergraph = apollo_router::TestHarness::builder()
             .with_subgraph_network_requests()

--- a/apollo-router/tests/redis_test.rs
+++ b/apollo-router/tests/redis_test.rs
@@ -22,6 +22,21 @@ mod test {
             None,
             None,
         );
+        // spawn tasks that listen for connection close or reconnect events
+        let mut error_rx = client.on_error();
+        let mut reconnect_rx = client.on_reconnect();
+        tokio::spawn(async move {
+            while let Ok(error) = error_rx.recv().await {
+                println!("Client disconnected with error: {:?}", error);
+            }
+        });
+        tokio::spawn(async move {
+            while reconnect_rx.recv().await.is_ok() {
+                println!("Redis client reconnected.");
+            }
+        });
+
+        println!("qp redis wait for connect");
         tokio::time::timeout(
             std::time::Duration::from_secs(10),
             client.wait_for_connect(),
@@ -103,12 +118,12 @@ mod test {
         let mut reconnect_rx = client.on_reconnect();
         tokio::spawn(async move {
             while let Ok(error) = error_rx.recv().await {
-                tracing::error!("Client disconnected with error: {:?}", error);
+                println!("Client disconnected with error: {:?}", error);
             }
         });
         tokio::spawn(async move {
             while reconnect_rx.recv().await.is_ok() {
-                tracing::info!("Redis client reconnected.");
+                println!("Redis client reconnected.");
             }
         });
 

--- a/apollo-router/tests/redis_test.rs
+++ b/apollo-router/tests/redis_test.rs
@@ -90,7 +90,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn apq() -> Result<(), BoxError> {
         let client = RedisClient::new(
-            RedisConfig::from_url("redis://127.0.0.1:6379").unwrap(),
+            RedisConfig::from_url("redis://localhost:6379").unwrap(),
             None,
             None,
         );
@@ -110,10 +110,13 @@ mod test {
         });
 
         println!("redis wait for connect");
-        client
-            .wait_for_connect()
-            .await
-            .expect("opening redis client");
+        tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            client.wait_for_connect(),
+        )
+        .await
+        .unwrap()
+        .expect("opening redis client");
         println!("redis connected");
 
         let config = json!({
@@ -124,7 +127,7 @@ mod test {
                             "limit": 2
                         },
                         "redis": {
-                            "urls": ["redis://127.0.0.1:6379"]
+                            "urls": ["redis://localhost:6379"]
                         }
                     }
                 }

--- a/apollo-router/tests/redis_test.rs
+++ b/apollo-router/tests/redis_test.rs
@@ -18,7 +18,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn query_planner() -> Result<(), BoxError> {
         let client = RedisClient::new(
-            RedisConfig::from_url("redis://127.0.0.1:6379").unwrap(),
+            RedisConfig::from_url("redis://redis:6379").unwrap(),
             None,
             None,
         );

--- a/apollo-router/tests/redis_test.rs
+++ b/apollo-router/tests/redis_test.rs
@@ -39,7 +39,7 @@ mod test {
 
         println!("qp redis wait for connect");
         tokio::time::timeout(
-            std::time::Duration::from_secs(10),
+            std::time::Duration::from_secs(60),
             client.wait_for_connect(),
         )
         .await

--- a/apollo-router/tests/redis_test.rs
+++ b/apollo-router/tests/redis_test.rs
@@ -5,6 +5,7 @@ mod test {
     use apollo_router::services::supergraph;
     use fred::prelude::ClientLike;
     use fred::prelude::KeysInterface;
+    use fred::types::ReconnectPolicy;
     use futures::StreamExt;
     use http::Method;
     use redis::AsyncCommands;
@@ -20,7 +21,7 @@ mod test {
         let client = fred::prelude::RedisClient::new(
             fred::types::RedisConfig::from_url("redis://redis:6379").unwrap(),
             None,
-            None,
+            Some(ReconnectPolicy::new_exponential(10, 1, 2000, 10)),
         );
         // spawn tasks that listen for connection close or reconnect events
         let mut error_rx = client.on_error();

--- a/apollo-router/tests/redis_test.rs
+++ b/apollo-router/tests/redis_test.rs
@@ -22,10 +22,13 @@ mod test {
             None,
             None,
         );
-        client
-            .wait_for_connect()
-            .await
-            .expect("opening redis client");
+        tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            client.wait_for_connect(),
+        )
+        .await
+        .unwrap()
+        .expect("opening redis client");
 
         client
         .del::<(), &'static str>("plan\x005abb5fecf7df056396fb90fdf38d430b8c1fec55ec132fde878161608af18b76\x00{ topProducts { name name2:name } }\x00-")

--- a/apollo-router/tests/redis_test.rs
+++ b/apollo-router/tests/redis_test.rs
@@ -75,7 +75,7 @@ mod test {
 
         let _ = supergraph.oneshot(request).await?.next_response().await;
 
-        let s:String = connection
+        let s:String = client
           .get("plan\x005abb5fecf7df056396fb90fdf38d430b8c1fec55ec132fde878161608af18b76\x00{ topProducts { name name2:name } }\x00-")
           .await
           .unwrap();

--- a/apollo-router/tests/redis_test.rs
+++ b/apollo-router/tests/redis_test.rs
@@ -19,7 +19,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn query_planner() -> Result<(), BoxError> {
         let client = fred::prelude::RedisClient::new(
-            fred::types::RedisConfig::from_url("redis://redis:6379").unwrap(),
+            fred::types::RedisConfig::from_url("redis://127.0.0.1:6379").unwrap(),
             None,
             Some(ReconnectPolicy::new_exponential(10, 1, 2000, 10)),
         );


### PR DESCRIPTION
Fix #2623
Fix #2606

This replaces our usage of the `redis` and `redis-cluster-async` crates with `fred`, which comes with support for Redis cluster and rustls out of the box. Rustls support is only available in fred 6.0.0-beta.2 though, not in a stable release.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests
