### PR TITLE
Disable all of jaeger_test.rs on non-linux x64

### DIFF
--- a/apollo-router/tests/jaeger_test.rs
+++ b/apollo-router/tests/jaeger_test.rs
@@ -1,3 +1,5 @@
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
 extern crate core;
 
 mod common;
@@ -13,7 +15,6 @@ use tower::BoxError;
 use crate::common::IntegrationTest;
 use crate::common::ValueExt;
 
-#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 #[tokio::test(flavor = "multi_thread")]
 async fn test_jaeger_tracing() -> Result<(), BoxError> {
     let tracer = opentelemetry_jaeger::new_agent_pipeline()


### PR DESCRIPTION
https://github.com/apollographql/router/pull/2673 disabled the only test of `apollo-router/tests/jaeger_test.rs` on platforms other than Linux x64, but left helper functions and other that items that support that test. This resulted in "unused" warnings, making `cargo xtask lint` fail in clippy.

This change the `#[cfg]` attribute to apply to the entire module instead of the test function, making `jaeger_test.rs` an empty file after macro expansion.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
