### PR TITLE
Update reports.proto for GraphOS usage reporting

### DIFF
--- a/apollo-router/src/plugins/telemetry/proto/reports.proto
+++ b/apollo-router/src/plugins/telemetry/proto/reports.proto
@@ -1,6 +1,9 @@
 syntax = "proto3";
 
 
+// Note: The Apollo usage reporting API is subject to change. We strongly encourage developers to contact Apollo support
+// at support@apollographql.com to discuss their use case prior to building their own reporting agent using this module.
+
 import "google/protobuf/timestamp.proto";
 
 message Trace {
@@ -243,9 +246,6 @@ message Trace {
   string operation_type = 35;
   string operation_subtype = 36;
 
-  // optional: this is populated from the report header when storing trace data, and it is not
-  // expected to be specified in the report's version of a trace
-  string agent_version = 34;
 
   HTTP http = 10;
 
@@ -328,29 +328,51 @@ message PathErrorStats {
 }
 
 message QueryLatencyStats {
+  // The latencies of all non-cached requests, so the sum of all counts should equal request_count minus cache_hits.
+  // This is an array of counts within a logarithmic range of 384 latency buckets. To calculate the bucket from a
+  // microsecond, use the formula: max(0, min(ceil(ln(x)/ln(1.1)), 383)). So for example, 323424 microseconds (323.424
+  // ms) corresponds to bucket 134. Buckets can be skipped using a negative number, so one request on that bucket could
+  // be represented as [-134, 1] (skip buckets numbered 0 to 133 and set a 1 in bucket 134).
   repeated sint64 latency_count = 13 [(js_use_toArray) = true];
+
+  // The total number of requests, including both cache hits and cache misses
   uint64 request_count = 2;
+
+  // The total number of requests that were cache hits. Each request should be represented in cache_latency_count
   uint64 cache_hits = 3;
+
   uint64 persisted_query_hits = 4;
   uint64 persisted_query_misses = 5;
+
+  // This array includes the latency buckets for all operations included in cache_hits
+  // See comment on latency_count for details.
   repeated sint64 cache_latency_count = 14 [(js_use_toArray) = true];
+
+  // Paths and counts for each error. The total number of requests with errors within this object should be the same as
+  // requests_with_errors_count below.
   PathErrorStats root_error_stats = 7;
+
+  // Total number of requests that contained at least one error
   uint64 requests_with_errors_count = 8;
+
   repeated sint64 public_cache_ttl_count = 15 [(js_use_toArray) = true];
   repeated sint64 private_cache_ttl_count = 16 [(js_use_toArray) = true];
   uint64 registered_operation_count = 11;
   uint64 forbidden_operation_count = 12;
+
   // The number of requests that were executed without field-level
   // instrumentation (and thus do not contribute to `observed_execution_count`
   // fields on this message's cousin-twice-removed FieldStats).
   uint64 requests_without_field_instrumentation = 17;
+
   // 1, 6, 9, and 10 were old int64 histograms
   reserved 1, 6, 9, 10;
 }
 
+// The context around a block of stats and traces indicating from which client the operation was executed and its
+// operation type. Operation type and subtype are only used by Apollo Router.
 message StatsContext {
-  // string client_reference_id = 1;
-  reserved 1;
+  reserved 1; // string client_reference_id = 1;
   string client_name = 2;
   string client_version = 3;
   string operation_type = 4;
@@ -378,7 +400,7 @@ message FieldStat {
   // Number of times that the resolver for this field is directly observed being
   // executed.
   uint64 observed_execution_count = 5;
-  // Same as `count` but potentially scaled upwards if the server was only
+  // Same as `observed_execution_count` but potentially scaled upwards if the server was only
   // performing field-level instrumentation on a sampling of operations.  For
   // example, if the server randomly instruments 1% of requests for this
   // operation, this number will be 100 times greater than
@@ -397,6 +419,7 @@ message FieldStat {
   // the same way as estimated_execution_count so its "total count" might be
   // greater than `observed_execution_count` and may not exactly equal
   // `estimated_execution_count` due to rounding.
+  // See comment on QueryLatencyStats's latency_count for details.
   repeated sint64 latency_count = 9 [(js_use_toArray) = true];
   reserved 1, 2, 7, 8;
 }
@@ -416,14 +439,14 @@ message ReferencedFieldsForType {
 
 
 
-// This is the top-level message used by the new traces ingress. This
-// is designed for the apollo-engine-reporting TypeScript agent and will
-// eventually be documented as a public ingress API. This message consists
-// solely of traces; the equivalent of the StatsReport is automatically
-// generated server-side from this message. Agent should either send a trace or include it in the stats
-// for every request in this report. Generally, buffering up until a large
-// size has been reached (say, 4MB) or 5-10 seconds has passed is appropriate.
-// This message used to be know as FullTracesReport, but got renamed since it isn't just for traces anymore
+// This is the top-level message used by Apollo Server, Apollo Router, and other libraries to report usage information
+// to Apollo. This message consists of traces and stats for operations. By default, each individual operation execution
+// should be either represented as a trace or within stats, but not both. However if the "traces_pre_aggregated" field
+// is set to true, all operations should be included in stats and anything specified as a trace is not added in to the
+// aggregate stats. For performance reasons, we recommend that traces are sampled so that only somewhere around 1% of
+// operation executions are sent as traces. Additionally, buffering operations up until a large size has been reached
+// (say, 4MB) or 5-10 seconds has passed is appropriate.
+// This message used to be known as FullTracesReport, but got renamed since it isn't just for traces anymore.
 message Report {
   message OperationCountByType {
     string type = 1;
@@ -449,7 +472,8 @@ message Report {
   // Note: This will override the end_time from traces.
   google.protobuf.Timestamp end_time = 2; // required if no traces in this message
 
-  // Total number of operations processed during this period.
+  // Total number of operations processed during this period. This includes all operations, even if they are sampled
+  // and not included in the query latency stats.
   uint64 operation_count = 6;
 
   // Total number of operations broken up by operation type and operation subtype.

--- a/apollo-router/tests/snapshots/apollo_reports__client_name.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__client_name.snap
@@ -32,7 +32,6 @@ traces_per_query:
         client_version: ""
         operation_type: query
         operation_subtype: ""
-        agent_version: "[agent_version]"
         http:
           method: 4
           request_headers: {}
@@ -175,7 +174,6 @@ traces_per_query:
                         client_version: ""
                         operation_type: ""
                         operation_subtype: ""
-                        agent_version: "[agent_version]"
                         http: ~
                         cache_policy: ~
                         query_plan: ~
@@ -419,7 +417,6 @@ traces_per_query:
                               client_version: ""
                               operation_type: ""
                               operation_subtype: ""
-                              agent_version: "[agent_version]"
                               http: ~
                               cache_policy: ~
                               query_plan: ~
@@ -527,7 +524,6 @@ traces_per_query:
                               client_version: ""
                               operation_type: ""
                               operation_subtype: ""
-                              agent_version: "[agent_version]"
                               http: ~
                               cache_policy: ~
                               query_plan: ~

--- a/apollo-router/tests/snapshots/apollo_reports__client_version.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__client_version.snap
@@ -32,7 +32,6 @@ traces_per_query:
         client_version: my client version
         operation_type: query
         operation_subtype: ""
-        agent_version: "[agent_version]"
         http:
           method: 4
           request_headers: {}
@@ -175,7 +174,6 @@ traces_per_query:
                         client_version: ""
                         operation_type: ""
                         operation_subtype: ""
-                        agent_version: "[agent_version]"
                         http: ~
                         cache_policy: ~
                         query_plan: ~
@@ -419,7 +417,6 @@ traces_per_query:
                               client_version: ""
                               operation_type: ""
                               operation_subtype: ""
-                              agent_version: "[agent_version]"
                               http: ~
                               cache_policy: ~
                               query_plan: ~
@@ -527,7 +524,6 @@ traces_per_query:
                               client_version: ""
                               operation_type: ""
                               operation_subtype: ""
-                              agent_version: "[agent_version]"
                               http: ~
                               cache_policy: ~
                               query_plan: ~

--- a/apollo-router/tests/snapshots/apollo_reports__condition_else.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__condition_else.snap
@@ -33,7 +33,6 @@ traces_per_query:
         client_version: ""
         operation_type: query
         operation_subtype: ""
-        agent_version: "[agent_version]"
         http:
           method: 4
           request_headers: {}
@@ -181,7 +180,6 @@ traces_per_query:
                               client_version: ""
                               operation_type: ""
                               operation_subtype: ""
-                              agent_version: "[agent_version]"
                               http: ~
                               cache_policy: ~
                               query_plan: ~
@@ -425,7 +423,6 @@ traces_per_query:
                                     client_version: ""
                                     operation_type: ""
                                     operation_subtype: ""
-                                    agent_version: "[agent_version]"
                                     http: ~
                                     cache_policy: ~
                                     query_plan: ~
@@ -533,7 +530,6 @@ traces_per_query:
                                     client_version: ""
                                     operation_type: ""
                                     operation_subtype: ""
-                                    agent_version: "[agent_version]"
                                     http: ~
                                     cache_policy: ~
                                     query_plan: ~

--- a/apollo-router/tests/snapshots/apollo_reports__condition_if.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__condition_if.snap
@@ -33,7 +33,6 @@ traces_per_query:
         client_version: ""
         operation_type: query
         operation_subtype: ""
-        agent_version: "[agent_version]"
         http:
           method: 4
           request_headers: {}
@@ -181,7 +180,6 @@ traces_per_query:
                               client_version: ""
                               operation_type: ""
                               operation_subtype: ""
-                              agent_version: "[agent_version]"
                               http: ~
                               cache_policy: ~
                               query_plan: ~
@@ -437,7 +435,6 @@ traces_per_query:
                                               client_version: ""
                                               operation_type: ""
                                               operation_subtype: ""
-                                              agent_version: "[agent_version]"
                                               http: ~
                                               cache_policy: ~
                                               query_plan: ~
@@ -545,7 +542,6 @@ traces_per_query:
                                               client_version: ""
                                               operation_type: ""
                                               operation_subtype: ""
-                                              agent_version: "[agent_version]"
                                               http: ~
                                               cache_policy: ~
                                               query_plan: ~

--- a/apollo-router/tests/snapshots/apollo_reports__non_defer.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__non_defer.snap
@@ -32,7 +32,6 @@ traces_per_query:
         client_version: ""
         operation_type: query
         operation_subtype: ""
-        agent_version: "[agent_version]"
         http:
           method: 4
           request_headers: {}
@@ -175,7 +174,6 @@ traces_per_query:
                         client_version: ""
                         operation_type: ""
                         operation_subtype: ""
-                        agent_version: "[agent_version]"
                         http: ~
                         cache_policy: ~
                         query_plan: ~
@@ -419,7 +417,6 @@ traces_per_query:
                               client_version: ""
                               operation_type: ""
                               operation_subtype: ""
-                              agent_version: "[agent_version]"
                               http: ~
                               cache_policy: ~
                               query_plan: ~
@@ -527,7 +524,6 @@ traces_per_query:
                               client_version: ""
                               operation_type: ""
                               operation_subtype: ""
-                              agent_version: "[agent_version]"
                               http: ~
                               cache_policy: ~
                               query_plan: ~

--- a/apollo-router/tests/snapshots/apollo_reports__send_header.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__send_header.snap
@@ -32,7 +32,6 @@ traces_per_query:
         client_version: ""
         operation_type: query
         operation_subtype: ""
-        agent_version: "[agent_version]"
         http:
           method: 4
           request_headers:
@@ -178,7 +177,6 @@ traces_per_query:
                         client_version: ""
                         operation_type: ""
                         operation_subtype: ""
-                        agent_version: "[agent_version]"
                         http: ~
                         cache_policy: ~
                         query_plan: ~
@@ -422,7 +420,6 @@ traces_per_query:
                               client_version: ""
                               operation_type: ""
                               operation_subtype: ""
-                              agent_version: "[agent_version]"
                               http: ~
                               cache_policy: ~
                               query_plan: ~
@@ -530,7 +527,6 @@ traces_per_query:
                               client_version: ""
                               operation_type: ""
                               operation_subtype: ""
-                              agent_version: "[agent_version]"
                               http: ~
                               cache_policy: ~
                               query_plan: ~

--- a/apollo-router/tests/snapshots/apollo_reports__send_variable_value.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__send_variable_value.snap
@@ -34,7 +34,6 @@ traces_per_query:
         client_version: ""
         operation_type: query
         operation_subtype: ""
-        agent_version: "[agent_version]"
         http:
           method: 4
           request_headers: {}
@@ -177,7 +176,6 @@ traces_per_query:
                         client_version: ""
                         operation_type: ""
                         operation_subtype: ""
-                        agent_version: "[agent_version]"
                         http: ~
                         cache_policy: ~
                         query_plan: ~
@@ -428,7 +426,6 @@ traces_per_query:
                                             client_version: ""
                                             operation_type: ""
                                             operation_subtype: ""
-                                            agent_version: "[agent_version]"
                                             http: ~
                                             cache_policy: ~
                                             query_plan: ~
@@ -536,7 +533,6 @@ traces_per_query:
                                             client_version: ""
                                             operation_type: ""
                                             operation_subtype: ""
-                                            agent_version: "[agent_version]"
                                             http: ~
                                             cache_policy: ~
                                             query_plan: ~

--- a/apollo-router/tests/snapshots/apollo_reports__trace_id.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__trace_id.snap
@@ -32,7 +32,6 @@ traces_per_query:
         client_version: ""
         operation_type: query
         operation_subtype: ""
-        agent_version: "[agent_version]"
         http:
           method: 4
           request_headers: {}
@@ -175,7 +174,6 @@ traces_per_query:
                         client_version: ""
                         operation_type: ""
                         operation_subtype: ""
-                        agent_version: "[agent_version]"
                         http: ~
                         cache_policy: ~
                         query_plan: ~
@@ -419,7 +417,6 @@ traces_per_query:
                               client_version: ""
                               operation_type: ""
                               operation_subtype: ""
-                              agent_version: "[agent_version]"
                               http: ~
                               cache_policy: ~
                               query_plan: ~
@@ -527,7 +524,6 @@ traces_per_query:
                               client_version: ""
                               operation_type: ""
                               operation_subtype: ""
-                              agent_version: "[agent_version]"
                               http: ~
                               cache_policy: ~
                               query_plan: ~


### PR DESCRIPTION
This largely updates the documentation for the protobuf we use for reporting
usage information to GraphOS, however, it does remove an unused `agent_version`.

Ref: (Internal) 1954fb92372cb02b69148a503a0de687806c0604

Fixes failing CI: https://app.circleci.com/pipelines/github/apollographql/router/12130/workflows/f27c0f53-20b0-49ef-8387-306b37f3dc89/jobs/79862

