### PR TITLE
remove unneeded schema parsing steps

### DIFF
--- a/.changesets/maint_geal_unneeded_schema_parsing.md
+++ b/.changesets/maint_geal_unneeded_schema_parsing.md
@@ -1,0 +1,5 @@
+### Remove unneeded schema parsing steps ([PR #3547](https://github.com/apollographql/router/pull/3547))
+
+We need access to a parsed schema in various parts of the router, sometimes before the point where it is actually parsed and integrated with the rest of the configuration, so it was parsed multiple times to mitigate that. Some architecture changes made these parsing steps obsolete so they were removed.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3547

--- a/apollo-router/src/orbiter/mod.rs
+++ b/apollo-router/src/orbiter/mod.rs
@@ -24,6 +24,7 @@ use crate::plugin::DynPlugin;
 use crate::router_factory::RouterSuperServiceFactory;
 use crate::router_factory::YamlRouterFactory;
 use crate::services::router_service::RouterCreator;
+use crate::services::HasSchema;
 use crate::spec::Schema;
 use crate::Configuration;
 
@@ -110,10 +111,9 @@ impl RouterSuperServiceFactory for OrbiterRouterSuperServiceFactory {
             .await
             .map(|factory| {
                 if env::var("APOLLO_TELEMETRY_DISABLED").unwrap_or_default() != "true" {
+                    let schema = factory.supergraph_creator.schema();
+
                     tokio::task::spawn(async move {
-                        let schema = Arc::new(Schema::parse(&schema, &configuration).expect(
-                            "if we get here the schema was already parsed successfully elsewhere",
-                        ));
                         tracing::debug!("sending anonymous usage data to Apollo");
                         let report = create_report(configuration, schema);
                         if let Err(e) = send(report).await {

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -33,7 +33,6 @@ use crate::configuration::ListenAddr;
 use crate::router::Event::UpdateLicense;
 use crate::router_factory::RouterFactory;
 use crate::router_factory::RouterSuperServiceFactory;
-use crate::spec::Schema;
 use crate::uplink::license_enforcement::LicenseEnforcementReport;
 use crate::uplink::license_enforcement::LicenseState;
 use crate::uplink::license_enforcement::LICENSE_EXPIRED_URL;
@@ -313,13 +312,8 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         S: HttpServerFactory,
         FA: RouterSuperServiceFactory,
     {
-        let parsed_schema = Arc::new(
-            Schema::parse(&schema, &configuration)
-                .map_err(|e| ServiceCreationError(e.to_string().into()))?,
-        );
-
         // Check the license
-        let report = LicenseEnforcementReport::build(&configuration, &parsed_schema);
+        let report = LicenseEnforcementReport::build(&configuration);
 
         match license {
             LicenseState::Licensed => {

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -25,7 +25,6 @@ use serde::Serialize;
 use serde_json::Value;
 use thiserror::Error;
 
-use crate::spec::Schema;
 use crate::Configuration;
 
 pub(crate) const LICENSE_EXPIRED_URL: &str = "https://go.apollo.dev/o/elp";
@@ -83,10 +82,7 @@ impl LicenseEnforcementReport {
         !self.restricted_config_in_use.is_empty()
     }
 
-    pub(crate) fn build(
-        configuration: &Configuration,
-        _schema: &Schema,
-    ) -> LicenseEnforcementReport {
+    pub(crate) fn build(configuration: &Configuration) -> LicenseEnforcementReport {
         LicenseEnforcementReport {
             restricted_config_in_use: Self::validate_configuration(
                 configuration,
@@ -297,7 +293,6 @@ mod test {
     use insta::assert_snapshot;
     use serde_json::json;
 
-    use crate::spec::Schema;
     use crate::uplink::license_enforcement::Audience;
     use crate::uplink::license_enforcement::Claims;
     use crate::uplink::license_enforcement::License;
@@ -305,20 +300,15 @@ mod test {
     use crate::uplink::license_enforcement::OneOrMany;
     use crate::Configuration;
 
-    fn check(router_yaml: &str, supergraph_schema: &str) -> LicenseEnforcementReport {
+    fn check(router_yaml: &str) -> LicenseEnforcementReport {
         let config = Configuration::from_str(router_yaml).expect("router config must be valid");
-        let schema =
-            Schema::parse(supergraph_schema, &config).expect("supergraph schema must be valid");
 
-        LicenseEnforcementReport::build(&config, &schema)
+        LicenseEnforcementReport::build(&config)
     }
 
     #[test]
     fn test_oss() {
-        let report = check(
-            include_str!("testdata/oss.router.yaml"),
-            include_str!("testdata/oss.graphql"),
-        );
+        let report = check(include_str!("testdata/oss.router.yaml"));
 
         assert!(
             report.restricted_config_in_use.is_empty(),
@@ -328,10 +318,7 @@ mod test {
 
     #[test]
     fn test_restricted_features_via_config() {
-        let report = check(
-            include_str!("testdata/restricted.router.yaml"),
-            include_str!("testdata/oss.graphql"),
-        );
+        let report = check(include_str!("testdata/restricted.router.yaml"));
 
         assert!(
             !report.restricted_config_in_use.is_empty(),


### PR DESCRIPTION
We do not need to parse the schema before license enforcement because it does not use it.
We do not need it either in orbiter because the factory contains the parsed schema

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
