### PR TITLE
Revert "Update Dockerfile.router to use heredoc"

### DIFF
--- a/.changesets/fix_muscle_peach_thunderstorm_musical.md
+++ b/.changesets/fix_muscle_peach_thunderstorm_musical.md
@@ -1,0 +1,9 @@
+### Resolve Docker `unrecognized subcommand` error ([Issue #2966](https://github.com/apollographql/router/issues/2966))
+
+We've repaired the Docker build of the v1.15.0 release which broke due to the introduction of syntax in the Dockerfile which can only be used by the the `docker buildx` tooling [which leverages Moby BuildKit](https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/).
+
+Furthermore, the change didn't apply to the "`diy`" (do it yourself), and we'd like to prevent the two Dockerfiles from deviating more than necessary.
+
+Overall, this reverts [apollographql/router#2925](https://github.com/apollographql/router/pull/2925).
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/2968

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -36,15 +36,16 @@ LABEL org.opencontainers.image.source="https://github.com/apollographql/router"
 ENV APOLLO_ROUTER_CONFIG_PATH="/dist/config/router.yaml"
 
 # Create a wrapper script to run the router, use exec to ensure signals are handled correctly
-COPY <<EOF /dist/router_wrapper.sh
-#!/usr/bin/env bash
-set -e
-if [ -f "/usr/bin/heaptrack" ]; then
-  exec heaptrack -o /dist/data/router_heaptrack /dist/router "$@"
-else
-  exec /dist/router "$@"
-fi
-EOF
+RUN \
+  echo '#!/usr/bin/env bash \
+\nset -e \
+\n \
+\nif [ -f "/usr/bin/heaptrack" ]; then \
+\n    exec heaptrack -o /dist/data/router_heaptrack /dist/router "$@" \
+\nelse \
+\n    exec /dist/router "$@" \
+\nfi \
+' > /dist/router_wrapper.sh
 
 # Make sure we can run our wrapper
 RUN chmod 755 /dist/router_wrapper.sh


### PR DESCRIPTION
This broke the release of v1.15.0.  Turns out this[ may only be compatible with](https://www.docker.com/blog/introduction-to-heredocs-in-dockerfiles/) `docker buildx`.

Furthermore, the change wasn't made to the `diy` dockerfile, and we'd like to prevent the two Dockerfiles from deviating more than necessary.

Reverts apollographql/router#2925
Fixes https://github.com/apollographql/router/issues/2966