### PR TITLE
prep release: v1.18.0

### DIFF
--- a/.changesets/docs_abernix_pr_2607_follow_up.md
+++ b/.changesets/docs_abernix_pr_2607_follow_up.md
@@ -1,5 +1,0 @@
-### Indicate that `apollo_router_cache_size` is a count of cache entries
-
-This follows-up [PR #2607](https://github.com/apollographql/router/pull/2607) which added `apollo_router_cache_size`.  It adds `apollo_router_cache_size` to the documntation and indicates that this is the number of cache entries (that is, a count).
-
-By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/3044

--- a/.changesets/feat_geal_query_planning_metric.md
+++ b/.changesets/feat_geal_query_planning_metric.md
@@ -1,5 +1,0 @@
-### add a metric tracking query planning time 
-
-we need a way to track query planning time without going through the traces
-
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2974

--- a/.changesets/fix_fix_gzip_encoding.md
+++ b/.changesets/fix_fix_gzip_encoding.md
@@ -1,5 +1,0 @@
-### Fix panic when compressing small responses with gzip 
-
-1.17.0 has a regression where compressing small responses would trigger invalid buffer management, and the router would panic.
-
-By [@dbanty](https://github.com/dbanty) in https://github.com/apollographql/router/pull/3047

--- a/.changesets/fix_subgraph_status_code_not_in_gql_error.md
+++ b/.changesets/fix_subgraph_status_code_not_in_gql_error.md
@@ -1,7 +1,0 @@
-### Fixes a bug preventing status code from making it out to the graphQL error extensions
-
-> When contextually available, includes the HTTP status code with `SubrequestHttpError`. This provides plugins the ability to access the status code directly. Currently string parsing of the `reason` is the only way to determine the status.
-
-Previous merge request added the status_code to the Error enum, but it was not serialized into the graphql error extensions which are available to plugins.
-
-By [@scottdouglas1989](https://github.com/scottdouglas1989) in https://github.com/apollographql/router/pull/3005

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 
+# [1.18.0] - 2023-05-05
+
+## 🚀 Features
+
+### add a metric tracking query planning time 
+
+we need a way to track query planning time without going through the traces
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2974
+
+## 🐛 Fixes
+
+### Fix panic when compressing small responses with gzip 
+
+1.17.0 has a regression where compressing small responses would trigger invalid buffer management, and the router would panic.
+
+By [@dbanty](https://github.com/dbanty) in https://github.com/apollographql/router/pull/3047
+
+### Fixes a bug preventing status code from making it out to the graphQL error extensions
+
+> When contextually available, includes the HTTP status code with `SubrequestHttpError`. This provides plugins the ability to access the status code directly. Currently string parsing of the `reason` is the only way to determine the status.
+
+Previous merge request added the status_code to the Error enum, but it was not serialized into the graphql error extensions which are available to plugins.
+
+By [@scottdouglas1989](https://github.com/scottdouglas1989) in https://github.com/apollographql/router/pull/3005
+
+## 📚 Documentation
+
+### Indicate that `apollo_router_cache_size` is a count of cache entries
+
+This follows-up [PR #2607](https://github.com/apollographql/router/pull/2607) which added `apollo_router_cache_size`.  It adds `apollo_router_cache_size` to the documntation and indicates that this is the number of cache entries (that is, a count).
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/3044
+
+
+
 # [1.17.0] - 2023-05-04
 
 ## 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,25 +8,25 @@ This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.
 
 ## 🚀 Features
 
-### add a metric tracking query planning time 
+### Introduced new metric which tracks query planning time
 
-we need a way to track query planning time without going through the traces
+We've introduced a `apollo_router_query_planning_time` histogram which captures time spent in the query planning phase.  This is documented along with our other metrics [in the documentation](https://www.apollographql.com/docs/router/configuration/metrics/#available-metrics).
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2974
 
 ## 🐛 Fixes
 
-### Fix panic when compressing small responses with gzip 
+### Small gzip'd responses no longer cause a panic
 
-1.17.0 has a regression where compressing small responses would trigger invalid buffer management, and the router would panic.
+A regression introduced in v1.17.0 — again related to compression — has been resolved.  This occurred when small responses used invalid buffer management, causing a panic.
 
 By [@dbanty](https://github.com/dbanty) in https://github.com/apollographql/router/pull/3047
 
-### Fixes a bug preventing status code from making it out to the graphQL error extensions
+### HTTP status codes are now returned in `SubrequestHttpError` as intended
 
-> When contextually available, includes the HTTP status code with `SubrequestHttpError`. This provides plugins the ability to access the status code directly. Currently string parsing of the `reason` is the only way to determine the status.
+When contextually available, the HTTP status code is included within `SubrequestHttpError`. This provides plugins the ability to access the status code directly. Previously, only string parsing of the `reason` could be used to determine the status code.
 
-Previous merge request added the status_code to the Error enum, but it was not serialized into the graphql error extensions which are available to plugins.
+This corrects a previous contribution which added the status code, but neglected to serialize it properly into the `extensions` in the response which are made available to plugins.  Thank you to the same contributor for the correction!
 
 By [@scottdouglas1989](https://github.com/scottdouglas1989) in https://github.com/apollographql/router/pull/3005
 
@@ -34,11 +34,9 @@ By [@scottdouglas1989](https://github.com/scottdouglas1989) in https://github.co
 
 ### Indicate that `apollo_router_cache_size` is a count of cache entries
 
-This follows-up [PR #2607](https://github.com/apollographql/router/pull/2607) which added `apollo_router_cache_size`.  It adds `apollo_router_cache_size` to the documntation and indicates that this is the number of cache entries (that is, a count).
+This follows-up [PR #2607](https://github.com/apollographql/router/pull/2607) which added `apollo_router_cache_size`.  It adds `apollo_router_cache_size` to [the documentation](https://www.apollographql.com/docs/router/configuration/metrics/#available-metrics) and indicates that this is the number of cache entries (that is, a count).
 
 By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/3044
-
-
 
 # [1.17.0] - 2023-05-04
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "access-json",
  "anyhow",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "apollo-parser 0.4.1",
  "apollo-router",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-scaffold"
-version = "1.17.0"
+version = "1.18.0"
 dependencies = [
  "anyhow",
  "cargo-scaffold",

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "1.17.0"
+version = "1.18.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-scaffold"
-version = "1.17.0"
+version = "1.18.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -22,7 +22,7 @@ apollo-router = { path ="{{integration_test}}apollo-router" }
 apollo-router = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
 # Note if you update these dependencies then also update xtask/Cargo.toml
-apollo-router = "1.17.0"
+apollo-router = "1.18.0"
 {{/if}}
 {{/if}}
 async-trait = "0.1.52"

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -13,7 +13,7 @@ apollo-router-scaffold = { path ="{{integration_test}}apollo-router-scaffold" }
 {{#if branch}}
 apollo-router-scaffold = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
-apollo-router-scaffold = { git = "https://github.com/apollographql/router.git", tag = "v1.17.0" }
+apollo-router-scaffold = { git = "https://github.com/apollographql/router.git", tag = "v1.18.0" }
 {{/if}}
 {{/if}}
 anyhow = "1.0.58"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "1.17.0"
+version = "1.18.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 repository = "https://github.com/apollographql/router/"
 documentation = "https://docs.rs/apollo-router"

--- a/dockerfiles/tracing/docker-compose.datadog.yml
+++ b/dockerfiles/tracing/docker-compose.datadog.yml
@@ -3,7 +3,7 @@ services:
 
   apollo-router:
     container_name: apollo-router
-    image: ghcr.io/apollographql/router:v1.17.0
+    image: ghcr.io/apollographql/router:v1.18.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/datadog.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.jaeger.yml
+++ b/dockerfiles/tracing/docker-compose.jaeger.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     #build: ./router
-    image: ghcr.io/apollographql/router:v1.17.0
+    image: ghcr.io/apollographql/router:v1.18.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/jaeger.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.zipkin.yml
+++ b/dockerfiles/tracing/docker-compose.zipkin.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     build: ./router
-    image: ghcr.io/apollographql/router:v1.17.0
+    image: ghcr.io/apollographql/router:v1.18.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/zipkin.router.yaml:/etc/config/configuration.yaml

--- a/docs/source/containerization/docker.mdx
+++ b/docs/source/containerization/docker.mdx
@@ -11,7 +11,7 @@ The default behaviour of the router images is suitable for a quickstart or devel
 
 Note: The [docker documentation](https://docs.docker.com/engine/reference/run/) for the run command may be helpful when reading through the examples.
 
-Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v1.17.0`
+Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v1.18.0`
 
 ## Override the configuration
 

--- a/docs/source/containerization/kubernetes.mdx
+++ b/docs/source/containerization/kubernetes.mdx
@@ -13,7 +13,7 @@ import { Link } from 'gatsby';
 
 [Helm](https://helm.sh) is the package manager for kubernetes.
 
-There is a complete [helm chart definition](https://github.com/apollographql/router/tree/v1.17.0/helm/chart/router) in the repo which illustrates how to use helm to deploy the router in kubernetes.
+There is a complete [helm chart definition](https://github.com/apollographql/router/tree/v1.18.0/helm/chart/router) in the repo which illustrates how to use helm to deploy the router in kubernetes.
 
 In both the following examples, we are using helm to install the router:
  - into namespace "router-deploy" (create namespace if it doesn't exist)
@@ -64,10 +64,10 @@ kind: ServiceAccount
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-1.17.0
+    helm.sh/chart: router-1.18.0
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.17.0"
+    app.kubernetes.io/version: "v1.18.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: router/templates/secret.yaml
@@ -76,10 +76,10 @@ kind: Secret
 metadata:
   name: "release-name-router"
   labels:
-    helm.sh/chart: router-1.17.0
+    helm.sh/chart: router-1.18.0
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.17.0"
+    app.kubernetes.io/version: "v1.18.0"
     app.kubernetes.io/managed-by: Helm
 data:
   managedFederationApiKey: "UkVEQUNURUQ="
@@ -90,10 +90,10 @@ kind: ConfigMap
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-1.17.0
+    helm.sh/chart: router-1.18.0
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.17.0"
+    app.kubernetes.io/version: "v1.18.0"
     app.kubernetes.io/managed-by: Helm
 data:
   configuration.yaml: |
@@ -117,10 +117,10 @@ kind: Service
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-1.17.0
+    helm.sh/chart: router-1.18.0
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.17.0"
+    app.kubernetes.io/version: "v1.18.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -143,10 +143,10 @@ kind: Deployment
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-1.17.0
+    helm.sh/chart: router-1.18.0
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.17.0"
+    app.kubernetes.io/version: "v1.18.0"
     app.kubernetes.io/managed-by: Helm
   
   annotations:
@@ -172,7 +172,7 @@ spec:
         - name: router
           securityContext:
             {}
-          image: "ghcr.io/apollographql/router:v1.17.0"
+          image: "ghcr.io/apollographql/router:v1.18.0"
           imagePullPolicy: IfNotPresent
           args:
             - --hot-reload
@@ -223,10 +223,10 @@ kind: Pod
 metadata:
   name: "release-name-router-test-connection"
   labels:
-    helm.sh/chart: router-1.17.0
+    helm.sh/chart: router-1.18.0
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.17.0"
+    app.kubernetes.io/version: "v1.18.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test

--- a/helm/chart/router/Chart.yaml
+++ b/helm/chart/router/Chart.yaml
@@ -20,10 +20,10 @@ type: application
 # so it matches the shape of our release process and release automation.
 # By proxy of that decision, this version uses SemVer 2.0.0, though the prefix
 # of "v" is not included.
-version: 1.17.0
+version: 1.18.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.17.0"
+appVersion: "v1.18.0"

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -2,7 +2,7 @@
 
 [router](https://github.com/apollographql/router) Rust Graph Routing runtime for Apollo Federation
 
-![Version: 1.17.0](https://img.shields.io/badge/Version-1.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.17.0](https://img.shields.io/badge/AppVersion-v1.17.0-informational?style=flat-square)
+![Version: 1.18.0](https://img.shields.io/badge/Version-1.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.18.0](https://img.shields.io/badge/AppVersion-v1.18.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@
 ## Get Repo Info
 
 ```console
-helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.17.0
+helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.18.0
 ```
 
 ## Install Chart
@@ -19,7 +19,7 @@ helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.17.0
 **Important:** only helm3 is supported
 
 ```console
-helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 1.17.0 --values my-values.yaml
+helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 1.18.0 --values my-values.yaml
 ```
 
 _See [configuration](#configuration) below._

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/router/releases/downloa
 
 # Router version defined in apollo-router's Cargo.toml
 # Note: Change this line manually during the release steps.
-PACKAGE_VERSION="v1.17.0"
+PACKAGE_VERSION="v1.18.0"
 
 download_binary() {
     downloader --check


### PR DESCRIPTION
> **Note**
>
> When approved, this PR will merge into **the `1.18.0` branch** which will — upon being approved itself — merge into `main`.
>
> **Things to review in this PR**:
>  - Changelog correctness (There is a preview below, but it is not necessarily the most up to date.  See the _Files Changed_ for the true reality.)
>  - Version bumps
>  - That it targets the right release branch (`1.18.0` in this case!).
>
---
## 🚀 Features

### Introduced new metric which tracks query planning time

We've introduced a `apollo_router_query_planning_time` histogram which captures time spent in the query planning phase.  This is documented along with our other metrics [in the documentation](https://www.apollographql.com/docs/router/configuration/metrics/#available-metrics).

By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/2974

## 🐛 Fixes

### Small gzip'd responses no longer cause a panic

A regression introduced in v1.17.0 — again related to compression — has been resolved.  This occurred when small responses used invalid buffer management, causing a panic.

By [@dbanty](https://github.com/dbanty) in https://github.com/apollographql/router/pull/3047

### HTTP status codes are now returned in `SubrequestHttpError` as intended

When contextually available, the HTTP status code is included within `SubrequestHttpError`. This provides plugins the ability to access the status code directly. Previously, only string parsing of the `reason` could be used to determine the status code.

This corrects a previous contribution which added the status code, but neglected to serialize it properly into the `extensions` in the response which are made available to plugins.  Thank you to the same contributor for the correction!

By [@scottdouglas1989](https://github.com/scottdouglas1989) in https://github.com/apollographql/router/pull/3005

## 📚 Documentation

### Indicate that `apollo_router_cache_size` is a count of cache entries

This follows-up [PR #2607](https://github.com/apollographql/router/pull/2607) which added `apollo_router_cache_size`.  It adds `apollo_router_cache_size` to [the documentation](https://www.apollographql.com/docs/router/configuration/metrics/#available-metrics) and indicates that this is the number of cache entries (that is, a count).

By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/3044
