### PR TITLE
deps: Use nu-ansi-term to replace unmaintained ansi_term

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,6 @@ name = "apollo-router"
 version = "1.14.0"
 dependencies = [
  "access-json",
- "ansi_term",
  "anyhow",
  "apollo-compiler",
  "apollo-parser 0.5.0",
@@ -334,6 +333,7 @@ dependencies = [
  "multer",
  "multimap",
  "notify",
+ "nu-ansi-term 0.47.0",
  "once_cell",
  "opentelemetry",
  "opentelemetry-datadog",
@@ -3538,6 +3538,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df031e117bca634c262e9bd3173776844b6c17a90b3741c9163663b4385af76"
+dependencies = [
+ "windows-sys 0.45.0",
+]
+
+[[package]]
 name = "num"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6277,7 +6286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
 dependencies = [
  "matchers",
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
  "once_cell",
  "regex",
  "serde",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -40,7 +40,6 @@ features = ["docs_rs"]
 askama = "0.11.1"
 access-json = "0.1.0"
 anyhow = "1.0.68"
-ansi_term = "0.12"
 apollo-compiler = "0.7.0"
 apollo-parser = "0.5.0"
 arc-swap = "1.6.0"
@@ -104,6 +103,7 @@ multer = "2.0.4"
 multimap = "0.8.3"
 # To avoid tokio issues
 notify = { version = "5.1.0", default-features = false, features=["macos_kqueue"] }
+nu-ansi-term = "0.47"
 once_cell = "1.16.0"
 
 # Any package that starts with `opentelemetry` needs to be updated with care

--- a/apollo-router/src/plugins/telemetry/formatters/text.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/text.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use ansi_term::Color;
-use ansi_term::Style;
+use nu_ansi_term::Color;
+use nu_ansi_term::Style;
 use opentelemetry::trace::TraceContextExt;
 use tracing_core::Event;
 use tracing_core::Level;

--- a/xtask/Cargo.lock
+++ b/xtask/Cargo.lock
@@ -27,15 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anstream"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1104,6 +1095,15 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df031e117bca634c262e9bd3173776844b6c17a90b3741c9163663b4385af76"
+dependencies = [
  "windows-sys 0.45.0",
 ]
 
@@ -2604,7 +2604,6 @@ dependencies = [
 name = "xtask"
 version = "1.5.0"
 dependencies = [
- "ansi_term",
  "anyhow",
  "base64 0.20.0",
  "camino",
@@ -2619,6 +2618,7 @@ dependencies = [
  "itertools",
  "libc",
  "memorable-wordlist",
+ "nu-ansi-term",
  "octorust",
  "once_cell",
  "regex",

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,7 +9,6 @@ license = "LicenseRef-ELv2"
 publish = false
 
 [dependencies]
-ansi_term = "0.12"
 anyhow = "1"
 base64 = "0.20"
 camino = "1"
@@ -24,6 +23,7 @@ git2 = { version = "0.16.1", features = ["vendored-openssl"] }
 itertools = "0.10.5"
 libc = "0.2"
 memorable-wordlist = "0.1.7"
+nu-ansi-term = "0.47"
 octorust = "0.2.2"
 once_cell = "1"
 regex="1.7.1"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,8 +1,8 @@
 mod commands;
 
-use ansi_term::Colour::Green;
 use anyhow::Result;
 use clap::Parser;
+use nu_ansi_term::Color::Green;
 
 fn main() -> Result<()> {
     let app = Xtask::parse();


### PR DESCRIPTION
Partially fixes https://rustsec.org/advisories/RUSTSEC-2021-0139

`clap` is still depending on [ansi_term](https://github.com/ogham/rust-ansi-term).

cargo audit before the change:
```
Crate:     ansi_term
Version:   0.12.1
Warning:   unmaintained
Title:     ansi_term is Unmaintained
Date:      2021-08-18
ID:        RUSTSEC-2021-0139
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0139
Dependency tree:
ansi_term 0.12.1
├── clap 2.34.0
│   ├── structopt 0.3.26
│   │   └── cargo-scaffold 0.8.7
│   │       └── apollo-router-scaffold 1.12.1
│   └── cargo-scaffold 0.8.7
└── apollo-router 1.12.1
    ├── throw-error 0.1.0
    ├── supergraph_sdl 0.1.0
    ├── rhai-surrogate-cache-key 0.1.0
    ├── rhai-subgraph-request-log 0.1.0
    ├── rhai-logging 0.1.0
    ├── rhai-error-response-mutate 0.1.0
    ├── rhai-data-response-mutate 0.1.0
    ├── propagate-status-code 0.1.0
    ├── op-name-to-header 0.1.0
    ├── jwt-claims 0.1.0
    ├── hello-world 0.1.0
    ├── forbid_anonymous_operations_rhai 0.1.0
    ├── forbid-anonymous-operations 0.1.0
    ├── external-subgraph 0.1.0
    ├── cookies-to-headers 0.1.0
    ├── context-data 0.1.0
    ├── async-allow-client-id 0.1.0
    ├── apollo-router-benchmarks 1.12.1
    └── add-timestamp-header 0.1.0
```

cargo audit after the change:
```
Crate:     ansi_term
Version:   0.12.1
Warning:   unmaintained
Title:     ansi_term is Unmaintained
Date:      2021-08-18
ID:        RUSTSEC-2021-0139
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0139
Dependency tree:
ansi_term 0.12.1
└── clap 2.34.0
    ├── structopt 0.3.26
    │   └── cargo-scaffold 0.8.7
    │       └── apollo-router-scaffold 1.12.1
    └── cargo-scaffold 0.8.7
```
