### PR TITLE
docs: Fix duplicated scheme in comment within Tracing config

### DIFF
--- a/docs/source/configuration/tracing.mdx
+++ b/docs/source/configuration/tracing.mdx
@@ -153,7 +153,7 @@ The Apollo Router can be configured to connect to either the default agent addre
 telemetry:
   tracing:
     datadog:
-      # Either 'default' or a URL (example: 'http://http://127.0.0.1:8126')
+      # Either 'default' or a URL (example: 'http://127.0.0.1:8126')
       endpoint: default
 ```
 


### PR DESCRIPTION
The URL in the comment was showing as `http://http://` previously, which is certainly incorrect!