### PR TITLE
Update router bridge and add option for `reuse_query_fragments` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4927,9 +4927,9 @@ dependencies = [
 
 [[package]]
 name = "router-bridge"
-version = "0.3.1+v2.4.9"
+version = "0.4.0+v2.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b5cc00d70b7be23f008349426d6da0578c01931102fe2431051142c347154de"
+checksum = "2ca7a000e3c4e1f6539581443354403f50d9a85b22c9a9a5572be0cf581c25df"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -171,7 +171,7 @@ reqwest = { version = "0.11.18", default-features = false, features = [
     "stream",
 ] }
 # note: this dependency should _always_ be pinned, prefix the version with an `=`
-router-bridge = "=0.3.1+v2.4.9"
+router-bridge = "=0.4.0+v2.4.10"
 rust-embed="6.8.1"
 rustls = "0.20.8"
 rustls-pemfile = "1.0.3"

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -534,6 +534,10 @@ pub(crate) struct Supergraph {
     /// Default: false
     pub(crate) introspection: bool,
 
+    /// Enable reuse of query fragments
+    /// Default: false
+    pub(crate) reuse_query_fragments: bool,
+
     /// Set to false to disable defer support
     pub(crate) defer_support: bool,
 
@@ -554,6 +558,7 @@ impl Supergraph {
         introspection: Option<bool>,
         defer_support: Option<bool>,
         query_planning: Option<QueryPlanning>,
+        reuse_query_fragments: Option<bool>,
     ) -> Self {
         Self {
             listen: listen.unwrap_or_else(default_graphql_listen),
@@ -561,6 +566,7 @@ impl Supergraph {
             introspection: introspection.unwrap_or_else(default_graphql_introspection),
             defer_support: defer_support.unwrap_or_else(default_defer_support),
             query_planning: query_planning.unwrap_or_default(),
+            reuse_query_fragments: reuse_query_fragments.unwrap_or_default(),
         }
     }
 }
@@ -575,6 +581,7 @@ impl Supergraph {
         introspection: Option<bool>,
         defer_support: Option<bool>,
         query_planning: Option<QueryPlanning>,
+        reuse_query_fragments: Option<bool>,
     ) -> Self {
         Self {
             listen: listen.unwrap_or_else(test_listen),
@@ -582,6 +589,7 @@ impl Supergraph {
             introspection: introspection.unwrap_or_else(default_graphql_introspection),
             defer_support: defer_support.unwrap_or_else(default_defer_support),
             query_planning: query_planning.unwrap_or_default(),
+            reuse_query_fragments: reuse_query_fragments.unwrap_or_default(),
         }
     }
 }

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1475,6 +1475,7 @@ expression: "&schema"
         "listen": "127.0.0.1:4000",
         "path": "/",
         "introspection": false,
+        "reuse_query_fragments": false,
         "defer_support": true,
         "query_planning": {
           "experimental_cache": {
@@ -1591,6 +1592,11 @@ expression: "&schema"
             }
           },
           "additionalProperties": false
+        },
+        "reuse_query_fragments": {
+          "description": "Enable reuse of query fragments Default: false",
+          "default": false,
+          "type": "boolean"
         }
       },
       "additionalProperties": false

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -110,6 +110,7 @@ mod introspection_tests {
                         enable_defer: Some(true),
                     }),
                     graphql_validation: true,
+                    reuse_query_fragments: Some(false),
                 },
             )
             .await

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -58,6 +58,7 @@ impl BridgeQueryPlanner {
         let planner = Planner::new(
             sdl,
             QueryPlannerConfig {
+                reuse_query_fragments: Some(configuration.supergraph.reuse_query_fragments),
                 incremental_delivery: Some(IncrementalDeliverySupport {
                     enable_defer: Some(configuration.supergraph.defer_support),
                 }),
@@ -132,6 +133,7 @@ impl BridgeQueryPlanner {
                             configuration.experimental_graphql_validation_mode,
                             GraphQLValidationMode::Legacy | GraphQLValidationMode::Both
                         ),
+                        reuse_query_fragments: Some(configuration.supergraph.reuse_query_fragments),
                     },
                 )
                 .await?,


### PR DESCRIPTION
Federation v2.4.9 enabled a new reuse_query_fragments feature that is causing issues.

https://github.com/apollographql/federation/pull/2639
https://github.com/apollographql/federation-rs/pull/382

Added an option in the router to enable this but have it disabled by default.

Fixes #3452

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
