### PR TITLE
prevent telemetry reload

### DIFF
--- a/apollo-router/src/plugins/telemetry/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/apollo.rs
@@ -33,7 +33,7 @@ pub(crate) const ENDPOINT_DEFAULT: &str =
 
 #[derive(Derivative)]
 #[derivative(Debug)]
-#[derive(Clone, Deserialize, JsonSchema)]
+#[derive(Clone, Deserialize, PartialEq, JsonSchema)]
 #[serde(deny_unknown_fields, default)]
 pub(crate) struct Config {
     /// The Apollo Studio endpoint for exporting traces and metrics.
@@ -140,7 +140,7 @@ schemar_fn!(
 );
 
 /// Forward headers
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub(crate) enum ForwardHeaders {
     /// Don't send any headers
@@ -179,7 +179,7 @@ schemar_fn!(
 );
 
 /// Forward GraphQL variables
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub(crate) enum ForwardValues {
     /// Dont send any variables

--- a/apollo-router/src/plugins/telemetry/metrics/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/mod.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use ::serde::Deserialize;
 use access_json::JSONQuery;
+use derivative::Derivative;
 use http::header::HeaderName;
 use http::response::Parts;
 use http::HeaderMap;
@@ -44,7 +45,7 @@ pub(crate) const METRIC_PREFIX_VALUE: &str = "value.";
 
 pub(crate) type MetricsExporterHandle = Box<dyn Any + Send + Sync + 'static>;
 
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 /// Configuration to add custom attributes/labels on metrics
 pub(crate) struct MetricsAttributesConf {
@@ -55,7 +56,7 @@ pub(crate) struct MetricsAttributesConf {
 }
 
 /// Configuration to add custom attributes/labels on metrics to subgraphs
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct SubgraphAttributesConf {
     /// Attributes for all subgraphs
@@ -65,7 +66,7 @@ pub(crate) struct SubgraphAttributesConf {
 }
 
 /// Configuration to add custom attributes/labels on metrics to subgraphs
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct AttributesForwardConf {
     /// Configuration to insert custom attributes/labels in metrics
@@ -81,7 +82,7 @@ pub(crate) struct AttributesForwardConf {
     pub(crate) errors: Option<ErrorsForward>,
 }
 
-#[derive(Clone, JsonSchema, Deserialize, Debug)]
+#[derive(Clone, PartialEq, JsonSchema, Deserialize, Debug)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 /// Configuration to insert custom attributes/labels in metrics
 pub(crate) struct Insert {
@@ -92,7 +93,7 @@ pub(crate) struct Insert {
 }
 
 /// Configuration to forward from headers/body
-#[derive(Debug, Clone, Deserialize, JsonSchema, Default)]
+#[derive(Debug, Clone, PartialEq, Deserialize, JsonSchema, Default)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Forward {
     /// Forward header values as custom attributes/labels in metrics
@@ -101,7 +102,7 @@ pub(crate) struct Forward {
     pub(crate) body: Option<Vec<BodyForward>>,
 }
 
-#[derive(Debug, Clone, Deserialize, JsonSchema, Default)]
+#[derive(Debug, Clone, PartialEq, Deserialize, JsonSchema, Default)]
 #[serde(deny_unknown_fields, default)]
 pub(crate) struct ErrorsForward {
     /// Will include the error message in a "message" attribute
@@ -116,9 +117,10 @@ schemar_fn!(
     "Using a regex on the header name"
 );
 
-#[derive(Clone, JsonSchema, Deserialize, Debug)]
+#[derive(Clone, JsonSchema, Derivative, Deserialize, Debug)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 #[serde(untagged)]
+#[derivative(PartialEq)]
 /// Configuration to forward header values in metric labels
 pub(crate) enum HeaderForward {
     /// Match via header name
@@ -138,11 +140,12 @@ pub(crate) enum HeaderForward {
         /// Using a regex on the header name
         #[schemars(schema_with = "forward_header_matching")]
         #[serde(deserialize_with = "deserialize_regex")]
+        #[derivative(PartialEq = "ignore")]
         matching: Regex,
     },
 }
 
-#[derive(Clone, JsonSchema, Deserialize, Debug)]
+#[derive(Clone, PartialEq, JsonSchema, Deserialize, Debug)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 /// Configuration to forward body values in metric attributes/labels
 pub(crate) struct BodyForward {
@@ -156,7 +159,7 @@ pub(crate) struct BodyForward {
     pub(crate) default: Option<AttributeValue>,
 }
 
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 /// Configuration to forward context values in metric attributes/labels
 pub(crate) struct ContextForward {

--- a/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
@@ -26,7 +26,7 @@ use crate::services::router;
 use crate::ListenAddr;
 
 /// Prometheus configuration
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
     /// Set to true to enable

--- a/apollo-router/src/plugins/telemetry/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/otlp.rs
@@ -1,6 +1,7 @@
 //! Shared configuration for Otlp tracing and metrics.
 use std::collections::HashMap;
 
+use derivative::Derivative;
 use indexmap::map::Entry;
 use indexmap::IndexMap;
 use opentelemetry_otlp::HttpExporterBuilder;
@@ -22,7 +23,7 @@ use crate::plugins::telemetry::config::GenericWith;
 use crate::plugins::telemetry::tracing::parse_url_for_endpoint;
 use crate::plugins::telemetry::tracing::BatchProcessorConfig;
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
     /// The endpoint to send data to
@@ -123,15 +124,16 @@ pub(crate) enum EndpointDefault {
     Default,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, Default, JsonSchema)]
 #[serde(deny_unknown_fields, default)]
 pub(crate) struct HttpExporter {
     /// Headers to send on report requests
     pub(crate) headers: HashMap<String, String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, Default, JsonSchema)]
+#[derive(Debug, Clone, Derivative, Deserialize, Serialize, Default, JsonSchema)]
 #[serde(deny_unknown_fields, default)]
+#[derivative(PartialEq)]
 pub(crate) struct GrpcExporter {
     /// The optional domain name for tls config.
     /// Note that domain name is will be defaulted to match the endpoint is not explicitly set.
@@ -149,6 +151,7 @@ pub(crate) struct GrpcExporter {
         serialize_with = "metadata_map_serde::serialize"
     )]
     #[schemars(schema_with = "header_map", default)]
+    #[derivative(PartialEq = "ignore")]
     pub(crate) metadata: MetadataMap,
 }
 
@@ -195,7 +198,7 @@ impl GrpcExporter {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub(crate) enum Protocol {
     Grpc,

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -15,7 +15,7 @@ use crate::plugins::telemetry::tracing::BatchProcessorConfig;
 use crate::plugins::telemetry::tracing::SpanProcessorExt;
 use crate::plugins::telemetry::tracing::TracingConfigurator;
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
     /// The endpoint to send to

--- a/apollo-router/src/plugins/telemetry/tracing/jaeger.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/jaeger.rs
@@ -24,7 +24,7 @@ use crate::plugins::telemetry::tracing::BatchProcessorConfig;
 use crate::plugins::telemetry::tracing::SpanProcessorExt;
 use crate::plugins::telemetry::tracing::TracingConfigurator;
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields, untagged)]
 pub(crate) enum Config {
     Agent {
@@ -45,7 +45,7 @@ pub(crate) enum Config {
     },
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct AgentConfig {
     /// The endpoint to send to
@@ -54,7 +54,7 @@ pub(crate) struct AgentConfig {
     endpoint: AgentEndpoint,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct CollectorConfig {
     /// The endpoint to send reports to

--- a/apollo-router/src/plugins/telemetry/tracing/mod.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/mod.rs
@@ -162,7 +162,7 @@ where
 }
 
 /// Batch processor configuration
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(default)]
 pub(crate) struct BatchProcessorConfig {
     #[serde(deserialize_with = "humantime_serde::deserialize")]

--- a/apollo-router/src/plugins/telemetry/tracing/zipkin.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/zipkin.rs
@@ -16,7 +16,7 @@ use crate::plugins::telemetry::tracing::BatchProcessorConfig;
 use crate::plugins::telemetry::tracing::SpanProcessorExt;
 use crate::plugins::telemetry::tracing::TracingConfigurator;
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
     /// The endpoint to send to


### PR DESCRIPTION
This is an attempt at reducing memory leaks issues while we investigate the real cause. It seems the leak is related to the schema and configuration reloads, and I've seen data leak from the rhai and telemetry plugins. The idea here would be to keep the plugins around from one execution to the next, if the configuration did not change. Here this PR does it right inside the telemetry plugin, but ideally we would do that higher in the stack and expose a reload method for plugins that want to reset some state with the new schema.

*Description here*

Fixes #issue_number

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
