### PR TITLE
delete useless whitespace in log text formatter

### DIFF
--- a/.changesets/fix_bnjjj_fix_log_formatter_level.md
+++ b/.changesets/fix_bnjjj_fix_log_formatter_level.md
@@ -1,0 +1,5 @@
+### Delete useless space in text formatter ([PR #2755](https://github.com/apollographql/router/pull/2755))
+
+An useless space in front of the log level was added in logs when using the pretty text formatter.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/2755

--- a/apollo-router/src/plugins/telemetry/formatters/text.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/text.rs
@@ -34,8 +34,8 @@ impl Default for TextFormatter {
 impl TextFormatter {
     const TRACE_STR: &'static str = "TRACE";
     const DEBUG_STR: &'static str = "DEBUG";
-    const INFO_STR: &'static str = " INFO";
-    const WARN_STR: &'static str = " WARN";
+    const INFO_STR: &'static str = "INFO";
+    const WARN_STR: &'static str = "WARN";
     const ERROR_STR: &'static str = "ERROR";
 
     pub(crate) fn new() -> Self {

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -30,7 +30,7 @@ pub(crate) struct Config {
 
 impl TracingConfigurator for Config {
     fn apply(&self, builder: Builder, trace_config: &Trace) -> Result<Builder, BoxError> {
-        tracing::info!("configuring Datadog tracing: {}", self.batch_processor);
+        tracing::info!("Configuring Datadog tracing: {}", self.batch_processor);
         let url = match &self.endpoint {
             AgentEndpoint::Default(_) => None,
             AgentEndpoint::Url(s) => Some(s),

--- a/apollo-router/src/plugins/telemetry/tracing/jaeger.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/jaeger.rs
@@ -72,7 +72,7 @@ impl TracingConfigurator for Config {
                 agent,
                 batch_processor,
             } => {
-                tracing::info!("configuring Jaeger tracing: {}", batch_processor);
+                tracing::info!("Configuring Jaeger tracing: {}", batch_processor);
                 let socket = match &agent.endpoint {
                     AgentEndpoint::Default(_) => None,
                     AgentEndpoint::Url(u) => {
@@ -99,7 +99,7 @@ impl TracingConfigurator for Config {
                 collector,
                 batch_processor,
             } => {
-                tracing::info!("configuring Jaeger tracing: {}", batch_processor);
+                tracing::info!("Configuring Jaeger tracing: {}", batch_processor);
                 // We are waiting for a release of https://github.com/open-telemetry/opentelemetry-rust/issues/894
                 // Until that time we need to wrap a tracer provider with Jeager in.
                 let tracer_provider = opentelemetry_jaeger::new_collector_pipeline()

--- a/apollo-router/src/plugins/telemetry/tracing/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/otlp.rs
@@ -12,7 +12,7 @@ use crate::plugins::telemetry::tracing::TracingConfigurator;
 
 impl TracingConfigurator for super::super::otlp::Config {
     fn apply(&self, builder: Builder, _trace_config: &Trace) -> Result<Builder, BoxError> {
-        tracing::info!("configuring Otlp tracing: {}", self.batch_processor);
+        tracing::info!("Configuring Otlp tracing: {}", self.batch_processor);
         let exporter: SpanExporterBuilder = self.exporter()?;
         Ok(builder.with_span_processor(
             BatchSpanProcessor::builder(


### PR DESCRIPTION
An useless whitespace in front of the log level was added in logs when using the pretty text formatter.