### PR TITLE
add support for handling complex throw errors in responses

### DIFF
--- a/.changesets/fix_garypen_rhai_throw_error.md
+++ b/.changesets/fix_garypen_rhai_throw_error.md
@@ -1,0 +1,7 @@
+### Add support for throwing graphql errors in rhai responses ([Issue #3069](https://github.com/apollographql/router/issues/3069))
+
+It's possible to throw a graphql error from rhai when processing a request. This extends the capability to include when processing a response.
+
+Refer to the `Terminating client requests` section of the [Rhai api documentation](https://www.apollographql.com/docs/router/configuration/rhai) to learn how to throw GraphQL payloads.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3089

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -456,17 +456,28 @@ macro_rules! gen_map_response {
                         context: Context,
                         error_details: ErrorDetails,
                     ) -> $base::Response {
-                        let res = $base::Response::error_builder()
-                            .errors(vec![Error {
-                                // TODO
-                                message: error_details.message.unwrap_or_default(),
-                                ..Default::default()
-                            }])
-                            .status_code(error_details.status)
-                            .context(context)
-                            .build()
-                            .expect("can't fail to build our error message");
-                        res
+                        if let Some(body) = error_details.body {
+                            $base::Response::builder()
+                                .extensions(body.extensions)
+                                .errors(body.errors)
+                                .status_code(error_details.status)
+                                .context(context)
+                                .and_data(body.data)
+                                .and_label(body.label)
+                                .and_path(body.path)
+                                .build()
+                        } else {
+                            $base::Response::error_builder()
+                                .errors(vec![Error {
+                                    // TODO
+                                    message: error_details.message.unwrap_or_default(),
+                                    ..Default::default()
+                                }])
+                                .status_code(error_details.status)
+                                .context(context)
+                                .build()
+                                .expect("can't fail to build our error message")
+                        }
                     }
                     let shared_response = Shared::new(Mutex::new(Some(response)));
                     let result: Result<Dynamic, Box<EvalAltResult>> = if $callback.is_curried() {
@@ -515,18 +526,28 @@ macro_rules! gen_map_deferred_response {
                         context: Context,
                         error_details: ErrorDetails,
                     ) -> $response {
-                        let res = $response::error_builder()
-
-                        .errors(vec![Error {
-                                // TODO
-                                message: error_details.message.unwrap_or_default(),
-                                ..Default::default()
-                            }])
-                            .status_code(error_details.status)
-                            .context(context)
-                            .build()
-                            .expect("can't fail to build our error message");
-                        res
+                        if let Some(body) = error_details.body {
+                            $response::builder()
+                                .extensions(body.extensions)
+                                .errors(body.errors)
+                                .status_code(error_details.status)
+                                .context(context)
+                                .and_data(body.data)
+                                .and_label(body.label)
+                                .and_path(body.path)
+                                .build()
+                        } else {
+                            $response::error_builder()
+                                .errors(vec![Error {
+                                    // TODO
+                                    message: error_details.message.unwrap_or_default(),
+                                    ..Default::default()
+                                }])
+                                .status_code(error_details.status)
+                                .context(context)
+                                .build()
+                        }
+                                .expect("can't fail to build our error message")
                     }
 
                     // we split the response stream into headers+first response, then a stream of deferred responses

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -469,7 +469,6 @@ macro_rules! gen_map_response {
                         } else {
                             $base::Response::error_builder()
                                 .errors(vec![Error {
-                                    // TODO
                                     message: error_details.message.unwrap_or_default(),
                                     ..Default::default()
                                 }])
@@ -539,15 +538,13 @@ macro_rules! gen_map_deferred_response {
                         } else {
                             $response::error_builder()
                                 .errors(vec![Error {
-                                    // TODO
                                     message: error_details.message.unwrap_or_default(),
                                     ..Default::default()
                                 }])
                                 .status_code(error_details.status)
                                 .context(context)
                                 .build()
-                        }
-                                .expect("can't fail to build our error message")
+                        }.expect("can't fail to build our error message")
                     }
 
                     // we split the response stream into headers+first response, then a stream of deferred responses

--- a/docs/source/customizations/rhai-api.mdx
+++ b/docs/source/customizations/rhai-api.mdx
@@ -108,6 +108,7 @@ fn supergraph_service(service) {
                 }]
             }
         };
+    };
     // Map our request using our closure
     service.map_request(f);
 }


### PR DESCRIPTION
In #2677 we added support for throwing graphql errors from rhai. Support was added for requests. This extends the mechanism to include responses.

fixes: #3069

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
