### PR TITLE
Update example for claim forwarding

### DIFF
--- a/.changesets/docs_chop_schoolteacher_bandage_limousine.md
+++ b/.changesets/docs_chop_schoolteacher_bandage_limousine.md
@@ -1,0 +1,10 @@
+### Update example for claim forwarding ([Issue #3224](https://github.com/apollographql/router/issues/3224))
+
+The JWT claim example that we had in our docs was insecure as it iterated over the list of claims and set them as headers.
+A malicious user could have provided a valid JWT that was missing claims and then set those claims as headers.
+This would only have affected users who had configured their routers to forward all headers from the client to subgraphs.
+
+The documentation has been updated to explicitly list the claims that are forwarded to the subgraph.
+In addition, a new example has been added that uses extensions to forward claims.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3319

--- a/docs/source/configuration/authn-jwt.mdx
+++ b/docs/source/configuration/authn-jwt.mdx
@@ -154,7 +154,7 @@ Because claims are added to the context, you can define custom logic for handlin
 
 Below are 2 example [Rhai script](../customizations/rhai/) customizations that demonstrate actions the router can perform based on a request's claims.
 
-### Example: Forwarding claims to subgraphs
+### Example: Forwarding claims to subgraphs as headers
 
 Below is an example [Rhai script](../customizations/rhai/) that forwards a JWT's claims to individual subgraphs via HTTP headers (one header for each claim). This enables each subgraph to define logic to handle (or potentially reject) incoming requests based on claim details. This function should be imported and run in your [`main.rhai`](#example-mainrhai) file.
 
@@ -170,10 +170,36 @@ fn process_request(request) {
         status: 401
       };
     }
-    // Add each claim key-value pair as a separate HTTP header
-    for key in claims.keys() {
-      request.subgraph.headers[key] = claims[key].to_string();
+    // Add each claim key-value pair as a separate HTTP header.
+    // Note that that claims that are not present in the JWT will be added as empty strings.
+    let claim_names = ["claim_1", "claim_2", "claim_3"];
+    for claim_name in claim_names {
+      let claim = claims[claim_name];
+      claim = if claim == () {""} else {claim};
+      request.subgraph.headers[claim_name] = claim;
     }
+}
+```
+
+</ExpansionPanel>
+
+### Example: Forwarding claims to subgraphs as GraphQL extensions
+
+Below is an example [Rhai script](../customizations/rhai/) that forwards a JWT's claims to individual subgraphs via GraphQL extension. This enables each subgraph to define logic to handle (or potentially reject) incoming requests based on claim details. This function should be imported and run in your [`main.rhai`](#example-mainrhai) file.
+
+> This script should be run in the router's `SubgraphService`, which executes before the router sends a subquery to an individual subgraph. [Learn more about router services.](../customizations/rhai#router-request-lifecycle)
+
+<ExpansionPanel title="Click to expand">
+
+```rhai title="claims_forwarding.rhai"
+fn process_request(request) {
+    let claims = request.context[Router.APOLLO_AUTHENTICATION_JWT_CLAIMS];
+    if claims ==() {
+      throw #{
+        status: 401
+      };
+    }
+    request.subgraph.extensions["claims"] = claims;
 }
 ```
 


### PR DESCRIPTION
The JWT claim example that we had in our docs was insecure as it iterated over the list of claims and set them as headers.
A malicious user could have provided a valid JWT that was missing claims and then set those claims as headers.
This would only have affected users who had configured their routers to forward all headers from the client to subgraphs.

The documentation has been updated to explicitly list the claims that are forwarded to the subgraph.
In addition, a new example has been added that uses extensions to forward claims.
Fixes #3224

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
