### PR TITLE
Schema and config reloading now use async io

### DIFF
--- a/.changesets/fix_stagecoach_gown_sun_pellet.md
+++ b/.changesets/fix_stagecoach_gown_sun_pellet.md
@@ -3,6 +3,12 @@
 If you were using local schema or config then previously the Router was performing blocking IO in an async thread. This could have caused stalls to serving requests and was generally bad practice.
 The Router now uses async IO for all config and schema reloads.
 
-Fixing the above surfaced an issue with the experimental `force-hot-reload` feature introduced for testing. This has also been fixed. 
+Fixing the above surfaced an issue with the experimental `force_hot_reload` feature introduced for testing. This has also been fixed and renamed to `force_reload`. 
+
+```diff
+experimental_chaos:
+-    force_hot_reload: 1m
++    force_reload: 1m
+```
 
 By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/3016

--- a/.changesets/fix_stagecoach_gown_sun_pellet.md
+++ b/.changesets/fix_stagecoach_gown_sun_pellet.md
@@ -1,0 +1,8 @@
+### Config and schema reloads now use async IO ([Issue #2613](https://github.com/apollographql/router/issues/2613))
+
+If you were using local schema or config then previously the Router was performing blocking IO in an async thread. This could have caused stalls to serving requests and was generally bad practice.
+The Router now uses async IO for all config and schema reloads.
+
+Fixing the above surfaced an issue with the experimental `force-hot-reload` feature introduced for testing. This has also been fixed. 
+
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/3016

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -1037,7 +1037,7 @@ pub(crate) struct Chaos {
     /// at a regular time interval.
     #[serde(with = "humantime_serde")]
     #[schemars(with = "Option<String>")]
-    pub(crate) force_hot_reload: Option<std::time::Duration>,
+    pub(crate) force_reload: Option<std::time::Duration>,
 }
 
 /// Listening address.

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -15,7 +15,6 @@ use yaml_rust::scanner::Marker;
 
 use super::expansion::coerce;
 use super::expansion::Expansion;
-use super::experimental::Discussed;
 use super::plugins;
 use super::yaml;
 use super::Configuration;
@@ -108,9 +107,6 @@ pub(crate) fn validate_yaml_configuration(
         }
     }
 
