### PR TITLE
fix response formatting with defer and query filtering

### DIFF
--- a/.changesets/fix_geal_defer_label.md
+++ b/.changesets/fix_geal_defer_label.md
@@ -1,6 +1,6 @@
-### Fix deferred response formatting when filtering queries ([PR #3298](https://github.com/apollographql/router/pull/3298))
+### Fix deferred response formatting when filtering queries ([PR #3298](https://github.com/apollographql/router/pull/3298), [PR #3339](https://github.com/apollographql/router/pull/3339))
 
 Filtering queries requires two levels of response formatting, and its implementation shone light on issues with deferred responses. The response formatting side needs to recognize which deferred fragment generated it, and the deferred response shapes can change depending on request variables, due to the `@defer` directive's `if` argument. So far the response formatting code was not handling those variables.
 For now, this is solved by generating the response shapes for primary and deferred responses, for each combination of the variables used in `@defer` applications, limited to 32 unique variables. There will be follow up work with another approach that removes this limitation, but it will require a lot of deep changes in response formatting, so it will have to land a bit later.
 
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3298
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3298 and https://github.com/apollographql/router/pull/3339

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -170,7 +170,7 @@ impl BridgeQueryPlanner {
             .into();
         let (fragments, operations) =
             Query::extract_query_information(&compiler_guard, file_id, &self.schema)?;
-        let (subselections, defer_variables_set) =
+        let (subselections, defer_variables_set, always_defer) =
             crate::spec::query::subselections::collect_subselections(
                 &self.configuration,
                 &self.schema,
@@ -190,6 +190,7 @@ impl BridgeQueryPlanner {
             added_labels,
             defer_variables_set,
             is_original: true,
+            always_defer,
         })
     }
 

--- a/apollo-router/src/services/execution_service.rs
+++ b/apollo-router/src/services/execution_service.rs
@@ -174,7 +174,6 @@ impl Service<ExecutionRequest> for ExecutionService {
                             paths = filtered_query.format_response(
                                 &mut response,
                                 operation_name.as_deref(),
-                                is_deferred,
                                 variables.clone(),
                                 schema.api_schema(),
                                 variables_set
@@ -184,9 +183,9 @@ impl Service<ExecutionRequest> for ExecutionService {
                         paths.extend(query.format_response(
                             &mut response,
                             operation_name.as_deref(),
-                            is_deferred,
                             variables.clone(),
-                            schema.api_schema(), variables_set
+                            schema.api_schema(),
+                            variables_set
                         ).into_iter());
                         nullified_paths.extend(paths.into_iter());
                     });

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -28,7 +28,6 @@ struct FormatTest {
     expected_errors: Option<serde_json_bytes::Value>,
     expected_extensions: Option<serde_json_bytes::Value>,
     federation_version: FederationVersion,
-    is_deferred: bool,
 }
 
 #[derive(Default)]
@@ -83,12 +82,6 @@ impl FormatTest {
         self
     }
 
-    #[allow(unused)]
-    fn deferred(mut self) -> Self {
-        self.is_deferred = true;
-        self
-    }
-
     #[track_caller]
     fn test(self) {
         let schema = self.schema.expect("missing schema");
@@ -111,7 +104,6 @@ impl FormatTest {
         query.format_response(
             &mut response,
             self.operation,
-            self.is_deferred,
             self.variables
                 .unwrap_or_else(|| Value::Object(Object::default()))
                 .as_object()
@@ -4781,14 +4773,7 @@ fn fragment_on_interface_on_query() {
         }})
         .build();
 
-    query.format_response(
-        &mut response,
-        None,
-        false,
-        Default::default(),
-        api_schema,
-        0,
-    );
+    query.format_response(&mut response, None, Default::default(), api_schema, 0);
     assert_eq_and_ordered!(
         response.data.as_ref().unwrap(),
         &json! {{


### PR DESCRIPTION
Fix #3337

With a query contains a deferred fragment, and that deferred fragment containing a non nullable field, like this one:

```graphql
{
  a {
    b
    ... @defer {
      c
    }
  }
}
```

If the filter removes that non nullable `c` field, then the filtered query has this shape:

```graphql
{
  a {
    b
  }
}
```

Which will not be deferred, so only one response will be sent, without multipart. This is fine, because the server can decide if something must be deferred or not.

But this was triggering issues in response formatting, because response formatting for the original query was working from the original query, with the fragment, but ignoring the `@defer` directive.

Which means that if the response ends up being like this after the filtered query's formatting:

```json
{
  "a": {
    "b": 1,
  }
}
```

It was then formatted according to this shape:

```graphql
{
  a {
    b
    ... {
      c
    }
  }
}
```

which means that ullifying `c`c would propagate to nullifying `a` and result in:

```json
{
  "a": null
}
```

To fix this, we look at the deferred status, not from what the query planner reports, but from what each of the original or filtered query would consider deferred, depending on the presence of fragments with `@defer`, and the activated variables

*Description here*

Fixes #issue_number

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
