### PR TITLE
Fix visibility of telemetry plugin

### DIFF
--- a/.changesets/maint_bryn_fix_telemetry_plugin_visibility.md
+++ b/.changesets/maint_bryn_fix_telemetry_plugin_visibility.md
@@ -4,4 +4,4 @@ The telemetry plugin is currently pub. However, since the refactor of the Teleme
 
 It is not a breaking change to fix this as the plugin was exported under the _private module which was clearly marked as internal. However, this can be removed altogether.
 
-By [@AUTHOR](https://github.com/AUTHOR) in https://github.com/apollographql/router/pull/2740
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2740

--- a/.changesets/maint_bryn_fix_telemetry_plugin_visibility.md
+++ b/.changesets/maint_bryn_fix_telemetry_plugin_visibility.md
@@ -1,4 +1,4 @@
-### Brief but complete sentence that stands on its own ([Issue #2739](https://github.com/apollographql/router/issues/2739))
+### Fix visibility of telemetry plugin ([Issue #2739](https://github.com/apollographql/router/issues/2739))
 
 The telemetry plugin is currently pub. However, since the refactor of the Telemetry plugin and associated tests this doesn't need to be.
 

--- a/.changesets/maint_bryn_fix_telemetry_plugin_visibility.md
+++ b/.changesets/maint_bryn_fix_telemetry_plugin_visibility.md
@@ -1,0 +1,7 @@
+### Brief but complete sentence that stands on its own ([Issue #2739](https://github.com/apollographql/router/issues/2739))
+
+The telemetry plugin is currently pub. However, since the refactor of the Telemetry plugin and associated tests this doesn't need to be.
+
+It is not a breaking change to fix this as the plugin was exported under the _private module which was clearly marked as internal. However, this can be removed altogether.
+
+By [@AUTHOR](https://github.com/AUTHOR) in https://github.com/apollographql/router/pull/2740

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -100,6 +100,5 @@ pub mod _private {
     pub use crate::plugin::PluginFactory;
     pub use crate::plugin::PLUGINS;
     // For tests
-    pub use crate::plugins::telemetry::Telemetry as TelemetryPlugin;
     pub use crate::router_factory::create_test_service_factory_from_yaml;
 }

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -54,7 +54,7 @@ impl<T> GenericWith<T> for T where Self: Sized {}
 /// Telemetry configuration
 #[derive(Clone, Default, Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
-pub struct Conf {
+pub(crate) struct Conf {
     /// Logging configuration
     #[serde(rename = "experimental_logging", default)]
     pub(crate) logging: Logging,

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -132,7 +132,7 @@ const GLOBAL_TRACER_NAME: &str = "apollo-router";
 const DEFAULT_EXPOSE_TRACE_ID_HEADER: &str = "apollo-trace-id";
 
 #[doc(hidden)] // Only public for integration tests
-pub struct Telemetry {
+pub(crate) struct Telemetry {
     config: Arc<config::Conf>,
     metrics: BasicMetrics,
     // Do not remove _metrics_exporters. Metrics will not be exported if it is removed.

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -23,7 +23,6 @@ use super::subgraph_service::MakeSubgraphService;
 use super::subgraph_service::SubgraphServiceFactory;
 use super::ExecutionServiceFactory;
 use super::QueryPlannerContent;
-use crate::_private::TelemetryPlugin;
 use crate::error::CacheResolverError;
 use crate::error::ServiceBuildError;
 use crate::graphql;
@@ -32,6 +31,7 @@ use crate::introspection::Introspection;
 #[cfg(test)]
 use crate::plugin::test::MockSupergraphService;
 use crate::plugin::DynPlugin;
+use crate::plugins::telemetry::Telemetry;
 use crate::plugins::traffic_shaping::TrafficShaping;
 use crate::plugins::traffic_shaping::APOLLO_TRAFFIC_SHAPING;
 use crate::query_planner::BridgeQueryPlanner;
@@ -341,7 +341,7 @@ impl PluggableSupergraphServiceBuilder {
         // Activate the telemetry plugin.
         // We must NOT fail to go live with the new router from this point as the telemetry plugin activate interacts with globals.
         for (_, plugin) in plugins.iter_mut() {
-            if let Some(telemetry) = plugin.as_any_mut().downcast_mut::<TelemetryPlugin>() {
+            if let Some(telemetry) = plugin.as_any_mut().downcast_mut::<Telemetry>() {
                 telemetry.activate();
             }
         }


### PR DESCRIPTION
The telemetry plugin is currently pub. However, since the refactor of the Telemetry plugin and associated tests this doesn't need to be.

It is not a breaking change to fix this as the plugin was exported under the _private module which was clearly marked as internal. However, this can be removed altogether.

Previously we also had the Telemetry struct exported as TelemetryPlugin. This is no-longer necessary so I renamed the struct for consistency.
