### PR TITLE
Bring root span name in line with otel semantic conventions.

### DIFF
--- a/.changesets/fix_capsule_add_skull_sail.md
+++ b/.changesets/fix_capsule_add_skull_sail.md
@@ -1,0 +1,9 @@
+### Bring root span name in line with otel semantic conventions. ([Issue #3229](https://github.com/apollographql/router/issues/3229))
+
+Root span name has changed from `request` to `<graphql.operation.kind> <graphql.operation.name>`
+
+[Open Telemetry graphql semantic conventions](https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/instrumentation/graphql/) specify that the root span name must match the operation kind and name. 
+
+Many tracing providers don't have good support for filtering traces via attribute, so this change will bring significant usability enhancements to the tracing experience.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3364

--- a/apollo-router/src/axum_factory/utils.rs
+++ b/apollo-router/src/axum_factory/utils.rs
@@ -135,8 +135,12 @@ impl PropagatingMakeSpan {
                 "http.route" = %request.uri(),
                 "http.flavor" = ?request.version(),
                 "http.status" = 500, // This prevents setting later
+                "otel.name" = ::tracing::field::Empty,
                 "otel.kind" = "SERVER",
-                "apollo_router.license" = LICENSE_EXPIRED_SHORT_MESSAGE
+                "graphql.operation.name" = ::tracing::field::Empty,
+                "graphql.operation.type" = ::tracing::field::Empty,
+                "apollo_router.license" = LICENSE_EXPIRED_SHORT_MESSAGE,
+                "apollo_private.request" = true,
             )
         } else {
             tracing::info_span!(
@@ -144,10 +148,11 @@ impl PropagatingMakeSpan {
                 "http.method" = %request.method(),
                 "http.route" = %request.uri(),
                 "http.flavor" = ?request.version(),
+                "otel.name" = ::tracing::field::Empty,
                 "otel.kind" = "SERVER",
                 "graphql.operation.name" = ::tracing::field::Empty,
                 "graphql.operation.type" = ::tracing::field::Empty,
-                "otel.name" = ::tracing::field::Empty,
+                "apollo_private.request" = true,
             )
         }
     }

--- a/apollo-router/src/axum_factory/utils.rs
+++ b/apollo-router/src/axum_factory/utils.rs
@@ -145,7 +145,9 @@ impl PropagatingMakeSpan {
                 "http.route" = %request.uri(),
                 "http.flavor" = ?request.version(),
                 "otel.kind" = "SERVER",
-
+                "graphql.operation.name" = ::tracing::field::Empty,
+                "graphql.operation.type" = ::tracing::field::Empty,
+                "otel.name" = ::tracing::field::Empty,
             )
         }
     }

--- a/apollo-router/src/context/mod.rs
+++ b/apollo-router/src/context/mod.rs
@@ -21,6 +21,9 @@ use crate::json_ext::Value;
 
 pub(crate) mod extensions;
 
+/// The key of the resolved operation name. This is subject to change and should not be relied on.
+pub(crate) const OPERATION_NAME: &str = "operation_name";
+
 /// Holds [`Context`] entries.
 pub(crate) type Entries = Arc<DashMap<String, Value>>;
 

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -68,6 +68,8 @@ use self::reload::NullFieldFormatter;
 use self::reload::OPENTELEMETRY_TRACER_HANDLE;
 use self::tracing::apollo_telemetry::APOLLO_PRIVATE_DURATION_NS;
 use self::tracing::reload::ReloadTracer;
+use crate::axum_factory::utils::REQUEST_SPAN_NAME;
+use crate::context::OPERATION_NAME;
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
@@ -128,8 +130,6 @@ const CLIENT_NAME: &str = "apollo_telemetry::client_name";
 const CLIENT_VERSION: &str = "apollo_telemetry::client_version";
 const SUBGRAPH_FTV1: &str = "apollo_telemetry::subgraph_ftv1";
 pub(crate) const OPERATION_KIND: &str = "apollo_telemetry::operation_kind";
-pub(crate) const GRAPHQL_OPERATION_NAME_CONTEXT_KEY: &str =
-    "apollo_telemetry::graphql_operation_name";
 pub(crate) const STUDIO_EXCLUDE: &str = "apollo_telemetry::studio::exclude";
 pub(crate) const LOGGING_DISPLAY_HEADERS: &str = "apollo_telemetry::logging::display_headers";
 pub(crate) const LOGGING_DISPLAY_BODY: &str = "apollo_telemetry::logging::display_body";
