### PR TITLE
chore: Nightly Release CI Slack notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 # across projects.  See https://circleci.com/orbs/ for more information.
 orbs:
   gh: circleci/github-cli@2.2.0
-  slack: circleci/slack@4.9.3
+  slack: circleci/slack@4.12.1
 
 executors:
   amd_linux_build: &amd_linux_build_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,7 +527,7 @@ jobs:
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
-                          "text": ":x: A `nightly` release run has **failed** for << parameters.platform >> on ${CIRCLE_BRANCH}!"
+                          "text": ":x: A `nightly` release run has **failed** for `${CIRCLE_JOB}` on `${CIRCLE_BRANCH}`!"
                         }
                       },
                       {
@@ -555,7 +555,7 @@ jobs:
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
-                          "text": ":white_check_mark: A `nightly` build has completed for << parameters.platform >> on ${CIRCLE_BRANCH}."
+                          "text": ":white_check_mark: A `nightly` build has completed for `${CIRCLE_JOB}` on `${CIRCLE_BRANCH}`."
                         }
                       },
                       {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -655,7 +655,6 @@ workflows:
       - test:
           requires:
             - lint
-          context: router
           matrix:
             parameters:
               platform:
@@ -666,6 +665,7 @@ workflows:
     jobs:
       - build_release:
           nightly: true
+          context: router
           matrix:
             parameters:
               platform:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,7 +527,7 @@ jobs:
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
-                          "text": ":x: A `nightly` release run has **failed** for `${CIRCLE_JOB}` on `${CIRCLE_BRANCH}`!"
+                          "text": ":x: A `nightly` release run has **failed** for `${CIRCLE_JOB}` on `${CIRCLE_PROJECT_REPONAME}`'s `${CIRCLE_BRANCH}`!"
                         }
                       },
                       {
@@ -555,7 +555,7 @@ jobs:
                         "type": "section",
                         "text": {
                           "type": "mrkdwn",
-                          "text": ":white_check_mark: A `nightly` build has completed for `${CIRCLE_JOB}` on `${CIRCLE_BRANCH}`."
+                          "text": ":white_check_mark: A `nightly` build has completed for `${CIRCLE_JOB}` on `${CIRCLE_PROJECT_REPONAME}`'s `${CIRCLE_BRANCH}`."
                         }
                       },
                       {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ version: 2.1
 # across projects.  See https://circleci.com/orbs/ for more information.
 orbs:
   gh: circleci/github-cli@2.2.0
+  slack: circleci/slack@4.9.3
 
 executors:
   amd_linux_build: &amd_linux_build_executor
@@ -421,6 +422,12 @@ jobs:
       - setup_environment:
           platform: << parameters.platform >>
       - xtask_test
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+      - slack/notify:
+          event: pass
+          template: success_tagged_deploy_1
 
   test_updated:
     environment:
@@ -594,6 +601,7 @@ workflows:
       - test:
           requires:
             - lint
+          context: router
           matrix:
             parameters:
               platform:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,12 +422,6 @@ jobs:
       - setup_environment:
           platform: << parameters.platform >>
       - xtask_test
-      - slack/notify:
-          event: fail
-          template: basic_fail_1
-      - slack/notify:
-          event: pass
-          template: success_tagged_deploy_1
 
   test_updated:
     environment:
@@ -520,6 +514,66 @@ jobs:
             - "*"
       - store_artifacts:
           path: artifacts/
+      - when:
+          condition:
+            equal: [ true, << parameters.nightly >> ]
+          steps:
+            - slack/notify:
+                event: fail
+                custom: |
+                  {
+                    "blocks": [
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": ":x: A `nightly` release run has **failed** for << parameters.platform >> on ${CIRCLE_BRANCH}!"
+                        }
+                      },
+                      {
+                        "type": "actions",
+                        "elements": [
+                          {
+                            "type": "button",
+                            "action_id": "success_tagged_deploy_view",
+                            "text": {
+                              "type": "plain_text",
+                              "text": "View Job"
+                            },
+                            "url": "${CIRCLE_BUILD_URL}"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+            - slack/notify:
+                event: pass
+                custom: |
+                  {
+                    "blocks": [
+                      {
+                        "type": "section",
+                        "text": {
+                          "type": "mrkdwn",
+                          "text": ":white_check_mark: A `nightly` build has completed for << parameters.platform >> on ${CIRCLE_BRANCH}."
+                        }
+                      },
+                      {
+                        "type": "actions",
+                        "elements": [
+                          {
+                            "type": "button",
+                            "action_id": "success_tagged_deploy_view",
+                            "text": {
+                              "type": "plain_text",
+                              "text": "View Job"
+                            },
+                            "url": "${CIRCLE_BUILD_URL}"
+                          }
+                        ]
+                      }
+                    ]
+                  }
 
   publish_github_release:
     docker:


### PR DESCRIPTION
This is a small addition to https://github.com/apollographql/router/issues/242 which, when coupled with the already-landed https://github.com/apollographql/router/pull/2409, I think polishes it off nicely by letting us be notified in advance if a nightly build — which is nearly the entire release process — has succeeded or, more importantly, failed.

<img width="623" alt="image" src="https://user-images.githubusercontent.com/841294/226299224-e3123b32-324c-49a0-b93b-4d4b02865e62.png">

Resolves #2409