-    let discussed = Discussed::new();
-    discussed.log_experimental_used(&yaml);
-    discussed.log_preview_used(&yaml);
     let expanded_yaml = expansion.expand(&yaml)?;
     let parsed_yaml = super::yaml::parse(raw_yaml)?;
     if let Err(errors_it) = schema.validate(&expanded_yaml) {

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -581,11 +581,11 @@ expression: "&schema"
     "experimental_chaos": {
       "description": "Configuration for chaos testing, trying to reproduce bugs that require uncommon conditions. You probably don’t want this in production!",
       "default": {
-        "force_hot_reload": null
+        "force_reload": null
       },
       "type": "object",
       "properties": {
-        "force_hot_reload": {
+        "force_reload": {
           "description": "Force a hot reload of the Router (as if the schema or configuration had changed) at a regular time interval.",
           "default": null,
           "type": "string",

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -616,6 +616,7 @@ impl ReloadSource {
                     Poll::Ready(Some(Event::Reload))
                 }
                 // We must return pending even if the queue is empty, otherwise the stream will never be polled again
+                // The waker will still be used, so this won't end up in a hot loop.
                 Poll::Ready(None) => Poll::Pending,
                 Poll::Pending => Poll::Pending,
             }

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -9,9 +9,8 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::str::FromStr;
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
@@ -28,14 +27,15 @@ use hyper::Body;
 use thiserror::Error;
 use tokio::sync::RwLock;
 use tokio::task::spawn;
+use tokio_util::time::DelayQueue;
 use tower::BoxError;
 use tower::ServiceExt;
 use tracing_futures::WithSubscriber;
 use url::Url;
 
-use self::Event::ForcedHotReload;
 use self::Event::NoMoreConfiguration;
 use self::Event::NoMoreSchema;
+use self::Event::Reload;
 use self::Event::Shutdown;
 use self::Event::UpdateConfiguration;
 use self::Event::UpdateSchema;
@@ -374,44 +374,8 @@ impl ConfigurationSource {
                                     })
                                     .boxed()
                             } else {
-                                #[cfg(any(test, not(unix)))]
-                                {
-                                    stream::once(future::ready(UpdateConfiguration(configuration)))
-                                        .boxed()
-                                }
-                                #[cfg(all(not(test), unix))]
-                                {
-                                    let mut signal = tokio::signal::unix::signal(
-                                        tokio::signal::unix::SignalKind::hangup(),
-                                    )
-                                    .expect("Failed to install SIGHUP signal handler");
-
-                                    let signal_stream =
-                                        futures::stream::poll_fn(move |cx| signal.poll_recv(cx))
-                                            .filter_map(move |_| {
-                                                let path = path.clone();
-                                                async move {
-                                                    match ConfigurationSource::read_config_async(
-                                                        &path,
-                                                    )
-                                                    .await
-                                                    {
-                                                        Ok(configuration) => {
-                                                            Some(UpdateConfiguration(configuration))
-                                                        }
-                                                        Err(err) => {
-                                                            tracing::error!("{}", err);
-                                                            None
-                                                        }
-                                                    }
-                                                }
-                                            })
-                                            .boxed();
-                                    stream::once(future::ready(UpdateConfiguration(configuration)))
-                                        .boxed()
-                                        .chain(signal_stream)
-                                        .boxed()
-                                }
+                                stream::once(future::ready(UpdateConfiguration(configuration)))
+                                    .boxed()
                             }
                         }
                         Err(err) => {
@@ -603,64 +567,61 @@ enum ReadConfigError {
     Validation(crate::configuration::ConfigurationError),
 }
 
-pub(crate) struct ForcedHotReloadSource {
-    config: Arc<ForcedHotReloadConfig>,
-    timer: Option<tokio::time::Interval>,
-}
-
 #[derive(Default)]
-pub(crate) struct ForcedHotReloadConfig {
-    interval_seconds: AtomicU64, // zero: disabled
+struct ReloadSourceInner {
+    queue: DelayQueue<()>,
+    period: Option<Duration>,
 }
 
-impl ForcedHotReloadConfig {
-    pub(crate) fn period(&self) -> Option<Duration> {
-        match self.interval_seconds.load(Ordering::Acquire) {
-            0 => None,
-            secs => Some(Duration::from_secs(secs)),
+/// Reload source is an internal event emitter for the state machine that will send reload events on SIGUP and/or on a timer.
+#[derive(Clone, Default)]
+pub(crate) struct ReloadSource {
+    inner: Arc<Mutex<ReloadSourceInner>>,
+}
+
+impl ReloadSource {
+    fn set_period(&self, period: &Option<Duration>) {
+        let mut inner = self.inner.lock().unwrap();
+        // Clear the queue before setting the period
+        inner.queue.clear();
+        inner.period = *period;
+        if let Some(period) = period {
+            inner.queue.insert((), *period);
         }
     }
 
-    pub(crate) fn set_period(&self, new_period: Option<Duration>) {
-        let new_seconds = if let Some(duration) = new_period {
-            duration.as_secs().max(1) // round to at least 1 second
-        } else {
-            0
-        };
-        self.interval_seconds.store(new_seconds, Ordering::Release)
-    }
-}
+    fn into_stream(self) -> impl Stream<Item = Event> {
+        #[cfg(unix)]
+        let signal_stream = {
+            let mut signal = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::hangup())
+                .expect("Failed to install SIGHUP signal handler");
 
-impl ForcedHotReloadSource {
-    pub(crate) fn new(config: Arc<ForcedHotReloadConfig>) -> Self {
-        let mut new = Self {
-            config,
-            timer: None,
-        };
-        new.check_config();
-        new
-    }
-
-    fn check_config(&mut self) {
-        let configured = self.config.period();
-        if configured != self.timer.as_ref().map(|t| t.period()) {
-            self.timer = configured.map(|period| {
-                let mut interval = tokio::time::interval(period);
-                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-                interval
+            futures::stream::poll_fn(move |cx| match signal.poll_recv(cx) {
+                Poll::Ready(Some(_)) => Poll::Ready(Some(Event::Reload)),
+                Poll::Ready(None) => Poll::Ready(None),
+                Poll::Pending => Poll::Pending,
             })
-        }
-    }
+            .boxed()
+        };
+        #[cfg(not(unix))]
+        let signal_stream = futures::stream::empty().boxed();
 
-    fn into_stream(mut self) -> impl Stream<Item = Event> {
-        futures::stream::poll_fn(move |ctx: &mut Context<'_>| {
-            self.check_config();
-            if let Some(timer) = &mut self.timer {
-                timer.poll_tick(ctx).map(|_| Some(Event::ForcedHotReload))
-            } else {
-                Poll::Pending
+        let periodic_reload = futures::stream::poll_fn(move |cx| {
+            let mut inner = self.inner.lock().unwrap();
+            match inner.queue.poll_expired(cx) {
+                Poll::Ready(Some(_expired)) => {
+                    if let Some(period) = inner.period {
+                        inner.queue.insert((), period);
+                    }
+                    Poll::Ready(Some(Event::Reload))
+                }
+                // We must return pending even if the queue is empty, otherwise the stream will never be polled again
+                Poll::Ready(None) => Poll::Pending,
+                Poll::Pending => Poll::Pending,
             }
-        })
+        });
+
+        futures::stream::select(signal_stream, periodic_reload)
     }
 }
 
@@ -812,7 +773,7 @@ impl RouterHttpServer {
         shutdown: Option<ShutdownSource>,
     ) -> RouterHttpServer {
         let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
-        let (event_stream, forced_hot_reload_config) = generate_event_stream(
+        let event_stream = generate_event_stream(
             shutdown.unwrap_or(ShutdownSource::CtrlC),
             configuration.unwrap_or_default(),
             schema,
@@ -821,8 +782,7 @@ impl RouterHttpServer {
         );
         let server_factory = AxumHttpServerFactory::new();
         let router_factory = OrbiterRouterSuperServiceFactory::new(YamlRouterFactory::default());
-        let state_machine =
-            StateMachine::new(server_factory, router_factory, forced_hot_reload_config);
+        let state_machine = StateMachine::new(server_factory, router_factory);
         let listen_addresses = state_machine.listen_addresses.clone();
         let result = spawn(
             async move { state_machine.process_events(event_stream).await }
@@ -903,7 +863,7 @@ pub(crate) enum Event {
     NoMoreEntitlement,
 
     /// Artificial hot reload for chaos testing
-    ForcedHotReload,
+    Reload,
 
     /// The server should gracefully shutdown.
     Shutdown,
@@ -930,7 +890,7 @@ impl Debug for Event {
             NoMoreEntitlement => {
                 write!(f, "NoMoreEntitlement")
             }
-            ForcedHotReload => {
+            Reload => {
                 write!(f, "ForcedHotReload")
             }
             Shutdown => {
@@ -965,23 +925,30 @@ fn generate_event_stream(
     schema: SchemaSource,
     entitlement: EntitlementSource,
     shutdown_receiver: oneshot::Receiver<()>,
-) -> (impl Stream<Item = Event>, Arc<ForcedHotReloadConfig>) {
-    let forced_hot_reload_config = Arc::new(ForcedHotReloadConfig::default());
-    // Chain is required so that the final shutdown message is sent.
+) -> impl Stream<Item = Event> {
+    let reload_source = ReloadSource::default();
+
     let stream = stream::select_all(vec![
         shutdown.into_stream().boxed(),
-        configuration.into_stream().boxed(),
         schema.into_stream().boxed(),
         entitlement.into_stream().boxed(),
-        ForcedHotReloadSource::new(forced_hot_reload_config.clone())
+        reload_source.clone().into_stream().boxed(),
+        configuration
             .into_stream()
+            .map(move |config_event| {
+                if let Event::UpdateConfiguration(config) = &config_event {
+                    reload_source.set_period(&config.experimental_chaos.force_reload)
+                }
+                config_event
+            })
             .boxed(),
         shutdown_receiver.into_stream().map(|_| Shutdown).boxed(),
     ])
     .take_while(|msg| future::ready(!matches!(msg, Shutdown)))
+    // Chain is required so that the final shutdown message is sent.
     .chain(stream::iter(vec![Shutdown]))
     .boxed();
-    (stream, forced_hot_reload_config)
+    stream
 }
 
 #[cfg(test)]

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -9,10 +9,10 @@ use tokio::sync::mpsc;
 use tokio::sync::OwnedRwLockWriteGuard;
 use tokio::sync::RwLock;
 use ApolloRouterError::ServiceCreationError;
-use Event::ForcedHotReload;
 use Event::NoMoreConfiguration;
 use Event::NoMoreEntitlement;
 use Event::NoMoreSchema;
+use Event::Reload;
 use Event::Shutdown;
 
 use super::http_server_factory::HttpServerFactory;
@@ -30,7 +30,6 @@ use super::state_machine::State::Stopped;
 use crate::configuration::Configuration;
 use crate::configuration::ListenAddr;
 use crate::router::Event::UpdateEntitlement;
-use crate::router::ForcedHotReloadConfig;
 use crate::router_factory::RouterFactory;
 use crate::router_factory::RouterSuperServiceFactory;
 use crate::spec::Schema;
@@ -296,10 +295,6 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
             entitlement
         };
 
-        state_machine
-            .forced_hot_reload_config
-            .set_period(configuration.experimental_chaos.force_hot_reload);
-
         let router_service_factory = state_machine
             .router_configurator
             .create(
@@ -375,7 +370,6 @@ where
     router_configurator: FA,
     pub(crate) listen_addresses: Arc<RwLock<ListenAddresses>>,
     listen_addresses_guard: Option<OwnedRwLockWriteGuard<ListenAddresses>>,
-    forced_hot_reload_config: Arc<ForcedHotReloadConfig>,
 }
 
 impl<S, FA> StateMachine<S, FA>
@@ -384,11 +378,7 @@ where
     FA: RouterSuperServiceFactory + Send,
     FA::RouterFactory: RouterFactory,
 {
-    pub(crate) fn new(
-        http_server_factory: S,
-        router_factory: FA,
-        forced_hot_reload_config: Arc<ForcedHotReloadConfig>,
-    ) -> Self {
+    pub(crate) fn new(http_server_factory: S, router_factory: FA) -> Self {
         // Listen address is created locked so that if a consumer tries to examine the listen address before the state machine has reached running state they are blocked.
         let listen_addresses: Arc<RwLock<ListenAddresses>> = Default::default();
         let listen_addresses_guard = Some(
@@ -402,7 +392,6 @@ where
             router_configurator: router_factory,
             listen_addresses,
             listen_addresses_guard,
-            forced_hot_reload_config,
         }
     }
 
@@ -444,7 +433,7 @@ where
                         .update_inputs(&mut self, None, None, Some(entitlement))
                         .await
                 }
-                ForcedHotReload => state.update_inputs(&mut self, None, None, None).await,
+                Reload => state.update_inputs(&mut self, None, None, None).await,
                 NoMoreEntitlement => state.no_more_entitlement().await,
                 Shutdown => state.shutdown().await,
             };
@@ -690,7 +679,7 @@ mod tests {
     async fn listen_addresses_are_locked() {
         let router_factory = create_mock_router_configurator(0);
         let (server_factory, _) = create_mock_server_factory(0);
-        let state_machine = StateMachine::new(server_factory, router_factory, Default::default());
+        let state_machine = StateMachine::new(server_factory, router_factory);
         assert!(state_machine.listen_addresses.try_read().is_err());
     }
 
@@ -1049,7 +1038,7 @@ mod tests {
         router_factory: MockMyRouterConfigurator,
         events: Vec<Event>,
     ) -> Result<(), ApolloRouterError> {
-        let state_machine = StateMachine::new(server_factory, router_factory, Default::default());
+        let state_machine = StateMachine::new(server_factory, router_factory);
         state_machine
             .process_events(stream::iter(events).boxed())
             .await

--- a/apollo-router/src/uplink/entitlement_stream.rs
+++ b/apollo-router/src/uplink/entitlement_stream.rs
@@ -458,7 +458,7 @@ mod test {
                 }
                 Event::UpdateEntitlement(_) => SimpleEvent::UpdateEntitlement,
                 Event::NoMoreEntitlement => SimpleEvent::NoMoreEntitlement,
-                Event::ForcedHotReload => SimpleEvent::ForcedHotReload,
+                Event::Reload => SimpleEvent::ForcedHotReload,
                 Event::Shutdown => SimpleEvent::Shutdown,
             }
         }

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -466,6 +466,14 @@ impl IntegrationTest {
         panic!("unable to shutdown router, this probably means a hang and should be investigated");
     }
 
+    #[allow(dead_code)]
+    #[cfg(target_family = "unix")]
+    pub async fn send_sighup(&mut self) {
+        unsafe {
+            libc::kill(self.pid(), libc::SIGHUP);
+        }
+    }
+
     #[cfg(target_os = "linux")]
     pub fn dump_stack_traces(&mut self) {
         if let Ok(trace) = rstack::TraceOptions::new()

--- a/apollo-router/tests/lifecycle_tests.rs
+++ b/apollo-router/tests/lifecycle_tests.rs
@@ -129,13 +129,13 @@ async fn test_force_hot_reload() -> Result<(), BoxError> {
     let mut router = IntegrationTest::builder()
         .config(
             "experimental_chaos:
-                force_hot_reload: 10s",
+                force_reload: 1s",
         )
         .build()
         .await;
     router.start().await;
     router.assert_started().await;
-    tokio::time::sleep(Duration::from_secs(11)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
     router.assert_reloaded().await;
     router.graceful_shutdown().await;
     Ok(())

--- a/apollo-router/tests/lifecycle_tests.rs
+++ b/apollo-router/tests/lifecycle_tests.rs
@@ -125,7 +125,7 @@ async fn test_graceful_shutdown() -> Result<(), BoxError> {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_force_hot_reload() -> Result<(), BoxError> {
+async fn test_force_reload() -> Result<(), BoxError> {
     let mut router = IntegrationTest::builder()
         .config(
             "experimental_chaos:
@@ -136,6 +136,21 @@ async fn test_force_hot_reload() -> Result<(), BoxError> {
     router.start().await;
     router.assert_started().await;
     tokio::time::sleep(Duration::from_secs(2)).await;
+    router.assert_reloaded().await;
+    router.graceful_shutdown().await;
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread")]
+async fn test_reload_via_sighup() -> Result<(), BoxError> {
+    let mut router = IntegrationTest::builder()
+        .config(HAPPY_CONFIG)
+        .build()
+        .await;
+    router.start().await;
+    router.assert_started().await;
+    router.send_sighup().await;
     router.assert_reloaded().await;
     router.graceful_shutdown().await;
     Ok(())

--- a/apollo-router/tests/lifecycle_tests.rs
+++ b/apollo-router/tests/lifecycle_tests.rs
@@ -211,9 +211,9 @@ async fn test_experimental_notice() {
         .build()
         .await;
     router.start().await;
+    router.assert_started().await;
     router
         .assert_log_contains("You're using some \\\"experimental\\\" features of the Apollo Router")
         .await;
-    router.assert_started().await;
     router.graceful_shutdown().await;
 }


### PR DESCRIPTION
If you were using local schema or config then previously the Router was performing blocking IO in an async thread. This could have caused stalls to serving requests and was generally bad practice.
The Router now uses async IO for all config and schema reloads.

Fixing the above surfaced an issue with the experimental `force_hot_reload` feature introduced for testing. This has also been fixed and renamed to `force_reload`. 

```diff
experimental_chaos:
-    force_hot_reload: 1m
+    force_reload: 1m
```

The context around the issue with force hot reload is that if the stream was ever determined to be empty then it would never get polled again and therefore it would not have the opportunity to update when it would produce a reload event on config change.

Fixes #2613

*Description here*

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- Performance impact assessed and acceptable
  - [x] pr - Basic stress test that finds the max RPS when no features are configured
  - [x] reload - Reload test over a long period of time
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
