### PR TITLE
add support for delta aggregation to otlp metrics

### DIFF
--- a/.changesets/feat_garypen_metrics_as_delta.md
+++ b/.changesets/feat_garypen_metrics_as_delta.md
@@ -1,0 +1,13 @@
+### Add support for delta aggregation to otlp metrics ([PR #3412](https://github.com/apollographql/router/pull/3412))
+
+Add a new configuration option (Temporality) to the otlp metrics configuration.
+
+This may be useful to fix problems with metrics when being processed by datadog which tends to expect Delta, rather than Cumulative, aggregations.
+
+See:
+ - https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6129
+ - https://github.com/DataDog/documentation/pull/15840
+
+for more details.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3412

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -4100,12 +4100,23 @@ expression: "&schema"
                   ]
                 },
                 "temporality": {
-                  "description": "Temporality",
+                  "description": "Temporality for export (default: `Cumulative`). Note that when exporting to Datadog agent use `Delta`.",
                   "default": "cumulative",
-                  "type": "string",
-                  "enum": [
-                    "cumulative",
-                    "delta"
+                  "oneOf": [
+                    {
+                      "description": "Export cumulative metrics.",
+                      "type": "string",
+                      "enum": [
+                        "cumulative"
+                      ]
+                    },
+                    {
+                      "description": "Export delta metrics. `Delta` should be used when exporting to DataDog Agent.",
+                      "type": "string",
+                      "enum": [
+                        "delta"
+                      ]
+                    }
                   ]
                 }
               },
@@ -4563,12 +4574,23 @@ expression: "&schema"
                   ]
                 },
                 "temporality": {
-                  "description": "Temporality",
+                  "description": "Temporality for export (default: `Cumulative`). Note that when exporting to Datadog agent use `Delta`.",
                   "default": "cumulative",
-                  "type": "string",
-                  "enum": [
-                    "cumulative",
-                    "delta"
+                  "oneOf": [
+                    {
+                      "description": "Export cumulative metrics.",
+                      "type": "string",
+                      "enum": [
+                        "cumulative"
+                      ]
+                    },
+                    {
+                      "description": "Export delta metrics. `Delta` should be used when exporting to DataDog Agent.",
+                      "type": "string",
+                      "enum": [
+                        "delta"
+                      ]
+                    }
                   ]
                 }
               },

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -4098,6 +4098,15 @@ expression: "&schema"
                     "grpc",
                     "http"
                   ]
+                },
+                "temporality": {
+                  "description": "Temporality",
+                  "default": "cumulative",
+                  "type": "string",
+                  "enum": [
+                    "cumulative",
+                    "delta"
+                  ]
                 }
               },
               "additionalProperties": false,
@@ -4551,6 +4560,15 @@ expression: "&schema"
                   "enum": [
                     "grpc",
                     "http"
+                  ]
+                },
+                "temporality": {
+                  "description": "Temporality",
+                  "default": "cumulative",
+                  "type": "string",
+                  "enum": [
+                    "cumulative",
+                    "delta"
                   ]
                 }
               },

--- a/apollo-router/src/plugins/telemetry/metrics/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/otlp.rs
@@ -9,6 +9,7 @@ use tower::BoxError;
 use crate::plugins::telemetry::config::MetricsCommon;
 use crate::plugins::telemetry::metrics::MetricsBuilder;
 use crate::plugins::telemetry::metrics::MetricsConfigurator;
+use crate::plugins::telemetry::otlp::Temporality;
 
 // TODO Remove MetricExporterBuilder once upstream issue is fixed
 // This has to exist because Http is not currently supported for metrics export
@@ -38,23 +39,41 @@ impl MetricsConfigurator for super::super::otlp::Config {
         metrics_config: &MetricsCommon,
     ) -> Result<MetricsBuilder, BoxError> {
         let exporter: MetricExporterBuilder = self.exporter()?;
+
         match exporter.exporter {
             Some(exporter) => {
-                let exporter = opentelemetry_otlp::new_pipeline()
-                    .metrics(
-                        selectors::simple::histogram(metrics_config.buckets.clone()),
-                        aggregation::stateless_temporality_selector(),
-                        opentelemetry::runtime::Tokio,
-                    )
-                    .with_exporter(exporter)
-                    .with_resource(Resource::new(
-                        metrics_config
-                            .resources
-                            .clone()
-                            .into_iter()
-                            .map(|(k, v)| KeyValue::new(k, v)),
-                    ))
-                    .build()?;
+                let exporter = match self.temporality {
+                    Temporality::Cumulative => opentelemetry_otlp::new_pipeline()
+                        .metrics(
+                            selectors::simple::histogram(metrics_config.buckets.clone()),
+                            aggregation::stateless_temporality_selector(),
+                            opentelemetry::runtime::Tokio,
+                        )
+                        .with_exporter(exporter)
+                        .with_resource(Resource::new(
+                            metrics_config
+                                .resources
+                                .clone()
+                                .into_iter()
+                                .map(|(k, v)| KeyValue::new(k, v)),
+                        ))
+                        .build()?,
+                    Temporality::Delta => opentelemetry_otlp::new_pipeline()
+                        .metrics(
+                            selectors::simple::histogram(metrics_config.buckets.clone()),
+                            aggregation::delta_temporality_selector(),
+                            opentelemetry::runtime::Tokio,
+                        )
+                        .with_exporter(exporter)
+                        .with_resource(Resource::new(
+                            metrics_config
+                                .resources
+                                .clone()
+                                .into_iter()
+                                .map(|(k, v)| KeyValue::new(k, v)),
+                        ))
+                        .build()?,
+                };
                 builder = builder.with_meter_provider(exporter.clone());
                 builder = builder.with_exporter(exporter);
                 Ok(builder)

--- a/apollo-router/src/plugins/telemetry/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/otlp.rs
@@ -211,8 +211,10 @@ pub(crate) enum Protocol {
 #[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub(crate) enum Temporality {
+    /// Export cumulative metrics.
     #[default]
     Cumulative,
+    /// Export delta metrics. `Delta` should be used when exporting to DataDog Agent.
     Delta,
 }
 

--- a/apollo-router/src/plugins/telemetry/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/otlp.rs
@@ -46,7 +46,8 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) batch_processor: BatchProcessorConfig,
 
-    /// Temporality
+    /// Temporality for export (default: `Cumulative`).
+    /// Note that when exporting to Datadog agent use `Delta`.
     #[serde(default)]
     pub(crate) temporality: Temporality,
 }

--- a/apollo-router/src/plugins/telemetry/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/otlp.rs
@@ -45,6 +45,10 @@ pub(crate) struct Config {
     /// Batch processor settings
     #[serde(default)]
     pub(crate) batch_processor: BatchProcessorConfig,
+
+    /// Temporality
+    #[serde(default)]
+    pub(crate) temporality: Temporality,
 }
 
 impl Config {
@@ -201,6 +205,14 @@ pub(crate) enum Protocol {
     #[default]
     Grpc,
     Http,
+}
+
+#[derive(Debug, Default, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
+pub(crate) enum Temporality {
+    #[default]
+    Cumulative,
+    Delta,
 }
 
 mod metadata_map_serde {


### PR DESCRIPTION
Add a new configuration option (Temporality) to the otlp metrics configuration.

This may be useful to fix problems with metrics when being processed by datadog which tends to expect Delta, rather than Cumulative, aggregations.

See:
 - https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6129
 - https://github.com/DataDog/documentation/pull/15840

for more details.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
