### PR TITLE
prep release: v1.18.1

### DIFF
--- a/.changesets/fix_garypen_3065_reload_logging.md
+++ b/.changesets/fix_garypen_3065_reload_logging.md
@@ -1,7 +1,0 @@
-### add more details to the state machine `Running` processing ([Issue #3065](https://github.com/apollographql/router/issues/3065))
-
-It's difficult to know from the logs why a router state reload has been triggered and the current logs don't make it clear that it's possible for a state change trigger to be ignored.
-
-This change adds details about the triggers of potential state changes to the logs and also make it easier to see when an unentitled event causes a state change to be ignored.
-
-By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3066

--- a/.changesets/fix_geal_resize_flushed_buffer.md
+++ b/.changesets/fix_geal_resize_flushed_buffer.md
@@ -1,6 +1,0 @@
-### use a large enough buffer to flush in 
-
-When writing a deferred response, if the output buffer was too small to write the entire compressed response, the compressor would write a small chunk, that did not decompress to the entire primary response, and would then wait for the next response to send the rest. Unfortunately, we cannot really know the output size we need in advance, and if we asked the decoder, it will tell us that it flushed all the data, even if it could have sent more.
-So in here we raise the output buffer size, and do a second buffer growing step after flushing if necessary.
-
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3067

--- a/.changesets/maint_bnjjj_follow_up_3011.md
+++ b/.changesets/maint_bnjjj_follow_up_3011.md
@@ -1,5 +1,0 @@
-### Refactor the way we're redacting errors for Apollo telemetry
-
-Preprocess errors in a more readable way.
-
-By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/3030

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.
 
 When writing a deferred response, if the output buffer was too small to write the entire compressed response, the compressor would write a small chunk that did not decompress to the entire primary response, and would then wait for the next response to send the rest.
 
-Unfortunately, we cannot really know the output size we need in advance, and if we asked the decoder, it will tell us that it flushed all the data, even if it could have sent more.  To compensate for this, we raise the output buffer size, and do a second buffer growing step after flushing, if necessary.
+Unfortunately, we cannot really know the output size we need in advance, and if we asked the decoder, it would tell us that it flushed all the data, even if it could have sent more.  To compensate for this, we raise the output buffer size, and grow the buffer a second time after flushing, if necessary.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3067
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.
 
 ## 🐛 Fixes
 
+### Fix multipart response compression by using a large enough buffer
+
+When writing a deferred response, if the output buffer was too small to write the entire compressed response, the compressor would write a small chunk that did not decompress to the entire primary response, and would then wait for the next response to send the rest.
+
+Unfortunately, we cannot really know the output size we need in advance, and if we asked the decoder, it will tell us that it flushed all the data, even if it could have sent more.  To compensate for this, we raise the output buffer size, and do a second buffer growing step after flushing, if necessary.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3067
+
 ### Emit more log details to the state machine's `Running` phase ([Issue #3065](https://github.com/apollographql/router/issues/3065))
 
 This change adds details about the triggers of potential state changes to the logs and also makes it easier to see when an un-entitled event causes a state change to be ignored.
@@ -16,13 +24,6 @@ Prior to this change, it was difficult to know from the logs why a router state 
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3066
 
-### Fix multipart response compression by using a large enough buffer
-
-When writing a deferred response, if the output buffer was too small to write the entire compressed response, the compressor would write a small chunk that did not decompress to the entire primary response, and would then wait for the next response to send the rest.
-
-Unfortunately, we cannot really know the output size we need in advance, and if we asked the decoder, it will tell us that it flushed all the data, even if it could have sent more.  To compensate for this, we raise the output buffer size, and do a second buffer growing step after flushing, if necessary.
-
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3067
 
 ### Respect GraphOS/Studio metric "backoff" guidance ([Issue #2888](https://github.com/apollographql/router/issues/2888))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@ All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 
+# [1.18.1] - 2023-05-11
+
+## 🐛 Fixes
+
+### add more details to the state machine `Running` processing ([Issue #3065](https://github.com/apollographql/router/issues/3065))
+
+It's difficult to know from the logs why a router state reload has been triggered and the current logs don't make it clear that it's possible for a state change trigger to be ignored.
+
+This change adds details about the triggers of potential state changes to the logs and also make it easier to see when an unentitled event causes a state change to be ignored.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3066
+
+### use a large enough buffer to flush in 
+
+When writing a deferred response, if the output buffer was too small to write the entire compressed response, the compressor would write a small chunk, that did not decompress to the entire primary response, and would then wait for the next response to send the rest. Unfortunately, we cannot really know the output size we need in advance, and if we asked the decoder, it will tell us that it flushed all the data, even if it could have sent more.
+So in here we raise the output buffer size, and do a second buffer growing step after flushing if necessary.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3067
+
+## 🛠 Maintenance
+
+### Refactor the way we're redacting errors for Apollo telemetry
+
+Preprocess errors in a more readable way.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/3030
+
+
+
 # [1.18.0] - 2023-05-05
 
 ## 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,18 +8,19 @@ This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.
 
 ## 🐛 Fixes
 
