### PR TITLE
Migrate xtask from StructOpt to Clap

### DIFF
--- a/.changesets/maint_snap_clap_clap_snap.md
+++ b/.changesets/maint_snap_clap_clap_snap.md
@@ -1,0 +1,5 @@
+### Migrate xtask from StructOpt to Clap ([Issue #2807](https://github.com/apollographql/router/issues/2807))
+
+Migrated xtask from `StructOpt` to `Clap` as `StructOpt` is in maintenance mode.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2808

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -228,7 +228,7 @@ pub struct Opt {
     pub(crate) version: bool,
 }
 
-/// Wrapper so that structop can display the default config path in the help message.
+/// Wrapper so that clap can display the default config path in the help message.
 /// Uses ProjectDirs to get the default location.
 #[derive(Debug)]
 struct ProjectDir {

--- a/xtask/Cargo.lock
+++ b/xtask/Cargo.lock
@@ -176,13 +176,39 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "4.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "ce38afc168d8665cfc75c7b1dd9672e50716a137f433f070991619744a67342a"
 dependencies = [
  "bitflags",
- "textwrap",
- "unicode-width",
+ "clap_derive",
+ "clap_lex",
+ "is-terminal",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fddf67631444a3a3e3e5ac51c36a5e01335302de677bd78759eaa90ab1f46644"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "033f6b7a4acb1f358c742aaca805c939ee73b4c6209ae4318ec7aca81c42e646"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -346,6 +372,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -560,7 +607,7 @@ checksum = "4e55df64cc702c4ad6647f8df13a799ad11688a3781fadf5045f7ba12733fa9b"
 dependencies = [
  "graphql-introspection-query",
  "graphql-parser",
- "heck 0.4.1",
+ "heck",
  "lazy_static",
  "proc-macro2",
  "quote",
@@ -607,15 +654,6 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
@@ -625,6 +663,15 @@ name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -771,10 +818,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7d6c6f8c91b4b9ed43484ad1a938e393caf35960fce7f82a040497207bd8e9e"
+dependencies = [
+ "libc",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "itertools"
@@ -891,6 +960,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+
+[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,7 +1079,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6058e64324c71e02bc2b150e4f3bc8286db6c83092132ffa3f6b1eab0f9def5"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
 ]
 
@@ -1081,6 +1156,12 @@ dependencies = [
  "rand 0.8.5",
  "thiserror",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "parking_lot"
@@ -1444,6 +1525,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,28 +1806,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "structopt"
-version = "0.3.26"
+name = "strsim"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1792,15 +1869,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
 ]
 
 [[package]]
@@ -2061,12 +2129,6 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
 
 [[package]]
 name = "unicode-width"
@@ -2435,6 +2497,7 @@ dependencies = [
  "camino",
  "cargo_metadata",
  "chrono",
+ "clap",
  "console",
  "dialoguer",
  "flate2",
@@ -2450,7 +2513,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_traversal",
- "structopt",
  "tap",
  "tar",
  "tempfile",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,6 +13,7 @@ ansi_term = "0.12"
 anyhow = "1"
 base64 = "0.20"
 camino = "1"
+clap = {version="4.1.10", features=["derive"]}
 cargo_metadata = "0.15"
 chrono = "0.4.24"
 console = "0.15.5"
@@ -34,7 +35,6 @@ reqwest = { version = "0.11", default-features = false, features = [
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1"
 serde_json_traversal = "0.2"
-structopt = { version = "0.3", default-features = false }
 tar = "0.4"
 tempfile = "3"
 tap = "1.0.1"

--- a/xtask/src/commands/all.rs
+++ b/xtask/src/commands/all.rs
@@ -1,20 +1,20 @@
 use anyhow::Result;
-use structopt::StructOpt;
+use clap::Parser;
 
 use super::Compliance;
 use super::Licenses;
 use super::Lint;
 use super::Test;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct All {
-    #[structopt(flatten)]
+    #[command(flatten)]
     compliance: Compliance,
-    #[structopt(flatten)]
+    #[command(flatten)]
     licenses: Licenses,
-    #[structopt(flatten)]
+    #[command(flatten)]
     lint: Lint,
-    #[structopt(flatten)]
+    #[command(flatten)]
     test: Test,
 }
 

--- a/xtask/src/commands/changeset/mod.rs
+++ b/xtask/src/commands/changeset/mod.rs
@@ -46,7 +46,6 @@ use matching_pull_request::matching_pull_request::Variables;
 use matching_pull_request::MatchingPullRequest;
 use memorable_wordlist;
 use serde::Serialize;
-use structopt::StructOpt;
 use tinytemplate::format_unescaped;
 use tinytemplate::TinyTemplate;
 use xtask::PKG_PROJECT_ROOT;
@@ -87,7 +86,7 @@ impl Command {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 pub enum Command {
     /// Add a new changeset
     Create(Create),
@@ -186,14 +185,14 @@ impl fmt::Display for Classification {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Parser)]
 pub struct Create {
     /// Use the current branch as the file name
-    #[structopt(short = "b", long = "--with-branch-name")]
+    #[clap(short = 'b', long = "with-branch-name")]
     with_branch_name: bool,
 
     /// The classification of the changeset
-    #[structopt(short = "c", long = "--class")]
+    #[clap(short = 'c', long = "class")]
     classification: Option<Classification>,
 }
 

--- a/xtask/src/commands/compliance.rs
+++ b/xtask/src/commands/compliance.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
-use structopt::StructOpt;
 use xtask::*;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Parser)]
 pub struct Compliance {}
 
 impl Compliance {

--- a/xtask/src/commands/dev.rs
+++ b/xtask/src/commands/dev.rs
@@ -1,17 +1,16 @@
 use anyhow::Result;
-use structopt::StructOpt;
 
 use super::Compliance;
 use super::Lint;
 use super::Test;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Parser)]
 pub struct Dev {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     compliance: Compliance,
-    #[structopt(flatten)]
+    #[clap(flatten)]
     lint: Lint,
-    #[structopt(flatten)]
+    #[clap(flatten)]
     test: Test,
 }
 

--- a/xtask/src/commands/dist.rs
+++ b/xtask/src/commands/dist.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
-use structopt::StructOpt;
 use xtask::*;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Parser)]
 pub struct Dist {}
 
 impl Dist {

--- a/xtask/src/commands/licenses.rs
+++ b/xtask/src/commands/licenses.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
-use structopt::StructOpt;
 use xtask::*;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Parser)]
 pub struct Licenses {}
 
 impl Licenses {

--- a/xtask/src/commands/lint.rs
+++ b/xtask/src/commands/lint.rs
@@ -2,13 +2,12 @@ use std::process::Command;
 
 use anyhow::ensure;
 use anyhow::Result;
-use structopt::StructOpt;
 use xtask::*;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Parser)]
 pub struct Lint {
     /// apply formatting fixes
-    #[structopt(long)]
+    #[clap(long)]
     fmt: bool,
 }
 

--- a/xtask/src/commands/package/macos.rs
+++ b/xtask/src/commands/package/macos.rs
@@ -13,7 +13,7 @@ use xtask::*;
 
 const ENTITLEMENTS: &str = "macos-entitlements.plist";
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 pub struct PackageMacos {
     /// Keychain keychain_password.
     #[structopt(long)]

--- a/xtask/src/commands/package/macos.rs
+++ b/xtask/src/commands/package/macos.rs
@@ -8,39 +8,38 @@ use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
 use serde_json_traversal::serde_json_traversal;
-use structopt::StructOpt;
 use xtask::*;
 
 const ENTITLEMENTS: &str = "macos-entitlements.plist";
 
-#[derive(Debug, clap::Subcommand)]
+#[derive(Debug, clap::Parser)]
 pub struct PackageMacos {
     /// Keychain keychain_password.
-    #[structopt(long)]
+    #[clap(long)]
     keychain_password: String,
 
     /// Certificate bundle in base64.
-    #[structopt(long)]
+    #[clap(long)]
     cert_bundle_base64: String,
 
     /// Certificate bundle keychain_password.
-    #[structopt(long)]
+    #[clap(long)]
     cert_bundle_password: String,
 
     /// Primary bundle ID.
-    #[structopt(long)]
+    #[clap(long)]
     primary_bundle_id: String,
 
     /// Apple team ID.
-    #[structopt(long)]
+    #[clap(long)]
     apple_team_id: String,
 
     /// Apple username.
-    #[structopt(long)]
+    #[clap(long)]
     apple_username: String,
 
     /// Notarization password.
-    #[structopt(long)]
+    #[clap(long)]
     notarization_password: String,
 }
 

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -26,7 +26,7 @@ pub struct Package {
     output: Utf8PathBuf,
 
     #[cfg(target_os = "macos")]
-    #[structopt(flatten)]
+    #[clap(flatten)]
     macos: macos::PackageMacos,
 
     #[clap(long)]

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -9,35 +9,28 @@ use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
 use camino::Utf8PathBuf;
-use structopt::StructOpt;
 use xtask::*;
 
 const INCLUDE: &[&str] = &["README.md", "LICENSE", "licenses.html"];
+
 pub(crate) const TARGET_X86_64_MUSL_LINUX: &str = "x86_64-unknown-linux-musl";
 pub(crate) const TARGET_X86_64_GNU_LINUX: &str = "x86_64-unknown-linux-gnu";
 pub(crate) const TARGET_AARCH64_GNU_LINUX: &str = "aarch64-unknown-linux-gnu";
 pub(crate) const TARGET_X86_64_WINDOWS: &str = "x86_64-pc-windows-msvc";
 pub(crate) const TARGET_X86_64_MACOS: &str = "x86_64-apple-darwin";
-pub(crate) const POSSIBLE_TARGETS: [&str; 5] = [
-    TARGET_X86_64_MUSL_LINUX,
-    TARGET_X86_64_GNU_LINUX,
-    TARGET_AARCH64_GNU_LINUX,
-    TARGET_X86_64_WINDOWS,
-    TARGET_X86_64_MACOS,
-];
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Parser)]
 pub struct Package {
     /// Output tarball.
-    #[structopt(long)]
+    #[clap(long)]
     output: Utf8PathBuf,
 
     #[cfg(target_os = "macos")]
     #[structopt(flatten)]
     macos: macos::PackageMacos,
 
-    #[structopt(long, default_value, possible_values = &POSSIBLE_TARGETS)]
-    target: Target,
+    #[clap(long)]
+    target: Option<Target>,
 }
 
 impl Package {
@@ -59,8 +52,11 @@ impl Package {
             }
             self.output.to_owned()
         } else if self.output.is_dir() {
-            self.output
-                .join(format!("router-v{}-{}.tar.gz", *PKG_VERSION, self.target))
+            self.output.join(format!(
+                "router-v{}-{}.tar.gz",
+                *PKG_VERSION,
+                self.target.clone().unwrap_or_default()
+            ))
         } else {
             self.output.to_owned()
         };
@@ -95,13 +91,19 @@ impl Package {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, clap::ValueEnum)]
 pub(crate) enum Target {
+    #[value(name = "x86_64-unknown-linux-musl")]
     MuslLinux,
+    #[value(name = "x86_64-unknown-linux-gnu")]
     GnuLinux,
+    #[value(name = "aarch64-unknown-linux-gnu")]
     ArmLinux,
+    #[value(name = "x86_64-pc-windows-msvc")]
     Windows,
+    #[value(name = "x86_64-apple-darwin")]
     MacOS,
+    #[value(skip)]
     Other,
 }
 

