### PR TITLE
[docs] Update coprocessor docs for GET requests

### DIFF
--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -588,6 +588,8 @@ Currently, this value is always `1`.
 <td>
 
 The body of the corresponding request or response.
+  
+This field is populated when the underlying HTTP method is `POST`. If you are looking for operation data on `GET` requests, that info will be populated in the `path` parameter per the [GraphQL over HTTP spec](https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#get).
 
 If your coprocessor [returns a _different_ value](#responding-to-coprocessor-requests) for `body`, the router replaces the existing body with that value. This is common when [terminating a client request](#terminating-a-client-request).
 


### PR DESCRIPTION
Add docs clarifying the `body` field and the fact it is not sent when the request is a GET