-### add more details to the state machine `Running` processing ([Issue #3065](https://github.com/apollographql/router/issues/3065))
+### Emit more log details to the state machine's `Running` phase ([Issue #3065](https://github.com/apollographql/router/issues/3065))
 
-It's difficult to know from the logs why a router state reload has been triggered and the current logs don't make it clear that it's possible for a state change trigger to be ignored.
+This change adds details about the triggers of potential state changes to the logs and also makes it easier to see when an un-entitled event causes a state change to be ignored.
 
-This change adds details about the triggers of potential state changes to the logs and also make it easier to see when an unentitled event causes a state change to be ignored.
+Prior to this change, it was difficult to know from the logs why a router state reload had been triggered and the logs didn't make it clear that it was possible that the state change was going to be ignored.
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3066
 
-### use a large enough buffer to flush in 
+### Fix multipart response compression by using a large enough buffer
 
-When writing a deferred response, if the output buffer was too small to write the entire compressed response, the compressor would write a small chunk, that did not decompress to the entire primary response, and would then wait for the next response to send the rest. Unfortunately, we cannot really know the output size we need in advance, and if we asked the decoder, it will tell us that it flushed all the data, even if it could have sent more.
-So in here we raise the output buffer size, and do a second buffer growing step after flushing if necessary.
+When writing a deferred response, if the output buffer was too small to write the entire compressed response, the compressor would write a small chunk that did not decompress to the entire primary response, and would then wait for the next response to send the rest.
+
+Unfortunately, we cannot really know the output size we need in advance, and if we asked the decoder, it will tell us that it flushed all the data, even if it could have sent more.  To compensate for this, we raise the output buffer size, and do a second buffer growing step after flushing, if necessary.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3067
 
@@ -27,10 +28,9 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 
 ### Refactor the way we're redacting errors for Apollo telemetry
 
