### PR TITLE
diy dockerfile: two small improvements

### DIFF
--- a/dockerfiles/diy/build_docker_image.sh
+++ b/dockerfiles/diy/build_docker_image.sh
@@ -1,7 +1,5 @@
 #! /bin/sh
 
-cd "$(dirname "$0")"
-
 ###
 # Build docker images from git commit hash or tag or from released version.
 #
@@ -133,6 +131,9 @@ if ! BUILD_DIR=$(mktemp -d -t "router-build.XXXXXXXXXX"); then
 fi
 
 echo "Building in: ${BUILD_DIR}"
+
+# Move to this script's directory so we can find the files that are next to it.
+cd "$(dirname "${0}")" || terminate "Couldn't cd to source location";
 
 # Copy in our dockerfiles, we'll need them later
 mkdir "${BUILD_DIR}/dockerfiles"

--- a/dockerfiles/diy/build_docker_image.sh
+++ b/dockerfiles/diy/build_docker_image.sh
@@ -1,5 +1,7 @@
 #! /bin/sh
 
+cd "$(dirname "$0")"
+
 ###
 # Build docker images from git commit hash or tag or from released version.
 #
@@ -143,7 +145,7 @@ cd "${BUILD_DIR}" || terminate "Couldn't cd to ${BUILD_DIR}";
 
 # If we are building, clone our repo
 if [ "${BUILD_IMAGE}" = true ]; then
-    git clone "${GIT_REPO}" > /dev/null 2>&1 || terminate "Couldn't clone repository"
+    git clone "${GIT_REPO}" router > /dev/null 2>&1 || terminate "Couldn't clone repository"
     cd router || terminate "Couldn't cd to router"
     # Either unset or blank (equivalent for our purposes)
     if [ -z "${ROUTER_VERSION}" ]; then


### PR DESCRIPTION
- Add a `cd` to the top so that you don't have to be in the script's directory for the relative paths in the "Copy in our dockerfiles" section to work.

- Specify the directory name when cloning a repository, to support forks with names other than `router`.
