### PR TITLE
Use a thread to clean up trace_providers rather than tokio::spawn_blocking

### DIFF
--- a/.changesets/maint_riding_pellet_burrito_glacier.md
+++ b/.changesets/maint_riding_pellet_burrito_glacier.md
@@ -1,0 +1,10 @@
+### Use a thread to clean up trace_providers rather than tokio blocking_task ([Issue #2668](https://github.com/apollographql/router/issues/2668))
+
+Otel shutdown may sometime hang due to `Telemetry::Drop` using a `tokio::spawn_blocking` to flush the `trace_provider`.
+
+Tokio doesn't finish executing tasks before termination https://github.com/tokio-rs/tokio/issues/1156.
+This means that if the runtime is shutdown there is potentially a race where `trace_provider` may not be flushed.
+By using a thread it doesn't matter if the tokio runtime is shut down.
+This is likely to happen in tests due to the tokio runtime being destroyed when the test method exits.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2757

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -2,10 +2,11 @@
 // With regards to ELv2 licensing, this entire file is license key functionality
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::Arc;
+use std::thread;
 use std::time::Duration;
 use std::time::Instant;
-use std::{fmt, thread};
 
 use ::tracing::field;
 use ::tracing::info_span;


### PR DESCRIPTION
Otel shutdown may sometime hang due to `Telemetry::Drop` using a `tokio::spawn_blocking` to flush the `trace_provider`.

Tokio doesn't finish executing tasks before termination https://github.com/tokio-rs/tokio/issues/1156.
This means that if the runtime is shutdown there is potentially a race where `trace_provider` may not be flushed.
By using a thread it doesn't matter if the tokio runtime is shut down.
This is likely to happen in tests due to the tokio runtime being destroyed when the test method exits.

Fixes #2668

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
