### PR TITLE
Don't add an error if subgraph response is missing `_entities`.

### DIFF
--- a/apollo-router/src/axum_factory/snapshots/apollo_router__axum_factory__tests__defer_is_not_buffered.snap
+++ b/apollo-router/src/axum_factory/snapshots/apollo_router__axum_factory__tests__defer_is_not_buffered.snap
@@ -24,16 +24,6 @@ expression: parts
         "extensions": {
           "code": "FETCH_ERROR"
         }
-      },
-      {
-        "message": "Subgraph response from 'reviews' was missing key `_entities`",
-        "path": [
-          "topProducts",
-          "@"
-        ],
-        "extensions": {
-          "code": "PARSE_ERROR"
-        }
       }
     ],
     "hasNext": true

--- a/apollo-router/src/plugins/traffic_shaping/cache.rs
+++ b/apollo-router/src/plugins/traffic_shaping/cache.rs
@@ -162,13 +162,9 @@ where
                 .and_then(|v| v.as_object_mut())
                 .map(|o| o.insert("_entities", new_entities.into()));
             response.response.body_mut().data = data;
-            Ok(response)
-        } else {
-            Err(FetchError::MalformedResponse {
-                reason: "expected  entities".to_string(),
-            }
-            .into())
         }
+
+        Ok(response)
     } else {
         let entities = insert_entities_in_result(&mut Vec::new(), &cache, &mut result).await?;
         let mut data = Object::default();

--- a/apollo-router/src/services/snapshots/apollo_router__services__supergraph_service__tests__missing_entities.snap
+++ b/apollo-router/src/services/snapshots/apollo_router__services__supergraph_service__tests__missing_entities.snap
@@ -1,0 +1,20 @@
+---
+source: apollo-router/src/services/supergraph_service.rs
+expression: stream.next_response().await.unwrap()
+---
+{
+  "data": {
+    "currentUser": {
+      "id": "0",
+      "activeOrganization": {
+        "id": "1",
+        "name": null
+      }
+    }
+  },
+  "errors": [
+    {
+      "message": "error"
+    }
+  ]
+}


### PR DESCRIPTION
Removed error added if subgraph response did not include entities. Instead a warning is raised in the logs.

Fixes #3402

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
