### PR TITLE
Tentative fix for broken parent based sampling introduced in #2894

### DIFF
--- a/apollo-router/src/plugins/telemetry/reload.rs
+++ b/apollo-router/src/plugins/telemetry/reload.rs
@@ -3,13 +3,21 @@ use anyhow::Result;
 use once_cell::sync::OnceCell;
 use opentelemetry::metrics::noop::NoopMeterProvider;
 use opentelemetry::sdk::trace::Tracer;
+use opentelemetry::trace::SamplingDecision;
+use opentelemetry::trace::SamplingResult;
+use opentelemetry::trace::TraceContextExt;
 use opentelemetry::trace::TracerProvider;
 use tower::BoxError;
+use tracing::Subscriber;
 use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_opentelemetry::OtelData;
+use tracing_subscriber::filter::Filtered;
 use tracing_subscriber::fmt::FormatFields;
+use tracing_subscriber::layer::Filter;
 use tracing_subscriber::layer::Layer;
 use tracing_subscriber::layer::Layered;
 use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::reload::Handle;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
@@ -20,14 +28,25 @@ use crate::plugins::telemetry::formatters::text::TextFormatter;
 use crate::plugins::telemetry::formatters::FilteringFormatter;
 use crate::plugins::telemetry::metrics;
 use crate::plugins::telemetry::metrics::layer::MetricsLayer;
+use crate::plugins::telemetry::metrics::{
+    METRIC_PREFIX_COUNTER, METRIC_PREFIX_HISTOGRAM, METRIC_PREFIX_MONOTONIC_COUNTER,
+    METRIC_PREFIX_VALUE,
+};
 use crate::plugins::telemetry::tracing::reload::ReloadTracer;
 
-type LayeredTracer = Layered<OpenTelemetryLayer<Registry, ReloadTracer<Tracer>>, Registry>;
+pub(super) type LayeredTracer = Layered<
+    Filtered<OpenTelemetryLayer<Registry, ReloadTracer<Tracer>>, SamplingFilter, Registry>,
+    Registry,
+>;
 
 // These handles allow hot tracing of layers. They have complex type definitions because tracing has
 // generic types in the layer definition.
 pub(super) static OPENTELEMETRY_TRACER_HANDLE: OnceCell<
     ReloadTracer<opentelemetry::sdk::trace::Tracer>,
+> = OnceCell::new();
+
+static FMT_LAYER_HANDLE: OnceCell<
+    Handle<Box<dyn Layer<LayeredTracer> + Send + Sync>, LayeredTracer>,
 > = OnceCell::new();
 
 #[allow(clippy::type_complexity)]
@@ -44,15 +63,13 @@ static METRICS_LAYER_HANDLE: OnceCell<
     >,
 > = OnceCell::new();
 
