### PR TITLE
chore: Setup Remote Docker in Release process earlier

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -635,6 +635,9 @@ jobs:
       VERSION: << pipeline.git.tag >>
     steps:
       - checkout
+      - setup_remote_docker:
+          version: 20.10.11
+          docker_layer_caching: true
       - attach_workspace:
           at: artifacts
       - gh/setup
@@ -660,10 +663,6 @@ jobs:
               *) gh release create $VERSION --notes-file /dev/null --title $VERSION artifacts/* ;;
 
             esac
-
-      - setup_remote_docker:
-          version: 20.10.11
-          docker_layer_caching: true
       - run:
           name: Docker build
           command: |


### PR DESCRIPTION
By setting up the remote Docker process _earlier_ in the CircleCI release process, this makes it easier to _use_ that remote Docker instance when doing the "Re-run with SSH" step in CircleCI since  it's _not_ possible to setup the Remote Docker _from_ SSH.  If a step before the Remote Docker step fails to run (thus necessitating the Retry with SSH), then it's impossible to manually finish the release (or even debug) using the SSH console.

(This is a follow-up lesson/todo from a couple past occurrences right now.  Overall, it should be a no-op on the regular happy-path process.)
