### PR TITLE
Also support "preview" features, in addition to "experimental" features

### DIFF
--- a/.changesets/feat_preview_features.md
+++ b/.changesets/feat_preview_features.md
@@ -1,0 +1,9 @@
+### Also support "preview" features, in addition to "experimental" features 
+
+This expands on the existing mechanism that was originally introduced in https://github.com/apollographql/router/pull/2242, which supports the notion of an "experimental" feature, and make it compatible with the notion of "preview" features.
+
+When preview or experimental features are used, an `INFO`-level log is emitted during startup to notify of which features are used and shows URLs to their GitHub discussions, for feedback. Additionally, `router config experimental` and `router config preview` CLI sub-commands list all such features in the current Router version, regardless of which are used in a given configuration file.
+
+For more information about launch stages, please see the documentation here: https://www.apollographql.com/docs/resources/product-launch-stages/
+
+By [@o0ignition0o](https://github.com/o0ignition0o), [@abernix](https://github.com/abernix), and [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/2960

--- a/apollo-router/feature_discussions.json
+++ b/apollo-router/feature_discussions.json
@@ -1,6 +1,8 @@
 {
+  "experimental": {
     "experimental_retry": "https://github.com/apollographql/router/discussions/2241",
     "experimental_response_trace_id": "https://github.com/apollographql/router/discussions/2147",
-    "experimental_logging": "https://github.com/apollographql/router/discussions/1961",
-    "experimental_jwt_authentication": "https://github.com/apollographql/router/discussions/2391"
+    "experimental_logging": "https://github.com/apollographql/router/discussions/1961"
+  },
+  "preview": {}
 }

--- a/apollo-router/src/configuration/experimental.rs
+++ b/apollo-router/src/configuration/experimental.rs
@@ -82,12 +82,10 @@ impl Discussed {
             let list = list.join("\n");
             tracing::info!(
                 "You're using some \"{prefix}\" features of the Apollo Router \
-                (those which have their configuration prefixed by \"{prefix}_\"). \
-                {stage_description} \
-                Here is a list of links where you can give your opinion:
-
-                {list}
-
+                (those which have their configuration prefixed by \"{prefix}_\").\n\
+                {stage_description}\n\
+                Here is a list of links where you can give your opinion:\n\n\
+                {list}\n\n\
                 For more information about launch stages, please see the documentation here: \
                 https://www.apollographql.com/docs/resources/product-launch-stages/",
             );

--- a/apollo-router/src/configuration/experimental.rs
+++ b/apollo-router/src/configuration/experimental.rs
@@ -16,29 +16,26 @@ impl Discussed {
     }
 
     pub(crate) fn print_experimental(&self) {
-        let available_exp_confs_str: Vec<String> = self
-            .experimental
-            .iter()
-            .map(|(used_exp_conf, discussion_link)| {
-                format!("\t- {used_exp_conf}: {discussion_link}")
-            })
-            .collect();
-        println!(
-            "List of all experimental configurations with related GitHub discussions:\n\n{}",
-            available_exp_confs_str.join("\n")
-        );
+        self.print("experimental", &self.experimental)
     }
 
     pub(crate) fn print_preview(&self) {
-        let available_confs_str: Vec<String> = self
-            .preview
+        self.print("preview", &self.preview)
+    }
+
+    pub(crate) fn print(&self, stage: &str, urls: &HashMap<String, String>) {
+        let list = urls
             .iter()
-            .map(|(used_conf, discussion_link)| format!("\t- {used_conf}: {discussion_link}"))
-            .collect();
-        println!(
-            "List of all preview configurations with related GitHub discussions:\n\n{}",
-            available_confs_str.join("\n")
-        );
+            .map(|(config_key, discussion_link)| format!("\t- {config_key}: {discussion_link}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        if list.is_empty() {
+            println!("This Router version has no {stage} configuration")
+        } else {
+            println!(
+                "List of all {stage} configurations with related GitHub discussions:\n\n{list}"
+            )
+        }
     }
 
     pub(crate) fn log_experimental_used(&self, conf: &Value) {

--- a/apollo-router/src/configuration/experimental.rs
+++ b/apollo-router/src/configuration/experimental.rs
@@ -71,7 +71,7 @@ impl Discussed {
         urls: &HashMap<String, String>,
         stage_description: &str,
     ) {
-        let used = get_configurations(conf, prefix);
+        let used = get_configurations(conf, &format!("{prefix}_"));
         let needed_discussions = used
             .into_iter()
             .filter_map(|config_key| {

--- a/apollo-router/src/configuration/experimental.rs
+++ b/apollo-router/src/configuration/experimental.rs
@@ -42,42 +42,56 @@ impl Discussed {
     }
 
     pub(crate) fn log_experimental_used(&self, conf: &Value) {
-        let used_experimental_conf = get_configurations(conf, "experimental");
-
-        let needed_discussions: Vec<String> = used_experimental_conf
-            .into_iter()
-            .filter_map(|used_exp_conf| {
-                self.experimental
-                    .get(&used_exp_conf)
-                    .map(|discussion_link| format!("\t- {used_exp_conf}: {discussion_link}"))
-            })
-            .collect();
-        if !needed_discussions.is_empty() {
-            tracing::info!(
-                r#"You're using some "experimental" features (configuration prefixed by "experimental_" or contained within an "experimental" section). We may make breaking changes in future releases.
-To help us design the stable version we need your feedback. Here is a list of links where you can give your opinion:
-
-{}
-"#,
-                needed_discussions.join("\n")
-            );
-        }
+        self.log_used(
+            conf,
+            "experimental",
+            &self.experimental,
+            "We may make breaking changes in future releases. \
+            To help us design the stable version we need your feedback.",
+        )
     }
 
     pub(crate) fn log_preview_used(&self, conf: &Value) {
-        let used_preview_conf = get_configurations(conf, "preview");
+        self.log_used(
+            conf,
+            "preview",
+            &self.preview,
+            "These features are not officially supported with any SLA \
+            and may still contain bugs or undergo iteration. \
+            You're encouraged to try preview features in test environments \
+            to familiarize yourself with upcoming functionality \
+            before it reaches general availability.",
+        )
+    }
 
-        let needed_discussions: Vec<String> = used_preview_conf
+    fn log_used(
+        &self,
+        conf: &Value,
+        prefix: &str,
+        urls: &HashMap<String, String>,
+        stage_description: &str,
+    ) {
+        let used = get_configurations(conf, prefix);
+        let needed_discussions = used
             .into_iter()
-            .filter_map(|used_conf| {
-                self.experimental
-                    .get(&used_conf)
-                    .map(|discussion_link| format!("\t- {used_conf}: {discussion_link}"))
+            .filter_map(|config_key| {
+                urls.get(&config_key)
+                    .map(|discussion_link| format!("\t- {config_key}: {discussion_link}"))
             })
-            .collect();
+            .collect::<Vec<String>>()
+            .join("\n");
+
         if !needed_discussions.is_empty() {
             tracing::info!(
-                r#"You're using some "preview" features of the Apollo Router (those which have their configuration prefixed by "preview").  These features are not officially supported with any SLA and may still contain bugs or undergo iteration. You're encouraged to try preview features in test environments to familiarize yourself with upcoming functionality before it reaches general availability. For more information about launch stages, please see the documentation here: https://www.apollographql.com/docs/resources/product-launch-stages/"#,
+                "You're using some \"{prefix}\" features of the Apollo Router \
+                (those which have their configuration prefixed by \"{prefix}_\"). \
+                {stage_description} \
+                Here is a list of links where you can give your opinion:
+
+                {needed_discussions}
+
+                For more information about launch stages, please see the documentation here: \
+                https://www.apollographql.com/docs/resources/product-launch-stages/",
             );
         }
     }
@@ -92,7 +106,7 @@ fn get_configurations(conf: &Value, prefix: &str) -> Vec<String> {
 fn visit_configurations(conf: &Value, prefix: &str, fields: &mut Vec<String>) {
     if let Value::Object(object) = conf {
         object.iter().for_each(|(field_name, val)| {
-            if field_name.starts_with(&format!("{}_", prefix)) {
+            if field_name.starts_with(prefix) {
                 fields.push(field_name.clone());
             }
             visit_configurations(val, prefix, fields);

--- a/apollo-router/src/configuration/experimental.rs
+++ b/apollo-router/src/configuration/experimental.rs
@@ -24,14 +24,15 @@ impl Discussed {
     }
 
     pub(crate) fn print(&self, stage: &str, urls: &HashMap<String, String>) {
-        let list = urls
+        let mut list: Vec<_> = urls
             .iter()
             .map(|(config_key, discussion_link)| format!("\t- {config_key}: {discussion_link}"))
-            .collect::<Vec<_>>()
-            .join("\n");
+            .collect();
         if list.is_empty() {
             println!("This Router version has no {stage} configuration")
         } else {
+            list.sort();
+            let list = list.join("\n");
             println!(
                 "List of all {stage} configurations with related GitHub discussions:\n\n{list}"
             )
@@ -69,23 +70,23 @@ impl Discussed {
         stage_description: &str,
     ) {
         let used = get_configurations(conf, &format!("{prefix}_"));
-        let needed_discussions = used
+        let mut list: Vec<_> = used
             .into_iter()
             .filter_map(|config_key| {
                 urls.get(&config_key)
                     .map(|discussion_link| format!("\t- {config_key}: {discussion_link}"))
             })
-            .collect::<Vec<String>>()
-            .join("\n");
-
-        if !needed_discussions.is_empty() {
+            .collect();
+        if !list.is_empty() {
+            list.sort();
+            let list = list.join("\n");
             tracing::info!(
                 "You're using some \"{prefix}\" features of the Apollo Router \
                 (those which have their configuration prefixed by \"{prefix}_\"). \
                 {stage_description} \
                 Here is a list of links where you can give your opinion:
 
-                {needed_discussions}
+                {list}
 
                 For more information about launch stages, please see the documentation here: \
                 https://www.apollographql.com/docs/resources/product-launch-stages/",

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -46,7 +46,7 @@ use thiserror::Error;
 
 use self::cors::Cors;
 use self::expansion::Expansion;
-pub(crate) use self::experimental::print_all_experimental_conf;
+pub(crate) use self::experimental::Discussed;
 pub(crate) use self::schema::generate_config_schema;
 pub(crate) use self::schema::generate_upgrade;
 use self::subgraph::SubgraphConfiguration;

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -15,7 +15,7 @@ use yaml_rust::scanner::Marker;
 
 use super::expansion::coerce;
 use super::expansion::Expansion;
-use super::experimental::log_used_experimental_conf;
+use super::experimental::Discussed;
 use super::plugins;
 use super::yaml;
 use super::Configuration;
@@ -107,7 +107,10 @@ pub(crate) fn validate_yaml_configuration(
             tracing::warn!("configuration could not be upgraded automatically as it had errors")
         }
     }
-    log_used_experimental_conf(&yaml);
+
+    let discussed = Discussed::new();
+    discussed.log_experimental_used(&yaml);
+    discussed.log_preview_used(&yaml);
     let expanded_yaml = expansion.expand(&yaml)?;
     let parsed_yaml = super::yaml::parse(raw_yaml)?;
     if let Err(errors_it) = schema.validate(&expanded_yaml) {

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -22,10 +22,10 @@ use once_cell::sync::OnceCell;
 use url::ParseError;
 use url::Url;
 
-use crate::configuration;
 use crate::configuration::generate_config_schema;
 use crate::configuration::generate_upgrade;
 use crate::configuration::ConfigurationError;
+use crate::configuration::Discussed;
 use crate::plugins::telemetry::reload::init_telemetry;
 use crate::router::ConfigurationSource;
 use crate::router::RouterHttpServer;
@@ -127,6 +127,8 @@ enum ConfigSubcommand {
     },
     /// List all the available experimental configurations with related GitHub discussion
     Experimental,
+    /// List all the available preview configurations with related GitHub discussion
+    Preview,
 }
 
 /// Options for the router
@@ -384,7 +386,13 @@ impl Executable {
             Some(Commands::Config(ConfigSubcommandArgs {
                 command: ConfigSubcommand::Experimental,
             })) => {
-                configuration::print_all_experimental_conf();
+                Discussed::new().print_experimental();
+                Ok(())
+            }
+            Some(Commands::Config(ConfigSubcommandArgs {
+                command: ConfigSubcommand::Preview,
+            })) => {
+                Discussed::new().print_preview();
                 Ok(())
             }
             None => Self::inner_start(shutdown, schema, config, entitlement, opt).await,

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -691,13 +691,13 @@ mod tests {
         {
           query: Query
         }
-        
+
         directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
         directive @join__graph(name: String!, url: String!) on ENUM_VALUE
         directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
         directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
         directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-                
+
         scalar link__Import
         enum link__Purpose {
           SECURITY
@@ -711,9 +711,9 @@ mod tests {
           errorField: String
           nonNullErrorField: String!
         }
-        
+
         scalar join__FieldSet
-        
+
         enum join__Graph {
           COMPUTERS @join__graph(name: "computers", url: "http://localhost:4001/")
         }
@@ -768,8 +768,8 @@ mod tests {
         let request = supergraph::Request::fake_builder()
             .context(defer_context())
             .query(
-                r#"query { 
-                computer(id: "Computer1") {   
+                r#"query {
+                computer(id: "Computer1") {
                   id
                   ...ComputerErrorField @defer
                 }
@@ -1173,55 +1173,55 @@ mod tests {
     query: Query
     mutation: Mutation
   }
-  
+
   directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-  
+
   directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
-  
+
   directive @join__graph(name: String!, url: String!) on ENUM_VALUE
-  
+
   directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
-  
+
   directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
-  
+
   directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-  
+
   directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-  
+
   scalar join__FieldSet
-  
+
   enum join__Graph {
     PRODUCTS @join__graph(name: "products", url: "http://products:4000/graphql")
     USERS @join__graph(name: "users", url: "http://users:4000/graphql")
   }
-  
+
   scalar link__Import
-  
+
   enum link__Purpose {
     SECURITY
     EXECUTION
   }
-  
+
   type MakePaymentResult
     @join__type(graph: USERS)
   {
     id: ID!
     paymentStatus: PaymentStatus
   }
-  
+
   type Mutation
     @join__type(graph: USERS)
   {
     makePayment(userId: ID!): MakePaymentResult!
   }
-  
-  
+
+
  type PaymentStatus
     @join__type(graph: USERS)
   {
     id: ID!
   }
-  
+
   type Query
     @join__type(graph: PRODUCTS)
     @join__type(graph: USERS)
@@ -1399,7 +1399,7 @@ mod tests {
             {
                 query: Query
             }
-        
+
             directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
             directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
             directive @join__graph(name: String!, url: String!) on ENUM_VALUE
@@ -1407,7 +1407,7 @@ mod tests {
             directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
             directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
             directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
-        
+
             scalar join__FieldSet
             enum join__Graph {
                 USER @join__graph(name: "user", url: "http://localhost:4000/graphql")
@@ -1428,7 +1428,7 @@ mod tests {
             id: ID!
             name: String!
             }
-        
+
             type User implements Identity
                 @join__implements(graph: USER, interface: "Identity")
                 @join__type(graph: USER, key: "id")
@@ -2254,7 +2254,7 @@ mod tests {
           {
             foo: Foo! @join__field(graph: S1)
           }
-          
+
           type Foo
             @join__owner(graph: S1)
             @join__type(graph: S1)
@@ -2262,7 +2262,7 @@ mod tests {
             id: ID! @join__field(graph: S1)
             bar: Bar! @join__field(graph: S1)
           }
-          
+
           type Bar
           @join__owner(graph: S1)
           @join__type(graph: S1, key: "id")

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -187,12 +187,16 @@ impl IntegrationTest {
                         message: String,
                     }
                     let log = serde_json::from_str::<Log>(&line).unwrap();
-                    collected.push(format!(
-                        "{}: {}",
-                        log.level,
-                        // Redacted so we don't need to update snapshots every release
-                        version_line_re.replace(&log.message, "Apollo Router [version number] ")
-                    ))
+                    // Omit this message from snapshots since it depends on external environment
+                    if !log.message.starts_with("RUST_BACKTRACE=full detected") {
+                        collected.push(format!(
+                            "{}: {}",
+                            log.level,
+                            // Redacted so we don't need to update snapshots every release
+                            version_line_re
+                                .replace(&log.message, "Apollo Router [version number] ")
+                        ))
+                    }
                 }
                 let _ = stdio_tx.send(line).await;
             }

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -375,7 +375,12 @@ impl IntegrationTest {
 
     #[cfg(target_os = "windows")]
     pub async fn graceful_shutdown(&mut self) {
-        // On windows we have to do complicated things to gracefully shutdown. One day we may get around to this, but it's not a priority.
+        // We don’t have SIGTERM on Windows, so do a non-graceful kill instead
+        self.kill().await
+    }
+
+    #[allow(dead_code)]
+    pub async fn kill(&mut self) {
         let _ = self
             .router
             .as_mut()

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -130,17 +130,20 @@ impl IntegrationTest {
 
         fs::write(&test_config_location, config).expect("could not write config");
 
-        let router_location = PathBuf::from(env!("CARGO_BIN_EXE_router"));
         let (stdio_tx, stdio_rx) = tokio::sync::mpsc::channel(2000);
         Self {
             router: None,
-            router_location,
+            router_location: Self::router_location(),
             test_config_location,
             _lock: lock,
             stdio_tx,
             stdio_rx,
             _subgraphs: subgraphs,
         }
+    }
+
+    pub fn router_location() -> PathBuf {
+        PathBuf::from(env!("CARGO_BIN_EXE_router"))
     }
 
     #[allow(dead_code)]

--- a/apollo-router/tests/lifecycle_tests.rs
+++ b/apollo-router/tests/lifecycle_tests.rs
@@ -199,7 +199,7 @@ async fn test_experimental_notice() {
         .await;
     router.start().await;
     router.assert_started().await;
-    router.graceful_shutdown().await;
+    router.kill().await;
 
     insta::assert_snapshot!(rx.await.unwrap());
 }

--- a/apollo-router/tests/lifecycle_tests.rs
+++ b/apollo-router/tests/lifecycle_tests.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use apollo_router::graphql;
 use futures::FutureExt;
 use serde_json::json;
+use tokio::process::Command;
 use tower::BoxError;
 use wiremock::ResponseTemplate;
 
@@ -138,4 +139,44 @@ async fn test_force_hot_reload() -> Result<(), BoxError> {
     router.assert_reloaded().await;
     router.graceful_shutdown().await;
     Ok(())
+}
+
+async fn command_output(command: &mut Command) -> String {
+    let output = command.output().await.unwrap();
+    let success = output.status.success();
+    let exit_code = output.status.code();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    format!(
+        "Success: {success:?}\n\
+        Exit code: {exit_code:?}\n\
+        stderr:\n\
+        {stderr}\n\
+        stdout:\n\
+        {stdout}"
+    )
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cli_config_experimental() {
+    insta::assert_snapshot!(
+        command_output(
+            Command::new(IntegrationTest::router_location())
+                .arg("config")
+                .arg("experimental")
+        )
+        .await
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_cli_config_preview() {
+    insta::assert_snapshot!(
+        command_output(
+            Command::new(IntegrationTest::router_location())
+                .arg("config")
+                .arg("preview")
+        )
+        .await
+    );
 }

--- a/apollo-router/tests/lifecycle_tests.rs
+++ b/apollo-router/tests/lifecycle_tests.rs
@@ -164,6 +164,7 @@ async fn test_cli_config_experimental() {
             Command::new(IntegrationTest::router_location())
                 .arg("config")
                 .arg("experimental")
+                .env("RUST_BACKTRACE", "") // Avoid "RUST_BACKTRACE=full detected" log on CI
         )
         .await
     );
@@ -176,6 +177,7 @@ async fn test_cli_config_preview() {
             Command::new(IntegrationTest::router_location())
                 .arg("config")
                 .arg("preview")
+                .env("RUST_BACKTRACE", "") // Avoid "RUST_BACKTRACE=full detected" log on CI
         )
         .await
     );

--- a/apollo-router/tests/lifecycle_tests.rs
+++ b/apollo-router/tests/lifecycle_tests.rs
@@ -211,7 +211,7 @@ async fn test_experimental_notice() {
     let logs: Vec<_> = log_lines
         .iter()
         .map(|line| {
-            let log = serde_json::from_str::<Log>(&line).unwrap();
+            let log = serde_json::from_str::<Log>(line).unwrap();
             format!("{}: {}", log.level, log.message)
         })
         .collect();

--- a/apollo-router/tests/snapshots/lifecycle_tests__cli_config_experimental.snap
+++ b/apollo-router/tests/snapshots/lifecycle_tests__cli_config_experimental.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-router/tests/lifecycle_tests.rs
+expression: "command_output(Command::new(IntegrationTest::router_location()).arg(\"config\").arg(\"experimental\")).await"
+---
+Success: true
+Exit code: Some(0)
+stderr:
+
+stdout:
+List of all experimental configurations with related GitHub discussions:
+
+	- experimental_response_trace_id: https://github.com/apollographql/router/discussions/2147
+	- experimental_logging: https://github.com/apollographql/router/discussions/1961
+	- experimental_retry: https://github.com/apollographql/router/discussions/2241
+

--- a/apollo-router/tests/snapshots/lifecycle_tests__cli_config_experimental.snap
+++ b/apollo-router/tests/snapshots/lifecycle_tests__cli_config_experimental.snap
@@ -9,7 +9,7 @@ stderr:
 stdout:
 List of all experimental configurations with related GitHub discussions:
 
-	- experimental_response_trace_id: https://github.com/apollographql/router/discussions/2147
 	- experimental_logging: https://github.com/apollographql/router/discussions/1961
+	- experimental_response_trace_id: https://github.com/apollographql/router/discussions/2147
 	- experimental_retry: https://github.com/apollographql/router/discussions/2241
 

--- a/apollo-router/tests/snapshots/lifecycle_tests__cli_config_preview.snap
+++ b/apollo-router/tests/snapshots/lifecycle_tests__cli_config_preview.snap
@@ -7,7 +7,5 @@ Exit code: Some(0)
 stderr:
 
 stdout:
-List of all preview configurations with related GitHub discussions:
-
-
+This Router version has no preview configuration
 

--- a/apollo-router/tests/snapshots/lifecycle_tests__cli_config_preview.snap
+++ b/apollo-router/tests/snapshots/lifecycle_tests__cli_config_preview.snap
@@ -1,0 +1,13 @@
+---
+source: apollo-router/tests/lifecycle_tests.rs
+expression: "command_output(Command::new(IntegrationTest::router_location()).arg(\"config\").arg(\"preview\")).await"
+---
+Success: true
+Exit code: Some(0)
+stderr:
+
+stdout:
+List of all preview configurations with related GitHub discussions:
+
+
+

--- a/apollo-router/tests/snapshots/lifecycle_tests__experimental_notice.snap
+++ b/apollo-router/tests/snapshots/lifecycle_tests__experimental_notice.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/tests/lifecycle_tests.rs
-expression: collect_stdio(rx).await
+expression: rx.await.unwrap()
 ---
 INFO: Apollo Router [version number] // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)
 INFO: Anonymous usage data collection is disabled.
@@ -13,6 +13,3 @@ Here is a list of links where you can give your opinion:
 For more information about launch stages, please see the documentation here: https://www.apollographql.com/docs/resources/product-launch-stages/
 INFO: Health check endpoint exposed at http://127.0.0.1:8088/health
 INFO: GraphQL endpoint exposed at http://127.0.0.1:4000/ 🚀
-INFO: shutting down
-INFO: all connections shut down
-INFO: stopped

--- a/apollo-router/tests/snapshots/lifecycle_tests__experimental_notice.snap
+++ b/apollo-router/tests/snapshots/lifecycle_tests__experimental_notice.snap
@@ -1,8 +1,8 @@
 ---
 source: apollo-router/tests/lifecycle_tests.rs
-expression: "logs.join(\"\\n\")"
+expression: collect_stdio(rx).await
 ---
-INFO: Apollo Router v1.14.0 // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)
+INFO: Apollo Router [version number] // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)
 INFO: Anonymous usage data collection is disabled.
 INFO: You're using some "experimental" features of the Apollo Router (those which have their configuration prefixed by "experimental_").
 We may make breaking changes in future releases. To help us design the stable version we need your feedback.

--- a/apollo-router/tests/snapshots/lifecycle_tests__experimental_notice.snap
+++ b/apollo-router/tests/snapshots/lifecycle_tests__experimental_notice.snap
@@ -1,0 +1,18 @@
+---
+source: apollo-router/tests/lifecycle_tests.rs
+expression: "logs.join(\"\\n\")"
+---
+INFO: Apollo Router v1.14.0 // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)
+INFO: Anonymous usage data collection is disabled.
+INFO: You're using some "experimental" features of the Apollo Router (those which have their configuration prefixed by "experimental_").
+We may make breaking changes in future releases. To help us design the stable version we need your feedback.
+Here is a list of links where you can give your opinion:
+
+	- experimental_logging: https://github.com/apollographql/router/discussions/1961
+
+For more information about launch stages, please see the documentation here: https://www.apollographql.com/docs/resources/product-launch-stages/
+INFO: Health check endpoint exposed at http://127.0.0.1:8088/health
+INFO: GraphQL endpoint exposed at http://127.0.0.1:4000/ 🚀
+INFO: shutting down
+INFO: all connections shut down
+INFO: stopped


### PR DESCRIPTION
This expands on the existing mechanism that was originally introduced in https://github.com/apollographql/router/pull/2242, which supports the notion of an "experimental" feature, and make it compatible with the notion of "preview" features.

Most of this code was written by @o0Ignition0o, I just extracted it and put it here! 😄 

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [-] Documentation[^2] completed
- [-] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [-] Unit Tests
    - [-] Integration Tests
    - [x] Manual Tests

