### PR TITLE
Add tests for per-type metrics

### DIFF
--- a/apollo-router/src/plugins/telemetry/metrics/apollo/duration_histogram.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/duration_histogram.rs
@@ -87,11 +87,21 @@ impl<T: Copy + Default + AddAssign> DurationHistogram<T> {
         }
         self.buckets[bucket] += value;
     }
+
+    pub(crate) fn trim_trailing_zeroes(&mut self)
+    where
+        T: PartialEq,
+    {
+        let zero = T::default();
+        let last_non_zero = self.buckets.iter().rposition(|b| *b != zero).unwrap_or(0);
+        self.buckets.truncate(last_non_zero + 1);
+    }
 }
 
 impl DurationHistogram<u64> {
     /// Convert to the type expected by the Protobuf-generated struct for `repeated sint64`.
-    pub(crate) fn buckets_to_i64(self) -> Vec<i64> {
+    pub(crate) fn buckets_to_i64(mut self) -> Vec<i64> {
+        self.trim_trailing_zeroes();
         // This optimizes to nothing: https://rust.godbolt.org/z/YMh8e55de
         self.buckets.into_iter().map(|x| x as i64).collect()
     }
@@ -102,7 +112,8 @@ impl DurationHistogram<f64> {
     ///
     /// When estimating, rounding to integer values is only done after aggregating in memory
     /// a number data points by summing floating-point values.
-    pub(crate) fn buckets_to_i64(self) -> Vec<i64> {
+    pub(crate) fn buckets_to_i64(mut self) -> Vec<i64> {
+        self.trim_trailing_zeroes();
         self.buckets.into_iter().map(|x| x as i64).collect()
     }
 }
@@ -207,5 +218,18 @@ mod test {
         h1 += h2;
         assert_eq!(h1.buckets, [0, 0, 0, 0, 0, 1, 0, 0, 3, 0, 0, 0, 0, 0, 0, 1]);
         assert_eq!(h1.total, 5);
+    }
+
+    #[test]
+    fn trim() {
+        let mut h = DurationHistogram::new(None);
+        assert_eq!(h.buckets.len(), DEFAULT_SIZE);
+        h.increment_duration(Some(Duration::from_nanos(1500)), 1);
+        h.increment_duration(Some(Duration::from_nanos(2020)), 1);
+        h.increment_duration(Some(Duration::from_nanos(1500)), 1);
+        assert_eq!(h.buckets.len(), DEFAULT_SIZE);
+        h.trim_trailing_zeroes();
+        assert_eq!(h.buckets, [0, 0, 0, 0, 0, 2, 0, 0, 1]);
+        assert_eq!(h.total, 3);
     }
 }

--- a/apollo-router/tests/apollo_reports.rs
+++ b/apollo-router/tests/apollo_reports.rs
@@ -1,4 +1,3 @@
-use std::io::Cursor;
 use std::io::Read;
 use std::sync::Arc;
 use std::time::Duration;
@@ -18,6 +17,8 @@ use flate2::read::GzDecoder;
 use http::header::ACCEPT;
 use once_cell::sync::Lazy;
 use prost::Message;
+use prost_types::Timestamp;
+use proto::reports::trace::Node;
 use serde_json::json;
 use tokio::sync::Mutex;
 use tokio::sync::OnceCell;
@@ -25,6 +26,8 @@ use tower::Service;
 use tower::ServiceExt;
 use tower_http::decompression::DecompressionLayer;
 
+use crate::proto::reports::trace::node::Id::Index;
+use crate::proto::reports::trace::node::Id::ResponseName;
 use crate::proto::reports::Report;
 use crate::proto::reports::Trace;
 
@@ -109,89 +112,7 @@ async fn get_router_service(mocked: bool) -> BoxCloneService {
         .expect("router service must have got created")
 }
 
-fn subgraph_mocks(subgraph: &str) -> subgraph::BoxService {
-    let builder = MockSubgraph::builder();
-    // base64 FTV1 blobs were manually captured from un-mocked responses
-    if subgraph == "products" {
-        let ftv1 = "GgwIqZ34nwYQgKDdjAMiDAipnfifBhDAm6CMA1jDrixy/AFi+QEKC3RvcFByb2R1Y3RzGglbUHJvZHVjdF1A1cQYSKv9HmJEEABiHwoDdXBjGgdTdHJpbmchQPq1I0jxnSRqB1Byb2R1Y3RiHwoEbmFtZRoGU3RyaW5nQPXjJEi1nSVqB1Byb2R1Y3RiRBABYh8KA3VwYxoHU3RyaW5nIUDBmyZIib0magdQcm9kdWN0Yh8KBG5hbWUaBlN0cmluZ0DI8CZI+4YnagdQcm9kdWN0YkQQAmIfCgN1cGMaB1N0cmluZyFAiOMnSJL8J2oHUHJvZHVjdGIfCgRuYW1lGgZTdHJpbmdA95YoSP+tKGoHUHJvZHVjdGoFUXVlcnn5AQAAAAAAAPA/";
-        builder.with_json(
-            json!({"query": "{topProducts{__typename upc name}}"}),
-            json!({
-                "data": {"topProducts": [
-                    {"__typename": "Product", "upc": "1", "name": "Table"},
-                    {"__typename": "Product", "upc": "2", "name": "Couch"},
-                    {"__typename": "Product", "upc": "3", "name": "Chair"}
-                ]},
-                "extensions": {"ftv1": process_ftv1(subgraph, ftv1)}
-            }),
-        )
-    } else if subgraph == "reviews" {
-        let ftv1 = "GgwIqZ34nwYQwJ6htQMiDAipnfifBhDAlae0A1j4mWxynQNimgMKCV9lbnRpdGllcxoKW19FbnRpdHldIUDBjhBIh+4VYqMBEABingEKB3Jldmlld3MaCFtSZXZpZXddQLvDGEichl5iOxAAYjcKBmF1dGhvchoEVXNlckDqjF9IrIdnYhcKAmlkGgNJRCFAttxnSJCAaGoEVXNlcmoGUmV2aWV3YjsQAWI3CgZhdXRob3IaBFVzZXJAqLVhSMiXaGIXCgJpZBoDSUQhQPK2aEiKyGhqBFVzZXJqBlJldmlld2oHUHJvZHVjdGJlEAFiYQoHcmV2aWV3cxoIW1Jldmlld11A2ZYdSOrxYmI7EABiNwoGYXV0aG9yGgRVc2VyQPKiY0j40mhiFwoCaWQaA0lEIUCc9GhIiINpagRVc2VyagZSZXZpZXdqB1Byb2R1Y3RiZRACYmEKB3Jldmlld3MaCFtSZXZpZXddQLX6WEjO2GRiOxAAYjcKBmF1dGhvchoEVXNlckCmhWVI4o1pYhcKAmlkGgNJRCFAyq5pSJi9aWoEVXNlcmoGUmV2aWV3agdQcm9kdWN0agVRdWVyefkBAAAAAAAA8D8=";
-        builder.with_json(
-            json!({
-                "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on Product{reviews{author{__typename id}}}}}",
-                "variables": {"representations": [
-                    {"__typename": "Product", "upc": "1"},
-                    {"__typename": "Product", "upc": "2"},
-                    {"__typename": "Product", "upc": "3"},
-                ]}
-            }),
-            json!({
-                "data": {"_entities": [
-                    {"reviews": [
-                        {"author": {"__typename": "User", "id": "1"}},
-                        {"author": {"__typename": "User", "id": "2"}},
-                    ]},
-                    {"reviews": [
-                        {"author": {"__typename": "User", "id": "1"}},
-                    ]},
-                    {"reviews": [
-                        {"author": {"__typename": "User", "id": "2"}},
-                    ]}
-                ]},
-                "extensions": {"ftv1": process_ftv1(subgraph, ftv1)}
-            })
-        )
-    } else if subgraph == "accounts" {
-        let ftv1 = "GgwIqZ34nwYQwOSeygMiDAipnfifBhDA5J7KA1jSozhybGJqCglfZW50aXRpZXMaCltfRW50aXR5XSFAoMgfSNWMKmIgEABiHAoEbmFtZRoGU3RyaW5nQL6OLkjelC9qBFVzZXJiIBABYhwKBG5hbWUaBlN0cmluZ0DMwTFIkpAyagRVc2VyagVRdWVyefkBAAAAAAAA8D8=";
-        builder.with_json(
-            json!({
-                "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}",
-                "variables": {"representations": [
-                    {"__typename": "User", "id": "1"},
-                    {"__typename": "User", "id": "2"},
-                ]}
-            }),
-            json!({
-                "data": {"_entities": [
-                    {"name": "Ada Lovelace"},
-                    {"name": "Alan Turing"},
-                ]},
-                "extensions": {"ftv1": process_ftv1(subgraph, ftv1)}
-            })
-        )
-    } else {
-        builder
-    }
-    .build()
-    .boxed()
-}
-
-fn process_ftv1(subgraph: &str, ftv1: &str) -> String {
-    let mut trace = Trace::decode(Cursor::new(base64::decode(ftv1).unwrap())).unwrap();
-    let root = trace.root.as_mut().unwrap();
-    if subgraph == "products" {
-        let top_products = &mut root.child[0];
-        top_products.error.push(Default::default());
-        top_products.error.push(Default::default());
-    } else if subgraph == "accounts" {
-        let entities = &mut root.child[0];
-        let entities_0 = &mut entities.child[0];
-        let entities_0_name = &mut entities_0.child[0];
-        entities_0_name.error.push(Default::default());
-        entities_0_name.start_time = 1_000_000;
-        entities_0_name.end_time = 1_002_000;
-    }
+fn encode_ftv1(trace: Trace) -> String {
     base64::encode(trace.encode_to_vec())
 }
 
@@ -473,4 +394,530 @@ async fn test_stats_mocked() {
             ".query_latency_stats.latency_count" => "[latency_count]"
         });
     });
