### PR TITLE
fix(deps): update `cargo-scaffold` to v0.8.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-scaffold"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6828446789083ba7a028638e2033176eeb854397e75bdebcfdd04fa001c31d6f"
+checksum = "21a5530a79425d641868d027a01ffd47ef14ff7804860ee51b4e3a32e374075e"
 dependencies = [
  "anyhow",
  "buildstructor 0.3.2",
@@ -2432,9 +2432,9 @@ checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "git2"
-version = "0.14.4"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+checksum = "ccf7f68c2995f392c49fffb4f95ae2c873297830eb25c6bc4c114ce8f4562acc"
 dependencies = [
  "bitflags",
  "libc",
@@ -3176,9 +3176,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.13.5+1.4.5"
+version = "0.14.2+1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e5ea06c26926f1002dd553fded6cfcdc9784c1f60feeb58368b4d9b07b6dba"
+checksum = "7f3d95f6b51075fe9810a7ae22c7095f12b98005ab364d8544797a825ce946a4"
 dependencies = [
  "cc",
  "libc",

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.68"
 clap = { version = "4.1.4", features = ["derive"] }
-cargo-scaffold = { version = "0.8.7", default-features = false }
+cargo-scaffold = { version = "0.8.9", default-features = false }
 regex = "1"
 str_inflector = "0.12.0"
 toml = "0.5.11"


### PR DESCRIPTION
Specifically, to bring in https://github.com/iomentum/cargo-scaffold/pull/38, released in `cargo-scaffold@0.8.9`.
