### PR TITLE
fix: Add content-type header for publishing Datadog metrics

### DIFF
--- a/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
@@ -128,6 +128,7 @@ impl Service<router::Request> for PrometheusService {
             Ok(router::Response {
                 response: http::Response::builder()
                     .status(StatusCode::OK)
+                    .header(http::header::CONTENT_TYPE, "text/plain; version=0.0.4")
                     .body::<hyper::Body>(result.into())
                     .map_err(BoxError::from)?,
                 context: req.context,

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -243,7 +243,7 @@ impl IntegrationTest {
     }
 
     #[allow(dead_code)]
-    pub async fn get_metrics(&self) -> reqwest::Result<String> {
+    pub async fn get_metrics_response(&self) -> reqwest::Result<reqwest::Response> {
         let client = reqwest::Client::new();
 
         let request = client
@@ -253,9 +253,7 @@ impl IntegrationTest {
             .build()
             .unwrap();
 
-        let res = client.execute(request).await?;
-
-        res.text().await
+        client.execute(request).await
     }
 
     #[allow(dead_code)]

--- a/apollo-router/tests/metrics_tests.rs
+++ b/apollo-router/tests/metrics_tests.rs
@@ -22,7 +22,14 @@ async fn test_metrics_reloading() -> Result<(), BoxError> {
 
         // Validate metric headers.
         let metrics_headers = metrics_response.headers();
-        assert!("text/plain; version=0.0.4" == metrics_headers.get(http::header::CONTENT_TYPE).unwrap().to_str().unwrap());
+        assert!(
+            "text/plain; version=0.0.4"
+                == metrics_headers
+                    .get(http::header::CONTENT_TYPE)
+                    .unwrap()
+                    .to_str()
+                    .unwrap()
+        );
 
         // Validate metric request body.
         let metrics = metrics_response.text().await?;

--- a/apollo-router/tests/metrics_tests.rs
+++ b/apollo-router/tests/metrics_tests.rs
@@ -17,7 +17,15 @@ async fn test_metrics_reloading() -> Result<(), BoxError> {
         router.run_query().await;
         router.run_query().await;
 
-        let metrics = router.get_metrics().await.unwrap();
+        // Get Prometheus metrics.
+        let metrics_response = router.get_metrics_response().await.unwrap();
+
+        // Validate metric headers.
+        let metrics_headers = metrics_response.headers();
+        assert!("text/plain; version=0.0.4" == metrics_headers.get(http::header::CONTENT_TYPE).unwrap().to_str().unwrap());
+
+        // Validate metric request body.
+        let metrics = metrics_response.text().await?;
         assert!(metrics.contains(r#"apollo_router_cache_hit_count{kind="query planner",service_name="apollo-router",storage="memory"} 2"#));
         assert!(metrics.contains(r#"apollo_router_cache_miss_count{kind="query planner",service_name="apollo-router",storage="memory"} 1"#));
         assert!(metrics.contains("apollo_router_cache_hit_time"));
@@ -25,6 +33,7 @@ async fn test_metrics_reloading() -> Result<(), BoxError> {
         assert!(metrics.contains("apollo_router_session_count_total"));
         assert!(metrics.contains("apollo_router_session_count_active"));
         assert!(metrics.contains("custom_header=\"test_custom\""));
+
         router.touch_config().await;
         router.assert_reloaded().await;
     }


### PR DESCRIPTION
Add required content-type header for publishing Datadog metrics from Prometheus.

"content-type": text/plain; version=0.0.4

Fixes #2697

After this change the `content-type` header is added:

```
shaunp@IT-USA-VY1069 router % http http://localhost:9090/metrics
HTTP/1.1 200 OK
content-length: 256
content-type: text/plain; version=0.0.4
date: Mon, 27 Feb 2023 23:32:25 GMT

# HELP apollo_router_session_count_total apollo_router_session_count_total
# TYPE apollo_router_session_count_total gauge
apollo_router_session_count_total{listener="http://0.0.0.0:9090",service_namespace="api-platforms",service_name="one-graph-router"} 1
```

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [X] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
