### PR TITLE
chore: updates 'altool' to 'notarytool' for macos codesigning

### DIFF
--- a/.changesets/maint_avery_update_macos_notarizer.md
+++ b/.changesets/maint_avery_update_macos_notarizer.md
@@ -1,0 +1,3 @@
+### chore: updates `altool` to `notarytool` for MacOS codesigning ([Issue #3275](https://github.com/apollographql/router/issues/3275))
+
+By [@EverlastingBugstopper](https://github.com/EverlastingBugstopper) in https://github.com/apollographql/router/pull/3334

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -506,7 +506,6 @@ jobs:
       RELEASE_BIN: router
       APPLE_TEAM_ID: "YQK948L752"
       APPLE_USERNAME: "opensource@apollographql.com"
-      MACOS_PRIMARY_BUNDLE_ID: com.apollographql.router
     steps:
       - checkout
       - setup_environment:
@@ -535,7 +534,6 @@ jobs:
                   --cert-bundle-password ${MACOS_CERT_BUNDLE_PASSWORD}
                   --keychain-password ${MACOS_KEYCHAIN_PASSWORD}
                   --notarization-password ${MACOS_NOTARIZATION_PASSWORD}
-                  --primary-bundle-id ${MACOS_PRIMARY_BUNDLE_ID}
                   --output artifacts/
       - when:
           condition:

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -4,7 +4,6 @@ use std::time::Instant;
 
 use futures::Stream;
 use graphql_client::QueryBody;
-use once_cell::sync::Lazy;
 use thiserror::Error;
 use tokio::sync::mpsc::channel;
 use tokio_stream::wrappers::ReceiverStream;

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -4,6 +4,7 @@ use std::time::Instant;
 
 use futures::Stream;
 use graphql_client::QueryBody;
+use once_cell::sync::Lazy;
 use thiserror::Error;
 use tokio::sync::mpsc::channel;
 use tokio_stream::wrappers::ReceiverStream;
@@ -322,8 +323,7 @@ async fn http_request<Query>(
 where
     Query: graphql_client::GraphQLQuery,
 {
-    let client = reqwest::Client::builder().timeout(timeout).build()?;
-    let res = client.post(url).json(request_body).send().await?;
+    let res = UPLINK_CLIENT.post(url).json(request_body).send().await?;
     tracing::debug!("uplink response {:?}", res);
     let response_body: graphql_client::Response<Query::ResponseData> = res.json().await?;
     Ok(response_body)

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -323,7 +323,8 @@ async fn http_request<Query>(
 where
     Query: graphql_client::GraphQLQuery,
 {
-    let res = UPLINK_CLIENT.post(url).json(request_body).send().await?;
+    let client = reqwest::Client::builder().timeout(timeout).build()?;
+    let res = client.post(url).json(request_body).send().await?;
     tracing::debug!("uplink response {:?}", res);
     let response_body: graphql_client::Response<Query::ResponseData> = res.json().await?;
     Ok(response_body)

--- a/xtask/src/commands/package/macos.rs
+++ b/xtask/src/commands/package/macos.rs
@@ -24,10 +24,6 @@ pub struct PackageMacos {
     #[clap(long)]
     cert_bundle_password: String,
 
-    /// Primary bundle ID.
-    #[clap(long)]
-    primary_bundle_id: String,
-
     /// Apple team ID.
     #[clap(long)]
     apple_team_id: String,

--- a/xtask/src/commands/package/macos.rs
+++ b/xtask/src/commands/package/macos.rs
@@ -208,80 +208,27 @@ impl PackageMacos {
 
         eprintln!("Beginning notarization process...");
         let output = Command::new("xcrun")
-            .args(["altool", "--notarize-app", "--primary-bundle-id"])
-            .arg(&self.primary_bundle_id)
-            .arg("--username")
-            .arg(&self.apple_username)
-            .arg("--password")
-            .arg(&self.notarization_password)
-            .arg("--asc-provider")
-            .arg(&self.apple_team_id)
-            .arg("--file")
-            .arg(&dist_zip)
-            .args(["--output-format", "json"])
+            .args([
+                "notarytool",
+                "submit",
+                dist_zip,
+                "--apple-id",
+                &self.apple_username,
+                "--team-id",
+                &self.apple_team_id,
+                "--password",
+                &self.notarization_password,
+                "--wait",
+                "--timeout",
+                "20m",
+            ])
             .stderr(Stdio::inherit())
             .output()
             .context("could not start command xcrun")?;
         let _ = std::io::stdout().write(&output.stdout);
         ensure!(output.status.success(), "command exited with error",);
-        let json: serde_json::Value =
-            serde_json::from_slice(&output.stdout).context("could not parse json output")?;
-        let success_message = serde_json_traversal!(json => success-message)
-            .unwrap()
-            .as_str()
-            .unwrap();
-        let request_uuid = serde_json_traversal!(json => notarization-upload => RequestUUID)
-            .unwrap()
-            .as_str()
-            .unwrap();
-        eprintln!("Success message: {success_message}");
-        eprintln!("Request UUID: {request_uuid}");
 
-        let start_time = std::time::Instant::now();
-        let duration = std::time::Duration::from_secs(60 * 5);
-        let result = loop {
-            eprintln!("Checking notarization status...");
-            let output = Command::new("xcrun")
-                .args(["altool", "--notarization-info"])
-                .arg(request_uuid)
-                .arg("--username")
-                .arg(&self.apple_username)
-                .arg("--password")
-                .arg(&self.notarization_password)
-                .args(["--output-format", "json"])
-                .stderr(Stdio::inherit())
-                .output()
-                .context("could not start command xcrun")?;
-
-            let status = if !output.status.success() {
-                // NOTE: if the exit status is failure we need to keep trying otherwise the
-                //       process becomes a bit flaky
-                eprintln!("command exited with error");
-                None
-            } else {
-                let json: serde_json::Value = serde_json::from_slice(&output.stdout)
-                    .context("could not parse json output")?;
-                serde_json_traversal!(json => notarization-info => Status)
-                    .ok()
-                    .and_then(|x| x.as_str())
-                    .map(|x| x.to_string())
-            };
-
-            if !matches!(
-                status.as_deref(),
-                Some("in progress") | None if start_time.elapsed() < duration
-            ) {
-                break status;
-            }
-
-            std::thread::sleep(std::time::Duration::from_secs(5));
-        };
-        match result.as_deref() {
-            Some("success") => eprintln!("Notarization successful"),
-            Some("in progress") => bail!("Notarization timeout"),
-            Some(other) => bail!("Notarization failed: {}", other),
-            None => bail!("Notarization failed without status message"),
-        }
+        eprintln!("Notarization successful");
 
         Ok(())
     }

--- a/xtask/src/commands/package/macos.rs
+++ b/xtask/src/commands/package/macos.rs
@@ -3,11 +3,9 @@ use std::path::Path;
 use std::process::Command;
 use std::process::Stdio;
 
-use anyhow::bail;
 use anyhow::ensure;
 use anyhow::Context;
 use anyhow::Result;
-use serde_json_traversal::serde_json_traversal;
 use xtask::*;
 
 const ENTITLEMENTS: &str = "macos-entitlements.plist";
@@ -205,6 +203,10 @@ impl PackageMacos {
             &mut zip,
         )?;
         zip.finish()?;
+
+        let dist_zip = dist_zip
+            .to_str()
+            .unwrap_or_else(|| panic!("'{} is not valid UTF-8", dist_zip.display()));
 
         eprintln!("Beginning notarization process...");
         let output = Command::new("xcrun")


### PR DESCRIPTION
Updates `altool` to `notarytool` for MacOS codesigning

Fixes #3275

prior art: 

https://github.com/apollographql/federation-rs/pull/370
https://github.com/apollographql/rover/pull/1658

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

- No docs need updating, implementation detail.
- Performance impact measurement not necessary, code changes are to `xtask`.
- [x] Testing included cutting a `nightly` to ensure it worked, which it was: https://app.circleci.com/pipelines/github/apollographql/router/13325/workflows/e47ad4b3-8358-4742-9ce5-c313783576b8

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
