### PR TITLE
Fix default Uplink endpoint URLs

### DIFF
--- a/.changesets/fix_toss_a_coin_to_your_witcher.md
+++ b/.changesets/fix_toss_a_coin_to_your_witcher.md
@@ -1,0 +1,10 @@
+### Fix Uplink URLs ([Issue #2827](https://github.com/apollographql/router/issues/2827))
+
+The Uplink URLs that come with the router were incorrect. The primary URL worked, but the backup URL did not.
+
+This fixes and adds an integration test to ensure that all Uplink URLs can be contacted and data retrieved.
+
+Users of older versions of the router should upgrade as soon as possible.
+However, if this is not possible then a workaround is to set `APOLLO_UPLINK_ENDPOINTS=https://uplink.api.apollographql.com/,https://aws.uplink.api.apollographql.com/`.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2830

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -17,8 +17,8 @@ pub(crate) mod entitlement;
 pub(crate) mod entitlement_stream;
 pub(crate) mod schema_stream;
 
-const GCP_URL: &str = "https://uplink.api.apollographql.com/graphql";
-const AWS_URL: &str = "https://aws.uplink.api.apollographql.com/graphql";
+const GCP_URL: &str = "https://uplink.api.apollographql.com";
+const AWS_URL: &str = "https://aws.uplink.api.apollographql.com";
 
 #[derive(Debug, Error)]
 pub(crate) enum Error {

--- a/apollo-router/src/uplink/schema_stream.rs
+++ b/apollo-router/src/uplink/schema_stream.rs
@@ -74,36 +74,45 @@ impl From<supergraph_sdl_query::ResponseData> for UplinkResponse<String> {
 
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
     use std::time::Duration;
 
     use futures::stream::StreamExt;
+    use url::Url;
 
     use crate::uplink::schema_stream::SupergraphSdlQuery;
     use crate::uplink::stream_from_uplink;
+    use crate::uplink::Endpoints;
+    use crate::uplink::AWS_URL;
+    use crate::uplink::GCP_URL;
 
     #[tokio::test]
     async fn integration_test() {
-        if let (Ok(apollo_key), Ok(apollo_graph_ref)) = (
-            std::env::var("TEST_APOLLO_KEY"),
-            std::env::var("TEST_APOLLO_GRAPH_REF"),
-        ) {
-            let results = stream_from_uplink::<SupergraphSdlQuery, String>(
-                apollo_key,
-                apollo_graph_ref,
-                None,
-                Duration::from_secs(1),
-                Duration::from_secs(5),
-            )
-            .take(1)
-            .collect::<Vec<_>>()
-            .await;
+        for url in &[GCP_URL, AWS_URL] {
+            if let (Ok(apollo_key), Ok(apollo_graph_ref)) = (
+                std::env::var("TEST_APOLLO_KEY"),
+                std::env::var("TEST_APOLLO_GRAPH_REF"),
+            ) {
+                let results = stream_from_uplink::<SupergraphSdlQuery, String>(
+                    apollo_key,
+                    apollo_graph_ref,
+                    Some(Endpoints::fallback(vec![
+                        Url::from_str(url).expect("url must be valid")
+                    ])),
+                    Duration::from_secs(1),
+                    Duration::from_secs(5),
+                )
+                .take(1)
+                .collect::<Vec<_>>()
+                .await;
 
-            assert!(!results
-                .get(0)
-                .expect("expected one result")
-                .as_ref()
-                .expect("schema should be OK")
-                .is_empty())
+                let schema = results
+                    .get(0)
+                    .unwrap_or_else(|| panic!("expected one result from {}", url))
+                    .as_ref()
+                    .unwrap_or_else(|_| panic!("schema should be OK from {}", url));
+                assert!(schema.contains("type Product"))
+            }
         }
     }
 }


### PR DESCRIPTION
The Uplink URLs that come with the router were incorrect. The primary URL worked, but the backup URL did not.

This fixes and adds an integration test to ensure that all Uplink URLs can be contacted and data retrieved.

Users of older versions of the router should upgrade as soon as possible.
However, if this is not possible then a workaround is to set `APOLLO_UPLINK_ENDPOINTS=https://uplink.api.apollographql.com/,https://aws.uplink.api.apollographql.com/`.

Fixes #2827 
<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
