### PR TITLE
Treats the value of the deployment extra labels as possible templates

### DIFF
--- a/.changesets/config_extra_labels_tpl.md
+++ b/.changesets/config_extra_labels_tpl.md
@@ -1,0 +1,22 @@
+### Treat helm extra labels values as templates
+
+When a helm chart users add extra labels to the Kubernetes Deployment and pods (via the helm chart), they may want to use a piece of data from the `Values` or the `Chart` eg using the Chart version as a label value.
+
+At the moment doing something like:
+```
+extraLabels:
+  env: {{ .Chart.AppVersion }}
+```
+is interpreted as:
+```
+labels:
+  env: {{ .Chart.AppVersion }}
+```
+
+This is "normal" because by default strings are not interpolated. The fix basically iterates over the `extraLabels` and uses the `tpl` function on the values (only). The result being then
+```
+labels:
+  env: "v1.2.3"
+```
+
+By [@gscheibel](https://github.com/gscheibel) in https://github.com/apollographql/router/pull/2962

--- a/helm/chart/router/templates/_helpers.tpl
+++ b/helm/chart/router/templates/_helpers.tpl
@@ -99,3 +99,20 @@ Usage:
 "/metrics"
 {{- end }}
 {{- end -}}
+
+{{/*
+This function takes the `extraLabels` map and templatizes the values.
+This allows to pass references from the values and interprates them as template.
+A use case for this usage is to add a custom label to the deployment referencing the version of the chart.
+For example:
+
+```
+extraLabels:
+  custom-version: {{ .Chart.AppVersion }}
+```
+*/}}
+{{- define "common.templatizeExtraLabels" -}}
+{{- range $key, $value := .Values.extraLabels }}
+{{ printf "%s: %s" $key (include  "common.tplvalues.render" ( dict "value" $value "context" $))}}
+{{- end -}}
+{{- end -}}

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "router.labels" . | nindent 4 }}
     {{- if .Values.extraLabels }}
-    {{- toYaml .Values.extraLabels | nindent 4 }}
+    {{- include "common.templatizeExtraLabels" . | nindent 4 }}
     {{- end }}
   {{/* There may not be much configuration so check that there is something */}}
   {{- if (((((.Values.router).configuration).telemetry).metrics).prometheus).enabled }}
@@ -35,7 +35,7 @@ spec:
       labels:
         {{- include "router.selectorLabels" . | nindent 8 }}
         {{- if .Values.extraLabels }}
-        {{- toYaml .Values.extraLabels | nindent 8 }}
+        {{- include "common.templatizeExtraLabels" . | nindent 8 }}
         {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
When a helm chart users add extra labels to the Kubernetes Deployment and pods (via the helm chart), they may want to use a piece of data from the `Values` or the `Chart` eg using the Chart version as a label value.

At the moment doing something like:
```
extraLabels:
  env: {{ .Chart.AppVersion }}
```
is interpreted as:
```
labels:
  env: {{ .Chart.AppVersion }}
```

This is "normal" because by default strings are not interpolated. The fix basically iterates over the `extraLabels` and uses the `tpl` function on the values (only). The result being then
```
labels:
  env: "v1.2.3"
```

