### PR TITLE
Add a context try_into_iter() and use it in the co-processor

### DIFF
--- a/.changesets/fix_garypen_context_coprocessor.md
+++ b/.changesets/fix_garypen_context_coprocessor.md
@@ -1,0 +1,9 @@
+### Improve subgraph co-processor context processing ([Issue #3058](https://github.com/apollographql/router/issues/3058))
+
+Each call to a subgraph co-processor could update the entire request context as a single operation. This is racy and could lead to difficult to predict context modifications depending on the order in which subgraph requests and responses are processed by the router.
+
+This fix modifies the router so that subgraph co-processor context updates are merged within the existing context. This is still racy, but means that subgraphs are only racing to perform updates at the context key level, rather than across the entire context. This is a substantial improvement on the current situation.
+
+Future enhancements will provide a more comprehensive mechanism that will support some form of sequencing or change arbitration across subgraphs.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3054

--- a/apollo-router/src/context.rs
+++ b/apollo-router/src/context.rs
@@ -176,7 +176,9 @@ impl Context {
     }
 
     /// Convert the context into an iterator.
-    pub fn try_into_iter(self) -> Result<impl IntoIterator<Item = (String, Value)>, BoxError> {
+    pub(crate) fn try_into_iter(
+        self,
+    ) -> Result<impl IntoIterator<Item = (String, Value)>, BoxError> {
         Ok(Arc::try_unwrap(self.entries)
             .map_err(|_e| anyhow::anyhow!("cannot take ownership of dashmap"))?
             .into_iter())

--- a/apollo-router/src/plugins/coprocessor.rs
+++ b/apollo-router/src/plugins/coprocessor.rs
@@ -563,7 +563,9 @@ where
         }
 
         if let Some(context) = co_processor_output.context {
-            res.context = context;
+            for (key, value) in context.try_into_iter()? {
+                res.context.upsert_json_value(key, move |_current| value);
+            }
         }
 
         return Ok(ControlFlow::Break(res));
@@ -581,7 +583,11 @@ where
     request.router_request = http::Request::from_parts(parts, new_body);
 
     if let Some(context) = co_processor_output.context {
-        request.context = context;
+        for (key, value) in context.try_into_iter()? {
+            request
+                .context
+                .upsert_json_value(key, move |_current| value);
+        }
     }
 
     if let Some(headers) = co_processor_output.headers {
@@ -666,7 +672,11 @@ where
     }
 
     if let Some(context) = co_processor_output.context {
-        response.context = context;
+        for (key, value) in context.try_into_iter()? {
+            response
+                .context
+                .upsert_json_value(key, move |_current| value);
+        }
     }
 
     if let Some(headers) = co_processor_output.headers {
@@ -765,13 +775,17 @@ where
                 *http_response.headers_mut() = internalize_header_map(headers)?;
             }
 
-            let mut subgraph_response = subgraph::Response {
+            let subgraph_response = subgraph::Response {
                 response: http_response,
                 context: request.context,
             };
 
             if let Some(context) = co_processor_output.context {
-                subgraph_response.context = context;
+                for (key, value) in context.try_into_iter()? {
+                    subgraph_response
+                        .context
+                        .upsert_json_value(key, move |_current| value);
+                }
             }
 
             subgraph_response
@@ -791,7 +805,11 @@ where
     request.subgraph_request = http::Request::from_parts(parts, new_body);
 
     if let Some(context) = co_processor_output.context {
-        request.context = context;
+        for (key, value) in context.try_into_iter()? {
+            request
+                .context
+                .upsert_json_value(key, move |_current| value);
+        }
     }
 
     if let Some(headers) = co_processor_output.headers {
@@ -883,7 +901,11 @@ where
     }
 
     if let Some(context) = co_processor_output.context {
-        response.context = context;
+        for (key, value) in context.try_into_iter()? {
+            response
+                .context
+                .upsert_json_value(key, move |_current| value);
+        }
     }
 
     if let Some(headers) = co_processor_output.headers {

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -1500,14 +1500,14 @@ fn store_ftv1(subgraph_name: &ByteString, resp: SubgraphResponse) -> SubgraphRes
             // Record the ftv1 trace for processing later
             Span::current().record("apollo_private.ftv1", ftv1.as_str());
             resp.context
-                .upsert_json_value(SUBGRAPH_FTV1, |value: Value| {
+                .upsert_json_value(SUBGRAPH_FTV1, move |value: Value| {
                     let mut vec = match value {
                         Value::Array(array) => array,
                         // upsert_json_value populate the entry with null if it was vacant
                         Value::Null => Vec::new(),
                         _ => panic!("unexpected JSON value kind"),
                     };
-                    vec.push(json!([subgraph_name.clone(), ftv1.clone()]));
+                    vec.push(json!([subgraph_name.clone(), ftv1]));
                     Value::Array(vec)
                 })
         }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -1507,7 +1507,7 @@ fn store_ftv1(subgraph_name: &ByteString, resp: SubgraphResponse) -> SubgraphRes
                         Value::Null => Vec::new(),
                         _ => panic!("unexpected JSON value kind"),
                     };
-                    vec.push(json!([subgraph_name.clone(), ftv1]));
+                    vec.push(json!([subgraph_name, ftv1]));
                     Value::Array(vec)
                 })
         }


### PR DESCRIPTION
also:
 - Modify upsert to use FnOnce rather than Fn to minimize cloning

@lennyburdette This is an attempt at a more performant fix than your PR #3049. I think the end result is the same, it should just be slightly more performant by avoiding cloning and also makes the base `Context` slightly more efficient.

Could you try a build from this branch against your test case and confirm it's still doing what you expect?

also: I've thought a little more about this and even though this is "better" than what we have on `dev` right now, I still think there is problem. This change means that we aren't racing across an entire context, but we are still racing across subgraph responses for each context update and that means there is no way to sequence the updating, which is a possible problem. It really only becomes and issue with this approach if both subgraphs are performing updates agains the same key, so that's why it's a bit better than current `dev`, but it's still a potential problem.


Fixes #3058 

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
