### PR TITLE
Add a very expressive list of commands to `RELEASE_CHECKLIST.md`

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -97,7 +97,7 @@ A release can be cut from any branch, but we assume you'll be doing it from `dev
    > For this command, `GITHUB_TOKEN` is **not used**, but it is still _required_ at the moment, so it's set here to `prep`.  This is a bug in the releasing script that needs to be changed.
 
    ```
-   GITHUB_TOKEN=prep cargo xtask release prepare $APOLLO_ROUTER_RELEASE_VERSION --current-branch --dry-run
+   cargo xtask release prepare $APOLLO_ROUTER_RELEASE_VERSION
    ```
 
    Running this command will:

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -82,7 +82,7 @@ A release can be cut from any branch, but we assume you'll be doing it from `dev
 7. Push this new branch to the appropriate remote.  We will open a PR for it **later**, but this will be the **base** for the PR created in the next step).  (And `--set-upstream` will of course track this locally.  This is commonly abbreviated as `-u`.)
 
    ```
-   git push --set-upstream "${APOLLO_ROUTER_RELEASE_GIT_ORIGIN}"
+   git push --set-upstream "${APOLLO_ROUTER_RELEASE_GIT_ORIGIN}" "${APOLLO_ROUTER_RELEASE_VERSION}"
    ```
 
 8. Create _another_ new branch called `prep-#.#.#` off of `#.#.#`.  This branch will be used for bumping version numbers and getting review on the changelog.  We'll do this using the same environment variable, so you can just run:
@@ -135,7 +135,7 @@ A release can be cut from any branch, but we assume you'll be doing it from `dev
 14. Now push the branch up to the correct remote:
 
     ```
-    git push --set-upstream "${APOLLO_ROUTER_RELEASE_GIT_ORIGIN}"
+    git push --set-upstream "${APOLLO_ROUTER_RELEASE_GIT_ORIGIN}" "${APOLLO_ROUTER_RELEASE_VERSION}"
     ```
 
 15. Programatically create a small temporary file called `this_release.md` with the changelog details of _precisely this release_ from the `CHANGELOG.md`:

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -225,7 +225,7 @@ A release can be cut from any branch, but we assume you'll be doing it from `dev
     If those things look good, this PR is good to merge.
     EOM
     )"
