### PR TITLE
Add support for PodDisruptionBudget to helm chart

### DIFF
--- a/.changesets/feat_garypen_3345_pdb.md
+++ b/.changesets/feat_garypen_3345_pdb.md
@@ -1,0 +1,12 @@
+### Add support for PodDisruptionBudget to helm chart ([Issue #3345](https://github.com/apollographql/router/issues/3345))
+
+A [PodDisuptionBudget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) may now be specified for your router to limit the number of concurrent disruptions.
+
+Example Configuration:
+
+```yaml
+podDisruptionBudget:
+  minAvailable: 1
+```
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3469

--- a/helm/chart/router/templates/pdb.yaml
+++ b/helm/chart/router/templates/pdb.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.podDisruptionBudget -}}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "router.fullname" . }}
+  labels:
+    {{- include "router.labels" . | nindent 4 }}
+spec:
+{{- if .Values.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+{{- end }}
+{{- if .Values.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+{{- end }}
+  selector:
+    {{- include "router.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/chart/router/values.yaml
+++ b/helm/chart/router/values.yaml
@@ -200,6 +200,9 @@ tolerations: []
 
 affinity: {}
 
+# -- Sets the [pod disruption budget](https://kubernetes.io/docs/tasks/run-application/configure-pdb/) for Deployment pods
+podDisruptionBudget: {}
+
 # -- Set to existing PriorityClass name to control pod preemption by the scheduler
 priorityClassName: ""
 


### PR DESCRIPTION
Example Configuration:

```yaml
podDisruptionBudget:
  minAvailable: 1
```

fixes: #3345

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
