### PR TITLE
docs(metrics): `apollo_router_cache_size` is a count of cache entries

### DIFF
--- a/.changesets/docs_abernix_pr_2607_follow_up.md
+++ b/.changesets/docs_abernix_pr_2607_follow_up.md
@@ -1,0 +1,5 @@
+### Indicate that `apollo_router_cache_size` is a count of cache entries
+
+This follows-up [PR #2607](https://github.com/apollographql/router/pull/2607) which added `apollo_router_cache_size`.  It adds `apollo_router_cache_size` to the documntation and indicates that this is the number of cache entries (that is, a count).
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/3044

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -78,6 +78,7 @@ The following metrics are available when using Prometheus. Attributes are listed
 
 #### Cache
 
+- `apollo_router_cache_size` — Number of entries in the cache
 - `apollo_router_cache_hit_count` - Number of cache hits
 - `apollo_router_cache_miss_count` - Number of cache misses
 - `apollo_router_cache_hit_time` - Time to hit the cache in seconds


### PR DESCRIPTION
Follows up https://github.com/apollographql/router/pull/2607 with the documentation that explains the `apollo_router_cache_size` metric (a count of cache entries, not "bytes as in memory").