### PR TITLE
docs: fix description of external response

### DIFF
--- a/.changesets/docs_avery_extensibility_docs_polish.md
+++ b/.changesets/docs_avery_extensibility_docs_polish.md
@@ -1,0 +1,5 @@
+### Document `response` properly in the External Extensibility docs ([Issue #2725](https://github.com/apollographql/router/issues/2725))
+
+Updates the description of a response in the external extensibility page.
+
+By [@EverlastingBugstopper](https://github.com/EverlastingBugstopper) in https://github.com/apollographql/router/pull/2726

--- a/docs/source/configuration/external.mdx
+++ b/docs/source/configuration/external.mdx
@@ -117,7 +117,7 @@ A request from a client being processed by a router
 </td>
 <td>
 
-A request to a client being processed by a router
+A response from the router to the client
 
 </td>
 </tr>


### PR DESCRIPTION
Fixes #2725 by updating the description of a `response` in the external extensibility page

- [x] Documentation completed

**Exceptions**

The following are not applicable to a docs PR:

- [ ] Changes are compatible
- [ ] Performance impact assessed and acceptable
- Tests added and passing
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

