### PR TITLE
Create fewer compilers

### DIFF
--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -289,7 +289,7 @@ impl Service<QueryPlannerRequest> for BridgeQueryPlanner {
         let fut = async move {
             let start = Instant::now();
 
-            let mut compiler_guard = compiler.lock().await;
+            let mut compiler_guard = compiler.as_ref().expect("HAS A COMPILER").lock().await;
             let file_id = compiler_guard
                 .db
                 .source_file(QUERY_EXECUTABLE.into())
@@ -324,7 +324,7 @@ impl Service<QueryPlannerRequest> for BridgeQueryPlanner {
                     filtered_query.to_string(),
                     operation_name.to_owned(),
                     added_labels,
-                    compiler,
+                    compiler.expect("HAS A COMPILER"),
                 )
                 .await;
             let duration = start.elapsed().as_secs_f64();

--- a/apollo-router/src/services/query_planner.rs
+++ b/apollo-router/src/services/query_planner.rs
@@ -23,7 +23,7 @@ pub(crate) struct Request {
     pub(crate) query: String,
     pub(crate) operation_name: Option<String>,
     #[derivative(Debug = "ignore")]
-    pub(crate) compiler: Arc<Mutex<ApolloCompiler>>,
+    pub(crate) compiler: Option<Arc<Mutex<ApolloCompiler>>>,
     pub(crate) context: Context,
 }
 
@@ -37,7 +37,7 @@ impl Request {
         query: String,
         operation_name: Option<String>,
         context: Context,
-        compiler: Arc<Mutex<ApolloCompiler>>,
+        compiler: Option<Arc<Mutex<ApolloCompiler>>>,
     ) -> Request {
         Self {
             query,
@@ -56,7 +56,7 @@ pub(crate) struct CachingRequest {
     pub(crate) operation_name: Option<String>,
     pub(crate) context: Context,
     #[derivative(Debug = "ignore")]
-    pub(crate) compiler: Arc<Mutex<ApolloCompiler>>,
+    pub(crate) compiler: Option<Arc<Mutex<ApolloCompiler>>>,
 }
 
 #[buildstructor::buildstructor]
@@ -68,7 +68,7 @@ impl CachingRequest {
     pub(crate) fn new(
         query: String,
         operation_name: Option<String>,
-        compiler: Arc<Mutex<ApolloCompiler>>,
+        compiler: Option<Arc<Mutex<ApolloCompiler>>>,
         context: Context,
     ) -> CachingRequest {
         Self {

--- a/apollo-router/src/services/supergraph.rs
+++ b/apollo-router/src/services/supergraph.rs
@@ -44,7 +44,6 @@ pub struct Request {
     /// Context for extension
     pub context: Context,
 
-    #[allow(dead_code)]
     pub(crate) compiler: Option<Arc<Mutex<ApolloCompiler>>>,
 }
 


### PR DESCRIPTION
Creating a compiler is compuatationally expensive. We need them to process requests, but we are creating too many.

This change moves the point of creation so that we only create a compiler when a query is first cached.

fixes: #3309

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

I manually tested this by modifying a plugin to replicate the behaviour outlined in the issue (#3309) and noted that compilers were created on every request. With these changes a compiler is only created once for each individual request.

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