+}
+
+fn subgraph_mocks(subgraph: &str) -> subgraph::BoxService {
+    let builder = MockSubgraph::builder();
+    // base64 FTV1 blobs were manually captured from un-mocked responses
+    if subgraph == "products" {
+        let trace = Trace {
+            start_time: Some(Timestamp { seconds: 1677594281, nanos: 831000000 }),
+            end_time: Some(Timestamp { seconds: 1677594281, nanos: 832000000 }),
+            duration_ns: 726851,
+            root: Some(
+                Node {
+                    original_field_name: "".into(),
+                    r#type: "".into(),
+                    parent_type: "".into(),
+                    cache_policy: None,
+                    start_time: 0,
+                    end_time: 0,
+                    error: vec![],
+                    child: vec![
+                        Node {
+                            original_field_name: "".into(),
+                            r#type: "[Product]".into(),
+                            parent_type: "Query".into(),
+                            cache_policy: None,
+                            start_time: 402005,
+                            end_time: 507563,
+                            // Synthetic errors for testing error stats
+                            error: vec![Default::default(), Default::default()],
+                            child: vec![
+                                Node {
+                                    original_field_name: "".into(),
+                                    r#type: "".into(),
+                                    parent_type: "".into(),
+                                    cache_policy: None,
+                                    start_time: 0,
+                                    end_time: 0,
+                                    error: vec![],
+                                    child: vec![
+                                        Node {
+                                            original_field_name: "".into(),
+                                            r#type: "String!".into(),
+                                            parent_type: "Product".into(),
+                                            cache_policy: None,
+                                            start_time: 580346,
+                                            end_time: 593649,
+                                            error: vec![],
+                                            child: vec![],
+                                            id: Some(ResponseName("upc".into())),
+                                        },
+                                        Node {
+                                            original_field_name: "".into(),
+                                            r#type: "String".into(),
+                                            parent_type: "Product".into(),
+                                            cache_policy: None,
+                                            start_time: 602613,
+                                            end_time: 609973,
+                                            error: vec![],
+                                            child: vec![],
+                                            id: Some(ResponseName("name".into())),
+                                        },
+                                    ],
+                                    id: Some(Index(0)),
+                                },
+                                Node {
+                                    original_field_name: "".into(),
+                                    r#type: "".into(),
+                                    parent_type: "".into(),
+                                    cache_policy: None,
+                                    start_time: 0,
+                                    end_time: 0,
+                                    error: vec![],
+                                    child: vec![
+                                        Node {
+                                            original_field_name: "".into(),
+                                            r#type: "String!".into(),
+                                            parent_type: "Product".into(),
+                                            cache_policy: None,
+                                            start_time: 626113,
+                                            end_time: 630409,
+                                            error: vec![],
+                                            child: vec![],
+                                            id: Some(ResponseName("upc".into())),
+                                        },
+                                        Node {
+                                            original_field_name: "".into(),
+                                            r#type: "String".into(),
+                                            parent_type: "Product".into(),
+                                            cache_policy: None,
+                                            start_time: 637000,
+                                            end_time: 639867,
+                                            error: vec![],
+                                            child: vec![],
+                                            id: Some(ResponseName("name".into())),
+                                        },
+                                    ],
+                                    id: Some(Index(1)),
+                                },
+                                Node {
+                                    original_field_name: "".into(),
+                                    r#type: "".into(),
+                                    parent_type: "".into(),
+                                    cache_policy: None,
+                                    start_time: 0,
+                                    end_time: 0,
+                                    error: vec![],
+                                    child: vec![
+                                        Node {
+                                            original_field_name: "".into(),
+                                            r#type: "String!".into(),
+                                            parent_type: "Product".into(),
+                                            cache_policy: None,
+                                            start_time: 651656,
+                                            end_time: 654866,
+                                            error: vec![],
+                                            child: vec![],
+                                            id: Some(ResponseName("upc".into())),
+                                        },
+                                        Node {
+                                            original_field_name: "".into(),
+                                            r#type: "String".into(),
+                                            parent_type: "Product".into(),
+                                            cache_policy: None,
+                                            start_time: 658295,
+                                            end_time: 661247,
+                                            error: vec![],
+                                            child: vec![],
+                                            id: Some(ResponseName("name".into())),
+                                        },
+                                    ],
+                                    id: Some(Index(2)),
+                                },
+                            ],
+                            id: Some(ResponseName("topProducts".into())),
+                        },
+                    ],
+                    id: None,
+                },
+            ),
+            field_execution_weight: 1.0,
+            ..Default::default()
+        };
+        builder.with_json(
+            json!({"query": "{topProducts{__typename upc name}}"}),
+            json!({
+                "data": {"topProducts": [
+                    {"__typename": "Product", "upc": "1", "name": "Table"},
+                    {"__typename": "Product", "upc": "2", "name": "Couch"},
+                    {"__typename": "Product", "upc": "3", "name": "Chair"}
+                ]},
+                "extensions": {"ftv1": encode_ftv1(trace)}
+            }),
+        )
+    } else if subgraph == "reviews" {
+        let trace = Trace {
+            start_time: Some(Timestamp { seconds: 1677594281, nanos: 915000000 }),
+            end_time: Some(Timestamp { seconds: 1677594281, nanos: 917000000 }),
+            duration_ns: 1772792,
+            root: Some(
+                Node {
+                    original_field_name: "".into(),
+                    r#type: "".into(),
+                    parent_type: "".into(),
+                    cache_policy: None,
+                    start_time: 0,
+                    end_time: 0,
+                    error: vec![],
+                    child: vec![
+                        Node {
+                            original_field_name: "".into(),
+                            r#type: "[_Entity]!".into(),
+                            parent_type: "Query".into(),
+                            cache_policy: None,
+                            start_time: 264001,
+                            end_time: 358151,
+                            error: vec![],
+                            child: vec![
+                                Node {
+                                    original_field_name: "".into(),
+                                    r#type: "".into(),
+                                    parent_type: "".into(),
+                                    cache_policy: None,
+                                    start_time: 0,
+                                    end_time: 0,
+                                    error: vec![],
+                                    child: vec![
+                                        Node {
+                                            original_field_name: "".into(),
+                                            r#type: "[Review]".into(),
+                                            parent_type: "Product".into(),
+                                            cache_policy: None,
+                                            start_time: 401851,
+                                            end_time: 1540892,
+                                            error: vec![],
+                                            child: vec![
+                                                Node {
+                                                    original_field_name: "".into(),
+                                                    r#type: "".into(),
+                                                    parent_type: "".into(),
+                                                    cache_policy: None,
+                                                    start_time: 0,
+                                                    end_time: 0,
+                                                    error: vec![],
+                                                    child: vec![
+                                                        Node {
+                                                            original_field_name: "".into(),
+                                                            r#type: "User".into(),
+                                                            parent_type: "Review".into(),
+                                                            cache_policy: None,
+                                                            start_time: 1558122,
+                                                            end_time: 1688492,
+                                                            error: vec![],
+                                                            child: vec![
+                                                                Node {
+                                                                    original_field_name: "".into(),
+                                                                    r#type: "ID!".into(),
+                                                                    parent_type: "User".into(),
+                                                                    cache_policy: None,
+                                                                    start_time: 1699382,
+                                                                    end_time: 1703952,
+                                                                    error: vec![],
+                                                                    child: vec![],
+                                                                    id: Some(ResponseName("id".into())),
+                                                                },
+                                                            ],
+                                                            id: Some(ResponseName("author".into())),
+                                                        },
+                                                    ],
+                                                    id: Some(Index(0)),
+                                                },
+                                                Node {
+                                                    original_field_name: "".into(),
+                                                    r#type: "".into(),
+                                                    parent_type: "".into(),
+                                                    cache_policy: None,
+                                                    start_time: 0,
+                                                    end_time: 0,
+                                                    error: vec![],
+                                                    child: vec![
+                                                        Node {
+                                                            original_field_name: "".into(),
+                                                            r#type: "User".into(),
+                                                            parent_type: "Review".into(),
+                                                            cache_policy: None,
+                                                            start_time: 1596072,
+                                                            end_time: 1706952,
+                                                            error: vec![],
+                                                            child: vec![
+                                                                Node {
+                                                                    original_field_name: "".into(),
+                                                                    r#type: "ID!".into(),
+                                                                    parent_type: "User".into(),
+                                                                    cache_policy: None,
+                                                                    start_time: 1710962,
+                                                                    end_time: 1713162,
+                                                                    error: vec![],
+                                                                    child: vec![],
+                                                                    id: Some(ResponseName("id".into())),
+                                                                },
+                                                            ],
+                                                            id: Some(ResponseName("author".into())),
+                                                        },
+                                                    ],
+                                                    id: Some(Index(1)),
+                                                },
+                                            ],
+                                            id: Some(ResponseName("reviews".into())),
+                                        },
+                                    ],
+                                    id: Some(Index(0)),
+                                },
+                                Node {
+                                    original_field_name: "".into(),
+                                    r#type: "".into(),
+                                    parent_type: "".into(),
+                                    cache_policy: None,
+                                    start_time: 0,
+                                    end_time: 0,
+                                    error: vec![],
+                                    child: vec![
+                                        Node {
+                                            original_field_name: "".into(),
+                                            r#type: "[Review]".into(),
+                                            parent_type: "Product".into(),
+                                            cache_policy: None,
+                                            start_time: 478041,
+                                            end_time: 1620202,
+                                            error: vec![],
+                                            child: vec![
+                                                Node {
+                                                    original_field_name: "".into(),
+                                                    r#type: "".into(),
+                                                    parent_type: "".into(),
+                                                    cache_policy: None,
+                                                    start_time: 0,
+                                                    end_time: 0,
+                                                    error: vec![],
+                                                    child: vec![
+                                                        Node {
+                                                            original_field_name: "".into(),
+                                                            r#type: "User".into(),
+                                                            parent_type: "Review".into(),
+                                                            cache_policy: None,
+                                                            start_time: 1626482,
+                                                            end_time: 1714552,
+                                                            error: vec![],
+                                                            child: vec![
+                                                                Node {
+                                                                    original_field_name: "".into(),
+                                                                    r#type: "ID!".into(),
+                                                                    parent_type: "User".into(),
+                                                                    cache_policy: None,
+                                                                    start_time: 1718812,
+                                                                    end_time: 1720712,
+                                                                    error: vec![],
+                                                                    child: vec![],
+                                                                    id: Some(ResponseName("id".into())),
+                                                                },
+                                                            ],
+                                                            id: Some(ResponseName("author".into())),
+                                                        },
+                                                    ],
+                                                    id: Some(Index(0)),
+                                                },
+                                            ],
+                                            id: Some(ResponseName("reviews".into())),
+                                        },
+                                    ],
+                                    id: Some(Index(1)),
+                                },
+                                Node {
+                                    original_field_name: "".into(),
+                                    r#type: "".into(),
+                                    parent_type: "".into(),
+                                    cache_policy: None,
+                                    start_time: 0,
+                                    end_time: 0,
+                                    error: vec![],
+                                    child: vec![
+                                        Node {
+                                            original_field_name: "".into(),
+                                            r#type: "[Review]".into(),
+                                            parent_type: "Product".into(),
+                                            cache_policy: None,
+                                            start_time: 1457461,
+                                            end_time: 1649742,
+                                            error: vec![],
+                                            child: vec![
+                                                Node {
+                                                    original_field_name: "".into(),
+                                                    r#type: "".into(),
+                                                    parent_type: "".into(),
+                                                    cache_policy: None,
+                                                    start_time: 0,
+                                                    end_time: 0,
+                                                    error: vec![],
+                                                    child: vec![
+                                                        Node {
+                                                            original_field_name: "".into(),
+                                                            r#type: "User".into(),
+                                                            parent_type: "Review".into(),
+                                                            cache_policy: None,
+                                                            start_time: 1655462,
+                                                            end_time: 1722082,
+                                                            error: vec![],
+                                                            child: vec![
+                                                                Node {
+                                                                    original_field_name: "".into(),
+                                                                    r#type: "ID!".into(),
+                                                                    parent_type: "User".into(),
+                                                                    cache_policy: None,
+                                                                    start_time: 1726282,
+                                                                    end_time: 1728152,
+                                                                    error: vec![],
+                                                                    child: vec![],
+                                                                    id: Some(ResponseName("id".into())),
+                                                                },
+                                                            ],
+                                                            id: Some(ResponseName("author".into())),
+                                                        },
+                                                    ],
+                                                    id: Some(Index(0)),
+                                                },
+                                            ],
+                                            id: Some(ResponseName("reviews".into())),
+                                        },
+                                    ],
+                                    id: Some(Index(2)),
+                                },
+                            ],
+                            id: Some(ResponseName("_entities".into())),
+                        },
+                    ],
+                    id: None,
+                },
+            ),
+            field_execution_weight: 1.0,
+            ..Default::default()
+        };
+        builder.with_json(
+            json!({
+                "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on Product{reviews{author{__typename id}}}}}",
+                "variables": {"representations": [
+                    {"__typename": "Product", "upc": "1"},
+                    {"__typename": "Product", "upc": "2"},
+                    {"__typename": "Product", "upc": "3"},
+                ]}
+            }),
+            json!({
+                "data": {"_entities": [
+                    {"reviews": [
+                        {"author": {"__typename": "User", "id": "1"}},
+                        {"author": {"__typename": "User", "id": "2"}},
+                    ]},
+                    {"reviews": [
+                        {"author": {"__typename": "User", "id": "1"}},
+                    ]},
+                    {"reviews": [
+                        {"author": {"__typename": "User", "id": "2"}},
+                    ]}
+                ]},
+                "extensions": {"ftv1": encode_ftv1(trace)}
+            })
+        )
+    } else if subgraph == "accounts" {
+        let trace = Trace {
+            start_time: Some(Timestamp { seconds: 1677594281, nanos: 961000000 }),
+            end_time: Some(Timestamp { seconds: 1677594281, nanos: 961000000 }),
+            duration_ns: 922066,
+            root: Some(
+                Node {
+                    original_field_name: "".into(),
+                    r#type: "".into(),
+                    parent_type: "".into(),
+                    cache_policy: None,
+                    start_time: 0,
+                    end_time: 0,
+                    error: vec![],
+                    child: vec![
+                        Node {
+                            original_field_name: "".into(),
+                            r#type: "[_Entity]!".into(),
+                            parent_type: "Query".into(),
+                            cache_policy: None,
+                            start_time: 517152,
+                            end_time: 689749,
+                            error: vec![],
+                            child: vec![
+                                Node {
+                                    original_field_name: "".into(),
+                                    r#type: "".into(),
+                                    parent_type: "".into(),
+                                    cache_policy: None,
+                                    start_time: 0,
+                                    end_time: 0,
+                                    error: vec![],
+                                    child: vec![
+                                        Node {
+                                            original_field_name: "".into(),
+                                            r#type: "String".into(),
+                                            parent_type: "User".into(),
+                                            cache_policy: None,
+                                            start_time: 1000000,
+                                            end_time: 1002000,
+                                            error: vec![],
+                                            child: vec![],
+                                            id: Some(ResponseName("name".into())),
+                                        },
+                                    ],
+                                    id: Some(Index(0)),
+                                },
+                                Node {
+                                    original_field_name: "".into(),
+                                    r#type: "".into(),
+                                    parent_type: "".into(),
+                                    cache_policy: None,
+                                    start_time: 0,
+                                    end_time: 0,
+                                    error: vec![],
+                                    child: vec![
+                                        Node {
+                                            original_field_name: "".into(),
+                                            r#type: "String".into(),
+                                            parent_type: "User".into(),
+                                            cache_policy: None,
+                                            start_time: 811212,
+                                            end_time: 821266,
+                                            // Synthetic error for testing error stats
+                                            error: vec![Default::default()],
+                                            child: vec![],
+                                            id: Some(ResponseName("name".into())),
+                                        },
+                                    ],
+                                    id: Some(Index(1)),
+                                },
+                            ],
+                            id: Some(ResponseName("_entities".into())),
+                        },
+                    ],
+                    id: None,
+                },
+            ),
+            field_execution_weight: 1.0,
+            ..Default::default()
+        };
+        builder.with_json(
+            json!({
+                "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}",
+                "variables": {"representations": [
+                    {"__typename": "User", "id": "1"},
+                    {"__typename": "User", "id": "2"},
+                ]}
+            }),
+            json!({
+                "data": {"_entities": [
+                    {"name": "Ada Lovelace"},
+                    {"name": "Alan Turing"},
+                ]},
+                "extensions": {"ftv1": encode_ftv1(trace)}
+            })
+        )
+    } else {
+        builder
+    }
+    .build()
+    .boxed()
 }

