### PR TITLE
chore: Update Uplink schema in source

### DIFF
--- a/apollo-router/src/uplink/entitlement_stream.rs
+++ b/apollo-router/src/uplink/entitlement_stream.rs
@@ -87,6 +87,9 @@ impl From<entitlement_query::ResponseData> for UplinkResponse<Entitlement> {
                     FetchErrorCode::ACCESS_DENIED => "ACCESS_DENIED".to_string(),
                     FetchErrorCode::UNKNOWN_REF => "UNKNOWN_REF".to_string(),
                     FetchErrorCode::RETRY_LATER => "RETRY_LATER".to_string(),
+                    FetchErrorCode::NOT_IMPLEMENTED_ON_THIS_INSTANCE => {
+                        "NOT_IMPLEMENTED_ON_THIS_INSTANCE".to_string()
+                    }
                     FetchErrorCode::Other(other) => other,
                 },
                 message: error.message,

--- a/apollo-router/src/uplink/schema_stream.rs
+++ b/apollo-router/src/uplink/schema_stream.rs
@@ -54,6 +54,9 @@ impl From<supergraph_sdl_query::ResponseData> for UplinkResponse<String> {
                     FetchErrorCode::ACCESS_DENIED => "ACCESS_DENIED".to_string(),
                     FetchErrorCode::UNKNOWN_REF => "UNKNOWN_REF".to_string(),
                     FetchErrorCode::RETRY_LATER => "RETRY_LATER".to_string(),
+                    FetchErrorCode::NOT_IMPLEMENTED_ON_THIS_INSTANCE => {
+                        "NOT_IMPLEMENTED_ON_THIS_INSTANCE".to_string()
+                    }
                     FetchErrorCode::Other(other) => other,
                 },
                 message: err.message,

--- a/apollo-router/src/uplink/uplink.graphql
+++ b/apollo-router/src/uplink/uplink.graphql
@@ -12,8 +12,23 @@ type Message {
   level: MessageLevel!
   body: String!
 }
+"A chunk of persisted queries"
+type PersistedQueriesChunk {
+  "Unique identifier."
+  id: ID!
+  "The chunk can be downloaded from any of those URLs, which might be transient."
+  urls: [String!]!
+}
+type PersistedQueriesResult {
+  "Unique identifier."
+  id: ID!
+  "Minimum delay before the next fetch should occur, in seconds."
+  minDelaySeconds: Float!
+  "List of URLs chunks are to be fetched from; chunks should be cached by ID between updates. null indicates there is no configured persisted query list."
+  chunks: [PersistedQueriesChunk!]
+}
 type Query {
-  "Fetch the configuration for a router. If a valid configuration is available, it will be readable as cSDL."
+  "Fetch the configuration for a router."
   routerConfig(
     "The reference to a graph variant, like `engine@prod` or `engine` (i.e. `engine@current`)."
     ref: String!,apiKey: String!, 
@@ -22,13 +37,18 @@ type Query {
   ): RouterConfigResponse!
   "Fetch the current entitlements for a router."
   routerEntitlements(apiKey: String!, 
-    "When specified and a match for the current entitlements, `Unchanged` is returned rather `EntitlementsResult`."
-    unlessId: ID,
     "When specified and the result is not newer, `Unchanged` is returned rather than `EntitlementsResult`."
     ifAfterId: ID,
     "The reference to a graph variant, like `engine@prod` or `engine` (i.e. `engine@current`)."
     ref: String!
   ): RouterEntitlementsResponse!
+  "Fetch the persisted queries for a router."
+  persistedQueries(apiKey: String!, 
+    "When specified and the result is not newer, `Unchanged` is returned rather than `PersistedQueriesResult`."
+    ifAfterId: ID,
+    "The reference to a graph variant, like `engine@prod` or `engine` (i.e. `engine@current`)."
+    ref: String!
+  ): PersistedQueriesResponse!
 }
 type RouterConfigResult {
   "Variant-unique identifier."
@@ -66,6 +86,7 @@ type Unchanged {
   "Minimum delay before the next fetch should occur, in seconds."
   minDelaySeconds: Float!
 }
+union PersistedQueriesResponse = FetchError | PersistedQueriesResult | Unchanged
 union RouterConfigResponse = RouterConfigResult | Unchanged | FetchError
 union RouterEntitlementsResponse = RouterEntitlementsResult | Unchanged | FetchError
 enum FetchErrorCode {
@@ -77,6 +98,8 @@ enum FetchErrorCode {
   UNKNOWN_REF
   "An internal server error occurred. Please retry with some backoff."
   RETRY_LATER
+  "This instance of Uplink does not support this feature. Please try another instance."
+  NOT_IMPLEMENTED_ON_THIS_INSTANCE
 }
 enum MessageLevel {
   ERROR


### PR DESCRIPTION
This resolves the `uplink::test::test_uplink_schema_is_up_to_date` test failures in CI.