### PR TITLE
chore: restore macos deps

### DIFF
--- a/xtask/Cargo.lock
+++ b/xtask/Cargo.lock
@@ -125,6 +125,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
+
+[[package]]
+name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
@@ -321,6 +327,15 @@ name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
 dependencies = [
  "cfg-if",
 ]
@@ -1130,7 +1145,7 @@ version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
- "base64",
+ "base64 0.21.2",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1229,7 +1244,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
- "base64",
+ "base64 0.21.2",
 ]
 
 [[package]]
@@ -2000,6 +2015,7 @@ name = "xtask"
 version = "1.5.0"
 dependencies = [
  "anyhow",
+ "base64 0.20.0",
  "camino",
  "cargo_metadata",
  "chrono",
@@ -2024,6 +2040,7 @@ dependencies = [
  "tokio",
  "walkdir",
  "which",
+ "zip",
 ]
 
 [[package]]
@@ -2040,3 +2057,14 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -41,5 +41,9 @@ tokio = "1.29.1"
 which = "4"
 walkdir = "2.3.3"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+base64 = "0.20"
+zip = { version = "0.6", default-features = false }
+
 [dev-dependencies]
 insta = { version = "1.30.0", features = ["json", "redactions", "yaml"] }


### PR DESCRIPTION
PR #3438 removed some unused dependencies, along with some used dependencies. 

~It seems like that PR was merged w/o waiting for tests? though i'm not sure, it seems like `dev ` maybe built ok in CI? I'm not seeing a CircleCI workflow for the `geal/cleanup` branch... Something is wonky here for sure.~

@glasser found [the job](https://app.circleci.com/pipelines/github/apollographql/router/13764/workflows/e6789216-8642-4a51-ac3b-ad9fe1d3de66/jobs/90226) for me (not sure why I couldn't find it) - CI passed with a false positive because the `xtask` binary is cached.

Perhaps we should invalidate the cache when `xtask/Cargo.toml` changes?

This PR adds back MacOS specific dependencies so that `xtask` can build properly.