### PR TITLE
Clarify timeout options

### DIFF
--- a/docs/source/configuration/traffic-shaping.mdx
+++ b/docs/source/configuration/traffic-shaping.mdx
@@ -57,8 +57,7 @@ The Apollo Router applies a default timeout of 30 seconds for all requests, incl
 - Requests the client makes to the router
 - Requests the router makes to subgraphs
 - Initial requests subgraphs make to the router for [subscription callbacks](https://www.apollographql.com/docs/react/data/subscriptions/#http)
-
-> **Note:** For subscriptions callbacks, the timeout only applies to the initial request to the router. Once the subscription has been established, the request duration can exceed the timeout.
+  - For subscriptions callbacks, the timeout only applies to the initial request to the router. Once the subscription has been established, the request duration can exceed the timeout.
 
 You can change the default timeout for client requests to the router like so:
 
@@ -75,6 +74,8 @@ traffic_shaping:
   all: 
     timeout: 50s # If subgraph requests take more than 50 seconds, cancel the request (30 seconds by default)
 ```
+
+> **Note:** Since [deferred](/executing-operations/defer-support/#what-is-defer) fragments are separate requests, each fragment's request is individually subject to timeouts.
 
 ### Compression
 

--- a/docs/source/configuration/traffic-shaping.mdx
+++ b/docs/source/configuration/traffic-shaping.mdx
@@ -60,7 +60,7 @@ The Apollo Router applies a default timeout of 30 seconds for all requests, incl
 
 > **Note:** For subscriptions callbacks, the timeout only applies to the initial request to the router. Once the subscription has been established, the request duration can exceed the timeout.
 
-You can change the default global timeout like so:
+You can change the timeout for all subgraph requests like so:
 
 ```yaml title="router.yaml"
 traffic_shaping:

--- a/docs/source/configuration/traffic-shaping.mdx
+++ b/docs/source/configuration/traffic-shaping.mdx
@@ -50,22 +50,31 @@ traffic_shaping:
 
 This rate limiting applies to all requests, there is no filtering per IP or other criteria.
 
-### Timeout
+### Timeouts
 
 The Apollo Router applies a default timeout of 30 seconds for all requests, including the following:
 
-- Requests the client makes to the Router
+- Requests the client makes to the router
 - Requests the router makes to subgraphs
-- Requests subgraphs make to the router ([subscription callbacks](https://www.apollographql.com/docs/react/data/subscriptions/#http))
+- Initial requests subgraphs make to the router for [subscription callbacks](https://www.apollographql.com/docs/react/data/subscriptions/#http)
 
-To configure timeouts use:
+> **Note:** For subscriptions callbacks, the timeout only applies to the initial request to the router. Once the subscription has been established, the request duration can exceed the timeout.
+
+You can change the default global timeout like so:
+
+```yaml title="router.yaml"
+traffic_shaping:
+  all: 
+    timeout: 50s # If requests take more than 50 seconds, cancel the request (30 seconds by default)
+```
+
+You change the default timeout only for client requests to the router like so:
 
 ```yaml title="router.yaml"
 traffic_shaping:
   router: 
-    timeout: 50s # If a request to the router takes more than 50secs then cancel the request (30 sec by default)
+    timeout: 50s # If client requests to the router take more than 50 seconds, cancel the request
 ```
-Note that for subscriptions the timeout only applies to the initial response from the Router. Once the subscription has been established the request duration can exceed the timeout.
 
 ### Compression
 

--- a/docs/source/configuration/traffic-shaping.mdx
+++ b/docs/source/configuration/traffic-shaping.mdx
@@ -60,20 +60,20 @@ The Apollo Router applies a default timeout of 30 seconds for all requests, incl
 
 > **Note:** For subscriptions callbacks, the timeout only applies to the initial request to the router. Once the subscription has been established, the request duration can exceed the timeout.
 
-You can change the timeout for all subgraph requests like so:
-
-```yaml title="router.yaml"
-traffic_shaping:
-  all: 
-    timeout: 50s # If requests take more than 50 seconds, cancel the request (30 seconds by default)
-```
-
-You change the default timeout only for client requests to the router like so:
+You can change the default timeout for client requests to the router like so:
 
 ```yaml title="router.yaml"
 traffic_shaping:
   router: 
-    timeout: 50s # If client requests to the router take more than 50 seconds, cancel the request
+    timeout: 50s # If client requests to the router take more than 50 seconds, cancel the request (30 seconds by default)
+```
+
+You can change the default timeout for all requests between the router and subgraphs like so:
+
+```yaml title="router.yaml"
+traffic_shaping:
+  all: 
+    timeout: 50s # If subgraph requests take more than 50 seconds, cancel the request (30 seconds by default)
 ```
 
 ### Compression


### PR DESCRIPTION
This PR adds some clarification around timeout configuration in https://github.com/apollographql/router/pull/3456.

Fixes https://github.com/apollographql/router/issues/3441

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
