### PR TITLE
alter unix_now() to return an i64, not a u64

### DIFF
--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -1628,11 +1628,11 @@ impl Rhai {
             .register_fn("uuid_v4", || -> String {
                 Uuid::new_v4().to_string()
             })
-            .register_fn("unix_now", ||-> u64 {
-                match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
-                    Ok(v)=> v.as_secs(),
-                    Err(_)=>0
-                }
+            .register_fn("unix_now", ||-> Result<i64, Box<EvalAltResult>> {
+                SystemTime::now()
+                    .duration_since(SystemTime::UNIX_EPOCH)
+                    .map_err(|e| e.to_string().into())
+                    .map(|x| x.as_secs() as i64)
             })
             // Add query plan getter to execution request
             .register_get(

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -505,8 +505,8 @@ fn it_can_create_unix_now() {
     let st = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .expect("can get system time")
-        .as_secs();
-    let unix_now: u64 = engine
+        .as_secs() as i64;
+    let unix_now: i64 = engine
         .eval(r#"unix_now()"#)
         .expect("can get unix_now() timestamp");
     // Always difficult to do timing tests. unix_now() should execute within a second of st,


### PR DESCRIPTION
rhai integers are always i64, so returning a u64 from unix_now() makes it difficult to work with.

If we truncate the u64 value to be an i64, we lose some representation of range, but we still have many seconds to work with, so it's the lesser evil in this situation.

I'm also modifying the error case so that in the very unlikely case that we can't get SystemTime we propagate the error rather than returning 0.

Making the change now is technically incompatible, but I think it's an acceptable kind of incompatibility in a dynamic language since the change improves useability.

*Description here*

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
~- [ ] Performance impact assessed and acceptable~
- Tests added and passing[^3]
    - [x] Unit Tests
    ~- [ ] Integration Tests~
    ~- [ ] Manual Tests~

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
