### PR TITLE
docs: need to propagate "cookie" header for allow_credentials to work

### DIFF
--- a/docs/source/configuration/cors.mdx
+++ b/docs/source/configuration/cors.mdx
@@ -70,6 +70,16 @@ cors:
   allow_credentials: true
 ```
 
+Additionally, you'll need to configure the router to forward the [`Cookie`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie) header to some (or all) of your subgraphs:
+
+```yaml title="router.yaml"
+headers:
+  all:
+    request:
+      - propagate:
+          named: cookie
+```
+
 For examples of sending cookies and authorization headers from Apollo Client, see [Authentication](/react/networking/authentication/).
 
 


### PR DESCRIPTION
*Description here*

It took me a while to figure out that my HTTP cookies weren't reaching my subgraphs because I hadn't configured my router to propagate the `cookie` header, like so:

```yaml
headers:
  all:
    request:
      - propagate:
          named: cookie
```

Figured I'd add this to the docs to help other folks out.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
