### PR TITLE
Update the opentelemetry library to 0.19 to fix the problem ignore da…

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -117,7 +117,7 @@ once_cell = "1.16.0"
 # groups `^tracing` and `^opentelemetry*` dependencies together as of
 # https://github.com/apollographql/router/pull/1509.  A comment which exists
 # there (and on `tracing` packages below) should be updated should this change.
-opentelemetry = { version = "0.18.0", features = [
+opentelemetry = { version = "0.19.0", features = [
     "rt-tokio",
     "metrics",
 ] }


### PR DESCRIPTION
*Description here*
According to this thread (https://github.com/open-telemetry/opentelemetry-rust/issues/876), the latest opentelemetry-datadog library should fix the problem that apollo router not sending tracing config to datadog

Fixes #1162 
https://github.com/apollographql/router/issues/1162#issuecomment-1138605182

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
