### PR TITLE
move authorization out of the authentication plugin

### DIFF
--- a/.changesets/breaking_geal_authorization_check.md
+++ b/.changesets/breaking_geal_authorization_check.md
@@ -1,0 +1,32 @@
+### Move authorization out of the authentication plugin 
+
+*Breaking change*: this changes the JWT plugin's behaviour, it only rejects requests with invalid tokens, but otherwise lets everything go through
+
+Now the authentication plugin only rejects invalid tokens (bad signature, expired, etc). Authorization must be handled later.
+As an example, a rhai script can be used to refuse all unauthenticated requests, like this:
+
+```
+fn supergraph_service(service) {
+    const request_callback = Fn("process_request");
+    service.map_request(request_callback);
+}
+
+// This will examine our context to determine if our user is authenticated.
+fn process_request(request) {
+    let claims = request.context[Router.APOLLO_AUTHENTICATION_JWT_CLAIMS];
+    if claims == () {
+        throw #{
+            status: 401,
+            message: "The request is not authenticated",
+            extensions: #{
+                code: "AUTH_ERROR",
+            }
+        };
+    }
+    // We are happy we are authenticated.
+}
+```
+
+This also adds support for the `extensions` field in GraphQL errors generated from rhai
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2708

--- a/.changesets/fix_telegram_fossil_doodle_sandbox.md
+++ b/.changesets/fix_telegram_fossil_doodle_sandbox.md
@@ -1,0 +1,8 @@
+###  Add content-type header for publishing Datadog metrics ([Issue #2697](https://github.com/apollographql/router/issues/2697))
+
+Add the required content-type header for publishing Datadog metrics from
+Prometheus:
+
+"content-type": text/plain; version=0.0.4
+
+By [@ShaunPhillips](https://github.com/ShaunPhillips) in https://github.com/apollographql/router/pull/2698

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4314,15 +4314,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5328,16 +5319,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi 0.3.9",
+ "rustix",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -226,7 +226,7 @@ reqwest = { version = "0.11.14", default-features = false, features = [
     "stream",
 ] }
 similar-asserts = "1.4.2"
-tempfile = "3.3.0"
+tempfile = "3.4.0"
 test-log = { version = "0.2.11", default-features = false, features = [
     "trace",
 ] }

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -49,9 +49,6 @@ pub(crate) const AUTHENTICATION_SPAN_NAME: &str = "authentication_plugin";
 
 #[derive(Debug, Display, Error)]
 enum AuthenticationError<'a> {
-    /// Missing {0} header
-    MissingHeader(&'a str),
-
     /// Configured header is not convertible to a string
     CannotConvertToString,
 
@@ -372,11 +369,7 @@ impl Plugin for AuthenticationPlugin {
                     match request.router_request.headers().get(&my_config.header_name) {
                         Some(value) => value.to_str(),
                         None => {
-                            return failure_message(
-                                request.context,
-                                AuthenticationError::MissingHeader(&my_config.header_name),
-                                StatusCode::UNAUTHORIZED,
-                            );
+                            return Ok(ControlFlow::Continue(request));
                         }
                     };
 

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -166,7 +166,7 @@ async fn it_rejects_when_there_is_no_auth_header() {
     .unwrap();
 
     let expected_error = graphql::Error::builder()
-        .message("Missing 'Authorization' header")
+        .message("The request is not authenticated")
         .extension_code("AUTH_ERROR")
         .build();
 

--- a/apollo-router/tests/fixtures/require_authentication.rhai
+++ b/apollo-router/tests/fixtures/require_authentication.rhai
@@ -9,7 +9,7 @@ fn process_request(request) {
     if claims == () {
         throw #{
             status: 401,
-            message: "Missing 'Authorization' header",
+            message: "The request is not authenticated",
             extensions: #{
                 code: "AUTH_ERROR",
             }

--- a/apollo-router/tests/fixtures/require_authentication.rhai
+++ b/apollo-router/tests/fixtures/require_authentication.rhai
@@ -1,0 +1,19 @@
+fn supergraph_service(service) {
+    const request_callback = Fn("process_request");
+    service.map_request(request_callback);
+}
+
+// This will examine our context to determine if our user is authenticated.
+fn process_request(request) {
+    let claims = request.context[Router.APOLLO_AUTHENTICATION_JWT_CLAIMS];
+    if claims == () {
+        throw #{
+            status: 401,
+            message: "Missing 'Authorization' header",
+            extensions: #{
+                code: "AUTH_ERROR",
+            }
+        };
+    }
+    // We are happy we are authenticated.
+}

--- a/docs/source/configuration/authn-jwt.mdx
+++ b/docs/source/configuration/authn-jwt.mdx
@@ -22,7 +22,7 @@ These are the high-level steps of JWT-based authentication with the Apollo Route
 
 1. Whenever a client authenticates with your system, your IdP issues that client a valid JSON Web Token (JWT).
 2. In its subsequent requests to your router, the authenticated client provides its JWT in a designated HTTP header.
-3. Whenever your router receives a client request, its authentication plugin extracts the JWT from the designated header (if present).
+3. Whenever your router receives a client request, its authentication plugin extracts the JWT from the designated header, if present. **If no JWT was presented, the request goes through, so rejecting requests based on authentication status is done at a later phase** ([see below](#working-with-jwt-claims))
 4. The authentication plugin validates the extracted JWT using a corresponding [JSON Web Key](https://www.rfc-editor.org/rfc/rfc7517) (**JWK**).
     - The plugin obtains all of its known JWKs from URLs that you specify in your router's configuration file. Each URL provides its keys within a single JSON object called a [JWK Set](https://www.rfc-editor.org/rfc/rfc7517#section-5) (or a **JWKS**).
     - Validation fails if the JWT is malformed, or if it's been expired for more than 60 seconds (this window accounts for synchronization issues).
@@ -143,7 +143,41 @@ The authentication plugin performs validation in the `RouterService`, which is t
 
 > **Important:** You _cannot_ build a router customization that interacts with an incoming JWT _before_ the authentication plugin validates it. Plugins that hook into the `RouterService` execute in an undefined order and might even execute in parallel.
 
-Below are two example [Rhai script](../customizations/rhai/) customizations that demonstrate actions the router can perform based on a request's claims.
+Below are three example [Rhai script](../customizations/rhai/) customizations that demonstrate actions the router can perform based on a request's claims.
+
+
+### Example: Rejecting unauthenticated requests
+
+Below is an example [Rhai script](../customizations/rhai/) that will reject requests which do not present a valid JWT.
+
+> This script hooks into the router's `SupergraphService`, which executes before the router begins generating the query plan for an operation. [Learn more about router services.](../customizations/overview#service-descriptions)
+
+<ExpansionPanel title="Click to expand">
+
+```rhai title="require_authentication.rhai"
+fn supergraph_service(service) {
+    const request_callback = Fn("process_request");
+    service.map_request(request_callback);
+}
+
+// This will examine our context to determine if our user is authenticated.
+fn process_request(request) {
+    let claims = request.context[Router.APOLLO_AUTHENTICATION_JWT_CLAIMS];
+    if claims == () {
+        throw #{
+            status: 401,
+            message: "The request is not authenticated",
+            extensions: #{
+                code: "AUTH_ERROR",
+            }
+        };
+    }
+    // We are happy we are authenticated.
+}
+```
+
+</ExpansionPanel>
+
 
 ### Example: Validating claims
 


### PR DESCRIPTION
*Breaking change*: this changes the JWT plugin's behaviour, it now lets all requests go through

now the authentication plugin only rejects invalid tokens (bad signature, expired, etc) but lets requests without tokens go through. The authorization decision is then handled later.
As an example, a rhai script can be used to refuse all unauthenticated requests

This also adds support for the `extensions` field in GraphQL errors generated from rhai

TODO:
- [ ] docs
- [ ] warn existing users about the change

*Description here*

Fixes #issue_number

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
