### PR TITLE
chore: Update our `cargo deny` configuration to migrate from `deny` to `bans`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,7 +26,7 @@ git-fetch-with-cli = true
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 
-# while https://github.com/chronotope/chrono/issues/499 is open. 
+# while https://github.com/chronotope/chrono/issues/499 is open.
 # We need to keep track of this issue, and make sure `tracing-subscriber` is updated
 # We will then be able to remove this
 ignore = ["RUSTSEC-2020-0159", "RUSTSEC-2020-0071"]
@@ -89,6 +89,29 @@ wildcards = "warn"
 # * all - Both lowest-version and simplest-path are used
 highlight = "all"
 
+# List of crates to deny
+deny = [
+  # `cargo-scaffold` uses `git2` which uses `libssh2-sys` and `libgit2-sys`.
+  # Both require `openssl-sys`. Adding this rule in this way is sufficient to
+  # allow those to use `openssl-sys` (not a runtime dependency), leveraging the
+  # capabilities of `cargo-deny` to "block" `openssl-sys`.  However, this isn't
+  # defensive enough on its own since we could introduce `git2` in
+  # `apollo-router` and we would inadvertently get `openssl-sys` and it would
+  # _not_ be blocked.  That's bad!  Unfortunately, the `wrappers` technique of
+  # `cargo-deny` only enables exceptions for _direct_ dependencies.  To defend
+  # against the above risk, we add additional rules here (below) which _only_
+  # allows `git2` in `cargo-scaffold`.  This is a bit wonky, since we may at
+  # some point want `git2` but does accomplish what we want with the desired
+  # exception.
+  { name = "openssl-sys", wrappers = ["git2", "libssh2-sys", "libgit2-sys"] },
+  # Note! This line is required to support the above exception.
+  { name = "git2", wrappers = ["cargo-scaffold"] },
+  # Note! This line is required to support the above exception.
+  { name = "libgit2-sys", wrappers = ["git2"] },
+  # Note! This line is required to support the above exception.
+  { name = "libssh2-sys", wrappers = ["libgit2-sys"] },
+]
+
 # This section is considered when running `cargo deny check sources`.
 # More documentation about the 'sources' section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
@@ -106,8 +129,3 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 [sources.allow-org]
 # 1 or more github.com organizations to allow git sources for
 github = ["open-telemetry", "apollographql", "tokio-rs"]
-
-[deny]
-name = "openssl-sys"
-# scaffold uses openssl for some reason
-wrappers = ["apollo-router-scaffold"]


### PR DESCRIPTION
Our `cargo deny` compliance tests have non-deterministically started to fail
in CI.  This seems to be a case of maybe having just put in a previously
supported configuration, rather than using the currently documented standard
of using `bans`, as seen in the [Ref Config].

Per my comment within the code, doing this defensively required some additional hurdles to be jumped.

[Ref Config]: https://embarkstudios.github.io/cargo-deny/cli/init.html
