### PR TITLE
Time-based forced hot-reload for chaos testing

### DIFF
--- a/.changesets/feat_chaos_reload.md
+++ b/.changesets/feat_chaos_reload.md
@@ -1,0 +1,12 @@
+### Time-based forced hot-reload for chaos testing
+
+The Router can now artificially be made to hot-reload (as if the configuration or schema had changed) at a configured time interval. This can help reproduce issues like reload-related memory leaks.
+
+The new configuration section for chaos testing is marked as experimental:
+
+```yaml
+experimental_chaos:
+    force_hot_reload: 1m
+```
+
+By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/2988

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -578,6 +578,22 @@ expression: "&schema"
       },
       "additionalProperties": false
     },
+    "experimental_chaos": {
+      "description": "Configuration for chaos testing, trying to reproduce bugs that require uncommon conditions. You probably don’t want this in production!",
+      "default": {
+        "force_hot_reload": null
+      },
+      "type": "object",
+      "properties": {
+        "force_hot_reload": {
+          "description": "Force a hot reload of the Router (as if the schema or configuration had changed) at a regular time interval.",
+          "default": null,
+          "type": "string",
+          "nullable": true
+        }
+      },
+      "additionalProperties": false
+    },
     "forbid_mutations": {
       "description": "Forbid mutations configuration",
       "type": "boolean"

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -9,6 +9,7 @@ use tokio::sync::mpsc;
 use tokio::sync::OwnedRwLockWriteGuard;
 use tokio::sync::RwLock;
 use ApolloRouterError::ServiceCreationError;
+use Event::ForcedHotReload;
 use Event::NoMoreConfiguration;
 use Event::NoMoreEntitlement;
 use Event::NoMoreSchema;
@@ -29,6 +30,7 @@ use super::state_machine::State::Stopped;
 use crate::configuration::Configuration;
 use crate::configuration::ListenAddr;
 use crate::router::Event::UpdateEntitlement;
+use crate::router::ForcedHotReloadConfig;
 use crate::router_factory::RouterFactory;
 use crate::router_factory::RouterSuperServiceFactory;
 use crate::spec::Schema;
@@ -294,6 +296,10 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
             entitlement
         };
 
+        state_machine
+            .forced_hot_reload_config
+            .set_period(configuration.experimental_chaos.force_hot_reload);
+
         let router_service_factory = state_machine
             .router_configurator
             .create(
@@ -369,6 +375,7 @@ where
     router_configurator: FA,
     pub(crate) listen_addresses: Arc<RwLock<ListenAddresses>>,
     listen_addresses_guard: Option<OwnedRwLockWriteGuard<ListenAddresses>>,
+    forced_hot_reload_config: Arc<ForcedHotReloadConfig>,
 }
 
 impl<S, FA> StateMachine<S, FA>
@@ -377,7 +384,11 @@ where
     FA: RouterSuperServiceFactory + Send,
     FA::RouterFactory: RouterFactory,
 {
-    pub(crate) fn new(http_server_factory: S, router_factory: FA) -> Self {
+    pub(crate) fn new(
+        http_server_factory: S,
+        router_factory: FA,
+        forced_hot_reload_config: Arc<ForcedHotReloadConfig>,
+    ) -> Self {
         // Listen address is created locked so that if a consumer tries to examine the listen address before the state machine has reached running state they are blocked.
         let listen_addresses: Arc<RwLock<ListenAddresses>> = Default::default();
         let listen_addresses_guard = Some(
@@ -391,6 +402,7 @@ where
             router_configurator: router_factory,
             listen_addresses,
             listen_addresses_guard,
+            forced_hot_reload_config,
         }
     }
 
@@ -432,6 +444,7 @@ where
                         .update_inputs(&mut self, None, None, Some(entitlement))
                         .await
                 }
+                ForcedHotReload => state.update_inputs(&mut self, None, None, None).await,
                 NoMoreEntitlement => state.no_more_entitlement().await,
                 Shutdown => state.shutdown().await,
             };
@@ -677,7 +690,7 @@ mod tests {
     async fn listen_addresses_are_locked() {
         let router_factory = create_mock_router_configurator(0);
         let (server_factory, _) = create_mock_server_factory(0);
-        let state_machine = StateMachine::new(server_factory, router_factory);
+        let state_machine = StateMachine::new(server_factory, router_factory, Default::default());
         assert!(state_machine.listen_addresses.try_read().is_err());
     }
 
@@ -1036,7 +1049,7 @@ mod tests {
         router_factory: MockMyRouterConfigurator,
         events: Vec<Event>,
     ) -> Result<(), ApolloRouterError> {
-        let state_machine = StateMachine::new(server_factory, router_factory);
+        let state_machine = StateMachine::new(server_factory, router_factory, Default::default());
         state_machine
             .process_events(stream::iter(events).boxed())
             .await

--- a/apollo-router/src/uplink/entitlement_stream.rs
+++ b/apollo-router/src/uplink/entitlement_stream.rs
@@ -439,6 +439,7 @@ mod test {
         HaltEntitlement,
         WarnEntitlement,
         NoMoreEntitlement,
+        ForcedHotReload,
         Shutdown,
     }
 
@@ -457,6 +458,7 @@ mod test {
                 }
                 Event::UpdateEntitlement(_) => SimpleEvent::UpdateEntitlement,
                 Event::NoMoreEntitlement => SimpleEvent::NoMoreEntitlement,
+                Event::ForcedHotReload => SimpleEvent::ForcedHotReload,
                 Event::Shutdown => SimpleEvent::Shutdown,
             }
         }

--- a/apollo-router/tests/lifecycle_tests.rs
+++ b/apollo-router/tests/lifecycle_tests.rs
@@ -122,3 +122,20 @@ async fn test_graceful_shutdown() -> Result<(), BoxError> {
 
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_force_hot_reload() -> Result<(), BoxError> {
+    let mut router = IntegrationTest::builder()
+        .config(
+            "experimental_chaos:
+                force_hot_reload: 10s",
+        )
+        .build()
+        .await;
+    router.start().await;
+    router.assert_started().await;
+    tokio::time::sleep(Duration::from_secs(11)).await;
+    router.assert_reloaded().await;
+    router.graceful_shutdown().await;
+    Ok(())
+}


### PR DESCRIPTION
The Router can now artificially be made to hot-reload (as if the configuration or schema had changed) at a configured time interval. This can help reproduce issues like reload-related memory leaks.

The new configuration section for chaos testing is marked as experimental.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
