### PR TITLE
Add `apollo_router_uplink_duration_seconds_bucket` to metrics docs.

### DIFF
--- a/.changesets/feat_bladder_dresser_glad_pill.md
+++ b/.changesets/feat_bladder_dresser_glad_pill.md
@@ -1,4 +1,4 @@
-### Uplink metrics and logging ([Issue #2769](https://github.com/apollographql/router/issues/2769), [Issue #2815](https://github.com/apollographql/router/issues/2815))
+### Uplink metrics and logging ([Issue #2769](https://github.com/apollographql/router/issues/2769), [Issue #2815](https://github.com/apollographql/router/issues/2815), [Issue #2816](https://github.com/apollographql/router/issues/2816))
 
 Adds metrics for uplink of the format:
 ```
@@ -31,4 +31,4 @@ A limitation of this is that it can't display metrics for the first poll to upli
 
 Logging messages have also been improved.
 
-By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2779, https://github.com/apollographql/router/pull/2817
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2779, https://github.com/apollographql/router/pull/2817, https://github.com/apollographql/router/pull/2819

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -81,7 +81,7 @@ All cache metrics listed above have the following attributes:
 - `storage`: The backend storage of the cache (`memory`, `redis`)
 
 #### Performance
-- `apollo_router_processing_time` - Time spent processing a request, outside of waiting for external or subgraph requests in seconds.
+- `apollo_router_processing_time` - Time spent processing a request (outside of waiting for external or subgraph requests) in seconds.
 
 #### Uplink
 - `apollo_router_uplink_duration_seconds_bucket` - Uplink request duration, attributes:

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -63,7 +63,7 @@ The following metrics are available when using Prometheus. Attributes are listed
 - `apollo_router_http_request_duration_seconds_bucket` - HTTP router request duration
 - `apollo_router_http_request_duration_seconds_bucket` - HTTP subgraph request duration, attributes:
   - `subgraph`: (Optional) The subgraph being queried.
-- `apollo_router_http_requests_total` - Total number of HTTP requests by HTTP Status 
+- `apollo_router_http_requests_total` - Total number of HTTP requests by HTTP status 
 - `apollo_router_timeout` - Number of triggered timeouts: 
 
 #### Session

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -62,7 +62,7 @@ The following metrics are available when using Prometheus. Attributes are listed
 #### HTTP
 - `apollo_router_http_request_duration_seconds_bucket` - HTTP router request duration
 - `apollo_router_http_request_duration_seconds_bucket` - HTTP subgraph request duration, attributes:
-  - `subgraph`: (Optional) the subgraph being queried.
+  - `subgraph`: (Optional) The subgraph being queried.
 - `apollo_router_http_requests_total` - Total number of HTTP requests by HTTP Status 
 - `apollo_router_timeout` - Number of triggered timeouts: 
 

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -68,7 +68,7 @@ The following metrics are available when using Prometheus. Attributes are listed
 
 #### Session
 - `apollo_router_session_count_total` - Number of currently connected clients 
-- `apollo_router_session_count_active` - Number of in flight GraphQL requests 
+- `apollo_router_session_count_active` - Number of in-flight GraphQL requests 
 
 #### Cache
 - `apollo_router_cache_hit_count` - Number of cache hits 

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -78,7 +78,7 @@ The following metrics are available when using Prometheus. Attributes are listed
 
 All cache metrics listed above have the following attributes:
 - `kind`: the cache being queried (`apq`, `query planner`, `introspection`)
-- `storage` the backend storage of the cache (`memory`, `redis`)
+- `storage`: The backend storage of the cache (`memory`, `redis`)
 
 #### Performance
 - `apollo_router_processing_time` - Time spent processing a request, outside of waiting for external or subgraph requests in seconds.

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -64,7 +64,7 @@ The following metrics are available when using Prometheus. Attributes are listed
 - `apollo_router_http_request_duration_seconds_bucket` - HTTP subgraph request duration, attributes:
   - `subgraph`: (Optional) The subgraph being queried.
 - `apollo_router_http_requests_total` - Total number of HTTP requests by HTTP status 
-- `apollo_router_timeout` - Number of triggered timeouts: 
+- `apollo_router_timeout` - Number of triggered timeouts
 
 #### Session
 - `apollo_router_session_count_total` - Number of currently connected clients 

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -76,7 +76,7 @@ The following metrics are available when using Prometheus. Attributes are listed
 - `apollo_router_cache_hit_time` - Time to hit the cache in seconds 
 - `apollo_router_cache_miss_time` - Time to miss the cache in seconds 
 
-All cache metrics have the following attributes:
+All cache metrics listed above have the following attributes:
 - `kind`: the cache being queried (`apq`, `query planner`, `introspection`)
 - `storage` the backend storage of the cache (`memory`, `redis`)
 

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -57,7 +57,7 @@ apollo_router_http_request_duration_seconds_bucket{le="0.9"} 1
 > Note that if you haven't run a query against the router yet, you'll see a blank page because no metrics have been generated!
 
 ### Available metrics
-The following metrics are available when using Prometheus. Where applicable, attributes are indicated.
+The following metrics are available when using Prometheus. Attributes are listed where applicable.
 
 #### Http
 - `apollo_router_http_request_duration_seconds_bucket` - HTTP router request duration

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -56,20 +56,42 @@ apollo_router_http_request_duration_seconds_bucket{le="0.9"} 1
 
 > Note that if you haven't run a query against the router yet, you'll see a blank page because no metrics have been generated!
 
-### Currently available metrics
-The following metrics are available using Prometheus:
+### Available metrics
+The following metrics are available when using Prometheus. Where applicable, attributes are indicated.
 
-- HTTP router request duration: `apollo_router_http_request_duration_seconds_bucket`
-- HTTP request duration by subgraph: `apollo_router_http_request_duration_seconds_bucket` with attribute `subgraph`
-- Total number of HTTP requests by HTTP Status: `apollo_router_http_requests_total`
-- Number of currently connected clients: `apollo_router_session_count_total`
-- Number of in flight GraphQL requests: `apollo_router_session_count_active`
-- Number of cache hits for different `kind` of cache (`apq`, `query planner`, `introspection`) and for different `storage` (`memory`, `redis`): `apollo_router_cache_hit_count`
-- Number of cache misses for different `kind` of cache (`apq`, `query planner`, `introspection`) and for different `storage` (`memory`, `redis`): `apollo_router_cache_miss_count`
-- Time to hit the cache for different `kind` of cache (`apq`, `query planner`, `introspection`) and for different `storage` (`memory`, `redis`), in seconds: `apollo_router_cache_hit_time`
-- Time to miss the cache for different `kind` of cache (`apq`, `query planner`, `introspection`) and for different `storage` (`memory`, `redis`), in seconds: `apollo_router_cache_miss_time`
-- Time spent processing a request, outside of waiting for external or subgraph requests, in seconds (`apollo_router_processing_time`)
-- Number of triggered timeouts: `apollo_router_timeout`
+#### Http
+- `apollo_router_http_request_duration_seconds_bucket` - HTTP router request duration
+- `apollo_router_http_request_duration_seconds_bucket` - HTTP subgraph request duration, attributes:
+  - `subgraph`: (Optional) the subgraph being queried.
+- `apollo_router_http_requests_total` - Total number of HTTP requests by HTTP Status 
+- `apollo_router_timeout` - Number of triggered timeouts: 
+
+#### Session
+- `apollo_router_session_count_total` - Number of currently connected clients 
+- `apollo_router_session_count_active` - Number of in flight GraphQL requests 
+
+#### Cache
+- `apollo_router_cache_hit_count` - Number of cache hits 
+- `apollo_router_cache_miss_count` - Number of cache misses 
+- `apollo_router_cache_hit_time` - Time to hit the cache in seconds 
+- `apollo_router_cache_miss_time` - Time to miss the cache in seconds 
+
+All cache metrics have the following attributes:
+- `kind`: the cache being queried (`apq`, `query planner`, `introspection`)
+- `storage` the backend storage of the cache (`memory`, `redis`)
+
+#### Performance
+- `apollo_router_processing_time` - Time spent processing a request, outside of waiting for external or subgraph requests in seconds.
+
+#### Uplink
+- `apollo_router_uplink_duration_seconds_bucket` - Uplink request duration, attributes:
+  - `url`: the url that was polled
+  - `query`: (`SupergraphSdl`, `Entitlement`)
+  - `kind`: (`new`, `unchanged`, `http_error`, `uplink_error`, `ignored`)
+  - `code`: the error code depending on type
+  - `error`: the error message
+
+Note that the initial call to uplink during router startup will not be reflected in metrics.
 
 ## Using OpenTelemetry Collector
 

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -59,7 +59,7 @@ apollo_router_http_request_duration_seconds_bucket{le="0.9"} 1
 ### Available metrics
 The following metrics are available when using Prometheus. Attributes are listed where applicable.
 
-#### Http
+#### HTTP
 - `apollo_router_http_request_duration_seconds_bucket` - HTTP router request duration
 - `apollo_router_http_request_duration_seconds_bucket` - HTTP subgraph request duration, attributes:
   - `subgraph`: (Optional) the subgraph being queried.

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -85,11 +85,11 @@ All cache metrics listed above have the following attributes:
 
 #### Uplink
 - `apollo_router_uplink_duration_seconds_bucket` - Uplink request duration, attributes:
-  - `url`: the url that was polled
-  - `query`: (`SupergraphSdl`, `Entitlement`)
-  - `kind`: (`new`, `unchanged`, `http_error`, `uplink_error`, `ignored`)
-  - `code`: the error code depending on type
-  - `error`: the error message
+  - `url`: The Uplink URL that was polled
+  - `query`: The query that the router sent to Uplink (`SupergraphSdl` or `Entitlement`)
+  - `kind`: (`new`, `unchanged`, `http_error`, `uplink_error`, or `ignored`)
+  - `code`: The error code depending on type (if an error occurred)
+  - `error`: The error message (if an error occurred)
 
 Note that the initial call to uplink during router startup will not be reflected in metrics.
 


### PR DESCRIPTION
Add `apollo_router_uplink_duration_seconds_bucket` to metrics docs.
Reworked structure for clarity.
Fixes #2816


<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
