### PR TITLE
GraphOS Enterprise: operation limits

### DIFF
--- a/.changesets/feat_operation_limits.md
+++ b/.changesets/feat_operation_limits.md
@@ -1,0 +1,18 @@
+### GraphOS Enterprise: operation limits
+
+You can define [operation limits](https://www.apollographql.com/docs/router/configuration/operation-limits) in your router's configuration to reject potentially malicious requests. An operation that exceeds _any_ specified limit is rejected.
+
+You define operation limits in your router's [YAML config file](https://www.apollographql.com/docs/router/configuration/overview#yaml-config-file), like so:
+
+```yaml
+supergraph:
+  limits:
+    max_depth: 100
+    max_height: 200
+    max_aliases: 30
+    max_root_fields: 20
+```
+
+See details in [operation limits documentation](https://www.apollographql.com/docs/router/configuration/operation-limits).
+
+By [@SimonSapin](https://github.com/SimonSapin), [@lrlna](https://github.com/lrlna), and [@StephenBarlow](https://github.com/StephenBarlow)

--- a/.changesets/feat_operation_limits.md
+++ b/.changesets/feat_operation_limits.md
@@ -5,12 +5,11 @@ You can define [operation limits](https://www.apollographql.com/docs/router/conf
 You define operation limits in your router's [YAML config file](https://www.apollographql.com/docs/router/configuration/overview#yaml-config-file), like so:
 
 ```yaml
-supergraph:
-  limits:
-    max_depth: 100
-    max_height: 200
-    max_aliases: 30
-    max_root_fields: 20
+preview_operation_limits:
+  max_depth: 100
+  max_height: 200
+  max_aliases: 30
+  max_root_fields: 20
 ```
 
 See details in [operation limits documentation](https://www.apollographql.com/docs/router/configuration/operation-limits).

--- a/apollo-router/feature_discussions.json
+++ b/apollo-router/feature_discussions.json
@@ -4,5 +4,7 @@
     "experimental_response_trace_id": "https://github.com/apollographql/router/discussions/2147",
     "experimental_logging": "https://github.com/apollographql/router/discussions/1961"
   },
-  "preview": {}
+  "preview": {
+    "preview_operation_limits": "https://github.com/apollographql/router/discussions/3040"
+  }
 }

--- a/apollo-router/src/configuration/migrations/0007-parser-recursion.yaml
+++ b/apollo-router/src/configuration/migrations/0007-parser-recursion.yaml
@@ -2,6 +2,6 @@ description: server.experimental_parser_recursion_limit moved to supergraph.limi
 actions:
   - type: move
     from: server.experimental_parser_recursion_limit
-    to: supergraph.preview_limits.parser_max_recursion
+    to: preview_operation_limits.parser_max_recursion
   - type: delete
     path: server

--- a/apollo-router/src/configuration/migrations/0007-parser-recursion.yaml
+++ b/apollo-router/src/configuration/migrations/0007-parser-recursion.yaml
@@ -2,6 +2,6 @@ description: server.experimental_parser_recursion_limit moved to supergraph.limi
 actions:
   - type: move
     from: server.experimental_parser_recursion_limit
-    to: supergraph.limits.parser_max_recursion
+    to: supergraph.preview_limits.parser_max_recursion
   - type: delete
     path: server

--- a/apollo-router/src/configuration/migrations/0007-parser-recursion.yaml
+++ b/apollo-router/src/configuration/migrations/0007-parser-recursion.yaml
@@ -1,0 +1,7 @@
+description: server.experimental_parser_recursion_limit moved to supergraph.limits.parser_max_recursion, not experimental anymore. remove the server section, now empty
+actions:
+  - type: move
+    from: server.experimental_parser_recursion_limit
+    to: supergraph.limits.parser_max_recursion
+  - type: delete
+    path: server

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -465,8 +465,10 @@ pub(crate) struct Supergraph {
     /// Query planning options
     pub(crate) query_planning: QueryPlanning,
 
-    /// Query complexity limiting
-    pub(crate) limits: Limits,
+    // NOTE: when renaming this to move out of preview, also update paths
+    // in `configuration/expansion.rs` and `uplink/entitlement.rs`.
+    /// Operation limits
+    pub(crate) preview_limits: Limits,
 }
 
 fn default_defer_support() -> bool {
@@ -490,7 +492,7 @@ impl Supergraph {
             introspection: introspection.unwrap_or_else(default_graphql_introspection),
             defer_support: defer_support.unwrap_or_else(default_defer_support),
             query_planning: query_planning.unwrap_or_default(),
-            limits: limits.unwrap_or_default(),
+            preview_limits: limits.unwrap_or_default(),
         }
     }
 }
@@ -513,7 +515,7 @@ impl Supergraph {
             introspection: introspection.unwrap_or_else(default_graphql_introspection),
             defer_support: defer_support.unwrap_or_else(default_defer_support),
             query_planning: query_planning.unwrap_or_default(),
-            limits: limits.unwrap_or_default(),
+            preview_limits: limits.unwrap_or_default(),
         }
     }
 }
@@ -541,7 +543,7 @@ impl Supergraph {
     }
 }
 
-/// Configuration options pertaining to the supergraph server component.
+/// Configuration for operation limits
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 #[serde(default)]

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -550,7 +550,25 @@ pub(crate) struct Limits {
     /// are rejected with a HTTP 400 Bad Request response and GraphQL error with
     /// `"extensions": {"code": "MAX_DEPTH_LIMIT"}`
     ///
-    /// TODO: define depth
+    /// Counts depth of an operation, looking at its selection sets,
+    /// including fields in fragments and inline fragments. The following
+    /// example has a depth of 3.
+    ///
+    /// ```graphql
+    /// query getProduct {
+    ///   book { # 1
+    ///     ...bookDetails
+    ///   }
+    /// }
+    ///
+    /// fragment bookDetails on Book {
+    ///   details { # 2
+    ///     ... on ProductDetailsBook {
+    ///       country # 3
+    ///     }
+    ///   }
+    /// }
+    /// ```
     pub(crate) max_depth: Option<u32>,
 
     /// If set, requests with operations higher than this maximum
@@ -578,7 +596,8 @@ pub(crate) struct Limits {
     /// are rejected with a HTTP 400 Bad Request response and GraphQL error with
     /// `"extensions": {"code": "MAX_ROOT_FIELDS_LIMIT"}`
     ///
-    /// TODO: define root fields (e.g. in the presence of fragment)
+    /// This limit counts only the top level fields in a selection set,
+    /// including fragments and inline fragments.
     pub(crate) max_root_fields: Option<u32>,
 
     /// If set, requests with operations with more aliases than this maximum
@@ -594,6 +613,9 @@ pub(crate) struct Limits {
     /// Limit recursion in the GraphQL parser to protect against stack overflow.
     /// default: 4096
     pub(crate) parser_max_recursion: usize,
+
+    /// Limit the number of tokens the GraphQL parser processes before aborting.
+    pub(crate) parser_max_tokens: usize,
 }
 
 #[allow(clippy::derivable_impls)] //  explicit is better here
@@ -611,6 +633,7 @@ impl Default for Limits {
             // but is still very high for "reasonable" queries.
             // https://docs.rs/apollo-parser/0.2.8/src/apollo_parser/parser/mod.rs.html#368
             parser_max_recursion: 4096,
+            parser_max_tokens: 15_000,
         }
     }
 }

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1139,23 +1139,6 @@ expression: "&schema"
       },
       "additionalProperties": false
     },
-    "server": {
-      "description": "Configuration options pertaining to the http server component.",
-      "default": {
-        "experimental_parser_recursion_limit": 4096
-      },
-      "type": "object",
-      "properties": {
-        "experimental_parser_recursion_limit": {
-          "description": "Experimental limitation of query depth default: 4096",
-          "default": 4096,
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0.0
-        }
-      },
-      "additionalProperties": false
-    },
     "supergraph": {
       "description": "Configuration for the supergraph",
       "default": {
@@ -1177,7 +1160,8 @@ expression: "&schema"
           "max_height": null,
           "max_root_fields": null,
           "max_aliases": null,
-          "warn_only": false
+          "warn_only": false,
+          "parser_max_recursion": 4096
         }
       },
       "type": "object",
@@ -1199,7 +1183,8 @@ expression: "&schema"
             "max_height": null,
             "max_root_fields": null,
             "max_aliases": null,
-            "warn_only": false
+            "warn_only": false,
+            "parser_max_recursion": 4096
           },
           "type": "object",
           "properties": {
@@ -1234,6 +1219,13 @@ expression: "&schema"
               "format": "uint32",
               "minimum": 0.0,
               "nullable": true
+            },
+            "parser_max_recursion": {
+              "description": "Limit recursion in the GraphQL parser to protect against stack overflow. default: 4096",
+              "default": 4096,
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
             },
             "warn_only": {
               "description": "If set to true (which is the default is dev mode), requests that exceed a `max_*` limit are *not* rejected. Instead they are executed normally, and a warning is logged.",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1171,6 +1171,13 @@ expression: "&schema"
             "redis": null
           },
           "warmed_up_queries": 0
