### PR TITLE
docs: add footnote about `RouterResponse` and `errors` key

### DIFF
--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -671,6 +671,8 @@ The JSON body of the corresponding request or response, depending on this coproc
 - If a request, this usually contains a `query` property containing the GraphQL query string.
 - If a response, this usually contains `data` and/or `error` properties for the GraphQL operation result.
 
+> The `RouterResponse` stage will return redacted errors within the `error` key if [subgraph error inclusion](../configuration/subgraph-error-inclusion) has been disabled.
+
 If your coprocessor [returns a _different_ value](#responding-to-coprocessor-requests) for `body`, the router replaces the existing body with that value. This is common when [terminating a client request](#terminating-a-client-request).
 
 </td>

--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -671,7 +671,7 @@ The JSON body of the corresponding request or response, depending on this coproc
 - If a request, this usually contains a `query` property containing the GraphQL query string.
 - If a response, this usually contains `data` and/or `error` properties for the GraphQL operation result.
 
-> The `RouterResponse` stage will return redacted errors within the `error` key if [subgraph error inclusion](../configuration/subgraph-error-inclusion) has been disabled.
+> The `RouterResponse` stage will return redacted errors within the `error` key by default. If you wish to process subgraph errors manually in your coprocessor you can enable [subgraph error inclusion](../configuration/subgraph-error-inclusion).
 
 If your coprocessor [returns a _different_ value](#responding-to-coprocessor-requests) for `body`, the router replaces the existing body with that value. This is common when [terminating a client request](#terminating-a-client-request).
 


### PR DESCRIPTION
*Description here*

Adds a small footnote about the `RouterResponse` stage returning redacted errors vs. all errors. 

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