-    echo "${apollo_release_pr_header}" | gh --repo "${APOLLO_ROUTER_RELEASE_GITHUB_REPO}" pr create -B "main" --title "release: v${APOLLO_ROUTER_RELEASE_VERSION}" --draft --body-file -
+    echo "${apollo_release_pr_header}" | gh --repo "${APOLLO_ROUTER_RELEASE_GITHUB_REPO}" pr create -B "main" --title "release: v${APOLLO_ROUTER_RELEASE_VERSION}" --body-file -
     ```
 
 21. Use the `gh` CLI to enable **auto-merge** (**_NOT_** auto-**_squash_**):
@@ -246,27 +246,33 @@ A release can be cut from any branch, but we assume you'll be doing it from `dev
     git tag -a "v${APOLLO_ROUTER_RELEASE_VERSION}" -m "${APOLLO_ROUTER_RELEASE_VERSION}" && git push "${APOLLO_ROUTER_RELEASE_GIT_ORIGIN}" "v${APOLLO_ROUTER_RELEASE_VERSION}"
     ```
 
-24. Follow the process by going to CircleCI for the repository.
-
-25. Open a PR that reconciles `dev`:
+24. Open a PR that reconciles `dev`:
 
     ```
     gh --repo "${APOLLO_ROUTER_RELEASE_GITHUB_REPO}" pr create --title "Reconcile \`dev\` after merge to \`main\` for v${APOLLO_ROUTER_RELEASE_VERSION}" -B dev -H main --body "Follow-up to the v${APOLLO_ROUTER_RELEASE_VERSION} being officially released, bringing version bumps and changelog updates into the \`dev\` branch."
     ```
+    
+25. 👀 Follow along with the process by [going to CircleCI for the repository](https://app.circleci.com/pipelines/github/apollographql/router) and clicking on `release` for the Git tag that appears at the top of the list.  **Wait for `publish_github_release` to finish on this job before continuing.**
 
-26. After the CI job has finished for the tag, update the release notes (this needs to be moved to CI, but requires `this_release.md` which we created earlier):
+26. After the CI job has finished for the tag, re-run the `perl` command from Step 15, which will regenerate the `this_release.md` with changes that happened in the release review.
+
+27. Change the links from `[@username](https://github.com/username)` to `@username` (TODO: Write more `perl` here. 😄)
+
+    This ensures that contribution credit is clearly displayed using the user avatars on the GitHub Releases page when the notes are published in the next step.
+
+28. Update the release notes on the now-published [GitHub Releases](https://github.com/apollographql/router/releases) (this needs to be moved to CI, but requires `this_release.md` which we created earlier):
 
     ```
     gh release edit v"${APOLLO_ROUTER_RELEASE_VERSION}" -F ./this_release.md
     ```
 
-27. Publish the Crate from your local computer from the `main` branch (this also needs to be moved to CI, but requires changing the release containers to be Rust-enabled and to restore the caches):
+29. Publish the Crate from your local computer from the `main` branch (this also needs to be moved to CI, but requires changing the release containers to be Rust-enabled and to restore the caches):
 
     ```
     cargo publish -p apollo-router
     ```
 
-28. (Optional) To have a "social banner" for this release, run [this `htmlq` command](https://crates.io/crates/htmlq) (like `jq` for HTML), open the link it produces, copy the image to your clipboard:
+30. (Optional) To have a "social banner" for this release, run [this `htmlq` command](https://crates.io/crates/htmlq) (`cargo install htmlq`; its `jq` for HTML), open the link it produces, copy the image to your clipboard:
 
     ```
     curl -s "https://github.com/apollographql/router/releases/tag/v${APOLLO_ROUTER_RELEASE_VERSION}" | htmlq 'meta[property="og:image"]' --attribute content

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -42,56 +42,235 @@ This is a list of the things that need to happen during a release.
 Build a Release
 ---------------
 
-### Prepare the Changelog (Full release only)
+Most of this will be executing some simple commands but here's a high level understanding and some terminology.  There will be a total of 3 pull-requests involved:
 
-If you are releasing a beta or a release candidate, no official changelog is
-needed, but you're not off the hook! You'll need to write testing instructions
-in lieu of an official changelog.
+- **a Release PR**: this will merge **into `main`**.  It will be a real merge commit and it **should NOT be squashed**.
+- **a Release _Prep_ PR**: this will merge into the release PR _above_.  It **SHOULD be squashed**.
+- **Reconciliation PR**: a PR that merges `main` back into `dev`.  It will be a real merge commit and it **should NOT be squashed**.
 
-1. Open the associated GitHub milestone for the release. All issues and PRs should be closed. If
-    they are not you should reassign all open issues and PRs to future
-    milestones.
-2. Go through the commit history since the last release. Ensure that all PRs
-    that have landed are marked with the milestone. You can use this to
-    show all the PRs that are merged on or after YYYY-MM-DD:
-    `https://github.com/issues?utf8=%E2%9C%93&q=repo%3Aapollographql%2Frouter+merged%3A%3E%3DYYYY-MM-DD`
-3. Go through the closed PRs in the milestone. Each should have a changelog
-    label indicating if the change is documentation, feature, fix, or
-    maintenance. If there is a missing label, please add one. If it is a
-    breaking change, also add a BREAKING label.
-4. Set the release date in `NEXT_CHANGELOG.md`. Add this release to the
-    `CHANGELOG.md`. Use the structure of previous entries.
+The examples below will use [the GitHub CLI (`gh`)](https://cli.github.com/) to simplify the steps.  We can automate it further in the future, but feels like the right level of abstraction right now.
 
-### Start a release PR
+A release can be cut from any branch, but we assume you'll be doing it from `dev`.  If you're just doing a release candidate, you can skip merging it back into `main`.
 
 1. Make sure you have `cargo` installed on your machine and in your `PATH`.
-2. Create a new branch "#.#.#" where "#.#.#" is this release's version
-    (release) or "#.#.#-rc.#" (release candidate)
-3. Update the `version` in `*/Cargo.toml` (do not forget the ones in scaffold templates).
-4. Update the `apollo-router` Git tags in the `dependencies` sections of the `Cargo.toml` files in `apollo-router-scaffold/templates/**`.
-5. Update the `PACKAGE_VERSION` value in `scripts/install.sh` (it should be prefixed with `v`!)
-6. Update `docker.mdx` and `kubernetes.mdx` with the release version.
-7. Update `helm/chart/router/Chart.yaml` as follows:
-   - update the version and the appVersion to the release version. e.g.: `appVersion: "v0.9.0"`
-8 Update `helm/chart/router/README.md` by running this from the repo root: `(cd helm/chart && helm-docs router)`.
-  (If not installed, you should [install `helm-docs`](https://github.com/norwoodj/helm-docs))
-9. Update the kubernetes section of the docs:
-  - go to the `helm/chart/router` folder
-  - run 
-  ```helm template --set router.configuration.telemetry.metrics.prometheus.enabled=true  --set managedFederation.apiKey="REDACTED" --set managedFederation.graphRef="REDACTED" --debug .```
-  - Paste the output in the `Kubernetes Configuration` example of the `docs/source/containerization/kubernetes.mdx` file
-9. Update `federation-version-support.mdx` with the latest version info. Use https://github.com/apollographql/version_matrix to generate the version matrix.
-10. Update the `image` of the Docker image within `docker-compose*.yml` files inside the `dockerfiles` directory.
-11. Update the license list with `cargo xtask licenses`.
-    (If not installed, you can install `cargo-about` by running `cargo install cargo-about`.)
-12. Add a new section in `CHANGELOG.md` with the contents of `NEXT_CHANGELOG.md`
-13. Put a Release date and the version number on the new `CHANGELOG.md` section
-14. Update the version in `NEXT_CHANGELOG.md`.
-15. Clear `NEXT_CHANGELOG.md` leaving only the template.
-16. Run `cargo check` so the lock file gets updated.
-17. Run `cargo xtask check-compliance`.
-18. Push up a commit with all the changes. The commit message should be "release: v#.#.#" or "release: v#.#.#-rc.#"
-19. Request review from the Router team.
+2. Pick the version number you are going to release.  This project uses [Semantic Versioning 2.0.0](https://semver.org/), so analyze the existing changes in the `.changesets/` directory to pick the right next version.  (e.g., If there are `feat_` changes, it must be a minor version bump.  If there are `breaking_` changes, it must be a _major_ version bump).  **Do not release a major version without explicit agreement from core team members**.
+3. Checkout the branch you want to cut from.  Typically, this is `dev`, but you could do this from another branch as well.
+
+   ```
+   git checkout dev
+   ```
+
+4. We'll set some environment variables for steps that follow this, to simplify copy and pasting.  Be sure to customize these for your own conditions, and **set the version you picked in the above step** as `APOLLO_ROUTER_RELEASE_VERSION`:
+
+   ```
+   APOLLO_ROUTER_RELEASE_VERSION=#.#.#
+   APOLLO_ROUTER_RELEASE_GIT_ORIGIN=public
+   APOLLO_ROUTER_RELEASE_GITHUB_REPO=apollographql/router
+   ```
+
+5. Make sure you have the latest from the remote before releasing, ensuring you're using the right remote!
+
+   ```
+   git pull "${APOLLO_ROUTER_RELEASE_GIT_ORIGIN}"
+   ```
+
+6. Create a new branch `#.#.#`.  (The `#.#.#` values should be this release's version, and it is perfectly acceptable to use prerelease semantics, e.g., a branch named `1.5.3-rc.9`).  To do this using the environment variable we just set, we'll just run the following from the same terminal:
+
+   ```
+   git checkout -b "${APOLLO_ROUTER_RELEASE_VERSION}"
+   ```
+7. Push this new branch to the appropriate remote.  We will open a PR for it **later**, but this will be the **base** for the PR created in the next step).  (And `--set-upstream` will of course track this locally.  This is commonly abbreviated as `-u`.)
+
+   ```
+   git push --set-upstream "${APOLLO_ROUTER_RELEASE_GIT_ORIGIN}"
+   ```
+
+8. Create _another_ new branch called `prep-#.#.#` off of `#.#.#`.  This branch will be used for bumping version numbers and getting review on the changelog.  We'll do this using the same environment variable, so you can just run:
+
+   ```
+   git checkout -b "prep-${APOLLO_ROUTER_RELEASE_VERSION}"
+   ```
+
+9. On this new `prep-#.#.#` branch, run the release automation script using this command to use the environment variable set previously:
+
+   > **Note**
+   > For this command, `GITHUB_TOKEN` is **not used**, but it is still _required_ at the moment, so it's set here to `prep`.  This is a bug in the releasing script that needs to be changed.
+
+   ```
+   GITHUB_TOKEN=prep cargo xtask release prepare $APOLLO_ROUTER_RELEASE_VERSION --current-branch --dry-run
+   ```
+
+   Running this command will:
+
+     - Bump the necessary versions to the version specified, including those in the documentation.
+     - Migrate the current set of `/.changesets/*.md` files into `/CHANGELOG.md` using the version specified.
+     - Run our compliance checks and update the `licenses.html` file as appropriate.
+     - Ensure we're not using any incompatible licenses in the release.
+
+10. **MANUALLY CHECK AND UPDATE** the `federation-version-support.mdx` with the latest version info. Use https://github.com/apollographql/version_matrix to generate the version matrix.
+
+11. Now, review and stage he changes produced by the previous step.  This is most safely done using the `--patch` (or `-p`) flag to `git add` (`-u` ignores untracked files).
+
+    ```
+    git add -up .
+    ```
+
+12. Now commit those changes locally, using a brief message:
+
+    ```
+    git commit -m "prep release: v${APOLLO_ROUTER_RELEASE_VERSION}"
+    ```
+
+13. (Optional) Make local edits to the newly rendered `CHANGELOG.md` entries to do some initial editoral.
+
+    These things should typically be resolved earlier in the review process, but need to be double checked:
+
+     - There are no breaking changes.
+     - Entries are in categories (e.g., Fixes vs Features) that make sense.
+     - Titles stand alone and work without their descriptions.
+     - You don't need to read the title for the description to make sense.
+     - Grammar is good.  (Or great! But don't let perfect be the enemy of good.)
+     - Formatting looks nice when rendered as markdown and follows common convention.
+
+14. Now push the branch up to the correct remote:
+
+    ```
+    git push --set-upstream "${APOLLO_ROUTER_RELEASE_GIT_ORIGIN}"
+    ```
+
+15. Programatically create a small temporary file called `this_release.md` with the changelog details of _precisely this release_ from the `CHANGELOG.md`:
+
+    > Note: This file could totally be created by the `xtask` if we merely decide convention for it and whether we want it checked in or not.  It will be used again later in process and, in theory, by CI.  Definitely not suggesting this should live on as regex.
+
+    ```
+    perl -0777 \
+      -sne 'print "$1\n" if m{
+        (?:\#\s               # Look for H1 Markdown (line starting with "# ")
+        \[v?\Q$version\E\]    # ...followed by [$version] (optionally with a "v")
+                              #    since some versions had that in the past.
+        \s.*?\n$)             # ... then "space" until the end of the line.
+        \s*                   # Ignore PRE-entry-whitespace
+        (.*?)                 # Capture the ACTUAL body of the release.  But do it
+                              # in a non-greedy way, leading us to stop when we
+                              # reach the next version boundary/heading.
+        \s*                   # Ignore POST-entry-whitespace
+        (?=^\#\s\[[^\]]+\]\s) # Once again, look for a version boundary.  This is
+                              # the same bit at the start, just on one line.
+      }msx' -- \
+        -version="${APOLLO_ROUTER_RELEASE_VERSION}" \
+        CHANGELOG.md >  this_release.md
+    ```
+
+16. Now, run this command to generate the header and the PR and keep them in an environment variable:
+
+    ```
+    apollo_prep_release_header="$(
+    cat <<EOM
+    > **Note**
+    >
+    > When approved, this PR will merge into **the \`${APOLLO_ROUTER_RELEASE_VERSION}\` branch** which will — upon being approved itself — merge into \`main\`.
+    >
+    > **Things to review in this PR**:
+    >  - Changelog correctness (There is a preview below, but it is not necessarily the most up to date.  See the _Files Changed_ for the true reality.)
+    >  - Version bumps
+    >  - That it targets the right release branch (\`${APOLLO_ROUTER_RELEASE_VERSION}\` in this case!).
+    >
+    ---
+    EOM
+    )"
+    apollo_prep_release_notes="$(cat ./this_release.md)"
+    ```
+
+17. Use the `gh` CLI to create the PR, using the previously-set environment variables:
+
+    ```
+    echo "${apollo_prep_release_header}\n${apollo_prep_release_notes}" | gh --repo "${APOLLO_ROUTER_RELEASE_GITHUB_REPO}" pr create -B "${APOLLO_ROUTER_RELEASE_VERSION}" --title "prep release: v${APOLLO_ROUTER_RELEASE_VERSION}" --body-file -
+    ```
+
+18. Use the `gh` CLI to enable **auto-squash** (**_NOT_** auto-**_merge_**) on the PR you just opened:
+
+    ```
+    gh --repo "${APOLLO_ROUTER_RELEASE_GITHUB_REPO}" pr merge --squash --body "" -t "prep release: v${APOLLO_ROUTER_RELEASE_VERSION}" --auto "prep-${APOLLO_ROUTER_RELEASE_VERSION}"
+    ```
+
+19. 🗣️ **Solicit feedback from the Router team on the prep PR**
+
+    Once approved, the PR will squash-merge itself into the next branch.
+
+20. After the PR has auto-merged, change your local branch back to the _non-_prep branch, pull any changes you (or others) may have added on GitHub :
+
+    ```
+    git checkout "${APOLLO_ROUTER_RELEASE_VERSION}"
+    git pull "${APOLLO_ROUTER_RELEASE_GIT_ORIGIN}"
+    ```
+
+20. Now, from your local final release branch, open the PR from the branch the prep PR already merged into:
+
+    ```
+    apollo_release_pr_header="$(
+    cat <<EOM
+
+    > **Note**
+    > **This particular PR should be true-merged to \`main\`.**
+
+    This PR represents the merge to \`main\` of the v${APOLLO_ROUTER_RELEASE_VERSION} release.
+
+    This PR is **primarily a merge commit**, so reviewing every individual commit shown below is **not necessary** since those have been reviewed in their own PR.
+
+    **However!** Some things to review on this PR:
+
+    - Does this PR target the right branch? (usually, \`main\`)
+    - Are the appropriate **version bumps** and **release note edits** in the end of the commit list (or within the last few commits).  In other words, "Did the 'release prep' PR actually land on this branch?"
+
+    If those things look good, this PR is good to merge.
+    EOM
+    )"
+    echo "${apollo_release_pr_header}" | gh --repo "${APOLLO_ROUTER_RELEASE_GITHUB_REPO}" pr create -B "main" --title "release: v${APOLLO_ROUTER_RELEASE_VERSION}" --draft --body-file -
+    ```
+
+21. Use the `gh` CLI to enable **auto-merge** (**_NOT_** auto-**_squash_**):
+
+    ```
+    gh --repo "${APOLLO_ROUTER_RELEASE_GITHUB_REPO}" pr merge --merge --body "" -t "release: v${APOLLO_ROUTER_RELEASE_VERSION}" --auto "${APOLLO_ROUTER_RELEASE_VERSION}"
+    ```
+
+22. 🗣️ **Solicit approval from the Router team, wait for the PR to pass CI and auto-merge into `main`**
+
+23. After the PR has merged to `main`, pull `main` to your local terminal, and Git tag & push the release:
+
+    This process will kick off the bulk of the release process on CircleCI, including building each architecture on its own infrastructure and notarizing the macOS binary.
+
+    ```
+    git checkout main
+    git pull "${APOLLO_ROUTER_RELEASE_GIT_ORIGIN}"
+    git tag -a "v${APOLLO_ROUTER_RELEASE_VERSION}" -m "${APOLLO_ROUTER_RELEASE_VERSION}" && git push "${APOLLO_ROUTER_RELEASE_GIT_ORIGIN}" "v${APOLLO_ROUTER_RELEASE_VERSION}"
+    ```
+
+24. Follow the process by going to CircleCI for the repository.
+
+25. Open a PR that reconciles `dev`:
+
+    ```
+    gh --repo "${APOLLO_ROUTER_RELEASE_GITHUB_REPO}" pr create --title "Reconcile \`dev\` after merge to \`main\` for v${APOLLO_ROUTER_RELEASE_VERSION}" -B dev -H main --body "Follow-up to the v${APOLLO_ROUTER_RELEASE_VERSION} being officially released, bringing version bumps and changelog updates into the \`dev\` branch."
+    ```
+
+26. After the CI job has finished for the tag, update the release notes (this needs to be moved to CI, but requires `this_release.md` which we created earlier):
+
+    ```
+    gh release edit v"${APOLLO_ROUTER_RELEASE_VERSION}" -F ./this_release.md
+    ```
+
+27. Publish the Crate from your local computer from the `main` branch (this also needs to be moved to CI, but requires changing the release containers to be Rust-enabled and to restore the caches):
+
+    ```
+    cargo publish -p apollo-router
+    ```
+
+28. (Optional) To have a "social banner" for this release, run [this `htmlq` command](https://crates.io/crates/htmlq) (like `jq` for HTML), open the link it produces, copy the image to your clipboard:
+
+    ```
+    curl -s "https://github.com/apollographql/router/releases/tag/v${APOLLO_ROUTER_RELEASE_VERSION}" | htmlq 'meta[property="og:image"]' --attribute content
+    ```
 
 ### Review
 


### PR DESCRIPTION
Overall, this commit adds a very verbose list of individually automated steps which can be automated into approximateily 3 fully-automated chunks.

For now, we're starting with testing the process with manual commands, and
this outlines those commands.  I've been using these for the release for a
while and literally just copy and paste the commands about after the 4th
step. (And stopping in the middle to fix the CHANGELOG.md and solicit PR
approval from the team).

Fixes https://github.com/apollographql/router/issues/170

