### PR TITLE
chore: Use `xlarge` Windows instances on our CircleCI "Release" workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ executors:
   windows_build: &windows_build_executor
     machine:
       image: "windows-server-2019-vs2019:stable"
-    resource_class: windows.medium
+    resource_class: windows.xlarge
     shell: bash.exe --login -eo pipefail
   windows_test: &windows_test_executor
     machine:


### PR DESCRIPTION
This puts the release machine at the same size as the machine we use for tests.

Ref: https://circleci.com/docs/configuration-reference/#windows-execution-environment

Hopefully Fixes: 50 minute Windows Releases