### PR TITLE
document claim augmentation via coprocessors

### DIFF
--- a/.changesets/docs_geal_document_claim_augmentation.md
+++ b/.changesets/docs_geal_document_claim_augmentation.md
@@ -1,0 +1,5 @@
+### Document claim augmentation via coprocessors ([Issue #3102](https://github.com/apollographql/router/issues/3102))
+
+Claims augmentation is a common use case where user information from the JWT claims is used to look up more context like roles from databases, before sending it to subgraphs. This can be done with subgraphs, but it was not documented yet, and there was confusion on the order in which the plugins were called. This clears the confusion and provides an example configuration.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3386

--- a/docs/source/configuration/authn-jwt.mdx
+++ b/docs/source/configuration/authn-jwt.mdx
@@ -263,6 +263,50 @@ fn subgraph_service(service, subgraph) {
 
 </ExpansionPanel>
 
+### Claim augmentation via coprocessors
+
+Tokens can come in with limited information, that is then used to look up user specific information like roles. This can be done with [coprocessors](/customizations/coprocessor).
+
+<ExpansionPanel title="Click to expand">
+
+The router level coprocessor is guaranteed to be called after the authentication plugin, so the coprocessor can receive the list of claims extracted from the token, use information like the `sub` (subject) claim to look up the user, insert its data in the claims list and return it to the router.
+
+If the router is configured with:
+
+```yaml title="router.yaml"
+authentication:
+  jwt:
+    jwks:
+      - url: "file:///etc/router/jwks.json"
+
+coprocessor:
+  url: http://127.0.0.1:8081
+  router:
+    request:
+      context: true
+```
+
+The coprocessor will then receive a request with this format:
+
+```json
+{
+    "version": 1,
+    "stage": "RouterRequest",
+    "control": "continue",
+    "id": "d0a8245df0efe8aa38a80dba1147fb2e",
+    "context": {
+        "entries": {
+            "apollo_authentication::JWT::claims": {
+                "exp": 10000000000,
+                "sub": "457f6bb6-789c-4e8b-8560-f3943a09e72a"
+            }
+        }
+    },
+    "method": "POST"
+}
+```
+</ExpansionPanel>
+
 ## Creating your own JWKS (advanced)
 
 > ⚠️ **Most third-party IdP services create and host a JWKS for you.** If you use a third-party IdP, consult its documentation to obtain the [JWKS URL](#jwks) to pass to your router.


### PR DESCRIPTION
Fix #3102

We documented plugin ordering guarantees in #3321, but it is worth calling out how ordering works between authentication and coprocessors, as claims augmentation is a common use case

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
