### PR TITLE
Do some hackery so we don't need RhaiHeaderMap

### DIFF
--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -30,7 +30,6 @@ use crate::http_ext;
 use crate::plugin::test::MockExecutionService;
 use crate::plugin::test::MockSupergraphService;
 use crate::plugin::DynPlugin;
-use crate::plugins::rhai::engine::RhaiHeaderMap;
 use crate::services::ExecutionRequest;
 use crate::services::SubgraphRequest;
 use crate::services::SupergraphRequest;
@@ -255,9 +254,9 @@ async fn it_can_access_sdl_constant() {
 #[test]
 fn it_provides_helpful_headermap_errors() {
     let mut engine = new_rhai_test_engine();
-    engine.register_fn("new_hm", || RhaiHeaderMap(HeaderMap::new()));
+    engine.register_fn("new_hm", HeaderMap::new);
 
-    let result = engine.eval::<RhaiHeaderMap>(
+    let result = engine.eval::<HeaderMap>(
         r#"
 let map = new_hm();
 map["ümlaut"] = "will fail";


### PR DESCRIPTION
I believe it's acceptable (from a rhai point of view) to have each module define its own type HeaderMap. When they are combined into a single module, as long as the type definition is the same (not even sure if this is checked) then everything works fine.

The change passes all of the tests and the example tests.

Also: polish up some of the functions which should be "pure". It will perhaps give us a performance benefit.

*Description here*

Fixes #issue_number

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
