### PR TITLE
fix the router-bridge version

### DIFF
--- a/.changesets/maint_geal_fix_router_bridge.md
+++ b/.changesets/maint_geal_fix_router_bridge.md
@@ -1,0 +1,5 @@
+### Fix the router-bridge version 
+
+When using the router as a library, router-bridge versions can be automatically updated, which can result in incompatibilities. We want to ensure that the router and router-bridge always work with vetted versions, so we fix it in Cargo.toml and update it manually
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2916

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -157,7 +157,7 @@ reqwest = { version = "0.11.15", default-features = false, features = [
     "json",
     "stream",
 ] }
-router-bridge = "0.2.0+v2.4.0"
+router-bridge = "=0.2.0+v2.4.0"
 rust-embed="6.4.2"
 rustls = "0.20.8"
 rustls-pemfile = "1.0.2"


### PR DESCRIPTION
when using the router as a library, router-bridge versions can be automatically updated. We want to ensure that the router and router-bridge always work with vetted versions, so we fix it in Cargo.toml and update it manually