### PR TITLE
Move operation limits and parser limits to General Availability

### DIFF
--- a/.changesets/feat_simon_operation_limits_ga.md
+++ b/.changesets/feat_simon_operation_limits_ga.md
@@ -1,0 +1,19 @@
+### Move operation limits and parser limits to General Availability ([PR #3356](https://github.com/apollographql/router/pull/3356))
+
+[Operation Limits](https://www.apollographql.com/docs/router/configuration/operation-limits) (a GraphOS Enterprise feature) and [parser limits](https://www.apollographql.com/docs/router/configuration/overview/#parser-based-limits) are now moving to General Availability, from Preview where they have been since Apollo Router 1.17.
+
+For more information about launch stages, please see the documentation here: https://www.apollographql.com/docs/resources/product-launch-stages/
+
+In addition to removing the `preview_` prefix, the configuration section has been renamed to just `limits` to encapsulate operation, parser and request limits. ([The request size limit](https://www.apollographql.com/docs/router/configuration/overview/#request-limits) is still [experimental](https://github.com/apollographql/router/discussions/3220).) Existing configuration files will keep working as before, only with a warning. To fix that warning, rename the configuration section like so:
+
+
+```diff
+-preview_operation_limits:
++limits:
+   max_depth: 100
+   max_height: 200
+   max_aliases: 30
+   max_root_fields: 20
+```
+
+By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/3356

--- a/apollo-router/feature_discussions.json
+++ b/apollo-router/feature_discussions.json
@@ -5,7 +5,5 @@
     "experimental_logging": "https://github.com/apollographql/router/discussions/1961",
     "experimental_http_max_request_bytes": "https://github.com/apollographql/router/discussions/3220"
   },
-  "preview": {
-    "preview_operation_limits": "https://github.com/apollographql/router/discussions/3040"
-  }
+  "preview": {}
 }

--- a/apollo-router/src/configuration/migrations/0007-parser-recursion.yaml
+++ b/apollo-router/src/configuration/migrations/0007-parser-recursion.yaml
@@ -1,7 +1,7 @@
-description: server.experimental_parser_recursion_limit moved to supergraph.limits.parser_max_recursion, not experimental anymore. remove the server section, now empty
+description: server.experimental_parser_recursion_limit moved to limits.parser_max_recursion, not experimental anymore. remove the server section, now empty
 actions:
   - type: move
     from: server.experimental_parser_recursion_limit
-    to: preview_operation_limits.parser_max_recursion
+    to: limits.parser_max_recursion
   - type: delete
     path: server

--- a/apollo-router/src/configuration/migrations/0008-operation-limits-ga.yaml
+++ b/apollo-router/src/configuration/migrations/0008-operation-limits-ga.yaml
@@ -1,0 +1,5 @@
+description: Operation limits are no longer preview, `preview_operation_limits` is renamed `limits`
+actions:
+  - type: move
+    from: preview_operation_limits
+    to: limits

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -144,11 +144,9 @@ pub struct Configuration {
     #[serde(default)]
     pub(crate) apq: Apq,
 
-    // NOTE: when renaming this to move out of preview, also update paths
-    // in `configuration/expansion.rs` and `uplink/license.rs`.
-    /// Operation limits
+    /// Configuration for operation limits, parser limits, HTTP limits, etc.
     #[serde(default)]
-    pub(crate) preview_operation_limits: OperationLimits,
+    pub(crate) limits: Limits,
 
     /// Configuration for chaos testing, trying to reproduce bugs that require uncommon conditions.
     /// You probably don’t want this in production!
@@ -188,7 +186,7 @@ impl<'de> serde::Deserialize<'de> for Configuration {
             apollo_plugins: ApolloPlugins,
             tls: Tls,
             apq: Apq,
-            preview_operation_limits: OperationLimits,
+            limits: Limits,
             experimental_chaos: Chaos,
         }
         let ad_hoc: AdHocConfiguration = serde::Deserialize::deserialize(deserializer)?;
@@ -203,7 +201,7 @@ impl<'de> serde::Deserialize<'de> for Configuration {
             .apollo_plugins(ad_hoc.apollo_plugins.plugins)
             .tls(ad_hoc.tls)
             .apq(ad_hoc.apq)
-            .operation_limits(ad_hoc.preview_operation_limits)
+            .operation_limits(ad_hoc.limits)
             .chaos(ad_hoc.experimental_chaos)
             .build()
             .map_err(|e| serde::de::Error::custom(e.to_string()))
@@ -236,7 +234,7 @@ impl Configuration {
         tls: Option<Tls>,
         notify: Option<Notify<String, graphql::Response>>,
         apq: Option<Apq>,
-        operation_limits: Option<OperationLimits>,
+        operation_limits: Option<Limits>,
         chaos: Option<Chaos>,
     ) -> Result<Self, ConfigurationError> {
         #[cfg(not(test))]
@@ -260,7 +258,7 @@ impl Configuration {
             homepage: homepage.unwrap_or_default(),
             cors: cors.unwrap_or_default(),
             apq: apq.unwrap_or_default(),
-            preview_operation_limits: operation_limits.unwrap_or_default(),
+            limits: operation_limits.unwrap_or_default(),
             experimental_chaos: chaos.unwrap_or_default(),
             plugins: UserPlugins {
                 plugins: Some(plugins),
@@ -302,7 +300,7 @@ impl Configuration {
         tls: Option<Tls>,
         notify: Option<Notify<String, graphql::Response>>,
         apq: Option<Apq>,
-        operation_limits: Option<OperationLimits>,
+        operation_limits: Option<Limits>,
         chaos: Option<Chaos>,
     ) -> Result<Self, ConfigurationError> {
         let configuration = Self {
@@ -312,7 +310,7 @@ impl Configuration {
             sandbox: sandbox.unwrap_or_else(|| Sandbox::fake_builder().build()),
             homepage: homepage.unwrap_or_else(|| Homepage::fake_builder().build()),
             cors: cors.unwrap_or_default(),
-            preview_operation_limits: operation_limits.unwrap_or_default(),
+            limits: operation_limits.unwrap_or_default(),
             experimental_chaos: chaos.unwrap_or_default(),
             plugins: UserPlugins {
                 plugins: Some(plugins),
@@ -559,11 +557,11 @@ impl Supergraph {
     }
 }
 
-/// Configuration for operation limits
+/// Configuration for operation limits, parser limits, HTTP limits, etc.
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 #[serde(default)]
-pub(crate) struct OperationLimits {
+pub(crate) struct Limits {
     /// If set, requests with operations deeper than this maximum
     /// are rejected with a HTTP 400 Bad Request response and GraphQL error with
     /// `"extensions": {"code": "MAX_DEPTH_LIMIT"}`
@@ -640,7 +638,7 @@ pub(crate) struct OperationLimits {
     pub(crate) experimental_http_max_request_bytes: usize,
 }
 
-impl Default for OperationLimits {
+impl Default for Limits {
     fn default() -> Self {
         Self {
             // These limits are opt-in

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1070,6 +1070,81 @@ expression: "&schema"
       },
       "additionalProperties": false
     },
+    "limits": {
+      "description": "Configuration for operation limits, parser limits, HTTP limits, etc.",
+      "default": {
+        "max_depth": null,
+        "max_height": null,
+        "max_root_fields": null,
+        "max_aliases": null,
+        "warn_only": false,
+        "parser_max_recursion": 4096,
+        "parser_max_tokens": 15000,
+        "experimental_http_max_request_bytes": 2000000
+      },
+      "type": "object",
+      "properties": {
+        "experimental_http_max_request_bytes": {
+          "description": "Limit the size of incoming HTTP requests read from the network, to protect against running out of memory. Default: 2000000 (2 MB)",
+          "default": 2000000,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "max_aliases": {
+          "description": "If set, requests with operations with more aliases than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ALIASES_LIMIT\"}`",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "max_depth": {
+          "description": "If set, requests with operations deeper than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nCounts depth of an operation, looking at its selection sets, including fields in fragments and inline fragments. The following example has a depth of 3.\n\n```graphql query getProduct { book { # 1 ...bookDetails } }\n\nfragment bookDetails on Book { details { # 2 ... on ProductDetailsBook { country # 3 } } } ```",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "max_height": {
+          "description": "If set, requests with operations higher than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nHeight is based on simple merging of fields using the same name or alias, but only within the same selection set. For example `name` here is only counted once and the query has height 3, not 4:\n\n```graphql query { name { first } name { last } } ```\n\nThis may change in a future version of Apollo Router to do [full field merging across fragments][merging] instead.\n\n[merging]: https://spec.graphql.org/October2021/#sec-Field-Selection-Merging]",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "max_root_fields": {
+          "description": "If set, requests with operations with more root fields than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ROOT_FIELDS_LIMIT\"}`\n\nThis limit counts only the top level fields in a selection set, including fragments and inline fragments.",
+          "default": null,
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0,
+          "nullable": true
+        },
+        "parser_max_recursion": {
+          "description": "Limit recursion in the GraphQL parser to protect against stack overflow. default: 4096",
+          "default": 4096,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "parser_max_tokens": {
+          "description": "Limit the number of tokens the GraphQL parser processes before aborting.",
+          "default": 15000,
+          "type": "integer",
+          "format": "uint",
+          "minimum": 0.0
+        },
+        "warn_only": {
+          "description": "If set to true (which is the default is dev mode), requests that exceed a `max_*` limit are *not* rejected. Instead they are executed normally, and a warning is logged.",
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "override_subgraph_url": {
       "description": "Subgraph URL mappings",
       "anyOf": [
@@ -1142,81 +1217,6 @@ expression: "&schema"
               "type": "string"
             }
           }
-        }
-      },
-      "additionalProperties": false
-    },
-    "preview_operation_limits": {
-      "description": "Operation limits",
-      "default": {
-        "max_depth": null,
-        "max_height": null,
-        "max_root_fields": null,
-        "max_aliases": null,
-        "warn_only": false,
-        "parser_max_recursion": 4096,
-        "parser_max_tokens": 15000,
-        "experimental_http_max_request_bytes": 2000000
-      },
-      "type": "object",
-      "properties": {
-        "experimental_http_max_request_bytes": {
-          "description": "Limit the size of incoming HTTP requests read from the network, to protect against running out of memory. Default: 2000000 (2 MB)",
-          "default": 2000000,
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0.0
-        },
-        "max_aliases": {
-          "description": "If set, requests with operations with more aliases than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ALIASES_LIMIT\"}`",
-          "default": null,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0,
-          "nullable": true
-        },
-        "max_depth": {
-          "description": "If set, requests with operations deeper than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nCounts depth of an operation, looking at its selection sets, including fields in fragments and inline fragments. The following example has a depth of 3.\n\n```graphql query getProduct { book { # 1 ...bookDetails } }\n\nfragment bookDetails on Book { details { # 2 ... on ProductDetailsBook { country # 3 } } } ```",
-          "default": null,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0,
-          "nullable": true
-        },
-        "max_height": {
-          "description": "If set, requests with operations higher than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nHeight is based on simple merging of fields using the same name or alias, but only within the same selection set. For example `name` here is only counted once and the query has height 3, not 4:\n\n```graphql query { name { first } name { last } } ```\n\nThis may change in a future version of Apollo Router to do [full field merging across fragments][merging] instead.\n\n[merging]: https://spec.graphql.org/October2021/#sec-Field-Selection-Merging]",
-          "default": null,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0,
-          "nullable": true
-        },
-        "max_root_fields": {
-          "description": "If set, requests with operations with more root fields than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ROOT_FIELDS_LIMIT\"}`\n\nThis limit counts only the top level fields in a selection set, including fragments and inline fragments.",
-          "default": null,
-          "type": "integer",
-          "format": "uint32",
-          "minimum": 0.0,
-          "nullable": true
-        },
-        "parser_max_recursion": {
-          "description": "Limit recursion in the GraphQL parser to protect against stack overflow. default: 4096",
-          "default": 4096,
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0.0
-        },
-        "parser_max_tokens": {
-          "description": "Limit the number of tokens the GraphQL parser processes before aborting.",
-          "default": 15000,
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0.0
-        },
-        "warn_only": {
-          "description": "If set to true (which is the default is dev mode), requests that exceed a `max_*` limit are *not* rejected. Instead they are executed normally, and a warning is logged.",
-          "default": false,
-          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@operation-limits-preview.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@operation-limits-preview.yaml.snap
@@ -4,5 +4,5 @@ expression: new_config
 ---
 ---
 limits:
-  parser_max_recursion: 100
+  parser_max_recursion: 1000
 

--- a/apollo-router/src/configuration/testdata/migrations/operation-limits-preview.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/operation-limits-preview.yaml
@@ -1,0 +1,2 @@
+preview_operation_limits:
+  parser_max_recursion: 1000

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -303,6 +303,12 @@ impl Service<QueryPlannerRequest> for BridgeQueryPlanner {
                     )))
                 }
                 Ok((modified_query, added_labels)) => {
+                    // We’ve already checked the original query against the configured token limit
+                    // when first parsing it.
+                    // We’ve now serialized a modified query (with labels added) and are about
+                    // to re-parse it, but that’s an internal detail that should not affect
+                    // which original queries are rejected because of the token limit.
+                    compiler_guard.db.set_token_limit(None);
                     compiler_guard.update_executable(file_id, &modified_query);
                     added_labels
                 }

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -491,7 +491,7 @@ impl RouterCreator {
             apq_layer,
             query_analysis_layer,
             experimental_http_max_request_bytes: configuration
-                .preview_operation_limits
+                .limits
                 .experimental_http_max_request_bytes,
         }
     }
@@ -724,7 +724,7 @@ mod tests {
                     hyper::Body::from(json_bytes)
                 });
             let config = serde_json::json!({
-                "preview_operation_limits": {
+                "limits": {
                     "experimental_http_max_request_bytes": experimental_http_max_request_bytes
                 }
             });

--- a/apollo-router/src/spec/operation_limits.rs
+++ b/apollo-router/src/spec/operation_limits.rs
@@ -64,7 +64,7 @@ pub(crate) fn check(
     compiler: &ApolloCompiler,
     operation_name: Option<String>,
 ) -> Result<(), OperationLimits<bool>> {
-    let config_limits = &configuration.preview_operation_limits;
+    let config_limits = &configuration.limits;
     let max = OperationLimits {
         depth: config_limits.max_depth,
         height: config_limits.max_height,

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -269,8 +269,8 @@ impl Query {
         configuration: &Configuration,
     ) -> (ApolloCompiler, FileId) {
         let mut compiler = ApolloCompiler::new()
-            .recursion_limit(configuration.preview_operation_limits.parser_max_recursion)
-            .token_limit(configuration.preview_operation_limits.parser_max_tokens);
+            .recursion_limit(configuration.limits.parser_max_recursion)
+            .token_limit(configuration.limits.parser_max_tokens);
         compiler.set_type_system_hir(schema.type_system.clone());
         let id = compiler.add_executable(query, QUERY_EXECUTABLE);
         (compiler, id)

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -161,19 +161,19 @@ impl LicenseEnforcementReport {
             // Per-operation limits are restricted but parser limits like `parser_max_recursion`
             // where the Router only configures apollo-rs are not.
             ConfigurationRestriction::builder()
-                .path("$.preview_operation_limits.max_depth")
+                .path("$.limits.max_depth")
                 .name("Operation depth limiting")
                 .build(),
             ConfigurationRestriction::builder()
-                .path("$.preview_operation_limits.max_height")
+                .path("$.limits.max_height")
                 .name("Operation height limiting")
                 .build(),
             ConfigurationRestriction::builder()
-                .path("$.preview_operation_limits.max_root_fields")
+                .path("$.limits.max_root_fields")
                 .name("Operation root fields limiting")
                 .build(),
             ConfigurationRestriction::builder()
-                .path("$.preview_operation_limits.max_aliases")
+                .path("$.limits.max_aliases")
                 .name("Operation aliases limiting")
                 .build(),
         ]

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config.snap
@@ -28,13 +28,13 @@ Configuration yaml:
   .subscription
 
 * Operation depth limiting
-  .preview_operation_limits.max_depth
+  .limits.max_depth
 
 * Operation height limiting
-  .preview_operation_limits.max_height
+  .limits.max_height
 
 * Operation root fields limiting
-  .preview_operation_limits.max_root_fields
+  .limits.max_root_fields
 
 * Operation aliases limiting
-  .preview_operation_limits.max_aliases
+  .limits.max_aliases

--- a/apollo-router/src/uplink/testdata/oss.router.yaml
+++ b/apollo-router/src/uplink/testdata/oss.router.yaml
@@ -2,5 +2,5 @@ health_check:
   enabled: false
 homepage:
   enabled: false
-preview_operation_limits:
+limits:
   parser_max_recursion: 1000

--- a/apollo-router/src/uplink/testdata/restricted.router.yaml
+++ b/apollo-router/src/uplink/testdata/restricted.router.yaml
@@ -20,7 +20,7 @@ supergraph:
       in_memory:
         limit: 1000
 
-preview_operation_limits:
+limits:
   max_depth: 20
   max_height: 100
   max_aliases: 100

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -521,7 +521,7 @@ const PARSER_LIMITS_TEST_QUERY_RECURSION: usize = 6;
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_under_recursion_limit() {
     let config = serde_json::json!({
-        "preview_operation_limits": {
+        "limits": {
             "parser_max_recursion": PARSER_LIMITS_TEST_QUERY_RECURSION
         }
     });
@@ -544,7 +544,7 @@ async fn query_just_under_recursion_limit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_at_recursion_limit() {
     let config = serde_json::json!({
-        "preview_operation_limits": {
+        "limits": {
             "parser_max_recursion": PARSER_LIMITS_TEST_QUERY_RECURSION - 1
         }
     });
@@ -575,7 +575,7 @@ async fn query_just_at_recursion_limit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_under_token_limit() {
     let config = serde_json::json!({
-        "preview_operation_limits": {
+        "limits": {
             "parser_max_tokens": PARSER_LIMITS_TEST_QUERY_TOKEN_COUNT,
         }
     });
@@ -598,7 +598,7 @@ async fn query_just_under_token_limit() {
 #[tokio::test(flavor = "multi_thread")]
 async fn query_just_at_token_limit() {
     let config = serde_json::json!({
-        "preview_operation_limits": {
+        "limits": {
             "parser_max_tokens": PARSER_LIMITS_TEST_QUERY_TOKEN_COUNT - 1,
         }
     });

--- a/apollo-router/tests/operation_limits.rs
+++ b/apollo-router/tests/operation_limits.rs
@@ -231,7 +231,7 @@ async fn build_test_harness(
     let get_execution_count = move || execution_count_2.load(Ordering::Acquire);
     let service = TestHarness::builder()
         .configuration_json(json!({
-            "preview_operation_limits": limits_config,
+            "limits": limits_config,
             "include_subgraph_errors": { "all": true },
         }))
         .unwrap()

--- a/apollo-router/tests/snapshots/lifecycle_tests__cli_config_preview.snap
+++ b/apollo-router/tests/snapshots/lifecycle_tests__cli_config_preview.snap
@@ -7,7 +7,5 @@ Exit code: Some(0)
 stderr:
 
 stdout:
-List of all preview configurations with related GitHub discussions:
-
-	- preview_operation_limits: https://github.com/apollographql/router/discussions/3040
+This Router version has no preview configuration
 

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -45,8 +45,7 @@
         "Operation limits": [
           "/configuration/operation-limits",
           [
-            "enterprise",
-            "preview"
+            "enterprise"
           ]
         ],
         "Privacy and data collection": "/privacy"

--- a/docs/source/configuration/operation-limits.mdx
+++ b/docs/source/configuration/operation-limits.mdx
@@ -3,7 +3,7 @@ title: Enforcing operation limits in the Apollo Router
 description: With GraphOS Enterprise
 ---
 
-> ⚠️ **This is an [Enterprise feature](../enterprise-features/) of the Apollo Router.** It requires an organization with a [GraphOS Enterprise plan](https://www.apollographql.com/pricing/). It is currently in [preview](/resources/product-launch-stages#preview).
+> ⚠️ **This is an [Enterprise feature](../enterprise-features/) of the Apollo Router.** It requires an organization with a [GraphOS Enterprise plan](https://www.apollographql.com/pricing/).
 >
 > If your organization _doesn't_ currently have an Enterprise plan, you can test out this functionality by signing up for a free [Enterprise trial](/graphos/org/plans/#enterprise-trials).
 
@@ -16,7 +16,7 @@ To use operation limits, you must run v1.17 or later of the Apollo Router. [Down
 You define operation limits in your router's [YAML config file](./configuration/overview/#yaml-config-file), like so:
 
 ```yaml title="router.yaml"
-preview_operation_limits:
+limits:
   max_depth: 100
   max_height: 200
   max_aliases: 30
@@ -120,6 +120,6 @@ Running in `warn_only` mode can be useful while you're testing to determine the 
 You can enable or disable `warn_only` mode in your router's [YAML config file](./configuration/overview/#yaml-config-file), like so:
 
 ```yaml title="router.yaml"
-preview_operation_limits:
+limits:
   warn_only: true # warn_only mode always enabled
 ```

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -542,7 +542,7 @@ The Apollo Router supports enforcing three types of request limits for enhanced 
 The router rejects any request that violates at least one of these limits.
 
 ```yaml title="router.yaml"
-preview_operation_limits:
+limits:
   # Network-based limits
   experimental_http_max_request_bytes: 2000000 # Default value: 2 MB
 


### PR DESCRIPTION
[Operation Limits](https://www.apollographql.com/docs/router/configuration/operation-limits) (a GraphOS Enterprise feature) and [parser limits](https://www.apollographql.com/docs/router/configuration/overview/#parser-based-limits) are now moving to General Availability, from Preview where they have been since Apollo Router 1.17.

For more information about launch stages, please see the documentation here: https://www.apollographql.com/docs/resources/product-launch-stages/

In addition to removing the `preview_` prefix, the configuration section has been rename to just `limits` to reflect that it concerns not only operations but also the parser and the requests. ([The request size limit](https://www.apollographql.com/docs/router/configuration/overview/#request-limits) is still [experimental](https://github.com/apollographql/router/discussions/3220).) Existing configuration files will keep working as before, only with a warning. To fix that warning, rename the configuration section like so:


```diff
-preview_operation_limits:
+limits:
   max_depth: 100
   max_height: 200
   max_aliases: 30
   max_root_fields: 20
```


<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

* The configuration section name change has an automatic migration.

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