--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -8,14 +8,13 @@ use chrono::prelude::Utc;
 use git2::Repository;
 use octorust::types::PullsCreateRequest;
 use octorust::Client;
-use structopt::StructOpt;
 use tap::TapFallible;
 use walkdir::WalkDir;
 use xtask::*;
 
 use crate::commands::changeset::slurp_and_remove_changesets;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 pub enum Command {
     /// Prepare a new release
     Prepare(Prepare),
@@ -55,18 +54,18 @@ impl FromStr for Version {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Parser)]
 pub struct Prepare {
     /// Release from the current branch rather than creating a new one.
-    #[structopt(long)]
+    #[clap(long)]
     current_branch: bool,
 
     /// Skip the license check
-    #[structopt(long)]
+    #[clap(long)]
     skip_license_ckeck: bool,
 
     /// Dry run, don't commit the changes and create the PR.
-    #[structopt(long)]
+    #[clap(long)]
     dry_run: bool,
 
     /// The new version that is being created OR to bump (major|minor|patch|current).

--- a/xtask/src/commands/test.rs
+++ b/xtask/src/commands/test.rs
@@ -1,25 +1,24 @@
 use anyhow::Result;
-use structopt::StructOpt;
 use xtask::*;
 
 const TEST_DEFAULT_ARGS: &[&str] = &["test"];
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Parser)]
 pub struct Test {
     /// The number of jobs to pass to cargo test via --jobs
-    #[structopt(long)]
+    #[clap(long)]
     jobs: Option<usize>,
 
     /// The number of threads to pass to cargo test via --test-threads
-    #[structopt(long)]
+    #[clap(long)]
     test_threads: Option<usize>,
 
     /// Pass --locked to cargo test
-    #[structopt(long)]
+    #[clap(long)]
     locked: bool,
 
     /// Pass --workspace to cargo test
-    #[structopt(long)]
+    #[clap(long)]
     workspace: bool,
 }
 

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -2,29 +2,30 @@ mod commands;
 
 use ansi_term::Colour::Green;
 use anyhow::Result;
-use structopt::StructOpt;
+use clap::Parser;
 
 fn main() -> Result<()> {
-    let app = Xtask::from_args();
+    let app = Xtask::parse();
     app.run()
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Parser)]
 #[structopt(
     name = "xtask",
     about = "Workflows used locally and in CI for developing Router"
 )]
 struct Xtask {
-    #[structopt(subcommand)]
+    #[command(subcommand)]
     pub command: Command,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Subcommand)]
 pub enum Command {
     /// Locally run all the checks required before a release.
     All(commands::All),
 
     /// Produce or consume changesets
+    #[command(subcommand)]
     Changeset(commands::changeset::Command),
 
     /// Check the code for licence and security compliance.
@@ -49,6 +50,7 @@ pub enum Command {
     Package(commands::Package),
 
     /// Prepare a release
+    #[command(subcommand)]
     Release(commands::release::Command),
 }
 


### PR DESCRIPTION
Migrated xtask from `StructOpt` to `Clap` as `StructOpt` is in maintenance mode.
Fixes #2807

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
