### PR TITLE
Do not fail JWT plugin init on JWKS download

### DIFF
--- a/.changesets/fix_geal_jwt_do_not_block_startup.md
+++ b/.changesets/fix_geal_jwt_do_not_block_startup.md
@@ -1,0 +1,5 @@
+### Do not fail JWT plugin init on JWKS download ([Issue #2747](https://github.com/apollographql/router/issues/2747))
+
+JWKS download can fail sometimes, but it can be temporary, so it should not fail plugin initialization. We still try to download them during initialization, to make a reasonable effort of starting a router with all the JWKS, but if one download fails we still go on
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2754

--- a/apollo-router/src/plugins/authentication/jwks.rs
+++ b/apollo-router/src/plugins/authentication/jwks.rs
@@ -21,7 +21,6 @@ use url::Url;
 
 use super::CLIENT;
 use super::DEFAULT_AUTHENTICATION_NETWORK_TIMEOUT;
-use crate::configuration::ConfigurationError;
 #[cfg(not(test))]
 use crate::error::LicenseError;
 use crate::plugins::authentication::DEFAULT_AUTHENTICATION_DOWNLOAD_INTERVAL;
@@ -65,7 +64,7 @@ impl JwksManager {
             .filter_map(|v| v)
             .collect();
 
-        let jwks_map = Arc::new(RwLock::new(map));
+        let jwks_map = Arc::new(RwLock::new(jwks_map));
         let (_drop_signal, drop_receiver) = oneshot::channel::<()>();
 
         tokio::task::spawn(poll(list.clone(), jwks_map.clone(), drop_receiver));

--- a/apollo-router/src/plugins/authentication/jwks.rs
+++ b/apollo-router/src/plugins/authentication/jwks.rs
@@ -58,11 +58,7 @@ impl JwksManager {
             })
             .collect::<Vec<_>>();
 
-        let jwks_map: HashMap<_, _> = join_all(downloads)
-            .await
-            .into_iter()
-            .filter_map(|v| v)
-            .collect();
+        let jwks_map: HashMap<_, _> = join_all(downloads).await.into_iter().flatten().collect();
 
         let jwks_map = Arc::new(RwLock::new(jwks_map));
         let (_drop_signal, drop_receiver) = oneshot::channel::<()>();


### PR DESCRIPTION
Fix #2747

JWKS download can fail sometimes, but it can be temporary, so it should not fail plugin initialization. We still try to download them during init, to make a reasonable effort of starting a router with all the JWKs, but if one download fails we still go on
