### PR TITLE
Add a message to the logs indicating when custom plugins are detected and there is a possibility that log entries may be silenced

### DIFF
--- a/.changesets/maint_rhubarb_waterfront_notebook.md
+++ b/.changesets/maint_rhubarb_waterfront_notebook.md
@@ -1,0 +1,10 @@
+### Add a message to the logs indicating when custom plugins are detected and there is a possibility that log entries may be silenced ([Issue #3526](https://github.com/apollographql/router/issues/3526))
+
+Since [#3477](https://github.com/apollographql/router/pull/3477), users who have created custom plugins no longer see their log entries.
+This is because the default logging filter now restricts log entries to those that are in the apollo module.
+
+Users that have custom plugins will need to configure the logging filter to include their modules, but they may not realise this.
+
+Now, if a custom plugin is detected then a message will be logged to the console indicating that the logging filter may need to be configured.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3540

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -622,7 +622,7 @@ impl Executable {
         let apollo_router_log = std::env::var("APOLLO_ROUTER_LOG").unwrap_or_default();
         if user_plugins_present
             && !rust_log_set
-            && ["", "off", "trace", "debug", "warn", "info"].contains(&apollo_router_log.as_str())
+            && ["trace", "debug", "warn", "error", "info"].contains(&apollo_router_log.as_str())
         {
             tracing::info!("Custom plugins are present. To see log messages from your plugins you must configure `RUST_LOG` or `APOLLO_ROUTER_LOG` environment variables. See the Router logging documentation for more details");
         }

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -28,6 +28,7 @@ use url::Url;
 use crate::configuration::generate_config_schema;
 use crate::configuration::generate_upgrade;
 use crate::configuration::Discussed;
+use crate::plugin::plugins;
 use crate::plugins::telemetry::reload::init_telemetry;
 use crate::router::ConfigurationSource;
 use crate::router::RouterHttpServer;
@@ -614,6 +615,17 @@ impl Executable {
                 _ => LicenseSource::default(),
             }
         };
+
+        // If there are custom plugins then if RUST_LOG hasn't been set and APOLLO_ROUTER_LOG contains one of the defaults.
+        let user_plugins_present = plugins().filter(|p| !p.is_apollo()).count() > 0;
+        let rust_log_set = std::env::var("RUST_LOG").is_ok();
+        let apollo_router_log = std::env::var("APOLLO_ROUTER_LOG").unwrap_or_default();
+        if user_plugins_present
+            && !rust_log_set
+            && ["", "off", "trace", "debug", "warn", "info"].contains(&apollo_router_log.as_str())
+        {
+            tracing::info!("Custom plugins are present. To see log messages from your plugins you must configure `RUST_LOG` or `APOLLO_ROUTER_LOG` environment variables. See the Router logging documentation for more details");
+        }
 
         let router = RouterHttpServer::builder()
             .configuration(configuration)

--- a/apollo-router/src/plugin/mod.rs
+++ b/apollo-router/src/plugin/mod.rs
@@ -184,6 +184,9 @@ impl fmt::Debug for PluginFactory {
 }
 
 impl PluginFactory {
+    pub(crate) fn is_apollo(&self) -> bool {
+        self.name.starts_with("apollo.") || self.name.starts_with("experimental.")
+    }
     /// Create a plugin factory.
     pub fn new<P: Plugin>(group: &str, name: &str) -> PluginFactory {
         let plugin_factory_name = if group.is_empty() {


### PR DESCRIPTION
If users plugins are detected and logging either hasn't been configured then emit a log message stating that user logs be be being silenced and point them towards what they need to do to configure their logging.

Fixes #3526

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
