### PR TITLE
Move APQ to top level

### DIFF
--- a/apollo-router/src/configuration/migrations/0006-apq.yaml
+++ b/apollo-router/src/configuration/migrations/0006-apq.yaml
@@ -1,0 +1,6 @@
+description: supergraph.apq moved to apq
+actions:
+  - type: move
+    from: supergraph.apq
+    to: apq
+

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -131,6 +131,10 @@ pub struct Configuration {
     #[serde(default)]
     pub(crate) tls: Tls,
 
+    /// Configures automatic persisted queries
+    #[serde(default)]
+    pub(crate) apq: Apq,
+
     /// Plugin configuration
     #[serde(default)]
     plugins: UserPlugins,
@@ -161,6 +165,7 @@ impl<'de> serde::Deserialize<'de> for Configuration {
             #[serde(flatten)]
             apollo_plugins: ApolloPlugins,
             tls: Tls,
+            apq: Apq,
         }
         let ad_hoc: AdHocConfiguration = serde::Deserialize::deserialize(deserializer)?;
 
@@ -174,6 +179,7 @@ impl<'de> serde::Deserialize<'de> for Configuration {
             .plugins(ad_hoc.plugins.plugins.unwrap_or_default())
             .apollo_plugins(ad_hoc.apollo_plugins.plugins)
             .tls(ad_hoc.tls)
+            .apq(ad_hoc.apq)
             .build()
             .map_err(|e| serde::de::Error::custom(e.to_string()))
     }
@@ -204,6 +210,7 @@ impl Configuration {
         plugins: Map<String, Value>,
         apollo_plugins: Map<String, Value>,
         tls: Option<Tls>,
+        apq: Option<Apq>,
     ) -> Result<Self, ConfigurationError> {
         let conf = Self {
             validated_yaml: Default::default(),
@@ -213,6 +220,7 @@ impl Configuration {
             sandbox: sandbox.unwrap_or_default(),
             homepage: homepage.unwrap_or_default(),
             cors: cors.unwrap_or_default(),
+            apq: apq.unwrap_or_default(),
             plugins: UserPlugins {
                 plugins: Some(plugins),
             },
@@ -270,6 +278,7 @@ impl Configuration {
         plugins: Map<String, Value>,
         apollo_plugins: Map<String, Value>,
         tls: Option<Tls>,
+        apq: Option<Apq>,
     ) -> Result<Self, ConfigurationError> {
         let configuration = Self {
             validated_yaml: Default::default(),
@@ -286,6 +295,7 @@ impl Configuration {
                 plugins: apollo_plugins,
             },
             tls: tls.unwrap_or_default(),
+            apq: apq.unwrap_or_default(),
         };
 
         configuration.validate()
@@ -450,9 +460,6 @@ pub(crate) struct Supergraph {
     /// Set to false to disable defer support
     pub(crate) defer_support: bool,
 
-    /// Configures automatic persisted queries
-    pub(crate) apq: Apq,
-
     /// Query planning options
     pub(crate) query_planning: QueryPlanning,
 }
@@ -469,7 +476,6 @@ impl Supergraph {
         path: Option<String>,
         introspection: Option<bool>,
         defer_support: Option<bool>,
-        apq: Option<Apq>,
         query_planning: Option<QueryPlanning>,
     ) -> Self {
         Self {
@@ -477,7 +483,6 @@ impl Supergraph {
             path: path.unwrap_or_else(default_graphql_path),
             introspection: introspection.unwrap_or_else(default_graphql_introspection),
             defer_support: defer_support.unwrap_or_else(default_defer_support),
-            apq: apq.unwrap_or_default(),
             query_planning: query_planning.unwrap_or_default(),
         }
     }
@@ -492,7 +497,6 @@ impl Supergraph {
         path: Option<String>,
         introspection: Option<bool>,
         defer_support: Option<bool>,
-        apq: Option<Apq>,
         query_planning: Option<QueryPlanning>,
     ) -> Self {
         Self {
@@ -500,7 +504,6 @@ impl Supergraph {
             path: path.unwrap_or_else(default_graphql_path),
             introspection: introspection.unwrap_or_else(default_graphql_introspection),
             defer_support: defer_support.unwrap_or_else(default_defer_support),
-            apq: apq.unwrap_or_default(),
             query_planning: query_planning.unwrap_or_default(),
         }
     }

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -8,6 +8,129 @@ expression: "&schema"
   "description": "The configuration for the router.\n\nCan be created through `serde::Deserialize` from various formats, or inline in Rust code with `serde_json::json!` and `serde_json::from_value`.",
   "type": "object",
   "properties": {
+    "apq": {
+      "description": "Configures automatic persisted queries",
+      "default": {
+        "enabled": true,
+        "experimental_cache": {
+          "in_memory": {
+            "limit": 512
+          },
+          "redis": null
+        },
+        "subgraph": {
+          "all": {
+            "enabled": false
+          },
+          "subgraphs": {}
+        }
+      },
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Activates Automatic Persisted Queries (enabled by default)",
+          "default": true,
+          "type": "boolean"
+        },
+        "experimental_cache": {
+          "description": "Cache configuration",
+          "default": {
+            "in_memory": {
+              "limit": 512
+            },
+            "redis": null
+          },
+          "type": "object",
+          "required": [
+            "in_memory"
+          ],
+          "properties": {
+            "in_memory": {
+              "description": "Configures the in memory cache (always active)",
+              "type": "object",
+              "required": [
+                "limit"
+              ],
+              "properties": {
+                "limit": {
+                  "description": "Number of entries in the Least Recently Used cache",
+                  "type": "integer",
+                  "format": "uint",
+                  "minimum": 1.0
+                }
+              },
+              "additionalProperties": false
+            },
+            "redis": {
+              "description": "Configures and activates the Redis cache",
+              "type": "object",
+              "required": [
+                "urls"
+              ],
+              "properties": {
+                "urls": {
+                  "description": "List of URLs to the Redis cluster",
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "format": "uri"
+                  }
+                }
+              },
+              "additionalProperties": false,
+              "nullable": true
+            }
+          },
+          "additionalProperties": false
+        },
+        "subgraph": {
+          "description": "Configuration options pertaining to the subgraph server component.",
+          "default": {
+            "all": {
+              "enabled": false
+            },
+            "subgraphs": {}
+          },
+          "type": "object",
+          "properties": {
+            "all": {
+              "description": "options applying to all subgraphs",
+              "default": {
+                "enabled": false
+              },
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "description": "Enable",
+                  "default": false,
+                  "type": "boolean"
+                }
+              },
+              "additionalProperties": false
+            },
+            "subgraphs": {
+              "description": "per subgraph options",
+              "default": {},
+              "type": "object",
+              "additionalProperties": {
+                "description": "Subgraph level Automatic Persisted Queries (APQ) configuration",
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "description": "Enable",
+                    "default": false,
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
     "authentication": {
       "description": "Authentication",
       "type": "object",
@@ -1030,21 +1153,6 @@ expression: "&schema"
         "path": "/",
         "introspection": false,
         "defer_support": true,
-        "apq": {
-          "enabled": true,
-          "experimental_cache": {
-            "in_memory": {
-              "limit": 512
-            },
-            "redis": null
-          },
-          "subgraph": {
-            "all": {
-              "enabled": false
-            },
-            "subgraphs": {}
-          }
-        },
         "query_planning": {
           "experimental_cache": {
             "in_memory": {
@@ -1057,129 +1165,6 @@ expression: "&schema"
       },
       "type": "object",
       "properties": {
-        "apq": {
-          "description": "Configures automatic persisted queries",
-          "default": {
-            "enabled": true,
-            "experimental_cache": {
-              "in_memory": {
-                "limit": 512
-              },
-              "redis": null
-            },
-            "subgraph": {
-              "all": {
-                "enabled": false
-              },
-              "subgraphs": {}
-            }
-          },
-          "type": "object",
-          "properties": {
-            "enabled": {
-              "description": "Activates Automatic Persisted Queries (enabled by default)",
-              "default": true,
-              "type": "boolean"
-            },
-            "experimental_cache": {
-              "description": "Cache configuration",
-              "default": {
-                "in_memory": {
-                  "limit": 512
-                },
-                "redis": null
-              },
-              "type": "object",
-              "required": [
-                "in_memory"
-              ],
-              "properties": {
-                "in_memory": {
-                  "description": "Configures the in memory cache (always active)",
-                  "type": "object",
-                  "required": [
-                    "limit"
-                  ],
-                  "properties": {
-                    "limit": {
-                      "description": "Number of entries in the Least Recently Used cache",
-                      "type": "integer",
-                      "format": "uint",
-                      "minimum": 1.0
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "redis": {
-                  "description": "Configures and activates the Redis cache",
-                  "type": "object",
-                  "required": [
-                    "urls"
-                  ],
-                  "properties": {
-                    "urls": {
-                      "description": "List of URLs to the Redis cluster",
-                      "type": "array",
-                      "items": {
-                        "type": "string",
-                        "format": "uri"
-                      }
-                    }
-                  },
-                  "additionalProperties": false,
-                  "nullable": true
-                }
-              },
-              "additionalProperties": false
-            },
-            "subgraph": {
-              "description": "Configuration options pertaining to the subgraph server component.",
-              "default": {
-                "all": {
-                  "enabled": false
-                },
-                "subgraphs": {}
-              },
-              "type": "object",
-              "properties": {
-                "all": {
-                  "description": "options applying to all subgraphs",
-                  "default": {
-                    "enabled": false
-                  },
-                  "type": "object",
-                  "properties": {
-                    "enabled": {
-                      "description": "Enable",
-                      "default": false,
-                      "type": "boolean"
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                "subgraphs": {
-                  "description": "per subgraph options",
-                  "default": {},
-                  "type": "object",
-                  "additionalProperties": {
-                    "description": "Subgraph level Automatic Persisted Queries (APQ) configuration",
-                    "type": "object",
-                    "properties": {
-                      "enabled": {
-                        "description": "Enable",
-                        "default": false,
-                        "type": "boolean"
-                      }
-                    },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "additionalProperties": false
-            }
-          },
-          "additionalProperties": false
-        },
         "defer_support": {
           "description": "Set to false to disable defer support",
           "default": true,

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@supergraph_apq_to_apq.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@supergraph_apq_to_apq.router.yaml.snap
@@ -1,0 +1,14 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+---
+---
+supergraph: {}
+apq:
+  experimental_cache:
+    in_memory:
+      limit: 2000
+    redis:
+      urls:
+        - "http://example.com"
+

--- a/apollo-router/src/configuration/testdata/migrations/supergraph_apq_to_apq.router.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/supergraph_apq_to_apq.router.yaml
@@ -1,0 +1,8 @@
+supergraph:
+  apq:
+    experimental_cache:
+      in_memory:
+        limit: 2000
+      redis:
+        urls:
+          - http://example.com

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -174,13 +174,12 @@ impl RouterSuperServiceFactory for YamlRouterFactory {
                         SubgraphService::new(
                             name,
                             configuration
-                                .supergraph
                                 .apq
                                 .subgraph
                                 .subgraphs
                                 .get(name)
                                 .map(|apq| apq.enabled)
-                                .unwrap_or(configuration.supergraph.apq.subgraph.all.enabled),
+                                .unwrap_or(configuration.apq.subgraph.all.enabled),
                             subgraph_root_store,
                             shaping.enable_subgraph_http2(name),
                         ),
@@ -262,13 +261,12 @@ impl YamlRouterFactory {
                         SubgraphService::new(
                             name,
                             configuration
-                                .supergraph
                                 .apq
                                 .subgraph
                                 .subgraphs
                                 .get(name)
                                 .map(|apq| apq.enabled)
-                                .unwrap_or(configuration.supergraph.apq.subgraph.all.enabled),
+                                .unwrap_or(configuration.apq.subgraph.all.enabled),
                             subgraph_root_store,
                             shaping.enable_subgraph_http2(name),
                         ),

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -190,7 +190,6 @@ mod apq_tests {
 
     use super::*;
     use crate::configuration::Apq;
-    use crate::configuration::Supergraph;
     use crate::error::Error;
     use crate::graphql::Response;
     use crate::services::layers::content_negociation::ACCEPTS_JSON_CONTEXT_KEY;
@@ -434,11 +433,8 @@ mod apq_tests {
         };
 
         let mut config = Configuration::default();
-        config.supergraph = Supergraph {
-            apq: Apq {
-                enabled: false,
-                ..Default::default()
-            },
+        config.apq = Apq {
+            enabled: false,
             ..Default::default()
         };
 

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -481,10 +481,10 @@ where
 {
     pub(crate) async fn new(supergraph_creator: Arc<SF>, configuration: &Configuration) -> Self {
         let static_page = StaticPageLayer::new(configuration);
-        let apq_layer = if configuration.supergraph.apq.enabled {
+        let apq_layer = if configuration.apq.enabled {
             APQLayer::with_cache(
                 DeduplicatingCache::from_configuration(
-                    &configuration.supergraph.apq.experimental_cache,
+                    &configuration.apq.experimental_cache,
                     "APQ",
                 )
                 .await,

--- a/apollo-router/tests/redis_test.rs
+++ b/apollo-router/tests/redis_test.rs
@@ -88,15 +88,13 @@ mod test {
             .expect("got redis connection");
 
         let config = json!({
-            "supergraph": {
-                "apq": {
-                    "experimental_cache": {
-                        "in_memory": {
-                            "limit": 2
-                        },
-                        "redis": {
-                            "urls": ["redis://127.0.0.1:6379"]
-                        }
+            "apq": {
+                "experimental_cache": {
+                    "in_memory": {
+                        "limit": 2
+                    },
+                    "redis": {
+                        "urls": ["redis://127.0.0.1:6379"]
                     }
                 }
             }

--- a/docs/source/configuration/caching.mdx
+++ b/docs/source/configuration/caching.mdx
@@ -6,11 +6,12 @@ The Apollo Router comes with an in-memory cache, used to store Automated Persist
 This is a Least Recently Used (LRU) cache, that can be configured as follows:
 
 ```yaml title="router.yaml"
+apq:
+  experimental_cache:
+    in_memory:
+      limit: 512
+      
 supergraph:
-  apq:
-    experimental_cache:
-      in_memory:
-        limit: 512
   query_planning:
     experimental_cache:
       in_memory:
@@ -27,13 +28,13 @@ It can be tested by building a custom Router binary, with the Cargo feature `exp
 This will activate a configuration option to connect to a Redis Cluster:
 
 ```yaml
+apq:
+  experimental_cache:
+    in_memory:
+      limit: 512
+    redis:
+      urls: ["redis://..."]
 supergraph:
-  apq:
-    experimental_cache:
-      in_memory:
-        limit: 512
-      redis:
-        urls: ["redis://..."]
   query_planning:
     experimental_cache:
       in_memory:

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -449,9 +449,8 @@ The Apollo Router automatically supports APQ with clients via its in-memory cach
 You can _disable_ this APQ support like so:
 
 ```yaml
-supergraph:
-  apq:
-    enabled: false
+apq:
+  enabled: false
 ```
 
 #### APQ with subgraphs
@@ -461,16 +460,15 @@ By default, the Apollo Router does _not_ use APQ when sending queries to its sub
 You can configure this APQ support with a combination of global and per-subgraph settings:
 
 ```yaml title="router.yaml"
-supergraph:
-  apq:
-    subgraph:
-      # Disable subgraph APQ globally unless overridden per-subgraph
-      all:
-        enabled: false
-      # Override global APQ setting for individual subgraphs
-      subgraphs:
-        products:
-          enabled: true
+apq:
+  subgraph:
+    # Disable subgraph APQ globally unless overridden per-subgraph
+    all:
+      enabled: false
+    # Override global APQ setting for individual subgraphs
+    subgraphs:
+      products:
+        enabled: true
 ```
 
 In the example above, subgraph APQ is disabled _except for_ the `products` subgraph.

--- a/router-old.yaml
+++ b/router-old.yaml
@@ -1,0 +1,3 @@
+supergraph:
+  apq:
+    enabled: true


### PR DESCRIPTION
For improved usability we will be moving items out of `supergraph` in router.yaml. This is because various plugins use stages as part of their yaml config.

```diff
< apq:
<   enabled: true
---
> supergraph:
>   apq:
>     enabled: true
```

Fixes #2744 

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
