### PR TITLE
Remove router side checks for uplink response freshness.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,15 +62,12 @@ This has not been a problem for most users, as the default mode of operation for
 The other mode of operation, is round-robin, which is triggered only when setting the `APOLLO_UPLINK_ENDPOINTS` environment variable. In this mode there is a much higher chance that the router will go back and forth between schema versions due to disagreement between the Apollo Uplink servers or any user-provided proxies set into this variable.
 
 This change introduces two fixes:
-
-1. The Router checks uplink messages against the last known message to see if it is newer. Older messages are discarded.
-2. The Router will _only_ use fallback strategy. Uplink endpoints are only eventually consistent, and therefore it is better to always poll a primary source of information if available.
-
-We will be improving the robustness of the solution over the next weeks, including via other fixes in this release, so this can be seen as an incremental improvement.
+1. The Router will only use fallback strategy. Uplink endpoints are not strongly consistent, and therefore it is better to always poll a primary source of information if available.
+2. Uplink already handled freshness of schema but now also handles entitlement freshness.
 
 > Note: We advise against using `APOLLO_UPLINK_ENDPOINTS` to try to cache uplink responses for high availability purposes. Each request to Uplink currently sends state which limits the usefulness of such a cache.
 
-By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2803 https://github.com/apollographql/router/pull/2826
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/2803, https://github.com/apollographql/router/pull/2826, https://github.com/apollographql/router/pull/2846
 
 ### Distributed caching: Don't send Redis' `CLIENT SETNAME` ([PR #2825](https://github.com/apollographql/router/pull/2825))
 

--- a/apollo-router/src/uplink/entitlement_query.graphql
+++ b/apollo-router/src/uplink/entitlement_query.graphql
@@ -1,6 +1,6 @@
-query EntitlementQuery($apiKey: String!, $graph_ref: String!, $unlessId: ID) {
+query EntitlementQuery($apiKey: String!, $graph_ref: String!, $ifAfterId: ID) {
 
-    routerEntitlements(unlessId: $unlessId, apiKey: $apiKey, ref: $graph_ref) {
+    routerEntitlements(ifAfterId: $ifAfterId, apiKey: $apiKey, ref: $graph_ref) {
         __typename
         ... on RouterEntitlementsResult {
             id

--- a/apollo-router/src/uplink/entitlement_stream.rs
+++ b/apollo-router/src/uplink/entitlement_stream.rs
@@ -42,7 +42,7 @@ impl From<UplinkRequest> for entitlement_query::Variables {
         entitlement_query::Variables {
             api_key: req.api_key,
             graph_ref: req.graph_ref,
-            unless_id: req.id,
+            if_after_id: req.id,
         }
     }
 }
@@ -54,11 +54,6 @@ impl From<entitlement_query::ResponseData> for UplinkResponse<Entitlement> {
                 if let Some(entitlement) = result.entitlement {
                     match Entitlement::from_str(&entitlement.jwt) {
                         Ok(jwt) => UplinkResponse::New {
-                            ordering_id: jwt
-                                .claims
-                                .as_ref()
-                                .map(|c| c.halt_at)
-                                .unwrap_or(SystemTime::UNIX_EPOCH),
                             response: jwt,
                             id: result.id,
                             // this will truncate the number of seconds to under u64::MAX, which should be
@@ -73,7 +68,6 @@ impl From<entitlement_query::ResponseData> for UplinkResponse<Entitlement> {
                     }
                 } else {
                     UplinkResponse::New {
-                        ordering_id: SystemTime::UNIX_EPOCH,
                         response: Entitlement::default(),
                         id: result.id,
                         // this will truncate the number of seconds to under u64::MAX, which should be

--- a/apollo-router/src/uplink/schema_stream.rs
+++ b/apollo-router/src/uplink/schema_stream.rs
@@ -5,9 +5,6 @@
 // Read more: https://github.com/hyperium/tonic/issues/1056
 #![allow(clippy::derive_partial_eq_without_eq)]
 
-use std::str::FromStr;
-use std::time::SystemTime;
-
 use graphql_client::GraphQLQuery;
 
 use crate::uplink::schema_stream::supergraph_sdl_query::FetchErrorCode;
@@ -40,13 +37,6 @@ impl From<supergraph_sdl_query::ResponseData> for UplinkResponse<String> {
     fn from(response: supergraph_sdl_query::ResponseData) -> Self {
         match response.router_config {
             SupergraphSdlQueryRouterConfig::RouterConfigResult(result) => UplinkResponse::New {
-                ordering_id: humantime::Timestamp::from_str(result.id.as_str())
-                    .map(Into::into)
-                    .unwrap_or_else(|e|{
-                        // There's not much we can do if we didn't understand the timestamp from uplink
-                        tracing::error!("uplink response had a malformed system time. This uplink event will be ignored. If you are not using a custom uplink proxy then this is a bug, please report to Apollo. Error was: {}", e);
-                        SystemTime::UNIX_EPOCH
-                    }),
                 response: result.supergraph_sdl,
                 id: result.id,
                 // this will truncate the number of seconds to under u64::MAX, which should be

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_with_ordering_skip_epoch.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_with_ordering_skip_epoch.snap
@@ -1,6 +1,0 @@
----
-source: apollo-router/src/uplink/mod.rs
-expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
----
-- Ok: "result QueryResult { name: \"ok\", ordering: 1 }"
-

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_with_ordering_skip_old.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_with_ordering_skip_old.snap
@@ -1,7 +1,0 @@
----
-source: apollo-router/src/uplink/mod.rs
-expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
----
-- Ok: "result QueryResult { name: \"ok\", ordering: 2 }"
-- Ok: "result QueryResult { name: \"ok\", ordering: 3 }"
-

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -87,7 +87,7 @@ All cache metrics listed above have the following attributes:
 - `apollo_router_uplink_fetch_duration_seconds_bucket` - Uplink request duration, attributes:
   - `url`: The Uplink URL that was polled
   - `query`: The query that the router sent to Uplink (`SupergraphSdl` or `Entitlement`)
-  - `kind`: (`new`, `unchanged`, `http_error`, `uplink_error`, or `ignored`)
+  - `kind`: (`new`, `unchanged`, `http_error`, `uplink_error`)
   - `code`: The error code depending on type (if an error occurred)
   - `error`: The error message (if an error occurred)
 


### PR DESCRIPTION
Update entitlement query to use ifAfterId rather than unlessId. This enables us to push all freshness checks to uplink.

Fixes #2794

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
