### PR TITLE
fix: upsert into context from coprocessors

### DIFF
--- a/.changesets/fix_lb_coprocessor_context.md
+++ b/.changesets/fix_lb_coprocessor_context.md
@@ -1,0 +1,5 @@
+### Upsert values from coprocessors into `Context`
+
+Upsert values from coprocessors into `Context` so that they persist across stages.
+
+By [@lennyburdette](https://github.com/lennyburdette) in https://github.com/apollographql/router/pull/3049

--- a/apollo-router/src/plugins/coprocessor.rs
+++ b/apollo-router/src/plugins/coprocessor.rs
@@ -563,7 +563,10 @@ where
         }
 
         if let Some(context) = co_processor_output.context {
-            res.context = context;
+            for entry in context.iter() {
+                res.context
+                    .upsert_json_value(entry.key(), |_| entry.value().clone());
+            }
         }
 
         return Ok(ControlFlow::Break(res));
@@ -581,7 +584,11 @@ where
     request.router_request = http::Request::from_parts(parts, new_body);
 
     if let Some(context) = co_processor_output.context {
-        request.context = context;
+        for entry in context.iter() {
+            request
+                .context
+                .upsert_json_value(entry.key(), |_| entry.value().clone());
+        }
     }
 
     if let Some(headers) = co_processor_output.headers {
@@ -666,7 +673,11 @@ where
     }
 
     if let Some(context) = co_processor_output.context {
-        response.context = context;
+        for entry in context.iter() {
+            response
+                .context
+                .upsert_json_value(entry.key(), |_| entry.value().clone());
+        }
     }
 
     if let Some(headers) = co_processor_output.headers {
@@ -765,13 +776,17 @@ where
                 *http_response.headers_mut() = internalize_header_map(headers)?;
             }
 
-            let mut subgraph_response = subgraph::Response {
+            let subgraph_response = subgraph::Response {
                 response: http_response,
                 context: request.context,
             };
 
             if let Some(context) = co_processor_output.context {
-                subgraph_response.context = context;
+                for entry in context.iter() {
+                    subgraph_response
+                        .context
+                        .upsert_json_value(entry.key(), |_| entry.value().clone());
+                }
             }
 
             subgraph_response
@@ -791,7 +806,11 @@ where
     request.subgraph_request = http::Request::from_parts(parts, new_body);
 
     if let Some(context) = co_processor_output.context {
-        request.context = context;
+        for entry in context.iter() {
+            request
+                .context
+                .upsert_json_value(entry.key(), |_| entry.value().clone());
+        }
     }
 
     if let Some(headers) = co_processor_output.headers {
@@ -883,7 +902,11 @@ where
     }
 
     if let Some(context) = co_processor_output.context {
-        response.context = context;
+        for entry in context.iter() {
+            response
+                .context
+                .upsert_json_value(entry.key(), |_| entry.value().clone());
+        }
     }
 
     if let Some(headers) = co_processor_output.headers {


### PR DESCRIPTION
I tried adding values to the context in the SubgraphResponse phase and using those values in a subsequent SubgraphRequest stage.

In my tests, values set in the SubgraphRequest stage are available to the SubgraphResponse stage of the same subgraph fetch, but values weren't persisting across multiple subgraph fetches.

@garypen suggested using upsert (in line with the docs for `Context`) and it fixed my issue!

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
