### PR TITLE
chore: vendors openssl in xtask

### DIFF
--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,14 +13,14 @@ ansi_term = "0.12"
 anyhow = "1"
 base64 = "0.20"
 camino = "1"
-clap = {version="4.1.10", features=["derive"]}
+clap = { version = "4.1.10", features = ["derive"] }
 cargo_metadata = "0.15"
 chrono = "0.4.24"
 console = "0.15.5"
 dialoguer = "0.10.3"
 flate2 = "1"
 graphql_client = { version = "0.12.0", features = ["reqwest-rustls"] }
-git2 = "0.16.1"
+git2 = { version = "0.16.1", features = ["vendored-openssl"] }
 itertools = "0.10.5"
 libc = "0.2"
 memorable-wordlist = "0.1.7"


### PR DESCRIPTION
This PR enables the `vendored-openssl` feature on the `git2` crate in the `xtask` workspace crate.

Fixes #2904 

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible
~- [ ] Documentation completed~
~- [ ] Performance impact assessed and acceptable~
~- Tests added and passing~
    ~- [ ] Unit Tests~
    ~- [ ] Integration Tests~
    ~- [ ] Manual Tests~

**Exceptions**

This is a no-op that requires _less_ configuration. Docs don't currently explain that you need to install `openssl` to build this crate so there's nothing to remove.