### PR TITLE
Move `curl` dependency to separate layer in Docker image

### DIFF
--- a/.changesets/fix_abernix_remove_curl.md
+++ b/.changesets/fix_abernix_remove_curl.md
@@ -1,0 +1,5 @@
+### Move `curl` dependency to separate layer in Docker image ([Issue #3144](https://github.com/apollographql/router/issues/3144))
+
+We've moved `curl` out of the Docker image we publish.  The `curl` command is only used in the image we produce today for the sake of downloading dependencies.  It is never used after that, but we can move it to a separate layer to further remove it from the image.
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/3146

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -1,15 +1,26 @@
-FROM debian:bullseye-slim
-
+FROM debian:bullseye-slim AS downloader
 ARG ROUTER_RELEASE=latest
-ARG DEBUG_IMAGE=false
-
-WORKDIR /dist
 
 # Install curl
 RUN \
   apt-get update -y \
   && apt-get install -y \
     curl
+
+WORKDIR /dist
+
+# Run the Router downloader which puts Router into current working directory
+RUN curl -sSL https://router.apollo.dev/download/nix/${ROUTER_RELEASE}/ | sh
+
+FROM debian:bullseye-slim AS distro
+ARG DEBUG_IMAGE=false
+
+WORKDIR /dist
+
+COPY --from=downloader /dist/router /dist
+
+# Update apt
+RUN apt-get update -y
 
 # If debug image, install heaptrack and make a data directory
 RUN \
@@ -20,9 +31,6 @@ RUN \
 
 # Clean up apt lists
 RUN rm -rf /var/lib/apt/lists/*
-
-# Run the Router downloader which puts Router into current working directory
-RUN curl -sSL https://router.apollo.dev/download/nix/${ROUTER_RELEASE}/ | sh
 
 # Make directories for config and schema
 RUN mkdir config schema

--- a/dockerfiles/diy/dockerfiles/Dockerfile.repo
+++ b/dockerfiles/diy/dockerfiles/Dockerfile.repo
@@ -36,11 +36,8 @@ ARG DEBUG_IMAGE=false
 
 WORKDIR /dist
 
-# Install curl
-RUN \
-  apt-get update -y \
-  && apt-get install -y \
-    curl
+# Update apt
+RUN apt-get update -y
 
 # Copy in the required files from our build image
 COPY --from=build --chown=root:root /dist /dist


### PR DESCRIPTION
The `curl` command is only used in the image we produce today for the sake
of downloading dependencies.  It is never used after that, but we can move
it to a separate layer to further remove it from the image.

Ref: https://github.com/apollographql/router/issues/3144
