### PR TITLE
move AllowOnlyHttpPostMutationsLayer at the supergraph service level

### DIFF
--- a/.changesets/maint_geal_move_post_mutation_layer.md
+++ b/.changesets/maint_geal_move_post_mutation_layer.md
@@ -1,0 +1,5 @@
+### move AllowOnlyHttpPostMutationsLayer at the supergraph service level ([PR #3374](https://github.com/apollographql/router/pull/3374))
+
+Now that we have access to a compiler in supergraph requests, we don't need to look into the query plan to know if a request contains mutations
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3374

--- a/apollo-router/src/services/execution_service.rs
+++ b/apollo-router/src/services/execution_service.rs
@@ -23,7 +23,6 @@ use tower::ServiceExt;
 use tower_service::Service;
 use tracing::Instrument;
 
-use super::layers::allow_only_http_post_mutations::AllowOnlyHttpPostMutationsLayer;
 use super::new_service::ServiceFactory;
 use super::Plugins;
 use super::SubgraphServiceFactory;
@@ -512,7 +511,6 @@ impl ServiceFactory<ExecutionRequest> for ExecutionServiceFactory {
             .map(|p| p.config.clone());
 
         ServiceBuilder::new()
-            .layer(AllowOnlyHttpPostMutationsLayer::default())
             .service(
                 self.plugins.iter().rev().fold(
                     crate::services::execution_service::ExecutionService {

--- a/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
+++ b/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
@@ -4,6 +4,10 @@
 
 use std::ops::ControlFlow;
 
+use apollo_compiler::hir::OperationType;
+use apollo_compiler::HirDatabase;
+use apollo_compiler::InputDatabase;
+use futures::future::BoxFuture;
 use http::header::HeaderName;
 use http::HeaderValue;
 use http::Method;
@@ -11,76 +15,131 @@ use http::StatusCode;
 use tower::BoxError;
 use tower::Layer;
 use tower::Service;
+use tower::ServiceBuilder;
 
 use crate::graphql::Error;
 use crate::json_ext::Object;
-use crate::layers::sync_checkpoint::CheckpointService;
-use crate::services::ExecutionRequest;
-use crate::services::ExecutionResponse;
+use crate::layers::async_checkpoint::AsyncCheckpointService;
+use crate::layers::ServiceBuilderExt;
+use crate::services::SupergraphRequest;
+use crate::services::SupergraphResponse;
+use crate::spec::query::QUERY_EXECUTABLE;
 
 #[derive(Default)]
 pub(crate) struct AllowOnlyHttpPostMutationsLayer {}
 
 impl<S> Layer<S> for AllowOnlyHttpPostMutationsLayer
 where
-    S: Service<ExecutionRequest, Response = ExecutionResponse, Error = BoxError> + Send + 'static,
-    <S as Service<ExecutionRequest>>::Future: Send + 'static,
+    S: Service<SupergraphRequest, Response = SupergraphResponse, Error = BoxError>
+        + Clone
+        + Send
+        + 'static,
+    <S as Service<SupergraphRequest>>::Future: Send + 'static,
 {
-    type Service = CheckpointService<S, ExecutionRequest>;
+    type Service = AsyncCheckpointService<
+        S,
+        BoxFuture<'static, Result<ControlFlow<SupergraphResponse, SupergraphRequest>, BoxError>>,
+        SupergraphRequest,
+    >;
 
     fn layer(&self, service: S) -> Self::Service {
-        CheckpointService::new(
-            |req: ExecutionRequest| {
-                if req.supergraph_request.method() != Method::POST
-                    && req.query_plan.contains_mutations()
-                {
-                    let errors = vec![Error::builder()
-                        .message("Mutations can only be sent over HTTP POST".to_string())
-                        .extension_code("MUTATION_FORBIDDEN")
-                        .build()];
-                    let mut res = ExecutionResponse::builder()
-                        .errors(errors)
-                        .extensions(Object::default())
-                        .status_code(StatusCode::METHOD_NOT_ALLOWED)
-                        .context(req.context)
-                        .build()?;
-                    res.response.headers_mut().insert(
-                        HeaderName::from_static("allow"),
-                        HeaderValue::from_static("POST"),
-                    );
-                    Ok(ControlFlow::Break(res))
-                } else {
-                    Ok(ControlFlow::Continue(req))
-                }
-            },
-            service,
-        )
+        ServiceBuilder::new()
+            .checkpoint_async(|req: SupergraphRequest| {
+                Box::pin(async {
+                    if req.supergraph_request.method() == Method::POST {
+                        return Ok(ControlFlow::Continue(req));
+                    }
+
+                    match req.compiler.as_ref() {
+                        None => return Ok(ControlFlow::Continue(req)),
+                        Some(compiler) => {
+                            let c = compiler.lock().await.snapshot();
+                            let file_id = c
+                                .source_file(QUERY_EXECUTABLE.into())
+                                .expect("the query is already loaded in the compiler");
+
+                            match c.find_operation(
+                                file_id,
+                                req.supergraph_request.body().operation_name.clone(),
+                            ) {
+                                None => {
+                                    let errors = vec![Error::builder()
+                                        .message("Cannot find operation".to_string())
+                                        .extension_code("MISSING_OPERATION")
+                                        .build()];
+                                    let res = SupergraphResponse::builder()
+                                        .errors(errors)
+                                        .extensions(Object::default())
+                                        .status_code(StatusCode::METHOD_NOT_ALLOWED)
+                                        .context(req.context)
+                                        .build()?;
+
+                                    return Ok(ControlFlow::Break(res));
+                                }
+                                Some(op) => {
+                                    if op.operation_ty() == OperationType::Mutation {
+                                        let errors = vec![Error::builder()
+                                            .message(
+                                                "Mutations can only be sent over HTTP POST"
+                                                    .to_string(),
+                                            )
+                                            .extension_code("MUTATION_FORBIDDEN")
+                                            .build()];
+                                        let mut res = SupergraphResponse::builder()
+                                            .errors(errors)
+                                            .extensions(Object::default())
+                                            .status_code(StatusCode::METHOD_NOT_ALLOWED)
+                                            .context(req.context)
+                                            .build()?;
+                                        res.response.headers_mut().insert(
+                                            HeaderName::from_static("allow"),
+                                            HeaderValue::from_static("POST"),
+                                        );
+                                        Ok(ControlFlow::Break(res))
+                                    } else {
+                                        Ok(ControlFlow::Continue(req))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                })
+                    as BoxFuture<
+                        'static,
+                        Result<ControlFlow<SupergraphResponse, SupergraphRequest>, BoxError>,
+                    >
+            })
+            .service(service)
     }
 }
 
 #[cfg(test)]
 mod forbid_http_get_mutations_tests {
-    use serde_json::json;
+    use std::sync::Arc;
+
+    use apollo_compiler::ApolloCompiler;
+    use tokio::sync::Mutex;
     use tower::ServiceExt;
 
     use super::*;
     use crate::error::Error;
-    use crate::graphql;
     use crate::graphql::Response;
-    use crate::http_ext;
-    use crate::plugin::test::MockExecutionService;
+    use crate::plugin::test::MockSupergraphService;
     use crate::query_planner::fetch::OperationKind;
-    use crate::query_planner::PlanNode;
-    use crate::query_planner::QueryPlan;
 
     #[tokio::test]
     async fn it_lets_http_post_queries_pass_through() {
-        let mut mock_service = MockExecutionService::new();
+        let mut mock_service = MockSupergraphService::new();
 
-        mock_service
-            .expect_call()
-            .times(1)
-            .returning(move |_| Ok(ExecutionResponse::fake_builder().build().unwrap()));
+        mock_service.expect_clone().returning(move || {
+            let mut service = MockSupergraphService::new();
+
+            service
+                .expect_call()
+                .times(1)
+                .returning(move |_| Ok(SupergraphResponse::fake_builder().build().unwrap()));
+            service
+        });
 
         let mut service_stack = AllowOnlyHttpPostMutationsLayer::default().layer(mock_service);
 
@@ -98,12 +157,17 @@ mod forbid_http_get_mutations_tests {
 
     #[tokio::test]
     async fn it_lets_http_post_mutations_pass_through() {
-        let mut mock_service = MockExecutionService::new();
+        let mut mock_service = MockSupergraphService::new();
 
-        mock_service
-            .expect_call()
-            .times(1)
-            .returning(move |_| Ok(ExecutionResponse::fake_builder().build().unwrap()));
+        mock_service.expect_clone().returning(move || {
+            let mut service = MockSupergraphService::new();
+
+            service
+                .expect_call()
+                .times(1)
+                .returning(move |_| Ok(SupergraphResponse::fake_builder().build().unwrap()));
+            service
+        });
 
         let mut service_stack = AllowOnlyHttpPostMutationsLayer::default().layer(mock_service);
 
@@ -121,12 +185,17 @@ mod forbid_http_get_mutations_tests {
 
     #[tokio::test]
     async fn it_lets_http_get_queries_pass_through() {
-        let mut mock_service = MockExecutionService::new();
+        let mut mock_service = MockSupergraphService::new();
 
-        mock_service
-            .expect_call()
-            .times(1)
-            .returning(move |_| Ok(ExecutionResponse::fake_builder().build().unwrap()));
+        mock_service.expect_clone().returning(move || {
+            let mut service = MockSupergraphService::new();
+
+            service
+                .expect_call()
+                .times(1)
+                .returning(move |_| Ok(SupergraphResponse::fake_builder().build().unwrap()));
+            service
+        });
 
         let mut service_stack = AllowOnlyHttpPostMutationsLayer::default().layer(mock_service);
 
@@ -158,8 +227,11 @@ mod forbid_http_get_mutations_tests {
         let expected_status = StatusCode::METHOD_NOT_ALLOWED;
         let expected_allow_header = "POST";
 
-        let mut service_stack =
-            AllowOnlyHttpPostMutationsLayer::default().layer(MockExecutionService::new());
+        let mut mock_service = MockSupergraphService::new();
+        mock_service
+            .expect_clone()
+            .returning(move || MockSupergraphService::new());
+        let mut service_stack = AllowOnlyHttpPostMutationsLayer::default().layer(mock_service);
 
         let forbidden_requests = [
             Method::GET,
@@ -192,46 +264,23 @@ mod forbid_http_get_mutations_tests {
         assert_eq!(&response.errors[0], expected_error);
     }
 
-    fn create_request(method: Method, operation_kind: OperationKind) -> ExecutionRequest {
-        let root: PlanNode = if operation_kind == OperationKind::Mutation {
-            serde_json::from_value(json!({
-                "kind": "Sequence",
-                "nodes": [
-                    {
-                        "kind": "Fetch",
-                        "serviceName": "product",
-                        "variableUsages": [],
-                        "operation": "{__typename}",
-                        "operationKind": "mutation"
-                      },
-                ]
-            }))
-            .unwrap()
-        } else {
-            serde_json::from_value(json!({
-                "kind": "Sequence",
-                "nodes": [
-                    {
-                        "kind": "Fetch",
-                        "serviceName": "product",
-                        "variableUsages": [],
-                        "operation": "{__typename}",
-                        "operationKind": "query"
-                      },
-                ]
-            }))
-            .unwrap()
+    fn create_request(method: Method, operation_kind: OperationKind) -> SupergraphRequest {
+        let query = match operation_kind {
+            OperationKind::Query => "query { a }",
+            OperationKind::Mutation => "mutation { a }",
+
+            OperationKind::Subscription => "subscription { a }",
         };
 
-        let request = http_ext::Request::fake_builder()
+        let mut compiler = ApolloCompiler::new();
+        compiler.add_executable(query, QUERY_EXECUTABLE);
+        let mut request = SupergraphRequest::fake_builder()
             .method(method)
-            .body(graphql::Request::default())
+            .query(query)
             .build()
-            .expect("expecting valid request");
+            .unwrap();
+        request.compiler = Some(Arc::new(Mutex::new(compiler)));
 
-        ExecutionRequest::fake_builder()
-            .supergraph_request(request)
-            .query_plan(QueryPlan::fake_builder().root(root).build())
-            .build()
+        request
     }
 }

--- a/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
+++ b/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
@@ -51,7 +51,7 @@ where
                     }
 
                     match req.compiler.as_ref() {
-                        None => return Ok(ControlFlow::Continue(req)),
+                        None => Ok(ControlFlow::Continue(req)),
                         Some(compiler) => {
                             let c = compiler.lock().await.snapshot();
                             let file_id = c
@@ -74,7 +74,7 @@ where
                                         .context(req.context)
                                         .build()?;
 
-                                    return Ok(ControlFlow::Break(res));
+                                    Ok(ControlFlow::Break(res))
                                 }
                                 Some(op) => {
                                     if op.operation_ty() == OperationType::Mutation {
@@ -230,7 +230,7 @@ mod forbid_http_get_mutations_tests {
         let mut mock_service = MockSupergraphService::new();
         mock_service
             .expect_clone()
-            .returning(move || MockSupergraphService::new());
+            .returning(MockSupergraphService::new);
         let mut service_stack = AllowOnlyHttpPostMutationsLayer::default().layer(mock_service);
 
         let forbidden_requests = [

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -12,12 +12,14 @@ use indexmap::IndexMap;
 use router_bridge::planner::Planner;
 use tokio::sync::Mutex;
 use tower::BoxError;
+use tower::Layer;
 use tower::ServiceBuilder;
 use tower::ServiceExt;
 use tower_service::Service;
 use tracing_futures::Instrument;
 
 use super::execution;
+use super::layers::allow_only_http_post_mutations::AllowOnlyHttpPostMutationsLayer;
 use super::layers::content_negociation;
 use super::layers::query_analysis::QueryAnalysisLayer;
 use super::new_service::ServiceFactory;
@@ -446,7 +448,8 @@ impl SupergraphCreator {
             .and_then(|plugin| plugin.1.as_any().downcast_ref::<TrafficShaping>())
             .expect("traffic shaping should always be part of the plugin list");
 
-        let supergraph_service = shaping.supergraph_service_internal(supergraph_service);
+        let supergraph_service = AllowOnlyHttpPostMutationsLayer::default()
+            .layer(shaping.supergraph_service_internal(supergraph_service));
 
         ServiceBuilder::new()
             .layer(content_negociation::SupergraphLayer::default())


### PR DESCRIPTION
Now that we have access to a compiler in supergraph requests, we don't need to look into the query plan to know if a request contains mutations

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
