### PR TITLE
Uplink: out of date handling and metrics

### DIFF
--- a/.changesets/feat_bladder_dresser_glad_pill.md
+++ b/.changesets/feat_bladder_dresser_glad_pill.md
@@ -4,21 +4,21 @@ Adds metrics for uplink of the format:
 ```
 # HELP apollo_router_uplink uplink
 # TYPE apollo_router_uplink histogram
-apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.001"} 0
-apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.005"} 0
-apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.015"} 0
-apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.05"} 0
-apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.1"} 0
-apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.2"} 0
-apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.3"} 1
-apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.4"} 1
-apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.5"} 1
-apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="1"} 1
-apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="5"} 1
-apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="10"} 1
-apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="+Inf"} 1
-apollo_router_uplink_duration_seconds_bucket_sum{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql"} 0.21680258
-apollo_router_uplink_duration_seconds_bucket_count{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql"} 1
+apollo_router_uplink_duration_seconds_bucket{kind="unchanged",query="SupergraphSdl",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql",le="0.001"} 0
+apollo_router_uplink_duration_seconds_bucket{kind="unchanged",query="SupergraphSdl",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql",le="0.005"} 0
+apollo_router_uplink_duration_seconds_bucket{kind="unchanged",query="SupergraphSdl",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql",le="0.015"} 0
+apollo_router_uplink_duration_seconds_bucket{kind="unchanged",query="SupergraphSdl",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql",le="0.05"} 0
+apollo_router_uplink_duration_seconds_bucket{kind="unchanged",query="SupergraphSdl",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql",le="0.1"} 0
+apollo_router_uplink_duration_seconds_bucket{kind="unchanged",query="SupergraphSdl",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql",le="0.2"} 0
+apollo_router_uplink_duration_seconds_bucket{kind="unchanged",query="SupergraphSdl",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql",le="0.3"} 1
+apollo_router_uplink_duration_seconds_bucket{kind="unchanged",query="SupergraphSdl",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql",le="0.4"} 1
+apollo_router_uplink_duration_seconds_bucket{kind="unchanged",query="SupergraphSdl",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql",le="0.5"} 1
+apollo_router_uplink_duration_seconds_bucket{kind="unchanged",query="SupergraphSdl",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql",le="1"} 1
+apollo_router_uplink_duration_seconds_bucket{kind="unchanged",query="SupergraphSdl",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql",le="5"} 1
+apollo_router_uplink_duration_seconds_bucket{kind="unchanged",query="SupergraphSdl",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql",le="10"} 1
+apollo_router_uplink_duration_seconds_bucket{kind="unchanged",query="SupergraphSdl",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql",le="+Inf"} 1
+apollo_router_uplink_duration_seconds_bucket_sum{kind="unchanged",query="SupergraphSdl",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql"} 0.21680258
+apollo_router_uplink_duration_seconds_bucket_count{kind="unchanged",query="SupergraphSdl",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql"} 1
 ```
 This is a histogram of duration which contains the following attributes:
 * url: the url that was polled

--- a/.changesets/feat_bladder_dresser_glad_pill.md
+++ b/.changesets/feat_bladder_dresser_glad_pill.md
@@ -1,4 +1,4 @@
-### Uplink metrics and logging ([Issue #2769](https://github.com/apollographql/router/issues/2769))
+### Uplink metrics and logging ([Issue #2769](https://github.com/apollographql/router/issues/2769), [Issue #2815](https://github.com/apollographql/router/issues/2815))
 
 Adds metrics for uplink of the format:
 ```
@@ -23,7 +23,7 @@ uplink_count{kind="duration",query="SupergraphSdl",service_name="apollo-router",
 This is a histogram of duration which contains the following attributes:
 * url: the url that was polled
 * query: SupergraphSdl|Entitlement
-* type: new|unchanged|http_error|uplink_error
+* type: new|unchanged|http_error|uplink_error|ignored
 * code: The error code depending on type
 * error: The error message
 

--- a/.changesets/feat_bladder_dresser_glad_pill.md
+++ b/.changesets/feat_bladder_dresser_glad_pill.md
@@ -2,23 +2,23 @@
 
 Adds metrics for uplink of the format:
 ```
