### PR TITLE
fix: Helm YAML for extraContainers (#2881)

### DIFF
--- a/.changesets/config_extra_containers_fix.md
+++ b/.changesets/config_extra_containers_fix.md
@@ -1,0 +1,5 @@
+### `extraContainers` in Helm charts, fixed
+
+Allow sidecars in router pods, most notably useful for coprocessors.
+
+By [@pcarrier(https://github.com/pcarrier) in https://github.com/apollographql/router/pull/2967

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -126,9 +126,9 @@ spec:
               {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
           {{- end }}
-          {{- if .Values.extraContainers }}
-          {{- tpl (toYaml .Values.extraContainers) $ | nindent 10 }}
-          {{- end }}
+        {{- if .Values.extraContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.extraContainers "context" $) | nindent 8 }}
+        {{- end }}
       {{- if or .Values.router.configuration .Values.extraVolumes }}
       volumes:
         {{- if .Values.router.configuration }}


### PR DESCRIPTION
The [previous PR](https://github.com/apollographql/router/pull/2881) does not indent correctly and makes it impossible to create extra containers.

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

I nurture a distaste for YAML, text/template, and Helm, merely copied from context, and do not understand the before nor the after.
This was tested using `helm package`, copying the resulting tarball in internal Helm charts, then running `helm install … --dry-run --debug`. While I'm not 100% sure it is correct, the generated YAML seemed correct after converting to JSON and back.