### PR TITLE
Status Code provided with SubrequestHttpError

### DIFF
--- a/.changesets/maint_subgraph_http_error_status_code.md
+++ b/.changesets/maint_subgraph_http_error_status_code.md
@@ -1,0 +1,5 @@
+### Adds HTTP status code to Subgraph HTTP error type
+
+When contextually available, includes the HTTP status code with `SubrequestHttpError`. This provides plugins the ability to access the status code directly. Currently string parsing of the `reason` is the only way to determine the status.
+
+By [@scottdouglas1989](https://github.com/scottdouglas1989) in https://github.com/apollographql/router/pull/2902

--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -972,6 +972,7 @@ async fn response_with_custom_endpoint_wildcard() -> Result<(), ApolloRouterErro
 async fn response_failure() -> Result<(), ApolloRouterError> {
     let router_service = router_service::from_supergraph_mock_callback(move |req| {
         let example_response = crate::error::FetchError::SubrequestHttpError {
+            status_code: Some(200),
             service: "Mock service".to_string(),
             reason: "Mock error".to_string(),
         }
@@ -1007,6 +1008,7 @@ async fn response_failure() -> Result<(), ApolloRouterError> {
     assert_eq!(
         response,
         crate::error::FetchError::SubrequestHttpError {
+            status_code: Some(200),
             service: "Mock service".to_string(),
             reason: "Mock error".to_string(),
         }

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -78,6 +78,8 @@ pub(crate) enum FetchError {
     ///
     /// note that this relates to a transport error and not a GraphQL error
     SubrequestHttpError {
+        status_code: Option<u16>,
+
         /// The service failed.
         service: String,
 

--- a/apollo-router/src/plugins/include_subgraph_errors.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors.rs
@@ -63,6 +63,7 @@ impl Plugin for IncludeSubgraphErrors {
                     // Create a redacted error to replace whatever error we have
                     tracing::info!("redacted subgraph({sub_name_error}) error");
                     _error = Box::new(crate::error::FetchError::SubrequestHttpError {
+                        status_code: None,
                         service: "redacted".to_string(),
                         reason: "redacted".to_string(),
                     });

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -1741,6 +1741,7 @@ mod tests {
             .times(1)
             .returning(move |_req: SubgraphRequest| {
                 Err(Box::new(FetchError::SubrequestHttpError {
+                    status_code: None,
                     service: String::from("my_subgraph_name_error"),
                     reason: String::from("cannot contact the subgraph"),
                 }))

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -258,6 +258,7 @@ impl FetchNode {
             // Unfortunately, not easy to fix here, because at this point we don't
             // know if we should be redacting errors for this subgraph...
             .map_err(|e| FetchError::SubrequestHttpError {
+                status_code: None,
                 service: service_name.to_string(),
                 reason: e.to_string(),
             })?

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -338,6 +338,7 @@ async fn call_http(
                     cloned_context.leave_active_request().await;
 
                     return Err(FetchError::SubrequestHttpError {
+                        status_code: None,
                         service: service_name.clone(),
                         reason: err.to_string(),
                     }.into());
@@ -364,6 +365,7 @@ async fn call_http(
 
                         Err(BoxError::from(FetchError::SubrequestHttpError {
                             service: service_name.clone(),
+                            status_code: Some(parts.status.as_u16()),
                             reason: format!(
                                 "{}: {}",
                                 parts.status.as_str(),
@@ -372,6 +374,7 @@ async fn call_http(
                         }))
                     } else {
                         Err(BoxError::from(FetchError::SubrequestHttpError {
+                            status_code: Some(parts.status.as_u16()),
                             service: service_name.clone(),
                             reason: format!("subgraph didn't return JSON (expected content-type: {} or content-type: {GRAPHQL_JSON_RESPONSE_HEADER_VALUE}; found content-type: {content_type:?})", APPLICATION_JSON.essence_str()),
                         }))
@@ -389,6 +392,7 @@ async fn call_http(
                     tracing::error!(fetch_error = format!("{err:?}").as_str());
 
                 return Err(FetchError::SubrequestHttpError {
+                    status_code: None,
                     service: service_name.clone(),
                     reason: err.to_string(),
                 }.into())


### PR DESCRIPTION
Includes the underlying HTTP status code in the `SubrequestHttpError` when available.

Currently, string parsing is required to pull out the HTTP status code from the `reason` of a `SubrequestHttpError` within a plugin.

This provides plugins a way to act on individual status codes in the event of `SubrequestHttpError`