### PR TITLE
chore: router-bridge 0.3.0+v2.4.8 -> =0.3.1+2.4.9

### DIFF
--- a/.changesets/maint_avery_update_and_pin_bridge.md
+++ b/.changesets/maint_avery_update_and_pin_bridge.md
@@ -1,0 +1,5 @@
+### chore: router-bridge 0.3.0+v2.4.8 -> =0.3.1+2.4.9 ([PR #3407](https://github.com/apollographql/router/pull/3407))
+
+Updates `router-bridge` from ` = "0.3.0+v2.4.8"` to ` = "0.3.1+v2.4.9"`, note that with this PR, this dependency is now pinned to an exact version. This version update started failing tests because of a minor ordering change and it was not immediately clear why the test was failing. Pinning this dependency (that we own) allows us to only bring in the update at the proper time and will make test failures caused by the update to be more easily identified.
+
+By [@EverlastingBugstopper](https://github.com/EverlastingBugstopper) in https://github.com/apollographql/router/pull/3407

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
+ "toml 0.7.6",
  "tonic 0.8.3",
  "tonic-build",
  "tower",
@@ -436,7 +437,7 @@ dependencies = [
  "regex",
  "str_inflector",
  "tempfile",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -534,7 +535,7 @@ dependencies = [
  "quote",
  "serde",
  "syn 1.0.109",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -939,7 +940,7 @@ dependencies = [
  "serde",
  "shell-words",
  "structopt",
- "toml",
+ "toml 0.5.11",
  "walkdir 2.3.3",
 ]
 
@@ -5389,6 +5390,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6152,18 +6162,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.6.2"
+name = "toml"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.10"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
+checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
 dependencies = [
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
  "winnow",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4919,9 +4919,9 @@ dependencies = [
 
 [[package]]
 name = "router-bridge"
-version = "0.3.0+v2.4.8"
+version = "0.3.1+v2.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16faf0e909e435375fb915a83eff5b891ab506d68c1c8410a4e2376fb61b48a6"
+checksum = "8b5cc00d70b7be23f008349426d6da0578c01931102fe2431051142c347154de"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -170,6 +170,7 @@ reqwest = { version = "0.11.18", default-features = false, features = [
     "json",
     "stream",
 ] }
+# note: this dependency should _always_ be pinned, prefix the version with an `=`
 router-bridge = "=0.3.1+v2.4.9"
 rust-embed="6.8.1"
 rustls = "0.20.8"
@@ -259,6 +260,7 @@ test-log = { version = "0.2.12", default-features = false, features = [
     "trace",
 ] }
 test-span = "0.7"
+toml = "0.7"
 tower-test = "0.4.0"
 
 # See note above in this file about `^tracing` packages which also applies to

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -170,7 +170,7 @@ reqwest = { version = "0.11.18", default-features = false, features = [
     "json",
     "stream",
 ] }
-router-bridge = "0.3.0+v2.4.8"
+router-bridge = "=0.3.1+v2.4.9"
 rust-embed="6.8.1"
 rustls = "0.20.8"
 rustls-pemfile = "1.0.3"

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -496,6 +496,9 @@ struct QueryPlan {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+
     use serde_json::json;
     use test_log::test;
 
@@ -953,5 +956,27 @@ mod tests {
                 Arc::new(Mutex::new(compiler)),
             )
             .await
+    }
+
+    #[test]
+    fn router_bridge_dependency_is_pinned() {
+        let cargo_manifest: toml::Value =
+            fs::read_to_string(PathBuf::from(&env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
+                .expect("could not read Cargo.toml")
+                .parse()
+                .expect("could not parse Cargo.toml");
+        let router_bridge_version = cargo_manifest
+            .get("dependencies")
+            .expect("Cargo.toml does not contain dependencies")
+            .as_table()
+            .expect("Cargo.toml dependencies key is not a table")
+            .get("router-bridge")
+            .expect("Cargo.toml dependencies does not have an entry for router-bridge")
+            .as_str()
+            .expect("router-bridge in Cargo.toml dependencies is not a string");
+        assert!(
+            router_bridge_version.contains("="),
+            "router-bridge in Cargo.toml is not pinned with a '=' prefix"
+        );
     }
 }

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -975,7 +975,7 @@ mod tests {
             .as_str()
             .expect("router-bridge in Cargo.toml dependencies is not a string");
         assert!(
-            router_bridge_version.contains("="),
+            router_bridge_version.contains('='),
             "router-bridge in Cargo.toml is not pinned with a '=' prefix"
         );
     }

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -712,7 +712,7 @@ mod tests {
             )
             .with_json(
                 serde_json::json!{{
-                    "query":"{computer(id:\"Computer1\"){errorField id}}",
+                    "query":"{computer(id:\"Computer1\"){id errorField}}",
                 }},
                 serde_json::json!{{
                     "data": {


### PR DESCRIPTION
Updates `router-bridge` from ` = "0.3.0+v2.4.8"` to ` = "=0.3.1+v2.4.9"`, note that with this PR, this dependency is now pinned to an exact version. This version update started failing tests because of a minor ordering change and it was not immediately clear why the test was failing. Pinning this dependency (that we own) allows us to only bring in the update at the proper time and will make test failures caused by the update to be more easily identified.

This was done once before in #2916 but it is fairly easy to forget to pin something when updating. To mitigate this, I've added a comment to the `Cargo.toml` and also a unit test that parses `Cargo.toml` and makes sure `router-bridge` contains an `=` to pin it.


**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests
