### PR TITLE
Make uplink logic ignore messages that are deemed older than the last message to be received

### DIFF
--- a/.changesets/fix_where_were_going_we_dont_need_roads.md
+++ b/.changesets/fix_where_were_going_we_dont_need_roads.md
@@ -1,0 +1,14 @@
+### Only process uplink messages that are deemed to be newer ([Issue #2794](https://github.com/apollographql/router/issues/2794))
+
+Uplink is served by multiple cloud providers to ensure high availability. However, this means that there will be periods of time uplink endpoints do not agree on what the latest data is.
+
+This has not been a problem for most users, as the default mode of operation for the router is to fallback to the secondary uplink endpoint if the first fails.
+The other mode of operation, triggered by setting `APOLLO_UPLINK_ENDPOINTS` is round-robin. When in this mode there is a much higher chance that the router will end up flapping due to disagreement on the uplink server side or by any user supplied proxies.
+
+This change introduces an interim fix that checks uplink messages against the last known message to see if it is newer. We will be improving the robustness of the solution over the next weeks, so this can be seen as an incremental improvement.
+
+Note that it is advised against using `APOLLO_UPLINK_ENDPOINTS` to try to cache uplink responses for HA purposes. Each request to uplink sends state, therefore limiting the usefulness of such a cache.   
+
+Part of #2794
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2803

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -163,7 +163,7 @@ where
                                 if sender.send(Ok(response)).await.is_err() {
                                     break;
                                 }
-                            } else {
+                            } else if ordering_id < last_ordering_id {
                                 tracing::debug!("ignoring uplink event as is was older than our last known message");
                             }
                         }

--- a/apollo-router/src/uplink/schema_query.graphql
+++ b/apollo-router/src/uplink/schema_query.graphql
@@ -6,6 +6,10 @@ query SupergraphSdlQuery($apiKey: String!, $graph_ref: String!, $ifAfterId: ID) 
             supergraphSdl: supergraphSDL
             minDelaySeconds
         }
+        ... on Unchanged {
+            id
+            minDelaySeconds
+        }
         ... on FetchError {
             code
             message

--- a/apollo-router/src/uplink/schema_stream.rs
+++ b/apollo-router/src/uplink/schema_stream.rs
@@ -5,6 +5,9 @@
 // Read more: https://github.com/hyperium/tonic/issues/1056
 #![allow(clippy::derive_partial_eq_without_eq)]
 
+use std::str::FromStr;
+use std::time::SystemTime;
+
 use graphql_client::GraphQLQuery;
 
 use crate::uplink::schema_stream::supergraph_sdl_query::FetchErrorCode;
@@ -37,15 +40,22 @@ impl From<supergraph_sdl_query::ResponseData> for UplinkResponse<String> {
     fn from(response: supergraph_sdl_query::ResponseData) -> Self {
         match response.router_config {
             SupergraphSdlQueryRouterConfig::RouterConfigResult(result) => UplinkResponse::New {
+                ordering_id: humantime::Timestamp::from_str(result.id.as_str())
+                    .map(Into::into)
+                    .unwrap_or_else(|e|{
+                        // There's not much we can do if we didn't understand the timestamp from uplink
+                        tracing::error!("uplink response had a malformed system time. This uplink event will be ignored. If you are not using a custom uplink proxy then this is a bug, please report to Apollo. Error was: {}", e);
+                        SystemTime::UNIX_EPOCH
+                    }),
                 response: result.supergraph_sdl,
                 id: result.id,
                 // this will truncate the number of seconds to under u64::MAX, which should be
                 // a large enough delay anyway
                 delay: result.min_delay_seconds as u64,
             },
-            SupergraphSdlQueryRouterConfig::Unchanged => UplinkResponse::Unchanged {
-                id: None,
-                delay: None,
+            SupergraphSdlQueryRouterConfig::Unchanged(response) => UplinkResponse::Unchanged {
+                id: Some(response.id),
+                delay: Some(response.min_delay_seconds as u64),
             },
             SupergraphSdlQueryRouterConfig::FetchError(err) => UplinkResponse::Error {
                 retry_later: err.code == FetchErrorCode::RETRY_LATER,

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_empty_http_round_robin.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_empty_http_round_robin.snap
@@ -2,6 +2,6 @@
 source: apollo-router/src/uplink/mod.rs
 expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
 ---
-- Ok: response
-- Ok: response
+- Ok: "result QueryResult { name: \"ok\", ordering: 1 }"
+- Ok: "result QueryResult { name: \"ok\", ordering: 2 }"
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_error_http_fallback.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_error_http_fallback.snap
@@ -2,6 +2,6 @@
 source: apollo-router/src/uplink/mod.rs
 expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
 ---
-- Ok: response
-- Ok: response
+- Ok: "result QueryResult { name: \"ok\", ordering: 1 }"
+- Ok: "result QueryResult { name: \"ok\", ordering: 2 }"
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_error_http_round_robin.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_error_http_round_robin.snap
@@ -2,6 +2,6 @@
 source: apollo-router/src/uplink/mod.rs
 expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
 ---
-- Ok: response
-- Ok: response
+- Ok: "result QueryResult { name: \"ok\", ordering: 1 }"
+- Ok: "result QueryResult { name: \"ok\", ordering: 2 }"
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_error_retry.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_error_retry.snap
@@ -3,5 +3,5 @@ source: apollo-router/src/uplink/mod.rs
 expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
 ---
 - Err: "uplink error: code=RETRY_LATER message=error message"
-- Ok: response
+- Ok: "result QueryResult { name: \"ok\", ordering: 1 }"
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_fallback.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_fallback.snap
@@ -2,6 +2,6 @@
 source: apollo-router/src/uplink/mod.rs
 expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
 ---
-- Ok: response
-- Ok: response
+- Ok: "result QueryResult { name: \"ok\", ordering: 1 }"
+- Ok: "result QueryResult { name: \"ok\", ordering: 2 }"
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_invalid.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_invalid.snap
@@ -2,5 +2,5 @@
 source: apollo-router/src/uplink/mod.rs
 expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
 ---
-- Err: "uplink error: code=INVALID_ENTITLEMENT message=invalid entitlement: InvalidToken"
+- Err: fetch failed from all endpoints
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_round_robin.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_round_robin.snap
@@ -2,6 +2,6 @@
 source: apollo-router/src/uplink/mod.rs
 expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
 ---
-- Ok: response
-- Ok: response
+- Ok: "result QueryResult { name: \"ok\", ordering: 1 }"
+- Ok: "result QueryResult { name: \"ok\", ordering: 2 }"
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_unchanged.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_unchanged.snap
@@ -2,6 +2,6 @@
 source: apollo-router/src/uplink/mod.rs
 expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
 ---
-- Ok: response
-- Ok: response
+- Ok: "result QueryResult { name: \"ok\", ordering: 1 }"
+- Ok: "result QueryResult { name: \"ok\", ordering: 2 }"
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_with_ordering_skip_epoch.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_with_ordering_skip_epoch.snap
@@ -3,5 +3,4 @@ source: apollo-router/src/uplink/mod.rs
 expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
 ---
 - Ok: "result QueryResult { name: \"ok\", ordering: 1 }"
-- Ok: "result QueryResult { name: \"ok\", ordering: 2 }"
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_with_ordering_skip_old.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_with_ordering_skip_old.snap
@@ -2,6 +2,6 @@
 source: apollo-router/src/uplink/mod.rs
 expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
 ---
-- Ok: "result QueryResult { name: \"ok\", ordering: 1 }"
 - Ok: "result QueryResult { name: \"ok\", ordering: 2 }"
+- Ok: "result QueryResult { name: \"ok\", ordering: 3 }"
 

--- a/apollo-router/src/uplink/testdata/test_query.graphql
+++ b/apollo-router/src/uplink/testdata/test_query.graphql
@@ -1,0 +1,21 @@
+query TestQuery($apiKey: String!, $graph_ref: String!, $ifAfterId: ID) {
+    uplinkQuery(ref: $graph_ref, apiKey: $apiKey, ifAfterId: $ifAfterId) {
+        __typename
+        ... on New {
+            id
+            data {
+                name
+                ordering
+            }
+            minDelaySeconds
+        }
+        ... on Unchanged {
+            id
+            minDelaySeconds
+        }
+        ... on FetchError {
+            code
+            message
+        }
+    }
+}

--- a/apollo-router/src/uplink/testdata/test_uplink.graphql
+++ b/apollo-router/src/uplink/testdata/test_uplink.graphql
@@ -1,0 +1,37 @@
+"""
+ISO 8601, extended format with nanoseconds, Zulu (or "[+-]seconds" as a string or number relative to now)
+"""
+scalar Timestamp
+type FetchError {
+  code: FetchErrorCode!
+  message: String!
+  "Minimum delay before the next fetch should occur, in seconds."
+  minDelaySeconds: Float!
+}
+
+type Query {
+  uplinkQuery(apiKey: String!,
+    ifAfterId: ID,
+    ref: String!
+  ): RouterTestResponse!
+}
+type Data {
+  name: String!
+  ordering: Int!
+}
+type New {
+  id: ID!
+  data: Data!
+  minDelaySeconds: Float!
+}
+type Unchanged {
+  id: ID!
+  minDelaySeconds: Float!
+}
+union RouterTestResponse = New | Unchanged | FetchError
+enum FetchErrorCode {
+  AUTHENTICATION_FAILED
+  ACCESS_DENIED
+  UNKNOWN_REF
+  RETRY_LATER
+}


### PR DESCRIPTION
Messages that are received from uplink are filtered if they are deemed to be older than the last message recieved.
This should prevent flapping of routers especially when `APOLLO_UPLINK_ENDPOINTS` is in use.

The tests had to be refactored as we needed to be able to test ordering ID and this wasn't possible with entitlements.

Part of #2794

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
