### PR TITLE
[docs] Update apollo-telemetry to mention that FTV1 is required for errors

### DIFF
--- a/docs/source/configuration/apollo-telemetry.mdx
+++ b/docs/source/configuration/apollo-telemetry.mdx
@@ -304,6 +304,16 @@ You can configure whether the Apollo Router reports GraphQL error information to
 - To prevent your router from reporting error information at all, you can set the `send` option to `false`.
 - To include all error details in your router's reports to GraphOS, you can set the `redact` option to `false`.
 
+<blockquote>
+
+**Your subgraph libraries must support federated tracing (also known as FTV1 tracing) to provide errors to GraphOS.**
+
+- To confirm support, check the `FEDERATED TRACING` entry for your library on [this page](/federation/building-supergraphs/supported-subgraphs).
+- Consult your library's documentation to learn how to enable federated tracing.
+    - If you use Apollo Server with `@apollo/subgraph`, federated tracing support is enabled automatically.
+
+</blockquote>
+
 See the example below:
 
 ```yaml title="router.yaml"

--- a/docs/source/configuration/apollo-telemetry.mdx
+++ b/docs/source/configuration/apollo-telemetry.mdx
@@ -310,7 +310,7 @@ You can configure whether the Apollo Router reports GraphQL error information to
 
 To confirm support:
 - Check the `FEDERATED TRACING` entry for your library on [the supported subgraphs page](/federation/building-supergraphs/supported-subgraphs).
-- If is federated tracing isn't yet enabled, consult your library's documentation to learn how to enable it.
+- If federated tracing isn't enabled automatically for your library, consult its documentation to learn how to enable it.
 
 </blockquote>
 

--- a/docs/source/configuration/apollo-telemetry.mdx
+++ b/docs/source/configuration/apollo-telemetry.mdx
@@ -309,7 +309,7 @@ You can configure whether the Apollo Router reports GraphQL error information to
 **Note:** Your subgraph libraries must support federated tracing (also known as FTV1 tracing) to provide errors to GraphOS. If you use Apollo Server with `@apollo/subgraph`, federated tracing support is enabled automatically.
 
 To confirm support:
-- Check the `FEDERATED TRACING` entry for your library on [this page](/federation/building-supergraphs/supported-subgraphs).
+- Check the `FEDERATED TRACING` entry for your library on [the supported subgraphs page](/federation/building-supergraphs/supported-subgraphs).
 - If is federated tracing isn't yet enabled, consult your library's documentation to learn how to enable it.
 
 </blockquote>

--- a/docs/source/configuration/apollo-telemetry.mdx
+++ b/docs/source/configuration/apollo-telemetry.mdx
@@ -306,11 +306,11 @@ You can configure whether the Apollo Router reports GraphQL error information to
 
 <blockquote>
 
-**Your subgraph libraries must support federated tracing (also known as FTV1 tracing) to provide errors to GraphOS.**
+**Note:** Your subgraph libraries must support federated tracing (also known as FTV1 tracing) to provide errors to GraphOS. If you use Apollo Server with `@apollo/subgraph`, federated tracing support is enabled automatically.
 
-- To confirm support, check the `FEDERATED TRACING` entry for your library on [this page](/federation/building-supergraphs/supported-subgraphs).
-- Consult your library's documentation to learn how to enable federated tracing.
-    - If you use Apollo Server with `@apollo/subgraph`, federated tracing support is enabled automatically.
+To confirm support:
+- Check the `FEDERATED TRACING` entry for your library on [this page](/federation/building-supergraphs/supported-subgraphs).
+- If is federated tracing isn't yet enabled, consult your library's documentation to learn how to enable it.
 
 </blockquote>
 


### PR DESCRIPTION
An edge case was reported by a customer and this was uncovered in Slack