### PR TITLE
keep errors set on nullified paths

### DIFF
--- a/apollo-router/src/services/snapshots/apollo_router__services__supergraph_service__tests__errors_on_nullified_paths.snap
+++ b/apollo-router/src/services/snapshots/apollo_router__services__supergraph_service__tests__errors_on_nullified_paths.snap
@@ -1,0 +1,27 @@
+---
+source: apollo-router/src/services/supergraph_service.rs
+expression: stream.next_response().await.unwrap()
+---
+{
+  "data": {
+    "foo": {
+      "id": 1,
+      "bar": {
+        "id": 2,
+        "something": null
+      }
+    }
+  },
+  "errors": [
+    {
+      "message": "Could not fetch bar",
+      "path": [
+        "foo",
+        "bar"
+      ],
+      "extensions": {
+        "code": "NOT_FOUND"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Fix #2731

Errors on nullified paths should still be transmitted

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
