### PR TITLE
Fix broken docs build due to duplicate tags

### DIFF
--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -611,9 +611,6 @@ The `RouterService` path that this coprocessor request pertains to.
 </td>
 </tr>
 
-</td>
-</tr>
-
 <tr>
 <td>
 


### PR DESCRIPTION
These duplicate table tags are breaking the docs build (MDX is clearly a fickle creature)