### PR TITLE
feat: batching support on router-service

### DIFF
--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -370,7 +370,7 @@ impl Plugin for Telemetry {
                             result,
                             start.elapsed(),
                         )
-                        .await;
+                            .await;
                         Self::update_metrics_on_last_response(
                             &ctx, config, field_level_instrumentation_ratio, metrics, sender, start, result,
                         )
@@ -595,15 +595,15 @@ impl Telemetry {
         config: &config::Conf,
     ) -> Box<
         dyn Layer<
-                ::tracing_subscriber::layer::Layered<
-                    OpenTelemetryLayer<
-                        ::tracing_subscriber::Registry,
-                        ReloadTracer<::opentelemetry::sdk::trace::Tracer>,
-                    >,
+            ::tracing_subscriber::layer::Layered<
+                OpenTelemetryLayer<
                     ::tracing_subscriber::Registry,
+                    ReloadTracer<::opentelemetry::sdk::trace::Tracer>,
                 >,
-            > + Send
-            + Sync,
+                ::tracing_subscriber::Registry,
+            >,
+        > + Send
+        + Sync,
     > {
         let logging = &config.logging;
         let fmt = match logging.format {
@@ -673,7 +673,7 @@ impl Telemetry {
         forward_rules: &ForwardValues,
     ) -> String {
         #[allow(clippy::mutable_key_type)] // False positive lint
-        let variables = variables
+            let variables = variables
             .iter()
             .map(|(name, value)| {
                 if match &forward_rules {
@@ -736,13 +736,13 @@ impl Telemetry {
                 let (first_response, rest) = stream.into_future().await;
 
                 if let Some(MetricsCommon {
-                    attributes:
-                        Some(MetricsAttributesConf {
-                            supergraph: Some(forward_attributes),
-                            ..
-                        }),
-                    ..
-                }) = &config.metrics.as_ref().and_then(|m| m.common.as_ref())
+                                attributes:
+                                Some(MetricsAttributesConf {
+                                         supergraph: Some(forward_attributes),
+                                         ..
+                                     }),
+                                ..
+                            }) = &config.metrics.as_ref().and_then(|m| m.common.as_ref())
                 {
                     let attributes = forward_attributes.get_attributes_from_router_response(
                         &parts,
@@ -1456,7 +1456,7 @@ impl CustomTraceIdPropagator {
             true,
             TraceState::default(),
         )
-        .into()
+            .into()
     }
 }
 
@@ -1842,7 +1842,7 @@ mod tests {
                 }
             }"#,
                 )
-                .unwrap(),
+                    .unwrap(),
                 Default::default(),
             )
             .await

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -254,8 +254,10 @@ where
                                         .uri(parts.uri.clone())
                                         .version(parts.version.clone());
                                 let headers = supergraph_request_builder.headers_mut().unwrap();
-                                for (key, value) in parts.headers.clone() {
-                                    headers.insert(key.unwrap(), value);
+                                for (header_name, header_value) in parts.headers.clone() {
+                                    if let Some(name) = header_name {
+                                        headers.insert(name, header_value);
+                                    }
                                 }
                                 let supergraph_request = SupergraphRequest {
                                     // supergraph_request: http::Request::from_parts(Parts::from_request(router_request), request),

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -691,13 +691,13 @@ mod tests {
         {
           query: Query
         }
-        
+
         directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
         directive @join__graph(name: String!, url: String!) on ENUM_VALUE
         directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
         directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
         directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-                
+
         scalar link__Import
         enum link__Purpose {
           SECURITY
@@ -711,9 +711,9 @@ mod tests {
           errorField: String
           nonNullErrorField: String!
         }
-        
+
         scalar join__FieldSet
-        
+
         enum join__Graph {
           COMPUTERS @join__graph(name: "computers", url: "http://localhost:4001/")
         }
@@ -768,8 +768,8 @@ mod tests {
         let request = supergraph::Request::fake_builder()
             .context(defer_context())
             .query(
-                r#"query { 
-                computer(id: "Computer1") {   
+                r#"query {
+                computer(id: "Computer1") {
                   id
                   ...ComputerErrorField @defer
                 }
@@ -1173,55 +1173,55 @@ mod tests {
     query: Query
     mutation: Mutation
   }
-  
+
   directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-  
+
   directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
-  
+
   directive @join__graph(name: String!, url: String!) on ENUM_VALUE
-  
+
   directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
-  
+
   directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
-  
+
   directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-  
+
   directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-  
+
   scalar join__FieldSet
-  
+
   enum join__Graph {
     PRODUCTS @join__graph(name: "products", url: "http://products:4000/graphql")
     USERS @join__graph(name: "users", url: "http://users:4000/graphql")
   }
-  
+
   scalar link__Import
-  
+
   enum link__Purpose {
     SECURITY
     EXECUTION
   }
-  
+
   type MakePaymentResult
     @join__type(graph: USERS)
   {
     id: ID!
     paymentStatus: PaymentStatus
   }
-  
+
   type Mutation
     @join__type(graph: USERS)
   {
     makePayment(userId: ID!): MakePaymentResult!
   }
-  
-  
+
+
  type PaymentStatus
     @join__type(graph: USERS)
   {
     id: ID!
   }
-  
+
   type Query
     @join__type(graph: PRODUCTS)
     @join__type(graph: USERS)
@@ -1399,7 +1399,7 @@ mod tests {
             {
                 query: Query
             }
-        
+
             directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
             directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
             directive @join__graph(name: String!, url: String!) on ENUM_VALUE
@@ -1407,7 +1407,7 @@ mod tests {
             directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
             directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
             directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-        
+
             scalar join__FieldSet
             enum join__Graph {
                 USER @join__graph(name: "user", url: "http://localhost:4000/graphql")
@@ -1428,7 +1428,7 @@ mod tests {
             id: ID!
             name: String!
             }
-        
+
             type User implements Identity
                 @join__implements(graph: USER, interface: "Identity")
                 @join__type(graph: USER, key: "id")
@@ -2254,7 +2254,7 @@ mod tests {
           {
             foo: Foo! @join__field(graph: S1)
           }
-          
+
           type Foo
             @join__owner(graph: S1)
             @join__type(graph: S1)
@@ -2262,7 +2262,7 @@ mod tests {
             id: ID! @join__field(graph: S1)
             bar: Bar! @join__field(graph: S1)
           }
-          
+
           type Bar
           @join__owner(graph: S1)
           @join__type(graph: S1, key: "id")


### PR DESCRIPTION
Add support to router_service to allow clients to send [batched requests](https://www.apollographql.com/blog/apollo-client/performance/batching-client-graphql-queries/).

The idea is to allow clients to send batched requests and have the router to deserialize the array of graphql operations and execute them concurrently. 

The relationship between the `router_service` and the `supergraph_service` becomes 1:n where n is the number of operations in the batch.

the process to allow this is the following
1. deserialize router request into a single or batch graphql requests using `GraphQLHttpRequest` enum.
2. if batch request, execute operations concurrently
3. asynchronously invoke `supergraph_service` for each operation in the batch
4. after collecting all futures join them using `futures::future::join_all()` (go from `Vec<FutureImpl<Response>>` to FutureImpl<Vec<Response>>)
5. create one `SupergraphResponse` with the the response of each graphql operation and context

https://github.com/apollographql/router/issues/126

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
