### PR TITLE
ELv2 license key functionality cleanup

### DIFF
--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 //! Axum http server factory. Axum provides routing capability on top of Hyper HTTP.
 use std::pin::Pin;
 use std::sync::atomic::AtomicU64;
@@ -58,8 +56,8 @@ use crate::router::ApolloRouterError;
 use crate::router_factory::Endpoint;
 use crate::router_factory::RouterFactory;
 use crate::services::router;
-use crate::uplink::entitlement::EntitlementState;
-use crate::uplink::entitlement::ENTITLEMENT_EXPIRED_SHORT_MESSAGE;
+use crate::uplink::license_enforcement::LicenseState;
+use crate::uplink::license_enforcement::LICENSE_EXPIRED_SHORT_MESSAGE;
 
 /// A basic http server using Axum.
 /// Uses streaming as primary method of response.
@@ -89,7 +87,7 @@ pub(crate) fn make_axum_router<RF>(
     service_factory: RF,
     configuration: &Configuration,
     mut endpoints: MultiMap<ListenAddr, Endpoint>,
-    entitlement: EntitlementState,
+    license: LicenseState,
 ) -> Result<ListenersAndRouters, ApolloRouterError>
 where
     RF: RouterFactory,
@@ -132,7 +130,7 @@ where
         endpoints
             .remove(&configuration.supergraph.listen)
             .unwrap_or_default(),
-        entitlement,
+        license,
     )?;
     let mut extra_endpoints = extra_endpoints(endpoints);
 
