### PR TITLE
fix: return valid GraphQL responses for invalid requests

### DIFF
--- a/.changesets/fix_avery_fix_invalid_graphql_response.md
+++ b/.changesets/fix_avery_fix_invalid_graphql_response.md
@@ -1,0 +1,7 @@
+### fix: return valid GraphQL responses for invalid requests ([Issue #2934](https://github.com/apollographql/router/issues/2934)), ([Issue #2946](https://github.com/apollographql/router/issues/2946))
+
+This PR fixes the way the router handles invalid requests. The router now returns GraphQL errors nested under a top level `errors` array rather than returning a single GraphQL error JSON object.
+
+A new error code has been introduced: "INVALID_CONTENT_TYPE_HEADER". Older versions of the router returned "INVALID_ACCEPT_HEADER" when an invalid content type header was sent.
+
+By [@EverlastingBugstopper](https://github.com/EverlastingBugstopper) in https://github.com/apollographql/router/pull/2947

--- a/.changesets/fix_avery_fix_invalid_graphql_response.md
+++ b/.changesets/fix_avery_fix_invalid_graphql_response.md
@@ -1,7 +1,7 @@
-### fix: return valid GraphQL responses for invalid requests ([Issue #2934](https://github.com/apollographql/router/issues/2934)), ([Issue #2946](https://github.com/apollographql/router/issues/2946))
+### Invalid requests now return proper GraphQL-shaped errors ([Issue #2934](https://github.com/apollographql/router/issues/2934)), ([Issue #2946](https://github.com/apollographql/router/issues/2946))
 
-This PR fixes the way the router handles invalid requests. The router now returns GraphQL errors nested under a top level `errors` array rather than returning a single GraphQL error JSON object.
+Certain invalid HTTP requests — such as when an unacceptable `content-type` header, or an unsupported `accept` header are received — now return proper GraphQL errors nested as elements in a top-level `errors` array, rather than returning a single GraphQL error JSON object, which was unintentional.
 
-A new error code has been introduced: "INVALID_CONTENT_TYPE_HEADER". Older versions of the router returned "INVALID_ACCEPT_HEADER" when an invalid content type header was sent.
+This also introduced a more semantically-correct error code, `INVALID_CONTENT_TYPE_HEADER`, rather than using `INVALID_ACCEPT_HEADER` when an invalid `content-type` header was received.
 
 By [@EverlastingBugstopper](https://github.com/EverlastingBugstopper) in https://github.com/apollographql/router/pull/2947

--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -1121,7 +1121,7 @@ async fn it_send_bad_content_type() -> Result<(), ApolloRouterError> {
     );
     assert_eq!(
         response.text().await.unwrap(),
-        r#"{"message":"'content-type' header can't be different from \"application/json\" or \"application/graphql-response+json\"","extensions":{"code":"INVALID_ACCEPT_HEADER"}}"#
+        r#"{"errors":[{"message":"'content-type' header can't be different from \"application/json\" or \"application/graphql-response+json\"","extensions":{"code":"INVALID_CONTENT_TYPE_HEADER"}}]}"#
     );
 
     server.shutdown().await
@@ -1160,7 +1160,7 @@ async fn it_sends_bad_accept_header() -> Result<(), ApolloRouterError> {
     );
     assert_eq!(
         response.text().await.unwrap(),
-        r#"{"message":"'accept' header can't be different from \\\"*/*\\\", \"application/json\", \"application/graphql-response+json\" or \"multipart/mixed;boundary=\\\"graphql\\\";deferSpec=20220824\"","extensions":{"code":"INVALID_ACCEPT_HEADER"}}"#
+        r#"{"errors":[{"message":"'accept' header can't be different from \\\"*/*\\\", \"application/json\", \"application/graphql-response+json\" or \"multipart/mixed;boundary=\\\"graphql\\\";deferSpec=20220824\"","extensions":{"code":"INVALID_ACCEPT_HEADER"}}]}"#
     );
 
     server.shutdown().await

--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -1121,7 +1121,7 @@ async fn it_send_bad_content_type() -> Result<(), ApolloRouterError> {
     );
     assert_eq!(
         response.text().await.unwrap(),
-        r#"{"errors":[{"message":"'content-type' header can't be different from \"application/json\" or \"application/graphql-response+json\"","extensions":{"code":"INVALID_CONTENT_TYPE_HEADER"}}]}"#
+        r#"{"errors":[{"message":"'content-type' header must be one of \"application/json\" or \"application/graphql-response+json\"","extensions":{"code":"INVALID_CONTENT_TYPE_HEADER"}}]}"#
     );
 
     server.shutdown().await
@@ -1160,7 +1160,7 @@ async fn it_sends_bad_accept_header() -> Result<(), ApolloRouterError> {
     );
     assert_eq!(
         response.text().await.unwrap(),
-        r#"{"errors":[{"message":"'accept' header can't be different from \\\"*/*\\\", \"application/json\", \"application/graphql-response+json\" or \"multipart/mixed;boundary=\\\"graphql\\\";deferSpec=20220824\"","extensions":{"code":"INVALID_ACCEPT_HEADER"}}]}"#
+        r#"{"errors":[{"message":"'accept' header must be one of \\\"*/*\\\", \"application/json\", \"application/graphql-response+json\" or \"multipart/mixed;boundary=\\\"graphql\\\";deferSpec=20220824\"","extensions":{"code":"INVALID_ACCEPT_HEADER"}}]}"#
     );
 
     server.shutdown().await

--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -1090,7 +1090,7 @@ async fn test_previous_health_check_returns_four_oh_four() {
 }
 
 #[test(tokio::test)]
-async fn it_send_bad_content_type() -> Result<(), ApolloRouterError> {
+async fn it_errors_on_bad_content_type_header() -> Result<(), ApolloRouterError> {
     let query = "query";
     let operation_name = "operationName";
 
@@ -1121,14 +1121,14 @@ async fn it_send_bad_content_type() -> Result<(), ApolloRouterError> {
     );
     assert_eq!(
         response.text().await.unwrap(),
-        r#"{"errors":[{"message":"'content-type' header must be one of \"application/json\" or \"application/graphql-response+json\"","extensions":{"code":"INVALID_CONTENT_TYPE_HEADER"}}]}"#
+        r#"{"errors":[{"message":"'content-type' header must be one of: \"application/json\" or \"application/graphql-response+json\"","extensions":{"code":"INVALID_CONTENT_TYPE_HEADER"}}]}"#
     );
 
     server.shutdown().await
 }
 
 #[test(tokio::test)]
-async fn it_sends_bad_accept_header() -> Result<(), ApolloRouterError> {
+async fn it_errors_on_bad_accept_header() -> Result<(), ApolloRouterError> {
     let query = "query";
     let operation_name = "operationName";
 
@@ -1160,7 +1160,7 @@ async fn it_sends_bad_accept_header() -> Result<(), ApolloRouterError> {
     );
     assert_eq!(
         response.text().await.unwrap(),
-        r#"{"errors":[{"message":"'accept' header must be one of \\\"*/*\\\", \"application/json\", \"application/graphql-response+json\" or \"multipart/mixed;boundary=\\\"graphql\\\";deferSpec=20220824\"","extensions":{"code":"INVALID_ACCEPT_HEADER"}}]}"#
+        r#"{"errors":[{"message":"'accept' header must be one of: \\\"*/*\\\", \"application/json\", \"application/graphql-response+json\" or \"multipart/mixed;boundary=\\\"graphql\\\";deferSpec=20220824\"","extensions":{"code":"INVALID_ACCEPT_HEADER"}}]}"#
     );
 
     server.shutdown().await

--- a/apollo-router/src/services/layers/content_negociation.rs
+++ b/apollo-router/src/services/layers/content_negociation.rs
@@ -53,20 +53,22 @@ where
                     let response: http::Response<hyper::Body> = http::Response::builder()
                         .status(StatusCode::UNSUPPORTED_MEDIA_TYPE)
                         .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
-                        .body(
-                            hyper::Body::from(
-                                serde_json::json!({
-                                    "errors": [
-                                        graphql::Error::builder()
-                                            .message(format!(
-                                                r#"'content-type' header must be one of: {:?} or {:?}"#,
-                                                APPLICATION_JSON.essence_str(),
-                                                GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
-                                            ))
-                                            .extension_code("INVALID_CONTENT_TYPE_HEADER")
-                                            .build()
-                                    ]
-                                }).to_string())).expect("cannot fail");
+                        .body(hyper::Body::from(
+                            serde_json::json!({
+                                "errors": [
+                                    graphql::Error::builder()
+                                        .message(format!(
+                                            r#"'content-type' header must be one of: {:?} or {:?}"#,
+                                            APPLICATION_JSON.essence_str(),
+                                            GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
+                                        ))
+                                        .extension_code("INVALID_CONTENT_TYPE_HEADER")
+                                        .build()
+                                ]
+                            })
+                            .to_string(),
+                        ))
+                        .expect("cannot fail");
 
                     return Ok(ControlFlow::Break(response.into()));
                 }

--- a/apollo-router/src/services/layers/content_negociation.rs
+++ b/apollo-router/src/services/layers/content_negociation.rs
@@ -95,7 +95,7 @@ where
                                     "errors": [
                                         graphql::Error::builder()
                                             .message(format!(
-                                                r#"'accept' header must be one of \"*/*\", {:?}, {:?} or {:?}"#,
+                                                r#"'accept' header must be one of: \"*/*\", {:?}, {:?} or {:?}"#,
                                                 APPLICATION_JSON.essence_str(),
                                                 GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
                                                 MULTIPART_DEFER_CONTENT_TYPE

--- a/apollo-router/src/services/layers/content_negociation.rs
+++ b/apollo-router/src/services/layers/content_negociation.rs
@@ -59,7 +59,7 @@ where
                                     "errors": [
                                         graphql::Error::builder()
                                             .message(format!(
-                                                r#"'content-type' header can't be different from {:?} or {:?}"#,
+                                                r#"'content-type' header must be one of: {:?} or {:?}"#,
                                                 APPLICATION_JSON.essence_str(),
                                                 GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
                                             ))

--- a/apollo-router/src/services/layers/content_negociation.rs
+++ b/apollo-router/src/services/layers/content_negociation.rs
@@ -55,19 +55,18 @@ where
                         .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
                         .body(
                             hyper::Body::from(
-                                serde_json::to_string(
-                                    &graphql::Error::builder()
-                                        .message(format!(
-                                            r#"'content-type' header can't be different from {:?} or {:?}"#,
-                                            APPLICATION_JSON.essence_str(),
-                                            GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
-                                        ))
-                                        .extension_code("INVALID_ACCEPT_HEADER")
-                                        .build(),
-                                )
-                                .unwrap_or_else(|_| String::from("Invalid request"))
-                        ))
-                        .expect("cannot fail");
+                                serde_json::json!({
+                                    "errors": [
+                                        graphql::Error::builder()
+                                            .message(format!(
+                                                r#"'content-type' header can't be different from {:?} or {:?}"#,
+                                                APPLICATION_JSON.essence_str(),
+                                                GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
+                                            ))
+                                            .extension_code("INVALID_CONTENT_TYPE_HEADER")
+                                            .build()
+                                    ]
+                                }).to_string())).expect("cannot fail");
 
                     return Ok(ControlFlow::Break(response.into()));
                 }
@@ -90,19 +89,19 @@ where
                 } else {
                     let response: http::Response<hyper::Body> = http::Response::builder().status(StatusCode::NOT_ACCEPTABLE).header(CONTENT_TYPE, APPLICATION_JSON.essence_str()).body(
                             hyper::Body::from(
-                                serde_json::to_string(
-                                    &graphql::Error::builder()
-                                        .message(format!(
-                                            r#"'accept' header can't be different from \"*/*\", {:?}, {:?} or {:?}"#,
-                                            APPLICATION_JSON.essence_str(),
-                                            GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
-                                            MULTIPART_DEFER_CONTENT_TYPE
-                                        ))
-                                        .extension_code("INVALID_ACCEPT_HEADER")
-                                        .build(),
-                                )
-                                .unwrap_or_else(|_| String::from("Invalid request"))
-                        )).expect("cannot fail");
+                                serde_json::json!({
+                                    "errors": [
+                                        graphql::Error::builder()
+                                            .message(format!(
+                                                r#"'accept' header can't be different from \"*/*\", {:?}, {:?} or {:?}"#,
+                                                APPLICATION_JSON.essence_str(),
+                                                GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
+                                                MULTIPART_DEFER_CONTENT_TYPE
+                                            ))
+                                            .extension_code("INVALID_ACCEPT_HEADER")
+                                            .build()
+                                    ]
+                                }).to_string())).expect("cannot fail");
 
                     Ok(ControlFlow::Break(response.into()))
                 }

--- a/apollo-router/src/services/layers/content_negociation.rs
+++ b/apollo-router/src/services/layers/content_negociation.rs
@@ -95,7 +95,7 @@ where
                                     "errors": [
                                         graphql::Error::builder()
                                             .message(format!(
-                                                r#"'accept' header can't be different from \"*/*\", {:?}, {:?} or {:?}"#,
+                                                r#"'accept' header must be one of \"*/*\", {:?}, {:?} or {:?}"#,
                                                 APPLICATION_JSON.essence_str(),
                                                 GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
                                                 MULTIPART_DEFER_CONTENT_TYPE

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -362,28 +362,22 @@ where
                                 Ok(RouterResponse { response, context })
                             } else {
                                 // this should be unreachable due to a previous check, but just to be sure...
-                                Ok(router::Response {
-                                response: http::Response::builder()
-                                    .status(StatusCode::NOT_ACCEPTABLE)
-                                    .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
-                                    .body(
-                                    Body::from(
-                                        serde_json::to_string(
-                                            &graphql::Error::builder()
-                                                .message(format!(
-                                                    r#"'accept' header can't be different from \"*/*\", {:?}, {:?} or {:?}"#,
-                                                    APPLICATION_JSON.essence_str(),
-                                                    GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
-                                                    MULTIPART_DEFER_CONTENT_TYPE
-                                                ))
-                                                .extension_code("INVALID_ACCEPT_HEADER")
-                                                .build(),
-                                        )
-                                        .unwrap_or_else(|_| String::from("Invalid request"))
+                                router::Response::error_builder()
+                                    .error(
+                                        graphql::Error::builder()
+                                            .message(format!(
+                                                r#"'accept' header can't be different from \"*/*\", {:?}, {:?} or {:?}"#,
+                                                APPLICATION_JSON.essence_str(),
+                                                GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
+                                                MULTIPART_DEFER_CONTENT_TYPE
+                                            ))
+                                            .extension_code("INVALID_ACCEPT_HEADER")
+                                            .build(),
                                     )
-                                ).expect("cannot fail"),
-                                context,
-                            })
+                                    .status_code(StatusCode::NOT_ACCEPTABLE)
+                                    .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                                    .context(context)
+                                    .build()
                             }
                         }
                     }
@@ -406,7 +400,7 @@ where
                                 .build(),
                         )
                         .status_code(StatusCode::BAD_REQUEST)
-                        .header(CONTENT_TYPE, APPLICATION_JSON.to_string())
+                        .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
                         .context(context)
                         .build()
                 }

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -366,7 +366,7 @@ where
                                     .error(
                                         graphql::Error::builder()
                                             .message(format!(
-                                                r#"'accept' header must be one of \"*/*\", {:?}, {:?} or {:?}"#,
+                                                r#"'accept' header must be one of: \"*/*\", {:?}, {:?} or {:?}"#,
                                                 APPLICATION_JSON.essence_str(),
                                                 GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
                                                 MULTIPART_DEFER_CONTENT_TYPE

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -366,7 +366,7 @@ where
                                     .error(
                                         graphql::Error::builder()
                                             .message(format!(
-                                                r#"'accept' header can't be different from \"*/*\", {:?}, {:?} or {:?}"#,
+                                                r#"'accept' header must be one of \"*/*\", {:?}, {:?} or {:?}"#,
                                                 APPLICATION_JSON.essence_str(),
                                                 GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
                                                 MULTIPART_DEFER_CONTENT_TYPE

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -396,23 +396,19 @@ where
                         error = %error,
                         %error
                     );
-                    Ok(router::Response {
-                        response: http::Response::builder()
-                            .status(StatusCode::BAD_REQUEST)
-                            .header(CONTENT_TYPE, APPLICATION_JSON.to_string())
-                            .body(Body::from(
-                                serde_json::to_string(
-                                    &graphql::Error::builder()
-                                        .message(String::from("Invalid GraphQL request"))
-                                        .extension_code("INVALID_GRAPHQL_REQUEST")
-                                        .extension("details", extension_details)
-                                        .build(),
-                                )
-                                .unwrap_or_else(|_| String::from("Invalid GraphQL request")),
-                            ))
-                            .expect("cannot fail"),
-                        context,
-                    })
+
+                    router::Response::error_builder()
+                        .error(
+                            graphql::Error::builder()
+                                .message(String::from("Invalid GraphQL request"))
+                                .extension_code("INVALID_GRAPHQL_REQUEST")
+                                .extension("details", extension_details)
+                                .build(),
+                        )
+                        .status_code(StatusCode::BAD_REQUEST)
+                        .header(CONTENT_TYPE, APPLICATION_JSON.to_string())
+                        .context(context)
+                        .build()
                 }
             }
         };

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -227,9 +227,13 @@ async fn empty_posts_should_not_work() {
     assert_eq!(1, actual.errors.len());
 
     let message = "Invalid GraphQL request";
+    let mut extensions_map = serde_json_bytes::map::Map::new();
+    extensions_map.insert("code", "INVALID_GRAPHQL_REQUEST".into());
+    extensions_map.insert("details", "failed to deserialize the request body into JSON: EOF while parsing a value at line 1 column 0".into());
     let expected_error = graphql::Error::builder()
         .message(message)
         .extension_code("INVALID_GRAPHQL_REQUEST")
+        .extensions(extensions_map)
         .build();
     assert_eq!(expected_error, actual.errors[0]);
     assert_eq!(registry.totals(), hashmap! {});


### PR DESCRIPTION
This PR fixes a few cases where the router returns GraphQL errors directly rather than nesting them under a top level `errors` array.

Fixes #2934
Fixes #2946

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
~- [ ] Documentation[^2] completed~
~- [ ] Performance impact assessed and acceptable~
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

No documentation needs to be updated because these are bugs. Performance should not be impacted because we are just constructing a slightly different response.
