### PR TITLE
Enable serde_json float_roundtrip feature

### DIFF
--- a/.changesets/fix_garypen_2951_float.md
+++ b/.changesets/fix_garypen_2951_float.md
@@ -1,0 +1,11 @@
+### Enable serde_json float_roundtrip feature ([Issue #2951](https://github.com/apollographql/router/issues/2951))
+
+This feature is explicitly designed to:
+
+"""
+Use sufficient precision when parsing fixed precision floats from JSON to ensure that they maintain accuracy when round-tripped through JSON. This comes at an approximately 2x performance cost for parsing floats compared to the default best-effort precision.
+"""
+
+Despite the performance impact for floats, we need the fix in order to prevent float values losing precision when processed by the router.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3338

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -13,7 +13,7 @@ apollo-router = { path = "../apollo-router" }
 criterion = { version = "0.4", features = ["async_tokio", "async_futures"] }
 memory-stats = "1.1.0"
 once_cell = "1"
-serde_json = { version = "1", features = ["preserve_order"] }
+serde_json = { version = "1", features = ["preserve_order", "float_roundtrip"] }
 tokio = { version = "1", features = ["full"] }
 tower = "0.4"
 

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -180,7 +180,7 @@ shellexpand = "3.1.0"
 sha2 = "0.10.7"
 serde = { version = "1.0.164", features = ["derive", "rc"] }
 serde_json_bytes = { version = "0.2.1", features = ["preserve_order"] }
-serde_json = { version = "1.0.99", features = ["preserve_order"] }
+serde_json = { version = "1.0.99", features = ["preserve_order", "float_roundtrip"] }
 serde_urlencoded = "0.7.1"
 serde_yaml = "0.8.26"
 static_assertions = "1.1.0"


### PR DESCRIPTION
This feature is explicitly designed to:

"""
Use sufficient precision when parsing fixed precision floats from JSON to ensure that they maintain accuracy when round-tripped through JSON. This comes at an approximately 2x performance cost for parsing floats compared to the default best-effort precision.
"""

Despite the performance impact for floats, we need the fix in order to prevent float values losing precision when processed by the router.

fixes: #2951

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

The manual testing was performed as described in the issue: #2951 

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
