### PR TITLE
Helm extra labels

### DIFF
--- a/.changesets/config_helm_extra_labels.md
+++ b/.changesets/config_helm_extra_labels.md
@@ -1,0 +1,5 @@
+### Helm extra labels
+
+Allow chart users to add custom labels to the router deployment and its pods.
+
+By [@gscheibel(https://github.com/gscheibel/) in https://github.com/apollographql/router/pull/2903

--- a/.changesets/config_helm_extra_labels.md
+++ b/.changesets/config_helm_extra_labels.md
@@ -1,5 +1,3 @@
-### Helm extra labels
-
-Allow chart users to add custom labels to the router deployment and its pods.
-
+### Helm: Router chart now supports `extraLabels` for Deployments/Pods
+Our Helm chart now supports a new value called `extraLabels`, which enables chart users to add custom labels to the Router Deployment and its Pods.
 By [@gscheibel(https://github.com/gscheibel/) in https://github.com/apollographql/router/pull/2903

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "router.labels" . | nindent 4 }}
   {{/* There may not be much configuration so check that there is something */}}
   {{- if (((((.Values.router).configuration).telemetry).metrics).prometheus).enabled }}
-    {{- toYaml .Values.router.additionalLabels | nindent 4 }}
+    {{- toYaml .Values.router.extraLabels | nindent 4 }}
   annotations:
     prometheus.io/path: {{ .Values.router.configuration.telemetry.metrics.prometheus.path | default "/metrics" }}
     prometheus.io/port: {{ (splitList ":" .Values.router.configuration.telemetry.metrics.prometheus.listen | last) | default "9090" | quote }}
@@ -32,7 +32,7 @@ spec:
       {{- end }}
       labels:
         {{- include "router.selectorLabels" . | nindent 8 }}
-        {{- toYaml .Values.router.additionalLabels | nindent 8 }}
+        {{- toYaml .Values.router.extraLabels | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "router.labels" . | nindent 4 }}
   {{/* There may not be much configuration so check that there is something */}}
   {{- if (((((.Values.router).configuration).telemetry).metrics).prometheus).enabled }}
+    {{- toYaml .Values.router.additionalLabels | nindent 4 }}
   annotations:
     prometheus.io/path: {{ .Values.router.configuration.telemetry.metrics.prometheus.path | default "/metrics" }}
     prometheus.io/port: {{ (splitList ":" .Values.router.configuration.telemetry.metrics.prometheus.listen | last) | default "9090" | quote }}
@@ -31,6 +32,7 @@ spec:
       {{- end }}
       labels:
         {{- include "router.selectorLabels" . | nindent 8 }}
+        {{- toYaml .Values.router.additionalLabels | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -4,9 +4,11 @@ metadata:
   name: {{ include "router.fullname" . }}
   labels:
     {{- include "router.labels" . | nindent 4 }}
+    {{- if .Values.extraLabels }}
+    {{- toYaml .Values.extraLabels | nindent 4 }}
+    {{- end }}
   {{/* There may not be much configuration so check that there is something */}}
   {{- if (((((.Values.router).configuration).telemetry).metrics).prometheus).enabled }}
-    {{- toYaml .Values.router.extraLabels | nindent 4 }}
   annotations:
     prometheus.io/path: {{ .Values.router.configuration.telemetry.metrics.prometheus.path | default "/metrics" }}
     prometheus.io/port: {{ (splitList ":" .Values.router.configuration.telemetry.metrics.prometheus.listen | last) | default "9090" | quote }}
@@ -32,7 +34,9 @@ spec:
       {{- end }}
       labels:
         {{- include "router.selectorLabels" . | nindent 8 }}
-        {{- toYaml .Values.router.extraLabels | nindent 8 }}
+        {{- if .Values.extraLabels }}
+        {{- toYaml .Values.extraLabels | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/chart/router/values.yaml
+++ b/helm/chart/router/values.yaml
@@ -86,6 +86,13 @@ containerPorts:
 #       - containerPort: 4001
 extraContainers: []
 
+# -- A map of extra labels to apply to the router deploment and containers
+# Example:
+# extraLabels:
+#   label_one_name: "label_one_value"
+#   label_two_name: "label_two_value"
+extraLabels: {}
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Add the capability for Helm users to set extra labels attached to the router deployment and its pods.