### PR TITLE
Re-structure the rhai logging output

### DIFF
--- a/.changesets/maint_garypen_2777_tracing.md
+++ b/.changesets/maint_garypen_2777_tracing.md
@@ -1,0 +1,25 @@
+### Re-structure the rhai logging output ([Issue #2777](https://github.com/apollographql/router/issues/2777))
+
+The Rhai logging output was implemented about a year ago. Since that time, significant efforts have been made with the rest of the router to standardize on a slightly different format. This change brings rhai log output into line with the rest of the router.
+
+It also addresses the requirement to make the "message" output specifiable by the script author.
+
+The impact of this change can be seen in this example. If we were to `log_info()` in our rhai script:
+
+```
+  log_info("this is info");
+```
+
+BEFORE:
+
+```
+{"timestamp":"2023-04-19T07:46:15.483358Z","level":"INFO","message":"rhai_info","out":"this is info"}
+```
+
+AFTER:
+
+```
+{"timestamp":"2023-04-19T07:46:15.483358Z","level":"INFO","message":"this is info","target":"src/rhai_logging.rhai"}
+```
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/2975

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -390,7 +390,11 @@ impl EngineBlock {
         main: PathBuf,
         sdl: Arc<String>,
     ) -> Result<Self, BoxError> {
-        let engine = Arc::new(Rhai::new_rhai_engine(scripts, sdl.to_string()));
+        let engine = Arc::new(Rhai::new_rhai_engine(
+            scripts,
+            sdl.to_string(),
+            main.clone(),
+        ));
         let ast = engine.compile_file(main)?;
         let mut scope = Scope::new();
         // Keep these two lower cases ones as mistakes until 2.0
@@ -1263,7 +1267,7 @@ impl Rhai {
         Ok(())
     }
 
-    fn new_rhai_engine(path: Option<PathBuf>, sdl: String) -> Engine {
+    fn new_rhai_engine(path: Option<PathBuf>, sdl: String, main: PathBuf) -> Engine {
         let mut engine = Engine::new();
         // If we pass in a path, use it to configure our engine
         // with a FileModuleResolver which allows import to work
@@ -1278,11 +1282,22 @@ impl Rhai {
 
         let base64_module = exported_module!(router_base64);
 
+        // Share main so we can move copies into each closure as required for logging
+        let shared_main = Shared::new(main.display().to_string());
+
+        let trace_main = shared_main.clone();
+        let debug_main = shared_main.clone();
+        let info_main = shared_main.clone();
+        let warn_main = shared_main.clone();
+        let error_main = shared_main.clone();
+
+        let print_main = shared_main;
+
         // Configure our engine for execution
         engine
             .set_max_expr_depths(0, 0)
-            .on_print(move |rhai_log| {
-                tracing::info!("{}", rhai_log);
+            .on_print(move |message| {
+                tracing::info!(%message, target = %print_main);
             })
             // Register our plugin module
             .register_global_module(module.into())
@@ -1546,20 +1561,20 @@ impl Rhai {
             })
             .register_fn("to_string", |id: &mut TraceId| -> String { id.to_string() })
             // Register a series of logging functions
-            .register_fn("log_trace", |out: Dynamic| {
-                tracing::trace!(%out, "rhai_trace");
+            .register_fn("log_trace", move |message: Dynamic| {
+                tracing::trace!(%message, target = %trace_main);
             })
-            .register_fn("log_debug", |out: Dynamic| {
-                tracing::debug!(%out, "rhai_debug");
+            .register_fn("log_debug", move |message: Dynamic| {
+                tracing::debug!(%message, target = %debug_main);
             })
-            .register_fn("log_info", |out: Dynamic| {
-                tracing::info!(%out, "rhai_info");
+            .register_fn("log_info", move |message: Dynamic| {
+                tracing::info!(%message, target = %info_main);
             })
-            .register_fn("log_warn", |out: Dynamic| {
-                tracing::warn!(%out, "rhai_warn");
+            .register_fn("log_warn", move |message: Dynamic| {
+                tracing::warn!(%message, target = %warn_main);
             })
-            .register_fn("log_error", |out: Dynamic| {
-                tracing::error!(%out, "rhai_error");
+            .register_fn("log_error", move |message: Dynamic| {
+                tracing::error!(%message, target = %error_main);
             })
             // Register a function for printing to stderr
             .register_fn("eprint", |x: &str| {

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -18,6 +18,7 @@ use uuid::Uuid;
 
 use super::process_error;
 use super::subgraph;
+use super::PathBuf;
 use super::Rhai;
 use super::RhaiExecutionDeferredResponse;
 use super::RhaiExecutionResponse;
@@ -154,7 +155,7 @@ async fn rhai_plugin_execution_service_error() -> Result<(), BoxError> {
 // A Rhai engine suitable for minimal testing. There are no scripts and the SDL is an empty
 // string.
 fn new_rhai_test_engine() -> Engine {
-    Rhai::new_rhai_engine(None, "".to_string())
+    Rhai::new_rhai_engine(None, "".to_string(), PathBuf::new())
 }
 
 // Some of these tests rely extensively on internal implementation details of the tracing_test crate.


### PR DESCRIPTION
The Rhai logging output was "standardized" about a year ago. Since that time, significant efforts have been made within the rest of the router to standardize on a slightly different format. This PR brings rhai log output into line with the rest of the router.

It also addresses the requirement to make the "message" output specifiable by the script author.

Note: The changes are source code compatible, but the format of the output log line is changing. I don't think we make compatibility commitments on this, but it's worth noting.

Fixes #2777 

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
