### PR TITLE
update to federation 2.4.1

### DIFF
--- a/.changesets/maint_toddler_discuss_both_volume.md
+++ b/.changesets/maint_toddler_discuss_both_volume.md
@@ -1,0 +1,5 @@
+### update to federation 2.4.1 
+
+
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/2957

--- a/.changesets/maint_toddler_discuss_both_volume.md
+++ b/.changesets/maint_toddler_discuss_both_volume.md
@@ -1,4 +1,4 @@
-### Update to federation 2.4.1
+### Update to federation 2.4.1 ([2937](https://github.com/apollographql/router/issues/2937))
 
 Update to federation 2.4.1, which includes a fix around [`@interfaceObject`](https://github.com/apollographql/federation/blob/main/gateway-js/CHANGELOG.md#241)
 

--- a/.changesets/maint_toddler_discuss_both_volume.md
+++ b/.changesets/maint_toddler_discuss_both_volume.md
@@ -1,5 +1,5 @@
-### update to federation 2.4.1 
+### Update to federation 2.4.1
 
-
+Update to federation 2.4.1, which includes a fix around [`@interfaceObject`](https://github.com/apollographql/federation/blob/main/gateway-js/CHANGELOG.md#241)
 
 By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/2957

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4828,9 +4828,9 @@ dependencies = [
 
 [[package]]
 name = "router-bridge"
-version = "0.2.0+v2.4.0"
+version = "0.2.1+v2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee609ab634b1d65bb1cd3e1dc7fd8b16f61c78e5116bdf489888360234e749aa"
+checksum = "4acbfd187f72fd4ac00ae1e050b011b87641135f7ef222fe462ee78964c037d4"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -157,7 +157,7 @@ reqwest = { version = "0.11.15", default-features = false, features = [
     "json",
     "stream",
 ] }
-router-bridge = "=0.2.0+v2.4.0"
+router-bridge = "=0.2.1+v2.4.1"
 rust-embed="6.4.2"
 rustls = "0.20.8"
 rustls-pemfile = "1.0.2"

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -732,7 +732,7 @@ mod tests {
             )
             .with_json(
                 serde_json::json!{{
-                    "query":"{computer(id:\"Computer1\"){id errorField}}",
+                    "query":"{computer(id:\"Computer1\"){errorField id}}",
                 }},
                 serde_json::json!{{
                     "data": {


### PR DESCRIPTION
fixes #2937

Update to federation 2.4.1, which includes a fix around [`@interfaceObject`](https://github.com/apollographql/federation/blob/main/gateway-js/CHANGELOG.md#241)
