### PR TITLE
fix description of request duration metric

### DIFF
--- a/apollo-router/src/plugins/telemetry/metrics/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/mod.rs
@@ -559,7 +559,7 @@ impl BasicMetrics {
                 .init(),
             http_requests_duration: meter
                 .f64_histogram("apollo_router_http_request_duration_seconds")
-                .with_description("Total number of HTTP requests made.")
+                .with_description("Duration of HTTP requests.")
                 .init(),
         }
     }


### PR DESCRIPTION
The description was copied from the total number of requests metric and has always been wrong. This fixes it.
