### PR TITLE
make sure the compression state is flushed

### DIFF
--- a/.changesets/fix_geal_fix_compression_finish.md
+++ b/.changesets/fix_geal_fix_compression_finish.md
@@ -1,5 +1,5 @@
 ### make sure the compression state is flushed ([Issue #3035](https://github.com/apollographql/router/issues/3035))
 
-In some cases, the "finish" call to flush the compression state at the end does not flush th entire state, so it has to be called multiple times.
+In some cases, the "finish" call to flush the compression state at the end does not flush the entire state, so it has to be called multiple times.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3037

--- a/.changesets/fix_geal_fix_compression_finish.md
+++ b/.changesets/fix_geal_fix_compression_finish.md
@@ -1,0 +1,5 @@
+### make sure the compression state is flushed ([Issue #3035](https://github.com/apollographql/router/issues/3035))
+
+In some cases, the "finish" call to flush the compression state at the end does not flush th entire state, so it has to be called multiple times.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3037

--- a/.changesets/fix_geal_fix_compression_finish.md
+++ b/.changesets/fix_geal_fix_compression_finish.md
@@ -2,4 +2,6 @@
 
 In some cases, the "finish" call to flush the compression state at the end does not flush the entire state, so it has to be called multiple times.
 
+This fixes a regression introduced in 1.16.0 by [#2986](https://github.com/apollographql/router/pull/2986) where large responses would be cut short when compressed.
+
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3037

--- a/apollo-router/src/axum_factory/compression/mod.rs
+++ b/apollo-router/src/axum_factory/compression/mod.rs
@@ -138,7 +138,9 @@ where {
 
                         let mut buf = partial_output.into_inner();
                         buf.resize(len, 0);
-                        let _ = tx.send(Ok(buf.freeze())).await;
+                        if (tx.send(Ok(buf.freeze())).await).is_err() {
+                            return;
+                        }
                         if is_flushed {
                             break;
                         }

--- a/apollo-router/src/axum_factory/compression/mod.rs
+++ b/apollo-router/src/axum_factory/compression/mod.rs
@@ -100,7 +100,10 @@ where {
                                 // so we resize and add more data
                                 if partial_output.unwritten().is_empty() {
                                     let _ = partial_output.into_inner();
-                                    buf.reserve(written);
+                                    buf.resize(
+                                        buf.len() + partial_input.unwritten().len() / 10,
+                                        0u8,
+                                    );
                                 }
                             } else {
                                 match self.flush(&mut partial_output) {

--- a/apollo-router/src/axum_factory/compression/mod.rs
+++ b/apollo-router/src/axum_factory/compression/mod.rs
@@ -79,7 +79,8 @@ where {
                         }
                     }
                     Ok(data) => {
-                        let mut buf = BytesMut::zeroed(1024);
+                        // most compression algorithms have a compression ratio of more than 90% for JSON
+                        let mut buf = BytesMut::zeroed(data.len() / 10);
                         let mut written = 0usize;
 
                         let mut partial_input = PartialBuffer::new(&*data);


### PR DESCRIPTION
Fix #3035

In some cases, the "finish" call to flush the compression state at the end does not flush th entire state, so it has to be called multiple times.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
