### PR TITLE
Update Dockerfile.router to use heredoc

### DIFF
--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -36,16 +36,15 @@ LABEL org.opencontainers.image.source="https://github.com/apollographql/router"
 ENV APOLLO_ROUTER_CONFIG_PATH="/dist/config/router.yaml"
 
 # Create a wrapper script to run the router, use exec to ensure signals are handled correctly
-RUN \
-  echo '#!/usr/bin/env bash \
-\nset -e \
-\n \
-\nif [ -f "/usr/bin/heaptrack" ]; then \
-\n    exec heaptrack -o /dist/data/router_heaptrack /dist/router "$@" \
-\nelse \
-\n    exec /dist/router "$@" \
-\nfi \
-' > /dist/router_wrapper.sh
+COPY <<EOF /dist/router_wrapper.sh
+#!/usr/bin/env bash
+set -e
+if [ -f "/usr/bin/heaptrack" ]; then
+  exec heaptrack -o /dist/data/router_heaptrack /dist/router "$@"
+else
+  exec /dist/router "$@"
+fi
+EOF
 
 # Make sure we can run our wrapper
 RUN chmod 755 /dist/router_wrapper.sh


### PR DESCRIPTION
See [this blog post](https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/) for more info.

Update Dockerfile.router to use COPY & heredoc vs RUN & echo