### PR TITLE
add a metric tracking coprocessor latency

### DIFF
--- a/.changesets/feat_geal_coprocessor_latency_metric.md
+++ b/.changesets/feat_geal_coprocessor_latency_metric.md
@@ -3,7 +3,7 @@
 Introduces a new metric for the router:
 
 ```
-apollo.router.operations.coprocessor_request_time
+apollo.router.operations.coprocessor.duration
 ```
 
 It has one attributes:

--- a/.changesets/feat_geal_coprocessor_latency_metric.md
+++ b/.changesets/feat_geal_coprocessor_latency_metric.md
@@ -1,0 +1,17 @@
+### add a metric tracking coprocessor latency ([Issue #2924](https://github.com/apollographql/router/issues/2924))
+
+Introduces a new metric for the router:
+
+```
+apollo.router.operations.coprocessor_request_time
+```
+
+It has one attributes:
+
+```
+coprocessor.stage: string (RouterRequest, RouterResponse, SubgraphRequest, SubgraphResponse)
+```
+
+It is an histogram metric tracking the time spent calling into the coprocessor
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3513

--- a/apollo-router/src/plugins/coprocessor.rs
+++ b/apollo-router/src/plugins/coprocessor.rs
@@ -563,7 +563,7 @@ where
     let duration = start.elapsed().as_secs_f64();
     drop(guard);
     tracing::info!(
-        histogram.apollo.router.operations.coprocessor_request_time = duration,
+        histogram.apollo.router.operations.coprocessor.duration = duration,
         coprocessor.stage = %PipelineStep::RouterRequest,
     );
 
@@ -719,7 +719,7 @@ where
     let duration = start.elapsed().as_secs_f64();
     drop(guard);
     tracing::info!(
-        histogram.apollo.router.operations.coprocessor_request_time = duration,
+        histogram.apollo.router.operations.coprocessor.duration = duration,
         coprocessor.stage = %PipelineStep::RouterResponse,
     );
 
@@ -891,7 +891,7 @@ where
     let duration = start.elapsed().as_secs_f64();
     drop(guard);
     tracing::info!(
-        histogram.apollo.router.operations.coprocessor_request_time = duration,
+        histogram.apollo.router.operations.coprocessor.duration = duration,
         coprocessor.stage = %PipelineStep::SubgraphRequest,
     );
 
@@ -1030,7 +1030,7 @@ where
     let duration = start.elapsed().as_secs_f64();
     drop(guard);
     tracing::info!(
-        histogram.apollo.router.operations.coprocessor_request_time = duration,
+        histogram.apollo.router.operations.coprocessor.duration = duration,
         coprocessor.stage = %PipelineStep::SubgraphResponse,
     );
 

--- a/apollo-router/src/plugins/coprocessor.rs
+++ b/apollo-router/src/plugins/coprocessor.rs
@@ -563,7 +563,7 @@ where
     let duration = start.elapsed().as_secs_f64();
     drop(guard);
     tracing::info!(
-        histogram.apollo.router.operations.coprocessor = duration,
+        histogram.apollo.router.operations.coprocessor_request_time = duration,
         coprocessor.stage = %PipelineStep::RouterRequest,
     );
 
@@ -719,7 +719,7 @@ where
     let duration = start.elapsed().as_secs_f64();
     drop(guard);
     tracing::info!(
-        histogram.apollo.router.operations.coprocessor = duration,
+        histogram.apollo.router.operations.coprocessor_request_time = duration,
         coprocessor.stage = %PipelineStep::RouterResponse,
     );
 
@@ -891,7 +891,7 @@ where
     let duration = start.elapsed().as_secs_f64();
     drop(guard);
     tracing::info!(
-        histogram.apollo.router.operations.coprocessor = duration,
+        histogram.apollo.router.operations.coprocessor_request_time = duration,
         coprocessor.stage = %PipelineStep::SubgraphRequest,
     );
 
@@ -1030,7 +1030,7 @@ where
     let duration = start.elapsed().as_secs_f64();
     drop(guard);
     tracing::info!(
-        histogram.apollo.router.operations.coprocessor = duration,
+        histogram.apollo.router.operations.coprocessor_request_time = duration,
         coprocessor.stage = %PipelineStep::SubgraphResponse,
     );
 

