### PR TITLE
Update router-bridge version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4919,9 +4919,9 @@ dependencies = [
 
 [[package]]
 name = "router-bridge"
-version = "0.2.9+v2.4.8"
+version = "0.3.0+v2.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf43310c7149f07a459e2b4c229e66af6e46b7b12aea8c0705762ce6caa902af"
+checksum = "16faf0e909e435375fb915a83eff5b891ab506d68c1c8410a4e2376fb61b48a6"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -170,7 +170,7 @@ reqwest = { version = "0.11.18", default-features = false, features = [
     "json",
     "stream",
 ] }
-router-bridge = "0.2.9+v2.4.8"
+router-bridge = "0.3.0+v2.4.8"
 rust-embed="6.8.1"
 rustls = "0.20.8"
 rustls-pemfile = "1.0.3"


### PR DESCRIPTION
Update to 0.3.0, as 0.2.9 was yanked. The release for 0.2.9 had a breaking change which caused issues when compiling stable router versions