### PR TITLE
implement claims checks

### DIFF
--- a/apollo-router/src/plugins/authentication/claims.rs
+++ b/apollo-router/src/plugins/authentication/claims.rs
@@ -1,0 +1,92 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use displaydoc::Display;
+use serde_json::Value;
+use thiserror::Error;
+
+use super::ClaimConf;
+
+#[derive(Debug, Display, Error)]
+
+pub(super) enum Error {
+    /// claim '{claim}' must be present
+    Absent { claim: String },
+    /// Invalid value for claim '{claim}': expected '{expected}', got '{value}'
+    NotEqual {
+        claim: String,
+        value: Value,
+        expected: Value,
+    },
+    /// Invalid value for claim '{claim}': '{value}' is not a string
+    NotAString { claim: String, value: Value },
+    /// Invalid value for claim '{claim}': '{value}' is not in the set of accepted strings {set:?}
+    NotInSet {
+        claim: String,
+        value: String,
+        set: BTreeSet<String>,
+    },
+}
+
+pub(super) fn check_claims(
+    config: &BTreeMap<String, ClaimConf>,
+    claims: &Value,
+) -> Result<(), Vec<Error>> {
+    let mut errors = vec![];
+
+    for (name, condition) in config {
+        if let Err(e) = check_claim(name, condition, claims) {
+            errors.push(e);
+        }
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors)
+    }
+}
+
+pub(super) fn check_claim(name: &str, condition: &ClaimConf, claims: &Value) -> Result<(), Error> {
+    let claim_value = claims.get(name);
+
+    match condition {
+        ClaimConf::Present => match claim_value {
+            None => Err(Error::Absent { claim: name.into() }),
+            Some(_) => Ok(()),
+        },
+        ClaimConf::Is(requested_value) => match claim_value {
+            None => Err(Error::Absent { claim: name.into() }),
+            Some(v) => {
+                if requested_value != v {
+                    Err(Error::NotEqual {
+                        claim: name.into(),
+                        value: v.clone(),
+                        expected: requested_value.clone(),
+                    })
+                } else {
+                    Ok(())
+                }
+            }
+        },
+        ClaimConf::OneOf(set) => match claim_value {
+            None => Err(Error::Absent { claim: name.into() }),
+            Some(v) => match v.as_str() {
+                None => Err(Error::NotAString {
+                    claim: name.into(),
+                    value: v.clone(),
+                }),
+                Some(s) => {
+                    if !set.contains(s) {
+                        Err(Error::NotInSet {
+                            claim: name.into(),
+                            value: s.into(),
+                            set: set.clone(),
+                        })
+                    } else {
+                        Ok(())
+                    }
+                }
+            },
+        },
+    }
+}


### PR DESCRIPTION
Fix #2867

_Note: this is an old PR. The intent here is good, but the solution is not. We should instead try to reuse the condition checks implemented in telemetry_

Implementation for config based claims validation. This adds the following conditions:
- claim presence
- claim equality (to a JSON value)
- claim value is one of a predefined list of strings

Todo:
- [ ] do we return an error message exposing the expected value or list of possible claim values? (ie would that leak too much information to the client)
- [ ] other kinds of conditions?
- [ ] per IdP configuration?

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
