### PR TITLE
Add status_code to SubrequestMalformedResponse

### DIFF
--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -61,6 +61,8 @@ pub(crate) enum FetchError {
 
     /// service '{service}' response was malformed: {reason}
     SubrequestMalformedResponse {
+        status_code: Option<u16>,
+
         /// The service that responded with the malformed response.
         service: String,
 

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -142,7 +142,7 @@ impl FetchError {
                     if let Some(status_code) = status_code {
                         extensions
                             .entry("status_code")
-                            .or_insert(status_code.into());
+                            .or_insert(*status_code.into());
                     }
                 }
                 FetchError::ExecutionFieldNotFound { field, .. } => {

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -120,13 +120,30 @@ impl FetchError {
                 .or_insert_with(|| self.extension_code().into());
             // Following these specs https://www.apollographql.com/docs/apollo-server/data/errors/#including-custom-error-details
             match self {
-                FetchError::SubrequestMalformedResponse { service, .. }
-                | FetchError::SubrequestUnexpectedPatchResponse { service }
-                | FetchError::SubrequestHttpError { service, .. }
+                FetchError::SubrequestUnexpectedPatchResponse { service }
                 | FetchError::CompressionError { service, .. } => {
                     extensions
                         .entry("service")
                         .or_insert_with(|| service.clone().into());
+                }
+                FetchError::SubrequestMalformedResponse {
+                    service,
+                    status_code,
+                    ..
+                }
+                | FetchError::SubrequestHttpError {
+                    service,
+                    status_code,
+                    ..
+                } => {
+                    extensions
+                        .entry("service")
+                        .or_insert_with(|| service.clone().into());
+                    if let Some(status_code) = status_code {
+                        extensions
+                            .entry("status_code")
+                            .or_insert(status_code.into());
+                    }
                 }
                 FetchError::ExecutionFieldNotFound { field, .. } => {
                     extensions

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -142,7 +142,7 @@ impl FetchError {
                     if let Some(status_code) = status_code {
                         extensions
                             .entry("status_code")
-                            .or_insert(*status_code.into());
+                            .or_insert((*status_code).into());
                     }
                 }
                 FetchError::ExecutionFieldNotFound { field, .. } => {

--- a/apollo-router/src/graphql.rs
+++ b/apollo-router/src/graphql.rs
@@ -114,14 +114,10 @@ impl Error {
         }
     }
 
-    pub(crate) fn from_value(
-        service_name: &str,
-        status_code: u16,
-        value: Value,
-    ) -> Result<Error, FetchError> {
+    pub(crate) fn from_value(service_name: &str, value: Value) -> Result<Error, FetchError> {
         let mut object =
             ensure_object!(value).map_err(|error| FetchError::SubrequestMalformedResponse {
-                status_code: Some(status_code),
+                status_code: None,
                 service: service_name.to_string(),
                 reason: error.to_string(),
             })?;
@@ -129,14 +125,14 @@ impl Error {
         let extensions =
             extract_key_value_from_object!(object, "extensions", Value::Object(o) => o)
                 .map_err(|err| FetchError::SubrequestMalformedResponse {
-                    status_code: Some(status_code),
+                    status_code: None,
                     service: service_name.to_string(),
                     reason: err.to_string(),
                 })?
                 .unwrap_or_default();
         let message = extract_key_value_from_object!(object, "message", Value::String(s) => s)
             .map_err(|err| FetchError::SubrequestMalformedResponse {
-                status_code: Some(status_code),
+                status_code: None,
                 service: service_name.to_string(),
                 reason: err.to_string(),
             })?
@@ -146,7 +142,7 @@ impl Error {
             .map(serde_json_bytes::from_value)
             .transpose()
             .map_err(|err| FetchError::SubrequestMalformedResponse {
-                status_code: Some(status_code),
+                status_code: None,
                 service: service_name.to_string(),
                 reason: err.to_string(),
             })?
@@ -155,7 +151,7 @@ impl Error {
             .map(serde_json_bytes::from_value)
             .transpose()
             .map_err(|err| FetchError::SubrequestMalformedResponse {
-                status_code: Some(status_code),
+                status_code: None,
                 service: service_name.to_string(),
                 reason: err.to_string(),
             })?;

--- a/apollo-router/src/graphql.rs
+++ b/apollo-router/src/graphql.rs
@@ -114,9 +114,14 @@ impl Error {
         }
     }
 
-    pub(crate) fn from_value(service_name: &str, value: Value) -> Result<Error, FetchError> {
+    pub(crate) fn from_value(
+        service_name: &str,
+        status_code: u16,
+        value: Value,
+    ) -> Result<Error, FetchError> {
         let mut object =
             ensure_object!(value).map_err(|error| FetchError::SubrequestMalformedResponse {
+                status_code: Some(status_code),
                 service: service_name.to_string(),
                 reason: error.to_string(),
             })?;
@@ -124,12 +129,14 @@ impl Error {
         let extensions =
             extract_key_value_from_object!(object, "extensions", Value::Object(o) => o)
                 .map_err(|err| FetchError::SubrequestMalformedResponse {
+                    status_code: Some(status_code),
                     service: service_name.to_string(),
                     reason: err.to_string(),
                 })?
                 .unwrap_or_default();
         let message = extract_key_value_from_object!(object, "message", Value::String(s) => s)
             .map_err(|err| FetchError::SubrequestMalformedResponse {
+                status_code: Some(status_code),
                 service: service_name.to_string(),
                 reason: err.to_string(),
             })?
@@ -139,6 +146,7 @@ impl Error {
             .map(serde_json_bytes::from_value)
             .transpose()
             .map_err(|err| FetchError::SubrequestMalformedResponse {
+                status_code: Some(status_code),
                 service: service_name.to_string(),
                 reason: err.to_string(),
             })?
@@ -147,6 +155,7 @@ impl Error {
             .map(serde_json_bytes::from_value)
             .transpose()
             .map_err(|err| FetchError::SubrequestMalformedResponse {
+                status_code: Some(status_code),
                 service: service_name.to_string(),
                 reason: err.to_string(),
             })?;

--- a/apollo-router/src/response.rs
+++ b/apollo-router/src/response.rs
@@ -88,20 +88,16 @@ impl Response {
     /// Create a [`Response`] from the supplied [`Bytes`].
     ///
     /// This will return an error (identifying the faulty service) if the input is invalid.
-    pub(crate) fn from_bytes(
-        service_name: &str,
-        status_code: u16,
-        b: Bytes,
-    ) -> Result<Response, FetchError> {
+    pub(crate) fn from_bytes(service_name: &str, b: Bytes) -> Result<Response, FetchError> {
         let value =
             Value::from_bytes(b).map_err(|error| FetchError::SubrequestMalformedResponse {
-                status_code: Some(status_code),
+                status_code: None,
                 service: service_name.to_string(),
                 reason: error.to_string(),
             })?;
         let mut object =
             ensure_object!(value).map_err(|error| FetchError::SubrequestMalformedResponse {
-                status_code: Some(status_code),
+                status_code: None,
                 service: service_name.to_string(),
                 reason: error.to_string(),
             })?;
@@ -109,25 +105,25 @@ impl Response {
         let data = object.remove("data");
         let errors = extract_key_value_from_object!(object, "errors", Value::Array(v) => v)
             .map_err(|err| FetchError::SubrequestMalformedResponse {
-                status_code: Some(status_code),
+                status_code: None,
                 service: service_name.to_string(),
                 reason: err.to_string(),
             })?
             .into_iter()
             .flatten()
-            .map(|v| Error::from_value(service_name, status_code, v))
+            .map(|v| Error::from_value(service_name, v))
             .collect::<Result<Vec<Error>, FetchError>>()?;
         let extensions =
             extract_key_value_from_object!(object, "extensions", Value::Object(o) => o)
                 .map_err(|err| FetchError::SubrequestMalformedResponse {
-                    status_code: Some(status_code),
+                    status_code: None,
                     service: service_name.to_string(),
                     reason: err.to_string(),
                 })?
                 .unwrap_or_default();
         let label = extract_key_value_from_object!(object, "label", Value::String(s) => s)
             .map_err(|err| FetchError::SubrequestMalformedResponse {
-                status_code: Some(status_code),
+                status_code: None,
                 service: service_name.to_string(),
                 reason: err.to_string(),
             })?
@@ -136,20 +132,20 @@ impl Response {
             .map(serde_json_bytes::from_value)
             .transpose()
             .map_err(|err| FetchError::SubrequestMalformedResponse {
-                status_code: Some(status_code),
+                status_code: None,
                 service: service_name.to_string(),
                 reason: err.to_string(),
             })?;
         let has_next = extract_key_value_from_object!(object, "hasNext", Value::Bool(b) => b)
             .map_err(|err| FetchError::SubrequestMalformedResponse {
-                status_code: Some(status_code),
+                status_code: None,
                 service: service_name.to_string(),
                 reason: err.to_string(),
             })?;
         let incremental =
             extract_key_value_from_object!(object, "incremental", Value::Array(a) => a).map_err(
                 |err| FetchError::SubrequestMalformedResponse {
-                    status_code: Some(status_code),
+                    status_code: None,
                     service: service_name.to_string(),
                     reason: err.to_string(),
                 },
@@ -160,7 +156,7 @@ impl Response {
                 .map(serde_json_bytes::from_value)
                 .collect::<Result<Vec<IncrementalResponse>, _>>()
                 .map_err(|err| FetchError::SubrequestMalformedResponse {
-                    status_code: Some(status_code),
+                    status_code: None,
                     service: service_name.to_string(),
                     reason: err.to_string(),
                 })?,

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -411,17 +411,15 @@ async fn call_http(
         );
     }
 
-    let status_code = parts.status.as_u16();
-
     let graphql: graphql::Response =
         tracing::debug_span!("parse_subgraph_response").in_scope(|| {
-            graphql::Response::from_bytes(&cloned_service_name, status_code, body).map_err(
-                |error| FetchError::SubrequestMalformedResponse {
-                    status_code: Some(status_code),
+            graphql::Response::from_bytes(&cloned_service_name, body).map_err(|error| {
+                FetchError::SubrequestMalformedResponse {
+                    status_code: Some(parts.status.as_u16()),
                     service: cloned_service_name.clone(),
                     reason: error.to_string(),
-                },
-            )
+                }
+            })
         })?;
 
     let resp = http::Response::from_parts(parts, graphql);

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -411,14 +411,17 @@ async fn call_http(
         );
     }
 
+    let status_code = parts.status.as_u16();
+
     let graphql: graphql::Response =
         tracing::debug_span!("parse_subgraph_response").in_scope(|| {
-            graphql::Response::from_bytes(&cloned_service_name, body).map_err(|error| {
-                FetchError::SubrequestMalformedResponse {
+            graphql::Response::from_bytes(&cloned_service_name, status_code, body).map_err(
+                |error| FetchError::SubrequestMalformedResponse {
+                    status_code: Some(status_code),
                     service: cloned_service_name.clone(),
                     reason: error.to_string(),
-                }
-            })
+                },
+            )
         })?;
 
     let resp = http::Response::from_parts(parts, graphql);


### PR DESCRIPTION
Similar to https://github.com/apollographql/router/pull/2902 this adds status_code to the SubrequestMalformedResponse error.

Fixes #2918 

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
