### PR TITLE
Add support for getting request method in Rhai

### DIFF
--- a/.changesets/feat_garypen_2467_rhai_method.md
+++ b/.changesets/feat_garypen_2467_rhai_method.md
@@ -1,0 +1,17 @@
+### Add support for getting request method in Rhai ([Issue #2467](https://github.com/apollographql/router/issues/2467))
+
+It may be useful to know the method of a request in your Rhai script.
+
+This adds support for getting the method and performing comparisons against String representations.
+
+```
+fn process_request(request) {
+    if request.method == "OPTIONS"  {
+        request.headers["x-custom-header"] = "value"
+    }
+}
+```
+
+Note: You may not modify the method.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3355

--- a/apollo-router/tests/fixtures/request_response_test.rhai
+++ b/apollo-router/tests/fixtures/request_response_test.rhai
@@ -3,10 +3,13 @@
 // If any of the tests fail, the thrown error will cause the respective rust
 // unit test to fail.
 
-fn process_common_request(check_context, request) {
-    if check_context {
+fn process_common_request(check_context_and_method, request) {
+    if check_context_and_method {
         if request.context.entries != () {
             throw(`context entries: expected: (), actual: ${request.context.entries}`);
+        }
+        if request.method != "GET" {
+            throw(`query: expected: "GET", actual: ${request.method}`);
         }
     }
     if request.body.operation_name != () {
@@ -35,6 +38,9 @@ fn process_supergraph_request(request) {
     }
     if request.headers["content-type"] != "application/json" {
         throw(`header["content-type"]: expected: "application/json", actual: ${request.headers.content-type}`);
+    }
+    if request.method.to_string() != "POST" {
+        throw(`query: expected: "POST", actual: ${request.method}`);
     }
     if request.body.operation_name != "canned" {
         throw(`operation name: expected: canned, actual: ${request.body.operation_name}`);

--- a/docs/source/customizations/rhai-api.mdx
+++ b/docs/source/customizations/rhai-api.mdx
@@ -263,11 +263,12 @@ Note: get() may fail, so it's best to handle exceptions when using it.
 
 ## `Request` interface
 
-All callback functions registered via `map_request` are passed a `request` object that represents the request sent by the client. This object provides the following fields, any of which a callback can modify in-place (read-write):
+All callback functions registered via `map_request` are passed a `request` object that represents the request sent by the client. This object provides the following fields, most of which a callback can modify in-place (read-write):
 
 ```
 request.context
 request.headers
+request.method
 request.body.query
 request.body.operation_name
 request.body.variables
@@ -275,6 +276,7 @@ request.body.extensions
 request.uri.host
 request.uri.path
 ```
+Note: `method` is read-only.
 
 **For `subgraph_service` callbacks only,** the `request` object provides _additional_ fields for interacting with the request that will be sent to the corresponding subgraph:
 
@@ -353,6 +355,14 @@ request.headers["set-cookie"] = [
 // You can also get multiple header values for a header using the values() fn
 // Note: It's probably more useful to do this on response headers. Simply illustrating the syntax here.
 print(`${request.headers.values("set-cookie")}`);
+```
+
+### `request.method`
+
+This is the HTTP method of the client request.
+
+```rhai
+print(`${request.method}`); // Log the HTTP method
 ```
 
 ### `request.body.query`


### PR DESCRIPTION
It may be useful to know the method of a request in your Rhai script.

This adds support for getting the method and performing comparisons against String representations.

```
fn process_request(request) {
    if request.method == "OPTIONS"  {
        request.headers["x-custom-header"] = "value"
    }
}
```

Note: You may not modify the method.

fixes: #2467

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
