### PR TITLE
chore: Update CHANGELOG.md to reference correct metric name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,7 @@ By [@geal](https://github.com/geal) in https://github.com/apollographql/router/p
 
 For monitoring, observability and debugging requirements around Uplink-related behaviors (those which occur as part of Managed Federation) the router now emits better log messages and emits new metrics around these facilities.  The new metrics are:
 
-- `apollo_router_uplink_duration_seconds_bucket`: A _histogram_ of durations with the following attributes:
+- `apollo_router_uplink_fetch_duration_seconds_bucket`: A _histogram_ of durations with the following attributes:
 
   - `url`: The URL that was polled
   - `query`: `SupergraphSdl` or `Entitlement`


### PR DESCRIPTION
The rename of a newly introduced metric in Apollo Router 1.13.0 was logged in the CHANGELOG using the _wrong_ metric name.  The metric was renamed from `apollo_router_uplink_duration_seconds_bucket` to `apollo_router_uplink_fetch_duration_seconds_bucket` in https://github.com/apollographql/router/pull/2826, but we failed to catch this discrepancy in the changelog for the v1.13.0 [release].

Ref: https://github.com/apollographql/router/pull/2826
[release]: https://github.com/apollographql/router/pull/2841
