### PR TITLE
breaking: all file paths must be valid UTF-8

### DIFF
--- a/.changesets/breaking_avery_camino.md
+++ b/.changesets/breaking_avery_camino.md
@@ -1,0 +1,5 @@
+### All file paths must be valid UTF-8
+
+All file paths defined in `router.yaml` configuration or via CLI options must be valid UTF-8. This may break your setup if you are storing router configuration files at file paths that are not valid UTF-8, otherwise behavior is not impacted. Restricting invalid UTF-8 paths makes working with file paths internally much easier as they can always be represented as proper strings as opposed to doing a lossy conversion every time a file path needs to be displayed.
+
+By [@EverlastingBugstopper](https://github.com/EverlastingBugstopper) in https://github.com/apollographql/router/pull/3314

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,6 +289,7 @@ dependencies = [
  "brotli",
  "buildstructor 0.5.3",
  "bytes",
+ "camino",
  "ci_info",
  "clap 4.3.3",
  "console-subscriber",
@@ -418,6 +419,7 @@ dependencies = [
  "apollo-router",
  "apollo-smith",
  "arbitrary",
+ "camino",
  "criterion",
  "memory-stats",
  "once_cell",
@@ -431,6 +433,7 @@ name = "apollo-router-scaffold"
 version = "1.22.0"
 dependencies = [
  "anyhow",
+ "camino",
  "cargo-scaffold",
  "clap 4.3.3",
  "copy_dir",
@@ -555,6 +558,7 @@ dependencies = [
  "anyhow",
  "apollo-router",
  "async-trait",
+ "camino",
  "http",
  "schemars",
  "serde",
@@ -928,6 +932,15 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
+]
+
+[[package]]
+name = "camino"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c530edf18f37068ac2d977409ed5cd50d53d73bc653c7647b48eb78976ac9ae2"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -21,6 +21,7 @@ tower = "0.4"
 apollo-smith = { version = "0.3.2", features = ["parser-impl"] }
 apollo-parser = "0.4.1"
 arbitrary = "1.3.0"
+camino = "1.1.4"
 
 [[bench]]
 name = "basic_composition"

--- a/apollo-router-benchmarks/build.rs
+++ b/apollo-router-benchmarks/build.rs
@@ -1,7 +1,9 @@
+use camino::Utf8PathBuf;
+
 const GENERATED_QUERIES_COUNT: usize = 100;
 
 fn main() {
-    let out_dir = std::path::PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
+    let out_dir = Utf8PathBuf::from(std::env::var("OUT_DIR").unwrap());
 
     // used by `benches/memory_use.rs`
     let queries_path = out_dir.join("queries.rs");

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.71"
+camino = "1.1.4"
 clap = { version = "4.3.3", features = ["derive"] }
 cargo-scaffold = { version = "0.8.9", default-features = false }
 regex = "1"

--- a/apollo-router-scaffold/src/plugin.rs
+++ b/apollo-router-scaffold/src/plugin.rs
@@ -1,8 +1,8 @@
 use std::fs;
-use std::path::Path;
-use std::path::PathBuf;
 
 use anyhow::Result;
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use cargo_scaffold::ScaffoldDescription;
 use clap::Subcommand;
 use inflector::Inflector;
@@ -18,7 +18,7 @@ pub enum PluginAction {
 
         /// Optional override of the scaffold template path.
         #[clap(long)]
-        template_override: Option<PathBuf>,
+        template_override: Option<Utf8PathBuf>,
     },
 
     /// Remove a plugin.
@@ -40,7 +40,7 @@ impl PluginAction {
     }
 }
 
-fn create_plugin(name: &str, template_path: &Option<PathBuf>) -> Result<()> {
+fn create_plugin(name: &str, template_path: &Option<Utf8PathBuf>) -> Result<()> {
     let plugin_path = plugin_path(name);
     if plugin_path.exists() {
         return Err(anyhow::anyhow!("plugin '{}' already exists", name));
@@ -57,12 +57,12 @@ fn create_plugin(name: &str, template_path: &Option<PathBuf>) -> Result<()> {
     let version = get_router_version(cargo_toml);
 
     let opts = cargo_scaffold::Opts::builder()
-        .template_path(template_path.as_ref().unwrap_or(&PathBuf::from(
+        .template_path(template_path.as_ref().unwrap_or(&Utf8PathBuf::from(
             "https://github.com/apollographql/router.git",
         )))
         .git_ref(version)
         .repository_template_path(
-            PathBuf::from("apollo-router-scaffold")
+            Utf8PathBuf::from("apollo-router-scaffold")
                 .join("templates")
                 .join("plugin"),
         )
@@ -117,7 +117,7 @@ fn create_plugin(name: &str, template_path: &Option<PathBuf>) -> Result<()> {
 
     println!(
         "Plugin created at '{}'.\nRemember to add the plugin to your router.yaml to activate it.",
-        plugin_path.display()
+        plugin_path
     );
     Ok(())
 }
@@ -153,7 +153,7 @@ fn remove_plugin(name: &str) -> Result<()> {
 
     // Remove the mod;
     let mod_path = mod_path();
-    if Path::new(&mod_path).exists() {
+    if Utf8Path::new(&mod_path).exists() {
         let mut mod_rs = std::fs::read_to_string(&mod_path)?;
         let re = Regex::new(&format!(r"(?m)^mod {snake_name};$")).unwrap();
         mod_rs = re.replace(&mod_rs, "").to_string();
@@ -163,17 +163,17 @@ fn remove_plugin(name: &str) -> Result<()> {
 
     println!(
         "Plugin removed at '{}'. This is a best effort, and you may need to edit some files manually.",
-        plugin_path.display()
+        plugin_path
     );
     Ok(())
 }
 
-fn mod_path() -> PathBuf {
-    PathBuf::from("src").join("plugins").join("mod.rs")
+fn mod_path() -> Utf8PathBuf {
+    Utf8PathBuf::from("src").join("plugins").join("mod.rs")
 }
 
-fn plugin_path(name: &str) -> PathBuf {
-    PathBuf::from("src")
+fn plugin_path(name: &str) -> Utf8PathBuf {
+    Utf8PathBuf::from("src")
         .join("plugins")
         .join(format!("{}.rs", name.to_snake_case()))
 }

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -70,6 +70,7 @@ backtrace = "0.3.67"
 base64 = "0.20.0"
 buildstructor = "0.5.3"
 bytes = "1.4.0"
+camino = { version = "1.1.4", features = ["serde1"] }
 clap = { version = "4.3.3", default-features = false, features = [
     "env",
     "derive",
@@ -276,6 +277,7 @@ rstack = { version = "0.3.3", features = ["dw"], default-features = false }
 
 
 [build-dependencies]
+camino = "1.1.4"
 tonic-build = "0.8.4"
 
 

--- a/apollo-router/build/studio.rs
+++ b/apollo-router/build/studio.rs
@@ -1,9 +1,10 @@
 use std::error::Error;
-use std::path::PathBuf;
+
+use camino::Utf8PathBuf;
 
 pub fn main() -> Result<(), Box<dyn Error>> {
-    let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").unwrap());
-    let src = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap()).join("src");
+    let out_dir = Utf8PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let src = Utf8PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("src");
     let proto_dir = src.join("plugins").join("telemetry").join("proto");
     let reports_src = proto_dir.join("reports.proto");
     let reports_out = out_dir.join("reports.proto");
@@ -22,7 +23,7 @@ pub fn main() -> Result<(), Box<dyn Error>> {
     content = content.replace("[(js_preEncoded) = true]", "");
     std::fs::write(&reports_out, &content)?;
 
-    println!("cargo:rerun-if-changed={}", reports_src.to_str().unwrap());
+    println!("cargo:rerun-if-changed={}", reports_src);
 
     // Process the proto files
 

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -16,6 +16,7 @@ use std::iter;
 use std::net::IpAddr;
 use std::net::SocketAddr;
 use std::num::NonZeroUsize;
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 #[cfg(not(test))]
@@ -1089,7 +1090,7 @@ pub enum ListenAddr {
     SocketAddr(SocketAddr),
     /// Unix socket.
     #[cfg(unix)]
-    UnixSocket(std::path::PathBuf),
+    UnixSocket(PathBuf),
 }
 
 impl ListenAddr {

--- a/apollo-router/src/configuration/tests.rs
+++ b/apollo-router/src/configuration/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
 
+use camino::Utf8PathBuf;
 use http::Uri;
 #[cfg(unix)]
 use insta::assert_json_snapshot;
@@ -583,7 +583,7 @@ supergraph:
 
 #[test]
 fn expansion_from_file() {
-    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut path = Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push("src");
     path.push("configuration");
     path.push("testdata");
@@ -594,7 +594,7 @@ fn expansion_from_file() {
 supergraph:
   introspection: ${{file.{}}}
         "#,
-            path.to_string_lossy()
+            path
         ),
         Expansion::builder().supported_mode("file").build(),
         Mode::NoUpgrade,
@@ -736,19 +736,19 @@ fn test_configuration_validate_and_sanitize() {
 
 #[test]
 fn load_tls() {
-    let mut cert_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut cert_path = Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     cert_path.push("src");
     cert_path.push("configuration");
     cert_path.push("testdata");
     cert_path.push("server.crt");
-    let cert_path = cert_path.to_string_lossy();
+    let cert_path = cert_path.to_string();
 
-    let mut key_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut key_path = Utf8PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     key_path.push("src");
     key_path.push("configuration");
     key_path.push("testdata");
     key_path.push("server.key");
-    let key_path = key_path.to_string_lossy();
+    let key_path = key_path.to_string();
 
     let cfg = validate_yaml_configuration(
         &format!(

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::path::Path;
 
+use camino::Utf8Path;
 use jsonwebtoken::encode;
 use jsonwebtoken::get_current_timestamp;
 use jsonwebtoken::jwk::CommonParameters;
@@ -20,7 +20,7 @@ use crate::plugin::test;
 use crate::services::supergraph;
 
 fn create_an_url(filename: &str) -> String {
-    let jwks_base = Path::new("tests");
+    let jwks_base = Utf8Path::new("tests");
 
     let jwks_path = jwks_base.join("fixtures").join(filename);
 

--- a/apollo-router/src/plugins/rhai/engine.rs
+++ b/apollo-router/src/plugins/rhai/engine.rs
@@ -1,9 +1,9 @@
-use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::SystemTime;
 
+use camino::Utf8PathBuf;
 use http::header::InvalidHeaderName;
 use http::uri::Authority;
 use http::uri::Parts;
@@ -1076,7 +1076,11 @@ impl Rhai {
         Ok(())
     }
 
-    pub(super) fn new_rhai_engine(path: Option<PathBuf>, sdl: String, main: PathBuf) -> Engine {
+    pub(super) fn new_rhai_engine(
+        path: Option<Utf8PathBuf>,
+        sdl: String,
+        main: Utf8PathBuf,
+    ) -> Engine {
         let mut engine = Engine::new();
         // If we pass in a path, use it to configure our engine
         // with a FileModuleResolver which allows import to work
@@ -1095,7 +1099,7 @@ impl Rhai {
         let base64_module = exported_module!(router_base64);
 
         // Share main so we can move copies into each closure as required for logging
-        let shared_main = Arc::new(main.display().to_string());
+        let shared_main = Arc::new(main.to_string());
 
         let trace_main = shared_main.clone();
         let debug_main = shared_main.clone();

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -18,12 +18,12 @@ use uuid::Uuid;
 
 use super::process_error;
 use super::subgraph;
-use super::PathBuf;
 use super::Rhai;
 use super::RhaiExecutionDeferredResponse;
 use super::RhaiExecutionResponse;
 use super::RhaiSupergraphDeferredResponse;
 use super::RhaiSupergraphResponse;
+use super::Utf8PathBuf;
 use crate::graphql::Error;
 use crate::graphql::Request;
 use crate::http_ext;
@@ -155,7 +155,7 @@ async fn rhai_plugin_execution_service_error() -> Result<(), BoxError> {
 // A Rhai engine suitable for minimal testing. There are no scripts and the SDL is an empty
 // string.
 fn new_rhai_test_engine() -> Engine {
-    Rhai::new_rhai_engine(None, "".to_string(), PathBuf::new())
+    Rhai::new_rhai_engine(None, "".to_string(), Utf8PathBuf::new())
 }
 
 // Some of these tests rely extensively on internal implementation details of the tracing_test crate.

--- a/apollo-router/src/router/event/configuration.rs
+++ b/apollo-router/src/router/event/configuration.rs
@@ -1,8 +1,8 @@
-use std::path::Path;
-use std::path::PathBuf;
 use std::pin::Pin;
 use std::time::Duration;
 
+use camino::Utf8Path;
+use camino::Utf8PathBuf;
 use derivative::Derivative;
 use derive_more::Display;
 use derive_more::From;
@@ -37,7 +37,7 @@ pub enum ConfigurationSource {
     #[display(fmt = "File")]
     File {
         /// The path of the configuration file.
-        path: PathBuf,
+        path: Utf8PathBuf,
 
         /// `true` to watch the file for changes and hot apply them.
         watch: bool,
@@ -71,10 +71,7 @@ impl ConfigurationSource {
             } => {
                 // Sanity check, does the config file exists, if it doesn't then bail.
                 if !path.exists() {
-                    tracing::error!(
-                        "configuration file at path '{}' does not exist.",
-                        path.to_string_lossy()
-                    );
+                    tracing::error!("configuration file at path '{}' does not exist.", path);
                     stream::empty().boxed()
                 } else {
                     match ConfigurationSource::read_config(&path) {
@@ -115,11 +112,11 @@ impl ConfigurationSource {
         .boxed()
     }
 
-    fn read_config(path: &Path) -> Result<Configuration, ReadConfigError> {
+    fn read_config(path: &Utf8Path) -> Result<Configuration, ReadConfigError> {
         let config = std::fs::read_to_string(path)?;
         config.parse().map_err(ReadConfigError::Validation)
     }
-    async fn read_config_async(path: &Path) -> Result<Configuration, ReadConfigError> {
+    async fn read_config_async(path: &Utf8Path) -> Result<Configuration, ReadConfigError> {
         let config = tokio::fs::read_to_string(path).await?;
         config.parse().map_err(ReadConfigError::Validation)
     }
@@ -178,7 +175,9 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn config_by_file_missing() {
         let mut stream = ConfigurationSource::File {
-            path: temp_dir().join("does_not_exit"),
+            path: Utf8PathBuf::try_from(temp_dir())
+                .expect("temp dir not valid UTF-8")
+                .join("does_not_exit"),
             watch: true,
             delay: None,
         }

--- a/apollo-router/src/router/event/license.rs
+++ b/apollo-router/src/router/event/license.rs
@@ -1,8 +1,8 @@
-use std::path::PathBuf;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::time::Duration;
 
+use camino::Utf8PathBuf;
 use derivative::Derivative;
 use derive_more::Display;
 use derive_more::From;
@@ -41,7 +41,7 @@ pub enum LicenseSource {
     #[display(fmt = "File")]
     File {
         /// The path of the license file.
-        path: PathBuf,
+        path: Utf8PathBuf,
 
         /// `true` to watch the file for changes and hot apply them.
         watch: bool,
@@ -84,10 +84,7 @@ impl LicenseSource {
             LicenseSource::File { path, watch } => {
                 // Sanity check, does the schema file exists, if it doesn't then bail.
                 if !path.exists() {
-                    tracing::error!(
-                        "License file at path '{}' does not exist.",
-                        path.to_string_lossy()
-                    );
+                    tracing::error!("License file at path '{}' does not exist.", path);
                     stream::empty().boxed()
                 } else {
                     // The license file exists try and load it

--- a/apollo-router/src/router/event/schema.rs
+++ b/apollo-router/src/router/event/schema.rs
@@ -1,7 +1,7 @@
-use std::path::PathBuf;
 use std::pin::Pin;
 use std::time::Duration;
 
+use camino::Utf8PathBuf;
 use derivative::Derivative;
 use derive_more::Display;
 use derive_more::From;
@@ -34,7 +34,7 @@ pub enum SchemaSource {
     #[display(fmt = "File")]
     File {
         /// The path of the schema file.
-        path: PathBuf,
+        path: Utf8PathBuf,
 
         /// `true` to watch the file for changes and hot apply them.
         watch: bool,
@@ -89,10 +89,7 @@ impl SchemaSource {
             } => {
                 // Sanity check, does the schema file exists, if it doesn't then bail.
                 if !path.exists() {
-                    tracing::error!(
-                        "Schema file at path '{}' does not exist.",
-                        path.to_string_lossy()
-                    );
+                    tracing::error!("Schema file at path '{}' does not exist.", path);
                     stream::empty().boxed()
                 } else {
                     //The schema file exists try and load it
@@ -204,7 +201,9 @@ mod tests {
     #[test(tokio::test)]
     async fn schema_by_file_missing() {
         let mut stream = SchemaSource::File {
-            path: temp_dir().join("does_not_exist"),
+            path: Utf8PathBuf::try_from(temp_dir())
+                .expect("temp dir is not valid UTF-8")
+                .join("does_not_exist"),
             watch: true,
             delay: None,
         }

--- a/apollo-router/tests/docs.rs
+++ b/apollo-router/tests/docs.rs
@@ -1,8 +1,7 @@
 #[test]
 #[cfg(target_family = "unix")]
 fn check_config_json() {
-    use std::path::Path;
-
+    use camino::Utf8Path;
     use regex::Regex;
     use serde_json::Value;
 
@@ -20,7 +19,7 @@ fn check_config_json() {
                 );
                 if path != "/" {
                     let path_in_docs = format!("../docs/source{path}.mdx");
-                    let path_in_docs = Path::new(&path_in_docs);
+                    let path_in_docs = Utf8Path::new(&path_in_docs);
                     assert!(
                         path_in_docs.exists(),
                         "{path} in docs/source/config.json did not exist"

--- a/examples/async-auth/rust/Cargo.toml
+++ b/examples/async-auth/rust/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 anyhow = "1"
 apollo-router = { path = "../../../apollo-router" }
 async-trait = "0.1"
+camino = "1.1.4"
 http = "0.2"
 schemars = { version = "0.8", features = ["url"] }
 serde = "1"

--- a/examples/async-auth/rust/src/allow_client_id_from_file.rs
+++ b/examples/async-auth/rust/src/allow_client_id_from_file.rs
@@ -1,5 +1,4 @@
 use std::ops::ControlFlow;
-use std::path::PathBuf;
 
 use apollo_router::graphql;
 use apollo_router::layers::ServiceBuilderExt;
@@ -7,6 +6,7 @@ use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
 use apollo_router::services::supergraph;
+use camino::Utf8PathBuf;
 use http::StatusCode;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -24,7 +24,7 @@ struct AllowClientIdConfig {
 
 struct AllowClientIdFromFile {
     header: String,
-    allowed_ids_path: PathBuf,
+    allowed_ids_path: Utf8PathBuf,
 }
 
 #[async_trait::async_trait]
@@ -33,7 +33,7 @@ impl Plugin for AllowClientIdFromFile {
 
     async fn new(init: PluginInit<Self::Config>) -> Result<Self, BoxError> {
         let AllowClientIdConfig { path, header } = init.config;
-        let allowed_ids_path = PathBuf::from(path.as_str());
+        let allowed_ids_path = Utf8PathBuf::from(path.as_str());
         Ok(Self {
             allowed_ids_path,
             header,

--- a/xtask/src/commands/package/macos.rs
+++ b/xtask/src/commands/package/macos.rs
@@ -1,5 +1,4 @@
 use std::io::Write as _;
-use std::path::Path;
 use std::process::Command;
 use std::process::Stdio;
 
@@ -7,6 +6,7 @@ use anyhow::bail;
 use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
+use camino::Utf8Path;
 use serde_json_traversal::serde_json_traversal;
 use xtask::*;
 
@@ -44,7 +44,7 @@ pub struct PackageMacos {
 }
 
 impl PackageMacos {
-    pub fn run(&self, release_path: impl AsRef<Path>) -> Result<()> {
+    pub fn run(&self, release_path: impl AsRef<Utf8Path>) -> Result<()> {
         let release_path = release_path.as_ref();
         let temp = tempfile::tempdir().context("could not create temporary directory")?;
 
@@ -195,9 +195,9 @@ impl PackageMacos {
         let options = zip::write::FileOptions::default()
             .compression_method(zip::CompressionMethod::Stored)
             .unix_permissions(0o755);
-        let path = Path::new("dist").join(RELEASE_BIN);
-        eprintln!("Adding {} as {}...", release_path.display(), path.display());
-        zip.start_file(path.to_str().unwrap(), options)?;
+        let path = Utf8Path::new("dist").join(RELEASE_BIN);
+        eprintln!("Adding {} as {}...", release_path, path);
+        zip.start_file(path, options)?;
         std::io::copy(
             &mut std::io::BufReader::new(
                 std::fs::File::open(release_path).context("could not open file")?,

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -2,12 +2,12 @@
 mod macos;
 
 use std::fmt;
-use std::path::Path;
 use std::str::FromStr;
 
 use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
+use camino::Utf8Path;
 use camino::Utf8PathBuf;
 use xtask::*;
 
@@ -70,7 +70,7 @@ impl Package {
         let mut ar = tar::Builder::new(&mut file);
         eprintln!("Adding {release_path}...");
         ar.append_file(
-            Path::new("dist").join(RELEASE_BIN),
+            Utf8Path::new("dist").join(RELEASE_BIN),
             &mut std::fs::File::open(release_path).context("could not open binary")?,
         )
         .context("could not add file to TGZ archive")?;
@@ -78,7 +78,7 @@ impl Package {
         for path in INCLUDE {
             eprintln!("Adding {path}...");
             ar.append_file(
-                Path::new("dist").join(path),
+                Utf8Path::new("dist").join(path),
                 &mut std::fs::File::open(PKG_PROJECT_ROOT.join(path))
                     .context("could not open binary")?,
             )


### PR DESCRIPTION
!! BREAKING !!

All file paths defined in `router.yaml` configuration or via CLI options must be valid UTF-8. This may break your setup if you are storing router configuration files at file paths that are not valid UTF-8, otherwise behavior is not impacted. Restricting invalid UTF-8 paths makes working with file paths internally much easier as they can always be represented as proper strings as opposed to doing a lossy conversion every time a file path needs to be displayed.

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