--- a/apollo-router/src/plugins/coprocessor.rs
+++ b/apollo-router/src/plugins/coprocessor.rs
@@ -5,6 +5,7 @@ use std::ops::ControlFlow;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
 use bytes::Bytes;
 use futures::future::ready;
@@ -557,8 +558,15 @@ where
 
     tracing::debug!(?payload, "externalized output");
     let guard = request.context.enter_active_request();
+    let start = Instant::now();
     let co_processor_result = payload.call(http_client, &coprocessor_url).await;
+    let duration = start.elapsed().as_secs_f64();
     drop(guard);
+    tracing::info!(
+        histogram.apollo.router.operations.coprocessor = duration,
+        coprocessor.stage = %PipelineStep::RouterRequest,
+    );
+
     tracing::debug!(?co_processor_result, "co-processor returned");
     let co_processor_output = co_processor_result?;
 
@@ -706,8 +714,15 @@ where
     // Second, call our co-processor and get a reply.
     tracing::debug!(?payload, "externalized output");
     let guard = response.context.enter_active_request();
+    let start = Instant::now();
     let co_processor_result = payload.call(http_client.clone(), &coprocessor_url).await;
+    let duration = start.elapsed().as_secs_f64();
     drop(guard);
+    tracing::info!(
+        histogram.apollo.router.operations.coprocessor = duration,
+        coprocessor.stage = %PipelineStep::RouterResponse,
+    );
+
     tracing::debug!(?co_processor_result, "co-processor returned");
     let co_processor_output = co_processor_result?;
 
@@ -871,8 +886,15 @@ where
 
     tracing::debug!(?payload, "externalized output");
     let guard = request.context.enter_active_request();
+    let start = Instant::now();
     let co_processor_result = payload.call(http_client, &coprocessor_url).await;
+    let duration = start.elapsed().as_secs_f64();
     drop(guard);
+    tracing::info!(
+        histogram.apollo.router.operations.coprocessor = duration,
+        coprocessor.stage = %PipelineStep::SubgraphRequest,
+    );
+
     tracing::debug!(?co_processor_result, "co-processor returned");
     let co_processor_output = co_processor_result?;
     validate_coprocessor_output(&co_processor_output, PipelineStep::SubgraphRequest)?;
@@ -1003,8 +1025,15 @@ where
 
     tracing::debug!(?payload, "externalized output");
     let guard = response.context.enter_active_request();
+    let start = Instant::now();
     let co_processor_result = payload.call(http_client, &coprocessor_url).await;
+    let duration = start.elapsed().as_secs_f64();
     drop(guard);
+    tracing::info!(
+        histogram.apollo.router.operations.coprocessor = duration,
+        coprocessor.stage = %PipelineStep::SubgraphResponse,
+    );
+
     tracing::debug!(?co_processor_result, "co-processor returned");
     let co_processor_output = co_processor_result?;
 

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -92,6 +92,7 @@ All cache metrics listed above have the following attributes:
 #### Coprocessor
 
 - `apollo_router_operations_coprocessor_total` - Total operations with co-processors enabled.
+- `apollo_router_operations_coprocessor_request_time` - Time spent waiting for the coprocessor to answer, in seconds
 
 The coprocessor operations metric has the following attributes:
 

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -92,7 +92,7 @@ All cache metrics listed above have the following attributes:
 #### Coprocessor
 
 - `apollo_router_operations_coprocessor_total` - Total operations with co-processors enabled.
-- `apollo_router_operations_coprocessor_request_time` - Time spent waiting for the coprocessor to answer, in seconds
+- `apollo_router_operations_coprocessor.duration` - Time spent waiting for the coprocessor to answer, in seconds
 
 The coprocessor operations metric has the following attributes:
 


### PR DESCRIPTION
Fix #2924 

Introduces a new metric for the router:

```
apollo.router.operations.coprocessor.duration
```

It has one attributes:

```
coprocessor.stage: string (RouterRequest, RouterResponse, SubgraphRequest, SubgraphResponse)
```

It is an histogram metric tracking the time spent calling into the coprocessor

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
