### PR TITLE
Feat: Add init containers options to helm chart

### DIFF
--- a/.changesets/feat_add_helm_init_containers.md
+++ b/.changesets/feat_add_helm_init_containers.md
@@ -1,4 +1,4 @@
-### Helm: add init containers to deployemt ([PR #3444](https://github.com/apollographql/router/pull/3444))
+### Helm: add init containers to deployemt ([Issue #3248](https://github.com/apollographql/router/issues/3248))
 
 This is a new option when starting the router, so that before starting another container runs and performs necessary tasks.
 

--- a/.changesets/feat_add_helm_init_containers.md
+++ b/.changesets/feat_add_helm_init_containers.md
@@ -1,0 +1,5 @@
+### Helm: add init containers to deployemt ([PR #3444](https://github.com/apollographql/router/pull/3444))
+
+This is a new option when starting the router, so that before starting another container runs and performs necessary tasks.
+
+By [@laszlorostas](https://github.com/laszlorostas) in https://github.com/apollographql/router/pull/3444

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -129,10 +129,10 @@ spec:
         {{- if .Values.extraContainers }}
           {{- include "common.tplvalues.render" (dict "value" .Values.extraContainers "context" $) | nindent 8 }}
         {{- end }}
-        {{- if .Values.initContainers }}
-        initContainers:
-          {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
-        {{- end }}
+      {{- if .Values.initContainers }}
+      initContainers:
+        {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+      {{- end }}
       {{- if or .Values.router.configuration .Values.extraVolumes }}
       volumes:
         {{- if .Values.router.configuration }}

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -130,6 +130,7 @@ spec:
           {{- include "common.tplvalues.render" (dict "value" .Values.extraContainers "context" $) | nindent 8 }}
         {{- end }}
         {{- if .Values.initContainers }}
+        initContainers:
           {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
         {{- end }}
       {{- if or .Values.router.configuration .Values.extraVolumes }}

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -129,7 +129,7 @@ spec:
         {{- if .Values.extraContainers }}
           {{- include "common.tplvalues.render" (dict "value" .Values.extraContainers "context" $) | nindent 8 }}
         {{- end }}
-      {{- if .Values.initContainers }}
+      {{- if .Values.initContainers }}BREAK
       initContainers:
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
       {{- end }}

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -129,6 +129,9 @@ spec:
         {{- if .Values.extraContainers }}
           {{- include "common.tplvalues.render" (dict "value" .Values.extraContainers "context" $) | nindent 8 }}
         {{- end }}
+        {{- if .Values.initContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
+        {{- end }}
       {{- if or .Values.router.configuration .Values.extraVolumes }}
       volumes:
         {{- if .Values.router.configuration }}

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -129,7 +129,7 @@ spec:
         {{- if .Values.extraContainers }}
           {{- include "common.tplvalues.render" (dict "value" .Values.extraContainers "context" $) | nindent 8 }}
         {{- end }}
-      {{- if .Values.initContainers }}BREAK
+      {{- if .Values.initContainers }}
       initContainers:
         {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
       {{- end }}

--- a/helm/chart/router/values.yaml
+++ b/helm/chart/router/values.yaml
@@ -86,6 +86,14 @@ containerPorts:
 #       - containerPort: 4001
 extraContainers: []
 
+# -- An array of init containers to include in the router pod
+# Example:
+# initContainers:
+#   - name: init-myservice
+#     image: busybox:1.28
+#     command: ["sh"]
+initContainers: []
+
 # -- A map of extra labels to apply to the router deploment and containers
 # Example:
 # extraLabels:


### PR DESCRIPTION
*The init container option created in the router's helm chart*

Feature  #3248