-static FMT_LAYER_HANDLE: OnceCell<
-    Handle<Box<dyn Layer<LayeredTracer> + Send + Sync>, LayeredTracer>,
-> = OnceCell::new();
-
 pub(crate) fn init_telemetry(log_level: &str) -> Result<()> {
     let hot_tracer = ReloadTracer::new(
         opentelemetry::sdk::trace::TracerProvider::default().versioned_tracer("noop", None, None),
     );
-    let opentelemetry_layer = tracing_opentelemetry::layer().with_tracer(hot_tracer.clone());
+    let opentelemetry_layer = tracing_opentelemetry::layer()
+        .with_tracer(hot_tracer.clone())
+        .with_filter(SamplingFilter::new());
 
     // We choose json or plain based on tty
     let fmt = if atty::is(atty::Stream::Stdout) {
@@ -125,16 +142,84 @@ pub(super) fn reload_metrics(layer: MetricsLayer) {
     }
 }
 
-#[allow(clippy::type_complexity)]
-pub(super) fn reload_fmt(
-    layer: Box<
-        dyn Layer<Layered<OpenTelemetryLayer<Registry, ReloadTracer<Tracer>>, Registry>>
-            + Send
-            + Sync,
-    >,
-) {
+pub(super) fn reload_fmt(layer: Box<dyn Layer<LayeredTracer> + Send + Sync>) {
     if let Some(handle) = FMT_LAYER_HANDLE.get() {
         handle.reload(layer).expect("fmt layer reload must succeed");
+    }
+}
+
+pub(crate) struct SamplingFilter {}
+
+impl SamplingFilter {
+    pub(crate) fn new() -> Self {
+        Self {}
+    }
+}
+
+impl<S> Filter<S> for SamplingFilter
+where
+    S: Subscriber + for<'span> LookupSpan<'span>,
+{
+    fn enabled(
+        &self,
+        meta: &tracing::Metadata<'_>,
+        cx: &tracing_subscriber::layer::Context<'_, S>,
+    ) -> bool {
+        // Sampling and Otel is a complex topic. Let's break this down.
+        // The desire is to have complete traces if they were deemed to be sampled at the root span. The root span can either be local or remote.
+        // How is a root span detected? It is NOT just if the span has a parent. Otel makes a sampling decision and stores this in the otel context which is stored in the tracing context.
+        //
+        // The otel context can be created in one of two ways:
+        // 1. If the root span is remote then in `PropagatingMakeSpan` we set up a context (this happens in our axum code).
+        // 2. If the root span is not remote we asl the otel sampler if we should sample or not and create a context (this happens in the otel tracing layer).
+        // The layer doesn't know if the tracer will actually export the span or not, so it is important that
+        // if there are no exporters set then the configured sampler should be always_off. Otherwise otel will go through the process of creating spans even thought they will never be exported.
+        //
+        // There is another optimisation that we can do, that does make a bit of difference.
+        // We can detect at the filter level if the trace is being sampled or not and early abort telling otel if it is.
+        // The root span must always be supplied to the otel layer, as it will make the sampling decision and set up the root otel context.
+        // This is slightly less efficient that completely presampling, but is lest complex to implement and more sympathetic to the existing otel code.
+
+        if meta.is_span() {
+            if let Some(current_span) = cx.lookup_current() {
+                if let Some(otel_data) = current_span.extensions().get::<OtelData>() {
+                    let otel_context = &otel_data.parent_cx;
+                    let span_ref = otel_context.span();
+                    let otel_span_context = span_ref.span_context();
+                    let is_sampled = otel_span_context.is_sampled();
+
+                    let builder_sample = matches!(
+                        otel_data.builder.sampling_result,
+                        Some(SamplingResult {
+                            decision: SamplingDecision::RecordAndSample,
+                            ..
+                        })
+                    );
+                    // If we have got here then we know the span is not a root span.
+                    // The sampling decision has two possible sources:
+                    // 1. The builder sampling result. This contains the result of the sampler for the root span.
+                    // 2. The otel span context. This contains the result of the sampler for the parent span.
+                    // The root span context is never valid, so children of root spans will always use the builder sampling result.
+                    // Their ancestors will always use the otel span context is_sampled.
+                    let decision = is_sampled || builder_sample;
+                    return decision;
+                }
+            }
+            // If we get here it's because the span is a root. It should go to the otel layer to make the sampling decision.
+        } else if meta.is_event() {
+            // If this is an event then let it through if it is not a metric event
+            for field in meta.fields() {
+                let field_name = field.name();
+                if field_name.starts_with(METRIC_PREFIX_MONOTONIC_COUNTER)
+                    || field_name.starts_with(METRIC_PREFIX_HISTOGRAM)
+                    || field_name.starts_with(METRIC_PREFIX_COUNTER)
+                    || field_name.starts_with(METRIC_PREFIX_VALUE)
+                {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 }
 

--- a/apollo-router/tests/fixtures/jaeger-no-sample.router.yaml
+++ b/apollo-router/tests/fixtures/jaeger-no-sample.router.yaml
@@ -1,5 +1,8 @@
 telemetry:
+  apollo:
+    field_level_instrumentation_sampler: always_off
   tracing:
+
     experimental_response_trace_id:
       enabled: true
       header_name: apollo-custom-trace-id
@@ -7,7 +10,7 @@ telemetry:
       jaeger: true
     trace_config:
       service_name: router
-      sampler: always_on
+      sampler: always_off
     jaeger:
       batch_processor:
         scheduled_delay: 100ms

--- a/apollo-router/tests/fixtures/no-telemetry.router.yaml
+++ b/apollo-router/tests/fixtures/no-telemetry.router.yaml
@@ -3,16 +3,9 @@ telemetry:
     experimental_response_trace_id:
       enabled: true
       header_name: apollo-custom-trace-id
-    propagation:
-      jaeger: true
     trace_config:
       service_name: router
       sampler: always_on
-    jaeger:
-      batch_processor:
-        scheduled_delay: 100ms
-      agent:
-        endpoint: default
   experimental_logging:
     when_header:
       - name: apollo-router-log-request


### PR DESCRIPTION
This is an alternate implementation of the trace prefiltering that allows root spans to go to the regular Otel Layer for sampling and then prefilters child spans based on the decision at the root.

It adds tests for local and remote spans, but cannot be merged yet as a test needs to be added for sampling and it has been noted that there is a point in the trace for a request where it looks like there are two root spans in tracing making root detection unreliable. We must ensure that for each trace the decision to sample is only taken once.

The performance is pretty good. Almost on a par with the other filtering span PR, but is less invasive.

Fixes #3103

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
