### PR TITLE
fix: regression to gzip encoding causing panicks

### DIFF
--- a/.changesets/fix_fix_gzip_encoding.md
+++ b/.changesets/fix_fix_gzip_encoding.md
@@ -1,0 +1,5 @@
+### Fix panic when compressing small responses with gzip 
+
+1.17.0 has a regression where compressing small responses would trigger invalid buffer management, and the router would panic.
+
+By [@dbanty](https://github.com/dbanty) in https://github.com/apollographql/router/pull/3047

--- a/apollo-router/src/axum_factory/compression/mod.rs
+++ b/apollo-router/src/axum_factory/compression/mod.rs
@@ -81,29 +81,20 @@ where {
                     Ok(data) => {
                         // most compression algorithms have a compression ratio of more than 90% for JSON
                         let mut buf = BytesMut::zeroed(data.len() / 10);
-                        let mut written = 0usize;
 
                         let mut partial_input = PartialBuffer::new(&*data);
+                        let mut partial_output = PartialBuffer::new(&mut buf);
                         loop {
-                            let mut partial_output = PartialBuffer::new(&mut buf);
-                            partial_output.advance(written);
-
                             if let Err(e) = self.encode(&mut partial_input, &mut partial_output) {
                                 let _ = tx.send(Err(e.into())).await;
                                 return;
                             }
 
-                            written += partial_output.written().len();
-
                             if !partial_input.unwritten().is_empty() {
                                 // there was not enough space in the output buffer to compress everything,
                                 // so we resize and add more data
                                 if partial_output.unwritten().is_empty() {
-                                    let _ = partial_output.into_inner();
-                                    buf.resize(
-                                        buf.len() + partial_input.unwritten().len() / 10,
-                                        0u8,
-                                    );
+                                    partial_output.extend(partial_input.unwritten().len() / 10);
                                 }
                             } else {
                                 match self.flush(&mut partial_output) {

--- a/apollo-router/src/axum_factory/compression/mod.rs
+++ b/apollo-router/src/axum_factory/compression/mod.rs
@@ -218,4 +218,13 @@ mod tests {
 
         assert!(stream.next().await.is_none());
     }
+
+    #[tokio::test]
+    async fn gzip_header_writing() {
+        let compressor = Compressor::new(["gzip"].into_iter()).unwrap();
+        let body: Body = r#"{"data":{"me":{"id":"1","name":"Ada Lovelace"}}}"#.into();
+
+        let mut stream = compressor.process(body);
+        let _ = stream.next().await.unwrap().unwrap();
+    }
 }

--- a/apollo-router/src/axum_factory/compression/util.rs
+++ b/apollo-router/src/axum_factory/compression/util.rs
@@ -1,4 +1,7 @@
 #![allow(dead_code)]
+
+use bytes::BytesMut;
+
 // All code from this module is extracted from https://github.com/Nemo157/async-compression and is under MIT or Apache-2 licence
 // it will be removed when we find a long lasting solution to https://github.com/Nemo157/async-compression/issues/154
 pub(crate) fn _assert_send<T: Send>() {}
@@ -33,6 +36,13 @@ impl<B: AsRef<[u8]>> PartialBuffer<B> {
 
     pub(crate) fn into_inner(self) -> B {
         self.buffer
+    }
+}
+
+impl PartialBuffer<&mut BytesMut> {
+    /// Extend the interior mutable buffer by the given amount, filling with 0
+    pub(crate) fn extend(&mut self, amount: usize) {
+        self.buffer.resize(self.buffer.len() + amount, 0u8);
     }
 }
 


### PR DESCRIPTION
1.17.0 sometimes panics when doing gzip response encoding. The write head for the buffer was being extended by the total amount written so far (instead of the amount written by the current iteration).

Rather than just remove the `+` in `written += ...` I thought it would be more ergonomic to add the required method to the `PartialBuffer`.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable (via https://github.com/apollographql/router/pull/3052/checks?check_run_id=13259582083)
- Tests added and passing[^3]
    - [x] Unit Tests

Relates to https://github.com/apollographql/router/issues/1572
Root-cause: https://github.com/apollographql/router/pull/2986