@@ -159,19 +157,15 @@ impl HttpServerFactory for AxumHttpServerFactory {
         mut main_listener: Option<Listener>,
         previous_listeners: Vec<(ListenAddr, Listener)>,
         extra_endpoints: MultiMap<ListenAddr, Endpoint>,
-        entitlement: EntitlementState,
+        license: LicenseState,
         all_connections_stopped_sender: mpsc::Sender<()>,
     ) -> Self::Future
     where
         RF: RouterFactory,
     {
         Box::pin(async move {
-            let all_routers = make_axum_router(
-                service_factory,
-                &configuration,
-                extra_endpoints,
-                entitlement,
-            )?;
+            let all_routers =
+                make_axum_router(service_factory, &configuration, extra_endpoints, license)?;
 
             // serve main router
 
@@ -312,7 +306,7 @@ fn main_endpoint<RF>(
     service_factory: RF,
     configuration: &Configuration,
     endpoints_on_main_listener: Vec<Endpoint>,
-    entitlement: EntitlementState,
+    license: LicenseState,
 ) -> Result<ListenAddrAndRouter, ApolloRouterError>
 where
     RF: RouterFactory,
@@ -324,10 +318,10 @@ where
     let main_route = main_router::<RF>(configuration)
         .layer(middleware::from_fn(decompress_request_body))
         .layer(middleware::from_fn_with_state(
-            (entitlement, Instant::now(), Arc::new(AtomicU64::new(0))),
-            entitlement_handler,
+            (license, Instant::now(), Arc::new(AtomicU64::new(0))),
+            license_handler,
         ))
-        .layer(TraceLayer::new_for_http().make_span_with(PropagatingMakeSpan { entitlement }))
+        .layer(TraceLayer::new_for_http().make_span_with(PropagatingMakeSpan { license }))
         .layer(Extension(service_factory))
         .layer(cors);
 
@@ -339,22 +333,22 @@ where
     Ok(ListenAddrAndRouter(listener, route))
 }
 
-async fn entitlement_handler<B>(
-    State((entitlement, start, delta)): State<(EntitlementState, Instant, Arc<AtomicU64>)>,
+async fn license_handler<B>(
+    State((license, start, delta)): State<(LicenseState, Instant, Arc<AtomicU64>)>,
     request: Request<B>,
     next: Next<B>,
 ) -> Response {
     if matches!(
-        entitlement,
-        EntitlementState::EntitledHalt | EntitlementState::EntitledWarn
+        license,
+        LicenseState::LicensedHalt | LicenseState::LicensedWarn
     ) {
         ::tracing::error!(
            monotonic_counter.apollo_router_http_requests_total = 1u64,
            status = %500u16,
-           error = ENTITLEMENT_EXPIRED_SHORT_MESSAGE,
+           error = LICENSE_EXPIRED_SHORT_MESSAGE,
         );
 
-        // This will rate limit logs about entitlement to 1 a second.
+        // This will rate limit logs about license to 1 a second.
         // The way it works is storing the delta in seconds from a starting instant.
         // If the delta is over one second from the last time we logged then try and do a compare_exchange and if successfull log.
         // If not successful some other thread will have logged.
@@ -370,11 +364,11 @@ async fn entitlement_handler<B>(
                 )
                 .is_ok()
         {
-            ::tracing::error!("{}", ENTITLEMENT_EXPIRED_SHORT_MESSAGE);
+            ::tracing::error!("{}", LICENSE_EXPIRED_SHORT_MESSAGE);
         }
     }
 
-    if matches!(entitlement, EntitlementState::EntitledHalt) {
+    if matches!(license, LicenseState::LicensedHalt) {
         http::Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .body(UnsyncBoxBody::default())

--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -84,7 +84,7 @@ use crate::services::SupergraphResponse;
 use crate::services::MULTIPART_DEFER_CONTENT_TYPE;
 use crate::test_harness::http_client;
 use crate::test_harness::http_client::MaybeMultipart;
-use crate::uplink::entitlement::EntitlementState;
+use crate::uplink::license_enforcement::LicenseState;
 use crate::ApolloRouterError;
 use crate::Configuration;
 use crate::Context;
@@ -216,7 +216,7 @@ async fn init(
             None,
             vec![],
             MultiMap::new(),
-            EntitlementState::Unentitled,
+            LicenseState::Unlicensed,
             all_connections_stopped_sender,
         )
         .await
@@ -273,7 +273,7 @@ pub(super) async fn init_with_config(
             None,
             vec![],
             web_endpoints,
-            EntitlementState::Unentitled,
+            LicenseState::Unlicensed,
             all_connections_stopped_sender,
         )
         .await?;
@@ -339,7 +339,7 @@ async fn init_unix(
             None,
             vec![],
             MultiMap::new(),
-            EntitlementState::Unentitled,
+            LicenseState::Unlicensed,
             all_connections_stopped_sender,
         )
         .await
@@ -1771,7 +1771,7 @@ async fn it_supports_server_restart() {
             None,
             vec![],
             MultiMap::new(),
-            EntitlementState::default(),
+            LicenseState::default(),
             all_connections_stopped_sender,
         )
         .await
@@ -1800,7 +1800,7 @@ async fn it_supports_server_restart() {
             supergraph_service_factory,
             new_configuration,
             MultiMap::new(),
-            EntitlementState::default(),
+            LicenseState::default(),
         )
         .await
         .unwrap();

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -1,5 +1,3 @@
-// This entire file is license key functionality
-
 use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -1,5 +1,3 @@
-// This entire file is license key functionality
-
 use std::fmt::Display;
 use std::fmt::{self};
 use std::hash::Hash;

--- a/apollo-router/src/configuration/cors.rs
+++ b/apollo-router/src/configuration/cors.rs
@@ -1,5 +1,4 @@
 //! Cross Origin Resource Sharing (CORS configuration)
-// This entire file is license key functionality
 
 use std::str::FromStr;
 use std::time::Duration;

--- a/apollo-router/src/configuration/expansion.rs
+++ b/apollo-router/src/configuration/expansion.rs
@@ -1,5 +1,4 @@
 //! Environment variable expansion in the configuration file
-// This entire file is license key functionality
 
 use std::env;
 use std::env::VarError;

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 //! Logic for loading configuration in to an object model
 pub(crate) mod cors;
 mod expansion;
@@ -133,7 +131,7 @@ pub struct Configuration {
     pub(crate) apq: Apq,
 
     // NOTE: when renaming this to move out of preview, also update paths
-    // in `configuration/expansion.rs` and `uplink/entitlement.rs`.
+    // in `configuration/expansion.rs` and `uplink/license.rs`.
     /// Operation limits
     #[serde(default)]
     pub(crate) preview_operation_limits: OperationLimits,

--- a/apollo-router/src/configuration/schema.rs
+++ b/apollo-router/src/configuration/schema.rs
@@ -1,5 +1,4 @@
 //! Configuration schema generation and validation
-// This entire file is license key functionality
 
 use std::borrow::Cow;
 use std::cmp::Ordering;

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -207,7 +207,7 @@ pub struct Opt {
 
     /// Your Apollo Router license.
     /// EXPERIMENTAL and not subject to semver.
-    #[clap(skip = std::env::var("APOLLO_ROUTER_LICENSE").or_else(|| std::env::var("APOLLO_ROUTER_ENTITLEMENT")))]
+    #[clap(skip = std::env::var("APOLLO_ROUTER_LICENSE").ok())]
     apollo_router_license: Option<String>,
 
     /// License location relative to the current directory.

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -31,7 +31,7 @@ use crate::router::ConfigurationSource;
 use crate::router::RouterHttpServer;
 use crate::router::SchemaSource;
 use crate::router::ShutdownSource;
-use crate::EntitlementSource;
+use crate::LicenseSource;
 
 #[cfg(all(
     feature = "global-allocator",
@@ -205,18 +205,14 @@ pub struct Opt {
     #[clap(skip = std::env::var("APOLLO_GRAPH_REF").ok())]
     apollo_graph_ref: Option<String>,
 
-    /// Your Apollo Router entitlement.
+    /// Your Apollo Router license.
     /// EXPERIMENTAL and not subject to semver.
-    #[clap(skip = std::env::var("APOLLO_ROUTER_ENTITLEMENT").ok())]
-    apollo_router_entitlement: Option<String>,
+    #[clap(skip = std::env::var("APOLLO_ROUTER_LICENSE").ok() || std::env::var("APOLLO_ROUTER_ENTITLEMENT").ok())]
+    apollo_router_license: Option<String>,
 
-    /// Entitlement location relative to the current directory.
-    #[clap(
-        long = "entitlement",
-        env = "APOLLO_ROUTER_ENTITLEMENT_PATH",
-        hide(true)
-    )]
-    apollo_router_entitlement_path: Option<PathBuf>,
+    /// License location relative to the current directory.
+    #[clap(long = "license", env = "APOLLO_ROUTER_LICENSE_PATH", hide(true))]
+    apollo_router_license_path: Option<PathBuf>,
 
     /// The endpoints (comma separated) polled to fetch the latest supergraph schema.
     #[clap(long, env, action = ArgAction::Append)]
@@ -353,7 +349,7 @@ impl Executable {
     async fn start(
         shutdown: Option<ShutdownSource>,
         schema: Option<SchemaSource>,
-        entitlement: Option<EntitlementSource>,
+        license: Option<LicenseSource>,
         config: Option<ConfigurationSource>,
         cli_args: Option<Opt>,
     ) -> Result<()> {
@@ -403,7 +399,7 @@ impl Executable {
                 Discussed::new().print_preview();
                 Ok(())
             }
-            None => Self::inner_start(shutdown, schema, config, entitlement, opt).await,
+            None => Self::inner_start(shutdown, schema, config, license, opt).await,
         };
 
         //We should be good to shutdown the tracer provider now as the router should have finished everything.
@@ -415,7 +411,7 @@ impl Executable {
         shutdown: Option<ShutdownSource>,
         schema: Option<SchemaSource>,
         config: Option<ConfigurationSource>,
-        entitlement: Option<EntitlementSource>,
+        license: Option<LicenseSource>,
         mut opt: Opt,
     ) -> Result<()> {
         let uplink_endpoints: Option<Vec<Url>> = opt
@@ -542,28 +538,28 @@ impl Executable {
 
         // Order of precedence:
         // 1. explicit path from cli
-        // 2. env APOLLO_ROUTER_ENTITLEMENT
+        // 2. env APOLLO_ROUTER_LICENSE
         // 3. uplink
-        let entitlement = entitlement.unwrap_or_else(|| {
+        let license = license.unwrap_or_else(|| {
             match (
-                &opt.apollo_router_entitlement,
-                &opt.apollo_router_entitlement_path,
+                &opt.apollo_router_license,
+                &opt.apollo_router_license_path,
                 &opt.apollo_key,
                 &opt.apollo_graph_ref,
             ) {
-                (_, Some(entitlement_path), _, _) => {
-                    let entitlement_path = if entitlement_path.is_relative() {
-                        current_directory.join(entitlement_path)
+                (_, Some(license_path), _, _) => {
+                    let license_path = if license_path.is_relative() {
+                        current_directory.join(license_path)
                     } else {
-                        entitlement_path.clone()
+                        license_path.clone()
                     };
-                    EntitlementSource::File {
-                        path: entitlement_path,
+                    LicenseSource::File {
+                        path: license_path,
                         watch: opt.hot_reload,
                     }
                 }
-                (Some(_entitlement), _, _, _) => EntitlementSource::Env,
-                (_, _, Some(apollo_key), Some(apollo_graph_ref)) => EntitlementSource::Registry {
+                (Some(_license), _, _, _) => LicenseSource::Env,
+                (_, _, Some(apollo_key), Some(apollo_graph_ref)) => LicenseSource::Registry {
                     apollo_key: apollo_key.to_string(),
                     apollo_graph_ref: apollo_graph_ref.to_string(),
                     urls: uplink_endpoints.clone(),
@@ -571,14 +567,14 @@ impl Executable {
                     timeout: opt.apollo_uplink_timeout,
                 },
 
-                _ => EntitlementSource::default(),
+                _ => LicenseSource::default(),
             }
         });
 
         let router = RouterHttpServer::builder()
             .configuration(configuration)
             .schema(schema)
-            .entitlement(entitlement)
+            .license(license)
             .shutdown(shutdown.unwrap_or(ShutdownSource::CtrlC))
             .start();
         if let Err(err) = router.await {

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -207,7 +207,7 @@ pub struct Opt {
 
     /// Your Apollo Router license.
     /// EXPERIMENTAL and not subject to semver.
-    #[clap(skip = std::env::var("APOLLO_ROUTER_LICENSE").ok() || std::env::var("APOLLO_ROUTER_ENTITLEMENT").ok())]
+    #[clap(skip = std::env::var("APOLLO_ROUTER_LICENSE").or_else(|| std::env::var("APOLLO_ROUTER_ENTITLEMENT")))]
     apollo_router_license: Option<String>,
 
     /// License location relative to the current directory.

--- a/apollo-router/src/http_server_factory.rs
+++ b/apollo-router/src/http_server_factory.rs
@@ -1,4 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
 use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -15,7 +14,7 @@ use crate::configuration::Configuration;
 use crate::configuration::ListenAddr;
 use crate::router_factory::Endpoint;
 use crate::router_factory::RouterFactory;
-use crate::uplink::entitlement::EntitlementState;
+use crate::uplink::license_enforcement::LicenseState;
 
 /// Factory for creating the http server component.
 ///
@@ -32,7 +31,7 @@ pub(crate) trait HttpServerFactory {
         main_listener: Option<Listener>,
         previous_listeners: Vec<(ListenAddr, Listener)>,
         extra_endpoints: MultiMap<ListenAddr, Endpoint>,
-        entitlement: EntitlementState,
+        license: LicenseState,
         all_connections_stopped_sender: mpsc::Sender<()>,
     ) -> Self::Future
     where
@@ -112,7 +111,7 @@ impl HttpServerHandle {
         router: RF,
         configuration: Arc<Configuration>,
         web_endpoints: MultiMap<ListenAddr, Endpoint>,
-        entitlement: EntitlementState,
+        license: LicenseState,
     ) -> Result<Self, ApolloRouterError>
     where
         SF: HttpServerFactory,
@@ -138,7 +137,7 @@ impl HttpServerHandle {
                 Some(main_listener),
                 extra_listeners,
                 web_endpoints,
-                entitlement,
+                license,
                 self.all_connections_stopped_sender.clone(),
             )
             .await?;

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -80,7 +80,7 @@ pub use crate::executable::main;
 pub use crate::executable::Executable;
 pub use crate::router::ApolloRouterError;
 pub use crate::router::ConfigurationSource;
-pub use crate::router::EntitlementSource;
+pub use crate::router::LicenseSource;
 pub use crate::router::RouterHttpServer;
 pub use crate::router::SchemaSource;
 pub use crate::router::ShutdownSource;

--- a/apollo-router/src/orbiter/mod.rs
+++ b/apollo-router/src/orbiter/mod.rs
@@ -1,4 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
 use std::collections::HashMap;
 use std::env;
 use std::sync::Arc;

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 //! Plugin system for the router.
 //!
 //! Provides a customization mechanism for the router.

--- a/apollo-router/src/plugins/authentication/jwks.rs
+++ b/apollo-router/src/plugins/authentication/jwks.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;

--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -1,5 +1,4 @@
 //! Authentication plugin
-// With regards to ELv2 licensing, this entire file is license key functionality
 
 use std::ops::ControlFlow;
 use std::str::FromStr;

--- a/apollo-router/src/plugins/authorization/mod.rs
+++ b/apollo-router/src/plugins/authorization/mod.rs
@@ -1,5 +1,4 @@
 //! Authorization plugin
-// With regards to ELv2 licensing, this entire file is license key functionality
 
 use std::ops::ControlFlow;
 

--- a/apollo-router/src/plugins/coprocessor.rs
+++ b/apollo-router/src/plugins/coprocessor.rs
@@ -1,5 +1,4 @@
 //! Externalization plugin
-// With regards to ELv2 licensing, this entire file is license key functionality
 
 use std::collections::HashMap;
 use std::ops::ControlFlow;

--- a/apollo-router/src/plugins/telemetry/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/apollo.rs
@@ -1,5 +1,4 @@
 //! Configuration for apollo telemetry.
-// This entire file is license key functionality
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::num::NonZeroUsize;
@@ -266,16 +265,16 @@ pub(crate) enum SingleReport {
 #[derive(Default, Debug, Serialize)]
 pub(crate) struct Report {
     pub(crate) traces_per_query: HashMap<String, TracesAndStats>,
-    #[serde(serialize_with = "serialize_operation_count_by_type")]
-    pub(crate) operation_count_by_type:
-        HashMap<(OperationKind, Option<OperationSubType>), OperationCountByType>,
+    #[serde(serialize_with = "serialize_licensed_operation_count_by_type")]
+    pub(crate) licensed_operation_count_by_type:
+        HashMap<(OperationKind, Option<OperationSubType>), LicensedOperationCountByType>,
 }
 
 #[derive(Clone, Default, Debug, Serialize, PartialEq, Eq, Hash)]
-pub(crate) struct OperationCountByType {
+pub(crate) struct LicensedOperationCountByType {
     pub(crate) r#type: OperationKind,
     pub(crate) subtype: Option<OperationSubType>,
-    pub(crate) operation_count: u64,
+    pub(crate) licensed_operation_count: u64,
 }
 
 #[derive(Debug, Serialize, PartialEq, Eq, Hash, Clone, Copy)]
@@ -296,20 +295,20 @@ impl Display for OperationSubType {
     }
 }
 
-impl From<OperationCountByType>
+impl From<LicensedOperationCountByType>
     for crate::plugins::telemetry::apollo_exporter::proto::reports::report::OperationCountByType
 {
-    fn from(value: OperationCountByType) -> Self {
+    fn from(value: LicensedOperationCountByType) -> Self {
         Self {
             r#type: value.r#type.as_apollo_operation_type().to_string(),
             subtype: value.subtype.map(|s| s.to_string()).unwrap_or_default(),
-            operation_count: value.operation_count,
+            operation_count: value.licensed_operation_count,
         }
     }
 }
 
-fn serialize_operation_count_by_type<S>(
-    elt: &HashMap<(OperationKind, Option<OperationSubType>), OperationCountByType>,
+fn serialize_licensed_operation_count_by_type<S>(
+    elt: &HashMap<(OperationKind, Option<OperationSubType>), LicensedOperationCountByType>,
     serializer: S,
 ) -> Result<S::Ok, S::Error>
 where
@@ -349,7 +348,7 @@ impl Report {
             header: Some(header),
             end_time: Some(SystemTime::now().into()),
             operation_count_by_type: self
-                .operation_count_by_type
+                .licensed_operation_count_by_type
                 .values()
                 .cloned()
                 .map(|op| op.into())
@@ -395,17 +394,17 @@ impl AddAssign<SingleStatsReport> for Report {
             *self.traces_per_query.entry(k).or_default() += v;
         }
 
-        if let Some(operation_count_by_type) = report.operation_count_by_type {
+        if let Some(licensed_operation_count_by_type) = report.licensed_operation_count_by_type {
             let key = (
-                operation_count_by_type.r#type,
-                operation_count_by_type.subtype,
+                licensed_operation_count_by_type.r#type,
+                licensed_operation_count_by_type.subtype,
             );
-            self.operation_count_by_type
+            self.licensed_operation_count_by_type
                 .entry(key)
                 .and_modify(|e| {
-                    e.operation_count += 1;
+                    e.licensed_operation_count += 1;
                 })
-                .or_insert(operation_count_by_type);
+                .or_insert(licensed_operation_count_by_type);
         }
     }
 }

--- a/apollo-router/src/plugins/telemetry/apollo_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/apollo_exporter.rs
@@ -1,5 +1,4 @@
 //! Configuration for apollo telemetry exporter.
-// This entire file is license key functionality
 use std::error::Error;
 use std::fmt::Debug;
 use std::io::Write;
@@ -180,7 +179,8 @@ impl ApolloExporter {
 
     pub(crate) async fn submit_report(&self, report: Report) -> Result<(), ApolloExportError> {
         // We may be sending traces but with no operation count
-        if report.operation_count_by_type.is_empty() && report.traces_per_query.is_empty() {
+        if report.licensed_operation_count_by_type.is_empty() && report.traces_per_query.is_empty()
+        {
             return Ok(());
         }
 

--- a/apollo-router/src/plugins/telemetry/metrics/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo.rs
@@ -1,5 +1,4 @@
 //! Apollo metrics
-// With regards to ELv2 licensing, this entire file is license key functionality
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/snapshots/apollo_router__plugins__telemetry__metrics__apollo__studio__test__aggregation.snap
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/snapshots/apollo_router__plugins__telemetry__metrics__apollo__studio__test__aggregation.snap
@@ -1302,11 +1302,11 @@ expression: aggregated_metrics
       }
     }
   },
-  "operation_count_by_type": {
+  "licensed_operation_count_by_type": {
     "query": {
       "type": "query",
       "subtype": null,
-      "operation_count": 2
+      "licensed_operation_count": 2
     }
   }
 }

--- a/apollo-router/src/plugins/telemetry/metrics/apollo/studio.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo/studio.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use super::duration_histogram::DurationHistogram;
-use crate::plugins::telemetry::apollo::OperationCountByType;
+use crate::plugins::telemetry::apollo::LicensedOperationCountByType;
 use crate::plugins::telemetry::apollo_exporter::proto::reports::ReferencedFieldsForType;
 use crate::plugins::telemetry::apollo_exporter::proto::reports::StatsContext;
 
@@ -14,7 +14,7 @@ use crate::plugins::telemetry::apollo_exporter::proto::reports::StatsContext;
 pub(crate) struct SingleStatsReport {
     pub(crate) request_id: Uuid,
     pub(crate) stats: HashMap<String, SingleStats>,
-    pub(crate) operation_count_by_type: Option<OperationCountByType>,
+    pub(crate) licensed_operation_count_by_type: Option<LicensedOperationCountByType>,
 }
 
 #[derive(Default, Debug, Serialize)]
@@ -319,10 +319,10 @@ mod test {
 
         SingleStatsReport {
             request_id: Uuid::default(),
-            operation_count_by_type: OperationCountByType {
+            licensed_operation_count_by_type: LicensedOperationCountByType {
                 r#type: OperationKind::Query,
                 subtype: None,
-                operation_count: count.inc_u64(),
+                licensed_operation_count: count.inc_u64(),
             }
             .into(),
             stats: HashMap::from([(

--- a/apollo-router/src/plugins/telemetry/metrics/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_exclude.snap
+++ b/apollo-router/src/plugins/telemetry/metrics/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_exclude.snap
@@ -6,10 +6,10 @@ expression: results
   {
     "request_id": "[REDACTED]",
     "stats": {},
-    "operation_count_by_type": {
+    "licensed_operation_count_by_type": {
       "type": "query",
       "subtype": null,
-      "operation_count": 1
+      "licensed_operation_count": 1
     }
   }
 ]

--- a/apollo-router/src/plugins/telemetry/metrics/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_multiple_operations.snap
+++ b/apollo-router/src/plugins/telemetry/metrics/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_multiple_operations.snap
@@ -39,6 +39,6 @@ expression: results
         "referenced_fields_by_type": {}
       }
     },
-    "operation_count_by_type": null
+    "licensed_operation_count_by_type": null
   }
 ]

--- a/apollo-router/src/plugins/telemetry/metrics/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_parse_failure.snap
+++ b/apollo-router/src/plugins/telemetry/metrics/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_parse_failure.snap
@@ -39,6 +39,6 @@ expression: results
         "referenced_fields_by_type": {}
       }
     },
-    "operation_count_by_type": null
+    "licensed_operation_count_by_type": null
   }
 ]

--- a/apollo-router/src/plugins/telemetry/metrics/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_single_operation.snap
+++ b/apollo-router/src/plugins/telemetry/metrics/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_single_operation.snap
@@ -52,10 +52,10 @@ expression: results
         }
       }
     },
-    "operation_count_by_type": {
+    "licensed_operation_count_by_type": {
       "type": "query",
       "subtype": null,
-      "operation_count": 1
+      "licensed_operation_count": 1
     }
   }
 ]

--- a/apollo-router/src/plugins/telemetry/metrics/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_unknown_operation.snap
+++ b/apollo-router/src/plugins/telemetry/metrics/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_unknown_operation.snap
@@ -39,6 +39,6 @@ expression: results
         "referenced_fields_by_type": {}
       }
     },
-    "operation_count_by_type": null
+    "licensed_operation_count_by_type": null
   }
 ]

--- a/apollo-router/src/plugins/telemetry/metrics/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_validation_failure.snap
+++ b/apollo-router/src/plugins/telemetry/metrics/snapshots/apollo_router__plugins__telemetry__metrics__apollo__test__apollo_metrics_validation_failure.snap
@@ -39,6 +39,6 @@ expression: results
         "referenced_fields_by_type": {}
       }
     },
-    "operation_count_by_type": null
+    "licensed_operation_count_by_type": null
   }
 ]

--- a/apollo-router/src/plugins/telemetry/tracing/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo.rs
@@ -1,5 +1,4 @@
 //! Tracing configuration for apollo telemetry.
-// With regards to ELv2 licensing, this entire file is license key functionality
 use opentelemetry::sdk::trace::BatchSpanProcessor;
 use opentelemetry::sdk::trace::Builder;
 use serde::Serialize;

--- a/apollo-router/src/plugins/traffic_shaping/cache.rs
+++ b/apollo-router/src/plugins/traffic_shaping/cache.rs
@@ -1,4 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
 use std::collections::HashMap;
 use std::task::Context;
 use std::task::Poll;

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -6,7 +6,6 @@
 //! * Compression
 //! * Rate limiting
 //!
-// With regards to ELv2 licensing, this entire file is license key functionality
 mod cache;
 mod deduplication;
 mod rate;

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -1,5 +1,3 @@
-// This entire file is license key functionality
-
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::sync::Arc;

--- a/apollo-router/src/router/error.rs
+++ b/apollo-router/src/router/error.rs
@@ -20,11 +20,11 @@ pub enum ApolloRouterError {
     /// no valid schema was supplied
     NoSchema,
 
-    /// no valid entitlement was supplied
-    NoEntitlement,
+    /// no valid license was supplied
+    NoLicense,
 
-    /// entitlement violation
-    EntitlementViolation,
+    /// license violation
+    LicenseViolation,
 
     /// could not create router: {0}
     ServiceCreationError(BoxError),

--- a/apollo-router/src/router/event/configuration.rs
+++ b/apollo-router/src/router/event/configuration.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 use std::path::Path;
 use std::path::PathBuf;
 use std::pin::Pin;

--- a/apollo-router/src/router/event/license.rs
+++ b/apollo-router/src/router/event/license.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::str::FromStr;
@@ -12,37 +10,37 @@ use futures::prelude::*;
 use url::Url;
 
 use crate::router::Event;
-use crate::router::Event::NoMoreEntitlement;
-use crate::uplink::entitlement::Entitlement;
-use crate::uplink::entitlement_stream::EntitlementQuery;
-use crate::uplink::entitlement_stream::EntitlementStreamExt;
+use crate::router::Event::NoMoreLicense;
+use crate::uplink::license_enforcement::License;
+use crate::uplink::license_stream::LicenseQuery;
+use crate::uplink::license_stream::LicenseStreamExt;
 use crate::uplink::stream_from_uplink;
 use crate::uplink::Endpoints;
 
-type EntitlementStream = Pin<Box<dyn Stream<Item = Entitlement> + Send>>;
+type LicenseStream = Pin<Box<dyn Stream<Item = License> + Send>>;
 
-/// Entitlement controls availability of certain features of the Router.
+/// License controls availability of certain features of the Router.
 /// This API experimental and is subject to change outside of semver.
 #[derive(From, Display, Derivative)]
 #[derivative(Debug)]
 #[non_exhaustive]
-pub enum EntitlementSource {
-    /// A static entitlement. EXPERIMENTAL and not subject to semver.
+pub enum LicenseSource {
+    /// A static license. EXPERIMENTAL and not subject to semver.
     #[display(fmt = "Static")]
-    Static { entitlement: Entitlement },
+    Static { license: License },
 
-    /// An entitlement supplied via APOLLO_ROUTER_ENTITLEMENT. EXPERIMENTAL and not subject to semver.
+    /// A license supplied via APOLLO_ROUTER_LICENSE. EXPERIMENTAL and not subject to semver.
     #[display(fmt = "Env")]
     Env,
 
-    /// A stream of entitlement. EXPERIMENTAL and not subject to semver.
+    /// A stream of license. EXPERIMENTAL and not subject to semver.
     #[display(fmt = "Stream")]
-    Stream(#[derivative(Debug = "ignore")] EntitlementStream),
+    Stream(#[derivative(Debug = "ignore")] LicenseStream),
 
     /// A raw file that may be watched for changes. EXPERIMENTAL and not subject to semver.
     #[display(fmt = "File")]
     File {
-        /// The path of the entitlement file.
+        /// The path of the license file.
         path: PathBuf,
 
         /// `true` to watch the file for changes and hot apply them.
@@ -69,34 +67,32 @@ pub enum EntitlementSource {
     },
 }
 
-impl Default for EntitlementSource {
+impl Default for LicenseSource {
     fn default() -> Self {
-        EntitlementSource::Static {
-            entitlement: Default::default(),
+        LicenseSource::Static {
+            license: Default::default(),
         }
     }
 }
 
-impl EntitlementSource {
-    /// Convert this entitlement into a stream regardless of if is static or not. Allows for unified handling later.
+impl LicenseSource {
+    /// Convert this license into a stream regardless of if is static or not. Allows for unified handling later.
     pub(crate) fn into_stream(self) -> impl Stream<Item = Event> {
         match self {
-            EntitlementSource::Static { entitlement } => {
-                stream::once(future::ready(entitlement)).boxed()
-            }
-            EntitlementSource::Stream(stream) => stream.boxed(),
-            EntitlementSource::File { path, watch } => {
+            LicenseSource::Static { license } => stream::once(future::ready(license)).boxed(),
+            LicenseSource::Stream(stream) => stream.boxed(),
+            LicenseSource::File { path, watch } => {
                 // Sanity check, does the schema file exists, if it doesn't then bail.
                 if !path.exists() {
                     tracing::error!(
-                        "Entitlement file at path '{}' does not exist.",
+                        "License file at path '{}' does not exist.",
                         path.to_string_lossy()
                     );
                     stream::empty().boxed()
                 } else {
-                    // The entitlement file exists try and load it
+                    // The license file exists try and load it
                     match std::fs::read_to_string(&path).map(|e| e.parse()) {
-                        Ok(Ok(entitlement)) => {
+                        Ok(Ok(license)) => {
                             if watch {
                                 crate::files::watch(&path)
                                     .filter_map(move |_| {
@@ -105,7 +101,7 @@ impl EntitlementSource {
                                             let result = tokio::fs::read_to_string(&path).await;
                                             if let Err(e) = &result {
                                                 tracing::error!(
-                                                    "failed to read entitlement file, {}",
+                                                    "failed to read license file, {}",
                                                     e
                                                 );
                                             }
@@ -115,36 +111,33 @@ impl EntitlementSource {
                                     .filter_map(|e| async move {
                                         let result = e.parse();
                                         if let Err(e) = &result {
-                                            tracing::error!(
-                                                "failed to parse entitlement file, {}",
-                                                e
-                                            );
+                                            tracing::error!("failed to parse license file, {}", e);
                                         }
                                         result.ok()
                                     })
                                     .boxed()
                             } else {
-                                stream::once(future::ready(entitlement)).boxed()
+                                stream::once(future::ready(license)).boxed()
                             }
                         }
                         Ok(Err(err)) => {
-                            tracing::error!("Failed to parse entitlement: {}", err);
+                            tracing::error!("Failed to parse license: {}", err);
                             stream::empty().boxed()
                         }
                         Err(err) => {
-                            tracing::error!("Failed to read entitlement: {}", err);
+                            tracing::error!("Failed to read license: {}", err);
                             stream::empty().boxed()
                         }
                     }
                 }
             }
-            EntitlementSource::Registry {
+            LicenseSource::Registry {
                 apollo_key,
                 apollo_graph_ref,
                 urls,
                 poll_interval,
                 timeout,
-            } => stream_from_uplink::<EntitlementQuery, Entitlement>(
+            } => stream_from_uplink::<LicenseQuery, License>(
                 apollo_key,
                 apollo_graph_ref,
                 urls.map(Endpoints::fallback),
@@ -153,7 +146,7 @@ impl EntitlementSource {
             )
             .filter_map(|res| {
                 future::ready(match res {
-                    Ok(entitlement) => Some(entitlement),
+                    Ok(license) => Some(license),
                     Err(e) => {
                         tracing::error!("{}", e);
                         None
@@ -161,20 +154,19 @@ impl EntitlementSource {
                 })
             })
             .boxed(),
-            EntitlementSource::Env => {
+            LicenseSource::Env => {
                 // EXPERIMENTAL and not subject to semver.
-                match std::env::var("APOLLO_ROUTER_ENTITLEMENT").map(|e| Entitlement::from_str(&e))
-                {
-                    Ok(Ok(entitlement)) => stream::once(future::ready(entitlement)).boxed(),
+                match std::env::var("APOLLO_ROUTER_LICENSE").map(|e| License::from_str(&e)) {
+                    Ok(Ok(license)) => stream::once(future::ready(license)).boxed(),
                     Ok(Err(err)) => {
-                        tracing::error!("Failed to parse entitlement: {}", err);
+                        tracing::error!("Failed to parse license: {}", err);
                         stream::empty().boxed()
                     }
-                    Err(_) => stream::once(future::ready(Entitlement::default())).boxed(),
+                    Err(_) => stream::once(future::ready(License::default())).boxed(),
                 }
             }
         }
-        .expand_entitlements()
-        .chain(stream::iter(vec![NoMoreEntitlement]))
+        .expand_licenses()
+        .chain(stream::iter(vec![NoMoreLicense]))
     }
 }

--- a/apollo-router/src/router/event/mod.rs
+++ b/apollo-router/src/router/event/mod.rs
@@ -1,7 +1,5 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 mod configuration;
-mod entitlement;
+mod license;
 mod reload;
 mod schema;
 mod shutdown;
@@ -10,20 +8,20 @@ use std::fmt::Debug;
 use std::fmt::Formatter;
 
 pub use configuration::ConfigurationSource;
-pub use entitlement::EntitlementSource;
+pub use license::LicenseSource;
 pub(crate) use reload::ReloadSource;
 pub use schema::SchemaSource;
 pub use shutdown::ShutdownSource;
 
 use self::Event::NoMoreConfiguration;
-use self::Event::NoMoreEntitlement;
+use self::Event::NoMoreLicense;
 use self::Event::NoMoreSchema;
 use self::Event::Reload;
 use self::Event::Shutdown;
 use self::Event::UpdateConfiguration;
-use self::Event::UpdateEntitlement;
+use self::Event::UpdateLicense;
 use self::Event::UpdateSchema;
-use crate::uplink::entitlement::EntitlementState;
+use crate::uplink::license_enforcement::LicenseState;
 use crate::Configuration;
 
 /// Messages that are broadcast across the app.
@@ -40,11 +38,11 @@ pub(crate) enum Event {
     /// There are no more updates to the schema
     NoMoreSchema,
 
-    /// Update entitlement {}
-    UpdateEntitlement(EntitlementState),
+    /// Update license {}
+    UpdateLicense(LicenseState),
 
-    /// There were no more updates to entitlement.
-    NoMoreEntitlement,
+    /// There were no more updates to license.
+    NoMoreLicense,
 
     /// Artificial hot reload for chaos testing
     Reload,
@@ -68,11 +66,11 @@ impl Debug for Event {
             NoMoreSchema => {
                 write!(f, "NoMoreSchema")
             }
-            UpdateEntitlement(e) => {
-                write!(f, "UpdateEntitlement({e:?})")
+            UpdateLicense(e) => {
+                write!(f, "UpdateLicense({e:?})")
             }
-            NoMoreEntitlement => {
-                write!(f, "NoMoreEntitlement")
+            NoMoreLicense => {
+                write!(f, "NoMoreLicense")
             }
             Reload => {
                 write!(f, "ForcedHotReload")

--- a/apollo-router/src/router/event/reload.rs
+++ b/apollo-router/src/router/event/reload.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::task::Poll;

--- a/apollo-router/src/router/event/schema.rs
+++ b/apollo-router/src/router/event/schema.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::time::Duration;
@@ -132,27 +130,23 @@ impl SchemaSource {
                 urls,
                 poll_interval,
                 timeout,
-            } => {
-                // With regards to ELv2 licensing, the code inside this block
-                // is license key functionality
-                stream_from_uplink::<SupergraphSdlQuery, String>(
-                    apollo_key,
-                    apollo_graph_ref,
-                    urls.map(Endpoints::fallback),
-                    poll_interval,
-                    timeout,
-                )
-                .filter_map(|res| {
-                    future::ready(match res {
-                        Ok(schema) => Some(UpdateSchema(schema)),
-                        Err(e) => {
-                            tracing::error!("{}", e);
-                            None
-                        }
-                    })
+            } => stream_from_uplink::<SupergraphSdlQuery, String>(
+                apollo_key,
+                apollo_graph_ref,
+                urls.map(Endpoints::fallback),
+                poll_interval,
+                timeout,
+            )
+            .filter_map(|res| {
+                future::ready(match res {
+                    Ok(schema) => Some(UpdateSchema(schema)),
+                    Err(e) => {
+                        tracing::error!("{}", e);
+                        None
+                    }
                 })
-                .boxed()
-            }
+            })
+            .boxed(),
         }
         .chain(stream::iter(vec![NoMoreSchema]))
     }

--- a/apollo-router/src/router/event/shutdown.rs
+++ b/apollo-router/src/router/event/shutdown.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 use std::pin::Pin;
 
 use derivative::Derivative;

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -1,5 +1,4 @@
 use std::io;
-// With regards to ELv2 licensing, this entire file is license key functionality
 use std::sync::Arc;
 
 use axum::response::IntoResponse;

--- a/apollo-router/src/services/execution.rs
+++ b/apollo-router/src/services/execution.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 #![allow(missing_docs)] // FIXME
 
 use std::sync::Arc;

--- a/apollo-router/src/services/execution_service.rs
+++ b/apollo-router/src/services/execution_service.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 //! Implements the Execution phase of the request lifecycle.
 
 use std::future::ready;

--- a/apollo-router/src/services/external.rs
+++ b/apollo-router/src/services/external.rs
@@ -1,4 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
 #![allow(missing_docs)] // FIXME
 
 use std::collections::HashMap;

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -3,8 +3,6 @@
 //!  For more information on APQ see:
 //!  <https://www.apollographql.com/docs/apollo-server/performance/apq/>
 
-// This entire file is license key functionality
-
 use http::header::CACHE_CONTROL;
 use http::HeaderValue;
 use serde::Deserialize;

--- a/apollo-router/src/services/layers/static_page.rs
+++ b/apollo-router/src/services/layers/static_page.rs
@@ -3,8 +3,6 @@
 //!  For more information on APQ see:
 //!  <https://www.apollographql.com/docs/apollo-server/performance/apq/>
 
-// This entire file is license key functionality
-
 use std::borrow::Cow;
 use std::ops::ControlFlow;
 

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 //! Implementation of the various steps in the router's processing pipeline.
 
 use std::sync::Arc;

--- a/apollo-router/src/services/new_service.rs
+++ b/apollo-router/src/services/new_service.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 //! Create a new tower Service instance.
 use tower::Service;
 

--- a/apollo-router/src/services/query_planner.rs
+++ b/apollo-router/src/services/query_planner.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 #![allow(missing_docs)] // FIXME
 
 use std::sync::Arc;

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 #![allow(missing_docs)] // FIXME
 
 use bytes::Bytes;

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 //! Implements the router phase of the request lifecycle.
 
 use std::sync::Arc;

--- a/apollo-router/src/services/subgraph.rs
+++ b/apollo-router/src/services/subgraph.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 #![allow(missing_docs)] // FIXME
 
 use std::sync::Arc;

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 //! Tower fetcher for subgraphs.
 
 use std::collections::HashMap;

--- a/apollo-router/src/services/supergraph.rs
+++ b/apollo-router/src/services/supergraph.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 #![allow(missing_docs)] // FIXME
 
 use std::sync::Arc;

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 //! Implements the router phase of the request lifecycle.
 
 use std::sync::Arc;

--- a/apollo-router/src/services/transport.rs
+++ b/apollo-router/src/services/transport.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 #![allow(deprecated)]
 #![allow(missing_docs)]
 

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::sync::Arc;
@@ -12,7 +10,7 @@ use tokio::sync::OwnedRwLockWriteGuard;
 use tokio::sync::RwLock;
 use ApolloRouterError::ServiceCreationError;
 use Event::NoMoreConfiguration;
-use Event::NoMoreEntitlement;
+use Event::NoMoreLicense;
 use Event::NoMoreSchema;
 use Event::Reload;
 use Event::Shutdown;
@@ -32,14 +30,14 @@ use super::state_machine::State::Stopped;
 use crate::configuration::Configuration;
 use crate::configuration::Discussed;
 use crate::configuration::ListenAddr;
-use crate::router::Event::UpdateEntitlement;
+use crate::router::Event::UpdateLicense;
 use crate::router_factory::RouterFactory;
 use crate::router_factory::RouterSuperServiceFactory;
 use crate::spec::Schema;
-use crate::uplink::entitlement::EntitlementReport;
-use crate::uplink::entitlement::EntitlementState;
-use crate::uplink::entitlement::ENTITLEMENT_EXPIRED_URL;
-use crate::ApolloRouterError::NoEntitlement;
+use crate::uplink::license_enforcement::LicenseEnforcementReport;
+use crate::uplink::license_enforcement::LicenseState;
+use crate::uplink::license_enforcement::LICENSE_EXPIRED_URL;
+use crate::ApolloRouterError::NoLicense;
 
 #[derive(Default, Clone)]
 pub(crate) struct ListenAddresses {
@@ -53,13 +51,13 @@ enum State<FA: RouterSuperServiceFactory> {
     Startup {
         configuration: Option<Arc<Configuration>>,
         schema: Option<Arc<String>>,
-        entitlement: Option<EntitlementState>,
+        license: Option<LicenseState>,
         listen_addresses_guard: OwnedRwLockWriteGuard<ListenAddresses>,
     },
     Running {
         configuration: Arc<Configuration>,
         schema: Arc<String>,
-        entitlement: EntitlementState,
+        license: LicenseState,
         server_handle: Option<HttpServerHandle>,
         router_service_factory: FA::RouterFactory,
         all_connections_stopped_signal: mpsc::Receiver<()>,
@@ -105,11 +103,9 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         }
     }
 
-    async fn no_more_entitlement(self) -> Self {
+    async fn no_more_license(self) -> Self {
         match self {
-            Startup {
-                entitlement: None, ..
-            } => Errored(NoEntitlement),
+            Startup { license: None, .. } => Errored(NoLicense),
             _ => self,
         }
     }
@@ -119,7 +115,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         state_machine: &mut StateMachine<S, FA>,
         new_schema: Option<Arc<String>>,
         new_configuration: Option<Arc<Configuration>>,
-        new_entitlement: Option<EntitlementState>,
+        new_license: Option<LicenseState>,
     ) -> Self
     where
         S: HttpServerFactory,
@@ -129,15 +125,15 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
             Startup {
                 schema,
                 configuration,
-                entitlement,
+                license,
                 listen_addresses_guard,
             } => {
                 *schema = new_schema.or_else(|| schema.take());
                 *configuration = new_configuration.or_else(|| configuration.take());
-                *entitlement = new_entitlement.or_else(|| entitlement.take());
+                *license = new_license.or_else(|| license.take());
 
-                if let (Some(schema), Some(configuration), Some(entitlement)) =
-                    (schema, configuration, entitlement)
+                if let (Some(schema), Some(configuration), Some(license)) =
+                    (schema, configuration, license)
                 {
                     new_state = Some(
                         Self::try_start(
@@ -146,7 +142,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                             None,
                             configuration.clone(),
                             schema.clone(),
-                            *entitlement,
+                            *license,
                             listen_addresses_guard,
                         )
                         .map_ok_or_else(Errored, |f| f)
@@ -157,37 +153,37 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
             Running {
                 schema,
                 configuration,
-                entitlement,
+                license,
                 server_handle,
                 router_service_factory,
                 all_connections_stopped_signal: _,
             } => {
                 tracing::info!(
                     new_schema = new_schema.is_some(),
-                    new_entitlement = new_entitlement.is_some(),
+                    new_license = new_license.is_some(),
                     new_configuration = new_configuration.is_some(),
                     "reloading"
                 );
 
-                if new_entitlement == Some(EntitlementState::Unentitled)
-                    && *entitlement != EntitlementState::Unentitled
+                if new_license == Some(LicenseState::Unlicensed)
+                    && *license != LicenseState::Unlicensed
                 {
-                    // When we get an unentitled event, if we were entitled before then just carry on.
+                    // When we get an unlicensed event, if we were licensed before then just carry on.
                     // This means that users can delete and then undelete their graphs in studio while having their routers continue to run.
-                    tracing::info!("loss of entitlement detected, ignoring reload");
+                    tracing::info!("loss of license detected, ignoring reload");
                     return self;
                 }
 
                 // We update the running config. This is OK even in the case that the router could not reload as we always want to retain the latest information for when we try to reload next.
-                // In the case of a failed reload the server handle is retained, which has the old config/schema/entitlements in.
+                // In the case of a failed reload the server handle is retained, which has the old config/schema/license in.
                 if let Some(new_configuration) = new_configuration {
                     *configuration = new_configuration;
                 }
                 if let Some(new_schema) = new_schema {
                     *schema = new_schema;
                 }
-                if let Some(new_entitlement) = new_entitlement {
-                    *entitlement = new_entitlement;
+                if let Some(new_license) = new_license {
+                    *license = new_license;
                 }
 
                 let mut guard = state_machine.listen_addresses.clone().write_owned().await;
@@ -197,7 +193,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                     Some(router_service_factory),
                     configuration.clone(),
                     schema.clone(),
-                    *entitlement,
+                    *license,
                     &mut guard,
                 )
                 .await
@@ -255,7 +251,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         previous_router_service_factory: Option<&FA::RouterFactory>,
         configuration: Arc<Configuration>,
         schema: Arc<String>,
-        entitlement: EntitlementState,
+        license: LicenseState,
         listen_addresses_guard: &mut OwnedRwLockWriteGuard<ListenAddresses>,
     ) -> Result<State<FA>, ApolloRouterError>
     where
@@ -267,40 +263,40 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                 .map_err(|e| ServiceCreationError(e.to_string().into()))?,
         );
 
-        // Check the entitlements
-        let report = EntitlementReport::build(&configuration, &parsed_schema);
+        // Check the license
+        let report = LicenseEnforcementReport::build(&configuration, &parsed_schema);
 
-        match entitlement {
-            EntitlementState::Entitled => {
-                tracing::debug!("A valid Apollo entitlement has been detected.");
+        match license {
+            LicenseState::Licensed => {
+                tracing::debug!("A valid Apollo license has been detected.");
             }
-            EntitlementState::EntitledWarn if report.uses_restricted_features() => {
-                tracing::error!("Entitlement has expired. The Router will soon stop serving requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active entitlement for the following features:\n\n{}\n\nSee {ENTITLEMENT_EXPIRED_URL} for more information.", report);
+            LicenseState::LicensedWarn if report.uses_restricted_features() => {
+                tracing::error!("License has expired. The Router will soon stop serving requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.", report);
             }
-            EntitlementState::EntitledHalt if report.uses_restricted_features() => {
-                tracing::error!("Entitlement has expired. The Router will no longer serve requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active entitlement for the following features:\n\n{}\n\nSee {ENTITLEMENT_EXPIRED_URL} for more information.", report);
+            LicenseState::LicensedHalt if report.uses_restricted_features() => {
+                tracing::error!("License has expired. The Router will no longer serve requests. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an active license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.", report);
             }
-            EntitlementState::Unentitled if report.uses_restricted_features() => {
+            LicenseState::Unlicensed if report.uses_restricted_features() => {
                 // This is OSS, so fail to reload or start.
                 if std::env::var("APOLLO_KEY").is_ok() && std::env::var("APOLLO_GRAPH_REF").is_ok()
                 {
-                    tracing::error!("Entitlement not found. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides an entitlement for the following features:\n\n{}\n\nSee {ENTITLEMENT_EXPIRED_URL} for more information.", report);
+                    tracing::error!("License not found. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS that provides a license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.", report);
                 } else {
-                    tracing::error!("Not connected to GraphOS. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS (using APOLLO_KEY and APOLLO_GRAPH_REF) that provides an entitlement for the following features:\n\n{}\n\nSee {ENTITLEMENT_EXPIRED_URL} for more information.", report);
+                    tracing::error!("Not connected to GraphOS. In order to enable these features for a self-hosted instance of Apollo Router, the Router must be connected to a graph in GraphOS (using APOLLO_KEY and APOLLO_GRAPH_REF) that provides a license for the following features:\n\n{}\n\nSee {LICENSE_EXPIRED_URL} for more information.", report);
                 }
 
-                return Err(ApolloRouterError::EntitlementViolation);
+                return Err(ApolloRouterError::LicenseViolation);
             }
             _ => {
-                tracing::debug!("A valid Apollo entitlement was not detected. However, no restricted features are in use.");
+                tracing::debug!("A valid Apollo license was not detected. However, no restricted features are in use.");
             }
         }
 
-        // If there are no restricted featured in use then the effective entitlement is Entitled as we don't need warn or halt behavior.
-        let effective_entitlement = if !report.uses_restricted_features() {
-            EntitlementState::Entitled
+        // If there are no restricted featured in use then the effective license is Licensed as we don't need warn or halt behavior.
+        let effective_license = if !report.uses_restricted_features() {
+            LicenseState::Licensed
         } else {
-            entitlement
+            license
         };
 
         let router_service_factory = state_machine
@@ -330,7 +326,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                         Default::default(),
                         Default::default(),
                         web_endpoints,
-                        effective_entitlement,
+                        effective_license,
                         all_connections_stopped_sender,
                     )
                     .await?
@@ -342,7 +338,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                         router_service_factory.clone(),
                         configuration.clone(),
                         web_endpoints,
-                        effective_entitlement,
+                        effective_license,
                     )
                     .await?
             }
@@ -364,7 +360,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         Ok(Running {
             configuration,
             schema,
-            entitlement,
+            license,
             server_handle: Some(server_handle),
             router_service_factory,
             all_connections_stopped_signal,
@@ -377,7 +373,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
 /// If config and schema are not supplied then the machine ends with an error.
 /// Once schema and config are obtained running state is entered.
 /// Config and schema updates will try to swap in the new values into the running state. In future we may trigger an http server restart if for instance socket address is encountered.
-/// At any point a shutdown event will cause the machine to try to get to stopped state.  
+/// At any point a shutdown event will cause the machine to try to get to stopped state.
 pub(crate) struct StateMachine<S, FA>
 where
     S: HttpServerFactory,
@@ -448,7 +444,7 @@ where
         let mut state: State<FA> = Startup {
             configuration: None,
             schema: None,
-            entitlement: None,
+            license: None,
             listen_addresses_guard: self
                 .listen_addresses_guard
                 .take()
@@ -472,13 +468,13 @@ where
                         .await
                 }
                 NoMoreSchema => state.no_more_schema().await,
-                UpdateEntitlement(entitlement) => {
+                UpdateLicense(license) => {
                     state
-                        .update_inputs(&mut self, None, None, Some(entitlement))
+                        .update_inputs(&mut self, None, None, Some(license))
                         .await
                 }
                 Reload => state.update_inputs(&mut self, None, None, None).await,
-                NoMoreEntitlement => state.no_more_entitlement().await,
+                NoMoreLicense => state.no_more_license().await,
                 Shutdown => state.shutdown().await,
             };
 
@@ -581,17 +577,17 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn no_entitlement() {
+    async fn no_license() {
         let router_factory = create_mock_router_configurator(0);
         let (server_factory, _) = create_mock_server_factory(0);
         assert_matches!(
             execute(
                 server_factory,
                 router_factory,
-                stream::iter(vec![NoMoreEntitlement])
+                stream::iter(vec![NoMoreLicense])
             )
             .await,
-            Err(NoEntitlement)
+            Err(NoLicense)
         );
     }
     fn test_config_restricted() -> Configuration {
@@ -602,7 +598,7 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn restricted_entitled() {
+    async fn restricted_licensed() {
         let router_factory = create_mock_router_configurator(1);
         let (server_factory, shutdown_receivers) = create_mock_server_factory(1);
 
@@ -613,7 +609,7 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(test_config_restricted()),
                     UpdateSchema(example_schema()),
-                    UpdateEntitlement(EntitlementState::Entitled),
+                    UpdateLicense(LicenseState::Licensed),
                     Shutdown
                 ])
             )
@@ -624,7 +620,7 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn restricted_entitled_halted() {
+    async fn restricted_licensed_halted() {
         let router_factory = create_mock_router_configurator(1);
         let (server_factory, shutdown_receivers) = create_mock_server_factory(1);
 
@@ -635,7 +631,7 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(test_config_restricted()),
                     UpdateSchema(example_schema()),
-                    UpdateEntitlement(EntitlementState::EntitledHalt),
+                    UpdateLicense(LicenseState::LicensedHalt),
                     Shutdown
                 ])
             )
@@ -646,7 +642,7 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn restricted_entitled_warn() {
+    async fn restricted_licensed_warn() {
         let router_factory = create_mock_router_configurator(1);
         let (server_factory, shutdown_receivers) = create_mock_server_factory(1);
 
@@ -657,7 +653,7 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(test_config_restricted()),
                     UpdateSchema(example_schema()),
-                    UpdateEntitlement(EntitlementState::EntitledWarn),
+                    UpdateLicense(LicenseState::LicensedWarn),
                     Shutdown
                 ])
             )
@@ -668,11 +664,11 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn restricted_entitled_unentitled() {
+    async fn restricted_licensed_unlicensed() {
         let router_factory = create_mock_router_configurator(2);
         let (server_factory, shutdown_receivers) = create_mock_server_factory(2);
 
-        // The unentitled event is dropped so we should get a reload
+        // The unlicensed event is dropped so we should get a reload
         assert_matches!(
             execute(
                 server_factory,
@@ -680,8 +676,8 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(test_config_restricted()),
                     UpdateSchema(example_schema()),
-                    UpdateEntitlement(EntitlementState::Entitled),
-                    UpdateEntitlement(EntitlementState::Unentitled),
+                    UpdateLicense(LicenseState::Licensed),
+                    UpdateLicense(LicenseState::Unlicensed),
                     UpdateConfiguration(test_config_restricted()),
                     Shutdown
                 ])
@@ -693,7 +689,7 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn restricted_unentitled() {
+    async fn restricted_unlicensed() {
         let router_factory = create_mock_router_configurator(0);
         let (server_factory, shutdown_receivers) = create_mock_server_factory(0);
 
@@ -704,18 +700,18 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(test_config_restricted()),
                     UpdateSchema(example_schema()),
-                    UpdateEntitlement(EntitlementState::Unentitled),
+                    UpdateLicense(LicenseState::Unlicensed),
                     Shutdown
                 ])
             )
             .await,
-            Err(ApolloRouterError::EntitlementViolation)
+            Err(ApolloRouterError::LicenseViolation)
         );
         assert_eq!(shutdown_receivers.lock().unwrap().len(), 0);
     }
 
     #[test(tokio::test)]
-    async fn unrestricted_unentitled_restricted_entitled() {
+    async fn unrestricted_unlicensed_restricted_licensed() {
         let router_factory = create_mock_router_configurator(2);
         let (server_factory, shutdown_receivers) = create_mock_server_factory(2);
 
@@ -726,9 +722,9 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(Configuration::builder().build().unwrap()),
                     UpdateSchema(example_schema()),
-                    UpdateEntitlement(EntitlementState::Unentitled),
+                    UpdateLicense(LicenseState::Unlicensed),
                     UpdateConfiguration(test_config_restricted()),
-                    UpdateEntitlement(EntitlementState::Entitled),
+                    UpdateLicense(LicenseState::Licensed),
                     Shutdown
                 ])
             )
@@ -768,7 +764,7 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(Configuration::builder().build().unwrap()),
                     UpdateSchema(example_schema()),
-                    UpdateEntitlement(EntitlementState::default()),
+                    UpdateLicense(LicenseState::default()),
                     Shutdown
                 ])
             )
@@ -790,7 +786,7 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(Configuration::builder().build().unwrap()),
                     UpdateSchema(minimal_schema.to_owned()),
-                    UpdateEntitlement(EntitlementState::default()),
+                    UpdateLicense(LicenseState::default()),
                     UpdateSchema(example_schema()),
                     Shutdown
                 ])
@@ -802,7 +798,7 @@ mod tests {
     }
 
     #[test(tokio::test)]
-    async fn startup_reload_entitlement() {
+    async fn startup_reload_license() {
         let router_factory = create_mock_router_configurator(2);
         let (server_factory, shutdown_receivers) = create_mock_server_factory(2);
         let minimal_schema = include_str!("testdata/minimal_supergraph.graphql");
@@ -813,8 +809,8 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(Configuration::builder().build().unwrap()),
                     UpdateSchema(minimal_schema.to_owned()),
-                    UpdateEntitlement(EntitlementState::default()),
-                    UpdateEntitlement(EntitlementState::default()),
+                    UpdateLicense(LicenseState::default()),
+                    UpdateLicense(LicenseState::default()),
                     Shutdown
                 ])
             )
@@ -836,7 +832,7 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(Configuration::builder().build().unwrap()),
                     UpdateSchema(example_schema()),
-                    UpdateEntitlement(EntitlementState::default()),
+                    UpdateLicense(LicenseState::default()),
                     UpdateConfiguration(
                         Configuration::builder()
                             .supergraph(
@@ -868,7 +864,7 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(Configuration::builder().build().unwrap()),
                     UpdateSchema(example_schema()),
-                    UpdateEntitlement(EntitlementState::default()),
+                    UpdateLicense(LicenseState::default()),
                     Shutdown
                 ])
             )
@@ -895,7 +891,7 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(Configuration::builder().build().unwrap()),
                     UpdateSchema(example_schema()),
-                    UpdateEntitlement(EntitlementState::default()),
+                    UpdateLicense(LicenseState::default()),
                 ])
             )
             .await,
@@ -933,7 +929,7 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(Configuration::builder().build().unwrap()),
                     UpdateSchema(example_schema()),
-                    UpdateEntitlement(EntitlementState::default()),
+                    UpdateLicense(LicenseState::default()),
                     UpdateSchema(example_schema()),
                     Shutdown
                 ])
@@ -984,7 +980,7 @@ mod tests {
                 stream::iter(vec![
                     UpdateConfiguration(Configuration::builder().build().unwrap()),
                     UpdateSchema(example_schema()),
-                    UpdateEntitlement(EntitlementState::default()),
+                    UpdateLicense(LicenseState::default()),
                     UpdateConfiguration(
                         Configuration::builder()
                             .homepage(Homepage::builder().enabled(true).build())
@@ -1085,7 +1081,7 @@ mod tests {
             _extra_listeners: Vec<(ListenAddr, Listener)>,
             _web_endpoints: MultiMap<ListenAddr, Endpoint>,
 
-            _entitlment: EntitlementState,
+            _license: LicenseState,
             _all_connections_stopped_sender: mpsc::Sender<()>,
         ) -> Self::Future
         where

--- a/apollo-router/src/test_harness.rs
+++ b/apollo-router/src/test_harness.rs
@@ -281,7 +281,7 @@ impl<'a> TestHarness<'a> {
         use crate::axum_factory::tests::make_axum_router;
         use crate::axum_factory::ListenAddrAndRouter;
         use crate::router_factory::RouterFactory;
-        use crate::uplink::entitlement::EntitlementState;
+        use crate::uplink::license_enforcement::LicenseState;
 
         let (config, supergraph_creator) = self.build_common().await?;
         let router_creator = RouterCreator::new(
@@ -296,7 +296,7 @@ impl<'a> TestHarness<'a> {
             router_creator,
             &config,
             web_endpoints,
-            EntitlementState::Unentitled,
+            LicenseState::Unlicensed,
         )?;
         let ListenAddrAndRouter(_listener, router) = routers.main;
         Ok(router.boxed())

--- a/apollo-router/src/uplink/license.jwks.json
+++ b/apollo-router/src/uplink/license.jwks.json
@@ -1,4 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
 {
   "keys": [
     {

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 // tonic does not derive `Eq` for the gRPC message types, which causes a warning from Clippy. The
 // current suggestion is to explicitly allow the lint in the module that imports the protos.
 // Read more: https://github.com/hyperium/tonic/issues/1056
@@ -30,16 +28,16 @@ use thiserror::Error;
 use crate::spec::Schema;
 use crate::Configuration;
 
-pub(crate) const ENTITLEMENT_EXPIRED_URL: &str = "https://go.apollo.dev/o/elp";
-pub(crate) const ENTITLEMENT_EXPIRED_SHORT_MESSAGE: &str =
-    "Apollo entitlement expired https://go.apollo.dev/o/elp";
+pub(crate) const LICENSE_EXPIRED_URL: &str = "https://go.apollo.dev/o/elp";
+pub(crate) const LICENSE_EXPIRED_SHORT_MESSAGE: &str =
+    "Apollo license expired https://go.apollo.dev/o/elp";
 
 static JWKS: OnceCell<JwkSet> = OnceCell::new();
 
 #[derive(Error, Display, Debug)]
 pub enum Error {
-    /// invalid entitlement: {0}
-    InvalidEntitlement(jsonwebtoken::errors::Error),
+    /// invalid license: {0}
+    InvalidLicense(jsonwebtoken::errors::Error),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -76,17 +74,20 @@ where
 }
 
 #[derive(Debug)]
-pub(crate) struct EntitlementReport {
+pub(crate) struct LicenseEnforcementReport {
     restricted_config_in_use: Vec<ConfigurationRestriction>,
 }
 
-impl EntitlementReport {
+impl LicenseEnforcementReport {
     pub(crate) fn uses_restricted_features(&self) -> bool {
         !self.restricted_config_in_use.is_empty()
     }
 
-    pub(crate) fn build(configuration: &Configuration, _schema: &Schema) -> EntitlementReport {
-        EntitlementReport {
+    pub(crate) fn build(
+        configuration: &Configuration,
+        _schema: &Schema,
+    ) -> LicenseEnforcementReport {
+        LicenseEnforcementReport {
             restricted_config_in_use: Self::validate_configuration(
                 configuration,
                 &Self::configuration_restrictions(),
@@ -175,7 +176,7 @@ impl EntitlementReport {
     }
 }
 
-impl Display for EntitlementReport {
+impl Display for LicenseEnforcementReport {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let restricted_config = self
             .restricted_config_in_use
@@ -187,24 +188,24 @@ impl Display for EntitlementReport {
     }
 }
 
-/// Entitlement controls availability of certain features of the Router. It must be constructed from a base64 encoded JWT
+/// License controls availability of certain features of the Router. It must be constructed from a base64 encoded JWT
 /// This API experimental and is subject to change outside of semver.
 #[derive(Debug, Clone, Default)]
-pub struct Entitlement {
+pub struct License {
     pub(crate) claims: Option<Claims>,
 }
 
-/// Entitlements are converted into a stream of entitlement states by the expander
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
-pub(crate) enum EntitlementState {
-    Entitled,
-    EntitledWarn,
-    EntitledHalt,
+/// Licenses are converted into a stream of license states by the expander
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
+pub(crate) enum LicenseState {
+    Licensed,
+    LicensedWarn,
+    LicensedHalt,
     #[default]
-    Unentitled,
+    Unlicensed,
 }
 
-impl Display for Entitlement {
+impl Display for License {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if let Some(claims) = &self.claims {
             write!(
@@ -214,12 +215,12 @@ impl Display for Entitlement {
                     .unwrap_or_else(|_| "claim serialization error".to_string())
             )
         } else {
-            write!(f, "no entitlement")
+            write!(f, "no license")
         }
     }
 }
 
-impl FromStr for Entitlement {
+impl FromStr for License {
     type Err = Error;
 
     fn from_str(jwt: &str) -> Result<Self, Self::Err> {
@@ -244,8 +245,8 @@ impl FromStr for Entitlement {
                     &DecodingKey::from_jwk(jwk).expect("router.jwks.json must be valid"),
                     &validation,
                 )
-                .map_err(Error::InvalidEntitlement)
-                .map(|r| Entitlement {
+                .map_err(Error::InvalidLicense)
+                .map(|r| License {
                     claims: Some(r.claims),
                 })
             })
@@ -253,7 +254,7 @@ impl FromStr for Entitlement {
             .transpose()
             .map(|e| {
                 let e = e.unwrap_or_default();
-                tracing::debug!("decoded entitlement {jwt}->{e}");
+                tracing::debug!("decoded license {jwt}->{e}");
                 e
             })
     }
@@ -267,12 +268,12 @@ pub(crate) struct ConfigurationRestriction {
     value: Option<Value>,
 }
 
-impl Entitlement {
+impl License {
     pub(crate) fn jwks() -> &'static JwkSet {
         JWKS.get_or_init(|| {
             // Strip the comments from the top of the file.
             let re = Regex::new("(?m)^//.*$").expect("regex must be valid");
-            let jwks = re.replace(include_str!("router.jwks.json"), "");
+            let jwks = re.replace(include_str!("license.jwks.json"), "");
             serde_json::from_str::<JwkSet>(&jwks).expect("router jwks must be valid")
         })
     }
@@ -288,19 +289,19 @@ mod test {
     use serde_json::json;
 
     use crate::spec::Schema;
-    use crate::uplink::entitlement::Audience;
-    use crate::uplink::entitlement::Claims;
-    use crate::uplink::entitlement::Entitlement;
-    use crate::uplink::entitlement::EntitlementReport;
-    use crate::uplink::entitlement::OneOrMany;
+    use crate::uplink::license_enforcement::Audience;
+    use crate::uplink::license_enforcement::Claims;
+    use crate::uplink::license_enforcement::License;
+    use crate::uplink::license_enforcement::LicenseEnforcementReport;
+    use crate::uplink::license_enforcement::OneOrMany;
     use crate::Configuration;
 
-    fn check(router_yaml: &str, supergraph_schema: &str) -> EntitlementReport {
+    fn check(router_yaml: &str, supergraph_schema: &str) -> LicenseEnforcementReport {
         let config = Configuration::from_str(router_yaml).expect("router config must be valid");
         let schema = Schema::parse(supergraph_schema, &config, None)
             .expect("supergraph schema must be valid");
 
-        EntitlementReport::build(&config, &schema)
+        LicenseEnforcementReport::build(&config, &schema)
     }
 
     #[test]
@@ -331,10 +332,10 @@ mod test {
     }
 
     #[test]
-    fn test_entitlement_parse() {
-        let entitlement = Entitlement::from_str("eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJodHRwczovL3d3dy5hcG9sbG9ncmFwaHFsLmNvbS8iLCJzdWIiOiJhcG9sbG8iLCJhdWQiOiJTRUxGX0hPU1RFRCIsIndhcm5BdCI6MTY3NjgwODAwMCwiaGFsdEF0IjoxNjc4MDE3NjAwfQ.tXexfjZ2SQeqSwkWQ7zD4XBoxS_Hc5x7tSNJ3ln-BCL_GH7i3U9hsIgdRQTczCAjA_jjk34w39DeSV0nTc5WBw").expect("must be able to decode JWT");
+    fn test_license_parse() {
+        let license = License::from_str("eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJodHRwczovL3d3dy5hcG9sbG9ncmFwaHFsLmNvbS8iLCJzdWIiOiJhcG9sbG8iLCJhdWQiOiJTRUxGX0hPU1RFRCIsIndhcm5BdCI6MTY3NjgwODAwMCwiaGFsdEF0IjoxNjc4MDE3NjAwfQ.tXexfjZ2SQeqSwkWQ7zD4XBoxS_Hc5x7tSNJ3ln-BCL_GH7i3U9hsIgdRQTczCAjA_jjk34w39DeSV0nTc5WBw").expect("must be able to decode JWT");
         assert_eq!(
-            entitlement.claims,
+            license.claims,
             Some(Claims {
                 iss: "https://www.apollographql.com/".to_string(),
                 sub: "apollo".to_string(),
@@ -346,10 +347,10 @@ mod test {
     }
 
     #[test]
-    fn test_entitlement_parse_with_whitespace() {
-        let entitlement = Entitlement::from_str("   eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJodHRwczovL3d3dy5hcG9sbG9ncmFwaHFsLmNvbS8iLCJzdWIiOiJhcG9sbG8iLCJhdWQiOiJTRUxGX0hPU1RFRCIsIndhcm5BdCI6MTY3NjgwODAwMCwiaGFsdEF0IjoxNjc4MDE3NjAwfQ.tXexfjZ2SQeqSwkWQ7zD4XBoxS_Hc5x7tSNJ3ln-BCL_GH7i3U9hsIgdRQTczCAjA_jjk34w39DeSV0nTc5WBw\n ").expect("must be able to decode JWT");
+    fn test_license_parse_with_whitespace() {
+        let license = License::from_str("   eyJhbGciOiJFZERTQSJ9.eyJpc3MiOiJodHRwczovL3d3dy5hcG9sbG9ncmFwaHFsLmNvbS8iLCJzdWIiOiJhcG9sbG8iLCJhdWQiOiJTRUxGX0hPU1RFRCIsIndhcm5BdCI6MTY3NjgwODAwMCwiaGFsdEF0IjoxNjc4MDE3NjAwfQ.tXexfjZ2SQeqSwkWQ7zD4XBoxS_Hc5x7tSNJ3ln-BCL_GH7i3U9hsIgdRQTczCAjA_jjk34w39DeSV0nTc5WBw\n ").expect("must be able to decode JWT");
         assert_eq!(
-            entitlement.claims,
+            license.claims,
             Some(Claims {
                 iss: "https://www.apollographql.com/".to_string(),
                 sub: "apollo".to_string(),
@@ -361,8 +362,8 @@ mod test {
     }
 
     #[test]
-    fn test_entitlement_parse_fail() {
-        Entitlement::from_str("invalid").expect_err("jwt must fail parse");
+    fn test_license_parse_fail() {
+        License::from_str("invalid").expect_err("jwt must fail parse");
     }
 
     #[test]

--- a/apollo-router/src/uplink/license_query.graphql
+++ b/apollo-router/src/uplink/license_query.graphql
@@ -1,4 +1,4 @@
-query EntitlementQuery($apiKey: String!, $graph_ref: String!, $ifAfterId: ID) {
+query LicenseQuery($apiKey: String!, $graph_ref: String!, $ifAfterId: ID) {
 
     routerEntitlements(ifAfterId: $ifAfterId, apiKey: $apiKey, ref: $graph_ref) {
         __typename

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 use std::fmt::Debug;
 use std::time::Duration;
 use std::time::Instant;
@@ -12,8 +10,8 @@ use tokio_stream::wrappers::ReceiverStream;
 use tracing::instrument::WithSubscriber;
 use url::Url;
 
-pub(crate) mod entitlement;
-pub(crate) mod entitlement_stream;
+pub(crate) mod license_enforcement;
+pub(crate) mod license_stream;
 pub(crate) mod schema_stream;
 
 const GCP_URL: &str = "https://uplink.api.apollographql.com";
@@ -684,7 +682,7 @@ mod test {
         MockResponses::builder()
             .mock_server(&mock_server)
             .endpoint(&url1)
-            .response(response_invalid_entitlement())
+            .response(response_invalid_license())
             .build()
             .await;
         let results = stream_from_uplink::<TestQuery, QueryResult>(
@@ -821,7 +819,7 @@ mod test {
         }))
     }
 
-    fn response_invalid_entitlement() -> ResponseTemplate {
+    fn response_invalid_license() -> ResponseTemplate {
         ResponseTemplate::new(StatusCode::OK).set_body_json(json!(
         {
             "data":{

--- a/apollo-router/src/uplink/schema_stream.rs
+++ b/apollo-router/src/uplink/schema_stream.rs
@@ -1,5 +1,3 @@
-// With regards to ELv2 licensing, this entire file is license key functionality
-
 // tonic does not derive `Eq` for the gRPC message types, which causes a warning from Clippy. The
 // current suggestion is to explicitly allow the lint in the module that imports the protos.
 // Read more: https://github.com/hyperium/tonic/issues/1056

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__license__test__oss_restricted_features_via_config.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__license__test__oss_restricted_features_via_config.snap
@@ -1,5 +1,5 @@
 ---
-source: apollo-router/src/uplink/entitlement.rs
+source: apollo-router/src/uplink/license.rs
 expression: err.to_string()
 ---
 TODO PREAMBLE

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config.snap
@@ -1,5 +1,5 @@
 ---
-source: apollo-router/src/uplink/entitlement.rs
+source: apollo-router/src/uplink/license_enforcement.rs
 expression: report.to_string()
 ---
 Configuration yaml:

--- a/apollo-router/tests/metrics_tests.rs
+++ b/apollo-router/tests/metrics_tests.rs
@@ -60,8 +60,8 @@ async fn test_metrics_reloading() -> Result<(), BoxError> {
         .await;
 
     if std::env::var("APOLLO_KEY").is_ok() && std::env::var("APOLLO_GRAPH_REF").is_ok() {
-        router.assert_metrics_contains(r#"apollo_router_uplink_fetch_duration_seconds_count{kind="unchanged",query="Entitlement",service_name="apollo-router",url="https://uplink.api.apollographql.com/graphql",otel_scope_name="apollo/router",otel_scope_version=""}"#, Some(Duration::from_secs(120))).await;
-        router.assert_metrics_contains(r#"apollo_router_uplink_fetch_count_total{query="Entitlement",service_name="apollo-router",status="success",otel_scope_name="apollo/router",otel_scope_version=""}"#, Some(Duration::from_secs(1))).await;
+        router.assert_metrics_contains(r#"apollo_router_uplink_fetch_duration_seconds_count{kind="unchanged",query="License",service_name="apollo-router",url="https://uplink.api.apollographql.com/",otel_scope_name="apollo/router",otel_scope_version=""}"#, Some(Duration::from_secs(120))).await;
+        router.assert_metrics_contains(r#"apollo_router_uplink_fetch_count_total{query="License",service_name="apollo-router",status="success",otel_scope_name="apollo/router",otel_scope_version=""}"#, Some(Duration::from_secs(1))).await;
     }
 
     Ok(())

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -99,14 +99,14 @@ All cache metrics listed above have the following attributes:
 - `apollo_router_uplink_fetch_duration_seconds_bucket` - Uplink request duration, attributes:
 
   - `url`: The Uplink URL that was polled
-  - `query`: The query that the router sent to Uplink (`SupergraphSdl` or `Entitlement`)
+  - `query`: The query that the router sent to Uplink (`SupergraphSdl` or `License`)
   - `kind`: (`new`, `unchanged`, `http_error`, `uplink_error`)
   - `code`: The error code depending on type (if an error occurred)
   - `error`: The error message (if an error occurred)
 
 - `apollo_router_uplink_fetch_count_total`
   - `status`: (`success`, `failure`)
-  - `query`: The query that the router sent to Uplink (`SupergraphSdl` or `Entitlement`)
+  - `query`: The query that the router sent to Uplink (`SupergraphSdl` or `License`)
 
 Note that the initial call to uplink during router startup will not be reflected in metrics.
 

--- a/docs/source/enterprise-features.mdx
+++ b/docs/source/enterprise-features.mdx
@@ -30,9 +30,9 @@ To enable support for the Apollo Router's Enterprise features:
 
 After enabling support, you can begin using all Enterprise features. Consult [the documentation for each feature](#list-of-features) to learn more.
 
-### The Enterprise entitlement
+### The Enterprise license
 
-Whenever your router instance starts up and connects to GraphOS, it fetches an **entitlement**, which is the credential that authorizes its use of Enterprise features:
+Whenever your router instance starts up and connects to GraphOS, it fetches a **license**, which is the credential that authorizes its use of Enterprise features:
 
 ```mermaid
 flowchart LR;
@@ -42,28 +42,28 @@ flowchart LR;
   subgraph "GraphOS";
   uplink(Apollo Uplink)
   end;
-  router--"Fetches supergraph schema<br/>and entitlement"-->uplink;
+  router--"Fetches supergraph schema<br/>and license"-->uplink;
 ```
 
-A router instance retains its entitlement for the duration of its execution. If you terminate a router instance and then later start a new instance on the same machine, it must fetch a new entitlement.
+A router instance retains its license for the duration of its execution. If you terminate a router instance and then later start a new instance on the same machine, it must fetch a new license.
 
-Entitlements are served via [Apollo Uplink](/federation/managed-federation/uplink/), the same multi-cloud endpoint that your router uses to fetch its supergraph schema from GraphOS. Because of this, entitlements introduce no additional network dependencies, meaning your router's uptime remains unaffected.
+Licenses are served via [Apollo Uplink](/federation/managed-federation/uplink/), the same multi-cloud endpoint that your router uses to fetch its supergraph schema from GraphOS. Because of this, licenses introduce no additional network dependencies, meaning your router's uptime remains unaffected.
 
 > [Learn more about multi-cloud Uplink.](https://www.apollographql.com/blog/announcement/backend/introducing-multi-cloud-support-for-apollo-uplink)
 
-A router instance's entitlement is valid for the duration of your organization's current subscription billing period (plus a [grace period](#grace-period-for-expired-plans)), even if the router temporarily becomes disconnected from GraphOS.
+A router instance's license is valid for the duration of your organization's current subscription billing period (plus a [grace period](#grace-period-for-expired-plans)), even if the router temporarily becomes disconnected from GraphOS.
 
-### Entitlements with local development
+### Licenses with local development
 
 While building your supergraph, you might run an Apollo Router instance on your local machine (such as with the [`rover dev`](/graphos/graphs/local-development) command). It's likely that this router instance _doesn't_ currently connect to GraphOS, because it obtains its supergraph schema via another mechanism. For example, `rover dev` performs composition locally after introspecting your running subgraphs, which might change frequently as you develop.
 
-**You _can_ use Enterprise router features with a locally composed supergraph schema!** To do so, your router must still connect to GraphOS to obtain its [entitlement](#the-enterprise-entitlement).
+**You _can_ use Enterprise router features with a locally composed supergraph schema!** To do so, your router must still connect to GraphOS to obtain its [license](#the-enterprise-license).
 
 #### Setup
 
 These steps work both for running the router executable directly (`./router`) and for running it via `rover dev`:
 
-1. [Create a new variant](/graphos/graphs/federated-graphs/#adding-a-variant-via-the-rover-cli) for your supergraph that you'll use _only_ to fetch Enterprise entitlements.
+1. [Create a new variant](/graphos/graphs/federated-graphs/#adding-a-variant-via-the-rover-cli) for your supergraph that you'll use _only_ to fetch Enterprise licenses.
     - Give the variant a name that clearly distinguishes it from variants that track schemas and metrics.
     - Every team member that runs a router locally can use this same variant.
     - When you create this variant, publish a dummy subgraph schema like the following (your router won't use it):
@@ -83,28 +83,28 @@ These steps work both for running the router executable directly (`./router`) an
     APOLLO_GRAPH_REF="..." APOLLO_KEY="..." ./router --supergraph schema.graphql
     ```
 
-    - The value of `APOLLO_GRAPH_REF` is the graph ref for the new, entitlement-specific variant you created (e.g., `docs-example-graph@local-entitlements`).
+    - The value of `APOLLO_GRAPH_REF` is the graph ref for the new, license-specific variant you created (e.g., `docs-example-graph@local-licenses`).
     - The value of `APOLLO_KEY` is the graph API key you created.
 
-4. Your router will fetch an Enterprise entitlement while using its locally composed supergraph schema.
+4. Your router will fetch an Enterprise license while using its locally composed supergraph schema.
 
 ### Common errors
 
 **If your router doesn't successfully connect to GraphOS,** it logs an error that begins with one of the following strings if any Enterprise features are enabled:
 
-| Error Message | Description |
-|---------------|-------------|
+| Error Message               | Description |
+|-----------------------------|-------------|
 | `Not connected to GraphOS.` | At least one of the `APOLLO_KEY` and `APOLLO_GRAPH_REF` environment variables wasn't set on router startup. |
-| `Entitlement not found.` | The router connected to GraphOS with credentials that are not associated with a GraphOS Enterprise plan. |
-| `Entitlement has expired.` | Your organization's GraphOS Enterprise subscription has ended. **Your router will stop processing incoming requests at the end of the standard [grace period](#grace-period-for-expired-plans).** |
+| `License not found.`        | The router connected to GraphOS with credentials that are not associated with a GraphOS Enterprise plan. |
+| `License has expired.`      | Your organization's GraphOS Enterprise subscription has ended. **Your router will stop processing incoming requests at the end of the standard [grace period](#grace-period-for-expired-plans).** |
 
 ## Grace period for expired plans
 
-If your organization terminates its GraphOS Enterprise subscription, your router's Enterprise entitlement is considered expired at the end of your final paid subscription period. GraphOS provides a grace period for expired entitlements so that you can disable Enterprise features before they produce breaking errors in your router.
+If your organization terminates its GraphOS Enterprise subscription, your router's Enterprise license is considered expired at the end of your final paid subscription period. GraphOS provides a grace period for expired licenses so that you can disable Enterprise features before they produce breaking errors in your router.
 
-If your router has an expired Enterprise entitlement, its behavior degrades according to the following schedule, _if_ any Enterprise features are still enabled:
+If your router has an expired Enterprise license, its behavior degrades according to the following schedule, _if_ any Enterprise features are still enabled:
 
-- **For the first 14 days after your entitlement expires,** your router continues to behave as though it has a valid entitlement.
+- **For the first 14 days after your license expires,** your router continues to behave as though it has a valid license.
 - **After 14 days,** your router begins a **soft outage**: it continues processing client requests, but it emits logs and metrics that indicate it's experiencing an outage.
 - **After 28 days,** your router begins a **hard outage**. It no longer processes incoming client requests and continues emitting logs and metrics from the soft outage.
 


### PR DESCRIPTION
This commit does not change the licensing of this project, but it does aim to simplify and bring clarity and maintain a free and open core to the Router.  This simplification is offered via a couple changes to so-called "license key functionality", which is the mechanism which enables "GraphOS Enterprise" features in the Router for Enterprise customers.

- Changes terminology within the codebase from "entitlement" to "license" to avoid unnecessary indirection between the terms.
- Remove superfluous "license key functionality" annotations throughout the codebase.
