### PR TITLE
chore: adds integration test for example YAML configuration

### DIFF
--- a/.changesets/maint_avery_test_yamls.md
+++ b/.changesets/maint_avery_test_yamls.md
@@ -1,5 +1,5 @@
-### chore: adds integration test for example YAML configuration ([Issue #2932](https://github.com/apollographql/router/issues/2932))
+### Adds an integration test for all YAML configuration files in `./examples` ([Issue #2932](https://github.com/apollographql/router/issues/2932))
 
-Adds an integration test that iterates over `./examples` looking for `.yaml` files that don't have a `Cargo.toml` or `.skipconfigvalidation` sibling, and then running `setup_router_and_registry` on them.
+Adds an integration test that iterates over `./examples` looking for `.yaml` files that don't have a `Cargo.toml` or `.skipconfigvalidation` sibling file, and then running `setup_router_and_registry` on them, fast failing on any errors along the way.
 
 By [@EverlastingBugstopper](https://github.com/EverlastingBugstopper) in https://github.com/apollographql/router/pull/3097

--- a/.changesets/maint_avery_test_yamls.md
+++ b/.changesets/maint_avery_test_yamls.md
@@ -1,0 +1,5 @@
+### chore: adds integration test for example YAML configuration ([Issue #2932](https://github.com/apollographql/router/issues/2932))
+
+Adds an integration test that iterates over `./examples` looking for `.yaml` files that don't have a `Cargo.toml` or `.skipconfigvalidation` sibling, and then running `setup_router_and_registry` on them.
+
+By [@EverlastingBugstopper](https://github.com/EverlastingBugstopper) in https://github.com/apollographql/router/pull/3097

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -1073,7 +1073,13 @@ impl ValueExt for Value {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn all_stock_router_example_yamls_are_valid() {
-    for entry in walkdir::WalkDir::new("../examples").into_iter().flatten() {
+    let root_dir = option_env!("CARGO_MANIFEST_DIR").expect("could not find $CARGO_MANIFEST_DIR");
+    let examples_dir = std::path::PathBuf::try_from(&root_dir)
+        .unwrap_or_else(|e| {
+            panic!("could not create PathBuf from $CARGO_MANIFEST_DIR ({root_dir}): {e}")
+        })
+        .join("examples");
+    for entry in walkdir::WalkDir::new(examples_dir).into_iter().flatten() {
         let entry_path = entry.path();
         let display_path = entry_path.display().to_string();
         let entry_parent = entry_path

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -28,7 +28,8 @@ use serde_json_bytes::json;
 use serde_json_bytes::Value;
 use tower::BoxError;
 use tower::ServiceExt;
-use walkdir::{DirEntry, WalkDir};
+use walkdir::DirEntry;
+use walkdir::WalkDir;
 
 macro_rules! assert_federated_response {
     ($query:expr, $service_requests:expr $(,)?) => {

--- a/apollo-router/tests/lifecycle_tests.rs
+++ b/apollo-router/tests/lifecycle_tests.rs
@@ -95,7 +95,7 @@ async fn test_reload_config_with_broken_plugin_recovery() -> Result<(), BoxError
 }
 
 #[tokio::test(flavor = "multi_thread")]
-// #[cfg(target_family = "unix")]
+#[cfg(target_family = "unix")]
 async fn test_graceful_shutdown() -> Result<(), BoxError> {
     let mut router = IntegrationTest::builder()
         .config(HAPPY_CONFIG)

--- a/apollo-router/tests/lifecycle_tests.rs
+++ b/apollo-router/tests/lifecycle_tests.rs
@@ -95,7 +95,7 @@ async fn test_reload_config_with_broken_plugin_recovery() -> Result<(), BoxError
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[cfg(target_family = "unix")]
+// #[cfg(target_family = "unix")]
 async fn test_graceful_shutdown() -> Result<(), BoxError> {
     let mut router = IntegrationTest::builder()
         .config(HAPPY_CONFIG)


### PR DESCRIPTION
Adds an integration test that iterates over `./examples` looking for `.yaml` files that don't have a `Cargo.toml` or `.skipconfigvalidation` sibling, and then running `setup_router_and_registry` on them.

Fixes #2932