### PR TITLE
Otel Ensure that service name is correctly picked up from env

### DIFF
--- a/.changesets/fix_coupon_shotgun_ridge_bodyguard.md
+++ b/.changesets/fix_coupon_shotgun_ridge_bodyguard.md
@@ -1,0 +1,5 @@
+### Otel Ensure that service name is correctly picked up from env and resources ([Issue #3215](https://github.com/apollographql/router/issues/3215))
+
+`OTEL_SERVICE_NAME` env and `service.name` resource are now correctly used when creating tracing exporters.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3307

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -816,8 +816,10 @@ mod tests {
 
     #[test]
     fn test_service_name() {
-        let mut router_config = Trace::default();
-        router_config.service_name = "foo".to_string();
+        let router_config = Trace {
+            service_name: "foo".to_string(),
+            ..Default::default()
+        };
         let otel_config: Config = (&router_config).into();
         assert_eq!(
             Some(Value::String("foo".into())),

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -1,5 +1,6 @@
 //! Configuration for the telemetry plugin.
 use std::collections::BTreeMap;
+use std::env;
 
 use axum::headers::HeaderName;
 use opentelemetry::sdk::resource::EnvResourceDetector;
@@ -554,11 +555,9 @@ impl From<&Trace> for opentelemetry::sdk::trace::Config {
             ));
         }
 
-        // Take the env variables first, and then layer on the rest of the resources, last entry wins
-        let resource = EnvResourceDetector::default()
-            .detect(Duration::from_secs(0))
-            .merge(&Resource::new(resource_defaults))
-            .merge(&mut Resource::new(
+        // Take the default first, then config, then env resources, then env variable. Last entry wins
+        let resource = Resource::new(resource_defaults)
+            .merge(&Resource::new(
                 config
                     .attributes
                     .iter()
@@ -569,6 +568,18 @@ impl From<&Trace> for opentelemetry::sdk::trace::Config {
                         )
                     })
                     .collect::<Vec<KeyValue>>(),
+            ))
+            .merge(&EnvResourceDetector::new().detect(Duration::from_secs(0)))
+            .merge(&Resource::new(
+                env::var("OTEL_SERVICE_NAME")
+                    .ok()
+                    .map(|v| {
+                        vec![KeyValue::new(
+                            opentelemetry_semantic_conventions::resource::SERVICE_NAME,
+                            v,
+                        )]
+                    })
+                    .unwrap_or_default(),
             ));
 
         trace_config = trace_config.with_resource(resource);
@@ -644,6 +655,8 @@ impl Conf {
 
 #[cfg(test)]
 mod tests {
+    use opentelemetry::sdk::trace::Config;
+    use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
     use serde_json::json;
 
     use super::*;
@@ -799,5 +812,34 @@ mod tests {
         AttributeValue::try_from(json!([1, true])).expect_err("mixed conversion must fail");
         AttributeValue::try_from(json!([1.1, true])).expect_err("mixed conversion must fail");
         AttributeValue::try_from(json!([true, "bar"])).expect_err("mixed conversion must fail");
+    }
+
+    #[test]
+    fn test_service_name() {
+        let mut router_config = Trace::default();
+        router_config.service_name = "foo".to_string();
+        let otel_config: Config = (&router_config).into();
+        assert_eq!(
+            Some(Value::String("foo".into())),
+            otel_config.resource.get(SERVICE_NAME)
+        );
+
+        // Env should take precedence
+        env::set_var("OTEL_RESOURCE_ATTRIBUTES", "service.name=bar");
+        let otel_config: Config = (&router_config).into();
+        assert_eq!(
+            Some(Value::String("bar".into())),
+            otel_config.resource.get(SERVICE_NAME)
+        );
+
+        // Env should take precedence
+        env::set_var("OTEL_SERVICE_NAME", "bif");
+        let otel_config: Config = (&router_config).into();
+        assert_eq!(
+            Some(Value::String("bif".into())),
+            otel_config.resource.get(SERVICE_NAME)
+        );
+        env::remove_var("OTEL_SERVICE_NAME");
+        env::remove_var("OTEL_RESOURCE_ATTRIBUTES");
     }
 }

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -5,8 +5,9 @@ use std::collections::HashMap;
 use lazy_static::lazy_static;
 use opentelemetry::sdk::trace::BatchSpanProcessor;
 use opentelemetry::sdk::trace::Builder;
-use opentelemetry::Key;
 use opentelemetry::Value;
+use opentelemetry::{sdk, Key};
+use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
@@ -58,7 +59,7 @@ impl TracingConfigurator for Config {
             AgentEndpoint::Url(s) => Some(s),
         };
         let enable_span_mapping = self.enable_span_mapping.then_some(true);
-
+        let trace_config: sdk::trace::Config = trace_config.into();
         let exporter = opentelemetry_datadog::new_pipeline()
             .with(&url, |builder, e| {
                 builder.with_agent_endpoint(e.to_string().trim_end_matches('/'))
@@ -77,8 +78,15 @@ impl TracingConfigurator for Config {
                             .unwrap_or(span.name.as_ref())
                     })
             })
-            .with_service_name(trace_config.service_name.clone())
-            .with_trace_config(trace_config.into())
+            .with(
+                &trace_config.resource.get(SERVICE_NAME),
+                |builder, service_name| {
+                    // Datadog exporter incorrectly ignores the service name in the resource
+                    // Set it explicitly here
+                    builder.with_service_name(service_name.as_str())
+                },
+            )
+            .with_trace_config(trace_config)
             .build_exporter()?;
         Ok(builder.with_span_processor(
             BatchSpanProcessor::builder(exporter, opentelemetry::runtime::Tokio)

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -3,10 +3,11 @@
 use std::collections::HashMap;
 
 use lazy_static::lazy_static;
+use opentelemetry::sdk;
 use opentelemetry::sdk::trace::BatchSpanProcessor;
 use opentelemetry::sdk::trace::Builder;
+use opentelemetry::Key;
 use opentelemetry::Value;
-use opentelemetry::{sdk, Key};
 use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
 use schemars::JsonSchema;
 use serde::Deserialize;


### PR DESCRIPTION
OTEL_SERVICE_NAME env and service.name resource are now correctly used when creating tracing exporters.

This required two fixes:

- Datadog exporter should pick up the `service.name` resource rather than grabbing the service name directly from the config.
- Resource creation picks up service name in order of precedence:
  1. OTEL_SERVICE_NAME
  2. `service.name`
  3. config yaml

Fixes #3215

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
