### PR TITLE
Merge `main` into `dev`

### DIFF
--- a/docs/source/configuration/tracing.mdx
+++ b/docs/source/configuration/tracing.mdx
@@ -153,7 +153,7 @@ The Apollo Router can be configured to connect to either the default agent addre
 telemetry:
   tracing:
     datadog:
-      # Either 'default' or a URL (example: 'http://http://127.0.0.1:8126')
+      # Either 'default' or a URL (example: 'http://127.0.0.1:8126')
       endpoint: default
 ```
 

--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -611,9 +611,6 @@ The `RouterService` path that this coprocessor request pertains to.
 </td>
 </tr>
 
-</td>
-</tr>
-
 <tr>
 <td>
 


### PR DESCRIPTION
This merges `main` into `dev` and includes #2922, which is meant to fix another documentation build problem.