### PR TITLE
Make execution::Request.compiler public

### DIFF
--- a/apollo-router/src/services/execution.rs
+++ b/apollo-router/src/services/execution.rs
@@ -31,8 +31,7 @@ pub struct Request {
     /// It normally also contains type information from the schema,
     /// but might not if this `Request` was created in tests
     /// with `fake_builder()` without providing a `schema` parameter.
-    #[allow(unused)] // TODO: find some uses
-    pub(crate) compiler: apollo_compiler::Snapshot,
+    pub compiler: apollo_compiler::Snapshot,
 
     pub context: Context,
 }

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -270,6 +270,7 @@ impl Query {
         let mut compiler = ApolloCompiler::new()
             .recursion_limit(configuration.preview_operation_limits.parser_max_recursion)
             .token_limit(configuration.preview_operation_limits.parser_max_tokens);
+        compiler.set_type_system_hir(schema.type_system.clone());
         let id = compiler.add_executable(&query, "query");
         let ast = compiler.db.ast(id);
 


### PR DESCRIPTION
This is a follow-up on https://github.com/apollographql/router/pull/2482 which sets the query compiler type system and makes the execution request snapshot public. It would be very handy for us to have access to the compiler snapshot in our router plugins for query analysis. 

**Checklist**

- [x] Changes are compatible
- [x] Documentation
- [ ] Performance impact assessed and acceptable
- Tests added and passing
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests
