### PR TITLE
adding support for specified log "message" / type

### DIFF
--- a/.changesets/feat_log_message_support.md
+++ b/.changesets/feat_log_message_support.md
@@ -1,0 +1,25 @@
+### Adding support for specified log "message" / type parameter ([Issue #2777](https://github.com/apollographql/router/issues/2777))
+
+The current logs only state the output for "rhai_*", which while mostly descriptive, doesn't cover the use-case of needing custom logs for observability. This change adds a second optional parameter to the `log_` commands in Rhai to specify the `message` attribute. For example: 
+
+```rhai
+fn subgraph_service(service, subgraph) {
+    service.map_response(|response| {
+        if response.body.errors != {} {
+            log_error(response.body.errors, `Subgraph: ${subgraph}`);
+        }
+    });
+}
+```
+
+Which would return an example log similar to: 
+
+```json
+{"timestamp":"2023-03-16T16:08:44.738148Z","level":"ERROR","out":"redacted","message":"Subgraph: 2"}
+```
+
+This will enable customers to have APMs effectively parse logs to be more meaningful to them. 
+
+Previously, logs would only be bucketed under the `rhai_error` `message` value.
+
+By [@lleadbet](https://github.com/lleadbet) in https://github.com/apollographql/router/pull/2797

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -1549,17 +1549,32 @@ impl Rhai {
             .register_fn("log_trace", |out: Dynamic| {
                 tracing::trace!(%out, "rhai_trace");
             })
+            .register_fn("log_trace", |out: Dynamic, message: &str| {
+                tracing::trace!(%out, message);
+            })
             .register_fn("log_debug", |out: Dynamic| {
                 tracing::debug!(%out, "rhai_debug");
+            })
+            .register_fn("log_debug", |out: Dynamic, message: &str| {
+                tracing::debug!(%out, message);
             })
             .register_fn("log_info", |out: Dynamic| {
                 tracing::info!(%out, "rhai_info");
             })
+            .register_fn("log_info", |out: Dynamic, message: &str| {
+                tracing::info!(%out, message);
+            })
             .register_fn("log_warn", |out: Dynamic| {
                 tracing::warn!(%out, "rhai_warn");
             })
+            .register_fn("log_warn", |out: Dynamic, message: &str| {
+                tracing::warn!(%out, message);
+            })
             .register_fn("log_error", |out: Dynamic| {
                 tracing::error!(%out, "rhai_error");
+            })
+            .register_fn("log_error", |out: Dynamic, message: &str| {
+                tracing::error!(%out, message);
             })
             // Register a function for printing to stderr
             .register_fn("eprint", |x: &str| {

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -177,6 +177,11 @@ fn it_logs_messages() {
         r#"log_info("info log")"#,
         r#"log_warn("warn log")"#,
         r#"log_error("error log")"#,
+        r#"log_trace("trace log", "tests")"#,
+        r#"log_debug("debug log", "tests")"#,
+        r#"log_info("info log", "tests")"#,
+        r#"log_warn("warn log", "tests")"#,
+        r#"log_error("error log", "tests")"#,
     ];
     for log in input_logs {
         engine.eval::<()>(log).expect("it logged a message");
@@ -200,6 +205,28 @@ fn it_logs_messages() {
     assert!(tracing_test::internal::logs_with_scope_contain(
         "apollo_router",
         "error log"
+    ));
+
+    // tests for including the
+    assert!(tracing_test::internal::logs_with_scope_contain(
+        "apollo_router",
+        "trace log tests",
+    ));
+    assert!(tracing_test::internal::logs_with_scope_contain(
+        "apollo_router",
+        "debug log tests"
+    ));
+    assert!(tracing_test::internal::logs_with_scope_contain(
+        "apollo_router",
+        "info log tests"
+    ));
+    assert!(tracing_test::internal::logs_with_scope_contain(
+        "apollo_router",
+        "warn log tests"
+    ));
+    assert!(tracing_test::internal::logs_with_scope_contain(
+        "apollo_router",
+        "error log tests"
     ));
 }
 

--- a/docs/source/customizations/rhai-api.mdx
+++ b/docs/source/customizations/rhai-api.mdx
@@ -52,6 +52,16 @@ log_debug("debug-level log message");
 log_trace("trace-level log message");
 ```
 
+Lastly, you can also pass a second parameter to set the `message` value on logs to specify the source if `rhai_` value isn't sufficient.
+
+```rhai
+log_error("error-level log message", "docs");
+log_warn("warn-level log message", "docs");
+log_info("info-level log message", "docs");
+log_debug("debug-level log message", "docs");
+log_trace("trace-level log message", "docs");
+```
+
 ## Terminating client requests
 
 Your Rhai script can terminate the associated client request that triggered it. To do so, it throws an exception. This returns an `Internal Server Error` to the client with a `500` response code.

--- a/docs/source/customizations/rhai-api.mdx
+++ b/docs/source/customizations/rhai-api.mdx
@@ -52,7 +52,7 @@ log_debug("debug-level log message");
 log_trace("trace-level log message");
 ```
 
-Lastly, you can also pass a second parameter to set the `message` value on logs to specify the source if `rhai_` value isn't sufficient.
+Lastly, you can also pass a second parameter to set the `message` value on logs to specify the source if the `rhai_` value isn't sufficient.
 
 ```rhai
 log_error("error-level log message", "docs");

--- a/examples/logging/rhai/README.md
+++ b/examples/logging/rhai/README.md
@@ -1,6 +1,6 @@
 # Rhai script
 
-Demonstrates extracting body details and header manipulation via Rhai script.
+Demonstrates basic logging using Rhai.
 
 Usage:
 

--- a/examples/logging/rhai/src/rhai_logging.rhai
+++ b/examples/logging/rhai/src/rhai_logging.rhai
@@ -55,6 +55,13 @@ fn process_request(request) {
     log_info("this is info level log message");
     log_debug("this is debug level log message");
     log_trace("this is trace level log message");
+
+    // this logs the messages with the "request" message attribute
+    log_error("this is error level log message", "request");
+    log_warn("this is warn level log message", "request");
+    log_info("this is info level log message", "request");
+    log_debug("this is debug level log message", "request");
+    log_trace("this is trace level log message", "request");
 }
 
 // Generate a log for each response at this stage
@@ -65,4 +72,11 @@ fn process_response(response) {
     log_info("this is info level log message");
     log_debug("this is debug level log message");
     log_trace("this is trace level log message");
+
+    // this logs the messages with the "response" message attribute
+    log_error("this is error level log message", "response");
+    log_warn("this is warn level log message", "response");
+    log_info("this is info level log message", "response");
+    log_debug("this is debug level log message", "response");
+    log_trace("this is trace level log message", "response");
 }


### PR DESCRIPTION
*Description here*

Fixes #2777. 

The current logs only state the output for "rhai_*", which while mostly descriptive, doesn't cover the use-case of needing custom logs for observability. For example: 

```rhai
fn subgraph_service(service, subgraph) {
    service.map_response(|response| {
        if response.body.errors != {} {
            log_error(response.body.errors, `Subgraph: ${subgraph}`);
        }
    });
}
```

Will enable customers to have per-subgraph error logging coming from the router, annotated with the subgraph name without parsing the `out` value. 

Previously, this would only be bucketed under the `rhai_error` message type. 

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