-# HELP uplink uplink
-# TYPE uplink histogram
-uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.001"} 0
-uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.005"} 0
-uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.015"} 0
-uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.05"} 0
-uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.1"} 0
-uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.2"} 0
-uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.3"} 1
-uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.4"} 1
-uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.5"} 1
-uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="1"} 1
-uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="5"} 1
-uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="10"} 1
-uplink_bucket{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="+Inf"} 1
-uplink_sum{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql"} 0.21680258
-uplink_count{kind="duration",query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql"} 1
+# HELP apollo_router_uplink uplink
+# TYPE apollo_router_uplink histogram
+apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.001"} 0
+apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.005"} 0
+apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.015"} 0
+apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.05"} 0
+apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.1"} 0
+apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.2"} 0
+apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.3"} 1
+apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.4"} 1
+apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="0.5"} 1
+apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="1"} 1
+apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="5"} 1
+apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="10"} 1
+apollo_router_uplink_duration_seconds_bucket{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql",le="+Inf"} 1
+apollo_router_uplink_duration_seconds_bucket_sum{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql"} 0.21680258
+apollo_router_uplink_duration_seconds_bucket_count{query="SupergraphSdl",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql"} 1
 ```
 This is a histogram of duration which contains the following attributes:
 * url: the url that was polled

--- a/.changesets/feat_bladder_dresser_glad_pill.md
+++ b/.changesets/feat_bladder_dresser_glad_pill.md
@@ -31,4 +31,4 @@ A limitation of this is that it can't display metrics for the first poll to upli
 
 Logging messages have also been improved.
 
-By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2779
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2779, https://github.com/apollographql/router/pull/2817

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -244,7 +244,7 @@ where
                                 now.elapsed().as_secs_f64(),
                             query,
                             url = url.to_string(),
-                            "type" = "empty"
+                            "kind" = "empty"
                         );
                     }
                     Some(UplinkResponse::New { ordering_id, .. })
@@ -255,7 +255,7 @@ where
                                 now.elapsed().as_secs_f64(),
                             query,
                             url = url.to_string(),
-                            "type" = "new"
+                            "kind" = "new"
                         );
                         return Ok(response.expect("we are in the some branch, qed"));
                     }
@@ -265,7 +265,7 @@ where
                                 now.elapsed().as_secs_f64(),
                             query,
                             url = url.to_string(),
-                            "type" = "ignored"
+                            "kind" = "ignored"
                         );
                         tracing::debug!(
                             "ignoring uplink event as is was equal to or older than our last known message. Other endpoints will be tried"
@@ -277,7 +277,7 @@ where
                                 now.elapsed().as_secs_f64(),
                             query,
                             url = url.to_string(),
-                            "type" = "unchanged"
+                            "kind" = "unchanged"
                         );
                         return Ok(response.expect("we are in the some branch, qed"));
                     }
@@ -287,7 +287,7 @@ where
                                 now.elapsed().as_secs_f64(),
                             query,
                             url = url.to_string(),
-                            "type" = "uplink_error",
+                            "kind" = "uplink_error",
                             error = message,
                             code
                         );
@@ -300,7 +300,7 @@ where
                     histogram.apollo_router_uplink_duration_seconds = now.elapsed().as_secs_f64(),
                     query = std::any::type_name::<Query>(),
                     url = url.to_string(),
-                    "type" = "http_error",
+                    "kind" = "http_error",
                     error = e.to_string(),
                     code = e.status().unwrap_or_default().as_str()
                 );

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -239,32 +239,71 @@ where
 
                 match &response {
                     None => {
-                        tracing::info!(histogram.uplink = now.elapsed().as_secs_f64(), query, kind = %"duration", url = url.to_string(), "type"="empty");
+                        tracing::info!(
+                            histogram.apollo_router_uplink_duration_seconds =
+                                now.elapsed().as_secs_f64(),
+                            query,
+                            url = url.to_string(),
+                            "type" = "empty"
+                        );
                     }
                     Some(UplinkResponse::New { ordering_id, .. })
                         if ordering_id > &last_ordering_id =>
                     {
-                        tracing::info!(histogram.uplink = now.elapsed().as_secs_f64(), query, kind = %"duration", url = url.to_string(), "type"="new");
+                        tracing::info!(
+                            histogram.apollo_router_uplink_duration_seconds =
+                                now.elapsed().as_secs_f64(),
+                            query,
+                            url = url.to_string(),
+                            "type" = "new"
+                        );
                         return Ok(response.expect("we are in the some branch, qed"));
                     }
                     Some(UplinkResponse::New { .. }) => {
-                        tracing::info!(histogram.uplink = now.elapsed().as_secs_f64(), query, kind = %"duration", url = url.to_string(), "type"="ignored");
+                        tracing::info!(
+                            histogram.apollo_router_uplink_duration_seconds =
+                                now.elapsed().as_secs_f64(),
+                            query,
+                            url = url.to_string(),
+                            "type" = "ignored"
+                        );
                         tracing::debug!(
                             "ignoring uplink event as is was older than our last known message. Other endpoints will be tried"
                         );
                     }
                     Some(UplinkResponse::Unchanged { .. }) => {
-                        tracing::info!(histogram.uplink = now.elapsed().as_secs_f64(), query, kind = %"duration", url = url.to_string(), "type"="unchanged");
+                        tracing::info!(
+                            histogram.apollo_router_uplink_duration_seconds =
+                                now.elapsed().as_secs_f64(),
+                            query,
+                            url = url.to_string(),
+                            "type" = "unchanged"
+                        );
                         return Ok(response.expect("we are in the some branch, qed"));
                     }
                     Some(UplinkResponse::Error { message, code, .. }) => {
-                        tracing::info!(histogram.uplink = now.elapsed().as_secs_f64(), query, kind = %"duration", url = url.to_string(), "type"="uplink_error", error=message, code);
+                        tracing::info!(
+                            histogram.apollo_router_uplink_duration_seconds =
+                                now.elapsed().as_secs_f64(),
+                            query,
+                            url = url.to_string(),
+                            "type" = "uplink_error",
+                            error = message,
+                            code
+                        );
                         return Ok(response.expect("we are in the some branch, qed"));
                     }
                 }
             }
             Err(e) => {
-                tracing::info!(histogram.uplink = now.elapsed().as_secs_f64(), query=std::any::type_name::<Query>(), kind = %"duration", url = url.to_string(), "type"="http_error", error=e.to_string(), code=e.status().unwrap_or_default().as_str());
+                tracing::info!(
+                    histogram.apollo_router_uplink_duration_seconds = now.elapsed().as_secs_f64(),
+                    query = std::any::type_name::<Query>(),
+                    url = url.to_string(),
+                    "type" = "http_error",
+                    error = e.to_string(),
+                    code = e.status().unwrap_or_default().as_str()
+                );
                 tracing::debug!(
                     "failed to fetch from Uplink endpoint {}: {}. Other endpoints will be tried",
                     url,

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -268,7 +268,7 @@ where
                             "type" = "ignored"
                         );
                         tracing::debug!(
-                            "ignoring uplink event as is was older than our last known message. Other endpoints will be tried"
+                            "ignoring uplink event as is was equal to or older than our last known message. Other endpoints will be tried"
                         );
                     }
                     Some(UplinkResponse::Unchanged { .. }) => {

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -770,14 +770,14 @@ mod test {
             .endpoint(&url1)
             .response(response_ok(1))
             .response(response_unchanged())
-            .response(response_ok(2))
+            .response(response_ok(3))
             .build()
             .await;
 
         MockResponses::builder()
             .mock_server(&mock_server)
             .endpoint(&url2)
-            .response(response_ok(3))
+            .response(response_ok(2))
             .build()
             .await;
 
@@ -788,7 +788,7 @@ mod test {
             Duration::from_secs(0),
             Duration::from_secs(1),
         )
-        .take(2)
+        .take(3)
         .collect::<Vec<_>>()
         .await;
         assert_yaml_snapshot!(results.into_iter().map(to_friendly).collect::<Vec<_>>());

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_unchanged_error.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_unchanged_error.snap
@@ -3,5 +3,6 @@ source: apollo-router/src/uplink/mod.rs
 expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
 ---
 - Ok: "result QueryResult { name: \"ok\", ordering: 1 }"
+- Ok: "result QueryResult { name: \"ok\", ordering: 2 }"
 - Ok: "result QueryResult { name: \"ok\", ordering: 3 }"
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_unchanged_error.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_unchanged_error.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/uplink/mod.rs
+expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
+---
+- Ok: "result QueryResult { name: \"ok\", ordering: 1 }"
+- Ok: "result QueryResult { name: \"ok\", ordering: 3 }"
+

--- a/apollo-router/tests/metrics_tests.rs
+++ b/apollo-router/tests/metrics_tests.rs
@@ -56,7 +56,7 @@ async fn test_metrics_reloading() -> Result<(), BoxError> {
         .await;
 
     if std::env::var("APOLLO_KEY").is_ok() && std::env::var("APOLLO_GRAPH_REF").is_ok() {
-        router.assert_metrics_contains(r#"uplink_count{kind="duration",query="Entitlement",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql"}"#, Some(Duration::from_secs(60))).await;
+        router.assert_metrics_contains(r#"apollo_router_uplink_duration_seconds_count{query="Entitlement",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql"}"#, Some(Duration::from_secs(60))).await;
     }
 
     Ok(())

--- a/apollo-router/tests/metrics_tests.rs
+++ b/apollo-router/tests/metrics_tests.rs
@@ -56,7 +56,7 @@ async fn test_metrics_reloading() -> Result<(), BoxError> {
         .await;
 
     if std::env::var("APOLLO_KEY").is_ok() && std::env::var("APOLLO_GRAPH_REF").is_ok() {
-        router.assert_metrics_contains(r#"apollo_router_uplink_duration_seconds_count{query="Entitlement",service_name="apollo-router",type="unchanged",url="https://uplink.api.apollographql.com/graphql"}"#, Some(Duration::from_secs(60))).await;
+        router.assert_metrics_contains(r#"apollo_router_uplink_duration_seconds_count{kind="unchanged",query="Entitlement",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql"}"#, Some(Duration::from_secs(60))).await;
     }
 
     Ok(())


### PR DESCRIPTION
Change uplink logic to allow reporting of out-of-date events via prometheus metric.

Out of date and unchanged responses will no longer halt trying uplink endpoints.

Fixes #2815

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
