### PR TITLE
Modify ``reuse_query_fragments` to allow federation to decide to default on or off

### DIFF
--- a/.changesets/fix_federation_fragments.md
+++ b/.changesets/fix_federation_fragments.md
@@ -1,13 +1,12 @@
-### Update router bridge and add option for `reuse_query_fragments`  ([Issue #3452](https://github.com/apollographql/router/issues/3452))
+### Add option to disable reuse of query fragments  ([Issue #3452](https://github.com/apollographql/router/issues/3452))
 
-Federation v2.4.9 enabled a new feature for [query fragment reuse](https://github.com/apollographql/federation/pull/2639) that is causing issues for some users.
-
-A new option has been added to he router config file to opt into this feature:
+A new option has been added to the Router to allow disabling of the reuse of query fragments. This is useful for debugging purposes.
 ```yaml
 supergraph:
-  experimental_reuse_query_fragments: true
+  experimental_reuse_query_fragments: false
 ```
 
-The default is disabled.
+The default value depends on the version of federation.
 
 By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3453
+****

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -535,9 +535,9 @@ pub(crate) struct Supergraph {
     pub(crate) introspection: bool,
 
     /// Enable reuse of query fragments
-    /// Default: false
+    /// Default: depends on the federation version
     #[serde(rename = "experimental_reuse_query_fragments")]
-    pub(crate) reuse_query_fragments: bool,
+    pub(crate) reuse_query_fragments: Option<bool>,
 
     /// Set to false to disable defer support
     pub(crate) defer_support: bool,
@@ -567,7 +567,7 @@ impl Supergraph {
             introspection: introspection.unwrap_or_else(default_graphql_introspection),
             defer_support: defer_support.unwrap_or_else(default_defer_support),
             query_planning: query_planning.unwrap_or_default(),
-            reuse_query_fragments: reuse_query_fragments.unwrap_or_default(),
+            reuse_query_fragments,
         }
     }
 }
@@ -590,7 +590,7 @@ impl Supergraph {
             introspection: introspection.unwrap_or_else(default_graphql_introspection),
             defer_support: defer_support.unwrap_or_else(default_defer_support),
             query_planning: query_planning.unwrap_or_default(),
-            reuse_query_fragments: reuse_query_fragments.unwrap_or_default(),
+            reuse_query_fragments,
         }
     }
 }

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1482,7 +1482,7 @@ expression: "&schema"
         "listen": "127.0.0.1:4000",
         "path": "/",
         "introspection": false,
-        "experimental_reuse_query_fragments": false,
+        "experimental_reuse_query_fragments": null,
         "defer_support": true,
         "query_planning": {
           "experimental_cache": {
@@ -1502,9 +1502,10 @@ expression: "&schema"
           "type": "boolean"
         },
         "experimental_reuse_query_fragments": {
-          "description": "Enable reuse of query fragments Default: false",
-          "default": false,
-          "type": "boolean"
+          "description": "Enable reuse of query fragments Default: depends on the federation version",
+          "default": null,
+          "type": "boolean",
+          "nullable": true
         },
         "introspection": {
           "description": "Enable introspection Default: false",

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -58,7 +58,7 @@ impl BridgeQueryPlanner {
         let planner = Planner::new(
             sdl,
             QueryPlannerConfig {
-                reuse_query_fragments: Some(configuration.supergraph.reuse_query_fragments),
+                reuse_query_fragments: configuration.supergraph.reuse_query_fragments,
                 incremental_delivery: Some(IncrementalDeliverySupport {
                     enable_defer: Some(configuration.supergraph.defer_support),
                 }),
@@ -133,7 +133,7 @@ impl BridgeQueryPlanner {
                             configuration.experimental_graphql_validation_mode,
                             GraphQLValidationMode::Legacy | GraphQLValidationMode::Both
                         ),
-                        reuse_query_fragments: Some(configuration.supergraph.reuse_query_fragments),
+                        reuse_query_fragments: configuration.supergraph.reuse_query_fragments,
                     },
                 )
                 .await?,

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -942,7 +942,7 @@ mod tests {
             )
             .with_json(
                 serde_json::json!{{
-                    "query":"{computer(id:\"Computer1\"){id errorField}}",
+                    "query":"{computer(id:\"Computer1\"){errorField id}}",
                 }},
                 serde_json::json!{{
                     "data": {


### PR DESCRIPTION
PR #3453 Incorrectly defaulted reuse query fragments to off. This is now controlled by federation.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
