### PR TITLE
remove the compiler from Query

### DIFF
--- a/.changesets/maint_geal_remove_compiler_from_query.md
+++ b/.changesets/maint_geal_remove_compiler_from_query.md
@@ -1,0 +1,5 @@
+### remove the compiler from Query ([Issue #3373](https://github.com/apollographql/router/issues/3373))
+
+we don't really need to carry the compiler inside that object, since it is now cached at the query analysis layer. We also should not carry it in the supergraph request and execution request, because that makes the builders hard to manipulate for plugin authors. Since we are not exposing the compiler in the public API yet, we move it inside the context's private entries, where it will be easily accessible from internal code.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3367

--- a/.changesets/maint_geal_remove_compiler_from_query.md
+++ b/.changesets/maint_geal_remove_compiler_from_query.md
@@ -1,5 +1,5 @@
 ### remove the compiler from Query ([Issue #3373](https://github.com/apollographql/router/issues/3373))
 
-we don't really need to carry the compiler inside that object, since it is now cached at the query analysis layer. We also should not carry it in the supergraph request and execution request, because that makes the builders hard to manipulate for plugin authors. Since we are not exposing the compiler in the public API yet, we move it inside the context's private entries, where it will be easily accessible from internal code.
+The `Query` object caches information extracted from the query that is used to format responses. It was carrying an `ApolloCompiler` instance, but now we don't really need it anymore, since it is now cached at the query analysis layer. We also should not carry it in the supergraph request and execution request, because that makes the builders hard to manipulate for plugin authors. Since we are not exposing the compiler in the public API yet, we move it inside the context's private entries, where it will be easily accessible from internal code.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3367

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -167,7 +167,6 @@ impl BridgeQueryPlanner {
         )?;
         Ok(Query {
             string: query,
-            compiler,
             fragments,
             operations,
             filtered_query: None,

--- a/apollo-router/src/services/execution.rs
+++ b/apollo-router/src/services/execution.rs
@@ -45,8 +45,8 @@ impl Request {
         supergraph_request: http::Request<graphql::Request>,
         query_plan: Arc<QueryPlan>,
         context: Context,
+        compiler: apollo_compiler::Snapshot,
     ) -> Request {
-        let compiler = query_plan.query.uncached_compiler(None).snapshot();
         Self {
             supergraph_request,
             query_plan,
@@ -61,8 +61,9 @@ impl Request {
         supergraph_request: http::Request<graphql::Request>,
         query_plan: Arc<QueryPlan>,
         context: Context,
+        compiler: apollo_compiler::Snapshot,
     ) -> Request {
-        let compiler = query_plan.query.compiler().await.snapshot();
+        //let compiler = query_plan.query.compiler().await.snapshot();
         Self {
             supergraph_request,
             query_plan,
@@ -81,11 +82,13 @@ impl Request {
         supergraph_request: Option<http::Request<graphql::Request>>,
         query_plan: Option<QueryPlan>,
         context: Option<Context>,
+        compiler: apollo_compiler::Snapshot,
     ) -> Request {
         Request::new(
             supergraph_request.unwrap_or_default(),
             Arc::new(query_plan.unwrap_or_else(|| QueryPlan::fake_builder().build())),
             context.unwrap_or_default(),
+            compiler,
         )
     }
 }

--- a/apollo-router/src/services/execution.rs
+++ b/apollo-router/src/services/execution.rs
@@ -52,7 +52,6 @@ impl Request {
         query_plan: Arc<QueryPlan>,
         context: Context,
     ) -> Request {
-        //let compiler = query_plan.query.compiler().await.snapshot();
         Self {
             supergraph_request,
             query_plan,

--- a/apollo-router/src/services/execution.rs
+++ b/apollo-router/src/services/execution.rs
@@ -23,14 +23,6 @@ pub struct Request {
 
     pub query_plan: Arc<QueryPlan>,
 
-    /// An apollo-compiler context that contains `self.query_plan.query`.
-    ///
-    /// It normally also contains type information from the schema,
-    /// but might not if this `Request` was created in tests
-    /// with `fake_builder()` without providing a `schema` parameter.
-    #[allow(unused)] // TODO: find some uses
-    pub(crate) compiler: apollo_compiler::Snapshot,
-
     pub context: Context,
 }
 
@@ -45,12 +37,10 @@ impl Request {
         supergraph_request: http::Request<graphql::Request>,
         query_plan: Arc<QueryPlan>,
         context: Context,
-        compiler: apollo_compiler::Snapshot,
     ) -> Request {
         Self {
             supergraph_request,
             query_plan,
-            compiler,
             context,
         }
     }
@@ -61,13 +51,11 @@ impl Request {
         supergraph_request: http::Request<graphql::Request>,
         query_plan: Arc<QueryPlan>,
         context: Context,
-        compiler: apollo_compiler::Snapshot,
     ) -> Request {
         //let compiler = query_plan.query.compiler().await.snapshot();
         Self {
             supergraph_request,
             query_plan,
-            compiler,
             context,
         }
     }
@@ -82,13 +70,11 @@ impl Request {
         supergraph_request: Option<http::Request<graphql::Request>>,
         query_plan: Option<QueryPlan>,
         context: Option<Context>,
-        compiler: apollo_compiler::Snapshot,
     ) -> Request {
         Request::new(
             supergraph_request.unwrap_or_default(),
             Arc::new(query_plan.unwrap_or_else(|| QueryPlan::fake_builder().build())),
             context.unwrap_or_default(),
-            compiler,
         )
     }
 }

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -123,11 +123,17 @@ impl QueryAnalysisLayer {
         };
 
         request.context.extend(&context);
+        request
+            .context
+            .private_entries
+            .lock()
+            .insert(Compiler(compiler));
 
         Ok(SupergraphRequest {
             supergraph_request: request.supergraph_request,
             context: request.context,
-            compiler: Some(compiler),
         })
     }
 }
+
+pub(crate) struct Compiler(pub(crate) Arc<Mutex<ApolloCompiler>>);

--- a/apollo-router/src/services/query_planner.rs
+++ b/apollo-router/src/services/query_planner.rs
@@ -2,15 +2,16 @@
 
 use std::sync::Arc;
 
-use crate::error::QueryPlannerError;
-use crate::graphql;
-use crate::query_planner::QueryPlan;
-use crate::Context;
 use async_trait::async_trait;
 use derivative::Derivative;
 use serde::Deserialize;
 use serde::Serialize;
 use static_assertions::assert_impl_all;
+
+use crate::error::QueryPlannerError;
+use crate::graphql;
+use crate::query_planner::QueryPlan;
+use crate::Context;
 
 assert_impl_all!(Request: Send);
 /// [`Context`] for the request.

--- a/apollo-router/src/services/query_planner.rs
+++ b/apollo-router/src/services/query_planner.rs
@@ -2,18 +2,15 @@
 
 use std::sync::Arc;
 
-use apollo_compiler::ApolloCompiler;
+use crate::error::QueryPlannerError;
+use crate::graphql;
+use crate::query_planner::QueryPlan;
+use crate::Context;
 use async_trait::async_trait;
 use derivative::Derivative;
 use serde::Deserialize;
 use serde::Serialize;
 use static_assertions::assert_impl_all;
-use tokio::sync::Mutex;
-
-use crate::error::QueryPlannerError;
-use crate::graphql;
-use crate::query_planner::QueryPlan;
-use crate::Context;
 
 assert_impl_all!(Request: Send);
 /// [`Context`] for the request.
@@ -22,8 +19,6 @@ assert_impl_all!(Request: Send);
 pub(crate) struct Request {
     pub(crate) query: String,
     pub(crate) operation_name: Option<String>,
-    #[derivative(Debug = "ignore")]
-    pub(crate) compiler: Arc<Mutex<ApolloCompiler>>,
     pub(crate) context: Context,
 }
 
@@ -33,17 +28,11 @@ impl Request {
     ///
     /// Required parameters are required in non-testing code to create a QueryPlannerRequest.
     #[builder]
-    pub(crate) fn new(
-        query: String,
-        operation_name: Option<String>,
-        context: Context,
-        compiler: Arc<Mutex<ApolloCompiler>>,
-    ) -> Request {
+    pub(crate) fn new(query: String, operation_name: Option<String>, context: Context) -> Request {
         Self {
             query,
             operation_name,
             context,
-            compiler,
         }
     }
 }
@@ -55,8 +44,6 @@ pub(crate) struct CachingRequest {
     pub(crate) query: String,
     pub(crate) operation_name: Option<String>,
     pub(crate) context: Context,
-    #[derivative(Debug = "ignore")]
-    pub(crate) compiler: Arc<Mutex<ApolloCompiler>>,
 }
 
 #[buildstructor::buildstructor]
@@ -68,13 +55,11 @@ impl CachingRequest {
     pub(crate) fn new(
         query: String,
         operation_name: Option<String>,
-        compiler: Arc<Mutex<ApolloCompiler>>,
         context: Context,
     ) -> CachingRequest {
         Self {
             query,
             operation_name,
-            compiler,
             context,
         }
     }

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -420,7 +420,6 @@ impl RouterService {
         Ok(SupergraphRequest {
             supergraph_request: http::Request::from_parts(parts, graphql_request?),
             context,
-            compiler: None,
         })
     }
 }

--- a/apollo-router/src/services/supergraph.rs
+++ b/apollo-router/src/services/supergraph.rs
@@ -1,8 +1,5 @@
 #![allow(missing_docs)] // FIXME
 
-use std::sync::Arc;
-
-use apollo_compiler::ApolloCompiler;
 use futures::future::ready;
 use futures::stream::once;
 use futures::stream::StreamExt;
@@ -17,7 +14,6 @@ use serde_json_bytes::ByteString;
 use serde_json_bytes::Map as JsonMap;
 use serde_json_bytes::Value;
 use static_assertions::assert_impl_all;
-use tokio::sync::Mutex;
 use tower::BoxError;
 
 use crate::error::Error;
@@ -26,10 +22,7 @@ use crate::http_ext::header_map;
 use crate::http_ext::TryIntoHeaderName;
 use crate::http_ext::TryIntoHeaderValue;
 use crate::json_ext::Path;
-use crate::spec::query::QUERY_EXECUTABLE;
 use crate::Context;
-
-use super::layers::query_analysis::Compiler;
 
 pub type BoxService = tower::util::BoxService<Request, Response, BoxError>;
 pub type BoxCloneService = tower::util::BoxCloneService<Request, Response, BoxError>;
@@ -124,21 +117,6 @@ impl Request {
             .entry(http::header::CONTENT_TYPE.into())
             .or_insert(HeaderValue::from_static(APPLICATION_JSON.essence_str()).into());
         let context = context.unwrap_or_default();
-
-        let entries = context.private_entries.lock();
-        if !entries.contains_key::<Compiler>() {
-            let mut compiler = ApolloCompiler::new();
-            if let Some(q) = query.as_ref() {
-                compiler.add_executable(&q, QUERY_EXECUTABLE);
-            }
-
-            context
-                .private_entries
-                .lock()
-                .insert(Compiler(Arc::new(Mutex::new(compiler))));
-        }
-
-        drop(entries);
 
         Request::new(
             query,

--- a/apollo-router/src/services/supergraph.rs
+++ b/apollo-router/src/services/supergraph.rs
@@ -1,8 +1,5 @@
 #![allow(missing_docs)] // FIXME
 
-use std::sync::Arc;
-
-use apollo_compiler::ApolloCompiler;
 use futures::future::ready;
 use futures::stream::once;
 use futures::stream::StreamExt;
@@ -17,7 +14,6 @@ use serde_json_bytes::ByteString;
 use serde_json_bytes::Map as JsonMap;
 use serde_json_bytes::Value;
 use static_assertions::assert_impl_all;
-use tokio::sync::Mutex;
 use tower::BoxError;
 
 use crate::error::Error;
@@ -43,9 +39,6 @@ pub struct Request {
 
     /// Context for extension
     pub context: Context,
-
-    #[allow(dead_code)]
-    pub(crate) compiler: Option<Arc<Mutex<ApolloCompiler>>>,
 }
 
 impl From<http::Request<graphql::Request>> for Request {
@@ -53,7 +46,6 @@ impl From<http::Request<graphql::Request>> for Request {
         Self {
             supergraph_request,
             context: Context::new(),
-            compiler: None,
         }
     }
 }
@@ -99,7 +91,6 @@ impl Request {
         Ok(Self {
             supergraph_request,
             context,
-            compiler: None,
         })
     }
 

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -267,7 +267,7 @@ async fn plan_query(
 ) -> Result<QueryPlannerResponse, CacheResolverError> {
     // FIXME: we have about 80 tests creating a supergraph service and crafting a supergraph request for it
     // none of those tests create a compiler to put it in the context, and the compiler cannot be created
-    // from inside the supergraph r'equest fake builder, because it needs a schema matching the query.
+    // from inside the supergraph request fake builder, because it needs a schema matching the query.
     // So while we are updating the tests to create a compiler manually, this here will make sure current
     // tests will pass
     {

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -131,6 +131,7 @@ async fn service_call(
     let context = req.context;
     let body = req.supergraph_request.body();
     let variables = body.variables.clone();
+    let compiler = req.compiler.as_ref().unwrap().lock().await.snapshot();
     let QueryPlannerResponse {
         content,
         context,
@@ -237,6 +238,7 @@ async fn service_call(
                             .supergraph_request(req.supergraph_request)
                             .query_plan(plan.clone())
                             .context(context)
+                            .compiler(compiler)
                             .build()
                             .await,
                     )

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -53,11 +53,6 @@ pub(crate) const QUERY_EXECUTABLE: &str = "query";
 #[derivative(PartialEq, Hash, Eq, Debug)]
 pub(crate) struct Query {
     pub(crate) string: String,
-    #[derivative(PartialEq = "ignore", Hash = "ignore", Debug = "ignore")]
-    #[serde(skip)]
-    // FIXME: find a way to have a correct compiler when deserializing
-    #[serde(default = "empty_compiler")]
-    pub(crate) compiler: Arc<Mutex<ApolloCompiler>>,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub(crate) fragments: Fragments,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
@@ -94,7 +89,6 @@ impl Query {
     pub(crate) fn empty() -> Self {
         Self {
             string: String::new(),
-            compiler: empty_compiler(),
             fragments: Fragments {
                 map: HashMap::new(),
             },
@@ -289,7 +283,6 @@ impl Query {
 
         Ok(Query {
             string: query,
-            compiler: Arc::new(Mutex::new(compiler)),
             fragments,
             operations,
             subselections: HashMap::new(),
@@ -342,10 +335,6 @@ impl Query {
             .collect::<Result<Vec<_>, SpecError>>()?;
 
         Ok((fragments, operations, defer_stats))
-    }
-
-    pub(crate) async fn compiler(&self) -> MutexGuard<'_, ApolloCompiler> {
-        self.compiler.lock().await
     }
 
     /// Create a new compiler for this query, without caching it

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -5521,7 +5521,6 @@ fn filtered_defer_fragment() {
     .unwrap();
     let mut query = Query {
         string: query.to_string(),
-        compiler: Arc::new(Mutex::new(compiler)),
         fragments,
         operations,
         filtered_query: None,
@@ -5546,7 +5545,6 @@ fn filtered_defer_fragment() {
 
     let filtered = Query {
         string: filtered_query.to_string(),
-        compiler: Arc::new(Mutex::new(compiler)),
         fragments,
         operations,
         filtered_query: None,


### PR DESCRIPTION
Fix #3373 

we don't really need to carry the compiler inside that object, since it is now cached at the query analysis layer. We also should not carry it in the supergraph request and execution request, because that makes the builders hard to manipulate for plugin authors. Since we are not exposing the compiler in the public API yet, we move it inside the context's private entries, where it will be easily accessible from internal code.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