+        },
+        "limits": {
+          "max_depth": null,
+          "max_height": null,
+          "max_root_fields": null,
+          "max_aliases": null,
+          "warn_only": false
         }
       },
       "type": "object",
@@ -1184,6 +1191,57 @@ expression: "&schema"
           "description": "Enable introspection Default: false",
           "default": false,
           "type": "boolean"
+        },
+        "limits": {
+          "description": "Query complexity limiting",
+          "default": {
+            "max_depth": null,
+            "max_height": null,
+            "max_root_fields": null,
+            "max_aliases": null,
+            "warn_only": false
+          },
+          "type": "object",
+          "properties": {
+            "max_aliases": {
+              "description": "If set, requests with operations with more aliases than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ALIASES_LIMIT\"}`",
+              "default": null,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0,
+              "nullable": true
+            },
+            "max_depth": {
+              "description": "If set, requests with operations deeper than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nTODO: define depth",
+              "default": null,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0,
+              "nullable": true
+            },
+            "max_height": {
+              "description": "If set, requests with operations higher than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nHeight is based on simple merging of fields using the same name or alias, but only within the same selection set. For example `name` here is only counted once and the query has height 3, not 4:\n\n```graphql query { name { first } name { last } } ```\n\nThis may change in a future version of Apollo Router to do [full field merging across fragments][merging] instead.\n\n[merging]: https://spec.graphql.org/October2021/#sec-Field-Selection-Merging]",
+              "default": null,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0,
+              "nullable": true
+            },
+            "max_root_fields": {
+              "description": "If set, requests with operations with more root fields than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ROOT_FIELDS_LIMIT\"}`\n\nTODO: define root fields (e.g. in the presence of fragment)",
+              "default": null,
+              "type": "integer",
+              "format": "uint32",
+              "minimum": 0.0,
+              "nullable": true
+            },
+            "warn_only": {
+              "description": "If set to true (which is the default is dev mode), requests that exceed a `max_*` limit are *not* rejected. Instead they are executed normally, and a warning is logged.",
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "additionalProperties": false
         },
         "listen": {
           "description": "The socket address and port to listen on Defaults to 127.0.0.1:4000",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1161,7 +1161,8 @@ expression: "&schema"
           "max_root_fields": null,
           "max_aliases": null,
           "warn_only": false,
-          "parser_max_recursion": 4096
+          "parser_max_recursion": 4096,
+          "parser_max_tokens": 15000
         }
       },
       "type": "object",
@@ -1184,7 +1185,8 @@ expression: "&schema"
             "max_root_fields": null,
             "max_aliases": null,
             "warn_only": false,
-            "parser_max_recursion": 4096
+            "parser_max_recursion": 4096,
+            "parser_max_tokens": 15000
           },
           "type": "object",
           "properties": {
@@ -1197,7 +1199,7 @@ expression: "&schema"
               "nullable": true
             },
             "max_depth": {
-              "description": "If set, requests with operations deeper than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nTODO: define depth",
+              "description": "If set, requests with operations deeper than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nCounts depth of an operation, looking at its selection sets, including fields in fragments and inline fragments. The following example has a depth of 3.\n\n```graphql query getProduct { book { # 1 ...bookDetails } }\n\nfragment bookDetails on Book { details { # 2 ... on ProductDetailsBook { country # 3 } } } ```",
               "default": null,
               "type": "integer",
               "format": "uint32",
@@ -1213,7 +1215,7 @@ expression: "&schema"
               "nullable": true
             },
             "max_root_fields": {
-              "description": "If set, requests with operations with more root fields than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ROOT_FIELDS_LIMIT\"}`\n\nTODO: define root fields (e.g. in the presence of fragment)",
+              "description": "If set, requests with operations with more root fields than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ROOT_FIELDS_LIMIT\"}`\n\nThis limit counts only the top level fields in a selection set, including fragments and inline fragments.",
               "default": null,
               "type": "integer",
               "format": "uint32",
@@ -1223,6 +1225,13 @@ expression: "&schema"
             "parser_max_recursion": {
               "description": "Limit recursion in the GraphQL parser to protect against stack overflow. default: 4096",
               "default": 4096,
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            },
+            "parser_max_tokens": {
+              "description": "Limit the number of tokens the GraphQL parser processes before aborting.",
+              "default": 15000,
               "type": "integer",
               "format": "uint",
               "minimum": 0.0

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1107,6 +1107,73 @@ expression: "&schema"
       },
       "additionalProperties": false
     },
