### PR TITLE
test multiple keys matching a JWT criteria

### DIFF
--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -571,7 +571,9 @@ async fn it_finds_key_with_criteria_kid_and_algorithm() {
 
     let (_issuer, key) = search_jwks(&jwks_manager, &criteria)
         .expect("search worked")
-        .expect("found a key");
+        .expect("found a key")
+        .pop()
+        .expect("list isn't empty");
     assert_eq!(Algorithm::HS256, key.common.algorithm.unwrap());
     assert_eq!("key2", key.common.key_id.unwrap());
 }
@@ -587,7 +589,9 @@ async fn it_finds_best_matching_key_with_criteria_algorithm() {
 
     let (_issuer, key) = search_jwks(&jwks_manager, &criteria)
         .expect("search worked")
-        .expect("found a key");
+        .expect("found a key")
+        .pop()
+        .expect("list isn't empty");
     assert_eq!(Algorithm::HS256, key.common.algorithm.unwrap());
     assert_eq!("key1", key.common.key_id.unwrap());
 }
@@ -617,7 +621,9 @@ async fn it_finds_key_with_criteria_algorithm_ec() {
 
     let (_issuer, key) = search_jwks(&jwks_manager, &criteria)
         .expect("search worked")
-        .expect("found a key");
+        .expect("found a key")
+        .pop()
+        .expect("list isn't empty");
     assert_eq!(Algorithm::ES256, key.common.algorithm.unwrap());
     assert_eq!(
         "afda85e09a320cf748177874592de64d",
@@ -636,7 +642,9 @@ async fn it_finds_key_with_criteria_algorithm_rsa() {
 
     let (_issuer, key) = search_jwks(&jwks_manager, &criteria)
         .expect("search worked")
-        .expect("found a key");
+        .expect("found a key")
+        .pop()
+        .expect("list isn't empty");
     assert_eq!(Algorithm::RS256, key.common.algorithm.unwrap());
     assert_eq!(
         "022516583d56b68faf40260fda72978a",


### PR DESCRIPTION
Fix #3017

in some cases, multiple keys can match what a JWT asks (algorithm and optional kid). Previously, we scored each possible match and only took the one with the highest score. But even then, we can have multiple keys with the same score (example: colliding kid between multiple JWKS in tests).
This changes the behaviour to:
- return a list of matching key instead of the one with the highest score
- try them one by one until the JWT is validated, or return an error
- if some keys were found with the highest possible score (matching alg, kid is present and matching too), then we only test those ones

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
