### PR TITLE
Disable cargo-deny for windows CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -550,10 +550,7 @@ jobs:
                 condition:
                   equal: [ true, << parameters.nightly >> ]
                 steps:
-                  - run:
-                      command: >
-                        cargo xtask release prepare nightly
-                      no_output_timeout: 30m
+                  - run: cargo xtask release prepare nightly
             - run:
                 command: >
                   cargo xtask dist

--- a/xtask/src/commands/compliance.rs
+++ b/xtask/src/commands/compliance.rs
@@ -6,6 +6,11 @@ pub struct Compliance {}
 
 impl Compliance {
     pub fn run(&self) -> Result<()> {
+        // Cargo deny is triggering `git credential-manager-core get`
+        // On windows CI this will hangs as it requires user input.
+        // The root cause seems to be the krates step in cargo-deny but did not manage to figure it out.
+        // Disabling as a temporary measure, but we must fix this soon. https://github.com/apollographql/router/issues/3237
+        #[cfg(not(windows))]
         cargo!(["deny", "-L", "error", "check"]);
         Ok(())
     }


### PR DESCRIPTION

Cargo deny is triggering `git credential-manager-core get`
On windows CI this will hangs as it requires user input.
The root cause seems to be the krates step in cargo-deny but did not manage to figure it out.
Disabling as a temporary measure, but we must fix this soon.

Will raise a new ticket to ensure we don't forget to actually fix this.

Fixes #3216
<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
