### PR TITLE
Revert "Improve Rhai errors"

### DIFF
--- a/.changesets/docs_debugging_rhai.md
+++ b/.changesets/docs_debugging_rhai.md
@@ -1,5 +1,0 @@
-### Add a "Debugging" section to the Rhai plugin docs
-
-There are now a few tips & tricks in our docs for debugging Rhai scripts including how to get syntax highlighting, how to interpret error messages, and recommendations for tracking down runtime errors.
-
-By [@dbanty](https://github.com/dbanty) in https://github.com/apollographql/router/pull/3254

--- a/.changesets/feat_add_script_path_to_rhai_errors.md
+++ b/.changesets/feat_add_script_path_to_rhai_errors.md
@@ -1,5 +1,0 @@
-### Include path to Rhai script in syntax error messages
-
-Syntax errors in the main Rhai script will now include the path to the script in the error message. This should make it more obvious where the error originates.
-
-By [@dbanty](https://github.com/dbanty) in https://github.com/apollographql/router/pull/3254

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -81,9 +81,7 @@ impl EngineBlock {
             sdl.to_string(),
             main.clone(),
         ));
-        let ast = engine
-            .compile_file(main.clone())
-            .map_err(|err| format!("in Rhai script {}: {}", main.display(), err))?;
+        let ast = engine.compile_file(main)?;
         let mut scope = Scope::new();
         // Keep these two lower cases ones as mistakes until 2.0
         // At 2.0 (or maybe before), replace with upper case

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -719,21 +719,3 @@ async fn it_cannot_process_om_subgraph_missing_message_and_body() {
         panic!("error processed incorrectly");
     }
 }
-
-#[tokio::test]
-async fn it_mentions_source_when_syntax_error_occurs() {
-    let err: Box<dyn std::error::Error> = crate::plugin::plugins()
-        .find(|factory| factory.name == "apollo.rhai")
-        .expect("Plugin not found")
-        .create_instance_without_schema(
-            &Value::from_str(r#"{"scripts":"tests/fixtures", "main":"syntax_errors.rhai"}"#)
-                .unwrap(),
-        )
-        .await
-        .err()
-        .unwrap();
-
-    assert!(err
-        .to_string()
-        .contains("tests/fixtures/syntax_errors.rhai"));
-}

--- a/apollo-router/tests/fixtures/syntax_errors.rhai
+++ b/apollo-router/tests/fixtures/syntax_errors.rhai
@@ -1,4 +1,0 @@
-fn supergraph_service(service) {
-    let response = Fn("supergraph_response")  // There should be a semicolon here
-    service.map_response(response);
-}

--- a/docs/source/customizations/rhai.mdx
+++ b/docs/source/customizations/rhai.mdx
@@ -435,17 +435,3 @@ If your router customization needs to do any of these, you can instead use [exte
 The Apollo Router requires that its Rhai engine implements the [sync feature](https://rhai.rs/book/start/features.html) to guarantee data integrity within the router's multi-threading execution environment. This means that [shared values](https://rhai.rs/book/language/fn-closure.html?highlight=deadlock#data-races-in-sync-builds-can-become-deadlocks) within Rhai might cause a deadlock.
 
 This is particularly risky when using closures within callbacks while referencing external data. Take particular care to avoid this kind of situation by making copies of data when required. The [examples/surrogate-cache-key directory](https://github.com/apollographql/router/tree/main/examples/surrogate-cache-key) contains an example of this, where "closing over" `response.headers` would cause a deadlock. To avoid this, a local copy of the required data is obtained and used in the closure.
-
-## Debugging
-
-### Understanding errors
-
-If there is a syntax error in a Rhai script, the router will log an error message at startup mentioning the `apollo.rhai` plugin. The line number in the error message describes where the error was _detected_, not where the error is present. For example, if you're missing a semicolon at the end of line 10, the error will mention line 11 (once Rhai realizes the mistake).
-
-### Syntax highlighting
-
-Syntax highlighting can make it easier to spot errors in a script. We recommend using the online [Rhai playground](https://rhai.rs/playground/stable/) or using VS Code with the [Rhai extension](https://marketplace.visualstudio.com/items?itemName=rhaiscript.vscode-rhai).
-
-### Logging
-
-For tracking down runtime errors, insert [logging](/docs/router/customizations/rhai-api#logging) statements to narrow down the issue.


### PR DESCRIPTION
Completely open to re-landing it with some variation of this and considering that it's happening only on Windows, it's almost undoubtedly a timing issue, but for now, this reverts apollographql/router#3254 as it's causing somewhat consistent failures in CI right now on Windows, [seen here](https://app.circleci.com/pipelines/github/apollographql/router/12962/workflows/aca214be-f9ed-453b-9775-9ada639c5f54/jobs/85133?invite=true#step-117-1196) with the following error:

```
---- plugins::rhai::tests::it_mentions_source_when_syntax_error_occurs stdout ----
thread 'plugins::rhai::tests::it_mentions_source_when_syntax_error_occurs' panicked at 'assertion failed: err.to_string().contains(\"tests/fixtures/syntax_errors.rhai\")', apollo-router\src\plugins\rhai\tests.rs:736:5
stack backtrace:
   0:     0x7ff669fdc702 - std::backtrace_rs::backtrace::dbghelp::trace
                               at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\..\..\backtrace\src\backtrace\dbghelp.rs:98
   1:     0x7ff669fdc702 - std::backtrace_rs::backtrace::trace_unsynchronized
                               at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\..\..\backtrace\src\backtrace\mod.rs:66
   2:     0x7ff669fdc702 - std::sys_common::backtrace::_print_fmt
                               at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\sys_common\backtrace.rs:65
   3:     0x7ff669fdc702 - std::sys_common::backtrace::_print::impl$0::fmt
                               at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\sys_common\backtrace.rs:44
   4:     0x7ff66a005c2b - core::fmt::write
                               at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\core\src\fmt\mod.rs:1254
   5:     0x7ff669fd560a - std::io::Write::write_fmt<alloc::vec::Vec<u8,alloc::alloc::Global> >
                               at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\io\mod.rs:1698
   6:     0x7ff669fdc44b - std::sys_common::backtrace::_print
                               at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\sys_common\backtrace.rs:47
   7:     0x7ff669fdc44b - std::sys_common::backtrace::print
                               at /rustc/90c541806f23a127002de5b4038be731ba1458ca/library\std\src\sys_common\backtrace.rs:34
   8:     0x7ff669fdf53a - std::panicking::default_hook::closure$1
```