--- a/apollo-router/tests/apollo_reports.rs
+++ b/apollo-router/tests/apollo_reports.rs
@@ -1,10 +1,13 @@
+use std::io::Cursor;
 use std::io::Read;
 use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::anyhow;
+use apollo_router::plugin::test::MockSubgraph;
 use apollo_router::services::router;
 use apollo_router::services::router::BoxCloneService;
+use apollo_router::services::subgraph;
 use apollo_router::services::supergraph;
 use apollo_router::TestHarness;
 use axum::body::Bytes;
@@ -15,72 +18,181 @@ use flate2::read::GzDecoder;
 use http::header::ACCEPT;
 use once_cell::sync::Lazy;
 use prost::Message;
+use serde_json::json;
 use tokio::sync::Mutex;
+use tokio::sync::OnceCell;
 use tower::Service;
 use tower::ServiceExt;
 use tower_http::decompression::DecompressionLayer;
 
 use crate::proto::reports::Report;
+use crate::proto::reports::Trace;
 
 static REPORTS: Lazy<Arc<Mutex<Vec<Report>>>> = Lazy::new(Default::default);
 static TEST: Lazy<Arc<Mutex<bool>>> = Lazy::new(Default::default);
 static ROUTER_SERVICE_RUNTIME: Lazy<Arc<tokio::runtime::Runtime>> = Lazy::new(|| {
     Arc::new(tokio::runtime::Runtime::new().expect("must be able to create tokio runtime"))
 });
