### PR TITLE
Move apollo telemetry from an opentelemetry exporter to a tracing layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry-zipkin",
  "p256 0.12.0",
+ "parking_lot 0.12.1",
  "paste",
  "pin-project-lite",
  "prometheus",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -203,6 +203,7 @@ yaml-rust = "0.4.5"
 wsl = "0.1.0"
 tokio-rustls = "0.23.4"
 http-serde = "1.1.2"
+parking_lot = "0.12.1"
 
 [target.'cfg(macos)'.dependencies]
 uname = "0.1.1"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1322,7 +1322,7 @@ expression: "&schema"
               }
             },
             "buffer_size": {
-              "description": "The buffer size for sending traces to Apollo. Increase this if you are experiencing lost traces.",
+              "description": "The buffer size for sending traces to Apollo. (deprecated, has no effect now)",
               "default": 10000,
               "type": "integer",
               "format": "uint",

--- a/apollo-router/src/plugins/telemetry/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/apollo.rs
@@ -60,7 +60,7 @@ pub(crate) struct Config {
     #[serde(deserialize_with = "deserialize_header_name")]
     pub(crate) client_version_header: HeaderName,
 
-    /// The buffer size for sending traces to Apollo. Increase this if you are experiencing lost traces.
+    /// The buffer size for sending traces to Apollo. (deprecated, has no effect now)
     pub(crate) buffer_size: NonZeroUsize,
 
     /// Enable field level instrumentation for subgraphs via ftv1. ftv1 tracing can cause performance issues as it is transmitted in band with subgraph responses.

--- a/apollo-router/src/plugins/telemetry/apollo_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/apollo_exporter.rs
@@ -65,7 +65,7 @@ impl Sender {
             Sender::Apollo(channel) => {
                 if let Err(err) = channel.to_owned().try_send(report) {
                     tracing::warn!(
-                        "could not send metrics to spaceport, metric will be dropped: {}",
+                        "could not send data to spaceport, metric will be dropped: {}",
                         err
                     );
                 }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -319,7 +319,7 @@ impl Plugin for Telemetry {
                 {
                     // Record the operation signature on the router span
                     Span::current().record(
-                        APOLLO_PRIVATE_OPERATION_SIGNATURE.as_str(),
+                        APOLLO_PRIVATE_OPERATION_SIGNATURE,
                         usage_reporting.stats_report_key.as_str(),
                     );
                 }

--- a/apollo-router/src/plugins/telemetry/reload.rs
+++ b/apollo-router/src/plugins/telemetry/reload.rs
@@ -144,3 +144,11 @@ pub(super) fn reload_fmt(
         handle.reload(layer).expect("fmt layer reload must succeed");
     }
 }
+
+pub(crate) fn reload_apollo(layer: Option<Exporter>) {
+    if let Some(handle) = APOLLO_LAYER_HANDLE.get() {
+        handle
+            .reload(layer)
+            .expect("metrics layer reload must succeed");
+    }
+}

--- a/apollo-router/src/plugins/telemetry/reload.rs
+++ b/apollo-router/src/plugins/telemetry/reload.rs
@@ -45,6 +45,7 @@ static METRICS_LAYER_HANDLE: OnceCell<
 type MetricsReloadLayer =
     tracing_subscriber::reload::Layer<MetricsLayer, Layered<FmtReloadLayer, LayeredTracer>>;
 
+#[allow(clippy::type_complexity)]
 static APOLLO_LAYER_HANDLE: OnceCell<
     Handle<Option<Exporter>, Layered<MetricsReloadLayer, Layered<FmtReloadLayer, LayeredTracer>>>,
 > = OnceCell::new();

--- a/apollo-router/src/plugins/telemetry/reload.rs
+++ b/apollo-router/src/plugins/telemetry/reload.rs
@@ -14,7 +14,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Registry;
 
-use super::tracing::apollo_telemetry::Exporter;
+use super::tracing::apollo_telemetry::ApolloLayer;
 use crate::plugins::telemetry::formatters::filter_metric_events;
 use crate::plugins::telemetry::formatters::text::TextFormatter;
 use crate::plugins::telemetry::formatters::FilteringFormatter;
@@ -47,7 +47,10 @@ type MetricsReloadLayer =
 
 #[allow(clippy::type_complexity)]
 static APOLLO_LAYER_HANDLE: OnceCell<
-    Handle<Option<Exporter>, Layered<MetricsReloadLayer, Layered<FmtReloadLayer, LayeredTracer>>>,
+    Handle<
+        Option<ApolloLayer>,
+        Layered<MetricsReloadLayer, Layered<FmtReloadLayer, LayeredTracer>>,
+    >,
 > = OnceCell::new();
 
 pub(crate) fn init_telemetry(log_level: &str) -> Result<()> {
@@ -145,7 +148,7 @@ pub(super) fn reload_fmt(
     }
 }
 
-pub(crate) fn reload_apollo(layer: Option<Exporter>) {
+pub(crate) fn reload_apollo(layer: Option<ApolloLayer>) {
     if let Some(handle) = APOLLO_LAYER_HANDLE.get() {
         handle
             .reload(layer)

--- a/apollo-router/src/plugins/telemetry/reload.rs
+++ b/apollo-router/src/plugins/telemetry/reload.rs
@@ -14,14 +14,13 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Registry;
 
+use super::tracing::apollo_telemetry::Exporter;
 use crate::plugins::telemetry::formatters::filter_metric_events;
 use crate::plugins::telemetry::formatters::text::TextFormatter;
 use crate::plugins::telemetry::formatters::FilteringFormatter;
 use crate::plugins::telemetry::metrics;
 use crate::plugins::telemetry::metrics::layer::MetricsLayer;
 use crate::plugins::telemetry::tracing::reload::ReloadTracer;
-
-use super::tracing::apollo_telemetry::Exporter;
 
 type LayeredTracer = Layered<OpenTelemetryLayer<Registry, ReloadTracer<Tracer>>, Registry>;
 

--- a/apollo-router/src/plugins/telemetry/tracing/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo.rs
@@ -1,6 +1,5 @@
 //! Tracing configuration for apollo telemetry.
 // With regards to ELv2 licensing, this entire file is license key functionality
-use opentelemetry::sdk::trace::BatchSpanProcessor;
 use opentelemetry::sdk::trace::Builder;
 use serde::Serialize;
 use tower::BoxError;
@@ -37,11 +36,7 @@ impl TracingConfigurator for Config {
                     .field_execution_sampler(field_level_instrumentation_sampler.clone())
                     .batch_config(batch_processor.clone())
                     .build()?;
-                /*builder.with_span_processor(
-                    BatchSpanProcessor::builder(exporter, opentelemetry::runtime::Tokio)
-                        .with_batch_config(batch_processor.clone().into())
-                        .build(),
-                )*/
+
                 reload_apollo(Some(exporter));
                 builder
             }

--- a/apollo-router/src/plugins/telemetry/tracing/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo.rs
@@ -20,7 +20,6 @@ impl TracingConfigurator for Config {
                 apollo_key: Some(key),
                 apollo_graph_ref: Some(reference),
                 schema_id,
-                buffer_size,
                 field_level_instrumentation_sampler,
                 batch_processor,
                 ..
@@ -32,7 +31,6 @@ impl TracingConfigurator for Config {
                     .apollo_key(key)
                     .apollo_graph_ref(reference)
                     .schema_id(schema_id)
-                    .buffer_size(*buffer_size)
                     .field_execution_sampler(field_level_instrumentation_sampler.clone())
                     .batch_config(batch_processor.clone())
                     .build()?;

--- a/apollo-router/src/plugins/telemetry/tracing/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo.rs
@@ -26,7 +26,7 @@ impl TracingConfigurator for Config {
             } => {
                 tracing::debug!("configuring exporter to Studio");
 
-                let exporter = apollo_telemetry::Exporter::builder()
+                let exporter = apollo_telemetry::ApolloLayer::builder()
                     .endpoint(endpoint.clone())
                     .apollo_key(key)
                     .apollo_graph_ref(reference)

--- a/apollo-router/src/plugins/telemetry/tracing/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo.rs
@@ -8,6 +8,7 @@ use tower::BoxError;
 use crate::plugins::telemetry::apollo::Config;
 use crate::plugins::telemetry::apollo_exporter::proto::reports::Trace;
 use crate::plugins::telemetry::config;
+use crate::plugins::telemetry::reload::reload_apollo;
 use crate::plugins::telemetry::tracing::apollo_telemetry;
 use crate::plugins::telemetry::tracing::TracingConfigurator;
 
@@ -36,13 +37,18 @@ impl TracingConfigurator for Config {
                     .field_execution_sampler(field_level_instrumentation_sampler.clone())
                     .batch_config(batch_processor.clone())
                     .build()?;
-                builder.with_span_processor(
+                /*builder.with_span_processor(
                     BatchSpanProcessor::builder(exporter, opentelemetry::runtime::Tokio)
                         .with_batch_config(batch_processor.clone().into())
                         .build(),
-                )
+                )*/
+                reload_apollo(Some(exporter));
+                builder
             }
-            _ => builder,
+            _ => {
+                reload_apollo(None);
+                builder
+            }
         })
     }
 }

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::io::Cursor;
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::SystemTime;
 use std::time::SystemTimeError;
@@ -133,7 +132,6 @@ impl Exporter {
         apollo_key: String,
         apollo_graph_ref: String,
         schema_id: String,
-        buffer_size: NonZeroUsize,
         field_execution_sampler: SamplerOption,
         batch_config: BatchProcessorConfig,
     ) -> Result<Self, BoxError> {
@@ -1308,9 +1306,7 @@ mod test {
         let trace = Trace::default();
         let encoded = base64::encode(trace.encode_to_vec());
         assert_eq!(
-            *decode_ftv1_trace(encoded.as_str())
-                .expect("there was a trace here")
-                .expect("the trace must be decoded"),
+            decode_ftv1_trace(encoded.as_str()).expect("the trace must be decoded"),
             trace
         );
     }

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -96,7 +96,7 @@ pub(crate) enum Error {
 /// [`Reporter`]: crate::plugins::telemetry::Reporter
 #[derive(Derivative)]
 #[derivative(Debug)]
-pub(crate) struct Exporter {
+pub(crate) struct ApolloLayer {
     field_execution_weight: f64,
     traces: Arc<Mutex<Vec<(String, proto::reports::Trace)>>>,
     #[derivative(Debug = "ignore")]
@@ -125,7 +125,7 @@ enum TreeData {
 }
 
 #[buildstructor::buildstructor]
-impl Exporter {
+impl ApolloLayer {
     #[builder]
     pub(crate) fn new(
         endpoint: Url,
@@ -487,7 +487,7 @@ impl LocalTrace {
     }
 }
 
-impl<S> Layer<S> for Exporter
+impl<S> Layer<S> for ApolloLayer
 where
     S: Subscriber + for<'span> LookupSpan<'span>,
 {

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -470,7 +470,7 @@ impl Exporter {
         }
     }
 
-    async fn send_traces(&mut self) -> Result<(), TraceError> {
+    /*async fn send_traces(&mut self) -> Result<(), TraceError> {
         let traces = {
             let mut v = Vec::new();
             std::mem::swap(&mut v, &mut *self.traces.lock());
@@ -484,7 +484,7 @@ impl Exporter {
             .submit_report(report)
             .map_err(|e| TraceError::ExportFailed(Box::new(e)))
             .await
-    }
+    }*/
 }
 
 struct LocalSpan {

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -934,8 +934,8 @@ where
         match parent_id {
             None => {
                 // extract root here
-                let extensions = span.extensions();
-                if let Some(local_trace) = extensions.get::<Arc<RwLock<LocalTrace>>>() {
+                let mut extensions = span.extensions_mut();
+                if let Some(local_trace) = extensions.remove::<Arc<RwLock<LocalTrace>>>() {
                     let mut spans_by_parent_id = HashMap::new();
                     {
                         let mut local = local_trace.write();
@@ -950,8 +950,8 @@ where
                 }
             }
             Some(parent_id) => {
-                let extensions = span.extensions();
-                if let Some(local_trace) = extensions.get::<Arc<RwLock<LocalTrace>>>() {
+                let mut extensions = span.extensions_mut();
+                if let Some(local_trace) = extensions.remove::<Arc<RwLock<LocalTrace>>>() {
                     let mut local = local_trace.write();
 
                     if let Some(mut local_span) = local.get_span_mut(&parent_id, &id) {

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -878,7 +878,9 @@ where
                     let mut local = local_trace.write();
                     if let Some(span) = local.get_span_mut(&parent_id, id) {
                         if let SpanKind::Request { http, .. } = &mut span.kind {
-                            http.response_headers = rh;
+                            if !rh.is_empty() {
+                                http.response_headers = rh;
+                            }
                         }
                     }
                 }
@@ -920,11 +922,15 @@ where
                             duration_ns, http, ..
                         } = &mut span.kind
                         {
-                            *duration_ns = duration_ns_opt;
+                            if duration_ns_opt.is_some() {
+                                *duration_ns = duration_ns_opt;
+                            }
                             if !rh.is_empty() {
                                 http.response_headers = rh;
                             }
-                            http.status_code = status_opt.unwrap_or(0);
+                            if let Some(status) = status_opt {
+                                http.status_code = status;
+                            }
                         }
                     }
                 }
@@ -951,8 +957,13 @@ where
                             ..
                         } = &mut span.kind
                         {
-                            *operation_name = op_name;
-                            *operation_signature = op_signature;
+                            if op_name.is_some() {
+                                *operation_name = op_name;
+                            }
+
+                            if op_signature.is_some() {
+                                *operation_signature = op_signature;
+                            }
                         }
                     }
                 }
@@ -972,7 +983,9 @@ where
                     let mut local = local_trace.write();
                     if let Some(span) = local.get_span_mut(&parent_id, id) {
                         if let SpanKind::Subgraph { trace } = &mut span.kind {
-                            *trace = ftv1_trace_opt;
+                            if ftv1_trace_opt.is_some() {
+                                *trace = ftv1_trace_opt;
+                            }
                         }
                     }
                 }
@@ -991,7 +1004,9 @@ where
                             sent_time_offset, ..
                         } = &mut span.kind
                         {
-                            *sent_time_offset = sent_time_offset_opt;
+                            if sent_time_offset_opt.is_some() {
+                                *sent_time_offset = sent_time_offset_opt;
+                            }
                         }
                     }
                 }

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -771,7 +771,6 @@ where
     ) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let parent_span = span.parent();
-        //let parent_id = parent_span.as_ref().map(|s| s.id());
 
         if let Some(parent_span) = parent_span {
             let extensions = span.extensions();


### PR DESCRIPTION
To simplify the implementation and increase reliability, the Apollo exporter, that was acting as an opentelemetry exporter, now moves up to a tracing-subscriber layer

Fixes #issue_number

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
