### PR TITLE
Upgrade to Rust 1.70

### DIFF
--- a/apollo-router-scaffold/templates/base/Dockerfile
+++ b/apollo-router-scaffold/templates/base/Dockerfile
@@ -1,6 +1,6 @@
 # Use the rust build image from docker as our base
 # renovate-automation: rustc version
-FROM rust:1.67.1 as build
+FROM rust:1.70.0 as build
 
 # Set our working directory for the build
 WORKDIR /usr/src/router

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -8,7 +8,7 @@ description = "A configurable, high-performance routing runtime for Apollo Feder
 license = "Elastic-2.0"
 
 # renovate-automation: rustc version
-rust-version = "1.67.0"
+rust-version = "1.70.0"
 edition = "2021"
 build = "build/main.rs"
 

--- a/apollo-router/README.md
+++ b/apollo-router/README.md
@@ -27,4 +27,4 @@ Most Apollo Router features can be defined using our [YAML configuration](https:
 If you prefer to write customizations in Rust or need more advanced customizations, see our section on [native customizations](https://www.apollographql.com/docs/router/customizations/native) for information on how to use `apollo-router` as a Rust library.  We also publish Rust-specific documentation on our [`apollo-router` crate docs](https://docs.rs/crate/apollo-router).
 
 <!-- renovate-automation: rustc version -->
-The minimum supported Rust version (MSRV) for this version of `apollo-router` is **1.67.0**.
+The minimum supported Rust version (MSRV) for this version of `apollo-router` is **1.70.0**.

--- a/apollo-router/src/plugin/test/service.rs
+++ b/apollo-router/src/plugin/test/service.rs
@@ -77,8 +77,7 @@ macro_rules! mock_async_service {
                     std::task::Poll::Ready(Ok(()))
                 }
                 fn call(&mut self, req: $request_type<$req_generic>) -> Self::Future {
-                    let r  = self.call(req);
-                    Box::pin(async move { r.await })
+                    Box::pin(self.call(req))
                 }
             }
         }

--- a/apollo-router/src/plugins/telemetry/apollo_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/apollo_exporter.rs
@@ -59,8 +59,9 @@ impl ExportError for ApolloExportError {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub(crate) enum Sender {
+    #[default]
     Noop,
     Apollo(mpsc::Sender<SingleReport>),
 }
@@ -78,12 +79,6 @@ impl Sender {
                 }
             }
         }
-    }
-}
-
-impl Default for Sender {
-    fn default() -> Self {
-        Sender::Noop
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/otlp.rs
@@ -195,17 +195,12 @@ impl GrpcExporter {
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub(crate) enum Protocol {
+    #[default]
     Grpc,
     Http,
-}
-
-impl Default for Protocol {
-    fn default() -> Self {
-        Protocol::Grpc
-    }
 }
 
 mod metadata_map_serde {

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -27,10 +27,11 @@ use crate::services::SubgraphRequest;
 use crate::spec::Schema;
 
 /// GraphQL operation type.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 pub enum OperationKind {
+    #[default]
     Query,
     Mutation,
     Subscription,
@@ -58,12 +59,6 @@ impl OperationKind {
             OperationKind::Mutation => "mutation",
             OperationKind::Subscription => "subscription",
         }
-    }
-}
-
-impl Default for OperationKind {
-    fn default() -> Self {
-        OperationKind::Query
     }
 }
 

--- a/apollo-router/src/router.rs
+++ b/apollo-router/src/router.rs
@@ -74,7 +74,7 @@ use crate::uplink::Endpoints;
 // Later we might add a public API for this (probably a builder similar to `test_harness.rs`),
 // see https://github.com/apollographql/router/issues/1496.
 // In the meantime keeping this function helps make sure it still compiles.
-async fn make_router_service<RF>(
+async fn make_router_service(
     schema: &str,
     configuration: Arc<Configuration>,
     extra_plugins: Vec<(String, Box<dyn DynPlugin>)>,

--- a/apollo-router/src/services/external.rs
+++ b/apollo-router/src/services/external.rs
@@ -39,17 +39,12 @@ pub(crate) enum PipelineStep {
     SubgraphResponse,
 }
 
-#[derive(Clone, Debug, Display, Deserialize, PartialEq, Serialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Display, Deserialize, PartialEq, Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) enum Control {
+    #[default]
     Continue,
     Break(u16),
-}
-
-impl Default for Control {
-    fn default() -> Self {
-        Control::Continue
-    }
 }
 
 impl Control {

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -31,15 +31,11 @@ struct FormatTest {
     is_deferred: bool,
 }
 
+#[derive(Default)]
 enum FederationVersion {
+    #[default]
     Fed1,
     Fed2,
-}
-
-impl Default for FederationVersion {
-    fn default() -> Self {
-        FederationVersion::Fed1
-    }
 }
 
 impl FormatTest {

--- a/apollo-router/src/uplink/entitlement.rs
+++ b/apollo-router/src/uplink/entitlement.rs
@@ -195,18 +195,13 @@ pub struct Entitlement {
 }
 
 /// Entitlements are converted into a stream of entitlement states by the expander
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub(crate) enum EntitlementState {
     Entitled,
     EntitledWarn,
     EntitledHalt,
+    #[default]
     Unentitled,
-}
-
-impl Default for EntitlementState {
-    fn default() -> Self {
-        EntitlementState::Unentitled
-    }
 }
 
 impl Display for Entitlement {

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -4,6 +4,7 @@
 
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -1075,9 +1076,11 @@ impl ValueExt for Value {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn all_stock_router_example_yamls_are_valid() {
-    let example_dir = "../examples";
+    let example_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/../examples");
     let example_directory_entries: Vec<DirEntry> = WalkDir::new(example_dir)
         .into_iter()
+        // Filter out `../examples/custom-global-allocator/target/` with its separate workspace
+        .filter_entry(|entry| entry.path().file_name() != Some(OsStr::new("target")))
         .map(|entry| {
             entry.unwrap_or_else(|e| panic!("invalid directory entry in {example_dir}: {e}"))
         })

--- a/dockerfiles/diy/dockerfiles/Dockerfile.repo
+++ b/dockerfiles/diy/dockerfiles/Dockerfile.repo
@@ -1,6 +1,6 @@
 # Use the rust build image from docker as our base
 # renovate-automation: rustc version
-FROM rust:1.67.1 as build
+FROM rust:1.70.0 as build
 
 # Set our working directory for the build
 WORKDIR /usr/src/router

--- a/docs/source/customizations/custom-binary.mdx
+++ b/docs/source/customizations/custom-binary.mdx
@@ -20,7 +20,7 @@ import ElasticNotice from '../../shared/elastic-notice.mdx';
 To compile the Apollo Router, you need to have the following installed:
 
 <!-- renovate-automation: rustc version -->
-* [Rust 1.67.1 or later](https://www.rust-lang.org/tools/install)
+* [Rust 1.70.0 or later](https://www.rust-lang.org/tools/install)
 * [Node.js 16.9.1 or later](https://nodejs.org/en/download/)
 
 After you install the above, also install the `cargo-xtask` and `cargo-scaffold` crates:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # renovate-automation: rustc version
-channel = "1.67.1"
+channel = "1.70.0"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
This enables by default the sparse index protocol for crates.io: 
* https://blog.rust-lang.org/inside-rust/2023/01/30/cargo-sparse-protocol.html
* https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#sparse-by-default-for-cratesio

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

Compat: custom binary users need to upgrade their toolchain
Tests: no behavior change

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
