### PR TITLE
set DEBUG_IMAGE=true when building debug docker image

### DIFF
--- a/.changesets/fix_garypen_3249_docker_heaptrack.md
+++ b/.changesets/fix_garypen_3249_docker_heaptrack.md
@@ -1,0 +1,9 @@
+### set DEBUG_IMAGE=true when building debug docker image ([Issue #3249](https://github.com/apollographql/router/issues/3249))
+
+Router debug docker images were designed to make use of heaptrack for debugging memory issues. However, this functionality was broken when we changed to multi-architecture docker image builds.
+
+This restores the heaptrack functionality to our debug docker images.
+
+fixes: #3249
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3250

--- a/.changesets/fix_garypen_3249_docker_heaptrack.md
+++ b/.changesets/fix_garypen_3249_docker_heaptrack.md
@@ -1,9 +1,7 @@
-### set DEBUG_IMAGE=true when building debug docker image ([Issue #3249](https://github.com/apollographql/router/issues/3249))
+### Restore missing debug tools in "debug" Docker images ([Issue #3249](https://github.com/apollographql/router/issues/3249))
 
-Router debug docker images were designed to make use of heaptrack for debugging memory issues. However, this functionality was broken when we changed to multi-architecture docker image builds.
+Debug Docker images were designed to make use of `heaptrack` for debugging memory issues. However, this functionality was inadvertently removed when we changed to multi-architecture Docker image builds.
 
 This restores the heaptrack functionality to our debug docker images.
-
-fixes: #3249
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3250

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -677,7 +677,7 @@ jobs:
             # Note: GH Token owned by apollo-bot2, no expire
             echo ${GITHUB_OCI_TOKEN} | docker login ghcr.io -u apollo-bot2 --password-stdin
             # Build and push debug image
-            docker buildx build --platform linux/amd64,linux/arm64 --push --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION}-debug .
+            docker buildx build --platform linux/amd64,linux/arm64 --push --build-arg DEBUG_IMAGE="true" --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION}-debug .
             # Build and push release image
             docker buildx build --platform linux/amd64,linux/arm64 --push --build-arg ROUTER_RELEASE=${VERSION} -f dockerfiles/Dockerfile.router -t ${ROUTER_TAG}:${VERSION} .
       - run:


### PR DESCRIPTION
If we don't set this flag, then heaptrack isn't installed.

fixes: #3249
