### PR TITLE
prep release: v1.19.0-alpha.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "1.18.0"
+version = "1.19.0-alpha.0"
 dependencies = [
  "access-json",
  "anyhow",
@@ -410,7 +410,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "1.18.0"
+version = "1.19.0-alpha.0"
 dependencies = [
  "apollo-parser 0.4.1",
  "apollo-router",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-scaffold"
-version = "1.18.0"
+version = "1.19.0-alpha.0"
 dependencies = [
  "anyhow",
  "cargo-scaffold",

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "1.18.0"
+version = "1.19.0-alpha.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-scaffold"
-version = "1.18.0"
+version = "1.19.0-alpha.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -22,7 +22,7 @@ apollo-router = { path ="{{integration_test}}apollo-router" }
 apollo-router = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
 # Note if you update these dependencies then also update xtask/Cargo.toml
-apollo-router = "1.18.0"
+apollo-router = "1.19.0-alpha.0"
 {{/if}}
 {{/if}}
 async-trait = "0.1.52"

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -13,7 +13,7 @@ apollo-router-scaffold = { path ="{{integration_test}}apollo-router-scaffold" }
 {{#if branch}}
 apollo-router-scaffold = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
-apollo-router-scaffold = { git = "https://github.com/apollographql/router.git", tag = "v1.18.0" }
+apollo-router-scaffold = { git = "https://github.com/apollographql/router.git", tag = "v1.19.0-alpha.0" }
 {{/if}}
 {{/if}}
 anyhow = "1.0.58"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "1.18.0"
+version = "1.19.0-alpha.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 repository = "https://github.com/apollographql/router/"
 documentation = "https://docs.rs/apollo-router"

--- a/dockerfiles/tracing/docker-compose.datadog.yml
+++ b/dockerfiles/tracing/docker-compose.datadog.yml
@@ -3,7 +3,7 @@ services:
 
   apollo-router:
     container_name: apollo-router
-    image: ghcr.io/apollographql/router:v1.18.0
+    image: ghcr.io/apollographql/router:v1.19.0-alpha.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/datadog.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.jaeger.yml
+++ b/dockerfiles/tracing/docker-compose.jaeger.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     #build: ./router
-    image: ghcr.io/apollographql/router:v1.18.0
+    image: ghcr.io/apollographql/router:v1.19.0-alpha.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/jaeger.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.zipkin.yml
+++ b/dockerfiles/tracing/docker-compose.zipkin.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     build: ./router
-    image: ghcr.io/apollographql/router:v1.18.0
+    image: ghcr.io/apollographql/router:v1.19.0-alpha.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/zipkin.router.yaml:/etc/config/configuration.yaml

--- a/docs/source/containerization/docker.mdx
+++ b/docs/source/containerization/docker.mdx
@@ -11,7 +11,7 @@ The default behaviour of the router images is suitable for a quickstart or devel
 
 Note: The [docker documentation](https://docs.docker.com/engine/reference/run/) for the run command may be helpful when reading through the examples.
 
-Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v1.18.0`
+Note: The exact image version to use is your choice depending on which release you wish to use. In the following examples, replace `<image version>` with your chosen version. e.g.: `v1.19.0-alpha.0`
 
 ## Override the configuration
 

--- a/docs/source/containerization/kubernetes.mdx
+++ b/docs/source/containerization/kubernetes.mdx
@@ -13,7 +13,7 @@ import { Link } from 'gatsby';
 
 [Helm](https://helm.sh) is the package manager for kubernetes.
 
-There is a complete [helm chart definition](https://github.com/apollographql/router/tree/v1.18.0/helm/chart/router) in the repo which illustrates how to use helm to deploy the router in kubernetes.
+There is a complete [helm chart definition](https://github.com/apollographql/router/tree/v1.19.0-alpha.0/helm/chart/router) in the repo which illustrates how to use helm to deploy the router in kubernetes.
 
 In both the following examples, we are using helm to install the router:
  - into namespace "router-deploy" (create namespace if it doesn't exist)
@@ -64,10 +64,10 @@ kind: ServiceAccount
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-1.18.0
+    helm.sh/chart: router-1.19.0-alpha.0
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.18.0"
+    app.kubernetes.io/version: "v1.19.0-alpha.0"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: router/templates/secret.yaml
@@ -76,10 +76,10 @@ kind: Secret
 metadata:
   name: "release-name-router"
   labels:
-    helm.sh/chart: router-1.18.0
+    helm.sh/chart: router-1.19.0-alpha.0
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.18.0"
+    app.kubernetes.io/version: "v1.19.0-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   managedFederationApiKey: "UkVEQUNURUQ="
@@ -90,10 +90,10 @@ kind: ConfigMap
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-1.18.0
+    helm.sh/chart: router-1.19.0-alpha.0
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.18.0"
+    app.kubernetes.io/version: "v1.19.0-alpha.0"
     app.kubernetes.io/managed-by: Helm
 data:
   configuration.yaml: |
@@ -117,10 +117,10 @@ kind: Service
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-1.18.0
+    helm.sh/chart: router-1.19.0-alpha.0
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.18.0"
+    app.kubernetes.io/version: "v1.19.0-alpha.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -143,10 +143,10 @@ kind: Deployment
 metadata:
   name: release-name-router
   labels:
-    helm.sh/chart: router-1.18.0
+    helm.sh/chart: router-1.19.0-alpha.0
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.18.0"
+    app.kubernetes.io/version: "v1.19.0-alpha.0"
     app.kubernetes.io/managed-by: Helm
   
   annotations:
@@ -172,7 +172,7 @@ spec:
         - name: router
           securityContext:
             {}
-          image: "ghcr.io/apollographql/router:v1.18.0"
+          image: "ghcr.io/apollographql/router:v1.19.0-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
             - --hot-reload
@@ -223,10 +223,10 @@ kind: Pod
 metadata:
   name: "release-name-router-test-connection"
   labels:
-    helm.sh/chart: router-1.18.0
+    helm.sh/chart: router-1.19.0-alpha.0
     app.kubernetes.io/name: router
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.18.0"
+    app.kubernetes.io/version: "v1.19.0-alpha.0"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test

--- a/helm/chart/router/Chart.yaml
+++ b/helm/chart/router/Chart.yaml
@@ -20,10 +20,10 @@ type: application
 # so it matches the shape of our release process and release automation.
 # By proxy of that decision, this version uses SemVer 2.0.0, though the prefix
 # of "v" is not included.
-version: 1.18.0
+version: 1.19.0-alpha.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.18.0"
+appVersion: "v1.19.0-alpha.0"

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -2,7 +2,7 @@
 
 [router](https://github.com/apollographql/router) Rust Graph Routing runtime for Apollo Federation
 
-![Version: 1.18.0](https://img.shields.io/badge/Version-1.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.18.0](https://img.shields.io/badge/AppVersion-v1.18.0-informational?style=flat-square)
+![Version: 1.19.0-alpha.0](https://img.shields.io/badge/Version-1.19.0--alpha.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.19.0-alpha.0](https://img.shields.io/badge/AppVersion-v1.19.0--alpha.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@
 ## Get Repo Info
 
 ```console
-helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.18.0
+helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.19.0-alpha.0
 ```
 
 ## Install Chart
@@ -19,7 +19,7 @@ helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.18.0
 **Important:** only helm3 is supported
 
 ```console
-helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 1.18.0 --values my-values.yaml
+helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 1.19.0-alpha.0 --values my-values.yaml
 ```
 
 _See [configuration](#configuration) below._

--- a/licenses.html
+++ b/licenses.html
@@ -9655,7 +9655,9 @@ additional terms or conditions.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-compiler</a></li>
                     <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-encoder</a></li>
+                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
                     <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
                     <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-smith</a></li>
                 </ul>
@@ -10308,8 +10310,6 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-compiler</a></li>
-                    <li><a href=" https://github.com/apollographql/apollo-rs ">apollo-parser</a></li>
                     <li><a href=" https://github.com/djc/askama ">askama_shared</a></li>
                     <li><a href=" https://github.com/gankra/backtrace-ext ">backtrace-ext</a></li>
                     <li><a href=" https://crates.io/crates/block-modes ">block-modes</a></li>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/router/releases/downloa
 
 # Router version defined in apollo-router's Cargo.toml
 # Note: Change this line manually during the release steps.
-PACKAGE_VERSION="v1.18.0"
+PACKAGE_VERSION="v1.19.0-alpha.0"
 
 download_binary() {
     downloader --check


### PR DESCRIPTION
This cuts an `1.19.0-alpha.0` of the https://github.com/apollographql/router/pull/2995 PR.  This was previously released as `1.16.0-alpha.0`, but the `1.16.0-alpha.0` never became `1.16.0`.  Instead, we've since released new actual releases that superceded it.  This alpha is the new candidate to become an official  `1.19.0`, but that is still not certain until further validations are complete. 