+    "preview_operation_limits": {
+      "description": "Operation limits",
+      "default": {
+        "max_depth": null,
+        "max_height": null,
+        "max_root_fields": null,
+        "max_aliases": null,
+        "warn_only": false,
+        "parser_max_recursion": 4096,
+        "parser_max_tokens": 15000
+      },
+      "type": "object",
+      "properties": {
+        "max_aliases": {
+          "description": "If set, requests with operations with more aliases than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ALIASES_LIMIT\"}`",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "max_depth": {
+          "description": "If set, requests with operations deeper than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nCounts depth of an operation, looking at its selection sets, including fields in fragments and inline fragments. The following example has a depth of 3.\n\n```graphql query getProduct { book { # 1 ...bookDetails } }\n\nfragment bookDetails on Book { details { # 2 ... on ProductDetailsBook { country # 3 } } } ```",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "max_height": {
+          "description": "If set, requests with operations higher than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nHeight is based on simple merging of fields using the same name or alias, but only within the same selection set. For example `name` here is only counted once and the query has height 3, not 4:\n\n```graphql query { name { first } name { last } } ```\n\nThis may change in a future version of Apollo Router to do [full field merging across fragments][merging] instead.\n\n[merging]: https://spec.graphql.org/October2021/#sec-Field-Selection-Merging]",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "max_root_fields": {
+          "description": "If set, requests with operations with more root fields than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ROOT_FIELDS_LIMIT\"}`\n\nThis limit counts only the top level fields in a selection set, including fragments and inline fragments.",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "parser_max_recursion": {
+          "description": "Limit recursion in the GraphQL parser to protect against stack overflow. default: 4096",
+          "default": 4096,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "parser_max_tokens": {
+          "description": "Limit the number of tokens the GraphQL parser processes before aborting.",
+          "default": 15000,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "warn_only": {
+          "description": "If set to true (which is the default is dev mode), requests that exceed a `max_*` limit are *not* rejected. Instead they are executed normally, and a warning is logged.",
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "rhai": {
       "description": "Configuration for the Rhai Plugin",
       "type": "object",
@@ -1154,15 +1221,6 @@ expression: "&schema"
             "redis": null
           },
           "warmed_up_queries": 0
-        },
-        "preview_limits": {
-          "max_depth": null,
-          "max_height": null,
-          "max_root_fields": null,
-          "max_aliases": null,
-          "warn_only": false,
-          "parser_max_recursion": 4096,
-          "parser_max_tokens": 15000
         }
       },
       "type": "object",
@@ -1195,73 +1253,6 @@ expression: "&schema"
           "description": "The HTTP path on which GraphQL requests will be served. default: \"/\"",
           "default": "/",
           "type": "string"
-        },
-        "preview_limits": {
-          "description": "Operation limits",
-          "default": {
-            "max_depth": null,
-            "max_height": null,
-            "max_root_fields": null,
-            "max_aliases": null,
-            "warn_only": false,
-            "parser_max_recursion": 4096,
-            "parser_max_tokens": 15000
-          },
-          "type": "object",
-          "properties": {
-            "max_aliases": {
-              "description": "If set, requests with operations with more aliases than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ALIASES_LIMIT\"}`",
-              "default": null,
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0.0,
-              "nullable": true
-            },
-            "max_depth": {
-              "description": "If set, requests with operations deeper than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nCounts depth of an operation, looking at its selection sets, including fields in fragments and inline fragments. The following example has a depth of 3.\n\n```graphql query getProduct { book { # 1 ...bookDetails } }\n\nfragment bookDetails on Book { details { # 2 ... on ProductDetailsBook { country # 3 } } } ```",
-              "default": null,
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0.0,
-              "nullable": true
-            },
-            "max_height": {
-              "description": "If set, requests with operations higher than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nHeight is based on simple merging of fields using the same name or alias, but only within the same selection set. For example `name` here is only counted once and the query has height 3, not 4:\n\n```graphql query { name { first } name { last } } ```\n\nThis may change in a future version of Apollo Router to do [full field merging across fragments][merging] instead.\n\n[merging]: https://spec.graphql.org/October2021/#sec-Field-Selection-Merging]",
-              "default": null,
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0.0,
-              "nullable": true
-            },
-            "max_root_fields": {
-              "description": "If set, requests with operations with more root fields than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ROOT_FIELDS_LIMIT\"}`\n\nThis limit counts only the top level fields in a selection set, including fragments and inline fragments.",
-              "default": null,
-              "type": "integer",
-              "format": "uint32",
-              "minimum": 0.0,
-              "nullable": true
-            },
-            "parser_max_recursion": {
-              "description": "Limit recursion in the GraphQL parser to protect against stack overflow. default: 4096",
-              "default": 4096,
-              "type": "integer",
-              "format": "uint",
-              "minimum": 0.0
-            },
-            "parser_max_tokens": {
-              "description": "Limit the number of tokens the GraphQL parser processes before aborting.",
-              "default": 15000,
-              "type": "integer",
-              "format": "uint",
-              "minimum": 0.0
-            },
-            "warn_only": {
-              "description": "If set to true (which is the default is dev mode), requests that exceed a `max_*` limit are *not* rejected. Instead they are executed normally, and a warning is logged.",
-              "default": false,
-              "type": "boolean"
-            }
-          },
-          "additionalProperties": false
         },
         "query_planning": {
           "description": "Query planning options",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1155,7 +1155,7 @@ expression: "&schema"
           },
           "warmed_up_queries": 0
         },
-        "limits": {
+        "preview_limits": {
           "max_depth": null,
           "max_height": null,
           "max_root_fields": null,
@@ -1177,8 +1177,27 @@ expression: "&schema"
           "default": false,
           "type": "boolean"
         },
-        "limits": {
-          "description": "Query complexity limiting",
+        "listen": {
+          "description": "The socket address and port to listen on Defaults to 127.0.0.1:4000",
+          "default": "127.0.0.1:4000",
+          "anyOf": [
+            {
+              "description": "Socket address.",
+              "type": "string"
+            },
+            {
+              "description": "Unix socket.",
+              "type": "string"
+            }
+          ]
+        },
+        "path": {
+          "description": "The HTTP path on which GraphQL requests will be served. default: \"/\"",
+          "default": "/",
+          "type": "string"
+        },
+        "preview_limits": {
+          "description": "Operation limits",
           "default": {
             "max_depth": null,
             "max_height": null,
@@ -1243,25 +1262,6 @@ expression: "&schema"
             }
           },
           "additionalProperties": false
-        },
-        "listen": {
-          "description": "The socket address and port to listen on Defaults to 127.0.0.1:4000",
-          "default": "127.0.0.1:4000",
-          "anyOf": [
-            {
-              "description": "Socket address.",
-              "type": "string"
-            },
-            {
-              "description": "Unix socket.",
-              "type": "string"
-            }
-          ]
-        },
-        "path": {
-          "description": "The HTTP path on which GraphQL requests will be served. default: \"/\"",
-          "default": "/",
-          "type": "string"
         },
         "query_planning": {
           "description": "Query planning options",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@parser_recursion.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@parser_recursion.router.yaml.snap
@@ -4,6 +4,6 @@ expression: new_config
 ---
 ---
 supergraph:
-  limits:
+  preview_limits:
     parser_max_recursion: 100
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@parser_recursion.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@parser_recursion.router.yaml.snap
@@ -1,0 +1,9 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+---
+---
+supergraph:
+  limits:
+    parser_max_recursion: 100
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@parser_recursion.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@parser_recursion.router.yaml.snap
@@ -3,7 +3,6 @@ source: apollo-router/src/configuration/tests.rs
 expression: new_config
 ---
 ---
-supergraph:
-  preview_limits:
-    parser_max_recursion: 100
+preview_operation_limits:
+  parser_max_recursion: 100
 

--- a/apollo-router/src/configuration/testdata/migrations/parser_recursion.router.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/parser_recursion.router.yaml
@@ -1,0 +1,2 @@
+server:
+  experimental_parser_recursion_limit: 100

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -301,23 +301,6 @@ impl IntoGraphQLErrors for QueryPlannerError {
     }
 }
 
-impl ErrorExtension for QueryPlannerError {
-    fn extension_code(&self) -> String {
-        match self {
-            QueryPlannerError::SchemaValidationErrors(_) => "SCHEMA_VALIDATION_ERRORS",
-            QueryPlannerError::PlanningErrors(_) => "PLANNING_ERRORS",
-            QueryPlannerError::JoinError(_) => "JOIN_ERROR",
-            QueryPlannerError::CacheResolverError(_) => "CACHE_RESOLVER_ERROR",
-            QueryPlannerError::EmptyPlan(_) => "EMPTY_PLAN",
-            QueryPlannerError::UnhandledPlannerResult => "UNHANDLED_PLANNER_RESULT",
-            QueryPlannerError::RouterBridgeError(_) => "ROUTER_BRIDGE_ERROR",
-            QueryPlannerError::SpecError(_) => "SPEC_ERROR",
-            QueryPlannerError::Introspection(_) => "INTROSPECTION",
-        }
-        .to_string()
-    }
-}
-
 #[derive(Clone, Debug, Error, Serialize, Deserialize)]
 /// Container for planner setup errors
 pub(crate) struct PlannerErrors(Arc<Vec<PlannerError>>);

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -127,19 +127,21 @@ impl BridgeQueryPlanner {
         self.schema.clone()
     }
 
-    async fn parse_selections(&self, query: String) -> Result<Query, QueryPlannerError> {
+    async fn parse_selections(&self, key: QueryKey) -> Result<Query, QueryPlannerError> {
+        let (query, operation_name) = key;
         let schema = self.schema.clone();
         let configuration = self.configuration.clone();
-        let query_parsing_future =
-            tokio::task::spawn_blocking(move || Query::parse(query, &schema, &configuration))
-                .instrument(tracing::info_span!("parse_query", "otel.kind" = "INTERNAL"));
-        match query_parsing_future.await {
-            Ok(res) => res.map_err(QueryPlannerError::from),
-            Err(err) => {
-                failfast_debug!("parsing query task failed: {}", err);
-                Err(QueryPlannerError::from(err))
-            }
+        let task_result = tokio::task::spawn_blocking(move || {
+            let mut query = Query::parse(query, &schema, &configuration)?;
+            crate::spec::operation_limits::check(&configuration, &mut query, operation_name)?;
+            Ok::<_, QueryPlannerError>(query)
+        })
+        .instrument(tracing::info_span!("parse_query", "otel.kind" = "INTERNAL"))
+        .await;
+        if let Err(err) = &task_result {
+            failfast_debug!("parsing query task failed: {}", err);
         }
+        task_result?
     }
 
     async fn introspection(&self, query: String) -> Result<QueryPlannerContent, QueryPlannerError> {
@@ -274,7 +276,7 @@ impl Service<QueryPlannerRequest> for BridgeQueryPlanner {
 
 impl BridgeQueryPlanner {
     async fn get(&self, key: QueryKey) -> Result<QueryPlannerContent, QueryPlannerError> {
-        let selections = self.parse_selections(key.0.clone()).await?;
+        let selections = self.parse_selections(key.clone()).await?;
 
         if selections.contains_introspection() {
             // If we have only one operation containing only the root field `__typename`

--- a/apollo-router/src/spec/mod.rs
+++ b/apollo-router/src/spec/mod.rs
@@ -4,6 +4,7 @@
 
 mod field_type;
 mod fragments;
+pub(crate) mod operation_limits;
 pub(crate) mod query;
 mod schema;
 mod selection;

--- a/apollo-router/src/spec/operation_limits.rs
+++ b/apollo-router/src/spec/operation_limits.rs
@@ -1,0 +1,224 @@
+use std::collections::HashMap;
+use std::collections::HashSet;
+
+use apollo_compiler::hir;
+use apollo_compiler::ApolloCompiler;
+use apollo_compiler::FileId;
+use apollo_compiler::HirDatabase;
+use apollo_compiler::InputDatabase;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::spec::Query;
+use crate::Configuration;
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub(crate) struct OperationLimits<T> {
+    pub(crate) depth: T,
+    pub(crate) height: T,
+    pub(crate) root_fields: T,
+    pub(crate) aliases: T,
+}
+
+/// If it swims like a burrito and quacks like a burrito…
+impl<A> OperationLimits<A> {
+    fn map<B>(self, mut f: impl FnMut(A) -> B) -> OperationLimits<B> {
+        OperationLimits {
+            depth: f(self.depth),
+            height: f(self.height),
+            root_fields: f(self.root_fields),
+            aliases: f(self.aliases),
+        }
+    }
+
+    fn combine<B, C>(
+        self,
+        other: OperationLimits<B>,
+        mut f: impl FnMut(&'static str, A, B) -> C,
+    ) -> OperationLimits<C> {
+        OperationLimits {
+            depth: f("depth", self.depth, other.depth),
+            height: f("height", self.height, other.height),
+            root_fields: f("root_fields", self.root_fields, other.root_fields),
+            aliases: f("aliases", self.aliases, other.aliases),
+        }
+    }
+}
+
+impl OperationLimits<bool> {
+    fn any(&self) -> bool {
+        // make the compile warn if we forget one
+        let Self {
+            depth,
+            height,
+            root_fields,
+            aliases,
+        } = *self;
+        depth || height || root_fields || aliases
+    }
+}
+
+/// Returns which limits are exceeded by the given query, if any
+pub(crate) fn check(
+    configuration: &Configuration,
+    query: &mut Query,
+    operation_name: Option<String>,
+) -> Result<(), OperationLimits<bool>> {
+    let config_limits = &configuration.supergraph.limits;
+    let max = OperationLimits {
+        depth: config_limits.max_depth,
+        height: config_limits.max_height,
+        root_fields: config_limits.max_root_fields,
+        aliases: config_limits.max_aliases,
+    };
+    if !max.map(|limit| limit.is_some()).any() {
+        // No configured limit
+        return Ok(());
+    }
+
+    // We only need `&ApolloCompiler` but
+    // `get_mut` allows accessing a Tokio `Mutex` without awaiting.
+    #[allow(clippy::expect_used)] // can’t really avoid this one
+    let compiler = query
+        .compiler
+        .get_mut()
+        .expect("compiler must be already initialized")
+        .get_mut();
+
+    let ids = compiler.db.executable_definition_files();
+    // We create a new compiler for each query
+    debug_assert_eq!(ids.len(), 1);
+    let query_id = ids[0];
+
+    let Some(operation) = compiler.db.find_operation(query_id, operation_name.clone())
+    else {
+        // Undefined or ambiguous operation name.
+        // The request is invalid and will be rejected by some other part of the router,
+        // if it wasn’t already before we got to this code path.
+        return Ok(())
+    };
+
+    let mut fragment_cache = HashMap::new();
+    let measured = count(
+        compiler,
+        query_id,
+        &mut fragment_cache,
+        operation.selection_set(),
+    );
+    let exceeded = max.combine(measured, |_, config, measured| {
+        if let Some(limit) = config {
+            measured > limit
+        } else {
+            false
+        }
+    });
+    if exceeded.any() {
+        let mut messages = Vec::new();
+        max.combine(measured, |ident, max, measured| {
+            if let Some(max) = max {
+                if measured > max {
+                    messages.push(format!("{ident}: {measured}, max_{ident}: {max}"))
+                }
+            }
+        });
+        let message = messages.join(", ");
+        let query = &query.string;
+        tracing::warn!(
+            "request exceeded complexity limits: {message}, \
+            query: {query:?}, operation name: {operation_name:?}"
+        );
+        if !config_limits.warn_only {
+            return Err(exceeded);
+        }
+    }
+    Ok(())
+}
+
+enum Computation<T> {
+    InProgress,
+    Done(T),
+}
+
+/// Recursively measure the given selection set against each limit
+fn count(
+    compiler: &ApolloCompiler,
+    query_id: FileId,
+    fragment_cache: &mut HashMap<String, Computation<OperationLimits<u32>>>,
+    selection_set: &hir::SelectionSet,
+) -> OperationLimits<u32> {
+    let mut counts = OperationLimits {
+        depth: 0,
+        height: 0,
+        root_fields: 0,
+        aliases: 0,
+    };
+    let mut fields_seen = HashSet::new();
+    for selection in selection_set.selection() {
+        match selection {
+            hir::Selection::Field(field) => {
+                let nested = count(compiler, query_id, fragment_cache, field.selection_set());
+                counts.depth = counts.depth.max(1 + nested.depth);
+                counts.height += nested.height;
+                counts.aliases += nested.aliases;
+                // Multiple aliases for the same field could use different arguments
+                // Until we do full merging for limit checking purpose,
+                // approximate measured height with an upper bound rather than a lower bound.
+                let used_name = if let Some(alias) = field.alias() {
+                    counts.aliases += 1;
+                    alias.name()
+                } else {
+                    field.name()
+                };
+                let not_seen_before = fields_seen.insert(used_name);
+                if not_seen_before {
+                    counts.height += 1;
+                    counts.root_fields += 1;
+                }
+            }
+            hir::Selection::InlineFragment(fragment) => {
+                let nested = count(compiler, query_id, fragment_cache, fragment.selection_set());
+                counts.depth = counts.depth.max(nested.depth);
+                counts.height += nested.height;
+                counts.aliases += nested.aliases;
+            }
+            hir::Selection::FragmentSpread(fragment) => {
+                let name = fragment.name();
+                let nested;
+                match fragment_cache.get(name) {
+                    None => {
+                        if let Some(definition) =
+                            compiler.db.find_fragment_by_name(query_id, name.to_owned())
+                        {
+                            fragment_cache.insert(name.to_owned(), Computation::InProgress);
+                            nested = count(
+                                compiler,
+                                query_id,
+                                fragment_cache,
+                                definition.selection_set(),
+                            );
+                            fragment_cache.insert(name.to_owned(), Computation::Done(nested));
+                        } else {
+                            // Undefined fragment. The operation invalid
+                            // and will be rejected by some other part of the router,
+                            // if it wasn’t already before we got to this code path.
+                            continue;
+                        }
+                    }
+                    Some(Computation::InProgress) => {
+                        // This fragment references itself (maybe indirectly).
+                        // https://spec.graphql.org/October2021/#sec-Fragment-spreads-must-not-form-cycles
+                        // The operation invalid
+                        // and will be rejected by some other part of the router,
+                        // if it wasn’t already before we got to this code path.
+                        continue;
+                    }
+                    Some(Computation::Done(cached)) => nested = *cached,
+                }
+                counts.depth = counts.depth.max(nested.depth);
+                counts.height += nested.height;
+                counts.aliases += nested.aliases;
+            }
+        }
+    }
+    counts
+}

--- a/apollo-router/src/spec/operation_limits.rs
+++ b/apollo-router/src/spec/operation_limits.rs
@@ -64,7 +64,7 @@ pub(crate) fn check(
     query: &mut Query,
     operation_name: Option<String>,
 ) -> Result<(), OperationLimits<bool>> {
-    let config_limits = &configuration.supergraph.preview_limits;
+    let config_limits = &configuration.preview_operation_limits;
     let max = OperationLimits {
         depth: config_limits.max_depth,
         height: config_limits.max_height,

--- a/apollo-router/src/spec/operation_limits.rs
+++ b/apollo-router/src/spec/operation_limits.rs
@@ -64,7 +64,7 @@ pub(crate) fn check(
     query: &mut Query,
     operation_name: Option<String>,
 ) -> Result<(), OperationLimits<bool>> {
-    let config_limits = &configuration.supergraph.limits;
+    let config_limits = &configuration.supergraph.preview_limits;
     let max = OperationLimits {
         depth: config_limits.max_depth,
         height: config_limits.max_height,

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -268,8 +268,8 @@ impl Query {
     ) -> Result<Self, SpecError> {
         let query = query.into();
         let mut compiler = ApolloCompiler::new()
-            .recursion_limit(configuration.supergraph.preview_limits.parser_max_recursion)
-            .token_limit(configuration.supergraph.preview_limits.parser_max_tokens);
+            .recursion_limit(configuration.preview_operation_limits.parser_max_recursion)
+            .token_limit(configuration.preview_operation_limits.parser_max_tokens);
         let id = compiler.add_executable(&query, "query");
         let ast = compiler.db.ast(id);
 

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -268,7 +268,7 @@ impl Query {
     ) -> Result<Self, SpecError> {
         let query = query.into();
         let mut compiler = ApolloCompiler::new()
-            .recursion_limit(configuration.server.experimental_parser_recursion_limit);
+            .recursion_limit(configuration.supergraph.limits.parser_max_recursion);
         let id = compiler.add_executable(&query, "query");
         let ast = compiler.db.ast(id);
 

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -268,7 +268,8 @@ impl Query {
     ) -> Result<Self, SpecError> {
         let query = query.into();
         let mut compiler = ApolloCompiler::new()
-            .recursion_limit(configuration.supergraph.limits.parser_max_recursion);
+            .recursion_limit(configuration.supergraph.limits.parser_max_recursion)
+            .token_limit(configuration.supergraph.limits.parser_max_tokens);
         let id = compiler.add_executable(&query, "query");
         let ast = compiler.db.ast(id);
 

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -43,10 +43,10 @@ pub(crate) const TYPENAME: &str = "__typename";
 #[derive(Derivative, Default, Serialize, Deserialize)]
 #[derivative(PartialEq, Hash, Eq, Debug)]
 pub(crate) struct Query {
-    string: String,
+    pub(crate) string: String,
     #[derivative(PartialEq = "ignore", Hash = "ignore", Debug = "ignore")]
     #[serde(skip)]
-    compiler: OnceCell<Mutex<ApolloCompiler>>,
+    pub(crate) compiler: OnceCell<Mutex<ApolloCompiler>>,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     fragments: Fragments,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -268,8 +268,8 @@ impl Query {
     ) -> Result<Self, SpecError> {
         let query = query.into();
         let mut compiler = ApolloCompiler::new()
-            .recursion_limit(configuration.supergraph.limits.parser_max_recursion)
-            .token_limit(configuration.supergraph.limits.parser_max_tokens);
+            .recursion_limit(configuration.supergraph.preview_limits.parser_max_recursion)
+            .token_limit(configuration.supergraph.preview_limits.parser_max_tokens);
         let id = compiler.add_executable(&query, "query");
         let ast = compiler.db.ast(id);
 

--- a/apollo-router/src/uplink/entitlement.rs
+++ b/apollo-router/src/uplink/entitlement.rs
@@ -153,6 +153,24 @@ impl EntitlementReport {
                 .path("$.traffic_shaping..experimental_entity_caching")
                 .name("Subgraph entity caching")
                 .build(),
+            // Per-operation limits are restricted but parser limits like `parser_max_recursion`
+            // where the Router only configures apollo-rs are not.
+            ConfigurationRestriction::builder()
+                .path("$.supergraph.limits.max_depth")
+                .name("Operation depth limiting")
+                .build(),
+            ConfigurationRestriction::builder()
+                .path("$.supergraph.limits.max_height")
+                .name("Operation height limiting")
+                .build(),
+            ConfigurationRestriction::builder()
+                .path("$.supergraph.limits.max_root_fields")
+                .name("Operation root fields limiting")
+                .build(),
+            ConfigurationRestriction::builder()
+                .path("$.supergraph.limits.max_aliases")
+                .name("Operation aliases limiting")
+                .build(),
         ]
     }
 }

--- a/apollo-router/src/uplink/entitlement.rs
+++ b/apollo-router/src/uplink/entitlement.rs
@@ -156,19 +156,19 @@ impl EntitlementReport {
             // Per-operation limits are restricted but parser limits like `parser_max_recursion`
             // where the Router only configures apollo-rs are not.
             ConfigurationRestriction::builder()
-                .path("$.supergraph.limits.max_depth")
+                .path("$.supergraph.preview_limits.max_depth")
                 .name("Operation depth limiting")
                 .build(),
             ConfigurationRestriction::builder()
-                .path("$.supergraph.limits.max_height")
+                .path("$.supergraph.preview_limits.max_height")
                 .name("Operation height limiting")
                 .build(),
             ConfigurationRestriction::builder()
-                .path("$.supergraph.limits.max_root_fields")
+                .path("$.supergraph.preview_limits.max_root_fields")
                 .name("Operation root fields limiting")
                 .build(),
             ConfigurationRestriction::builder()
-                .path("$.supergraph.limits.max_aliases")
+                .path("$.supergraph.preview_limits.max_aliases")
                 .name("Operation aliases limiting")
                 .build(),
         ]

--- a/apollo-router/src/uplink/entitlement.rs
+++ b/apollo-router/src/uplink/entitlement.rs
@@ -156,19 +156,19 @@ impl EntitlementReport {
             // Per-operation limits are restricted but parser limits like `parser_max_recursion`
             // where the Router only configures apollo-rs are not.
             ConfigurationRestriction::builder()
-                .path("$.supergraph.preview_limits.max_depth")
+                .path("$.preview_operation_limits.max_depth")
                 .name("Operation depth limiting")
                 .build(),
             ConfigurationRestriction::builder()
-                .path("$.supergraph.preview_limits.max_height")
+                .path("$.preview_operation_limits.max_height")
                 .name("Operation height limiting")
                 .build(),
             ConfigurationRestriction::builder()
-                .path("$.supergraph.preview_limits.max_root_fields")
+                .path("$.preview_operation_limits.max_root_fields")
                 .name("Operation root fields limiting")
                 .build(),
             ConfigurationRestriction::builder()
-                .path("$.supergraph.preview_limits.max_aliases")
+                .path("$.preview_operation_limits.max_aliases")
                 .name("Operation aliases limiting")
                 .build(),
         ]

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__entitlement__test__restricted_features_via_config.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__entitlement__test__restricted_features_via_config.snap
@@ -25,13 +25,13 @@ Configuration yaml:
   .traffic_shaping..experimental_entity_caching
 
 * Operation depth limiting
-  .supergraph.preview_limits.max_depth
+  .preview_operation_limits.max_depth
 
 * Operation height limiting
-  .supergraph.preview_limits.max_height
+  .preview_operation_limits.max_height
 
 * Operation root fields limiting
-  .supergraph.preview_limits.max_root_fields
+  .preview_operation_limits.max_root_fields
 
 * Operation aliases limiting
-  .supergraph.preview_limits.max_aliases
+  .preview_operation_limits.max_aliases

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__entitlement__test__restricted_features_via_config.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__entitlement__test__restricted_features_via_config.snap
@@ -23,3 +23,15 @@ Configuration yaml:
 
 * Subgraph entity caching
   .traffic_shaping..experimental_entity_caching
+
+* Operation depth limiting
+  .supergraph.limits.max_depth
+
+* Operation height limiting
+  .supergraph.limits.max_height
+
+* Operation root fields limiting
+  .supergraph.limits.max_root_fields
+
+* Operation aliases limiting
+  .supergraph.limits.max_aliases

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__entitlement__test__restricted_features_via_config.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__entitlement__test__restricted_features_via_config.snap
@@ -25,13 +25,13 @@ Configuration yaml:
   .traffic_shaping..experimental_entity_caching
 
 * Operation depth limiting
-  .supergraph.limits.max_depth
+  .supergraph.preview_limits.max_depth
 
 * Operation height limiting
-  .supergraph.limits.max_height
+  .supergraph.preview_limits.max_height
 
 * Operation root fields limiting
-  .supergraph.limits.max_root_fields
+  .supergraph.preview_limits.max_root_fields
 
 * Operation aliases limiting
-  .supergraph.limits.max_aliases
+  .supergraph.preview_limits.max_aliases

--- a/apollo-router/src/uplink/testdata/oss.router.yaml
+++ b/apollo-router/src/uplink/testdata/oss.router.yaml
@@ -3,5 +3,5 @@ health_check:
 homepage:
   enabled: false
 supergraph:
-  limits:
+  preview_limits:
     parser_max_recursion: 1000

--- a/apollo-router/src/uplink/testdata/oss.router.yaml
+++ b/apollo-router/src/uplink/testdata/oss.router.yaml
@@ -2,6 +2,5 @@ health_check:
   enabled: false
 homepage:
   enabled: false
-supergraph:
-  preview_limits:
-    parser_max_recursion: 1000
+preview_operation_limits:
+  parser_max_recursion: 1000

--- a/apollo-router/src/uplink/testdata/oss.router.yaml
+++ b/apollo-router/src/uplink/testdata/oss.router.yaml
@@ -2,4 +2,6 @@ health_check:
   enabled: false
 homepage:
   enabled: false
-
+supergraph:
+  limits:
+    parser_max_recursion: 1000

--- a/apollo-router/src/uplink/testdata/restricted.router.yaml
+++ b/apollo-router/src/uplink/testdata/restricted.router.yaml
@@ -19,6 +19,11 @@ supergraph:
           - https://example.com
       in_memory:
         limit: 1000
+  limits:
+    max_depth: 20
+    max_height: 100
+    max_aliases: 100
+    max_root_fields: 10
 
 apq:
   router:

--- a/apollo-router/src/uplink/testdata/restricted.router.yaml
+++ b/apollo-router/src/uplink/testdata/restricted.router.yaml
@@ -19,7 +19,7 @@ supergraph:
           - https://example.com
       in_memory:
         limit: 1000
-  limits:
+  preview_limits:
     max_depth: 20
     max_height: 100
     max_aliases: 100

--- a/apollo-router/src/uplink/testdata/restricted.router.yaml
+++ b/apollo-router/src/uplink/testdata/restricted.router.yaml
@@ -19,11 +19,12 @@ supergraph:
           - https://example.com
       in_memory:
         limit: 1000
-  preview_limits:
-    max_depth: 20
-    max_height: 100
-    max_aliases: 100
-    max_root_fields: 10
+
+preview_operation_limits:
+  max_depth: 20
+  max_height: 100
+  max_aliases: 100
+  max_root_fields: 10
 
 apq:
   router:

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -519,7 +519,7 @@ async fn missing_variables() {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_under_recursion_limit() {
     let config = serde_json::json!({
-        "supergraph": {"limits": {"parser_max_recursion": 12_usize}}
+        "supergraph": {"preview_limits": {"parser_max_recursion": 12_usize}}
     });
     let request = supergraph::Request::fake_builder()
         .query(r#"{ me { reviews { author { reviews { author { name } } } } } }"#)
@@ -540,7 +540,7 @@ async fn query_just_under_recursion_limit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_at_recursion_limit() {
     let config = serde_json::json!({
-        "supergraph": {"limits": {"parser_max_recursion": 5_usize}}
+        "supergraph": {"preview_limits": {"parser_max_recursion": 5_usize}}
     });
     let request = supergraph::Request::fake_builder()
         .query(r#"{ me { reviews { author { reviews { author { name } } } } } }"#)
@@ -559,7 +559,7 @@ async fn query_just_at_recursion_limit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_under_token_limit() {
     let config = serde_json::json!({
-        "supergraph": {"limits": {"parser_max_tokens": 36_usize}}
+        "supergraph": {"preview_limits": {"parser_max_tokens": 36_usize}}
     });
     let request = supergraph::Request::fake_builder()
         .query(r#"{ me { reviews { author { reviews { author { name } } } } } }"#)
@@ -580,7 +580,7 @@ async fn query_just_under_token_limit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_at_token_limit() {
     let config = serde_json::json!({
-        "supergraph": {"limits": {"parser_max_tokens": 34_usize}}
+        "supergraph": {"preview_limits": {"parser_max_tokens": 34_usize}}
     });
     let request = supergraph::Request::fake_builder()
         .query(r#"{ me { reviews { author { reviews { author { name } } } } } }"#)

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -519,7 +519,7 @@ async fn missing_variables() {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_under_recursion_limit() {
     let config = serde_json::json!({
-        "server": {"experimental_parser_recursion_limit": 12_usize}
+        "supergraph": {"limits": {"parser_max_recursion": 12_usize}}
     });
     let request = supergraph::Request::fake_builder()
         .query(r#"{ me { reviews { author { reviews { author { name } } } } } }"#)
@@ -540,7 +540,7 @@ async fn query_just_under_recursion_limit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_at_recursion_limit() {
     let config = serde_json::json!({
-        "server": {"experimental_parser_recursion_limit": 5_usize}
+        "supergraph": {"limits": {"parser_max_recursion": 5_usize}}
     });
     let request = supergraph::Request::fake_builder()
         .query(r#"{ me { reviews { author { reviews { author { name } } } } } }"#)

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -519,7 +519,7 @@ async fn missing_variables() {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_under_recursion_limit() {
     let config = serde_json::json!({
-        "supergraph": {"preview_limits": {"parser_max_recursion": 12_usize}}
+        "preview_operation_limits": {"parser_max_recursion": 12_usize}
     });
     let request = supergraph::Request::fake_builder()
         .query(r#"{ me { reviews { author { reviews { author { name } } } } } }"#)
@@ -540,7 +540,7 @@ async fn query_just_under_recursion_limit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_at_recursion_limit() {
     let config = serde_json::json!({
-        "supergraph": {"preview_limits": {"parser_max_recursion": 5_usize}}
+        "preview_operation_limits": {"parser_max_recursion": 5_usize}
     });
     let request = supergraph::Request::fake_builder()
         .query(r#"{ me { reviews { author { reviews { author { name } } } } } }"#)
@@ -559,7 +559,7 @@ async fn query_just_at_recursion_limit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_under_token_limit() {
     let config = serde_json::json!({
-        "supergraph": {"preview_limits": {"parser_max_tokens": 36_usize}}
+        "preview_operation_limits": {"parser_max_tokens": 36_usize}
     });
     let request = supergraph::Request::fake_builder()
         .query(r#"{ me { reviews { author { reviews { author { name } } } } } }"#)
@@ -580,7 +580,7 @@ async fn query_just_under_token_limit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_at_token_limit() {
     let config = serde_json::json!({
-        "supergraph": {"preview_limits": {"parser_max_tokens": 34_usize}}
+        "preview_operation_limits": {"parser_max_tokens": 34_usize}
     });
     let request = supergraph::Request::fake_builder()
         .query(r#"{ me { reviews { author { reviews { author { name } } } } } }"#)

--- a/apollo-router/tests/operation_limits.rs
+++ b/apollo-router/tests/operation_limits.rs
@@ -231,7 +231,7 @@ async fn build_test_harness(
     let get_execution_count = move || execution_count_2.load(Ordering::Acquire);
     let service = TestHarness::builder()
         .configuration_json(json!({
-            "supergraph": { "limits": limits_config },
+            "supergraph": { "preview_limits": limits_config },
             "include_subgraph_errors": { "all": true },
         }))
         .unwrap()

--- a/apollo-router/tests/operation_limits.rs
+++ b/apollo-router/tests/operation_limits.rs
@@ -1,0 +1,298 @@
+use std::sync::atomic::AtomicU32;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+
+use apollo_router::graphql;
+use apollo_router::services::execution;
+use apollo_router::services::supergraph;
+use apollo_router::TestHarness;
+use serde_json::json;
+use tower::ServiceExt;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_response_errors() {
+    let (mut service, execution_count) = build_test_harness(json!({
+        "max_root_fields": 1,
+        "max_aliases": 2,
+        "max_depth": 3,
+        "max_height": 4,
+    }))
+    .await;
+    macro_rules! expect_errors {
+        ($query: expr, $expected_error_codes: expr) => {
+            expect_errors(
+                run_request(&mut service, $query).await,
+                $expected_error_codes,
+            )
+        };
+    }
+
+    assert_eq!(execution_count(), 0);
+    expect_errors!("{ me { id }}", &[]);
+    assert_eq!(execution_count(), 1);
+
+    // This query is just under each limit
+    let query = "{
+            topProducts {
+                productName: name
+                reviews {
+                    reviewBody: body
+                }
+            }
+        }";
+    expect_errors!(query, &[]);
+    assert_eq!(execution_count(), 2);
+
+    // Exceeding any one limit is sufficient for the request to be rejected
+    let query = "{
+            me { id }
+            topProducts { name }
+        }";
+    expect_errors!(query, &["MAX_ROOT_FIELDS_LIMIT"]);
+    assert_eq!(execution_count(), 2); // no execution
+
+    let query = "{
+            topProducts {
+                productName: name
+                productReviews: reviews {
+                    reviewBody: body
+                }
+            }
+        }";
+    expect_errors!(query, &["MAX_ALIASES_LIMIT"]);
+    assert_eq!(execution_count(), 2);
+
+    // Max depth in a regular query
+    let query = "{
+            topProducts {
+                reviews {
+                    author {
+                        name
+                    }
+                }
+            }
+        }";
+    expect_errors!(query, &["MAX_DEPTH_LIMIT"]);
+    assert_eq!(execution_count(), 2);
+
+    // Max depth with a fragment
+    let query = "{
+            topProducts {
+                reviews {
+                    ... on Review {
+                       author {
+                           name
+                       }
+                    }
+                }
+            }
+        }";
+    expect_errors!(query, &["MAX_DEPTH_LIMIT"]);
+    assert_eq!(execution_count(), 2);
+
+    // Max height with a fragment
+    let query = "{
+            topProducts {
+                name
+                reviews {
+                    ...reviewBody
+                }
+            }
+        }
+        fragment reviewBody on Review {
+            body
+            id
+        }
+        ";
+    expect_errors!(query, &["MAX_HEIGHT_LIMIT"]);
+    assert_eq!(execution_count(), 2);
+
+    // If multiple limits are exceeded, as many errors are emitted
+    expect_errors!(
+        "{
+                topProducts {
+                    productName: name
+                    productReviews: reviews {
+                        reviewAuthor: author {
+                            name
+                        }
+                    }
+                }
+            }",
+        &["MAX_DEPTH_LIMIT", "MAX_HEIGHT_LIMIT", "MAX_ALIASES_LIMIT"]
+    );
+    assert_eq!(execution_count(), 2);
+
+    // Rejecting errors does not break the server
+    expect_errors!("{ me { id }}", &[]);
+    assert_eq!(execution_count(), 3); // new execution
+
+    // Aliases still contribute to height
+    let query = "{
+        topProducts {
+            productName: name
+            similarProduct: name
+            name
+            reviews {
+                body
+            }
+        }
+    }";
+    expect_errors!(query, &["MAX_HEIGHT_LIMIT"]);
+    assert_eq!(execution_count(), 3);
+
+    // Depth, height, and alias limits should be exceeded in this query with
+    // inline and named fragments.
+    let query = "
+    query getProduct{
+        topProducts {
+            ... on Product {
+                poorReviews: reviews {
+                    ...reviewsFragment
+                }
+                averageReviews: reviews {
+                    ...reviewsFragment
+                }
+            } 
+        }
+    }
+
+    fragment reviewsFragment on Review {
+        body
+        author {
+            penname: name
+        }
+    } 
+    ";
+    expect_errors!(
+        query,
+        &["MAX_DEPTH_LIMIT", "MAX_HEIGHT_LIMIT", "MAX_ALIASES_LIMIT"]
+    );
+    assert_eq!(execution_count(), 3);
+
+    // Depth, height, and alias limits should be exceeded in this query with
+    // inline and named fragments.
+    let query = "
+    query getProduct{
+        topProducts {
+            ... on Product {
+                poorReviews: reviews {
+                    ...reviewsFragment
+                }
+                averageReviews: reviews {
+                    ...reviewsFragment
+                }
+            } 
+        }
+    }
+
+    fragment reviewsFragment on Review {
+        body
+        author {
+            penname: name
+        }
+    } 
+    ";
+    expect_errors!(
+        query,
+        &["MAX_DEPTH_LIMIT", "MAX_HEIGHT_LIMIT", "MAX_ALIASES_LIMIT"]
+    );
+    assert_eq!(execution_count(), 3);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_warn_only() {
+    let (mut service, execution_count) = build_test_harness(json!({
+        "max_root_fields": 1,
+        "max_depth": 2,
+        "warn_only": true,
+    }))
+    .await;
+
+    // no limit exceedeed
+    expect_errors(run_request(&mut service, "{me { id }}").await, &[]);
+    assert_eq!(execution_count(), 1);
+
+    // exceeds limits, but still executed with a warning logged.
+    // no error in the response.
+    let query = "{
+        me { id }
+        topProducts { reviews { body } }
+    }";
+    expect_errors(run_request(&mut service, query).await, &[]);
+    assert_eq!(execution_count(), 2);
+}
+
+async fn build_test_harness(
+    limits_config: serde_json::Value,
+) -> (supergraph::BoxCloneService, impl Fn() -> u32) {
+    let execution_count = Arc::new(AtomicU32::new(0));
+    let execution_count_2 = execution_count.clone();
+    let get_execution_count = move || execution_count_2.load(Ordering::Acquire);
+    let service = TestHarness::builder()
+        .configuration_json(json!({
+            "supergraph": { "limits": limits_config },
+            "include_subgraph_errors": { "all": true },
+        }))
+        .unwrap()
+        // .log_level("warn")
+        .execution_hook(move |_inner_service| {
+            // Don’t actually execute (ignore the inner execution service),
+            // instead keep track of which requests were about to be executed
+            // with a counter and a marker in the dummy response.
+            let execution_count = execution_count.clone();
+            tower::service_fn(move |request: execution::Request| {
+                let execution_count = execution_count.clone();
+                async move {
+                    execution_count.fetch_add(1, Ordering::Release);
+                    Ok(execution::Response::builder()
+                        .data(json!({"reached execution": true})) // No error
+                        .context(request.context)
+                        .build()
+                        .unwrap())
+                }
+            })
+            .boxed()
+        })
+        .build_supergraph()
+        .await
+        .unwrap();
+    (service, get_execution_count)
+}
+
+async fn run_request(service: &mut supergraph::BoxCloneService, query: &str) -> graphql::Response {
+    let request = supergraph::Request::fake_builder()
+        .query(query)
+        .build()
+        .unwrap();
+    service
+        .oneshot(request)
+        .await
+        .unwrap()
+        .next_response()
+        .await
+        .unwrap()
+}
+
+#[track_caller]
+fn expect_errors(response: graphql::Response, expected_error_codes: &[&str]) {
+    let errors = response.errors;
+    if !errors
+        .iter()
+        .map(|err| err.extensions.get("code")?.as_str())
+        .eq(expected_error_codes.iter().map(|&code| Some(code)))
+    {
+        panic!("expected errors with codes {expected_error_codes:#?}, got {errors:#?}")
+    }
+    if expected_error_codes.is_empty() {
+        let reached_execution = response
+            .data
+            .expect("expected a response with data")
+            .get("reached execution")
+            .expect("expected data with a 'reached execution' key")
+            .as_bool();
+        assert!(reached_execution.unwrap());
+    } else {
+        assert!(response.data.is_none())
+    }
+}

--- a/apollo-router/tests/operation_limits.rs
+++ b/apollo-router/tests/operation_limits.rs
@@ -231,7 +231,7 @@ async fn build_test_harness(
     let get_execution_count = move || execution_count_2.load(Ordering::Acquire);
     let service = TestHarness::builder()
         .configuration_json(json!({
-            "supergraph": { "preview_limits": limits_config },
+            "preview_operation_limits": limits_config,
             "include_subgraph_errors": { "all": true },
         }))
         .unwrap()

--- a/apollo-router/tests/snapshots/lifecycle_tests__cli_config_preview.snap
+++ b/apollo-router/tests/snapshots/lifecycle_tests__cli_config_preview.snap
@@ -1,11 +1,13 @@
 ---
 source: apollo-router/tests/lifecycle_tests.rs
-expression: "command_output(Command::new(IntegrationTest::router_location()).arg(\"config\").arg(\"preview\")).await"
+expression: "command_output(Command::new(IntegrationTest::router_location()).arg(\"config\").arg(\"preview\").env(\"RUST_BACKTRACE\",\n            \"\")).await"
 ---
 Success: true
 Exit code: Some(0)
 stderr:
 
 stdout:
-This Router version has no preview configuration
+List of all preview configurations with related GitHub discussions:
+
+	- preview_operation_limits: https://github.com/apollographql/router/discussions/3040
 

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -42,6 +42,13 @@
             "enterprise"
           ]
         ],
+        "Operation limits": [
+          "/configuration/operation-limits",
+          [
+            "enterprise",
+            "preview"
+          ]
+        ],
         "Privacy and data collection": "/privacy"
       }
     },

--- a/docs/source/configuration/operation-limits.mdx
+++ b/docs/source/configuration/operation-limits.mdx
@@ -1,6 +1,6 @@
 ---
 title: Enforcing operation limits in the Apollo Router
-description: With GraphOS Enterprise 
+description: With GraphOS Enterprise
 ---
 
 > ⚠️ **This is an [Enterprise feature](../enterprise-features/) of the Apollo Router.** It requires an organization with a [GraphOS Enterprise plan](https://www.apollographql.com/pricing/).
@@ -30,7 +30,6 @@ supergraph:
 Each limit takes an integer value. You can define any combination of [supported limits](#supported-limits).
 
 ## Supported limits
-
 ### `max_depth`
 
 Limits the deepest nesting of selection sets in an operation, including fields in fragments.

--- a/docs/source/configuration/operation-limits.mdx
+++ b/docs/source/configuration/operation-limits.mdx
@@ -1,0 +1,124 @@
+---
+title: Enforcing operation limits in the Apollo Router
+description: With GraphOS Enterprise 
+---
+
+> ⚠️ **This is an [Enterprise feature](../enterprise-features/) of the Apollo Router.** It requires an organization with a [GraphOS Enterprise plan](https://www.apollographql.com/pricing/).
+>
+> This enterprise feature is currently in [preview](/resources/product-launch-stages#preview).
+
+You can define **operation limits** in your router's configuration to reject potentially malicious requests. An operation that exceeds _any_ specified limit is rejected (unless you run your router in [`warn_only` mode](#warn_only-mode)).
+
+## Setup
+
+To use operation limits, you must run v1.17 or later of the Apollo Router. [Download the latest version.](../quickstart#download-options)
+
+You define operation limits in your router's [YAML config file](./configuration/overview/#yaml-config-file), like so:
+
+```yaml title="router.yaml"
+supergraph:
+  limits:
+    max_depth: 100
+    max_height: 200
+    max_aliases: 30
+    max_root_fields: 20
+
+    # Uncomment to enable warn_only mode
+    # warn_only: true
+```
+
+Each limit takes an integer value. You can define any combination of [supported limits](#supported-limits).
+
+## Supported limits
+
+### `max_depth`
+
+Limits the deepest nesting of selection sets in an operation, including fields in fragments.
+
+The `GetBook` operation below has depth three:
+
+```graphql
+query GetBook {
+  book { # Depth 1 (root field)
+    ...bookDetails
+  }
+}
+
+fragment bookDetails on Book {
+  details { # Depth 2 (nested under `book`)
+    ... on ProductDetailsBook {
+      country # Depth 3 (nested under `details`)
+    }
+  }
+}
+```
+
+### `max_height`
+
+Limits the number of unique fields included in an operation, including fields of fragments. If a particular field is included _multiple_ times via aliases, it's counted only _once_.
+
+The `GetUser` operation below has height three:
+
+```graphql
+query GetUser {
+  user { # 1
+    id   # 2
+    name # 3
+    username: name # Aliased duplicate (not counted)
+  }
+}
+```
+
+### `max_aliases`
+
+Limits the total number of aliased fields in an operation, including fields of fragments.
+
+The `GetUser` operation below includes three aliases:
+
+```graphql
+query GetUser {
+  user {
+    nickname: name # 1
+    username: name # 2
+    username: name # 3
+  }
+}
+```
+
+### `max_root_fields`
+
+Limits the number of root fields in an operation, including root fields in fragments. If a particular root field is included _multiple_ times via aliases, _each usage_ is counted.
+
+The following operation includes three root fields:
+
+```graphql
+query GetTopProducts {
+  topBooks { # 1
+    id
+  }
+  topMovies { # 2
+    id
+  }
+  topGames { # 3
+    id
+  }
+}
+```
+
+## `warn_only` mode
+
+If you run your router in `warn_only` mode, operations that exceed defined limits are _not_ rejected. Instead, the router processes these operations as usual and emits a `WARN` trace that notes all exceeded limits, like so:
+
+```
+2023-03-15T19:08:23.123456Z WARN apollo_router::limits: max_depth exceeded, max_depth: 3, current_op_depth: 5, operation: "query GetOwnerLocation {cat {owner {location {postalCode}}}}"
+```
+
+Running in `warn_only` mode can be useful while you're testing to determine the most appropriate limits to set for your supergraph.
+
+You can enable or disable `warn_only` mode in your router's [YAML config file](./configuration/overview/#yaml-config-file), like so:
+
+```yaml title="router.yaml"
+supergraph:
+  preview_limits:
+    warn_only: true # warn_only mode always enabled
+```

--- a/docs/source/configuration/operation-limits.mdx
+++ b/docs/source/configuration/operation-limits.mdx
@@ -16,15 +16,14 @@ To use operation limits, you must run v1.17 or later of the Apollo Router. [Down
 You define operation limits in your router's [YAML config file](./configuration/overview/#yaml-config-file), like so:
 
 ```yaml title="router.yaml"
-supergraph:
-  preview_limits:
-    max_depth: 100
-    max_height: 200
-    max_aliases: 30
-    max_root_fields: 20
+preview_operation_limits:
+  max_depth: 100
+  max_height: 200
+  max_aliases: 30
+  max_root_fields: 20
 
-    # Uncomment to enable warn_only mode
-    # warn_only: true
+  # Uncomment to enable warn_only mode
+  # warn_only: true
 ```
 
 Each limit takes an integer value. You can define any combination of [supported limits](#supported-limits).
@@ -117,7 +116,6 @@ Running in `warn_only` mode can be useful while you're testing to determine the 
 You can enable or disable `warn_only` mode in your router's [YAML config file](./configuration/overview/#yaml-config-file), like so:
 
 ```yaml title="router.yaml"
-supergraph:
-  preview_limits:
-    warn_only: true # warn_only mode always enabled
+preview_operation_limits:
+  warn_only: true # warn_only mode always enabled
 ```

--- a/docs/source/configuration/operation-limits.mdx
+++ b/docs/source/configuration/operation-limits.mdx
@@ -17,7 +17,7 @@ You define operation limits in your router's [YAML config file](./configuration/
 
 ```yaml title="router.yaml"
 supergraph:
-  limits:
+  preview_limits:
     max_depth: 100
     max_height: 200
     max_aliases: 30
@@ -109,7 +109,7 @@ query GetTopProducts {
 If you run your router in `warn_only` mode, operations that exceed defined limits are _not_ rejected. Instead, the router processes these operations as usual and emits a `WARN` trace that notes all exceeded limits, like so:
 
 ```
-2023-03-15T19:08:23.123456Z WARN apollo_router::limits: max_depth exceeded, max_depth: 3, current_op_depth: 5, operation: "query GetOwnerLocation {cat {owner {location {postalCode}}}}"
+2023-03-15T19:08:23.123456Z WARN apollo_router::operation_limits: max_depth exceeded, max_depth: 3, current_op_depth: 5, operation: "query GetOwnerLocation {cat {owner {location {postalCode}}}}"
 ```
 
 Running in `warn_only` mode can be useful while you're testing to determine the most appropriate limits to set for your supergraph.

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -473,11 +473,10 @@ The Apollo Router supports enforcing two types of request limits for enhanced se
 You can set parser-based request limits in your YAML config file like so:
 
 ```yaml title="router.yaml"
-supergraph:
-  preview_limits:
-    # Default values are shown
-    parser_max_tokens: 15000
-    parser_max_recursion: 4096
+preview_operation_limits:
+  # Default values are shown
+  parser_max_tokens: 15000
+  parser_max_recursion: 4096
 ```
 
 The router rejects any request that violates at least one of these limits. See below for descriptions of individual limits.
@@ -555,10 +554,9 @@ example:
 You can specify GraphQL parser-specific limits in your router's [YAML config file](./configuration/overview/#yaml-config-file), like so:
 
 ```yaml title="router.yaml"
-supergraph:
-  preview_limits:
-    parser_max_recursion: 6000
-    parser_max_tokens: 20000
+preview_operation_limits:
+  parser_max_recursion: 6000
+  parser_max_tokens: 20000
 ```
 
 For other operation limits see [Enforcing operation limits in the Apollo Router](./configuration/operation-limits/).

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -459,6 +459,64 @@ tls:
         certificate_authorities: "${file./path/to/product_ca.crt}"
 ```
 
+### Request limits
+
+> Request limits are currently in [preview](/resources/product-launch-stages#preview).
+
+The Apollo Router supports enforcing two types of request limits for enhanced security:
+
+- Lexical, parser-based limits (documented here)
+- [Semantic, operation-based limits](./operation-limits/) (this is an [Enterprise feature](../enterprise-features/))
+
+> To set request limits, you must run v1.17 or later of the Apollo Router. [Download the latest version.](../quickstart#download-options)
+
+You can set parser-based request limits in your YAML config file like so:
+
+```yaml title="router.yaml"
+supergraph:
+  preview_limits:
+    # Default values are shown
+    parser_max_tokens: 15000
+    parser_max_recursion: 4096
+```
+
+The router rejects any request that violates at least one of these limits. See below for descriptions of individual limits.
+
+#### `parser_max_tokens`
+
+Limits the number of tokens a query document can include. This counts _all_ tokens, including both [lexical and ignored tokens](https://spec.graphql.org/October2021/#sec-Language.Source-Text.Lexical-Tokens).
+
+The default value is `15000`.
+
+#### `parser_max_recursion`
+
+Limits the deepest level of recursion allowed by the router's GraphQL parser to prevent stack overflows. This corresponds to the deepest nesting level of any single GraphQL operation or fragment defined in a query document.
+
+The default value is `4096`.
+
+In the example below, the `GetProducts` operation has a recursion of three, and the `ProductVariation` fragment has a recursion of two. Therefore, the _max_ recursion of the query document is three.
+
+```graphql
+query GetProducts {
+  allProducts { #1
+    ...productVariation
+    delivery { #2
+      fastestDelivery #3
+    }
+  }
+}
+
+fragment ProductVariation on Product {
+  variation { #1
+    name #2
+  }
+}
+```
+
+Note that the router calculates the recursion depth for each operation and fragment _separately_.  Even if a fragment is included in an operation, that fragment's recursion depth does not contribute to the _operation's_ recursion depth.
+
+> In versions of the Apollo Router prior to 1.17, this limit was defined via the config option `experimental_parser_recursion_limit`.
+
 ### Plugins
 
 You can customize the Apollo Router's behavior with [plugins](../customizations/overview). Each plugin can have its own section in the configuration file with arbitrary values:
@@ -474,7 +532,7 @@ plugins:
 
 You can reference variables directly in your YAML config file. This is useful for referencing secrets without including them in the file.
 
-Currently, the Apollo Router supports expansion of environment variables and file paths. Corresponding variables must be prefixed with `env.` or `file.`
+Currently, the Apollo Router supports expansion of environment variables and file paths. Corresponding variables are prefixed with `env.` and `file.`, respectively.
 
 The router uses Unix-style expansion. Here are some examples:
 

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -310,7 +310,7 @@ supergraph:
 
 ```yaml title="router.yaml"
 supergraph:
-  # The socket address and port to listen on. 
+  # The socket address and port to listen on.
   # Note that this must be quoted to avoid interpretation as an array in YAML.
   listen: '[::1]:4000'
 ```
@@ -550,6 +550,49 @@ supergraph:
 example:
   password: "${env.MY_PASSWORD}" #highlight-line
 ```
+
+### Parser limits
+You can specify GraphQL parser-specific limits in your router's [YAML config file](./configuration/overview/#yaml-config-file), like so:
+
+```yaml title="router.yaml"
+supergraph:
+  preview_limits:
+    parser_max_recursion: 6000
+    parser_max_tokens: 20000
+```
+
+For other operation limits see [Enforcing operation limits in the Apollo Router](./configuration/operation-limits/).
+
+#### `parser_max_recursion`
+Limits recursion in the parser to prevent stack overflows. Recursion is counted based on how nested a given GraphQL Definition is, specifically focusing Operation Definitions and Fragment Definitions. Each definition is counted separately, as the parser parses them separately.
+
+This limit has existed in the router as `experimental_parser_recursion_limit`. It has been renamed to `parser_max_recursion`.
+
+The router sets a default of **4_096** recursions.
+
+In the following example, `getProducts` Operation Definition has a recursion of three, whereas `productVariation` Fragment Definition has a recursion of two:
+
+```graphql
+query getProducts {
+  allProducts { #1
+    ...productVariation
+    delivery { #2
+        fastestDelivery #3
+    }
+  }
+}
+
+fragment productVariation on Product {
+  variation { #1
+    name #2
+  }
+}
+```
+
+#### `parser_max_tokens`
+Limits the number of tokens an operation can have. This counts _all_ tokens, including [ignored tokens](https://spec.graphql.org/October2021/#sec-Appendix-Grammar-Summary.Ignored-Tokens).
+
+The router sets a default of **15_000** tokens.
 
 ### Reusing configuration
 

--- a/docs/source/enterprise-features.mdx
+++ b/docs/source/enterprise-features.mdx
@@ -10,8 +10,9 @@ The Apollo Router provides expanded security, performance, and customization fea
 - Authentication of inbound requests via [JSON Web Token (JWT)](./configuration/authn-jwt/)
 - Redis-backed [distributed caching of query plans and persisted queries](./configuration/distributed-caching/)
 - Custom request handling in any language via [external coprocessing](./customizations/coprocessor/)
+- Mitigation of potentially malicious requests via [operation limits](./configuration/operation-limits)
 
-Documentation articles about Enterprise features are marked with a **❖** icon in the left navigation.
+Articles specifically about Enterprise features are marked with a **❖** icon in the left navigation.
 
 > **For details on these features,** see [this blog post](https://blog.apollographql.com/apollo-router-v1-12-improved-router-security-performance-and-extensibility) in addition to the documentation links above.
 


### PR DESCRIPTION
You can define operation limits in your router's configuration to reject potentially malicious requests. An operation that exceeds _any_ specified limit is rejected.

You define operation limits in your router's [YAML config file](https://www.apollographql.com/docs/router/configuration/overview#yaml-config-file), like so:

```yaml
preview_operation_limits:
  max_depth: 100
  max_height: 200
  max_aliases: 30
  max_root_fields: 20
```

See details in operation limits documentation in `docs/source/configuration/operation-limits.mdx` and soon at https://www.apollographql.com/docs/router/configuration/operation-limits.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

Compatibility: the new parser limit is enabled by default, operations larger than 15_000 tokens will be rejected. This affects ~0.1% of one corpus of 2.5 million known production GraphQL operations. Affected graphs should configure the limiter higher (and consider making smaller queries, as huge ones are likely expensive to execute.)