### PR TITLE
State machine will always retain most recent config

### DIFF
--- a/.changesets/fix_storeroom_dumbbell_searchlight_nudge.md
+++ b/.changesets/fix_storeroom_dumbbell_searchlight_nudge.md
@@ -10,14 +10,14 @@ For example, previously:
 
 1. Router starts with valid schema and config.
 2. Router config is set to something invalid and restart doesn't happen. 
-3. Router receives a new schema, but the router fails to restart because of config. 
-4. Router receives a new config that is valid. It restarts, but with the original schema.
+3. Router receives a new schema, the router restarts with the new schema and the original valid config.
 
 After this change the latest information is used to restart the router always:
 
 1. Router starts with valid schema and config.
 2. Router config is set to something invalid and restart doesn't happen. 
-3. Router receives a new schema, but the router fails to restart because of config. 
-4. Router receives a new config that is valid. It restarts, but with the latest schema.
+3. Router receives a new schema, but the router fails to restart because of config is still invalid.
+
+It is important not to reload on inconsistant states because the use of a new schema may directyly rely on changes in config to work correctly.
 
 By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2753

--- a/.changesets/fix_storeroom_dumbbell_searchlight_nudge.md
+++ b/.changesets/fix_storeroom_dumbbell_searchlight_nudge.md
@@ -8,8 +8,9 @@ Changing this behaviour means that the router must enter a good configuration st
 
 For example:
 
-Router starts with valid schema and config.
-Router config is set to something invalid and restart doesn't happen. Router receives a new schema, but the router fails to restart because of config. Router receives a new config that is valid. It restarts, but with the original schema.
+1. Router starts with valid schema and config.
+2. Router config is set to something invalid and restart doesn't happen. 
+3. Router receives a new schema, but the router fails to restart because of config. Router receives a new config that is valid. It restarts, but with the original schema.
 
 After this change the latest information is used to restart the router always.
 

--- a/.changesets/fix_storeroom_dumbbell_searchlight_nudge.md
+++ b/.changesets/fix_storeroom_dumbbell_searchlight_nudge.md
@@ -18,6 +18,6 @@ After this change the latest information is used to restart the router always:
 2. Router config is set to something invalid and restart doesn't happen. 
 3. Router receives a new schema, but the router fails to restart because of config is still invalid.
 
-It is important not to reload on inconsistant states because the use of a new schema may directyly rely on changes in config to work correctly.
+It is important not to reload on inconsistant states because the use of a new schema may directly rely on changes in config to work correctly.
 
 By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2753

--- a/.changesets/fix_storeroom_dumbbell_searchlight_nudge.md
+++ b/.changesets/fix_storeroom_dumbbell_searchlight_nudge.md
@@ -1,0 +1,16 @@
+### State machine will always retain most recent config ([Issue #2752](https://github.com/apollographql/router/issues/2752))
+
+Previously if the router failed to reload either for config or for schema changes it would discard the new information.
+
+Now It will always retain the new information.
+
+Changing this behaviour means that the router must enter a good configuration state before it will reload rather than reloading with potentially inconsistent state.
+
+For example:
+
+Router starts with valid schema and config.
+Router config is set to something invalid and restart doesn't happen. Router receives a new schema, but the router fails to restart because of config. Router receives a new config that is valid. It restarts, but with the original schema.
+
+After this change the latest information is used to restart the router always.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2753

--- a/.changesets/fix_storeroom_dumbbell_searchlight_nudge.md
+++ b/.changesets/fix_storeroom_dumbbell_searchlight_nudge.md
@@ -6,12 +6,18 @@ Now It will always retain the new information.
 
 Changing this behaviour means that the router must enter a good configuration state before it will reload rather than reloading with potentially inconsistent state.
 
-For example:
+For example, previously:
 
 1. Router starts with valid schema and config.
 2. Router config is set to something invalid and restart doesn't happen. 
-3. Router receives a new schema, but the router fails to restart because of config. Router receives a new config that is valid. It restarts, but with the original schema.
+3. Router receives a new schema, but the router fails to restart because of config. 
+4. Router receives a new config that is valid. It restarts, but with the original schema.
 
-After this change the latest information is used to restart the router always.
+After this change the latest information is used to restart the router always:
+
+1. Router starts with valid schema and config.
+2. Router config is set to something invalid and restart doesn't happen. 
+3. Router receives a new schema, but the router fails to restart because of config. 
+4. Router receives a new config that is valid. It restarts, but with the latest schema.
 
 By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2753


### PR DESCRIPTION
Previously if the router failed to reload either for config or for schema changes it would discard the new information.

Now It will always retain the new information.

Changing this behaviour means that the router must enter a good configuration state before it will reload rather than reloading with potentially inconsistent state.

For example:

1. Router starts with valid schema and config.
2. Router config is set to something invalid and restart doesn't happen. Router receives a new schema, but the router fails to restart because of config. 
3. Router receives a new config that is valid. It restarts, but with the original schema.

After this change the latest information is used to restart the router always.

Fixes #2752

This is related to #2747, but the auth plugin still needs fixing. 

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
