### PR TITLE
feat: add configurable custom mapping to dd exporter

### DIFF
--- a/.changesets/config_datadog_exporter_mapping.md
+++ b/.changesets/config_datadog_exporter_mapping.md
@@ -6,4 +6,5 @@ There is a [known issue](https://docs.rs/opentelemetry-datadog/latest/openteleme
 To fix, this, open-telemetry-datadog added [custom mapping functions](https://docs.rs/opentelemetry-datadog/0.6.0/opentelemetry_datadog/struct.DatadogPipelineBuilder.html#method.with_resource_mapping).
 
 All this logic is gated behind a yaml configuration boolean `enable_span_mapping` which if enabled will take the values from the span attributes.
+
 By [@samuelAndalon](https://github.com/samuelAndalon) in https://github.com/apollographql/router/pull/2790

--- a/.changesets/config_datadog_exporter_mapping.md
+++ b/.changesets/config_datadog_exporter_mapping.md
@@ -1,9 +1,9 @@
 ### Custom OpenTelemetry Datadog exporter mapping ([Issue #2228](https://github.com/apollographql/router/issues/2228))
 
-This PR fixes the issue with DD exporter not providing meaningful data in the DD traces.
+This PR fixes the issue with the DataDog exporter not providing meaningful contextual data in the Data Dog traces.
 There is a [known issue](https://docs.rs/opentelemetry-datadog/latest/opentelemetry_datadog/#quirks) where open telemetry is not fully compatible with datadog.
 
-To fix, this, open-telemetry-datadog added [custom mapping functions](https://docs.rs/opentelemetry-datadog/0.6.0/opentelemetry_datadog/struct.DatadogPipelineBuilder.html#method.with_resource_mapping).
+To fix this, opentelemetry-datadog added [custom mapping functions](https://docs.rs/opentelemetry-datadog/0.6.0/opentelemetry_datadog/struct.DatadogPipelineBuilder.html#method.with_resource_mapping).
 
 when `enable_span_mapping` is set to `true`, the Apollo Router will perform the following mapping:
 
@@ -25,8 +25,10 @@ query to `my-subgraph-name` and the following trace will be created:
                                                         | apollo_router subgraph_request    |
 ```
 
-As you can see, there is no clear information about the name of the Query, the name of the Subgraph, and name of Query
-sent to Subgraph, when `enable_span_mapping` the following trace will be created:
+As you can see, there is no clear information about the name of the query, the name of the subgraph, and the name of query
+sent to the subgraph.
+
+Instead when `enable_span_mapping` is set to `true` the following trace will be created:
 
 ```
     | request /graphql                                                                                   |
@@ -38,10 +40,6 @@ sent to Subgraph, when `enable_span_mapping` the following trace will be created
                                                       | subgraph_request MyQuery__my-subgraph-name__0    |
 ```
 
-
-
-
-
-All this logic is gated behind a yaml configuration boolean `enable_span_mapping` which if enabled will take the values from the span attributes.
+All this logic is gated behind the configuration `enable_span_mapping` which if set to `true` will take the values from the span attributes.
 
 By [@samuelAndalon](https://github.com/samuelAndalon) in https://github.com/apollographql/router/pull/2790

--- a/.changesets/config_datadog_exporter_mapping.md
+++ b/.changesets/config_datadog_exporter_mapping.md
@@ -1,0 +1,9 @@
+### Custom OpenTelemetry Datadog exporter mapping ([Issue #2228](https://github.com/apollographql/router/issues/2228))
+
+This PR fixes the issue with DD exporter not providing meaningful data in the DD traces.
+There is a [known issue](https://docs.rs/opentelemetry-datadog/latest/opentelemetry_datadog/#quirks) where open telemetry is not fully compatible with datadog.
+
+To fix, this, open-telemetry-datadog added [custom mapping functions](https://docs.rs/opentelemetry-datadog/0.6.0/opentelemetry_datadog/struct.DatadogPipelineBuilder.html#method.with_resource_mapping).
+
+All this logic is gated behind a yaml configuration boolean `enable_span_mapping` which if enabled will take the values from the span attributes.
+By [@samuelAndalon](https://github.com/samuelAndalon) in https://github.com/apollographql/router/pull/2790

--- a/.changesets/config_datadog_exporter_mapping.md
+++ b/.changesets/config_datadog_exporter_mapping.md
@@ -5,6 +5,43 @@ There is a [known issue](https://docs.rs/opentelemetry-datadog/latest/openteleme
 
 To fix, this, open-telemetry-datadog added [custom mapping functions](https://docs.rs/opentelemetry-datadog/0.6.0/opentelemetry_datadog/struct.DatadogPipelineBuilder.html#method.with_resource_mapping).
 
+when `enable_span_mapping` is set to `true`, the Apollo Router will perform the following mapping:
+
+1. Use the Open Telemetry span name to set the Data Dog span operation name.
+2. Use the Open Telemetry span attributes to set the DataDog span resource name.
+
+Example:
+
+Lets say we send a query `MyQuery` to the Apollo Router, then the Router using the operation's query plan will send a
+query to `my-subgraph-name` and the following trace will be created:
+
+```
+    | apollo_router request                                                                 |
+        | apollo_router router                                                              |
+            | apollo_router supergraph                                                      |
+            | apollo_router query_planning  | apollo_router execution                       |
+                                                | apollo_router fetch                       |
+                                                    | apollo_router subgraph                |
+                                                        | apollo_router subgraph_request    |
+```
+
+As you can see, there is no clear information about the name of the Query, the name of the Subgraph, and name of Query
+sent to Subgraph, when `enable_span_mapping` the following trace will be created:
+
+```
+    | request /graphql                                                                                   |
+        | router                                                                                         |
+            | supergraph MyQuery                                                                         |
+                | query_planning MyQuery  | execution                                                    |
+                                              | fetch fetch                                              |
+                                                  | subgraph my-subgraph-name                            |
+                                                      | subgraph_request MyQuery__my-subgraph-name__0    |
+```
+
+
+
+
+
 All this logic is gated behind a yaml configuration boolean `enable_span_mapping` which if enabled will take the values from the span attributes.
 
 By [@samuelAndalon](https://github.com/samuelAndalon) in https://github.com/apollographql/router/pull/2790

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -3805,6 +3805,11 @@ expression: "&schema"
                     }
                   }
                 },
+                "enable_span_mapping": {
+                  "description": "Enable datadog span mapping for span name and resource name.",
+                  "default": false,
+                  "type": "boolean"
+                },
                 "endpoint": {
                   "description": "The endpoint to send to",
                   "default": "default",

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -1,4 +1,9 @@
 //! Configuration for datadog tracing.
+
+use lazy_static::lazy_static;
+use std::collections::HashMap;
+use opentelemetry::Key;
+use opentelemetry::Value;
 use opentelemetry::sdk::trace::BatchSpanProcessor;
 use opentelemetry::sdk::trace::Builder;
 use schemars::JsonSchema;
@@ -15,6 +20,18 @@ use crate::plugins::telemetry::tracing::BatchProcessorConfig;
 use crate::plugins::telemetry::tracing::SpanProcessorExt;
 use crate::plugins::telemetry::tracing::TracingConfigurator;
 
+lazy_static! {
+    static ref SPAN_RESOURCE_NAME_ATTRIBUTE_MAPPING: HashMap<&'static str, &'static str> = {
+        let mut map = HashMap::new();
+        map.insert("request", "http.route");
+        map.insert("supergraph", "graphql.operation.name");
+        map.insert("query_planning", "graphql.operation.name");
+        map.insert("subgraph", "apollo.subgraph.name");
+        map.insert("subgraph_request", "graphql.operation.name");
+        map
+    };
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
@@ -26,6 +43,14 @@ pub(crate) struct Config {
     /// batch processor configuration
     #[serde(default)]
     pub(crate) batch_processor: BatchProcessorConfig,
+
+    /// Enable datadog span mapping for span name and resource name.
+    #[serde(default = "default_enable_span_mapping")]
+    pub(crate) enable_span_mapping: bool,
+}
+
+fn default_enable_span_mapping() -> bool {
+    false
 }
 
 impl TracingConfigurator for Config {
@@ -35,9 +60,27 @@ impl TracingConfigurator for Config {
             AgentEndpoint::Default(_) => None,
             AgentEndpoint::Url(s) => Some(s),
         };
+        let enable_span_mapping = match &self.enable_span_mapping {
+            true => Some(true),
+            false => None,
+        };
         let exporter = opentelemetry_datadog::new_pipeline()
             .with(&url, |b, e| {
-                b.with_agent_endpoint(e.to_string().trim_end_matches('/'))
+                builder.with_agent_endpoint(e.to_string().trim_end_matches('/'))
+            })
+            .with(&enable_span_mapping, |builder, _e| {
+                builder
+                    .with_name_mapping(|span, _model_config| span.name.as_ref())
+                    .with_resource_mapping(|span, _model_config|
+                        SPAN_RESOURCE_NAME_ATTRIBUTE_MAPPING
+                            .get(span.name.as_ref())
+                            .and_then(|key| span.attributes.get(&Key::from_static_str(key)))
+                            .and_then(|value| match value {
+                                Value::String(value) => Some(value.as_str()),
+                                _ => None,
+                            })
+                            .unwrap_or(span.name.as_ref())
+                    )
             })
             .with_service_name(trace_config.service_name.clone())
             .with_trace_config(trace_config.into())

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -1,11 +1,12 @@
 //! Configuration for datadog tracing.
 
-use lazy_static::lazy_static;
 use std::collections::HashMap;
-use opentelemetry::Key;
-use opentelemetry::Value;
+
+use lazy_static::lazy_static;
 use opentelemetry::sdk::trace::BatchSpanProcessor;
 use opentelemetry::sdk::trace::Builder;
+use opentelemetry::Key;
+use opentelemetry::Value;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
@@ -71,7 +72,7 @@ impl TracingConfigurator for Config {
             .with(&enable_span_mapping, |builder, _e| {
                 builder
                     .with_name_mapping(|span, _model_config| span.name.as_ref())
-                    .with_resource_mapping(|span, _model_config|
+                    .with_resource_mapping(|span, _model_config| {
                         SPAN_RESOURCE_NAME_ATTRIBUTE_MAPPING
                             .get(span.name.as_ref())
                             .and_then(|key| span.attributes.get(&Key::from_static_str(key)))
@@ -80,7 +81,7 @@ impl TracingConfigurator for Config {
                                 _ => None,
                             })
                             .unwrap_or(span.name.as_ref())
-                    )
+                    })
             })
             .with_service_name(trace_config.service_name.clone())
             .with_trace_config(trace_config.into())

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -46,12 +46,8 @@ pub(crate) struct Config {
     pub(crate) batch_processor: BatchProcessorConfig,
 
     /// Enable datadog span mapping for span name and resource name.
-    #[serde(default = "default_enable_span_mapping")]
+    #[serde(default)]
     pub(crate) enable_span_mapping: bool,
-}
-
-fn default_enable_span_mapping() -> bool {
-    false
 }
 
 impl TracingConfigurator for Config {
@@ -61,10 +57,8 @@ impl TracingConfigurator for Config {
             AgentEndpoint::Default(_) => None,
             AgentEndpoint::Url(s) => Some(s),
         };
-        let enable_span_mapping = match &self.enable_span_mapping {
-            true => Some(true),
-            false => None,
-        };
+        let enable_span_mapping = self.enable_span_mapping.then_some(true);
+
         let exporter = opentelemetry_datadog::new_pipeline()
             .with(&url, |builder, e| {
                 builder.with_agent_endpoint(e.to_string().trim_end_matches('/'))

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -65,7 +65,7 @@ impl TracingConfigurator for Config {
             false => None,
         };
         let exporter = opentelemetry_datadog::new_pipeline()
-            .with(&url, |b, e| {
+            .with(&url, |builder, e| {
                 builder.with_agent_endpoint(e.to_string().trim_end_matches('/'))
             })
             .with(&enable_span_mapping, |builder, _e| {

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -256,7 +256,11 @@ async fn call_http(
         subgraph_request, ..
     } = request;
 
-    let operation_name = subgraph_request.body().operation_name.clone().unwrap_or_default();
+    let operation_name = subgraph_request
+        .body()
+        .operation_name
+        .clone()
+        .unwrap_or_default();
     let (parts, _) = subgraph_request.into_parts();
 
     let body = serde_json::to_string(&body).expect("JSON serialization should not fail");

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -256,6 +256,7 @@ async fn call_http(
         subgraph_request, ..
     } = request;
 
+    let operation_name = subgraph_request.body().operation_name.clone().unwrap_or_default();
     let (parts, _) = subgraph_request.into_parts();
 
     let body = serde_json::to_string(&body).expect("JSON serialization should not fail");
@@ -312,7 +313,8 @@ async fn call_http(
         "http.route" = &display(path),
         "http.url" = &display(schema_uri),
         "net.transport" = "ip_tcp",
-        "apollo.subgraph.name" = %service_name
+        "apollo.subgraph.name" = %service_name,
+        "graphql.operation.name" = &display(operation_name)
     );
     get_text_map_propagator(|propagator| {
         propagator.inject_context(

--- a/docs/source/configuration/tracing.mdx
+++ b/docs/source/configuration/tracing.mdx
@@ -111,8 +111,8 @@ All trace exporters (apollo|datadog|zipkin|jaeger|otlp) have batch span processo
 
 `OpenTelemetry trace error occurred: cannot send span to the batch span processor because the channel is full`
 
-* **scheduled_delay** The delay from receiving the first span to the batch being sent. 
-* **max_concurrent_exports** The maximum number of overlapping export requests. For instance if ingest is taking a long time to respond there may be several overlapping export requests. 
+* **scheduled_delay** The delay from receiving the first span to the batch being sent.
+* **max_concurrent_exports** The maximum number of overlapping export requests. For instance if ingest is taking a long time to respond there may be several overlapping export requests.
 * **max_export_batch_size** The number of spans to include in a batch. Your ingest may have max message size limits.
 * **max_export_timeout** The timeout for sending spans before dropping the data.
 * **max_queue_size** The maximum number of spans to be buffered before dropping span data.
@@ -127,7 +127,7 @@ telemetry:
       max_export_batch_size: 10000
       max_export_timeout: 100s
       max_queue_size: 10000
-      
+
   tracing:
     # Datadog
     datadog:
@@ -153,9 +153,56 @@ The Apollo Router can be configured to connect to either the default agent addre
 telemetry:
   tracing:
     datadog:
-      # Either 'default' or a URL
+      # Either 'default' or a URL (example: 'http://http://127.0.0.1:8126')
       endpoint: default
 ```
+
+[Given that there are some incompatibilities](https://docs.rs/opentelemetry-datadog/latest/opentelemetry_datadog/#quirks)
+between Datadog and OpenTelemetry the datadog exporter might not provide
+meaningful information in the exported spans, to fix this you can configure the Apollo Router to perform a mapping for span name
+and span resource name.
+
+```yaml title="router.yaml"
+telemetry:
+  tracing:
+    datadog:
+      endpoint: default
+      enable_span_mapping: true
+```
+
+when `enable_span_mapping` is set to `true`, the Apollo Router will perform the following mapping:
+
+1. Use the Open Telemetry span name to set the Data Dog span operation name.
+2. Use the Open Telemetry span attributes to set the DataDog span resource name.
+
+Example:
+
+Lets say we send a query `MyQuery` to the Apollo Router, then the Router using the operation's query plan will send a
+query to `my-subgraph-name` and the following trace will be created:
+
+```
+    | apollo_router request                                                                 |
+        | apollo_router router                                                              |
+            | apollo_router supergraph                                                      |
+            | apollo_router query_planning  | apollo_router execution                       |
+                                                | apollo_router fetch                       |
+                                                    | apollo_router subgraph                |
+                                                        | apollo_router subgraph_request    |
+```
+
+As you can see, there is no clear information about the name of the Query, the name of the Subgraph, and name of Query
+sent to Subgraph, when `enable_span_mapping` the following trace will be created:
+
+```
+    | request /graphql                                                                                   |
+        | router                                                                                         |
+            | supergraph MyQuery                                                                         |
+                | query_planning MyQuery  | execution                                                    |
+                                              | fetch fetch                                              |
+                                                  | subgraph my-subgraph-name                            |
+                                                      | subgraph_request MyQuery__my-subgraph-name__0    |
+```
+
 
 ## Using Jaeger
 

--- a/docs/source/configuration/tracing.mdx
+++ b/docs/source/configuration/tracing.mdx
@@ -158,9 +158,8 @@ telemetry:
 ```
 
 [Given that there are some incompatibilities](https://docs.rs/opentelemetry-datadog/latest/opentelemetry_datadog/#quirks)
-between Datadog and OpenTelemetry the datadog exporter might not provide
-meaningful information in the exported spans, to fix this you can configure the Apollo Router to perform a mapping for span name
-and span resource name.
+between Datadog and OpenTelemetry, the DataDog exporter might not provide meaningful contextual information in the exported spans.
+To fix this, you can configure the Apollo Router to perform a mapping for the span name and the span resource name.
 
 ```yaml title="router.yaml"
 telemetry:
@@ -190,8 +189,10 @@ query to `my-subgraph-name` and the following trace will be created:
                                                         | apollo_router subgraph_request    |
 ```
 
-As you can see, there is no clear information about the name of the Query, the name of the Subgraph, and name of Query
-sent to Subgraph, when `enable_span_mapping` the following trace will be created:
+As you can see, there is no clear information about the name of the query, the name of the subgraph, and the name of the
+query sent to the subgraph.
+
+Instead when `enable_span_mapping` is set to `true` the following trace will be created:
 
 ```
     | request /graphql                                                                                   |


### PR DESCRIPTION
*Description here*
This PR fixes the issue with DD exporter not providing meaningful data in the DD traces.
[There is a known issue](https://docs.rs/opentelemetry-datadog/latest/opentelemetry_datadog/#quirks) where open telemetry is not fully compatible with datadog

causing this
![image](https://user-images.githubusercontent.com/6611331/225466962-d8a5b0f2-4761-4689-b0b6-7acea25457ab.png)

to fix, this, open-telemetry-datadog [added custom mapping functions](https://docs.rs/opentelemetry-datadog/0.6.0/opentelemetry_datadog/struct.DatadogPipelineBuilder.html#method.with_resource_mapping) 

after applying mapping for `span_name` and `resource_name` DD spans look like this (tested the change in our router implementation)
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/6611331/225468297-3378d159-34e5-43b9-b16f-6e3be5105574.png">

1. **supergraph** span resource name will be the name of the operation sent to the router, example: `myAwesomeQuery`
2. **subgraph** span resource name will be the name of the subgraph that router will be sending a query from query plan, example: `my-federated-subgraph`
3. **subgraph_request** span resouce name will be the name of the operation that router will send to subgraph taken from the query plan, example: `myAwesomeQuery__my-my-federated-subgraph__0`

All this logic is gated behind a yaml configuration boolean `enable_span_mapping` which if enabled will take the values from the span attributes.

Fixes #issue_number
https://github.com/apollographql/router/issues/2228
<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [X] Integration Tests
    - [X] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
