### PR TITLE
docs: Update the federation version matrix to show support for Federation 2.4.0

### DIFF
--- a/docs/source/federation-version-support.mdx
+++ b/docs/source/federation-version-support.mdx
@@ -27,7 +27,15 @@ The table below shows which version of federation each router release is compile
     <tbody>
     <tr>
         <td>
-            v1.11.0 and later (<a href="https://github.com/apollographql/router/releases">see latest releases</a>)
+            v1.13.1 and later (<a href="https://github.com/apollographql/router/releases">see latest releases</a>)
+        </td>
+        <td>
+            2.4.0
+        </td>
+    </tr>
+    <tr>
+        <td>
+            v1.11.0 - v1.13.0
         </td>
         <td>
             2.3.2


### PR DESCRIPTION
This follows up with a docs-only change to the version matrix following the relese of Router v1.13.1.

Router 1.13.1 now supports using schemas composed with Federation v2.4.0.  However, no new features are yet available in the Router on account of that Federation version, thus the patch release of the Router.

Ref: https://github.com/apollographql/router/pull/2872
Ref: https://github.com/apollographql/router/pull/2869
Ref: https://github.com/apollographql/router/pull/2706