### PR TITLE
Add coprocessor metrics

### DIFF
--- a/.changesets/feat_garypen_177_coprocessor_metrics.md
+++ b/.changesets/feat_garypen_177_coprocessor_metrics.md
@@ -1,0 +1,16 @@
+### Add coprocessor metrics ([PR #3483](https://github.com/apollographql/router/pull/3483))
+
+Introduces a new metric for the router:
+
+```
+apollo.router.operations.coprocessor
+```
+
+It has two attributes:
+
+```
+coprocessor.stage: string (RouterRequest, RouterResponse, SubgraphRequest, SubgraphResponse)
+coprocessor.succeeded: bool
+```
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3483

--- a/apollo-router/src/plugins/coprocessor.rs
+++ b/apollo-router/src/plugins/coprocessor.rs
@@ -285,7 +285,8 @@ impl RouterStage {
                 let sdl = sdl.clone();
 
                 async move {
-                    process_router_request_stage(
+                    let mut succeeded = true;
+                    let result = process_router_request_stage(
                         http_client,
                         coprocessor_url,
                         sdl,
@@ -294,11 +295,19 @@ impl RouterStage {
                     )
                     .await
                     .map_err(|error| {
+                        succeeded = false;
                         tracing::error!(
                             "external extensibility: router request stage error: {error}"
                         );
                         error
-                    })
+                    });
+                    tracing::info!(
+                        monotonic_counter.apollo.router.operations.coprocessor = 1u64,
+                        coprocessor.stage = %PipelineStep::RouterRequest,
+                        coprocessor.succeeded = succeeded,
+                        "Total operations with co-processors enabled"
+                    );
+                    result
                 }
             })
         });
@@ -314,7 +323,8 @@ impl RouterStage {
                 async move {
                     let response: router::Response = fut.await?;
 
-                    process_router_response_stage(
+                    let mut succeeded = true;
+                    let result = process_router_response_stage(
                         http_client,
                         coprocessor_url,
                         sdl,
@@ -323,11 +333,19 @@ impl RouterStage {
                     )
                     .await
                     .map_err(|error| {
+                        succeeded = false;
                         tracing::error!(
                             "external extensibility: router response stage error: {error}"
                         );
                         error
-                    })
+                    });
+                    tracing::info!(
+                        monotonic_counter.apollo.router.operations.coprocessor = 1u64,
+                        coprocessor.stage = %PipelineStep::RouterResponse,
+                        coprocessor.succeeded = succeeded,
+                        "Total operations with co-processors enabled"
+                    );
+                    result
                 }
             })
         });
@@ -400,7 +418,8 @@ impl SubgraphStage {
                 let request_config = request_config.clone();
 
                 async move {
-                    process_subgraph_request_stage(
+                    let mut succeeded = true;
+                    let result = process_subgraph_request_stage(
                         http_client,
                         coprocessor_url,
                         service_name,
@@ -409,11 +428,19 @@ impl SubgraphStage {
                     )
                     .await
                     .map_err(|error| {
+                        succeeded = false;
                         tracing::error!(
                             "external extensibility: subgraph request stage error: {error}"
                         );
                         error
-                    })
+                    });
+                    tracing::info!(
+                        monotonic_counter.apollo.router.operations.coprocessor = 1u64,
+                        coprocessor.stage = %PipelineStep::SubgraphRequest,
+                        coprocessor.succeeded = succeeded,
+                        "Total operations with co-processors enabled"
+                    );
+                    result
                 }
             })
         });
@@ -430,7 +457,8 @@ impl SubgraphStage {
                 async move {
                     let response: subgraph::Response = fut.await?;
 
-                    process_subgraph_response_stage(
+                    let mut succeeded = true;
+                    let result = process_subgraph_response_stage(
                         http_client,
                         coprocessor_url,
                         service_name,
@@ -439,11 +467,19 @@ impl SubgraphStage {
                     )
                     .await
                     .map_err(|error| {
+                        succeeded = false;
                         tracing::error!(
                             "external extensibility: subgraph response stage error: {error}"
                         );
                         error
-                    })
+                    });
+                    tracing::info!(
+                        monotonic_counter.apollo.router.operations.coprocessor = 1u64,
+                        coprocessor.stage = %PipelineStep::SubgraphResponse,
+                        coprocessor.succeeded = succeeded,
+                        "Total operations with co-processors enabled"
+                    );
+                    result
                 }
             })
         });

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -89,6 +89,15 @@ All cache metrics listed above have the following attributes:
 - `kind`: the cache being queried (`apq`, `query planner`, `introspection`)
 - `storage`: The backend storage of the cache (`memory`, `redis`)
 
+#### Coprocessor
+
+- `apollo_router_operations_coprocessor_total` - Total operations with co-processors enabled.
+
+The coprocessor operations metric has the following attributes:
+
+- `coprocessor.stage`: string (`RouterRequest`, `RouterResponse`, `SubgraphRequest`, `SubgraphResponse`)
+- `coprocessor.succeeded`: bool
+
 #### Performance
 
 - `apollo_router_processing_time` - Time spent processing a request (outside of waiting for external or subgraph requests) in seconds.


### PR DESCRIPTION
Introduces a new metric for the router:

```
apollo.router.operations.coprocessor
```

It has two attributes:

```
coprocessor.stage: string (RouterRequest, RouterResponse, SubgraphRequest, SubgraphResponse)
coprocessor.succeeded: bool
```

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

Ran a router with all coprocessor stages enabled and prometheus enabled. Sent in a request to generate a success metric. Then stopped the coprocessor and sent in another request to generate a fail metric. Examined the prometheus metrics to ensure they were as expected. e.g.:
```
# HELP apollo_router_operations_coprocessor_total apollo.router.operations.coprocessor
# TYPE apollo_router_operations_coprocessor_total counter
apollo_router_operations_coprocessor_total{coprocessor_stage="RouterRequest",coprocessor_succeeded="false",service_name="apollo-router",otel_scope_name="apollo/router",otel_scope_version=""} 1
apollo_router_operations_coprocessor_total{coprocessor_stage="RouterRequest",coprocessor_succeeded="true",service_name="apollo-router",otel_scope_name="apollo/router",otel_scope_version=""} 1
apollo_router_operations_coprocessor_total{coprocessor_stage="RouterResponse",coprocessor_succeeded="true",service_name="apollo-router",otel_scope_name="apollo/router",otel_scope_version=""} 1
apollo_router_operations_coprocessor_total{coprocessor_stage="SubgraphRequest",coprocessor_succeeded="true",service_name="apollo-router",otel_scope_name="apollo/router",otel_scope_version=""} 1
apollo_router_operations_coprocessor_total{coprocessor_stage="SubgraphResponse",coprocessor_succeeded="true",service_name="apollo-router",otel_scope_name="apollo/router",otel_scope_version=""} 1
```

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
