### PR TITLE
chore(tools): Use PR number in changeset titles when Issue is absent

### DIFF
--- a/xtask/Cargo.lock
+++ b/xtask/Cargo.lock
@@ -103,6 +103,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +298,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +322,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -360,6 +388,16 @@ dependencies = [
  "shell-words",
  "tempfile",
  "zeroize",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -497,6 +535,16 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -732,6 +780,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a28d25139df397cbca21408bb742cf6837e04cdbebf1b07b760caf971d6a972"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "pest",
+ "pest_derive",
+ "serde",
+ "similar",
+ "yaml-rust",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +877,12 @@ checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -932,6 +1002,50 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
+dependencies = [
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b79d4c71c865a25a4322296122e3924d30bc8ee0834c8bfc8b95f7f054afbfb"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c435bf1076437b851ebc8edc3a18442796b30f1728ffea6262d59bbe28b077e"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "745a452f8eb71e39ffd8ee32b3c5f51d03845f99786fa9b68db6ff509c505411"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1269,10 +1383,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "similar"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
 
 [[package]]
 name = "slab"
@@ -1496,6 +1627,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1553,6 +1696,12 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"
@@ -1923,6 +2072,7 @@ dependencies = [
  "dialoguer",
  "flate2",
  "graphql_client",
+ "insta",
  "itertools",
  "libc",
  "memorable-wordlist",
@@ -1941,6 +2091,15 @@ dependencies = [
  "walkdir",
  "which",
  "zip",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -41,3 +41,6 @@ tokio = "1.25.0"
 which = "4"
 zip = { version = "0.6", default-features = false }
 walkdir = "2.3.2"
+
+[dev-dependencies]
+insta = { version = "1.26.0", features = ["json", "redactions", "yaml"] }

--- a/xtask/src/commands/changeset/mod.rs
+++ b/xtask/src/commands/changeset/mod.rs
@@ -66,15 +66,29 @@ struct TemplateContext {
 
 const REPO_WITH_OWNER: &'static str = "apollographql/router";
 
-const EXAMPLE_TEMPLATE: &'static str = "### {title} {{ for issue in issues -}}
-([Issue #{issue.number}]({issue.url})){{ if not @last }}, {{ endif }}
-{{- endfor }}
+const EXAMPLE_TEMPLATE: &'static str = "### { title }
+{{- if issues -}}
+  {{- if issues }} {{ endif -}}
+  {{- for issue in issues -}}
+    ([Issue #{issue.number}]({issue.url}))
+    {{- if not @last }}, {{ endif -}}
+  {{- endfor -}}
+{{ else -}}
+  {{- if pulls -}}
+    {{- if pulls }} {{ endif -}}
+    {{- for pull in pulls -}}
+      ([PR #{pull.number}]({pull.url}))
+      {{- if not @last }}, {{ endif -}}
+    {{- endfor -}}
+  {{- else -}}
+  {{- endif -}}
+{{- endif }}
 
 {body}
 
-By [@{author}](https://github.com/{author}) in {{ for pull in pulls -}}
+By [@{author}](https://github.com/{author}){{ if pulls }} in {{ for pull in pulls -}}
 {pull.url}{{ if not @last }}, {{ endif }}
-{{- endfor }}
+{{- endfor }}{{ endif }}
 ";
 
 impl Command {
@@ -609,4 +623,165 @@ impl TryFrom<&DirEntry> for Changeset {
             path,
         })
     }
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_templatizes_with_multiple_issues_in_title_and_multiple_prs_in_footer() {
+        let test_context = TemplateContext {
+            title: String::from("TITLE"),
+            issues: vec![
+                TemplateResource {
+                    url: format!("https://github.com/{}/issues/ISSUE_NUMBER1", String::from("REPO_WITH_OWNER")),
+                    number: String::from("ISSUE_NUMBER1"),
+                },
+                TemplateResource {
+                    url: format!("https://github.com/{}/issues/ISSUE_NUMBER2", String::from("REPO_WITH_OWNER")),
+                    number: String::from("ISSUE_NUMBER2"),
+                },
+            ],
+            pulls: vec![
+                TemplateResource {
+                   url: format!("https://github.com/{}/pull/PULL_NUMBER1", String::from("REPO_WITH_OWNER")),
+                   number: String::from("PULL_NUMBER1"),
+                },
+                TemplateResource {
+                   url: format!("https://github.com/{}/pull/PULL_NUMBER2", String::from("REPO_WITH_OWNER")),
+                   number: String::from("PULL_NUMBER2"),
+                },
+            ],
+            author: String::from("AUTHOR"),
+            body: String::from("BODY"),
+        };
+
+        let mut tt = TinyTemplate::new();
+        tt.add_template("message", EXAMPLE_TEMPLATE).unwrap();
+        tt.set_default_formatter(&format_unescaped);
+        let rendered_template = tt.render("message", &test_context).unwrap().replace('\r', "");
+        insta::assert_snapshot!(rendered_template);
+    }
+
+    #[test]
+    fn it_templatizes_with_multiple_prs_in_footer() {
+        let test_context = TemplateContext {
+            title: String::from("TITLE"),
+            issues: vec!(TemplateResource {
+                url: format!("https://github.com/{}/issues/ISSUE_NUMBER", String::from("REPO_WITH_OWNER")),
+                number: String::from("ISSUE_NUMBER"),
+            }),
+            pulls: vec![
+                TemplateResource {
+                   url: format!("https://github.com/{}/pull/PULL_NUMBER1", String::from("REPO_WITH_OWNER")),
+                   number: String::from("PULL_NUMBER1"),
+                },
+                TemplateResource {
+                   url: format!("https://github.com/{}/pull/PULL_NUMBER2", String::from("REPO_WITH_OWNER")),
+                   number: String::from("PULL_NUMBER2"),
+                },
+            ],
+            author: String::from("AUTHOR"),
+            body: String::from("BODY"),
+        };
+
+        let mut tt = TinyTemplate::new();
+        tt.add_template("message", EXAMPLE_TEMPLATE).unwrap();
+        tt.set_default_formatter(&format_unescaped);
+        let rendered_template = tt.render("message", &test_context).unwrap().replace('\r', "");
+        insta::assert_snapshot!(rendered_template);
+    }
+
+    #[test]
+    fn it_templatizes_with_multiple_issues_in_title() {
+        let test_context = TemplateContext {
+            title: String::from("TITLE"),
+            issues: vec![
+                TemplateResource {
+                   url: format!("https://github.com/{}/issues/ISSUE_NUMBER1", String::from("REPO_WITH_OWNER")),
+                   number: String::from("ISSUE_NUMBER1"),
+                },
+                TemplateResource {
+                   url: format!("https://github.com/{}/issues/ISSUE_NUMBER2", String::from("REPO_WITH_OWNER")),
+                   number: String::from("ISSUE_NUMBER2"),
+                },
+            ],
+            pulls: vec!(TemplateResource {
+                url: format!("https://github.com/{}/pull/PULL_NUMBER", String::from("REPO_WITH_OWNER")),
+                number: String::from("PULL_NUMBER"),
+            }),
+            author: String::from("AUTHOR"),
+            body: String::from("BODY"),
+        };
+
+        let mut tt = TinyTemplate::new();
+        tt.add_template("message", EXAMPLE_TEMPLATE).unwrap();
+        tt.set_default_formatter(&format_unescaped);
+        let rendered_template = tt.render("message", &test_context).unwrap().replace('\r', "");
+        insta::assert_snapshot!(rendered_template);
+    }
+
+    #[test]
+    fn it_templatizes_with_prs_in_title_when_empty_issues() {
+        let test_context = TemplateContext {
+            title: String::from("TITLE"),
+            issues: vec!(),
+            pulls: vec!(TemplateResource {
+                url: format!("https://github.com/{}/pull/PULL_NUMBER", String::from("REPO_WITH_OWNER")),
+                number: String::from("PULL_NUMBER"),
+            }),
+            author: String::from("AUTHOR"),
+            body: String::from("BODY"),
+        };
+
+        let mut tt = TinyTemplate::new();
+        tt.add_template("message", EXAMPLE_TEMPLATE).unwrap();
+        tt.set_default_formatter(&format_unescaped);
+        let rendered_template = tt.render("message", &test_context).unwrap().replace('\r', "");
+        insta::assert_snapshot!(rendered_template);
+    }
+
+    #[test]
+    fn it_templatizes_without_prs_in_title_when_issues_present() {
+        let test_context = TemplateContext {
+            title: String::from("TITLE"),
+            issues: vec!(TemplateResource {
+                url: format!("https://github.com/{}/pull/ISSUE_NUMBER", String::from("REPO_WITH_OWNER")),
+                number: String::from("ISSUE_NUMBER"),
+            }),
+            pulls: vec!(TemplateResource {
+                url: format!("https://github.com/{}/pull/PULL_NUMBER", String::from("REPO_WITH_OWNER")),
+                number: String::from("PULL_NUMBER"),
+            }),
+            author: String::from("AUTHOR"),
+            body: String::from("BODY"),
+        };
+
+        let mut tt = TinyTemplate::new();
+        tt.add_template("message", EXAMPLE_TEMPLATE).unwrap();
+        tt.set_default_formatter(&format_unescaped);
+        let rendered_template = tt.render("message", &test_context).unwrap().replace('\r', "");
+        insta::assert_snapshot!(rendered_template);
+    }
+
+    #[test]
+    fn it_templatizes_with_neither_issues_or_prs() {
+        let test_context = TemplateContext {
+            title: String::from("TITLE"),
+            issues: vec!(),
+            pulls: vec!(),
+            author: String::from("AUTHOR"),
+            body: String::from("BODY"),
+        };
+
+        let mut tt = TinyTemplate::new();
+        tt.add_template("message", EXAMPLE_TEMPLATE).unwrap();
+        tt.set_default_formatter(&format_unescaped);
+        let rendered_template = tt.render("message", &test_context).unwrap().replace('\r', "");
+        insta::assert_snapshot!(rendered_template);
+    }
+
 }

--- a/xtask/src/commands/changeset/mod.rs
+++ b/xtask/src/commands/changeset/mod.rs
@@ -625,8 +625,6 @@ impl TryFrom<&DirEntry> for Changeset {
     }
 }
 
-
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -637,22 +635,34 @@ mod tests {
             title: String::from("TITLE"),
             issues: vec![
                 TemplateResource {
-                    url: format!("https://github.com/{}/issues/ISSUE_NUMBER1", String::from("REPO_WITH_OWNER")),
+                    url: format!(
+                        "https://github.com/{}/issues/ISSUE_NUMBER1",
+                        String::from("REPO_WITH_OWNER")
+                    ),
                     number: String::from("ISSUE_NUMBER1"),
                 },
                 TemplateResource {
-                    url: format!("https://github.com/{}/issues/ISSUE_NUMBER2", String::from("REPO_WITH_OWNER")),
+                    url: format!(
+                        "https://github.com/{}/issues/ISSUE_NUMBER2",
+                        String::from("REPO_WITH_OWNER")
+                    ),
                     number: String::from("ISSUE_NUMBER2"),
                 },
             ],
             pulls: vec![
                 TemplateResource {
-                   url: format!("https://github.com/{}/pull/PULL_NUMBER1", String::from("REPO_WITH_OWNER")),
-                   number: String::from("PULL_NUMBER1"),
+                    url: format!(
+                        "https://github.com/{}/pull/PULL_NUMBER1",
+                        String::from("REPO_WITH_OWNER")
+                    ),
+                    number: String::from("PULL_NUMBER1"),
                 },
                 TemplateResource {
-                   url: format!("https://github.com/{}/pull/PULL_NUMBER2", String::from("REPO_WITH_OWNER")),
-                   number: String::from("PULL_NUMBER2"),
+                    url: format!(
+                        "https://github.com/{}/pull/PULL_NUMBER2",
+                        String::from("REPO_WITH_OWNER")
+                    ),
+                    number: String::from("PULL_NUMBER2"),
                 },
             ],
             author: String::from("AUTHOR"),
@@ -662,7 +672,10 @@ mod tests {
         let mut tt = TinyTemplate::new();
         tt.add_template("message", EXAMPLE_TEMPLATE).unwrap();
         tt.set_default_formatter(&format_unescaped);
-        let rendered_template = tt.render("message", &test_context).unwrap().replace('\r', "");
+        let rendered_template = tt
+            .render("message", &test_context)
+            .unwrap()
+            .replace('\r', "");
         insta::assert_snapshot!(rendered_template);
     }
 
@@ -670,18 +683,27 @@ mod tests {
     fn it_templatizes_with_multiple_prs_in_footer() {
         let test_context = TemplateContext {
             title: String::from("TITLE"),
-            issues: vec!(TemplateResource {
-                url: format!("https://github.com/{}/issues/ISSUE_NUMBER", String::from("REPO_WITH_OWNER")),
+            issues: vec![TemplateResource {
+                url: format!(
+                    "https://github.com/{}/issues/ISSUE_NUMBER",
+                    String::from("REPO_WITH_OWNER")
+                ),
                 number: String::from("ISSUE_NUMBER"),
-            }),
+            }],
             pulls: vec![
                 TemplateResource {
-                   url: format!("https://github.com/{}/pull/PULL_NUMBER1", String::from("REPO_WITH_OWNER")),
-                   number: String::from("PULL_NUMBER1"),
+                    url: format!(
+                        "https://github.com/{}/pull/PULL_NUMBER1",
+                        String::from("REPO_WITH_OWNER")
+                    ),
+                    number: String::from("PULL_NUMBER1"),
                 },
                 TemplateResource {
-                   url: format!("https://github.com/{}/pull/PULL_NUMBER2", String::from("REPO_WITH_OWNER")),
-                   number: String::from("PULL_NUMBER2"),
+                    url: format!(
+                        "https://github.com/{}/pull/PULL_NUMBER2",
+                        String::from("REPO_WITH_OWNER")
+                    ),
+                    number: String::from("PULL_NUMBER2"),
                 },
             ],
             author: String::from("AUTHOR"),
@@ -691,7 +713,10 @@ mod tests {
         let mut tt = TinyTemplate::new();
         tt.add_template("message", EXAMPLE_TEMPLATE).unwrap();
         tt.set_default_formatter(&format_unescaped);
-        let rendered_template = tt.render("message", &test_context).unwrap().replace('\r', "");
+        let rendered_template = tt
+            .render("message", &test_context)
+            .unwrap()
+            .replace('\r', "");
         insta::assert_snapshot!(rendered_template);
     }
 
@@ -701,18 +726,27 @@ mod tests {
             title: String::from("TITLE"),
             issues: vec![
                 TemplateResource {
-                   url: format!("https://github.com/{}/issues/ISSUE_NUMBER1", String::from("REPO_WITH_OWNER")),
-                   number: String::from("ISSUE_NUMBER1"),
+                    url: format!(
+                        "https://github.com/{}/issues/ISSUE_NUMBER1",
+                        String::from("REPO_WITH_OWNER")
+                    ),
+                    number: String::from("ISSUE_NUMBER1"),
                 },
                 TemplateResource {
-                   url: format!("https://github.com/{}/issues/ISSUE_NUMBER2", String::from("REPO_WITH_OWNER")),
-                   number: String::from("ISSUE_NUMBER2"),
+                    url: format!(
+                        "https://github.com/{}/issues/ISSUE_NUMBER2",
+                        String::from("REPO_WITH_OWNER")
+                    ),
+                    number: String::from("ISSUE_NUMBER2"),
                 },
             ],
-            pulls: vec!(TemplateResource {
-                url: format!("https://github.com/{}/pull/PULL_NUMBER", String::from("REPO_WITH_OWNER")),
+            pulls: vec![TemplateResource {
+                url: format!(
+                    "https://github.com/{}/pull/PULL_NUMBER",
+                    String::from("REPO_WITH_OWNER")
+                ),
                 number: String::from("PULL_NUMBER"),
-            }),
+            }],
             author: String::from("AUTHOR"),
             body: String::from("BODY"),
         };
@@ -720,7 +754,10 @@ mod tests {
         let mut tt = TinyTemplate::new();
         tt.add_template("message", EXAMPLE_TEMPLATE).unwrap();
         tt.set_default_formatter(&format_unescaped);
-        let rendered_template = tt.render("message", &test_context).unwrap().replace('\r', "");
+        let rendered_template = tt
+            .render("message", &test_context)
+            .unwrap()
+            .replace('\r', "");
         insta::assert_snapshot!(rendered_template);
     }
 
@@ -728,11 +765,14 @@ mod tests {
     fn it_templatizes_with_prs_in_title_when_empty_issues() {
         let test_context = TemplateContext {
             title: String::from("TITLE"),
-            issues: vec!(),
-            pulls: vec!(TemplateResource {
-                url: format!("https://github.com/{}/pull/PULL_NUMBER", String::from("REPO_WITH_OWNER")),
+            issues: vec![],
+            pulls: vec![TemplateResource {
+                url: format!(
+                    "https://github.com/{}/pull/PULL_NUMBER",
+                    String::from("REPO_WITH_OWNER")
+                ),
                 number: String::from("PULL_NUMBER"),
-            }),
+            }],
             author: String::from("AUTHOR"),
             body: String::from("BODY"),
         };
@@ -740,7 +780,10 @@ mod tests {
         let mut tt = TinyTemplate::new();
         tt.add_template("message", EXAMPLE_TEMPLATE).unwrap();
         tt.set_default_formatter(&format_unescaped);
-        let rendered_template = tt.render("message", &test_context).unwrap().replace('\r', "");
+        let rendered_template = tt
+            .render("message", &test_context)
+            .unwrap()
+            .replace('\r', "");
         insta::assert_snapshot!(rendered_template);
     }
 
@@ -748,14 +791,20 @@ mod tests {
     fn it_templatizes_without_prs_in_title_when_issues_present() {
         let test_context = TemplateContext {
             title: String::from("TITLE"),
-            issues: vec!(TemplateResource {
-                url: format!("https://github.com/{}/pull/ISSUE_NUMBER", String::from("REPO_WITH_OWNER")),
+            issues: vec![TemplateResource {
+                url: format!(
+                    "https://github.com/{}/pull/ISSUE_NUMBER",
+                    String::from("REPO_WITH_OWNER")
+                ),
                 number: String::from("ISSUE_NUMBER"),
-            }),
-            pulls: vec!(TemplateResource {
-                url: format!("https://github.com/{}/pull/PULL_NUMBER", String::from("REPO_WITH_OWNER")),
+            }],
+            pulls: vec![TemplateResource {
+                url: format!(
+                    "https://github.com/{}/pull/PULL_NUMBER",
+                    String::from("REPO_WITH_OWNER")
+                ),
                 number: String::from("PULL_NUMBER"),
-            }),
+            }],
             author: String::from("AUTHOR"),
             body: String::from("BODY"),
         };
@@ -763,7 +812,10 @@ mod tests {
         let mut tt = TinyTemplate::new();
         tt.add_template("message", EXAMPLE_TEMPLATE).unwrap();
         tt.set_default_formatter(&format_unescaped);
-        let rendered_template = tt.render("message", &test_context).unwrap().replace('\r', "");
+        let rendered_template = tt
+            .render("message", &test_context)
+            .unwrap()
+            .replace('\r', "");
         insta::assert_snapshot!(rendered_template);
     }
 
@@ -771,8 +823,8 @@ mod tests {
     fn it_templatizes_with_neither_issues_or_prs() {
         let test_context = TemplateContext {
             title: String::from("TITLE"),
-            issues: vec!(),
-            pulls: vec!(),
+            issues: vec![],
+            pulls: vec![],
             author: String::from("AUTHOR"),
             body: String::from("BODY"),
         };
@@ -780,8 +832,10 @@ mod tests {
         let mut tt = TinyTemplate::new();
         tt.add_template("message", EXAMPLE_TEMPLATE).unwrap();
         tt.set_default_formatter(&format_unescaped);
-        let rendered_template = tt.render("message", &test_context).unwrap().replace('\r', "");
+        let rendered_template = tt
+            .render("message", &test_context)
+            .unwrap()
+            .replace('\r', "");
         insta::assert_snapshot!(rendered_template);
     }
-
 }

--- a/xtask/src/commands/changeset/snapshots/xtask__commands__changeset__tests__it_templatizes_with_multiple_issues_in_title.snap
+++ b/xtask/src/commands/changeset/snapshots/xtask__commands__changeset__tests__it_templatizes_with_multiple_issues_in_title.snap
@@ -1,0 +1,10 @@
+---
+source: src/commands/changeset/mod.rs
+expression: rendered_template
+---
+### TITLE ([Issue #ISSUE_NUMBER1](https://github.com/REPO_WITH_OWNER/issues/ISSUE_NUMBER1)), ([Issue #ISSUE_NUMBER2](https://github.com/REPO_WITH_OWNER/issues/ISSUE_NUMBER2))
+
+BODY
+
+By [@AUTHOR](https://github.com/AUTHOR) in https://github.com/REPO_WITH_OWNER/pull/PULL_NUMBER
+

--- a/xtask/src/commands/changeset/snapshots/xtask__commands__changeset__tests__it_templatizes_with_multiple_issues_in_title_and_multiple_prs_in_footer.snap
+++ b/xtask/src/commands/changeset/snapshots/xtask__commands__changeset__tests__it_templatizes_with_multiple_issues_in_title_and_multiple_prs_in_footer.snap
@@ -1,0 +1,10 @@
+---
+source: src/commands/changeset/mod.rs
+expression: rendered_template
+---
+### TITLE ([Issue #ISSUE_NUMBER1](https://github.com/REPO_WITH_OWNER/issues/ISSUE_NUMBER1)), ([Issue #ISSUE_NUMBER2](https://github.com/REPO_WITH_OWNER/issues/ISSUE_NUMBER2))
+
+BODY
+
+By [@AUTHOR](https://github.com/AUTHOR) in https://github.com/REPO_WITH_OWNER/pull/PULL_NUMBER1, https://github.com/REPO_WITH_OWNER/pull/PULL_NUMBER2
+

--- a/xtask/src/commands/changeset/snapshots/xtask__commands__changeset__tests__it_templatizes_with_multiple_prs_in_footer.snap
+++ b/xtask/src/commands/changeset/snapshots/xtask__commands__changeset__tests__it_templatizes_with_multiple_prs_in_footer.snap
@@ -1,0 +1,10 @@
+---
+source: src/commands/changeset/mod.rs
+expression: rendered_template
+---
+### TITLE ([Issue #ISSUE_NUMBER](https://github.com/REPO_WITH_OWNER/issues/ISSUE_NUMBER))
+
+BODY
+
+By [@AUTHOR](https://github.com/AUTHOR) in https://github.com/REPO_WITH_OWNER/pull/PULL_NUMBER1, https://github.com/REPO_WITH_OWNER/pull/PULL_NUMBER2
+

--- a/xtask/src/commands/changeset/snapshots/xtask__commands__changeset__tests__it_templatizes_with_neither_issues_or_prs.snap
+++ b/xtask/src/commands/changeset/snapshots/xtask__commands__changeset__tests__it_templatizes_with_neither_issues_or_prs.snap
@@ -1,0 +1,10 @@
+---
+source: src/commands/changeset/mod.rs
+expression: rendered_template
+---
+### TITLE
+
+BODY
+
+By [@AUTHOR](https://github.com/AUTHOR)
+

--- a/xtask/src/commands/changeset/snapshots/xtask__commands__changeset__tests__it_templatizes_with_prs_in_title_when_empty_issues.snap
+++ b/xtask/src/commands/changeset/snapshots/xtask__commands__changeset__tests__it_templatizes_with_prs_in_title_when_empty_issues.snap
@@ -1,0 +1,10 @@
+---
+source: src/commands/changeset/mod.rs
+expression: rendered_template
+---
+### TITLE ([PR #PULL_NUMBER](https://github.com/REPO_WITH_OWNER/pull/PULL_NUMBER))
+
+BODY
+
+By [@AUTHOR](https://github.com/AUTHOR) in https://github.com/REPO_WITH_OWNER/pull/PULL_NUMBER
+

--- a/xtask/src/commands/changeset/snapshots/xtask__commands__changeset__tests__it_templatizes_with_prs_when_empty_issues.snap
+++ b/xtask/src/commands/changeset/snapshots/xtask__commands__changeset__tests__it_templatizes_with_prs_when_empty_issues.snap
@@ -1,0 +1,10 @@
+---
+source: src/commands/changeset/mod.rs
+expression: rendered_template
+---
+### TITLE ([Pull #PULL_NUMBER](https://github.com/REPO_WITH_OWNER/pull/PULL_NUMBER))
+
+BODY
+
+By [@AUTHOR](https://github.com/AUTHOR) in https://github.com/REPO_WITH_OWNER/pull/PULL_NUMBER
+

--- a/xtask/src/commands/changeset/snapshots/xtask__commands__changeset__tests__it_templatizes_without_prs_in_title_when_issues_present.snap
+++ b/xtask/src/commands/changeset/snapshots/xtask__commands__changeset__tests__it_templatizes_without_prs_in_title_when_issues_present.snap
@@ -1,0 +1,10 @@
+---
+source: src/commands/changeset/mod.rs
+expression: rendered_template
+---
+### TITLE ([Issue #ISSUE_NUMBER](https://github.com/REPO_WITH_OWNER/pull/ISSUE_NUMBER))
+
+BODY
+
+By [@AUTHOR](https://github.com/AUTHOR) in https://github.com/REPO_WITH_OWNER/pull/PULL_NUMBER
+


### PR DESCRIPTION
Previously, it was just leaving it off, but it left things a bit
unharmonic/off-balance in terms of the resulting changeset template.  I'd
also just been manually adding those during the release process thus far, so
figured I'd just automate it now.

Also added a lot of tests and fixed a couple bugs with trailing spaces.

Relates to #https://github.com/apollographql/router/issues/2261
