### PR TITLE
Add manually configured http reqwest client config for otlp exporter over http

### DIFF
--- a/apollo-router/src/plugins/telemetry/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/otlp.rs
@@ -82,8 +82,14 @@ impl Config {
             }
             Protocol::Http => {
                 let http = self.http.clone();
+                let client = reqwest::Client::builder()
+                    .connect_timeout(self.batch_processor.max_export_timeout)
+                    .timeout(self.batch_processor.max_export_timeout)
+                    .build()?;
+
                 let exporter = opentelemetry_otlp::new_exporter()
                     .http()
+                    .with_http_client(client)
                     .with_env()
                     .with_timeout(self.batch_processor.max_export_timeout)
                     .with_endpoint(endpoint.as_str())


### PR DESCRIPTION
It seems that http timeout settings are currently ignored on the otlp side, so we need to use a manually configured client.


Fixes #2959

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
