### PR TITLE
chore: Separate out `router-bridge` updates from grouped Renovation

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -103,5 +103,14 @@
       "groupSlug": "cargo-tracing-packages",
       "dependencyDashboardApproval": true
     },
+    // We'll review these in a PR of their own since it has the most direct runtime
+    // implications on users that we'd like to be very intentional about.
+    {
+      "matchPackageNames": ["router-bridge"],
+      "groupName": "router-bridge updates (including federation)",
+      "groupSlug": "rust-router-bridge-updates",
+      "matchManagers": ["cargo"],
+      "automerge": false
+    }
   ]
 }


### PR DESCRIPTION
This puts the Renovation of `router-bridge` into a PR by itself and disables automerge for it so it doesn't end up riding along with other dependencies, as it did with https://github.com/apollographql/router/pull/2732.