### PR TITLE
Fix redis reconnections

### DIFF
--- a/.changesets/fix_geal_redis_fixes.md
+++ b/.changesets/fix_geal_redis_fixes.md
@@ -1,0 +1,9 @@
+### Fix redis reconnections ([Issue #3045](https://github.com/apollographql/router/issues/3045))
+
+The reconnection policy was using an exponential backoff delay with a maximum number of attempts. Once that maximum is reached, reconnection was never tried again (there's no baseline retry). We change that behaviour by adding infinite retries with a maximum delay of 2 seconds, and a timeout of 1 millisecond on redis commands, so that the router can continue serving requests in the meantime.
+
+This commit contains additional fixes:
+- release the lock on the in memory cache while waiting for redis, to let the in memory cache serve other requests
+- add a custom serializer for `SubSelectionKey`: this type is used as key in a `HashMap`, which is converted to a JSON object, and object keys must be strings, so a specific serializer is needed instead of the derived one
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3509

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -9,6 +9,7 @@ use fred::prelude::RedisError;
 use fred::prelude::RedisErrorKind;
 use fred::types::Expiration;
 use fred::types::FromRedis;
+use fred::types::PerformanceConfig;
 use fred::types::ReconnectPolicy;
 use fred::types::RedisConfig;
 use url::Url;
@@ -114,8 +115,11 @@ impl RedisCacheStorage {
 
         let client = RedisClient::new(
             config,
-            None, //perf policy
-            Some(ReconnectPolicy::new_exponential(10, 1, 2000, 10)),
+            Some(PerformanceConfig {
+                default_command_timeout_ms: 1,
+                ..Default::default()
+            }),
+            Some(ReconnectPolicy::new_exponential(10, 1, 200, 5)),
         );
         let _handle = client.connect();
 

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -119,7 +119,7 @@ impl RedisCacheStorage {
                 default_command_timeout_ms: 1,
                 ..Default::default()
             }),
-            Some(ReconnectPolicy::new_exponential(10, 1, 200, 5)),
+            Some(ReconnectPolicy::new_exponential(0, 1, 2000, 5)),
         );
         let _handle = client.connect();
 


### PR DESCRIPTION
Fix #3045 

The reconnection policy was using an exponential backoff delay with a maximum number of attempts. Once that maximum is reached, reconnection was never tried again (there's no baseline retry). We change that behaviour by adding infinite retries with a maximum delay of 2 seconds, and a timeout of 1 millisecond on redis commands, so that the router can continue serving requests in the meantime.

This PR contains additional fixes:
- release the lock on the in memory cache while waiting for redis, to let the in memory cache serve other requests
- add a custom serializer for `SubSelectionKey`: this type is used as key in a HashMap, which is converted to a JSON object, and object keys must be strings, so a specific serializer is needed instead of the derived one

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
