### PR TITLE
use a Drop guard to track active requests

### DIFF
--- a/.changesets/maint_geal_busy_timer_guard.md
+++ b/.changesets/maint_geal_busy_timer_guard.md
@@ -1,0 +1,5 @@
+### use a Drop guard to track active requests ([PR #3343](https://github.com/apollographql/router/pull/3343))
+
+manually tracking active requests is error prone because we might return early without decrementing the active requests. To make sure this is done properly, `enter_active_request` now returns a guard struct, that will decrement the count on drop
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3343

--- a/apollo-router/src/context/mod.rs
+++ b/apollo-router/src/context/mod.rs
@@ -205,13 +205,11 @@ impl Context {
     }
 
     /// Notify the busy timer that we're waiting on a network request
-    pub(crate) fn enter_active_request(&self) {
-        self.busy_timer.lock().increment_active_requests()
-    }
-
-    /// Notify the busy timer that we stopped waiting on a network request
-    pub(crate) fn leave_active_request(&self) {
-        self.busy_timer.lock().decrement_active_requests()
+    pub(crate) fn enter_active_request(&self) -> BusyTimerGuard {
+        self.busy_timer.lock().increment_active_requests();
+        BusyTimerGuard {
+            busy_timer: self.busy_timer.clone(),
+        }
     }
 
     /// How much time was spent working on the request
@@ -223,6 +221,16 @@ impl Context {
         for kv in other.entries.iter() {
             self.entries.insert(kv.key().clone(), kv.value().clone());
         }
+    }
+}
+
+pub(crate) struct BusyTimerGuard {
+    busy_timer: Arc<Mutex<BusyTimer>>,
+}
+
+impl Drop for BusyTimerGuard {
+    fn drop(&mut self) {
+        self.busy_timer.lock().decrement_active_requests()
     }
 }
 

--- a/apollo-router/src/plugins/coprocessor.rs
+++ b/apollo-router/src/plugins/coprocessor.rs
@@ -515,9 +515,9 @@ where
         .build();
 
     tracing::debug!(?payload, "externalized output");
-    request.context.enter_active_request();
+    let guard = request.context.enter_active_request();
     let co_processor_result = payload.call(http_client, &coprocessor_url).await;
-    request.context.leave_active_request();
+    drop(guard);
     tracing::debug!(?co_processor_result, "co-processor returned");
     let co_processor_output = co_processor_result?;
 
@@ -664,9 +664,9 @@ where
 
     // Second, call our co-processor and get a reply.
     tracing::debug!(?payload, "externalized output");
-    response.context.enter_active_request();
+    let guard = response.context.enter_active_request();
     let co_processor_result = payload.call(http_client.clone(), &coprocessor_url).await;
-    response.context.leave_active_request();
+    drop(guard);
     tracing::debug!(?co_processor_result, "co-processor returned");
     let co_processor_output = co_processor_result?;
 
@@ -739,11 +739,11 @@ where
 
                 // Second, call our co-processor and get a reply.
                 tracing::debug!(?payload, "externalized output");
-                generator_map_context.enter_active_request();
+                let guard = generator_map_context.enter_active_request();
                 let co_processor_result = payload
                     .call(generator_client, &generator_coprocessor_url)
                     .await;
-                generator_map_context.leave_active_request();
+                drop(guard);
                 tracing::debug!(?co_processor_result, "co-processor returned");
                 let co_processor_output = co_processor_result?;
 
@@ -829,9 +829,9 @@ where
         .build();
 
     tracing::debug!(?payload, "externalized output");
-    request.context.enter_active_request();
+    let guard = request.context.enter_active_request();
     let co_processor_result = payload.call(http_client, &coprocessor_url).await;
-    request.context.leave_active_request();
+    drop(guard);
     tracing::debug!(?co_processor_result, "co-processor returned");
     let co_processor_output = co_processor_result?;
     validate_coprocessor_output(&co_processor_output, PipelineStep::SubgraphRequest)?;
@@ -961,9 +961,9 @@ where
         .build();
 
     tracing::debug!(?payload, "externalized output");
-    response.context.enter_active_request();
+    let guard = response.context.enter_active_request();
     let co_processor_result = payload.call(http_client, &coprocessor_url).await;
-    response.context.leave_active_request();
+    drop(guard);
     tracing::debug!(?co_processor_result, "co-processor returned");
     let co_processor_output = co_processor_result?;
 

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -600,13 +600,12 @@ async fn call_http(
     let cloned_service_name = service_name.clone();
     let cloned_context = context.clone();
     let (parts, body) = async move {
-        cloned_context.enter_active_request();
+        let _active_request_guard = cloned_context.enter_active_request();
         let response = match client
             .call(request)
             .await {
                 Err(err) => {
                     tracing::error!(fetch_error = format!("{err:?}").as_str());
-                    cloned_context.leave_active_request();
 
                     return Err(FetchError::SubrequestHttpError {
                         status_code: None,
@@ -630,7 +629,6 @@ async fn call_http(
                 if !content_type_str.contains(APPLICATION_JSON.essence_str())
                     && !content_type_str.contains(GRAPHQL_JSON_RESPONSE_HEADER_VALUE)
                 {
-                    cloned_context.leave_active_request();
 
                     return if !parts.status.is_success() {
 
@@ -658,7 +656,6 @@ async fn call_http(
             .instrument(tracing::debug_span!("aggregate_response_data"))
             .await {
                 Err(err) => {
-                    cloned_context.leave_active_request();
 
                     tracing::error!(fetch_error = format!("{err:?}").as_str());
 
@@ -671,7 +668,6 @@ async fn call_http(
                 }, Ok(body) => body,
             };
 
-            cloned_context.leave_active_request();
 
         Ok((parts, body))
     }.instrument(subgraph_req_span).await?;


### PR DESCRIPTION
manually tracking active requests is error prone because we might return early without decrementing the active requests. To make sure this is done properly, `enter_active_request` now returns a guard struct, that will decrement the count on drop

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
