### PR TITLE
Retry metrics

### DIFF
--- a/apollo-router/src/plugins/traffic_shaping/retry.rs
+++ b/apollo-router/src/plugins/traffic_shaping/retry.rs
@@ -54,7 +54,7 @@ impl<Res, E> Policy<subgraph::Request, Res, E> for RetryPolicy {
                 let withdrew = self.budget.withdraw();
                 if withdrew.is_err() {
                     tracing::info!(
-                        monotonic_counter.apollo_router_subgraph_request_retry_total = 1u64,
+                        monotonic_counter.apollo_router_http_request_retry_total = 1u64,
                         status = "aborted",
                         subgraph = %self.subgraph_name,
                     );
@@ -63,7 +63,7 @@ impl<Res, E> Policy<subgraph::Request, Res, E> for RetryPolicy {
                 }
 
                 tracing::info!(
-                    monotonic_counter.apollo_router_subgraph_request_retry_total = 1u64,
+                    monotonic_counter.apollo_router_http_request_retry_total = 1u64,
                     subgraph = %self.subgraph_name,
                 );
 

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -62,9 +62,12 @@ The following metrics are available when using Prometheus. Attributes are listed
 #### HTTP
 - `apollo_router_http_request_duration_seconds_bucket` - HTTP router request duration
 - `apollo_router_http_request_duration_seconds_bucket` - HTTP subgraph request duration, attributes:
-  - `subgraph`: (Optional) The subgraph being queried.
+  - `subgraph`: (Optional) The subgraph being queried
 - `apollo_router_http_requests_total` - Total number of HTTP requests by HTTP status 
 - `apollo_router_timeout` - Number of triggered timeouts
+- `apollo_router_http_request_retry_total` - Number of subgraph requests retried, attributes:
+  - `subgraph`: The subgraph being queried
+  - `status` : If the retry was aborted (`aborted`)
 
 #### Session
 - `apollo_router_session_count_total` - Number of currently connected clients 


### PR DESCRIPTION
This follows-up on https://github.com/apollographql/router/pull/2829 with a couple changes:

- Update metrics.mdx
- Change `apollo_router_subgraph_request_retry_total` to `apollo_router_http_request_retry_total` (but tagged with `subgraph`, accordingly)