### PR TITLE
Add visitor traits for transforming or traversing queries

### DIFF
--- a/.changesets/feat_geal_query_planner_plugins.md
+++ b/.changesets/feat_geal_query_planner_plugins.md
@@ -1,6 +1,9 @@
 ### Query planner plugins ([Issue #3150](https://github.com/apollographql/router/issues/3150))
 
 We may need to modify a query between query plan caching and the query planner. This leads to the requirement to provide a query planner plugin capability. This capability is private to the router for now.
+
 The plugins need an ApolloCompiler instance to perform useful work on the query, so the caching layer, in case of cache miss, will generate a compiler instance and transmit it as part of the request going through query planner plugins. At the end of the chain, the query planner extracts the modified query from the compiler, uses it to generate a query plan, and generates the selections of both the original and filtered query for response formatting. This is done to ensure that the response does not leak data removed in the filtered query, but still keeps a shape expected by the original query, using the null propagation.
 
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3177
+A new visitor trait helps modifying the query.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3177 and https://github.com/apollographql/router/pull/3252

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,7 @@ dependencies = [
  "access-json",
  "anyhow",
  "apollo-compiler",
+ "apollo-encoder 0.5.1",
  "apollo-parser 0.5.3",
  "arc-swap",
  "askama",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -54,6 +54,7 @@ askama = "0.11.1"
 access-json = "0.1.0"
 anyhow = "1.0.71"
 apollo-compiler = "0.8.0"
+apollo-encoder = "0.5.1"
 apollo-parser = "0.5.3"
 arc-swap = "1.6.0"
 async-compression = { version = "0.3.15", features = [

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -38,6 +38,9 @@ use crate::spec::Selection;
 use crate::spec::SpecError;
 use crate::Configuration;
 
+pub(crate) mod transform;
+pub(crate) mod traverse;
+
 pub(crate) const TYPENAME: &str = "__typename";
 pub(crate) const QUERY_EXECUTABLE: &str = "query";
 

--- a/apollo-router/src/spec/query/transform.rs
+++ b/apollo-router/src/spec/query/transform.rs
@@ -1,0 +1,429 @@
+#![cfg_attr(not(test), allow(unused))] // TODO: remove when used
+
+use apollo_compiler::hir;
+use apollo_compiler::ApolloCompiler;
+use apollo_compiler::HirDatabase;
+use tower::BoxError;
+
+/// Transform an executable document with the given visitor.
+pub(crate) fn document(
+    visitor: &mut impl Visitor,
+    file_id: apollo_compiler::FileId,
+) -> Result<apollo_encoder::Document, BoxError> {
+    let mut encoder_node = apollo_encoder::Document::new();
+
+    for def in visitor.compiler().db.operations(file_id).iter() {
+        if let Some(op) = visitor.operation(def)? {
+            encoder_node.operation(op)
+        }
+    }
+    for def in visitor.compiler().db.fragments(file_id).values() {
+        if let Some(f) = visitor.fragment_definition(def)? {
+            encoder_node.fragment(f)
+        }
+    }
+
+    Ok(encoder_node)
+}
+
+pub(crate) trait Visitor: Sized {
+    /// A compiler that contains both the executable document to transform
+    /// and the corresponding type system definitions.
+    fn compiler(&self) -> &ApolloCompiler;
+
+    /// Transform an operation definition.
+    ///
+    /// Call the [`operation`] free function for the default behavior.
+    /// Return `Ok(None)` to remove this operation.
+    fn operation(
+        &mut self,
+        hir: &hir::OperationDefinition,
+    ) -> Result<Option<apollo_encoder::OperationDefinition>, BoxError> {
+        operation(self, hir)
+    }
+
+    /// Transform a fragment definition.
+    ///
+    /// Call the [`fragment_definition`] free function for the default behavior.
+    /// Return `Ok(None)` to remove this fragment.
+    fn fragment_definition(
+        &mut self,
+        hir: &hir::FragmentDefinition,
+    ) -> Result<Option<apollo_encoder::FragmentDefinition>, BoxError> {
+        fragment_definition(self, hir)
+    }
+
+    /// Transform a field within a selection set.
+    ///
+    /// Call the [`field`] free function for the default behavior.
+    /// Return `Ok(None)` to remove this field.
+    fn field(
+        &mut self,
+        parent_type: &str,
+        hir: &hir::Field,
+    ) -> Result<Option<apollo_encoder::Field>, BoxError> {
+        field(self, parent_type, hir)
+    }
+
+    /// Transform a fragment spread within a selection set.
+    ///
+    /// Call the [`fragment_spread`] free function for the default behavior.
+    /// Return `Ok(None)` to remove this fragment spread.
+    fn fragment_spread(
+        &mut self,
+        hir: &hir::FragmentSpread,
+    ) -> Result<Option<apollo_encoder::FragmentSpread>, BoxError> {
+        fragment_spread(self, hir)
+    }
+
+    /// Transform a inline fragment within a selection set.
+    ///
+    /// Call the [`inline_fragment`] free function for the default behavior.
+    /// Return `Ok(None)` to remove this inline fragment.
+    fn inline_fragment(
+        &mut self,
+        parent_type: &str,
+        hir: &hir::InlineFragment,
+    ) -> Result<Option<apollo_encoder::InlineFragment>, BoxError> {
+        inline_fragment(self, parent_type, hir)
+    }
+}
+
+/// The default behavior for transforming an operation.
+///
+/// Never returns `Ok(None)`, the `Option` is for `Visitor` impl convenience.
+pub(crate) fn operation(
+    visitor: &mut impl Visitor,
+    def: &hir::OperationDefinition,
+) -> Result<Option<apollo_encoder::OperationDefinition>, BoxError> {
+    let object_type = def
+        .object_type(&visitor.compiler().db)
+        .ok_or("ObjectTypeDefMissing")?;
+    let type_name = object_type.name();
+
+    let Some(selection_set) = selection_set(visitor, def.selection_set(), type_name)?
+    else { return Ok(None) };
+
+    let mut encoder_node =
+        apollo_encoder::OperationDefinition::new(operation_type(def.operation_ty()), selection_set);
+
+    if let Some(name) = def.name() {
+        encoder_node.name(Some(name.to_string()));
+    }
+
+    for def in def.variables() {
+        if let Some(v) = variable_definition(def)? {
+            encoder_node.variable_definition(v)
+        }
+    }
+
+    for hir in def.directives() {
+        if let Some(d) = directive(hir)? {
+            encoder_node.directive(d)
+        }
+    }
+
+    Ok(Some(encoder_node))
+}
+
+/// The default behavior for transforming a fragment definition.
+///
+/// Never returns `Ok(None)`, the `Option` is for `Visitor` impl convenience.
+pub(crate) fn fragment_definition(
+    visitor: &mut impl Visitor,
+    hir: &hir::FragmentDefinition,
+) -> Result<Option<apollo_encoder::FragmentDefinition>, BoxError> {
+    let name = hir.name();
+    let type_condition = hir.type_condition();
+
+    let Some(selection_set) = selection_set(visitor, hir.selection_set(), type_condition)?
+    else { return Ok(None) };
+
+    let type_condition = apollo_encoder::TypeCondition::new(type_condition.into());
+    let mut encoder_node =
+        apollo_encoder::FragmentDefinition::new(name.into(), type_condition, selection_set);
+    for hir in hir.directives() {
+        if let Some(d) = directive(hir)? {
+            encoder_node.directive(d)
+        }
+    }
+
+    Ok(Some(encoder_node))
+}
+
+/// The default behavior for transforming a field within a selection set.
+///
+/// Returns `Ok(None)` if the field had nested selections and they’re all removed.
+pub(crate) fn field(
+    visitor: &mut impl Visitor,
+    parent_type: &str,
+    hir: &hir::Field,
+) -> Result<Option<apollo_encoder::Field>, BoxError> {
+    let name = hir.name();
+
+    let mut encoder_node = apollo_encoder::Field::new(name.into());
+
+    if let Some(alias) = hir.alias() {
+        encoder_node.alias(Some(alias.name().into()));
+    }
+
+    for arg in hir.arguments() {
+        encoder_node.argument(apollo_encoder::Argument::new(
+            arg.name().into(),
+            value(arg.value())?,
+        ));
+    }
+
+    for hir in hir.directives() {
+        if let Some(d) = directive(hir)? {
+            encoder_node.directive(d)
+        }
+    }
+
+    let selections = hir.selection_set();
+    if !selections.selection().is_empty() {
+        let field_type = get_field_type(visitor, parent_type, name)
+            .ok_or_else(|| format!("cannot query field '{name}' on type '{parent_type}'"))?;
+        match selection_set(visitor, selections, &field_type)? {
+            // we expected some fields on that object but got none: that field should be removed
+            None => return Ok(None),
+            Some(selection_set) => encoder_node.selection_set(Some(selection_set)),
+        }
+    }
+
+    Ok(Some(encoder_node))
+}
+
+/// The default behavior for transforming a fragment spread.
+///
+/// Never returns `Ok(None)`, the `Option` is for `Visitor` impl convenience.
+pub(crate) fn fragment_spread(
+    visitor: &mut impl Visitor,
+    hir: &hir::FragmentSpread,
+) -> Result<Option<apollo_encoder::FragmentSpread>, BoxError> {
+    let _ = visitor; // Unused, but matches trait method signature
+    let name = hir.name();
+    let mut encoder_node = apollo_encoder::FragmentSpread::new(name.into());
+    for hir in hir.directives() {
+        if let Some(d) = directive(hir)? {
+            encoder_node.directive(d)
+        }
+    }
+    Ok(Some(encoder_node))
+}
+
+/// The default behavior for transforming an inline fragment.
+///
+/// Returns `Ok(None)` if all selections within the fragment are removed.
+pub(crate) fn inline_fragment(
+    visitor: &mut impl Visitor,
+    parent_type: &str,
+    hir: &hir::InlineFragment,
+) -> Result<Option<apollo_encoder::InlineFragment>, BoxError> {
+    let parent_type = hir.type_condition().unwrap_or(parent_type);
+
+    let Some(selection_set) = selection_set(visitor, hir.selection_set(), parent_type)?
+    else { return Ok(None) };
+
+    let mut encoder_node = apollo_encoder::InlineFragment::new(selection_set);
+
+    encoder_node.type_condition(
+        hir.type_condition()
+            .map(|name| apollo_encoder::TypeCondition::new(name.into())),
+    );
+
+    for hir in hir.directives() {
+        if let Some(d) = directive(hir)? {
+            encoder_node.directive(d)
+        }
+    }
+
+    Ok(Some(encoder_node))
+}
+
+fn get_field_type(visitor: &impl Visitor, parent: &str, field_name: &str) -> Option<String> {
+    Some(if field_name == "__typename" {
+        "String".into()
+    } else {
+        let db = &visitor.compiler().db;
+        db.types_definitions_by_name()
+            .get(parent)?
+            .field(db, field_name)?
+            .ty()
+            .name()
+    })
+}
+
+fn selection_set(
+    visitor: &mut impl Visitor,
+    hir: &hir::SelectionSet,
+    parent_type: &str,
+) -> Result<Option<apollo_encoder::SelectionSet>, BoxError> {
+    let selections = hir
+        .selection()
+        .iter()
+        .filter_map(|hir| selection(visitor, hir, parent_type).transpose())
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok((!selections.is_empty()).then(|| apollo_encoder::SelectionSet::with_selections(selections)))
+}
+
+fn selection(
+    visitor: &mut impl Visitor,
+    selection: &hir::Selection,
+    parent_type: &str,
+) -> Result<Option<apollo_encoder::Selection>, BoxError> {
+    Ok(match selection {
+        hir::Selection::Field(hir) => visitor
+            .field(parent_type, hir)?
+            .map(apollo_encoder::Selection::Field),
+        hir::Selection::FragmentSpread(hir) => visitor
+            .fragment_spread(hir)?
+            .map(apollo_encoder::Selection::FragmentSpread),
+        hir::Selection::InlineFragment(hir) => visitor
+            .inline_fragment(parent_type, hir)?
+            .map(apollo_encoder::Selection::InlineFragment),
+    })
+}
+
+fn variable_definition(
+    hir: &hir::VariableDefinition,
+) -> Result<Option<apollo_encoder::VariableDefinition>, BoxError> {
+    let name = hir.name();
+    let ty = ty(hir.ty());
+
+    let mut encoder_node = apollo_encoder::VariableDefinition::new(name.into(), ty);
+
+    if let Some(default_value) = hir.default_value() {
+        encoder_node.default_value(value(default_value)?);
+    }
+
+    for hir in hir.directives() {
+        if let Some(d) = directive(hir)? {
+            encoder_node.directive(d)
+        }
+    }
+
+    Ok(Some(encoder_node))
+}
+
+fn directive(hir: &hir::Directive) -> Result<Option<apollo_encoder::Directive>, BoxError> {
+    let name = hir.name().into();
+    let mut encoder_directive = apollo_encoder::Directive::new(name);
+
+    for arg in hir.arguments() {
+        encoder_directive.arg(apollo_encoder::Argument::new(
+            arg.name().into(),
+            value(arg.value())?,
+        ));
+    }
+
+    Ok(Some(encoder_directive))
+}
+
+// FIXME: apollo-rs should provide these three conversions, or unify types
+
+fn operation_type(hir: hir::OperationType) -> apollo_encoder::OperationType {
+    match hir {
+        hir::OperationType::Query => apollo_encoder::OperationType::Query,
+        hir::OperationType::Mutation => apollo_encoder::OperationType::Mutation,
+        hir::OperationType::Subscription => apollo_encoder::OperationType::Subscription,
+    }
+}
+
+fn ty(hir: &hir::Type) -> apollo_encoder::Type_ {
+    match hir {
+        hir::Type::NonNull { ty: hir, .. } => apollo_encoder::Type_::NonNull {
+            ty: Box::new(ty(hir)),
+        },
+        hir::Type::List { ty: hir, .. } => apollo_encoder::Type_::List {
+            ty: Box::new(ty(hir)),
+        },
+        hir::Type::Named { name, .. } => apollo_encoder::Type_::NamedType { name: name.clone() },
+    }
+}
+
+fn value(hir: &hir::Value) -> Result<apollo_encoder::Value, BoxError> {
+    Ok(match hir {
+        hir::Value::Variable(val) => apollo_encoder::Value::Variable(val.name().into()),
+        hir::Value::Int(val) => {
+            apollo_encoder::Value::Int(val.to_i32_checked().ok_or("Int value overflows i32")?)
+        }
+        hir::Value::Float(val) => apollo_encoder::Value::Float(val.get()),
+        hir::Value::String(val) => apollo_encoder::Value::String(val.clone()),
+        hir::Value::Boolean(val) => apollo_encoder::Value::Boolean(*val),
+        hir::Value::Null => apollo_encoder::Value::Null,
+        hir::Value::Enum(val) => apollo_encoder::Value::Enum(val.src().into()),
+        hir::Value::List(val) => {
+            apollo_encoder::Value::List(val.iter().map(value).collect::<Result<Vec<_>, _>>()?)
+        }
+        hir::Value::Object(val) => apollo_encoder::Value::Object(
+            val.iter()
+                .map(|(k, v)| Ok::<_, BoxError>((k.src().to_string(), value(v)?)))
+                .collect::<Result<Vec<_>, _>>()?,
+        ),
+    })
+}
+
+#[test]
+fn test_add_directive_to_fields() {
+    struct AddDirective<'a>(&'a ApolloCompiler);
+
+    impl<'a> Visitor for AddDirective<'a> {
+        fn compiler(&self) -> &ApolloCompiler {
+            self.0
+        }
+
+        fn field(
+            &mut self,
+            parent_type: &str,
+            hir: &hir::Field,
+        ) -> Result<Option<apollo_encoder::Field>, BoxError> {
+            Ok(field(self, parent_type, hir)?.map(|mut encoder_node| {
+                encoder_node.directive(apollo_encoder::Directive::new("added".into()));
+                encoder_node
+            }))
+        }
+    }
+
+    let mut compiler = ApolloCompiler::new();
+    let graphql = "
+        type Query {
+            a: String
+            b: Int
+            next: Query
+        }
+
+        query($id: ID = null) {
+            a
+            ... @defer {
+                b
+            }
+            ... F
+        }
+
+        fragment F on Query {
+            next {
+                a
+            }
+        }
+    ";
+    let file_id = compiler.add_document(graphql, "");
+    let mut visitor = AddDirective(&compiler);
+    let expected = "query($id: ID = null) {
+  a @added
+  ... on Query @defer {
+    b @added
+  }
+  ...F
+}
+fragment F on Query {
+  next @added {
+    a @added
+  }
+}
+";
+    assert_eq!(
+        document(&mut visitor, file_id).unwrap().to_string(),
+        expected
+    )
+}

--- a/apollo-router/src/spec/query/traverse.rs
+++ b/apollo-router/src/spec/query/traverse.rs
@@ -1,0 +1,225 @@
+#![cfg_attr(not(test), allow(unused))] // TODO: remove when used
+
+use apollo_compiler::hir;
+use apollo_compiler::ApolloCompiler;
+use apollo_compiler::HirDatabase;
+use tower::BoxError;
+
+/// Transform an executable document with the given visitor.
+pub(crate) fn document(
+    visitor: &mut impl Visitor,
+    file_id: apollo_compiler::FileId,
+) -> Result<(), BoxError> {
+    for def in visitor.compiler().db.operations(file_id).iter() {
+        visitor.operation(def)?;
+    }
+    for def in visitor.compiler().db.fragments(file_id).values() {
+        visitor.fragment_definition(def)?;
+    }
+    Ok(())
+}
+
+pub(crate) trait Visitor: Sized {
+    /// A compiler that contains both the executable document to transform
+    /// and the corresponding type system definitions.
+    fn compiler(&self) -> &ApolloCompiler;
+
+    /// Transform an operation definition.
+    ///
+    /// Call the [`operation`] free function for the default behavior.
+    /// Return `Ok(None)` to remove this operation.
+    fn operation(&mut self, hir: &hir::OperationDefinition) -> Result<(), BoxError> {
+        operation(self, hir)
+    }
+
+    /// Transform a fragment definition.
+    ///
+    /// Call the [`fragment_definition`] free function for the default behavior.
+    /// Return `Ok(None)` to remove this fragment.
+    fn fragment_definition(&mut self, hir: &hir::FragmentDefinition) -> Result<(), BoxError> {
+        fragment_definition(self, hir)
+    }
+
+    /// Transform a field within a selection set.
+    ///
+    /// Call the [`field`] free function for the default behavior.
+    /// Return `Ok(None)` to remove this field.
+    fn field(&mut self, parent_type: &str, hir: &hir::Field) -> Result<(), BoxError> {
+        field(self, parent_type, hir)
+    }
+
+    /// Transform a fragment spread within a selection set.
+    ///
+    /// Call the [`fragment_spread`] free function for the default behavior.
+    /// Return `Ok(None)` to remove this fragment spread.
+    fn fragment_spread(&mut self, hir: &hir::FragmentSpread) -> Result<(), BoxError> {
+        fragment_spread(self, hir)
+    }
+
+    /// Transform a inline fragment within a selection set.
+    ///
+    /// Call the [`inline_fragment`] free function for the default behavior.
+    /// Return `Ok(None)` to remove this inline fragment.
+    fn inline_fragment(
+        &mut self,
+        parent_type: &str,
+        hir: &hir::InlineFragment,
+    ) -> Result<(), BoxError> {
+        inline_fragment(self, parent_type, hir)
+    }
+}
+
+/// The default behavior for transforming an operation.
+///
+/// Never returns `Ok(None)`, the `Option` is for `Visitor` impl convenience.
+pub(crate) fn operation(
+    visitor: &mut impl Visitor,
+    def: &hir::OperationDefinition,
+) -> Result<(), BoxError> {
+    let object_type = def
+        .object_type(&visitor.compiler().db)
+        .ok_or("ObjectTypeDefMissing")?;
+    let type_name = object_type.name();
+    selection_set(visitor, def.selection_set(), type_name)?;
+    Ok(())
+}
+
+/// The default behavior for transforming a fragment definition.
+///
+/// Never returns `Ok(None)`, the `Option` is for `Visitor` impl convenience.
+pub(crate) fn fragment_definition(
+    visitor: &mut impl Visitor,
+    hir: &hir::FragmentDefinition,
+) -> Result<(), BoxError> {
+    let type_condition = hir.type_condition();
+    selection_set(visitor, hir.selection_set(), type_condition)?;
+    Ok(())
+}
+
+/// The default behavior for transforming a field within a selection set.
+///
+/// Returns `Ok(None)` if the field had nested selections and they’re all removed.
+pub(crate) fn field(
+    visitor: &mut impl Visitor,
+    parent_type: &str,
+    hir: &hir::Field,
+) -> Result<(), BoxError> {
+    let name = hir.name();
+    let selections = hir.selection_set();
+    if !selections.selection().is_empty() {
+        let field_type = get_field_type(visitor, parent_type, name)
+            .ok_or_else(|| format!("cannot query field '{name}' on type '{parent_type}'"))?;
+        selection_set(visitor, selections, &field_type)?
+    }
+    Ok(())
+}
+
+/// The default behavior for transforming a fragment spread.
+///
+/// Never returns `Ok(None)`, the `Option` is for `Visitor` impl convenience.
+pub(crate) fn fragment_spread(
+    visitor: &mut impl Visitor,
+    hir: &hir::FragmentSpread,
+) -> Result<(), BoxError> {
+    let _ = (visitor, hir); // Unused, but matches trait method signature
+    Ok(())
+}
+
+/// The default behavior for transforming an inline fragment.
+///
+/// Returns `Ok(None)` if all selections within the fragment are removed.
+pub(crate) fn inline_fragment(
+    visitor: &mut impl Visitor,
+    parent_type: &str,
+    hir: &hir::InlineFragment,
+) -> Result<(), BoxError> {
+    let parent_type = hir.type_condition().unwrap_or(parent_type);
+    selection_set(visitor, hir.selection_set(), parent_type)?;
+    Ok(())
+}
+
+fn get_field_type(visitor: &impl Visitor, parent: &str, field_name: &str) -> Option<String> {
+    Some(if field_name == "__typename" {
+        "String".into()
+    } else {
+        let db = &visitor.compiler().db;
+        db.types_definitions_by_name()
+            .get(parent)?
+            .field(db, field_name)?
+            .ty()
+            .name()
+    })
+}
+
+fn selection_set(
+    visitor: &mut impl Visitor,
+    hir: &hir::SelectionSet,
+    parent_type: &str,
+) -> Result<(), BoxError> {
+    hir.selection()
+        .iter()
+        .try_for_each(|hir| selection(visitor, hir, parent_type))
+}
+
+fn selection(
+    visitor: &mut impl Visitor,
+    selection: &hir::Selection,
+    parent_type: &str,
+) -> Result<(), BoxError> {
+    match selection {
+        hir::Selection::Field(hir) => visitor.field(parent_type, hir)?,
+        hir::Selection::FragmentSpread(hir) => visitor.fragment_spread(hir)?,
+        hir::Selection::InlineFragment(hir) => visitor.inline_fragment(parent_type, hir)?,
+    }
+    Ok(())
+}
+
+#[test]
+fn test_count_fields() {
+    struct CountFields<'a> {
+        compiler: &'a ApolloCompiler,
+        fields: u32,
+    }
+
+    impl<'a> Visitor for CountFields<'a> {
+        fn compiler(&self) -> &ApolloCompiler {
+            self.compiler
+        }
+
+        fn field(&mut self, parent_type: &str, hir: &hir::Field) -> Result<(), BoxError> {
+            self.fields += 1;
+            field(self, parent_type, hir)
+        }
+    }
+
+    let mut compiler = ApolloCompiler::new();
+    let graphql = "
+        type Query {
+            a: String
+            b: Int
+            next: Query
+        }
+
+        query($id: ID = null) {
+            a
+            ... @defer {
+                b
+            }
+            ... F
+            ... F
+        }
+
+        fragment F on Query {
+            next {
+                a
+            }
+        }
+    ";
+    let file_id = compiler.add_document(graphql, "");
+    let mut visitor = CountFields {
+        compiler: &compiler,
+        fields: 0,
+    };
+    document(&mut visitor, file_id).unwrap();
+    assert_eq!(visitor.fields, 4)
+}


### PR DESCRIPTION
We expect to use them inside query planner plugins: https://github.com/apollographql/router/pull/3177

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