-Preprocess errors in a more readable way.
+This follows-up on the federated subgraph trace error redaction mechanism changes which first appeared in [v1.16.0](https://github.com/apollographql/router/releases/tag/v1.16.0) via [PR #3011](https://github.com/apollographql/router/pull/3011) with some internal refactoring that improves the readability of the logic.  There should be no functional changes to the feature's behavior.
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/3030
-
 
 
 # [1.18.0] - 2023-05-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,14 @@ Unfortunately, we cannot really know the output size we need in advance, and if 
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3067
 
+### Respect GraphOS/Studio metric "backoff" guidance ([Issue #2888](https://github.com/apollographql/router/issues/2888))
+
+For stability reasons, GraphOS metric ingress will return an HTTP `429` status code with `Retry-After` guidance if it's unable to immediately accept a metric submission from a router.  A router instance should not try to submit further metrics until that amount of time (in seconds) has elapsed.  This fix provides support for this interaction.
+
+While observing a backoff request from GraphOS, the router will continue to collect metrics and no metrics are lost unless the router terminates before the timeout expires.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/2977
+
 ## 🛠 Maintenance
 
 ### Refactor the way we're redacting errors for Apollo telemetry

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "access-json",
  "anyhow",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "apollo-parser 0.4.1",
  "apollo-router",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-scaffold"
-version = "1.18.0"
+version = "1.18.1"
 dependencies = [
  "anyhow",
  "cargo-scaffold",

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "1.18.0"
+version = "1.18.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-scaffold"
-version = "1.18.0"
+version = "1.18.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -22,7 +22,7 @@ apollo-router = { path ="{{integration_test}}apollo-router" }
 apollo-router = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
 # Note if you update these dependencies then also update xtask/Cargo.toml
-apollo-router = "1.18.0"
+apollo-router = "1.18.1"
 {{/if}}
 {{/if}}
 async-trait = "0.1.52"

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -13,7 +13,7 @@ apollo-router-scaffold = { path ="{{integration_test}}apollo-router-scaffold" }
 {{#if branch}}
 apollo-router-scaffold = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
-apollo-router-scaffold = { git = "https://github.com/apollographql/router.git", tag = "v1.18.0" }
+apollo-router-scaffold = { git = "https://github.com/apollographql/router.git", tag = "v1.18.1" }
 {{/if}}
 {{/if}}
 anyhow = "1.0.58"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "1.18.0"
+version = "1.18.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 repository = "https://github.com/apollographql/router/"
 documentation = "https://docs.rs/apollo-router"

--- a/dockerfiles/tracing/docker-compose.datadog.yml
+++ b/dockerfiles/tracing/docker-compose.datadog.yml
@@ -3,7 +3,7 @@ services:
 
   apollo-router:
     container_name: apollo-router
-    image: ghcr.io/apollographql/router:v1.18.0
+    image: ghcr.io/apollographql/router:v1.18.1
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/datadog.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.jaeger.yml
+++ b/dockerfiles/tracing/docker-compose.jaeger.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     #build: ./router
-    image: ghcr.io/apollographql/router:v1.18.0
+    image: ghcr.io/apollographql/router:v1.18.1
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/jaeger.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.zipkin.yml
+++ b/dockerfiles/tracing/docker-compose.zipkin.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     build: ./router
-    image: ghcr.io/apollographql/router:v1.18.0
+    image: ghcr.io/apollographql/router:v1.18.1
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/zipkin.router.yaml:/etc/config/configuration.yaml

--- a/docs/source/containerization/docker.mdx
+++ b/docs/source/containerization/docker.mdx
@@ -11,7 +11,7 @@ The default behaviour of the router images is suitable for a quickstart or devel
 
 Note: The [docker documentation](https://docs.docker.com/engine/reference/run/) for the run command may be helpful when reading through the examples.
 
-Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v1.18.0`
+Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v1.18.1`
 
 ## Override the configuration
 

--- a/docs/source/containerization/kubernetes.mdx
+++ b/docs/source/containerization/kubernetes.mdx
@@ -13,7 +13,7 @@ import { Link } from 'gatsby';
 
 [Helm](https://helm.sh) is the package manager for kubernetes.
 
-There is a complete [helm chart definition](https://github.com/apollographql/router/tree/v1.18.0/helm/chart/router) in the repo which illustrates how to use helm to deploy the router in kubernetes.
+There is a complete [helm chart definition](https://github.com/apollographql/router/tree/v1.18.1/helm/chart/router) in the repo which illustrates how to use helm to deploy the router in kubernetes.
 
 In both the following examples, we are using helm to install the router:
  - into namespace "router-deploy" (create namespace if it doesn't exist)
@@ -64,10 +64,10 @@ kind: ServiceAccount
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-1.18.0
+    helm.sh/chart: router-1.18.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.18.0"
+    app.kubernetes.io/version: "v1.18.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: router/templates/secret.yaml
@@ -76,10 +76,10 @@ kind: Secret
 metadata:
   name: "release-name-router"
   labels:
-    helm.sh/chart: router-1.18.0
+    helm.sh/chart: router-1.18.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.18.0"
+    app.kubernetes.io/version: "v1.18.1"
     app.kubernetes.io/managed-by: Helm
 data:
   managedFederationApiKey: "UkVEQUNURUQ="
@@ -90,10 +90,10 @@ kind: ConfigMap
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-1.18.0
+    helm.sh/chart: router-1.18.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.18.0"
+    app.kubernetes.io/version: "v1.18.1"
     app.kubernetes.io/managed-by: Helm
 data:
   configuration.yaml: |
@@ -117,10 +117,10 @@ kind: Service
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-1.18.0
+    helm.sh/chart: router-1.18.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.18.0"
+    app.kubernetes.io/version: "v1.18.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -143,10 +143,10 @@ kind: Deployment
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-1.18.0
+    helm.sh/chart: router-1.18.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.18.0"
+    app.kubernetes.io/version: "v1.18.1"
     app.kubernetes.io/managed-by: Helm
   
   annotations:
@@ -172,7 +172,7 @@ spec:
         - name: router
           securityContext:
             {}
-          image: "ghcr.io/apollographql/router:v1.18.0"
+          image: "ghcr.io/apollographql/router:v1.18.1"
           imagePullPolicy: IfNotPresent
           args:
             - --hot-reload
@@ -223,10 +223,10 @@ kind: Pod
 metadata:
   name: "release-name-router-test-connection"
   labels:
-    helm.sh/chart: router-1.18.0
+    helm.sh/chart: router-1.18.1
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.18.0"
+    app.kubernetes.io/version: "v1.18.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test

--- a/helm/chart/router/Chart.yaml
+++ b/helm/chart/router/Chart.yaml
@@ -20,10 +20,10 @@ type: application
 # so it matches the shape of our release process and release automation.
 # By proxy of that decision, this version uses SemVer 2.0.0, though the prefix
 # of "v" is not included.
-version: 1.18.0
+version: 1.18.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.18.0"
+appVersion: "v1.18.1"

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -2,7 +2,7 @@
 
 [router](https://github.com/apollographql/router) Rust Graph Routing runtime for Apollo Federation
 
-![Version: 1.18.0](https://img.shields.io/badge/Version-1.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.18.0](https://img.shields.io/badge/AppVersion-v1.18.0-informational?style=flat-square)
+![Version: 1.18.1](https://img.shields.io/badge/Version-1.18.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.18.1](https://img.shields.io/badge/AppVersion-v1.18.1-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@
 ## Get Repo Info
 
 ```console
-helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.18.0
+helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.18.1
 ```
 
 ## Install Chart
@@ -19,7 +19,7 @@ helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.18.0
 **Important:** only helm3 is supported
 
 ```console
-helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 1.18.0 --values my-values.yaml
+helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 1.18.1 --values my-values.yaml
 ```
 
 _See [configuration](#configuration) below._

--- a/licenses.html
+++ b/licenses.html
@@ -9654,7 +9654,9 @@ additional terms or conditions.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-compiler</a></li>
                     <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-encoder</a></li>
+                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
                     <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
                     <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-smith</a></li>
                 </ul>
@@ -10307,8 +10309,6 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-compiler</a></li>
-                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
                     <li><a href=" https://github.com/djc/askama ">askama_shared</a></li>
                     <li><a href=" https://github.com/gankra/backtrace-ext ">backtrace-ext</a></li>
                     <li><a href=" https://crates.io/crates/block-modes ">block-modes</a></li>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/router/releases/downloa
 
 # Router version defined in apollo-router's Cargo.toml
 # Note: Change this line manually during the release steps.
-PACKAGE_VERSION="v1.18.0"
+PACKAGE_VERSION="v1.18.1"
 
 download_binary() {
     downloader --check


### PR DESCRIPTION
> **Note**
>
> When approved, this PR will merge into **the `1.18.1` branch** which will — upon being approved itself — merge into `main`.
>
> **Things to review in this PR**:
>  - Changelog correctness (There is a preview below, but it is not necessarily the most up to date.  See the _Files Changed_ for the true reality.)
>  - Version bumps
>  - That it targets the right release branch (`1.18.1` in this case!).
>
---
## 🐛 Fixes

### Fix multipart response compression by using a large enough buffer

When writing a deferred response, if the output buffer was too small to write the entire compressed response, the compressor would write a small chunk that did not decompress to the entire primary response, and would then wait for the next response to send the rest.

Unfortunately, we cannot really know the output size we need in advance, and if we asked the decoder, it will tell us that it flushed all the data, even if it could have sent more.  To compensate for this, we raise the output buffer size, and do a second buffer growing step after flushing, if necessary.

By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3067

### Emit more log details to the state machine's `Running` phase ([Issue #3065](https://github.com/apollographql/router/issues/3065))

This change adds details about the triggers of potential state changes to the logs and also makes it easier to see when an un-entitled event causes a state change to be ignored.

Prior to this change, it was difficult to know from the logs why a router state reload had been triggered and the logs didn't make it clear that it was possible that the state change was going to be ignored.

By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3066


### Respect GraphOS/Studio metric "backoff" guidance ([Issue #2888](https://github.com/apollographql/router/issues/2888))

For stability reasons, GraphOS metric ingress will return an HTTP `429` status code with `Retry-After` guidance if it's unable to immediately accept a metric submission from a router.  A router instance should not try to submit further metrics until that amount of time (in seconds) has elapsed.  This fix provides support for this interaction.

While observing a backoff request from GraphOS, the router will continue to collect metrics and no metrics are lost unless the router terminates before the timeout expires.

By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/2977

## 🛠 Maintenance

### Refactor the way we're redacting errors for Apollo telemetry

This follows-up on the federated subgraph trace error redaction mechanism changes which first appeared in [v1.16.0](https://github.com/apollographql/router/releases/tag/v1.16.0) via [PR #3011](https://github.com/apollographql/router/pull/3011) with some internal refactoring that improves the readability of the logic.  There should be no functional changes to the feature's behavior.

By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/3030
