### PR TITLE
Uplink metrics

### DIFF
--- a/.changesets/feat_bladder_dresser_glad_pill.md
+++ b/.changesets/feat_bladder_dresser_glad_pill.md
@@ -1,4 +1,4 @@
-### Uplink metrics ([Issue #2769](https://github.com/apollographql/router/issues/2769))
+### Uplink metrics and logging ([Issue #2769](https://github.com/apollographql/router/issues/2769))
 
 Adds metrics for uplink of the format:
 ```
@@ -28,5 +28,7 @@ This is a histogram of duration which contains the following attributes:
 * error: The error message
 
 A limitation of this is that it can't display metrics for the first poll to uplink as telemetry hasn't been set up yet.
+
+Logging messages have also been improved.
 
 By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2779

--- a/.changesets/feat_bladder_dresser_glad_pill.md
+++ b/.changesets/feat_bladder_dresser_glad_pill.md
@@ -1,0 +1,32 @@
+### Uplink metrics ([Issue #2769](https://github.com/apollographql/router/issues/2769))
+
+Adds metrics for uplink of the format:
+```
+# HELP uplink uplink
+# TYPE uplink histogram
+uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.001"} 0
+uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.005"} 0
+uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.015"} 0
+uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.05"} 0
+uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.1"} 0
+uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.2"} 0
+uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.3"} 1
+uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.4"} 1
+uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.5"} 1
+uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="1"} 1
+uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="5"} 1
+uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="10"} 1
+uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="+Inf"} 1
+uplink_sum{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql"} 0.21680258
+uplink_count{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql"} 1
+```
+This is a histogram of duration which contains the following attributes:
+* url: the url that was polled
+* query: SupergraphSdl|Entitlement
+* type: new|unchanged|http_error|uplink_error
+* code: The error code depending on type
+* error: The error message
+
+A limitation of this is that it can't display metrics for the first poll to uplink as telemetry hasn't been set up yet.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2779

--- a/apollo-router/src/plugins/telemetry/reload.rs
+++ b/apollo-router/src/plugins/telemetry/reload.rs
@@ -1,6 +1,3 @@
-use crate::plugins::telemetry::formatters::text::TextFormatter;
-use crate::plugins::telemetry::formatters::{filter_metric_events, FilteringFormatter};
-use crate::plugins::telemetry::metrics;
 use anyhow::anyhow;
 use anyhow::Result;
 use once_cell::sync::OnceCell;
@@ -17,6 +14,10 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Registry;
 
+use crate::plugins::telemetry::formatters::filter_metric_events;
+use crate::plugins::telemetry::formatters::text::TextFormatter;
+use crate::plugins::telemetry::formatters::FilteringFormatter;
+use crate::plugins::telemetry::metrics;
 use crate::plugins::telemetry::metrics::layer::MetricsLayer;
 use crate::plugins::telemetry::tracing::reload::ReloadTracer;
 

--- a/apollo-router/src/plugins/telemetry/reload.rs
+++ b/apollo-router/src/plugins/telemetry/reload.rs
@@ -1,3 +1,4 @@
+use crate::plugins::telemetry::metrics;
 use anyhow::anyhow;
 use anyhow::Result;
 use once_cell::sync::OnceCell;
@@ -93,6 +94,8 @@ pub(crate) fn init_telemetry(log_level: &str) -> Result<()> {
 
 pub(super) fn reload_metrics(layer: MetricsLayer) {
     if let Some(handle) = METRICS_LAYER_HANDLE.get() {
+        // If we are now going live with a new controller then maybe stash it.
+        metrics::prometheus::commit_new_controller();
         handle
             .reload(layer)
             .expect("metrics layer reload must succeed");

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -55,7 +55,7 @@ use crate::state_machine::ListenAddresses;
 use crate::state_machine::StateMachine;
 use crate::uplink::entitlement::Entitlement;
 use crate::uplink::entitlement::EntitlementState;
-use crate::uplink::entitlement_stream::EntitlementRequest;
+use crate::uplink::entitlement_stream::EntitlementQuery;
 use crate::uplink::entitlement_stream::EntitlementStreamExt;
 use crate::uplink::schema_stream::SupergraphSdlQuery;
 use crate::uplink::stream_from_uplink;
@@ -531,7 +531,7 @@ impl EntitlementSource {
                 urls,
                 poll_interval,
                 timeout,
-            } => stream_from_uplink::<EntitlementRequest, Entitlement>(
+            } => stream_from_uplink::<EntitlementQuery, Entitlement>(
                 apollo_key,
                 apollo_graph_ref,
                 urls.map(Endpoints::round_robin),

--- a/apollo-router/src/uplink/entitlement_query.graphql
+++ b/apollo-router/src/uplink/entitlement_query.graphql
@@ -1,4 +1,4 @@
-query EntitlementRequest($apiKey: String!, $graph_ref: String!, $unlessId: ID) {
+query EntitlementQuery($apiKey: String!, $graph_ref: String!, $unlessId: ID) {
 
     routerEntitlements(unlessId: $unlessId, apiKey: $apiKey, ref: $graph_ref) {
         __typename

--- a/apollo-router/src/uplink/entitlement_stream.rs
+++ b/apollo-router/src/uplink/entitlement_stream.rs
@@ -22,8 +22,8 @@ use tokio_util::time::DelayQueue;
 use crate::router::Event;
 use crate::uplink::entitlement::Entitlement;
 use crate::uplink::entitlement::EntitlementState;
-use crate::uplink::entitlement_stream::entitlement_request::EntitlementRequestRouterEntitlements;
-use crate::uplink::entitlement_stream::entitlement_request::FetchErrorCode;
+use crate::uplink::entitlement_stream::entitlement_query::EntitlementQueryRouterEntitlements;
+use crate::uplink::entitlement_stream::entitlement_query::FetchErrorCode;
 use crate::uplink::UplinkRequest;
 use crate::uplink::UplinkResponse;
 
@@ -35,11 +35,11 @@ use crate::uplink::UplinkResponse;
     response_derives = "PartialEq, Debug, Deserialize",
     deprecated = "warn"
 )]
-pub(crate) struct EntitlementRequest {}
+pub(crate) struct EntitlementQuery {}
 
-impl From<UplinkRequest> for entitlement_request::Variables {
+impl From<UplinkRequest> for entitlement_query::Variables {
     fn from(req: UplinkRequest) -> Self {
-        entitlement_request::Variables {
+        entitlement_query::Variables {
             api_key: req.api_key,
             graph_ref: req.graph_ref,
             unless_id: req.id,
@@ -47,13 +47,13 @@ impl From<UplinkRequest> for entitlement_request::Variables {
     }
 }
 
-impl From<entitlement_request::ResponseData> for UplinkResponse<Entitlement> {
-    fn from(response: entitlement_request::ResponseData) -> Self {
+impl From<entitlement_query::ResponseData> for UplinkResponse<Entitlement> {
+    fn from(response: entitlement_query::ResponseData) -> Self {
         match response.router_entitlements {
-            EntitlementRequestRouterEntitlements::RouterEntitlementsResult(result) => {
+            EntitlementQueryRouterEntitlements::RouterEntitlementsResult(result) => {
                 if let Some(entitlement) = result.entitlement {
                     match Entitlement::from_str(&entitlement.jwt) {
-                        Ok(entitlement) => UplinkResponse::Result {
+                        Ok(entitlement) => UplinkResponse::New {
                             response: entitlement,
                             id: result.id,
                             // this will truncate the number of seconds to under u64::MAX, which should be
@@ -67,7 +67,7 @@ impl From<entitlement_request::ResponseData> for UplinkResponse<Entitlement> {
                         },
                     }
                 } else {
-                    UplinkResponse::Result {
+                    UplinkResponse::New {
                         response: Entitlement::default(),
                         id: result.id,
                         // this will truncate the number of seconds to under u64::MAX, which should be
@@ -76,13 +76,11 @@ impl From<entitlement_request::ResponseData> for UplinkResponse<Entitlement> {
                     }
                 }
             }
-            EntitlementRequestRouterEntitlements::Unchanged(response) => {
-                UplinkResponse::Unchanged {
-                    id: Some(response.id),
-                    delay: Some(response.min_delay_seconds as u64),
-                }
-            }
-            EntitlementRequestRouterEntitlements::FetchError(error) => UplinkResponse::Error {
+            EntitlementQueryRouterEntitlements::Unchanged(response) => UplinkResponse::Unchanged {
+                id: Some(response.id),
+                delay: Some(response.min_delay_seconds as u64),
+            },
+            EntitlementQueryRouterEntitlements::FetchError(error) => UplinkResponse::Error {
                 retry_later: error.code == FetchErrorCode::RETRY_LATER,
                 code: match error.code {
                     FetchErrorCode::AUTHENTICATION_FAILED => "AUTHENTICATION_FAILED".to_string(),
@@ -245,7 +243,7 @@ mod test {
     use crate::uplink::entitlement::EntitlementState;
     use crate::uplink::entitlement::OneOrMany;
     use crate::uplink::entitlement_stream::to_positive_instant;
-    use crate::uplink::entitlement_stream::EntitlementRequest;
+    use crate::uplink::entitlement_stream::EntitlementQuery;
     use crate::uplink::entitlement_stream::EntitlementStreamExt;
     use crate::uplink::stream_from_uplink;
 
@@ -255,7 +253,7 @@ mod test {
             std::env::var("TEST_APOLLO_KEY"),
             std::env::var("TEST_APOLLO_GRAPH_REF"),
         ) {
-            let results = stream_from_uplink::<EntitlementRequest, Entitlement>(
+            let results = stream_from_uplink::<EntitlementQuery, Entitlement>(
                 apollo_key,
                 apollo_graph_ref,
                 None,

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -1,7 +1,8 @@
 // With regards to ELv2 licensing, this entire file is license key functionality
 
 use std::fmt::Debug;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+use std::time::Instant;
 
 use futures::Stream;
 use graphql_client::QueryBody;

--- a/apollo-router/src/uplink/schema_stream.rs
+++ b/apollo-router/src/uplink/schema_stream.rs
@@ -36,7 +36,7 @@ impl From<UplinkRequest> for supergraph_sdl_query::Variables {
 impl From<supergraph_sdl_query::ResponseData> for UplinkResponse<String> {
     fn from(response: supergraph_sdl_query::ResponseData) -> Self {
         match response.router_config {
-            SupergraphSdlQueryRouterConfig::RouterConfigResult(result) => UplinkResponse::Result {
+            SupergraphSdlQueryRouterConfig::RouterConfigResult(result) => UplinkResponse::New {
                 response: result.supergraph_sdl,
                 id: result.id,
                 // this will truncate the number of seconds to under u64::MAX, which should be

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_empty_http_fallback.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_empty_http_fallback.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/uplink/mod.rs
+expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
+---
+- Ok: response
+- Ok: response
+

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_empty_http_round_robin.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_empty_http_round_robin.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/uplink/mod.rs
+expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
+---
+- Ok: response
+- Ok: response
+

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -330,7 +330,7 @@ impl IntegrationTest {
     pub async fn assert_metrics_contains(&self, text: &str) {
         let now = Instant::now();
         let mut last_metrics = String::new();
-        while now.elapsed() < Duration::from_secs(5) {
+        while now.elapsed() < Duration::from_secs(10) {
             if let Ok(metrics) = self
                 .get_metrics_response()
                 .await

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -327,6 +327,28 @@ impl IntegrationTest {
     }
 
     #[allow(dead_code)]
+    pub async fn assert_metrics_contains(&self, text: &str) {
+        let now = Instant::now();
+        let mut last_metrics = String::new();
+        while now.elapsed() < Duration::from_secs(5) {
+            if let Ok(metrics) = self
+                .get_metrics_response()
+                .await
+                .expect("failed to fetch metrics")
+                .text()
+                .await
+            {
+                if metrics.contains(text) {
+                    return;
+                }
+                last_metrics = metrics;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("'{text}' not detected in metrics\n{last_metrics}");
+    }
+
+    #[allow(dead_code)]
     pub async fn assert_shutdown(&mut self) {
         let mut router = self.router.take().expect("router must have been started");
         let now = Instant::now();

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -327,10 +327,10 @@ impl IntegrationTest {
     }
 
     #[allow(dead_code)]
-    pub async fn assert_metrics_contains(&self, text: &str) {
+    pub async fn assert_metrics_contains(&self, text: &str, duration: Option<Duration>) {
         let now = Instant::now();
         let mut last_metrics = String::new();
-        while now.elapsed() < Duration::from_secs(10) {
+        while now.elapsed() < duration.unwrap_or_else(|| Duration::from_secs(15)) {
             if let Ok(metrics) = self
                 .get_metrics_response()
                 .await

--- a/apollo-router/tests/metrics_tests.rs
+++ b/apollo-router/tests/metrics_tests.rs
@@ -31,19 +31,28 @@ async fn test_metrics_reloading() -> Result<(), BoxError> {
                     .unwrap()
         );
 
-        // Validate metric request body.
-        let metrics = metrics_response.text().await?;
-        assert!(metrics.contains(r#"apollo_router_cache_hit_count{kind="query planner",service_name="apollo-router",storage="memory"} 2"#));
-        assert!(metrics.contains(r#"apollo_router_cache_miss_count{kind="query planner",service_name="apollo-router",storage="memory"} 1"#));
-        assert!(metrics.contains("apollo_router_cache_hit_time"));
-        assert!(metrics.contains("apollo_router_cache_miss_time"));
-        assert!(metrics.contains("apollo_router_session_count_total"));
-        assert!(metrics.contains("apollo_router_session_count_active"));
-        assert!(metrics.contains("custom_header=\"test_custom\""));
-
         router.touch_config().await;
         router.assert_reloaded().await;
     }
+
+    router.assert_metrics_contains(r#"apollo_router_cache_hit_count{kind="query planner",service_name="apollo-router",storage="memory"} 4"#).await;
+    router.assert_metrics_contains(r#"apollo_router_cache_miss_count{kind="query planner",service_name="apollo-router",storage="memory"} 2"#).await;
+    router
+        .assert_metrics_contains(r#"apollo_router_cache_hit_time"#)
+        .await;
+    router
+        .assert_metrics_contains(r#"apollo_router_cache_miss_time"#)
+        .await;
+    router
+        .assert_metrics_contains(r#"apollo_router_session_count_total"#)
+        .await;
+    router
+        .assert_metrics_contains(r#"apollo_router_session_count_active"#)
+        .await;
+    router
+        .assert_metrics_contains(r#"custom_header="test_custom""#)
+        .await;
+
     Ok(())
 }
 

--- a/apollo-router/tests/metrics_tests.rs
+++ b/apollo-router/tests/metrics_tests.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use tower::BoxError;
 
 use crate::common::IntegrationTest;
@@ -35,23 +37,27 @@ async fn test_metrics_reloading() -> Result<(), BoxError> {
         router.assert_reloaded().await;
     }
 
-    router.assert_metrics_contains(r#"apollo_router_cache_hit_count{kind="query planner",service_name="apollo-router",storage="memory"} 4"#).await;
-    router.assert_metrics_contains(r#"apollo_router_cache_miss_count{kind="query planner",service_name="apollo-router",storage="memory"} 2"#).await;
+    router.assert_metrics_contains(r#"apollo_router_cache_hit_count{kind="query planner",service_name="apollo-router",storage="memory"} 4"#, None).await;
+    router.assert_metrics_contains(r#"apollo_router_cache_miss_count{kind="query planner",service_name="apollo-router",storage="memory"} 2"#, None).await;
     router
-        .assert_metrics_contains(r#"apollo_router_cache_hit_time"#)
+        .assert_metrics_contains(r#"apollo_router_cache_hit_time"#, None)
         .await;
     router
-        .assert_metrics_contains(r#"apollo_router_cache_miss_time"#)
+        .assert_metrics_contains(r#"apollo_router_cache_miss_time"#, None)
         .await;
     router
-        .assert_metrics_contains(r#"apollo_router_session_count_total"#)
+        .assert_metrics_contains(r#"apollo_router_session_count_total"#, None)
         .await;
     router
-        .assert_metrics_contains(r#"apollo_router_session_count_active"#)
+        .assert_metrics_contains(r#"apollo_router_session_count_active"#, None)
         .await;
     router
-        .assert_metrics_contains(r#"custom_header="test_custom""#)
+        .assert_metrics_contains(r#"custom_header="test_custom""#, None)
         .await;
+
+    if std::env::var("APOLLO_KEY").is_ok() && std::env::var("APOLLO_GRAPH_REF").is_ok() {
+        router.assert_metrics_contains(r#"uplink_count{kind="duration",query="Entitlement",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql"}"#, Some(Duration::from_secs(60))).await;
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Adds metrics for uplink of the format:
```
# HELP uplink uplink
# TYPE uplink histogram
uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.001"} 0
uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.005"} 0
uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.015"} 0
uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.05"} 0
uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.1"} 0
uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.2"} 0
uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.3"} 1
uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.4"} 1
uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.5"} 1
uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="1"} 1
uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="5"} 1
uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="10"} 1
uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="+Inf"} 1
uplink_sum{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql"} 0.21680258
uplink_count{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql"} 1
```
This is a histogram of duration which contains the following attributes:
* url: the url that was polled
* query: SupergraphSdl|Entitlement
* type: new|unchanged|http_error|uplink_error
* code: The error code depending on type
* error: The error message

A limitation of this is that it can't display metrics for the first poll to uplink as telemetry hasn't been set up yet.

Fixes #2769

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
