### PR TITLE
docs: Rename router docset

### DIFF
--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -1,5 +1,5 @@
 {
-  "title": "Router",
+  "title": "Router (self-hosted)",
   "algoliaFilters": [
     "docset:router"
   ],


### PR DESCRIPTION
This (hopefully) helps clarify that this docset is specific to self-hosting the router as opposed to managing cloud routing via GraphOS.