+static CONFIG: OnceCell<serde_json::Value> = OnceCell::const_new();
 static ROUTER_SERVICE: Lazy<Arc<Mutex<Option<BoxCloneService>>>> = Lazy::new(Default::default);
+static MOCKED_ROUTER_SERVICE: Lazy<Arc<Mutex<Option<BoxCloneService>>>> =
+    Lazy::new(Default::default);
 
-async fn get_router_service() -> BoxCloneService {
-    let mut router_service = ROUTER_SERVICE.lock().await;
-    if router_service.is_none() {
-        let reports = &*REPORTS;
-        std::env::set_var("APOLLO_KEY", "test");
-        std::env::set_var("APOLLO_GRAPH_REF", "test");
+async fn config() -> serde_json::Value {
+    CONFIG
+        .get_or_init(|| async {
+            std::env::set_var("APOLLO_KEY", "test");
+            std::env::set_var("APOLLO_GRAPH_REF", "test");
 
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-        let app = axum::Router::new()
-            .route("/", post(report))
-            .layer(DecompressionLayer::new())
-            .layer(tower_http::add_extension::AddExtensionLayer::new(
-                reports.clone(),
-            ));
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            let app = axum::Router::new()
+                .route("/", post(report))
+                .layer(DecompressionLayer::new())
+                .layer(tower_http::add_extension::AddExtensionLayer::new(
+                    (*REPORTS).clone(),
+                ));
 
-        let mut config: serde_json::Value =
-            serde_yaml::from_str(include_str!("fixtures/apollo_reports.router.yaml"))
-                .expect("apollo_reports.router.yaml was invalid");
-        config = jsonpath_lib::replace_with(config, "$.telemetry.apollo.endpoint", &mut |_| {
-            Some(serde_json::Value::String(format!("http://{addr}")))
+            drop(ROUTER_SERVICE_RUNTIME.spawn(async move {
+                axum::Server::from_tcp(listener)
+                    .expect("mut be able to crete report receiver")
+                    .serve(app.into_make_service())
+                    .await
+                    .expect("could not start axum server")
+            }));
+
+            let mut config: serde_json::Value =
+                serde_yaml::from_str(include_str!("fixtures/apollo_reports.router.yaml"))
+                    .expect("apollo_reports.router.yaml was invalid");
+            config = jsonpath_lib::replace_with(config, "$.telemetry.apollo.endpoint", &mut |_| {
+                Some(serde_json::Value::String(format!("http://{addr}")))
+            })
+            .expect("Could not sub in endpoint");
+            config
         })
-        .expect("Could not sub in endpoint");
+        .await
+        .clone()
+}
 
-        drop(ROUTER_SERVICE_RUNTIME.spawn(async move {
-            axum::Server::from_tcp(listener)
-                .expect("mut be able to crete report receiver")
-                .serve(app.into_make_service())
-                .await
-                .expect("could not start axum server")
-        }));
-
-        *router_service = Some(
-            ROUTER_SERVICE_RUNTIME
-                .spawn(async {
-                    TestHarness::builder()
-                        .log_level("INFO")
-                        .configuration_json(config)
-                        .expect("test harness had config errors")
-                        .schema(include_str!("fixtures/supergraph.graphql"))
-                        .with_subgraph_network_requests()
-                        .build_router()
-                        .await
-                        .expect("could create router test harness")
-                })
-                .await
-                .expect("must be able to create router"),
-        );
+async fn get_router_service(mocked: bool) -> BoxCloneService {
+    let lazy = if mocked {
+        &MOCKED_ROUTER_SERVICE
+    } else {
+        &ROUTER_SERVICE
+    };
+    let mut router_service = lazy.lock().await;
+    if router_service.is_none() {
+        let config = config().await;
+        let service = ROUTER_SERVICE_RUNTIME
+            .spawn(async move {
+                let builder = TestHarness::builder()
+                    .try_log_level("INFO")
+                    .configuration_json(config)
+                    .expect("test harness had config errors")
+                    .schema(include_str!("fixtures/supergraph.graphql"));
+                let builder = if mocked {
+                    builder.subgraph_hook(|subgraph, _service| subgraph_mocks(subgraph))
+                } else {
+                    builder.with_subgraph_network_requests()
+                };
+                builder
+                    .build_router()
+                    .await
+                    .expect("could create router test harness")
+            })
+            .await
+            .expect("must be able to create router");
+        *router_service = Some(service);
     }
     router_service
         .clone()
         .expect("router service must have got created")
+}
+
+fn subgraph_mocks(subgraph: &str) -> subgraph::BoxService {
+    let builder = MockSubgraph::builder();
+    // base64 FTV1 blobs were manually captured from un-mocked responses
+    if subgraph == "products" {
+        let ftv1 = "GgwIqZ34nwYQgKDdjAMiDAipnfifBhDAm6CMA1jDrixy/AFi+QEKC3RvcFByb2R1Y3RzGglbUHJvZHVjdF1A1cQYSKv9HmJEEABiHwoDdXBjGgdTdHJpbmchQPq1I0jxnSRqB1Byb2R1Y3RiHwoEbmFtZRoGU3RyaW5nQPXjJEi1nSVqB1Byb2R1Y3RiRBABYh8KA3VwYxoHU3RyaW5nIUDBmyZIib0magdQcm9kdWN0Yh8KBG5hbWUaBlN0cmluZ0DI8CZI+4YnagdQcm9kdWN0YkQQAmIfCgN1cGMaB1N0cmluZyFAiOMnSJL8J2oHUHJvZHVjdGIfCgRuYW1lGgZTdHJpbmdA95YoSP+tKGoHUHJvZHVjdGoFUXVlcnn5AQAAAAAAAPA/";
+        builder.with_json(
+            json!({"query": "{topProducts{__typename upc name}}"}),
+            json!({
+                "data": {"topProducts": [
+                    {"__typename": "Product", "upc": "1", "name": "Table"},
+                    {"__typename": "Product", "upc": "2", "name": "Couch"},
+                    {"__typename": "Product", "upc": "3", "name": "Chair"}
+                ]},
+                "extensions": {"ftv1": process_ftv1(subgraph, ftv1)}
+            }),
+        )
+    } else if subgraph == "reviews" {
+        let ftv1 = "GgwIqZ34nwYQwJ6htQMiDAipnfifBhDAlae0A1j4mWxynQNimgMKCV9lbnRpdGllcxoKW19FbnRpdHldIUDBjhBIh+4VYqMBEABingEKB3Jldmlld3MaCFtSZXZpZXddQLvDGEichl5iOxAAYjcKBmF1dGhvchoEVXNlckDqjF9IrIdnYhcKAmlkGgNJRCFAttxnSJCAaGoEVXNlcmoGUmV2aWV3YjsQAWI3CgZhdXRob3IaBFVzZXJAqLVhSMiXaGIXCgJpZBoDSUQhQPK2aEiKyGhqBFVzZXJqBlJldmlld2oHUHJvZHVjdGJlEAFiYQoHcmV2aWV3cxoIW1Jldmlld11A2ZYdSOrxYmI7EABiNwoGYXV0aG9yGgRVc2VyQPKiY0j40mhiFwoCaWQaA0lEIUCc9GhIiINpagRVc2VyagZSZXZpZXdqB1Byb2R1Y3RiZRACYmEKB3Jldmlld3MaCFtSZXZpZXddQLX6WEjO2GRiOxAAYjcKBmF1dGhvchoEVXNlckCmhWVI4o1pYhcKAmlkGgNJRCFAyq5pSJi9aWoEVXNlcmoGUmV2aWV3agdQcm9kdWN0agVRdWVyefkBAAAAAAAA8D8=";
+        builder.with_json(
+            json!({
+                "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on Product{reviews{author{__typename id}}}}}",
+                "variables": {"representations": [
+                    {"__typename": "Product", "upc": "1"},
+                    {"__typename": "Product", "upc": "2"},
+                    {"__typename": "Product", "upc": "3"},
+                ]}
+            }),
+            json!({
+                "data": {"_entities": [
+                    {"reviews": [
+                        {"author": {"__typename": "User", "id": "1"}},
+                        {"author": {"__typename": "User", "id": "2"}},
+                    ]},
+                    {"reviews": [
+                        {"author": {"__typename": "User", "id": "1"}},
+                    ]},
+                    {"reviews": [
+                        {"author": {"__typename": "User", "id": "2"}},
+                    ]}
+                ]},
+                "extensions": {"ftv1": process_ftv1(subgraph, ftv1)}
+            })
+        )
+    } else if subgraph == "accounts" {
+        let ftv1 = "GgwIqZ34nwYQwOSeygMiDAipnfifBhDA5J7KA1jSozhybGJqCglfZW50aXRpZXMaCltfRW50aXR5XSFAoMgfSNWMKmIgEABiHAoEbmFtZRoGU3RyaW5nQL6OLkjelC9qBFVzZXJiIBABYhwKBG5hbWUaBlN0cmluZ0DMwTFIkpAyagRVc2VyagVRdWVyefkBAAAAAAAA8D8=";
+        builder.with_json(
+            json!({
+                "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on User{name}}}",
+                "variables": {"representations": [
+                    {"__typename": "User", "id": "1"},
+                    {"__typename": "User", "id": "2"},
+                ]}
+            }),
+            json!({
+                "data": {"_entities": [
+                    {"name": "Ada Lovelace"},
+                    {"name": "Alan Turing"},
+                ]},
+                "extensions": {"ftv1": process_ftv1(subgraph, ftv1)}
+            })
+        )
+    } else {
+        builder
+    }
+    .build()
+    .boxed()
+}
+
+fn process_ftv1(subgraph: &str, ftv1: &str) -> String {
+    let mut trace = Trace::decode(Cursor::new(base64::decode(ftv1).unwrap())).unwrap();
+    let root = trace.root.as_mut().unwrap();
+    if subgraph == "products" {
+        let top_products = &mut root.child[0];
+        top_products.error.push(Default::default());
+        top_products.error.push(Default::default());
+    } else if subgraph == "accounts" {
+        let entities = &mut root.child[0];
+        let entities_0 = &mut entities.child[0];
+        let entities_0_name = &mut entities_0.child[0];
+        entities_0_name.error.push(Default::default());
+        entities_0_name.start_time = 1_000_000;
+        entities_0_name.end_time = 1_002_000;
+    }
+    base64::encode(trace.encode_to_vec())
 }
 
 macro_rules! assert_report {
@@ -157,7 +269,7 @@ async fn report(
 }
 
 async fn get_trace_report(request: supergraph::Request) -> Report {
-    get_report(request, |r| {
+    get_report(false, request, |r| {
         let r = !r
             .traces_per_query
             .values()
@@ -170,19 +282,25 @@ async fn get_trace_report(request: supergraph::Request) -> Report {
     .await
 }
 
+fn has_metrics(r: &&Report) -> bool {
+    !r.traces_per_query
+        .values()
+        .next()
+        .expect("traces and stats required")
+        .stats_with_context
+        .is_empty()
+}
+
 async fn get_metrics_report(request: supergraph::Request) -> Report {
-    get_report(request, |r| {
-        !r.traces_per_query
-            .values()
-            .next()
-            .expect("traces and stats required")
-            .stats_with_context
-            .is_empty()
-    })
-    .await
+    get_report(false, request, has_metrics).await
+}
+
+async fn get_metrics_report_mocked(request: supergraph::Request) -> Report {
+    get_report(true, request, has_metrics).await
 }
 
 async fn get_report<T: Fn(&&Report) -> bool + Send + Sync + Copy + 'static>(
+    mocked: bool,
     request: supergraph::Request,
     filter: T,
 ) -> Report {
@@ -196,7 +314,7 @@ async fn get_report<T: Fn(&&Report) -> bool + Send + Sync + Copy + 'static>(
                 }
                 let req: router::Request = request.try_into().expect("could not convert request");
 
-                let response = get_router_service()
+                let response = get_router_service(mocked)
                     .await
                     .ready()
                     .await
@@ -339,4 +457,20 @@ async fn test_stats() {
         .unwrap();
     let report = get_metrics_report(request).await;
     assert_report!(report);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_stats_mocked() {
+    let request = supergraph::Request::fake_builder()
+        .query("query{topProducts{name reviews {author{name}} reviews{author{name}}}}")
+        .build()
+        .unwrap();
+    let report = get_metrics_report_mocked(request).await;
+    let per_query = report.traces_per_query.values().next().unwrap();
+    let stats = per_query.stats_with_context.first().unwrap();
+    insta::with_settings!({sort_maps => true}, {
+        insta::assert_yaml_snapshot!(stats, {
+            ".query_latency_stats.latency_count" => "[latency_count]"
+        });
+    });
 }

--- a/apollo-router/tests/apollo_reports.rs
+++ b/apollo-router/tests/apollo_reports.rs
@@ -544,6 +544,10 @@ fn subgraph_mocks(subgraph: &str) -> subgraph::BoxService {
                     {"__typename": "Product", "upc": "2", "name": "Couch"},
                     {"__typename": "Product", "upc": "3", "name": "Chair"}
                 ]},
+                "errors": [
+                    {"message": "", "path": ["topProducts"]},
+                    {"message": "", "path": ["topProducts"]},
+                ],
                 "extensions": {"ftv1": encode_ftv1(trace)}
             }),
         )
@@ -912,6 +916,9 @@ fn subgraph_mocks(subgraph: &str) -> subgraph::BoxService {
                     {"name": "Ada Lovelace"},
                     {"name": "Alan Turing"},
                 ]},
+                "errors": [
+                    {"message": "", "path": ["_entities", 1, "name"]},
+                ],
                 "extensions": {"ftv1": encode_ftv1(trace)}
             })
         )

--- a/apollo-router/tests/snapshots/apollo_reports__stats_mocked.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__stats_mocked.snap
@@ -1,0 +1,441 @@
+---
+source: apollo-router/tests/apollo_reports.rs
+expression: stats
+---
+context:
+  client_name: ""
+  client_version: ""
+query_latency_stats:
+  latency_count: "[latency_count]"
+  request_count: 1
+  cache_hits: 0
+  persisted_query_hits: 0
+  persisted_query_misses: 0
+  cache_latency_count:
+    - 0
+  root_error_stats:
+    children:
+      "service:accounts":
+        children:
+          _entities:
+            children:
+              name:
+                children: {}
+                errors_count: 1
+                requests_with_errors_count: 1
+            errors_count: 0
+            requests_with_errors_count: 0
+        errors_count: 0
+        requests_with_errors_count: 0
+      "service:products":
+        children:
+          topProducts:
+            children: {}
+            errors_count: 2
+            requests_with_errors_count: 1
+        errors_count: 0
+        requests_with_errors_count: 0
+    errors_count: 0
+    requests_with_errors_count: 0
+  requests_with_errors_count: 0
+  public_cache_ttl_count:
+    - 0
+  private_cache_ttl_count:
+    - 0
+  registered_operation_count: 0
+  forbidden_operation_count: 0
+  requests_without_field_instrumentation: 0
+per_type_stat:
+  Product:
+    per_field_stat:
+      name:
+        return_type: String
+        errors_count: 0
+        observed_execution_count: 3
+        estimated_execution_count: 3
+        requests_with_errors_count: 0
+        latency_count:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 2
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 1
+      reviews:
+        return_type: "[Review]"
+        errors_count: 0
+        observed_execution_count: 3
+        estimated_execution_count: 3
+        requests_with_errors_count: 0
+        latency_count:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 1
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 2
+      upc:
+        return_type: String!
+        errors_count: 0
+        observed_execution_count: 3
+        estimated_execution_count: 3
+        requests_with_errors_count: 0
+        latency_count:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 1
+          - 0
+          - 0
+          - 1
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 1
+  Query:
+    per_field_stat:
+      _entities:
+        return_type: "[_Entity]!"
+        errors_count: 0
+        observed_execution_count: 2
+        estimated_execution_count: 2
+        requests_with_errors_count: 0
+        latency_count:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 1
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 1
+      topProducts:
+        return_type: "[Product]"
+        errors_count: 2
+        observed_execution_count: 1
+        estimated_execution_count: 1
+        requests_with_errors_count: 1
+        latency_count:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 1
+  Review:
+    per_field_stat:
+      author:
+        return_type: User
+        errors_count: 0
+        observed_execution_count: 4
+        estimated_execution_count: 4
+        requests_with_errors_count: 0
+        latency_count:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 1
+          - 0
+          - 1
+          - 0
+          - 0
+          - 1
+          - 0
+          - 1
+  User:
+    per_field_stat:
+      id:
+        return_type: ID!
+        errors_count: 0
+        observed_execution_count: 4
+        estimated_execution_count: 4
+        requests_with_errors_count: 0
+        latency_count:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 2
+          - 0
+          - 1
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 1
+      name:
+        return_type: String
+        errors_count: 1
+        observed_execution_count: 2
+        estimated_execution_count: 2
+        requests_with_errors_count: 1
+        latency_count:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 1
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 1
+

--- a/apollo-router/tests/snapshots/apollo_reports__stats_mocked.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__stats_mocked.snap
@@ -37,7 +37,7 @@ query_latency_stats:
         requests_with_errors_count: 0
     errors_count: 0
     requests_with_errors_count: 0
-  requests_with_errors_count: 0
+  requests_with_errors_count: 1
   public_cache_ttl_count:
     - 0
   private_cache_ttl_count:


### PR DESCRIPTION
In order to test latency historgram computation and add synthetic field errors, this new test does not make network requests to subgraphs but instead mocks their responses.

Fixes https://github.com/apollographql/router/issues/2592

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
