### PR TITLE
Revert "Move Apollo telemetry from an opentelemetry exporter to a tracing layer (#2908)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,6 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry-zipkin",
  "p256 0.12.0",
- "parking_lot 0.12.1",
  "paste",
  "pin-project-lite",
  "prometheus",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -203,7 +203,6 @@ yaml-rust = "0.4.5"
 wsl = "0.1.0"
 tokio-rustls = "0.23.4"
 http-serde = "1.1.2"
-parking_lot = "0.12.1"
 
 [target.'cfg(macos)'.dependencies]
 uname = "0.1.1"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1331,7 +1331,7 @@ expression: "&schema"
               }
             },
             "buffer_size": {
-              "description": "The buffer size for sending traces to Apollo. (deprecated, has no effect now)",
+              "description": "The buffer size for sending traces to Apollo. Increase this if you are experiencing lost traces.",
               "default": 10000,
               "type": "integer",
               "format": "uint",

--- a/apollo-router/src/plugins/telemetry/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/apollo.rs
@@ -60,7 +60,7 @@ pub(crate) struct Config {
     #[serde(deserialize_with = "deserialize_header_name")]
     pub(crate) client_version_header: HeaderName,
 
-    /// The buffer size for sending traces to Apollo. (deprecated, has no effect now)
+    /// The buffer size for sending traces to Apollo. Increase this if you are experiencing lost traces.
     pub(crate) buffer_size: NonZeroUsize,
 
     /// Enable field level instrumentation for subgraphs via ftv1. ftv1 tracing can cause performance issues as it is transmitted in band with subgraph responses.

--- a/apollo-router/src/plugins/telemetry/apollo_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/apollo_exporter.rs
@@ -65,7 +65,7 @@ impl Sender {
             Sender::Apollo(channel) => {
                 if let Err(err) = channel.to_owned().try_send(report) {
                     tracing::warn!(
-                        "could not send data to spaceport, metric will be dropped: {}",
+                        "could not send metrics to spaceport, metric will be dropped: {}",
                         err
                     );
                 }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -319,7 +319,7 @@ impl Plugin for Telemetry {
                 {
                     // Record the operation signature on the router span
                     Span::current().record(
-                        APOLLO_PRIVATE_OPERATION_SIGNATURE,
+                        APOLLO_PRIVATE_OPERATION_SIGNATURE.as_str(),
                         usage_reporting.stats_report_key.as_str(),
                     );
                 }

--- a/apollo-router/src/plugins/telemetry/reload.rs
+++ b/apollo-router/src/plugins/telemetry/reload.rs
@@ -14,7 +14,6 @@ use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::Registry;
 
-use super::tracing::apollo_telemetry::ApolloLayer;
 use crate::plugins::telemetry::formatters::filter_metric_events;
 use crate::plugins::telemetry::formatters::text::TextFormatter;
 use crate::plugins::telemetry::formatters::FilteringFormatter;
@@ -30,27 +29,22 @@ pub(super) static OPENTELEMETRY_TRACER_HANDLE: OnceCell<
     ReloadTracer<opentelemetry::sdk::trace::Tracer>,
 > = OnceCell::new();
 
-static FMT_LAYER_HANDLE: OnceCell<
-    Handle<Box<dyn Layer<LayeredTracer> + Send + Sync>, LayeredTracer>,
-> = OnceCell::new();
-
-type FmtReloadLayer =
-    tracing_subscriber::reload::Layer<Box<dyn Layer<LayeredTracer> + Send + Sync>, LayeredTracer>;
-
 #[allow(clippy::type_complexity)]
 static METRICS_LAYER_HANDLE: OnceCell<
-    Handle<MetricsLayer, Layered<FmtReloadLayer, LayeredTracer>>,
+    Handle<
+        MetricsLayer,
+        Layered<
+            tracing_subscriber::reload::Layer<
+                Box<dyn Layer<LayeredTracer> + Send + Sync>,
+                LayeredTracer,
+            >,
+            LayeredTracer,
+        >,
+    >,
 > = OnceCell::new();
 
-type MetricsReloadLayer =
-    tracing_subscriber::reload::Layer<MetricsLayer, Layered<FmtReloadLayer, LayeredTracer>>;
-
-#[allow(clippy::type_complexity)]
-static APOLLO_LAYER_HANDLE: OnceCell<
-    Handle<
-        Option<ApolloLayer>,
-        Layered<MetricsReloadLayer, Layered<FmtReloadLayer, LayeredTracer>>,
-    >,
+static FMT_LAYER_HANDLE: OnceCell<
+    Handle<Box<dyn Layer<LayeredTracer> + Send + Sync>, LayeredTracer>,
 > = OnceCell::new();
 
 pub(crate) fn init_telemetry(log_level: &str) -> Result<()> {
@@ -90,8 +84,6 @@ pub(crate) fn init_telemetry(log_level: &str) -> Result<()> {
     let (metrics_layer, metrics_handle) =
         tracing_subscriber::reload::Layer::new(MetricsLayer::new(&NoopMeterProvider::default()));
 
-    let (apollo_layer, apollo_handle) = tracing_subscriber::reload::Layer::new(None);
-
     // Stash the reload handles so that we can hot reload later
     OPENTELEMETRY_TRACER_HANDLE
         .get_or_try_init(move || {
@@ -104,7 +96,6 @@ pub(crate) fn init_telemetry(log_level: &str) -> Result<()> {
                 .with(opentelemetry_layer)
                 .with(fmt_layer)
                 .with(metrics_layer)
-                .with(apollo_layer)
                 .with(EnvFilter::try_new(log_level)?)
                 .try_init()?;
 
@@ -116,10 +107,6 @@ pub(crate) fn init_telemetry(log_level: &str) -> Result<()> {
         .map_err(|_| anyhow!("failed to set metrics layer handle"))?;
     FMT_LAYER_HANDLE
         .set(fmt_handle)
-        .map_err(|_| anyhow!("failed to set fmt layer handle"))?;
-
-    APOLLO_LAYER_HANDLE
-        .set(apollo_handle)
         .map_err(|_| anyhow!("failed to set fmt layer handle"))?;
 
     Ok(())
@@ -145,13 +132,5 @@ pub(super) fn reload_fmt(
 ) {
     if let Some(handle) = FMT_LAYER_HANDLE.get() {
         handle.reload(layer).expect("fmt layer reload must succeed");
-    }
-}
-
-pub(crate) fn reload_apollo(layer: Option<ApolloLayer>) {
-    if let Some(handle) = APOLLO_LAYER_HANDLE.get() {
-        handle
-            .reload(layer)
-            .expect("metrics layer reload must succeed");
     }
 }

--- a/apollo-router/src/plugins/telemetry/tracing/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo.rs
@@ -1,5 +1,6 @@
 //! Tracing configuration for apollo telemetry.
 // With regards to ELv2 licensing, this entire file is license key functionality
+use opentelemetry::sdk::trace::BatchSpanProcessor;
 use opentelemetry::sdk::trace::Builder;
 use serde::Serialize;
 use tower::BoxError;
@@ -7,7 +8,6 @@ use tower::BoxError;
 use crate::plugins::telemetry::apollo::Config;
 use crate::plugins::telemetry::apollo_exporter::proto::reports::Trace;
 use crate::plugins::telemetry::config;
-use crate::plugins::telemetry::reload::reload_apollo;
 use crate::plugins::telemetry::tracing::apollo_telemetry;
 use crate::plugins::telemetry::tracing::TracingConfigurator;
 
@@ -20,28 +20,29 @@ impl TracingConfigurator for Config {
                 apollo_key: Some(key),
                 apollo_graph_ref: Some(reference),
                 schema_id,
+                buffer_size,
                 field_level_instrumentation_sampler,
                 batch_processor,
                 ..
             } => {
                 tracing::debug!("configuring exporter to Studio");
 
-                let exporter = apollo_telemetry::ApolloLayer::builder()
+                let exporter = apollo_telemetry::Exporter::builder()
                     .endpoint(endpoint.clone())
                     .apollo_key(key)
                     .apollo_graph_ref(reference)
                     .schema_id(schema_id)
+                    .buffer_size(*buffer_size)
                     .field_execution_sampler(field_level_instrumentation_sampler.clone())
                     .batch_config(batch_processor.clone())
                     .build()?;
-
-                reload_apollo(Some(exporter));
-                builder
+                builder.with_span_processor(
+                    BatchSpanProcessor::builder(exporter, opentelemetry::runtime::Tokio)
+                        .with_batch_config(batch_processor.clone().into())
+                        .build(),
+                )
             }
-            _ => {
-                reload_apollo(None);
-                builder
-            }
+            _ => builder,
         })
     }
 }


### PR DESCRIPTION
Revert "Move Apollo telemetry from an opentelemetry exporter to a tracing layer (#2908)"

This reverts commit 047b2931e2f5c597739bcd061773ce476fa43a6b.
