### PR TITLE
Update Gitleaks ignore file

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,5 +14,23 @@
     [ rules.allowlist ]
         commits = [
             "7fdb0a5a0831d309524e98503760c16bd3de160c",
+            # Example private key for test cases
+            "9d6464b96eed3a20c48d5ec653bf9986757c89e5",
             
+        ]
+
+[[ rules ]]
+    id = "jwt"
+    [ rules.allowlist ]
+        commits = [
+            # Example jwt
+            "f12bcddc663aa4c4d90218a1bb718fe74e0e7be3",
+        ]
+
+[[ rules ]]
+    id = "high-entropy-base64"
+    [ rules.allowlist ]
+        commits = [
+            # Non-Sensitive Test data
+            "728552f0ca934e0bc6803b803859d5c956a832d9",
         ]


### PR DESCRIPTION
This updates the .gitleaks.toml file in the root of the repo. This file is used to adjust gitleaks configuration when running against this repo. Primarily, this configuration is used to create a repo-local allowlist of detected "secret" values that should be allowed to remain in git history. Usually, this happens if the detected value is not actually a secret or if the detected value was a secret that has since been revoked/rotated.
