### PR TITLE
filter NOASSERTION licenses

### DIFF
--- a/.changesets/maint_garypen_3176_filter_licenses.md
+++ b/.changesets/maint_garypen_3176_filter_licenses.md
@@ -1,0 +1,5 @@
+### Improve `cargo-about` license checking ([Issue #3176](https://github.com/apollographql/router/issues/3176))
+
+From the description of this [cargo about PR](https://github.com/EmbarkStudios/cargo-about/pull/216), it is possible for "NOASSERTION" identifiers to be added when gathering license information, causing license checks to fail. This change uses the new `cargo-about` configuration `filter-noassertion` to eliminate the problem.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3178

--- a/about.toml
+++ b/about.toml
@@ -12,6 +12,9 @@ accepted = [
     "Unicode-DFS-2016"
 ]
 
+# See https://github.com/EmbarkStudios/cargo-about/pull/216
+filter-noassertion = true
+
 # Ignore non plublished crates, such as xtask for example
 private = { ignore = true }
 # Ignore dependencies used in tests only, test-log for example


### PR DESCRIPTION
Add support for new cargo about option to filter NOASSERTION licenses.

fixes: #3176

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
