### PR TITLE
docs: repair broken links to Rhai scripts

### DIFF
--- a/docs/source/configuration/header-propagation.mdx
+++ b/docs/source/configuration/header-propagation.mdx
@@ -209,7 +209,7 @@ headers:
 
 ## Response header propagation
 
-It is not currently possible to propagate response headers from subgraphs to clients using YAML configuration alone. It can however be achieved using [Rhai scripting]("../customizations/rhai").
+It is not currently possible to propagate response headers from subgraphs to clients using YAML configuration alone. It can however be achieved using [Rhai scripting](../customizations/rhai).
 
 This approach relies on the fact that all requests have context that can be used to store data for the duration of the request:
 
@@ -259,7 +259,7 @@ If you would like to see a YAML based solution then [please leave us a comment o
 
 ## Propagation between subgraphs
 
-It is not currently possible to propagate headers between subgraphs using yaml config alone. It can however be achieved using [Rhai scripting]("../customizations/rhai").
+It is not currently possible to propagate headers between subgraphs using yaml config alone. It can however be achieved using [Rhai scripting](../customizations/rhai).
 
 This approach relies on the fact that all requests have context that can be used to store data for the duration of the request:
 


### PR DESCRIPTION
This is a minor PR patching broken links caused by inclusion of quotes **"** in markdown links