### PR TITLE
docs: updating Rhai authn example to properly use to_string

### DIFF
--- a/docs/source/configuration/authn-jwt.mdx
+++ b/docs/source/configuration/authn-jwt.mdx
@@ -204,7 +204,7 @@ fn subgraph_service(service, subgraph) {
     }
     // Add each claim key-value pair as a separate HTTP header
     for key in claims.keys() {
-      request.subgraph.headers[key] = claims[key];
+      request.subgraph.headers[key] = claims[key].to_string();
     }
   };
 


### PR DESCRIPTION
*Description here*

The AuthN Rhai example didn't use the `to_string()` method on the claims, and if the claim was parsed as a non-string type, it would cause the script to error. 

Coercing the values to be all strings resolves the issue. 

<!-- start metadata -->

**Checklist**

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

This is just a minor docs update, no net new functionality. 

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
