### PR TITLE
experiment to replace opaque 500 errors with informative graphql

### DIFF
--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -2,6 +2,7 @@
 use std::sync::Arc;
 
 use displaydoc::Display;
+use http::StatusCode;
 use lazy_static::__Deref;
 use miette::Diagnostic;
 use miette::NamedSource;
@@ -14,6 +15,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
 use tokio::task::JoinError;
+use tower::BoxError;
 use tracing::level_filters::LevelFilter;
 
 pub(crate) use crate::configuration::ConfigurationError;
@@ -533,6 +535,31 @@ impl ParseErrors {
                 println!("{r:#?}");
             });
         };
+    }
+}
+#[derive(Debug, Error)]
+#[error("{context} ({source})")]
+pub(crate) struct ContextError {
+    /// HTTP StatusCode
+    pub(crate) status: StatusCode,
+    /// Context Error
+    pub(crate) context: String,
+    /// Extension Error
+    pub(crate) extension: String,
+    /// Source Error
+    pub(crate) source: BoxError,
+}
+
+#[buildstructor::buildstructor]
+impl ContextError {
+    #[builder(visibility = "pub(crate)")]
+    fn new(status: StatusCode, context: String, extension: String, source: BoxError) -> Self {
+        Self {
+            status,
+            context,
+            extension,
+            source,
+        }
     }
 }
 


### PR DESCRIPTION
EXPERIMENT FOR DISCUSSION

Currently, particularly if code is executing within a plugin, there are many places within the router where we don't/can't return helpful information to a client.

The result of such errors is something like this curl extract:

```
< HTTP/1.1 500 Internal Server Error
< content-type: text/plain; charset=utf-8
< content-length: 26
< date: Sat, 20 May 2023 10:35:52 GMT
<
* Connection #0 to host 127.0.0.1 left intact
router service call failed
```

Well, something has gone wrong and it could be pretty fatal. If you dig about in the logs (assuming you have access to them) you might be able to figure out what has gone wrong.

This experiment, provides a framework that we can leverage to gradually add support for more meaninful/informative errors to the router. Using the new `ContextError` type, we can return an informative error that, for example, could be used to transform the above into:

```
< HTTP/1.1 200 OK
< content-type: application/json
< content-length: 163
< date: Tue, 23 May 2023 14:09:00 GMT
<
* Connection #0 to host 127.0.0.1 left intact
{"errors":[{"message":"could not parse response body into JSON value (invalid number at line 2 column 2)","extensions":{"code":"EXTERNAL_DESERIALIZATION_ERROR"}}]}
```

This is a much more informative error, that gives us a lot more information about what has gone wrong.

`ContextError` allows the user to specify:
 - status code
 - contextual error message
 - extension code
 - source error

This information is then processed in the axum factory to generate the meaningful error above. If there is no ContextError to be processed, you get the existing behaviour, which allows us to progressively improve things.

What does everyone think?

*Description here*

Fixes #issue_number

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
