### PR TITLE
Change contains_attributes to when_header

### DIFF
--- a/docs/source/configuration/logging.mdx
+++ b/docs/source/configuration/logging.mdx
@@ -72,7 +72,7 @@ JSON-formatted logging provides compatibility with common searchable logging too
 > If you want to give feedback or participate in that feature feel free to join [this discussion on GitHub](https://github.com/apollographql/router/discussions/1961).
 
 By default some of our logs containing sensitive data (like request body, response body, headers) are not displayed even if we are in the right log level.
-For example if you need to display raw responses from one of your subgraph it won't be displayed by default. To enable them you have to configure it thanks to the `contains_attributes` setting.
+For example if you need to display raw responses from one of your subgraph it won't be displayed by default. To enable them you have to configure it with the `when_header` setting.
 Here is an example on how you can configure it:
 
 ```yaml title="router.yaml"


### PR DESCRIPTION
This was correct in the original PR, tested to confirm when_header works, contains_attributes returns an error due to an invalid config field.

*Description here*

Fixes a customer request

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
