### PR TITLE
don't try to convert bytes back to JSON on RouterRequest

### DIFF
--- a/apollo-router/src/plugins/coprocessor.rs
+++ b/apollo-router/src/plugins/coprocessor.rs
@@ -582,7 +582,7 @@ where
     // are present in our co_processor_output.
 
     let new_body = match co_processor_output.body {
-        Some(bytes) => Body::from(serde_json::to_vec(&bytes)?),
+        Some(bytes) => Body::from(bytes),
         None => Body::from(bytes),
     };
 


### PR DESCRIPTION
Now that we expect bytes back from the coprocessor, just take the bytes and don't try to convert back to JSON.

There was an error in the RouterRequest processing logic. I was still trying to convert coprocessor response bytes back to JSON and that worked but resulted in double escaped text which failed when the query planner tried to make sense of it.
