### PR TITLE
chore: Some changelog prep prior to 1.20.0 release

### DIFF
--- a/.changesets/feat_swan_cub_foot_audience.md
+++ b/.changesets/feat_swan_cub_foot_audience.md
@@ -1,6 +1,6 @@
 ### Configurable histogram buckets for metrics ([Issue #2333](https://github.com/apollographql/router/issues/2333))
 
-You can customize the buckets for all generated histograms:
+It is now possible to change the default bucketing for histograms generated for metrics:
 
 ```yaml title="router.yaml"
 telemetry:

--- a/.changesets/fix_bernard_helmtest.md
+++ b/.changesets/fix_bernard_helmtest.md
@@ -1,5 +1,5 @@
-### helm test always fails
+### Helm: Running of `helm test` no longer fails
 
-When running helm test it always generates an error because wget expects a 200 response, however calling a graphql endpoint without the proper body will return a 400 which is causing the test to fail. Using netcat (nc) will check that the port is up and return sucess once the router is working instead.
+Running `helm test` was generating an error since `wget` was sending a request without a proper body and expecting an HTTP status response of 2xx.   Without the proper body, it expectedly resulted in an HTTP status of 400.  By switching to using `netcat` (or `nc`) we will now check that the port is up and use that to determine that the router is functional.
 
 By [@bbardawilwiser](https://github.com/bbardawilwiser) in https://github.com/apollographql/router/pull/3096

--- a/.changesets/fix_fed_247.md
+++ b/.changesets/fix_fed_247.md
@@ -1,0 +1,9 @@
+### Federation v2.4.7 ([Issue #3170](https://github.com/apollographql/router/issues/3170), [Issue #3133](https://github.com/apollographql/router/issues/3133))
+
+This release bumps the Router's Federation support from v2.4.7 to v2.4.7, which brings in notable query planner fixes from [v2.4.7](https://github.com/apollographql/federation/releases/tag/%40apollo%2Fquery-planner%402.4.7).  Of note from those releases, this brings query planner fixes that (per that dependency's changelog):
+
+- Re-work the code use to try to reuse query named fragments to improve performance (thus sometimes improving query ([#2604](https://github.com/apollographql/federation/pull/2604)) planning performance)
+- Fix a raised assertion error (again, with a message of form like `Cannot add selection of field X to selection set of parent type Y`).
+- Fix a rare issue where an `interface` or `union` field was not being queried for all the types it should be.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3185

--- a/.changesets/fix_garypen_3173_ca_certs.md
+++ b/.changesets/fix_garypen_3173_ca_certs.md
@@ -1,7 +1,7 @@
-### Add ca-certificates to our docker image ([Issue #3173](https://github.com/apollographql/router/issues/3173))
+### Add `ca-certificates` to our Docker image ([Issue #3173](https://github.com/apollographql/router/issues/3173))
 
-We removed `curl` from our docker images to improve security, which meant that our implicit install of `ca-certificates` (as a dependency of `curl`) was no longer performed.
+We removed `curl` from our Docker images to improve security, which meant that our implicit install of `ca-certificates` (as a dependency of `curl`) was no longer performed.
 
-This fix manually installs the `ca-certificates` package which is required for the router to be able to process TLS requests.
+This fix reinstates the `ca-certificates` package explicitly, which is required for the router to be able to process TLS requests.
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3174

--- a/.changesets/fix_lib_global_alloc.md
+++ b/.changesets/fix_lib_global_alloc.md
@@ -1,8 +1,8 @@
 ### Set the global allocator in the library crate, not just the executable ([Issue #3126](https://github.com/apollographql/router/issues/3126))
 
-In 1.19, Apollo Router [switched to use jemalloc as the global Rust allocator on Linux](https://github.com/apollographql/router/blob/dev/CHANGELOG.md#improve-memory-fragmentation-and-resource-consumption-by-switching-to-jemalloc-as-the-memory-allocator-on-linux-pr-2882) to reduce memory fragmentation. However this is only done in the executable binary provided by the `apollo-router` crate, so that [custom binaries](https://www.apollographql.com/docs/router/customizations/custom-binary) using the crate as a library were not affected.
+In 1.19, Apollo Router [switched to use `jemalloc` as the global Rust allocator on Linux](https://github.com/apollographql/router/blob/dev/CHANGELOG.md#improve-memory-fragmentation-and-resource-consumption-by-switching-to-jemalloc-as-the-memory-allocator-on-linux-pr-2882) to reduce memory fragmentation. However, prior to this change this was only occurring in the executable binary provided by the `apollo-router` crate and [custom binaries](https://www.apollographql.com/docs/router/customizations/custom-binary) using the crate _as a library_ were not getting this benefit.
 
-Instead, the `apollo-router` library crate now sets the global allocator so that custom binaries also take advantage of this by default. If some other choice is desired, the `global-allocator` Cargo feature flag can be disabled in `Cargo.toml` with:
+The `apollo-router` library crate now sets the global allocator so that custom binaries also take advantage of this by default. If some other choice is desired, the `global-allocator` Cargo [feature flag](https://doc.rust-lang.org/cargo/reference/features.html) can be disabled in `Cargo.toml` with:
 
 ```toml
 [dependencies]

--- a/.changesets/maint_garypen_3176_filter_licenses.md
+++ b/.changesets/maint_garypen_3176_filter_licenses.md
@@ -1,5 +1,5 @@
 ### Improve `cargo-about` license checking ([Issue #3176](https://github.com/apollographql/router/issues/3176))
 
-From the description of this [cargo about PR](https://github.com/EmbarkStudios/cargo-about/pull/216), it is possible for "NOASSERTION" identifiers to be added when gathering license information, causing license checks to fail. This change uses the new `cargo-about` configuration `filter-noassertion` to eliminate the problem.
+From the description of this [cargo about PR](https://github.com/EmbarkStudios/cargo-about/pull/216), it is possible for `NOASSERTION` identifiers to be added when gathering license information, causing license checks to fail. This change uses the new `cargo-about` configuration `filter-noassertion` to eliminate the problem.
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3178

--- a/docs/source/federation-version-support.mdx
+++ b/docs/source/federation-version-support.mdx
@@ -27,7 +27,15 @@ The table below shows which version of federation each router release is compile
     <tbody>
     <tr>
     <td>
-            v1.19.1 and later (<a href="https://github.com/apollographql/router/releases">see latest releases</a>)
+            v1.20.0 and later (<a href="https://github.com/apollographql/router/releases">see latest releases</a>)
+        </td>
+        <td>
+            2.4.7
+        </td>
+    </tr>
+    <tr>
+        <td>
+            ️⚠️ v1.19.1
         </td>
         <td>
             2.4.6
@@ -35,7 +43,7 @@ The table below shows which version of federation each router release is compile
     </tr>
     <tr>
         <td>
-            v1.19.0
+            ⚠️ v1.19.0
         </td>
         <td>
             2.4.5


### PR DESCRIPTION
This should simplify the actual release in the next little bit and also updates the `federation-version-support.mdx` file.