### PR TITLE
Convert span metrics exporter into a dedicated span processor 

### DIFF
--- a/.changesets/fix_create_shout_advertisement_swirl.md
+++ b/.changesets/fix_create_shout_advertisement_swirl.md
@@ -1,0 +1,6 @@
+### Improve performance of span metrics ([Issue #ISSUE_NUMBER](https://github.com/apollographql/router/issues/3008))
+
+The Router surfaces metrics about span durations. This used to be implemented as an OTel Exporter. However, this is costly as the spans are sent over a channel to be processed.
+Instead, the processing of spans to metrics is noe implemented as a `SpanProcessor` directly.
+
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/3009

--- a/apollo-router/src/plugins/telemetry/metrics/span_metrics_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/span_metrics_exporter.rs
@@ -1,9 +1,9 @@
 use async_trait::async_trait;
-use futures::future::BoxFuture;
-use futures::FutureExt;
-use opentelemetry::sdk::export::trace::ExportResult;
 use opentelemetry::sdk::export::trace::SpanData;
-use opentelemetry::sdk::export::trace::SpanExporter;
+use opentelemetry::sdk::trace::Span;
+use opentelemetry::sdk::trace::SpanProcessor;
+use opentelemetry::trace::TraceResult;
+use opentelemetry::Context;
 use opentelemetry::Key;
 use opentelemetry::Value;
 
@@ -26,15 +26,13 @@ const IDLE_NS_ATTRIBUTE_NAME: Key = Key::from_static_str("idle_ns");
 const SUBGRAPH_ATTRIBUTE_NAME: Key = Key::from_static_str("apollo.subgraph.name");
 
 #[derive(Debug, Default)]
-pub(crate) struct Exporter {}
+pub(crate) struct Processor {}
 #[async_trait]
-impl SpanExporter for Exporter {
+impl SpanProcessor for Processor {
+    fn on_start(&self, _span: &mut Span, _cx: &Context) {}
     /// Export spans metrics to real metrics
-    fn export(&mut self, batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
-        for span in batch
-            .into_iter()
-            .filter(|s| SPAN_NAMES.contains(&s.name.as_ref()))
-        {
+    fn on_end(&self, span: SpanData) {
+        if SPAN_NAMES.contains(&span.name.as_ref()) {
             let busy = span
                 .attributes
                 .get(&BUSY_NS_ATTRIBUTE_NAME)
@@ -75,7 +73,13 @@ impl SpanExporter for Exporter {
                 ::tracing::info!(histogram.apollo_router_span = busy, kind = %"busy", span = %span.name);
             }
         }
+    }
 
-        async { Ok(()) }.boxed()
+    fn force_flush(&self) -> TraceResult<()> {
+        Ok(())
+    }
+
+    fn shutdown(&mut self) -> TraceResult<()> {
+        Ok(())
     }
 }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -597,7 +597,7 @@ impl Telemetry {
         builder = setup_tracing(builder, &tracing_config.otlp, &trace_config)?;
         builder = setup_tracing(builder, &config.apollo, &trace_config)?;
         // For metrics
-        builder = builder.with_simple_exporter(metrics::span_metrics_exporter::Exporter::default());
+        builder = builder.with_span_processor(metrics::span_metrics_exporter::Processor::default());
 
         let tracer_provider = builder.build();
         Ok(tracer_provider)

--- a/licenses.html
+++ b/licenses.html
@@ -46,8 +46,8 @@
         <ul class="licenses-overview">
             <li><a href="#MIT">MIT License</a> (93)</li>
             <li><a href="#Apache-2.0">Apache License 2.0</a> (57)</li>
+            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (9)</li>
             <li><a href="#ISC">ISC License</a> (9)</li>
-            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (8)</li>
             <li><a href="#Elastic-2.0">Elastic License 2.0</a> (2)</li>
             <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (2)</li>
             <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a> (1)</li>
@@ -10907,6 +10907,79 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/dalek-cryptography/curve25519-dalek ">curve25519-dalek</a></li>
+                </ul>
+                <pre class="license-text">Copyright (c) 2016-2021 isis agora lovecruft. All rights reserved.
+Copyright (c) 2016-2021 Henry de Valence. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS
+IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+
+&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
+
+Portions of curve25519-dalek were originally derived from Adam Langley&#x27;s
+Go ed25519 implementation, found at &lt;https://github.com/agl/ed25519/&gt;,
+under the following licence:
+
+&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
+
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS
+IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/dalek-cryptography/x25519-dalek ">x25519-dalek</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017-2021 isis agora lovecruft. All rights reserved.
@@ -10980,7 +11053,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/dropbox/rust-alloc-no-stdlib ">alloc-stdlib</a></li>
-                    <li><a href=" https://github.com/dalek-cryptography/curve25519-dalek ">curve25519-dalek</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) &lt;year&gt; &lt;owner&gt;. 
 


### PR DESCRIPTION
This avoids the use of a crossbeam channel being used to send spans to the exporter which shows up in the perf flamgraph.
(It's only a minor improvement so we may decide not to merge this)

Fixes #3008

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