@@ -235,6 +235,30 @@ impl Plugin for Telemetry {
         let config_later = self.config.clone();
 
         ServiceBuilder::new()
+            .map_response(|response: router::Response|{
+                // The current span *should* be the request span as we are outside the instrument block.
+                let span = Span::current();
+                if let Some(REQUEST_SPAN_NAME) = span.metadata().map(|metadata| metadata.name()) {
+
+                    //https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/instrumentation/graphql/
+                    let operation_kind = response.context.get::<_, String>(OPERATION_KIND);
+                    let operation_name = response.context.get::<_, String>(OPERATION_NAME);
+
+                    if let Ok(Some(operation_kind)) = &operation_kind {
+                        span.record("graphql.operation.type", operation_kind);
+                    }
+                    if let Ok(Some(operation_name)) = &operation_name {
+                        span.record("graphql.operation.name", operation_name);
+                    }
+                    match (&operation_kind, &operation_name) {
+                        (Ok(Some(kind)), Ok(Some(name))) => span.record("otel.name", format!("{kind} {name}")),
+                        (Ok(Some(kind)), _) => span.record("otel.name", kind),
+                        _ => span.record("otel.name", "GraphQL Operation")
+                    };
+                }
+
+                response
+            })
             .instrument(move |request: &router::Request| {
                 let apollo = config.apollo.as_ref().cloned().unwrap_or_default();
                 let trace_id = TraceId::maybe_new()
@@ -670,22 +694,11 @@ impl Telemetry {
         move |request: &SupergraphRequest| {
             let http_request = &request.supergraph_request;
             let query = http_request.body().query.as_deref().unwrap_or_default();
-            let operation_name = http_request
-                .body()
-                .operation_name
-                .as_deref()
-                .unwrap_or_default();
-            if let Some(operation_name) = &http_request.body().operation_name {
-                let _ = request
-                    .context
-                    .insert(GRAPHQL_OPERATION_NAME_CONTEXT_KEY, operation_name.clone());
-            }
-
             let span = info_span!(
                 SUPERGRAPH_SPAN_NAME,
                 graphql.document = query,
                 // TODO add graphql.operation.type
-                graphql.operation.name = operation_name,
+                graphql.operation.name = field::Empty,
                 otel.kind = "INTERNAL",
                 apollo_private.field_level_instrumentation_ratio =
                     field_level_instrumentation_ratio,
@@ -695,6 +708,13 @@ impl Telemetry {
                     &config.send_variable_values,
                 ),
             );
+            if let Some(operation_name) = request
+                .context
+                .get::<_, String>(OPERATION_NAME)
+                .unwrap_or_default()
+            {
+                span.record("graphql.operation.name", operation_name);
+            }
 
             span
         }
@@ -870,7 +890,7 @@ impl Telemetry {
             let mut attributes: HashMap<String, AttributeValue> = HashMap::new();
             if let Some(operation_name) = &req.supergraph_request.body().operation_name {
                 attributes.insert(
-                    "operation_name".to_string(),
+                    OPERATION_NAME.to_string(),
                     AttributeValue::String(operation_name.clone()),
                 );
             }

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -27,7 +27,6 @@ use serde::de::DeserializeOwned;
 use thiserror::Error;
 use url::Url;
 
-use crate::axum_factory::utils::REQUEST_SPAN_NAME;
 use crate::plugins::telemetry;
 use crate::plugins::telemetry::apollo::ErrorConfiguration;
 use crate::plugins::telemetry::apollo::ErrorsConfiguration;
@@ -73,6 +72,7 @@ use crate::query_planner::FLATTEN_SPAN_NAME;
 use crate::query_planner::PARALLEL_SPAN_NAME;
 use crate::query_planner::SEQUENCE_SPAN_NAME;
 
+const APOLLO_PRIVATE_REQUEST: Key = Key::from_static_str("apollo_private.request");
 pub(crate) const APOLLO_PRIVATE_DURATION_NS: &str = "apollo_private.duration_ns";
 const APOLLO_PRIVATE_DURATION_NS_KEY: Key = Key::from_static_str(APOLLO_PRIVATE_DURATION_NS);
 const APOLLO_PRIVATE_SENT_TIME_OFFSET: Key =
@@ -411,7 +411,7 @@ impl Exporter {
                 });
                 child_nodes
             }
-            REQUEST_SPAN_NAME => {
+            _ if span.attributes.get(&APOLLO_PRIVATE_REQUEST).is_some() => {
                 vec![TreeData::Request(
                     self.extract_root_trace(span, child_nodes),
                 )]
@@ -696,7 +696,9 @@ impl SpanExporter for Exporter {
         // We may get spans that simply don't complete. These need to be cleaned up after a period. It's the price of using ftv1.
         let mut traces: Vec<(String, proto::reports::Trace)> = Vec::new();
         for span in batch {
-            if span.name == REQUEST_SPAN_NAME || span.name == SUBSCRIPTION_EVENT_SPAN_NAME {
+            if span.attributes.get(&APOLLO_PRIVATE_REQUEST).is_some()
+                || span.name == SUBSCRIPTION_EVENT_SPAN_NAME
+            {
                 match self.extract_trace(span.into()) {
                     Ok(mut trace) => {
                         let mut operation_signature = Default::default();

--- a/apollo-router/src/query_planner/subscription.rs
+++ b/apollo-router/src/query_planner/subscription.rs
@@ -24,6 +24,7 @@ use super::rewrites;
 use super::rewrites::DataRewrite;
 use super::OperationKind;
 use super::PlanNode;
+use crate::context::OPERATION_NAME;
 use crate::error::FetchError;
 use crate::graphql;
 use crate::graphql::Error;
@@ -33,7 +34,6 @@ use crate::http_ext;
 use crate::json_ext::Path;
 use crate::notification::HandleStream;
 use crate::plugins::telemetry::tracing::apollo_telemetry::APOLLO_PRIVATE_DURATION_NS;
-use crate::plugins::telemetry::GRAPHQL_OPERATION_NAME_CONTEXT_KEY;
 use crate::plugins::telemetry::LOGGING_DISPLAY_BODY;
 use crate::query_planner::SUBSCRIBE_SPAN_NAME;
 use crate::services::SubgraphRequest;
@@ -254,7 +254,7 @@ impl SubscriptionNode {
 
         let operation_name = parameters
             .context
-            .get::<_, String>(GRAPHQL_OPERATION_NAME_CONTEXT_KEY)
+            .get::<_, String>(OPERATION_NAME)
             .ok()
             .flatten()
             .unwrap_or_default();

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -7,6 +7,7 @@ use http::StatusCode;
 use lru::LruCache;
 use tokio::sync::Mutex;
 
+use crate::context::OPERATION_NAME;
 use crate::services::SupergraphRequest;
 use crate::services::SupergraphResponse;
 use crate::spec::Query;
@@ -107,7 +108,7 @@ impl QueryAnalysisLayer {
                     .find_operation(file_id, op_name.clone())
                     .and_then(|operation| operation.name().map(|s| s.to_owned()));
 
-                context.insert("operation_name", operation_name).unwrap();
+                context.insert(OPERATION_NAME, operation_name).unwrap();
 
                 (*self.cache.lock().await).put(
                     QueryAnalysisKey {

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -31,7 +31,10 @@ use tokio::task;
 use tokio::time::Instant;
 use tower::BoxError;
 use tracing::info_span;
+use tracing_core::Dispatch;
 use tracing_core::LevelFilter;
+use tracing_futures::Instrument;
+use tracing_futures::WithSubscriber;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::EnvFilter;
@@ -54,6 +57,7 @@ pub struct IntegrationTest {
     stdio_rx: tokio::sync::mpsc::Receiver<String>,
     collect_stdio: Option<(tokio::sync::oneshot::Sender<String>, regex::Regex)>,
     _subgraphs: wiremock::MockServer,
+    subscriber: Option<Dispatch>,
 }
 
 struct TracedResponder(pub(crate) ResponseTemplate);
@@ -95,14 +99,14 @@ impl IntegrationTest {
         responder: Option<ResponseTemplate>,
         collect_stdio: Option<tokio::sync::oneshot::Sender<String>>,
     ) -> Self {
-        Self::init_telemetry(telemetry);
-
         // Prevent multiple integration tests from running at the same time
         let lock = LOCK
             .get_or_init(Default::default)
             .clone()
             .lock_owned()
             .await;
+
+        let subscriber = Self::init_telemetry(telemetry);
 
         let mut listener = None;
         for _ in 0..100 {
@@ -146,6 +150,7 @@ impl IntegrationTest {
             stdio_rx,
             collect_stdio,
             _subgraphs: subgraphs,
+            subscriber,
         }
     }
 
@@ -208,7 +213,7 @@ impl IntegrationTest {
         self.router = Some(router);
     }
 
-    fn init_telemetry(telemetry: Option<Telemetry>) {
+    fn init_telemetry(telemetry: Option<Telemetry>) -> Option<Dispatch> {
         match telemetry {
             Some(Telemetry::Jaeger) => {
                 let tracer = opentelemetry_jaeger::new_agent_pipeline()
@@ -224,8 +229,8 @@ impl IntegrationTest {
                         .with_filter(EnvFilter::from_default_env()),
                 );
 
-                let _ = tracing::subscriber::set_global_default(subscriber);
                 global::set_text_map_propagator(opentelemetry_jaeger::Propagator::new());
+                Some(Dispatch::new(subscriber))
             }
             Some(Telemetry::Datadog) => {
                 let tracer = opentelemetry_datadog::new_pipeline()
@@ -241,8 +246,8 @@ impl IntegrationTest {
                         .with_filter(EnvFilter::from_default_env()),
                 );
 
-                let _ = tracing::subscriber::set_global_default(subscriber);
                 global::set_text_map_propagator(opentelemetry_datadog::DatadogPropagator::new());
+                Some(Dispatch::new(subscriber))
             }
             Some(Telemetry::Otlp) => {
                 let tracer = opentelemetry_otlp::new_pipeline()
@@ -258,10 +263,10 @@ impl IntegrationTest {
                         .with_filter(EnvFilter::from_default_env()),
                 );
 
-                let _ = tracing::subscriber::set_global_default(subscriber);
                 global::set_text_map_propagator(
                     opentelemetry::sdk::propagation::TraceContextPropagator::new(),
                 );
+                Some(Dispatch::new(subscriber))
             }
             Some(Telemetry::Zipkin) => {
                 let tracer = opentelemetry_zipkin::new_pipeline()
@@ -277,10 +282,10 @@ impl IntegrationTest {
                         .with_filter(EnvFilter::from_default_env()),
                 );
 
-                let _ = tracing::subscriber::set_global_default(subscriber);
                 global::set_text_map_propagator(opentelemetry_zipkin::Propagator::new());
+                Some(Dispatch::new(subscriber))
             }
-            _ => {}
+            _ => None,
         }
     }
 
@@ -313,40 +318,67 @@ impl IntegrationTest {
             .expect("must be able to write config");
     }
 
-    pub fn run_query(&self) -> impl std::future::Future<Output = (String, reqwest::Response)> {
+    #[allow(dead_code)]
+    pub fn execute_default_query(
+        &self,
+    ) -> impl std::future::Future<Output = (String, reqwest::Response)> {
+        self.execute_query_internal(None)
+    }
+
+    #[allow(dead_code)]
+    pub fn execute_query(
+        &self,
+        query: &Value,
+    ) -> impl std::future::Future<Output = (String, reqwest::Response)> {
+        self.execute_query_internal(Some(query))
+    }
+
+    fn execute_query_internal(
+        &self,
+        query: Option<&Value>,
+    ) -> impl std::future::Future<Output = (String, reqwest::Response)> {
         assert!(
             self.router.is_some(),
             "router was not started, call `router.start().await; router.assert_started().await`"
         );
-        async {
-            let client = reqwest::Client::new();
-            let id = Uuid::new_v4().to_string();
+        let default_query =
+            &json!({"query":"query ExampleQuery {topProducts{name}}","variables":{}});
+        let query = query.unwrap_or(default_query).clone();
+        let id = Uuid::new_v4().to_string();
+        let dispatch = self.subscriber.clone();
+
+        async move {
             let span = info_span!("client_request", unit_test = id.as_str());
-            let _span_guard = span.enter();
 
-            let mut request = client
-                .post("http://localhost:4000")
-                .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
-                .header("apollographql-client-name", "custom_name")
-                .header("apollographql-client-version", "1.0")
-                .json(&json!({"query":"{topProducts{name}}","variables":{}}))
-                .build()
-                .unwrap();
+            async move {
+                let client = reqwest::Client::new();
 
-            global::get_text_map_propagator(|propagator| {
-                propagator.inject_context(
-                    &span.context(),
-                    &mut opentelemetry_http::HeaderInjector(request.headers_mut()),
-                );
-            });
-            request.headers_mut().remove(ACCEPT);
-            match client.execute(request).await {
-                Ok(response) => (id, response),
-                Err(err) => {
-                    panic!("unable to send successful request to router, {err}")
+                let mut request = client
+                    .post("http://localhost:4000")
+                    .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                    .header("apollographql-client-name", "custom_name")
+                    .header("apollographql-client-version", "1.0")
+                    .json(&query)
+                    .build()
+                    .unwrap();
+                global::get_text_map_propagator(|propagator| {
+                    propagator.inject_context(
+                        &tracing::span::Span::current().context(),
+                        &mut opentelemetry_http::HeaderInjector(request.headers_mut()),
+                    );
+                });
+                request.headers_mut().remove(ACCEPT);
+                match client.execute(request).await {
+                    Ok(response) => (id, response),
+                    Err(err) => {
+                        panic!("unable to send successful request to router, {err}")
+                    }
                 }
             }
+            .instrument(span)
+            .await
         }
+        .with_subscriber(dispatch.unwrap_or_default())
     }
 
     #[allow(dead_code)]
@@ -548,7 +580,6 @@ impl Drop for IntegrationTest {
         if let Some(child) = &mut self.router {
             let _ = child.start_kill();
         }
-        global::shutdown_tracer_provider();
     }
 }
 

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -341,8 +341,7 @@ impl IntegrationTest {
             self.router.is_some(),
             "router was not started, call `router.start().await; router.assert_started().await`"
         );
-        let default_query =
-            &json!({"query":"query ExampleQuery {topProducts{name}}","variables":{}});
+        let default_query = &json!({"query":"query {topProducts{name}}","variables":{}});
         let query = query.unwrap_or(default_query).clone();
         let id = Uuid::new_v4().to_string();
         let dispatch = self.subscriber.clone();

--- a/apollo-router/tests/jaeger_test.rs
+++ b/apollo-router/tests/jaeger_test.rs
@@ -27,14 +27,15 @@ async fn test_jaeger_tracing() -> Result<(), BoxError> {
     router.start().await;
     router.assert_started().await;
 
+    let query = json!({"query":"query ExampleQuery {topProducts{name}}","variables":{}});
     for _ in 0..2 {
-        let (id, result) = router.run_query().await;
+        let (id, result) = router.execute_query(&query).await;
         assert!(!result
             .headers()
             .get("apollo-custom-trace-id")
             .unwrap()
             .is_empty());
-        query_jaeger_for_trace(id).await?;
+        validate_trace(id, &query, Some("ExampleQuery")).await?;
         router.touch_config().await;
         router.assert_reloaded().await;
     }
@@ -42,7 +43,58 @@ async fn test_jaeger_tracing() -> Result<(), BoxError> {
     Ok(())
 }
 
-async fn query_jaeger_for_trace(id: String) -> Result<(), BoxError> {
+#[tokio::test(flavor = "multi_thread")]
+async fn test_jaeger_tracing_anonymous_operation() -> Result<(), BoxError> {
+    let mut router = IntegrationTest::builder()
+        .telemetry(Telemetry::Jaeger)
+        .config(include_str!("fixtures/jaeger.router.yaml"))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    let query = json!({"query":"query {topProducts{name}}","variables":{}});
+
+    let (id, result) = router.execute_query(&query).await;
+    assert!(!result
+        .headers()
+        .get("apollo-custom-trace-id")
+        .unwrap()
+        .is_empty());
+    validate_trace(id, &query, None).await?;
+    router.graceful_shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_jaeger_tracing_selected_operation() -> Result<(), BoxError> {
+    let mut router = IntegrationTest::builder()
+        .telemetry(Telemetry::Jaeger)
+        .config(include_str!("fixtures/jaeger.router.yaml"))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+    let query = json!({"query":"query ExampleQuery1 {topProducts{name}}\nquery ExampleQuery2 {topProducts{name}}","variables":{}, "operationName": "ExampleQuery2"});
+
+    let (id, result) = router.execute_query(&query).await;
+    assert!(!result
+        .headers()
+        .get("apollo-custom-trace-id")
+        .unwrap()
+        .is_empty());
+    validate_trace(id, &query, Some("ExampleQuery2")).await?;
+    router.graceful_shutdown().await;
+    Ok(())
+}
+
+async fn validate_trace(
+    id: String,
+    query: &Value,
+    operation_name: Option<&str>,
+) -> Result<(), BoxError> {
     let tags = json!({ "unit_test": id });
     let params = url::form_urlencoded::Serializer::new(String::new())
         .append_pair("service", "my_app")
@@ -51,16 +103,20 @@ async fn query_jaeger_for_trace(id: String) -> Result<(), BoxError> {
 
     let url = format!("http://localhost:16686/api/traces?{params}");
     for _ in 0..10 {
-        if find_valid_trace(&url).await.is_ok() {
+        if find_valid_trace(&url, query, operation_name).await.is_ok() {
             return Ok(());
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
-    find_valid_trace(&url).await?;
+    find_valid_trace(&url, query, operation_name).await?;
     Ok(())
 }
 
-async fn find_valid_trace(url: &str) -> Result<(), BoxError> {
+async fn find_valid_trace(
+    url: &str,
+    query: &Value,
+    operation_name: Option<&str>,
+) -> Result<(), BoxError> {
     // A valid trace has:
     // * All three services
     // * The correct spans
@@ -78,13 +134,16 @@ async fn find_valid_trace(url: &str) -> Result<(), BoxError> {
     verify_trace_participants(&trace)?;
 
     // Verify that we got the expected span operation names
-    verify_spans_present(&trace)?;
+    verify_spans_present(&trace, operation_name)?;
 
     // Verify that all spans have a path to the root 'client_request' span
     verify_span_parenting(&trace)?;
 
+    // Verify that root span fields are present
+    verify_root_span_fields(&trace, operation_name)?;
+
     // Verify that supergraph span fields are present
-    verify_supergraph_span_fields(&trace)?;
+    verify_supergraph_span_fields(&trace, query, operation_name)?;
 
     // Verify that router span fields are present
     verify_router_span_fields(&trace)?;
@@ -111,20 +170,75 @@ fn verify_router_span_fields(trace: &Value) -> Result<(), BoxError> {
     Ok(())
 }
 
-fn verify_supergraph_span_fields(trace: &Value) -> Result<(), BoxError> {
-    let supergraph_span = trace.select_path("$..spans[?(@.operationName == 'supergraph')]")?[0];
+fn verify_root_span_fields(trace: &Value, operation_name: Option<&str>) -> Result<(), BoxError> {
     // We can't actually assert the values on a span. Only that a field has been set.
+    let root_span_name = operation_name
+        .map(|name| format!("query {}", name))
+        .unwrap_or("query".to_string());
+    let request_span = trace.select_path(&format!(
+        "$..spans[?(@.operationName == '{root_span_name}')]"
+    ))?[0];
+
+    if let Some(operation_name) = operation_name {
+        assert_eq!(
+            request_span
+                .select_path("$.tags[?(@.key == 'graphql.operation.name')].value")?
+                .get(0),
+            Some(&&Value::String(operation_name.to_string()))
+        );
+    } else {
+        assert!(request_span
+            .select_path("$.tags[?(@.key == 'graphql.operation.name')].value")?
+            .get(0)
+            .is_none(),);
+    }
+
+    assert_eq!(
+        request_span
+            .select_path("$.tags[?(@.key == 'graphql.operation.type')].value")?
+            .get(0),
+        Some(&&Value::String("query".to_string()))
+    );
+
+    Ok(())
+}
+
+fn verify_supergraph_span_fields(
+    trace: &Value,
+    query: &Value,
+    operation_name: Option<&str>,
+) -> Result<(), BoxError> {
+    // We can't actually assert the values on a span. Only that a field has been set.
+    let supergraph_span = trace.select_path("$..spans[?(@.operationName == 'supergraph')]")?[0];
+
+    if let Some(operation_name) = operation_name {
+        assert_eq!(
+            supergraph_span
+                .select_path("$.tags[?(@.key == 'graphql.operation.name')].value")?
+                .get(0),
+            Some(&&Value::String(operation_name.to_string()))
+        );
+    } else {
+        assert!(supergraph_span
+            .select_path("$.tags[?(@.key == 'graphql.operation.name')].value")?
+            .get(0)
+            .is_none(),);
+    }
+
     assert_eq!(
         supergraph_span
             .select_path("$.tags[?(@.key == 'graphql.document')].value")?
             .get(0),
-        Some(&&Value::String("{topProducts{name}}".to_string()))
-    );
-    assert_eq!(
-        supergraph_span
-            .select_path("$.tags[?(@.key == 'graphql.operation.name')].value")?
-            .get(0),
-        Some(&&Value::String("".to_string()))
+        Some(&&Value::String(
+            query
+                .as_object()
+                .expect("should have been an object")
+                .get("query")
+                .expect("must have a query")
+                .as_str()
+                .expect("must be a string")
+                .to_string()
+        ))
     );
 
     Ok(())
@@ -147,7 +261,7 @@ fn verify_trace_participants(trace: &Value) -> Result<(), BoxError> {
     Ok(())
 }
 
-fn verify_spans_present(trace: &Value) -> Result<(), BoxError> {
+fn verify_spans_present(trace: &Value, operation_name: Option<&str>) -> Result<(), BoxError> {
     let operation_names: HashSet<String> = trace
         .select_path("$..operationName")?
         .into_iter()
@@ -157,7 +271,10 @@ fn verify_spans_present(trace: &Value) -> Result<(), BoxError> {
         [
             "execution",
             "HTTP POST",
-            "request",
+            operation_name
+                .map(|name| format!("query {name}"))
+                .unwrap_or("query".to_string())
+                .as_str(),
             "supergraph",
             "fetch",
             //"parse_query", Parse query will only happen once

--- a/apollo-router/tests/metrics_tests.rs
+++ b/apollo-router/tests/metrics_tests.rs
@@ -19,9 +19,9 @@ async fn test_metrics_reloading() -> Result<(), BoxError> {
     router.assert_started().await;
 
     for _ in 0..2 {
-        router.run_query().await;
-        router.run_query().await;
-        router.run_query().await;
+        router.execute_default_query().await;
+        router.execute_default_query().await;
+        router.execute_default_query().await;
 
         // Get Prometheus metrics.
         let metrics_response = router.get_metrics_response().await.unwrap();

--- a/apollo-router/tests/metrics_tests.rs
+++ b/apollo-router/tests/metrics_tests.rs
@@ -60,8 +60,8 @@ async fn test_metrics_reloading() -> Result<(), BoxError> {
         .await;
 
     if std::env::var("APOLLO_KEY").is_ok() && std::env::var("APOLLO_GRAPH_REF").is_ok() {
-        router.assert_metrics_contains(r#"apollo_router_uplink_fetch_duration_seconds_count{kind="unchanged",query="License",service_name="apollo-router",url="https://uplink.api.apollographql.com/",otel_scope_name="apollo/router",otel_scope_version=""}"#, Some(Duration::from_secs(120))).await;
-        router.assert_metrics_contains(r#"apollo_router_uplink_fetch_count_total{query="License",service_name="apollo-router",status="success",otel_scope_name="apollo/router",otel_scope_version=""}"#, Some(Duration::from_secs(1))).await;
+        router.assert_metrics_contains(r#"apollo_router_uplink_fetch_duration_seconds_count{kind="unchanged",query="License",service_name="apollo-router",url="https://uplink.api.apollographql.com/"}"#, Some(Duration::from_secs(120))).await;
+        router.assert_metrics_contains(r#"apollo_router_uplink_fetch_count_total{query="License",service_name="apollo-router",status="success"}"#, Some(Duration::from_secs(1))).await;
     }
 
     Ok(())

--- a/apollo-router/tests/snapshots/tracing_tests__traced_basic_composition.snap
+++ b/apollo-router/tests/snapshots/tracing_tests__traced_basic_composition.snap
@@ -36,6 +36,18 @@ expression: get_spans()
           [
             "otel.kind",
             "SERVER"
+          ],
+          [
+            "apollo_private.request",
+            true
+          ],
+          [
+            "graphql.operation.type",
+            "query"
+          ],
+          [
+            "otel.name",
+            "query"
           ]
         ],
         "metadata": {
@@ -48,7 +60,11 @@ expression: get_spans()
               "http.method",
               "http.route",
               "http.flavor",
-              "otel.kind"
+              "otel.name",
+              "otel.kind",
+              "graphql.operation.name",
+              "graphql.operation.type",
+              "apollo_private.request"
             ]
           }
         }
@@ -168,10 +184,6 @@ expression: get_spans()
                   [
                     "graphql.document",
                     "{ topProducts { upc name reviews {id product { name } author { id name } } } }"
-                  ],
-                  [
-                    "graphql.operation.name",
-                    ""
                   ],
                   [
                     "otel.kind",

--- a/apollo-router/tests/snapshots/tracing_tests__traced_basic_request.snap
+++ b/apollo-router/tests/snapshots/tracing_tests__traced_basic_request.snap
@@ -36,6 +36,18 @@ expression: get_spans()
           [
             "otel.kind",
             "SERVER"
+          ],
+          [
+            "apollo_private.request",
+            true
+          ],
+          [
+            "graphql.operation.type",
+            "query"
+          ],
+          [
+            "otel.name",
+            "query"
           ]
         ],
         "metadata": {
@@ -48,7 +60,11 @@ expression: get_spans()
               "http.method",
               "http.route",
               "http.flavor",
-              "otel.kind"
+              "otel.name",
+              "otel.kind",
+              "graphql.operation.name",
+              "graphql.operation.type",
+              "apollo_private.request"
             ]
           }
         }
@@ -168,10 +184,6 @@ expression: get_spans()
                   [
                     "graphql.document",
                     "{ topProducts { name name2:name } }"
-                  ],
-                  [
-                    "graphql.operation.name",
-                    ""
                   ],
                   [
                     "otel.kind",

--- a/apollo-router/tests/snapshots/tracing_tests__variables.snap
+++ b/apollo-router/tests/snapshots/tracing_tests__variables.snap
@@ -36,6 +36,18 @@ expression: get_spans()
           [
             "otel.kind",
             "SERVER"
+          ],
+          [
+            "apollo_private.request",
+            true
+          ],
+          [
+            "graphql.operation.name",
+            "ExampleQuery"
+          ],
+          [
+            "otel.name",
+            "GraphQL Operation"
           ]
         ],
         "metadata": {
@@ -48,7 +60,11 @@ expression: get_spans()
               "http.method",
               "http.route",
               "http.flavor",
-              "otel.kind"
+              "otel.name",
+              "otel.kind",
+              "graphql.operation.name",
+              "graphql.operation.type",
+              "apollo_private.request"
             ]
           }
         }
@@ -154,10 +170,6 @@ expression: get_spans()
                     "query ExampleQuery($topProductsFirst: Int, $reviewsForAuthorAuthorId: ID!) {\n                topProducts(first: $topProductsFirst) {\n                    name\n                    reviewsForAuthor(authorID: $reviewsForAuthorAuthorId) {\n                        body\n                        author {\n                            id\n                            name\n                        }\n                    }\n                }\n            }"
                   ],
                   [
-                    "graphql.operation.name",
-                    ""
-                  ],
-                  [
                     "otel.kind",
                     "INTERNAL"
                   ],
@@ -168,6 +180,10 @@ expression: get_spans()
                   [
                     "apollo_private.graphql.variables",
                     "{}"
+                  ],
+                  [
+                    "graphql.operation.name",
+                    "ExampleQuery"
                   ],
                   [
                     "apollo_private.operation_signature",

--- a/apollo-router/tests/subscription_load_test.rs
+++ b/apollo-router/tests/subscription_load_test.rs
@@ -33,7 +33,11 @@ async fn test_subscription_load() -> Result<(), BoxError> {
     }
 
     for _ in 0..100 {
-        let (_id, resp) = router.run_query().await;
+        let (_id, resp) = router
+            .execute_query(
+                &json!({"query":"query ExampleQuery {topProducts{name}}","variables":{}}),
+            )
+            .await;
         assert!(resp.status().is_success());
     }
 
@@ -61,7 +65,7 @@ async fn test_subscription_load_federated() -> Result<(), BoxError> {
     }
 
     for _ in 0..100 {
-        let (_id, resp) = router.run_query().await;
+        let (_id, resp) = router.execute_default_query().await;
         assert!(resp.status().is_success());
     }
 

--- a/apollo-router/tests/telemetry_test.rs
+++ b/apollo-router/tests/telemetry_test.rs
@@ -36,7 +36,7 @@ async fn test_otlp_tracing() -> Result<(), BoxError> {
         .await;
     router.start().await;
     router.assert_started().await;
-    router.run_query().await;
+    router.execute_default_query().await;
     Ok(())
 }
 
@@ -51,7 +51,7 @@ async fn test_datadog_tracing() -> Result<(), BoxError> {
 
     router.start().await;
     router.assert_started().await;
-    router.run_query().await;
+    router.execute_default_query().await;
     Ok(())
 }
 
@@ -66,7 +66,7 @@ async fn test_tracing() -> Result<(), BoxError> {
     router.start().await;
     router.assert_started().await;
 
-    let (_, response) = router.run_query().await;
+    let (_, response) = router.execute_default_query().await;
     assert!(response.headers().get("apollo-trace-id").is_none());
 
     Ok(())


### PR DESCRIPTION
https://opentelemetry.io/docs/specs/otel/trace/semantic_conventions/instrumentation/graphql/

Root span name has changed from request to `<graphql.operation.kind> <graphql.operation.name>`

Fixes #3229

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
