### PR TITLE
Upgrade libc crate from yanked version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3241,9 +3241,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "libfuzzer-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3241,9 +3241,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.145"
+version = "0.2.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc86cde3ff845662b8f4ef6cb50ea0e20c524eb3d29ae048287e06a1b3fa6a81"
+checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
 name = "libfuzzer-sys"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -105,7 +105,7 @@ jsonpath_lib = "0.3.0"
 jsonschema = { version = "0.16.1", default-features = false }
 jsonwebtoken = "8.3.0"
 lazy_static = "1.4.0"
-libc = "0.2.144"
+libc = "0.2.146"
 linkme = "0.3.10"
 lru = "0.8.1"
 mediatype = "0.19.13"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -105,7 +105,7 @@ jsonpath_lib = "0.3.0"
 jsonschema = { version = "0.16.1", default-features = false }
 jsonwebtoken = "8.3.0"
 lazy_static = "1.4.0"
-libc = "0.2.145"
+libc = "0.2.144"
 linkme = "0.3.10"
 lru = "0.8.1"
 mediatype = "0.19.13"


### PR DESCRIPTION
See https://github.com/rust-lang/libc/issues/3264

Requiring a yanked version causes `cargo update` to fail on CI: https://app.circleci.com/pipelines/github/apollographql/router/12758/workflows/52d4c586-1da7-453b-b90f-1366c72ae46b/jobs/83879?invite=true#step-115-7

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
