### PR TITLE
Restore HTTP payload size limit, make it configurable

### DIFF
--- a/.changesets/feat_limit_request_size.md
+++ b/.changesets/feat_limit_request_size.md
@@ -1,0 +1,17 @@
+### Restore HTTP payload size limit, make it configurable ([Issue #2000](https://github.com/apollographql/router/issues/2000))
+
+Early versions of Apollo Router used to rely on a part of the Axum web framework
+that imposed a 2 MB limit on the size of the HTTP request body.
+Version 1.7 changed to read the body directly, unintentionally removing this limit.
+
+The limit is now restored to help protect against unbounded memory usage, but is now configurable:
+
+```yaml
+preview_operation_limits:
+  http_max_request_bytes: 2000000 # Default value: 2 MB
+```
+
+This limit is checked while reading from the network, before JSON parsing.
+Both the GraphQL document and associated variables count toward it.
+
+By [@SimonSapin](https://github.com/SimonSapin in https://github.com/apollographql/router/pull/3130

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -621,6 +621,10 @@ pub(crate) struct OperationLimits {
 
     /// Limit the number of tokens the GraphQL parser processes before aborting.
     pub(crate) parser_max_tokens: usize,
+
+    /// Limit the size of incoming HTTP requests read from the network,
+    /// to protect against running out of memory. Default: 2000000 (2 MB)
+    pub(crate) http_max_request_bytes: usize,
 }
 
 impl Default for OperationLimits {
@@ -632,12 +636,13 @@ impl Default for OperationLimits {
             max_root_fields: None,
             max_aliases: None,
             warn_only: false,
+            http_max_request_bytes: 2_000_000,
+            parser_max_tokens: 15_000,
 
             // This is `apollo-parser`’s default, which protects against stack overflow
             // but is still very high for "reasonable" queries.
             // https://docs.rs/apollo-parser/0.2.8/src/apollo_parser/parser/mod.rs.html#368
             parser_max_recursion: 4096,
-            parser_max_tokens: 15_000,
         }
     }
 }

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1129,10 +1129,18 @@ expression: "&schema"
         "max_aliases": null,
         "warn_only": false,
         "parser_max_recursion": 4096,
-        "parser_max_tokens": 15000
+        "parser_max_tokens": 15000,
+        "http_max_request_bytes": 2000000
       },
       "type": "object",
       "properties": {
+        "http_max_request_bytes": {
+          "description": "Limit the size of incoming HTTP requests read from the network, to protect against running out of memory. Default: 2000000 (2 MB)",
+          "default": 2000000,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
         "max_aliases": {
           "description": "If set, requests with operations with more aliases than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ALIASES_LIMIT\"}`",
           "default": null,

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -513,8 +513,9 @@ tls:
 >
 > To set request limits, you must run v1.17 or later of the Apollo Router. [Download the latest version.](../quickstart#download-options)
 
-The Apollo Router supports enforcing two types of request limits for enhanced security:
+The Apollo Router supports enforcing three types of request limits for enhanced security:
 
+- Network-based limits
 - Lexical, parser-based limits
 - Semantic, operation-based limits (this is an [Enterprise feature](../enterprise-features/))
 
@@ -522,6 +523,9 @@ The router rejects any request that violates at least one of these limits.
 
 ```yaml title="router.yaml"
 preview_operation_limits:
+  # Network-based limits
+  http_max_request_bytes: 2000000 # Default value: 2 MB
+
   # Parser-based limits
   parser_max_tokens: 15000 # Default value
   parser_max_recursion: 4096 # Default value
@@ -536,6 +540,17 @@ preview_operation_limits:
 #### Operation-based limits (Enterprise only)
 
 See [this article](./operation-limits/).
+
+#### Network-based limits
+
+##### `http_max_request_bytes`
+
+Limits the amount of data read from the network for the body of HTTP requests,
+to protects against unbounded memory consumption.
+This limit is checked before JSON parsing.
+Both the GraphQL document and associated variables count toward it.
+
+The default value is `2000000` bytes, 2 MB.
 
 #### Parser-based limits
 


### PR DESCRIPTION
Fixes https://github.com/apollographql/router/issues/2000

Configuration:

```yaml
preview_operation_limits:
  http_max_request_bytes: 2000000 # Default value: 2 MB
```

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

This change could be a compatibility issue for users who rely on large requests and upgrading from a Router version that didn’t have this limit. However this issue is easily fixed through configuration. The error log (but not the HTTP response) mention the relevant configuration key.

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
