### PR TITLE
Fix: only add label arguments on defer directives

### DIFF
--- a/.changesets/maint_simon_uncolliding_relabel.md
+++ b/.changesets/maint_simon_uncolliding_relabel.md
@@ -1,7 +1,7 @@
-### Synthesize defer labels without RNG or collisions ([PR #3381](https://github.com/apollographql/router/pull/3381) and [PR #XXX](https://github.com/apollographql/router/pull/XXX))
+### Synthesize defer labels without RNG or collisions ([PR #3381](https://github.com/apollographql/router/pull/3381) and [PR #3423](https://github.com/apollographql/router/pull/3423))
 
 The `@defer` directive accepts a `label` argument, but it is optional. To more accurately handle deferred responses, the Router internally rewrites queries to add labels on the `@defer` directive where they are missing. Responses eventually receive the reverse treatment to look as expected by client.
 
 This was done be generating random strings, handling collision with existing labels, and maintaining a `HashSet` of which labels had been synthesized. Instead, we now add a prefix to pre-existing labels and generate new labels without it. When processing a response, the absence of that prefix indicates a synthetic label.
 
-By [@SimonSapin](https://github.com/SimonSapin) and [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/3381 and https://github.com/apollographql/router/pull/XXX
+By [@SimonSapin](https://github.com/SimonSapin) and [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/3381 and https://github.com/apollographql/router/pull/3423

--- a/.changesets/maint_simon_uncolliding_relabel.md
+++ b/.changesets/maint_simon_uncolliding_relabel.md
@@ -1,7 +1,7 @@
-### Synthesize defer labels without RNG or collisions ([PR #3381](https://github.com/apollographql/router/pull/3381))
+### Synthesize defer labels without RNG or collisions ([PR #3381](https://github.com/apollographql/router/pull/3381) and [PR #XXX](https://github.com/apollographql/router/pull/XXX))
 
-The `@defer` directive accepts a `label` argument, but it is optional. To more accurately handle deferred responses, the Router internally rewrites queries to add labels where they are missing. Responses eventually receive the reverse treatment to look as expected by client.
+The `@defer` directive accepts a `label` argument, but it is optional. To more accurately handle deferred responses, the Router internally rewrites queries to add labels on the `@defer` directive where they are missing. Responses eventually receive the reverse treatment to look as expected by client.
 
 This was done be generating random strings, handling collision with existing labels, and maintaining a `HashSet` of which labels had been synthesized. Instead, we now add a prefix to pre-existing labels and generate new labels without it. When processing a response, the absence of that prefix indicates a synthetic label.
 
-By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/3381
+By [@SimonSapin](https://github.com/SimonSapin) and [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/3381 and https://github.com/apollographql/router/pull/XXX

--- a/apollo-router/src/query_planner/labeler.rs
+++ b/apollo-router/src/query_planner/labeler.rs
@@ -106,7 +106,7 @@ pub(crate) fn directive(
         encoder_directive.arg(apollo_encoder::Argument::new(arg.name().into(), value));
     }
     // Add a generated label if there wasn’t one already
-    if !has_label {
+    if is_defer && !has_label {
         encoder_directive.arg(apollo_encoder::Argument::new(
             LABEL_NAME.into(),
             apollo_encoder::Value::String(visitor.generate_label()),

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -936,6 +936,33 @@ async fn defer_default_variable() {
     assert!(stream.next().await.is_none());
 }
 
+#[tokio::test(flavor = "multi_thread")]
+async fn include_if_works() {
+    let config = serde_json::json!({
+        "supergraph": {
+            "introspection": true
+        },
+    });
+
+    let query = "query { ... Test @include(if: false) } fragment Test on Query { __typename }";
+
+    let request = supergraph::Request::fake_builder()
+        .query(query)
+        .build()
+        .expect("expecting valid request");
+
+    let (router, _) = setup_router_and_registry(config).await;
+
+    let mut stream = router
+        .oneshot(request.try_into().unwrap())
+        .await
+        .unwrap()
+        .into_graphql_response_stream()
+        .await;
+
+    insta::assert_json_snapshot!(stream.next().await.unwrap().unwrap());
+}
+
 async fn query_node(request: &supergraph::Request) -> Result<graphql::Response, String> {
     reqwest::Client::new()
         .post("https://federation-demo-gateway.fly.dev/")

--- a/apollo-router/tests/snapshots/integration_tests__include_if_works.snap
+++ b/apollo-router/tests/snapshots/integration_tests__include_if_works.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/tests/integration_tests.rs
+expression: stream.next().await.unwrap().unwrap()
+---
+{
+  "data": {}
+}


### PR DESCRIPTION

The `@defer` directive accepts a `label` argument, but it is optional. To more accurately handle deferred responses, the Router internally rewrites queries to add labels on the `@defer` directive where they are missing. Responses eventually receive the reverse treatment to look as expected by client.

This was done be generating random strings, handling collision with existing labels, and maintaining a `HashSet` of which labels had been synthesized. Instead, we now add a prefix to pre-existing labels and generate new labels without it. When processing a response, the absence of that prefix indicates a synthetic label.
