### PR TITLE
Separate flate2 from dep grouping awaiting bump.

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -87,7 +87,7 @@ dhat = { version = "0.3.2", optional = true }
 diff = "0.1.13"
 directories = "4.0.1"
 displaydoc = "0.2"
-flate2 = "1.0.24" # TODO: bump the flate2 dependency once deno updates it
+flate2 = "1.0.24" # TODO: bump the flate2 dependency once deno updates it. Also, be sure to update Renovate configuration.
 fred = { version = "6.3.0", features = ["enable-rustls", "no-client-setname"] }
 futures = { version = "0.3.28", features = ["thread-pool"] }
 graphql_client = "0.11.0"

--- a/renovate.json5
+++ b/renovate.json5
@@ -78,6 +78,9 @@
     {
       "matchCurrentVersion": ">= 1.0.0",
       "matchManagers": [ "cargo", "npm" ],
+      // TODO: https://github.com/apollographql/router/pull/3194/commits/4e522a245e715e67d44c8dfc0a458bca1d054078
+      // Remove this after `flate2` is resolved.
+      "excludePackageNames": ["flate2"],
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "all non-major packages >= 1.0",
       "groupSlug": "all-non-major-gte-1.0",


### PR DESCRIPTION
Follows up on change in https://github.com/apollographql/router/pull/3194/commits/4e522a245e715e67d44c8dfc0a458bca1d054078, but allows Renovate to keep doing its work without the group getting hung up on that dependency over and over (and not letting anything else merge).
