### PR TITLE
update Rhai to 1.15.0 to fix issue with hanging example test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4822,9 +4822,9 @@ dependencies = [
 
 [[package]]
 name = "rhai"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2c99b27f6661b4d217b6aa21727c6a0808729266edfc8a8877042d609b1904e"
+checksum = "778dd6094c66d4e31cd7b28533aa38af6379e8bbc4fe7aedcb3ed83aa6dc315a"
 dependencies = [
  "ahash 0.8.3",
  "bitflags",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -163,7 +163,7 @@ prost = "0.11.9"
 prost-types = "0.11.9"
 proteus = "0.5.0"
 rand = "0.8.5"
-rhai = { version = "1.14.0", features = ["sync", "serde", "internals"] }
+rhai = { version = "1.15.0", features = ["sync", "serde", "internals"] }
 regex = "1.8.4"
 reqwest = { version = "0.11.18", default-features = false, features = [
     "rustls-tls",
@@ -249,6 +249,7 @@ reqwest = { version = "0.11.18", default-features = false, features = [
     "json",
     "stream",
 ] }
+rhai = { version = "1.15.0", features = ["sync", "serde", "internals", "testing-environ"] }
 similar-asserts = "1.4.2"
 tempfile = "3.6.0"
 test-log = { version = "0.2.12", default-features = false, features = [


### PR DESCRIPTION
One of our Rhai examples' tests have been regularly hanging in the CI builds for the last couple of months. Investigation uncovered a race condition within Rhai itself. This update brings in the fixed version of Rhai and should eliminate the hanging problem.

fixes: #3213
