### PR TITLE
docs(traffic-shaping): Indicate that query de-duplication is disabled by default

### DIFF
--- a/docs/source/configuration/traffic-shaping.mdx
+++ b/docs/source/configuration/traffic-shaping.mdx
@@ -126,7 +126,7 @@ To reduce the size of subgraph requests and the amount of work they might perfor
 
 ### Query deduplication
 
-If the Router is simultaneously processing similar queries, it may result in producing multiple identical requests to a subgraph.  With the `deduplicate_query` functionality enabled, the Router can avoid sending the same query multiple times and instead buffer one or more of the dependent queries pending the result of the first, and reuse that result to fulfill all of the initial queries.  This will reduce the overall traffic to the subgraph and the overall client request latency.  To meet the criteria for deduplication, the feature must be enabled and the subgraph queries must have have the same HTTP path, headers and body:
+If the Router is simultaneously processing similar queries, it may result in producing multiple identical requests to a subgraph.  With the `deduplicate_query` functionality enabled (by default, it is disabled), the Router can avoid sending the same query multiple times and instead buffer one or more of the dependent queries pending the result of the first, and reuse that result to fulfill all of the initial queries.  This will reduce the overall traffic to the subgraph and the overall client request latency.  To meet the criteria for deduplication, the feature must be enabled and the subgraph queries must have have the same HTTP path, headers and body:
 
 ```yaml title="router.yaml"
 traffic_shaping:


### PR DESCRIPTION
Hopefully removes the ambiguity noted in the referenced issue.  Merges to `main` intentionally as this docs change doesn't pertain to a specific version.

Closes https://github.com/apollographql/router/issues/3257