### PR TITLE
fix the prometheus descriptions as well as the metrics

### DIFF
--- a/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
@@ -158,7 +158,7 @@ impl Service<router::Request> for PrometheusService {
             // otel 0.19.0 started adding "_total" onto various statistics.
             // Let's remove any problems they may have created for us.
             let stats = String::from_utf8_lossy(&result);
-            let modified_stats = stats.replace("_total_total{", "_total{");
+            let modified_stats = stats.replace("_total_total", "_total");
             Ok(router::Response {
                 response: http::Response::builder()
                     .status(StatusCode::OK)


### PR DESCRIPTION
I didn't realise the descriptions on the prometheus stats were significant, so my prefious prometheus fix constrained itself to renaming the actual metrics.

This relaxes the regex pattern to include prom descriptions as well as metrics in the renaming.

fixes: #3491

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

Ran up an instance of the router and confirmed that prometheus descriptive text and metrics are correctly renamed.

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
