### PR TITLE
Support aliased top-level `__typename`

### DIFF
--- a/.changesets/fix_alias_typename.md
+++ b/.changesets/fix_alias_typename.md
@@ -1,0 +1,5 @@
+### Support bare top-level `__typename` when aliased ([Issue #2792](https://github.com/apollographql/router/issues/2792))
+
+PR #1762 implemented support for the query `{ __typename }` but it did not work properly if the top-level standalone `__typename` field was aliased. This now works properly.
+
+By [@glasser](https://github.com/glasser) in https://github.com/apollographql/router/pull/2791

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -218,12 +218,11 @@ impl BridgeQueryPlanner {
             // If we have only one operation containing only the root field `__typename`
             // (possibly aliased or repeated). (This does mean we fail to properly support
             // {"query": "query A {__typename} query B{somethingElse}", "operationName":"A"}.)
-            let output_keys_for_typenames = if selections.operations.len() == 1 {
-                selections.operations[0].is_only_typenames_with_output_keys()
-            } else {
-                None
-            };
-            if let Some(output_keys) = output_keys_for_typenames {
+            if let Some(output_keys) = selections
+                .operations
+                .get(0)
+                .and_then(|op| op.is_only_typenames_with_output_keys())
+            {
                 let operation_name = selections.operations[0].kind().to_string();
                 let data: Value = Value::Object(Map::from_iter(
                     output_keys

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -215,7 +215,7 @@ impl BridgeQueryPlanner {
         let selections = self.parse_selections(key.0.clone()).await?;
 
         if selections.contains_introspection() {
-            // If we have only one operation containing a only the root field `__typename`
+            // If we have only one operation containing only the root field `__typename`
             // (possibly aliased or repeated)
             if let Some(output_keys) = selections.contains_only_typenames_with_output_keys() {
                 let operation_name = selections.operations[0].kind().to_string();

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -11,7 +11,8 @@ use router_bridge::planner::Planner;
 use router_bridge::planner::QueryPlannerConfig;
 use router_bridge::planner::UsageReporting;
 use serde::Deserialize;
-use serde_json_bytes::json;
+use serde_json_bytes::Map;
+use serde_json_bytes::Value;
 use tower::Service;
 use tracing::Instrument;
 
@@ -23,7 +24,6 @@ use crate::introspection::Introspection;
 use crate::services::QueryPlannerContent;
 use crate::services::QueryPlannerRequest;
 use crate::services::QueryPlannerResponse;
-use crate::spec::query::TYPENAME;
 use crate::spec::Query;
 use crate::spec::Schema;
 use crate::Configuration;
@@ -215,14 +215,17 @@ impl BridgeQueryPlanner {
         let selections = self.parse_selections(key.0.clone()).await?;
 
         if selections.contains_introspection() {
-            // If we have only one operation containing a single root field `__typename`
-            if selections.contains_only_typename() {
+            // If we have only one operation containing a only the root field `__typename`
+            // (possibly aliased or repeated)
+            if let Some(output_keys) = selections.contains_only_typenames_with_output_keys() {
+                let operation_name = selections.operations[0].kind().to_string();
+                let data: Value = Value::Object(Map::from_iter(
+                    output_keys
+                        .into_iter()
+                        .map(|key| (key, Value::String(operation_name.clone().into()))),
+                ));
                 return Ok(QueryPlannerContent::Introspection {
-                    response: Box::new(
-                        graphql::Response::builder()
-                            .data(json!({TYPENAME: selections.operations[0].kind().to_string()}))
-                            .build(),
-                    ),
+                    response: Box::new(graphql::Response::builder().data(data).build()),
                 });
             } else {
                 return self.introspection(key.0).await;
@@ -378,5 +381,55 @@ mod tests {
             "couldn't plan query: query validation errors: Syntax Error: Unexpected <EOF>.",
             result.unwrap_err().to_string()
         );
+    }
+
+    #[test(tokio::test)]
+    async fn test_single_aliased_root_typename() {
+        let planner = BridgeQueryPlanner::new(
+            Arc::new(example_schema()),
+            Some(Arc::new(
+                Introspection::new(&Configuration::default()).await,
+            )),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+        let result = planner
+            .get(("{ x: __typename }".into(), None))
+            .await
+            .unwrap();
+        if let QueryPlannerContent::Introspection { response } = result {
+            assert_eq!(
+                r#"{"data":{"x":"Query"}}"#,
+                serde_json::to_string(&response).unwrap()
+            )
+        } else {
+            panic!();
+        }
+    }
+
+    #[test(tokio::test)]
+    async fn test_two_root_typenames() {
+        let planner = BridgeQueryPlanner::new(
+            Arc::new(example_schema()),
+            Some(Arc::new(
+                Introspection::new(&Configuration::default()).await,
+            )),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+        let result = planner
+            .get(("{ x: __typename __typename }".into(), None))
+            .await
+            .unwrap();
+        if let QueryPlannerContent::Introspection { response } = result {
+            assert_eq!(
+                r#"{"data":{"x":"Query","__typename":"Query"}}"#,
+                serde_json::to_string(&response).unwrap()
+            )
+        } else {
+            panic!();
+        }
     }
 }

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -934,14 +934,6 @@ impl Query {
         }
     }
 
-    pub(crate) fn contains_only_typenames_with_output_keys(&self) -> Option<Vec<ByteString>> {
-        if self.operations.len() == 1 {
-            self.operations[0].is_only_typenames_with_output_keys()
-        } else {
-            None
-        }
-    }
-
     pub(crate) fn contains_introspection(&self) -> bool {
         self.operations.iter().any(Operation::is_introspection)
     }
@@ -1078,7 +1070,7 @@ impl Operation {
     /// `__typename` at the root level (possibly more than one time, possibly
     /// with aliases). If so, returns Some with a Vec of the output keys
     /// corresponding.
-    fn is_only_typenames_with_output_keys(&self) -> Option<Vec<ByteString>> {
+    pub(crate) fn is_only_typenames_with_output_keys(&self) -> Option<Vec<ByteString>> {
         if self.selection_set.is_empty() {
             None
         } else {

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -934,8 +934,12 @@ impl Query {
         }
     }
 
-    pub(crate) fn contains_only_typename(&self) -> bool {
-        self.operations.len() == 1 && self.operations[0].is_only_typename()
+    pub(crate) fn contains_only_typenames_with_output_keys(&self) -> Option<Vec<ByteString>> {
+        if self.operations.len() == 1 {
+            self.operations[0].is_only_typenames_with_output_keys()
+        } else {
+            None
+        }
     }
 
     pub(crate) fn contains_introspection(&self) -> bool {
@@ -1070,19 +1074,30 @@ impl Operation {
         })
     }
 
-    /// A query or mutation containing only `__typename` at the root level
-    fn is_only_typename(&self) -> bool {
-        self.selection_set.len() == 1
-            && self
+    /// Checks to see if this is a query or mutation containing only
+    /// `__typename` at the root level (possibly more than one time, possibly
+    /// with aliases). If so, returns Some with a Vec of the output keys
+    /// corresponding.
+    fn is_only_typenames_with_output_keys(&self) -> Option<Vec<ByteString>> {
+        if self.selection_set.is_empty() {
+            None
+        } else {
+            let output_keys: Vec<ByteString> = self
                 .selection_set
-                .get(0)
-                .map(|s| s.is_typename_field())
-                .unwrap_or_default()
+                .iter()
+                .filter_map(|s| s.output_key_if_typename_field())
+                .collect();
+            if output_keys.len() == self.selection_set.len() {
+                Some(output_keys)
+            } else {
+                None
+            }
+        }
     }
 
     fn is_introspection(&self) -> bool {
         // If the only field is `__typename` it's considered as an introspection query
-        if self.is_only_typename() {
+        if self.is_only_typenames_with_output_keys().is_some() {
             return true;
         }
         self.selection_set.iter().all(|sel| match sel {

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -987,6 +987,45 @@ fn solve_query_with_single_typename() {
 }
 
 #[test]
+fn solve_query_with_aliased_typename() {
+    FormatTest::builder()
+        .schema(
+            "type Query {
+                get: Thing
+            }
+            type Thing {
+                array: [String]
+            }",
+        )
+        .query("{ aliased: __typename }")
+        .response(json! {{}})
+        .expected(json! {{
+            "aliased": "Query"
+        }})
+        .test();
+}
+
+#[test]
+fn solve_query_with_multiple_typenames() {
+    FormatTest::builder()
+        .schema(
+            "type Query {
+                get: Thing
+            }
+            type Thing {
+                array: [String]
+            }",
+        )
+        .query("{ aliased: __typename __typename }")
+        .response(json! {{}})
+        .expected(json! {{
+            "aliased": "Query",
+            "__typename": "Query"
+        }})
+        .test();
+}
+
+#[test]
 fn reformat_response_query_with_root_typename() {
     FormatTest::builder()
         .schema(

--- a/apollo-router/src/spec/selection.rs
+++ b/apollo-router/src/spec/selection.rs
@@ -169,6 +169,15 @@ impl Selection {
         matches!(self, Selection::Field {name, ..} if name.as_str() == TYPENAME)
     }
 
+    pub(crate) fn output_key_if_typename_field(&self) -> Option<ByteString> {
+        match self {
+            Selection::Field { name, alias, .. } if name.as_str() == TYPENAME => {
+                alias.as_ref().or(Some(name)).cloned()
+            }
+            _ => None,
+        }
+    }
+
     pub(crate) fn contains_error_path(&self, path: &[PathElement], fragments: &Fragments) -> bool {
         match (path.get(0), self) {
             (None, _) => true,


### PR DESCRIPTION
Fixes #2792

PR #1762 implemented support for the query `{ __typename }` but ignored the possibility that the field might be aliased or repeated. For spec compatibility (and because this is a convenient schema-agnostic query for testing purposes), support these cases as well.

Note that the `solve_*` tests of the formatter passed before this change, as the formatter already processed this correctly.
