### PR TITLE
Remove persisted docs from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,16 @@ This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.
 
 ### Persisted Queries w/opt-in safelisting (preview) ([PR #3347](https://github.com/apollographql/router/pull/3347))
 
-Persisted Queries is a forthcoming feature that helps you prevent unwanted traffic from reaching your graph.
+Persisted Queries is an upcoming feature that helps you prevent unwanted traffic from reaching your graph. It's in private preview and isn't available unless your enterprise organization has been granted preview access by Apollo.
 
-It has two modes of operation:
+Persisted Queries has two modes of operation:
 * **Unregistered operation monitoring**
-  * Your router can allow all GraphQL operations, while emitting structured traces containing unregistered operation bodies.
+  * Your router allows all GraphQL operations, while emitting structured traces containing unregistered operation bodies.
 * **Operation safelisting**
-  * Reject unregistered operations
-  * Require all operations to be sent as an ID
+  * Your router rejects unregistered operations.
+  * Your router requires all operations to be sent as an ID.
 
-Unlike automatic persisted queries (APQ), a safelist of operations lets you prevent a malicious actor from constructing a free-format query that could overload your subgraph services.
-
-This feature is in a private preview phase and aren't available unless your enterprise organization has been granted preview access by Apollo.
+Unlike automatic persisted queries (APQ), an operation safelist lets you prevent malicious actors from constructing a free-format query that could overload your subgraph services.
 
 By [@EverlastingBugstopper](https://github.com/EverlastingBugstopper) in https://github.com/apollographql/router/pull/3347
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,7 @@ This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.
 
 ### Persisted Queries w/opt-in safelisting (preview) ([PR #3347](https://github.com/apollographql/router/pull/3347))
 
-> ⚠️ **Persisted queries is an [Enterprise feature](https://www.apollographql.com/blog/platform/evaluating-apollo-router-understanding-free-and-open-vs-commercial-features/) of the Apollo Router.** It requires an organization with a [GraphOS Enterprise plan](https://www.apollographql.com/pricing/).
->
-> If your organization _doesn't_ currently have an Enterprise plan, you can test out this functionality by signing up for a free [Enterprise trial](https://www.apollographql.com/docs/graphos/org/plans/#enterprise-trials).
-
-Persisted Queries gives you the tools to prevent unwanted traffic from reaching your graph.
+Persisted Queries is a forthcoming feature that helps you prevent unwanted traffic from reaching your graph.
 
 It has two modes of operation:
 * **Unregistered operation monitoring**
@@ -23,9 +19,9 @@ It has two modes of operation:
   * Reject unregistered operations
   * Require all operations to be sent as an ID
 
-Unlike automatic persisted queries (APQ), the ability to create a safelist of operations allows you to prevent a malicious actor from constructing a free-format query that could overload your subgraph services.
+Unlike automatic persisted queries (APQ), a safelist of operations lets you prevent a malicious actor from constructing a free-format query that could overload your subgraph services.
 
-For more information con how to register queries and configure your router see the [Persisted Query documentation](https://www.apollographql.com/docs/graphos/routing/persisted-queries).
+This feature is in a private preview phase and aren't available unless your enterprise organization has been granted preview access by Apollo.
 
 By [@EverlastingBugstopper](https://github.com/EverlastingBugstopper) in https://github.com/apollographql/router/pull/3347
 


### PR DESCRIPTION
Removes (inactive) docs link and clarifies that persisted queries is a forthcoming feature.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
