### PR TITLE
WIP: Initial test implementation of the gcp stackdriver opentelemetry trace batch exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,6 +346,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-prometheus",
  "opentelemetry-semantic-conventions",
+ "opentelemetry-stackdriver",
  "opentelemetry-zipkin",
  "p256 0.12.0",
  "parking_lot 0.12.1",
@@ -2111,6 +2112,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2131,6 +2142,17 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2680,6 +2702,31 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "gcp_auth"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ab5724fa45095bf1965ff491e75182818ba13f2a8755b04d484a9ec6408b622"
+dependencies = [
+ "async-trait",
+ "base64 0.21.2",
+ "dirs-next",
+ "hyper",
+ "hyper-rustls 0.23.2",
+ "ring",
+ "rustls 0.20.8",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "tokio",
+ "tracing",
+ "tracing-futures",
+ "url",
+ "which",
 ]
 
 [[package]]
@@ -4221,6 +4268,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24e33428e6bf08c6f7fcea4ddb8e358fab0fe48ab877a87c70c6ebe20f673ce5"
 dependencies = [
  "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry-stackdriver"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff78d1abfa634182471924e542004d1b46996a31a481da114eda4abaad9d5b61"
+dependencies = [
+ "async-trait",
+ "futures",
+ "gcp_auth",
+ "hex",
+ "http",
+ "hyper",
+ "opentelemetry",
+ "opentelemetry-semantic-conventions",
+ "prost",
+ "prost-types",
+ "thiserror",
+ "tonic 0.8.3",
 ]
 
 [[package]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -76,7 +76,7 @@ clap = { version = "4.3.16", default-features = false, features = [
     "help",
 ] }
 console-subscriber = { version = "0.1.10", optional = true }
-ci_info = {version="0.14.10", features=["serde-1"] }
+ci_info = { version = "0.14.10", features = ["serde-1"] }
 dashmap = { version = "5.5.0", features = ["serde"] }
 derivative = "2.2.0"
 derive_more = { version = "0.99.17", default-features = false, features = [
@@ -115,7 +115,9 @@ mime = "0.3.17"
 multer = "2.1.0"
 multimap = "0.8.3"
 # To avoid tokio issues
-notify = { version = "5.2.0", default-features = false, features=["macos_kqueue"] }
+notify = { version = "5.2.0", default-features = false, features = [
+    "macos_kqueue",
+] }
 nu-ansi-term = "0.47"
 once_cell = "1.18.0"
 
@@ -130,10 +132,7 @@ once_cell = "1.18.0"
 # groups `^tracing` and `^opentelemetry*` dependencies together as of
 # https://github.com/apollographql/router/pull/1509.  A comment which exists
 # there (and on `tracing` packages below) should be updated should this change.
-opentelemetry = { version = "0.19.0", features = [
-    "rt-tokio",
-    "metrics",
-] }
+opentelemetry = { version = "0.19.0", features = ["rt-tokio", "metrics"] }
 opentelemetry-datadog = { version = "0.7.0", features = ["reqwest-client"] }
 opentelemetry-http = "0.8.0"
 opentelemetry-jaeger = { version = "0.18.0", features = [
@@ -155,6 +154,9 @@ opentelemetry-zipkin = { version = "0.17.0", default-features = false, features 
     "reqwest-rustls",
 ] }
 opentelemetry-prometheus = "0.12.0"
+opentelemetry-stackdriver = { version = "0.16.0", default-features = false, features = [
+    "gcp_auth",
+] }
 paste = "1.0.14"
 pin-project-lite = "0.2.10"
 prometheus = "0.13"
@@ -172,7 +174,7 @@ reqwest = { version = "0.11.18", default-features = false, features = [
 ] }
 # note: this dependency should _always_ be pinned, prefix the version with an `=`
 router-bridge = "=0.4.0+v2.4.10"
-rust-embed="6.8.1"
+rust-embed = "6.8.1"
 rustls = "0.20.8"
 rustls-pemfile = "1.0.3"
 schemars = { version = "0.8.12", features = ["url"] }
@@ -180,7 +182,10 @@ shellexpand = "3.1.0"
 sha2 = "0.10.7"
 serde = { version = "1.0.171", features = ["derive", "rc"] }
 serde_json_bytes = { version = "0.2.1", features = ["preserve_order"] }
-serde_json = { version = "1.0.103", features = ["preserve_order", "float_roundtrip"] }
+serde_json = { version = "1.0.103", features = [
+    "preserve_order",
+    "float_roundtrip",
+] }
 serde_urlencoded = "0.7.1"
 serde_yaml = "0.8.26"
 static_assertions = "1.1.0"
@@ -190,7 +195,12 @@ thiserror = "1.0.43"
 tokio = { version = "1.29.1", features = ["full"] }
 tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
 tokio-util = { version = "0.7.8", features = ["net", "codec", "time"] }
-tonic = { version = "0.8.3", features = ["transport", "tls", "tls-roots", "gzip"] }
+tonic = { version = "0.8.3", features = [
+    "transport",
+    "tls",
+    "tls-roots",
+    "gzip",
+] }
 tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.3.5", features = [
     "add-extension",
@@ -216,7 +226,9 @@ uuid = { version = "1.4.1", features = ["serde", "v4"] }
 yaml-rust = "0.4.5"
 wiremock = "0.5.19"
 wsl = "0.1.0"
-tokio-tungstenite = { version = "0.18.0", features = ["rustls-tls-native-roots"] }
+tokio-tungstenite = { version = "0.18.0", features = [
+    "rustls-tls-native-roots",
+] }
 tokio-rustls = "0.23.4"
 http-serde = "1.1.2"
 hmac = "0.12.1"
@@ -242,7 +254,12 @@ uname = "0.1.1"
 tikv-jemallocator = "0.5"
 
 [dev-dependencies]
-axum = { version = "0.6.19", features = ["headers", "json", "original-uri", "ws"] }
+axum = { version = "0.6.19", features = [
+    "headers",
+    "json",
+    "original-uri",
+    "ws",
+] }
 ecdsa = { version = "0.15.1", features = ["signing", "pem", "pkcs8"] }
 fred = { version = "6.3.0", features = ["enable-rustls", "no-client-setname"] }
 futures-test = "0.3.28"
@@ -259,7 +276,12 @@ reqwest = { version = "0.11.18", default-features = false, features = [
     "json",
     "stream",
 ] }
-rhai = { version = "1.15.1", features = ["sync", "serde", "internals", "testing-environ"] }
+rhai = { version = "1.15.1", features = [
+    "sync",
+    "serde",
+    "internals",
+    "testing-environ",
+] }
 similar-asserts = "1.4.2"
 tempfile = "3.6.0"
 test-log = { version = "0.2.12", default-features = false, features = [

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -135,6 +135,8 @@ pub(crate) struct Tracing {
     pub(crate) zipkin: Option<tracing::zipkin::Config>,
     /// Datadog exporter configuration
     pub(crate) datadog: Option<tracing::datadog::Config>,
+    /// Stackdriver exporter configuration
+    pub(crate) stackdriver: Option<tracing::stackdriver::Config>,
 }
 
 #[derive(Clone, Debug, Deserialize, JsonSchema, Default)]

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -594,6 +594,7 @@ impl Telemetry {
         builder = setup_tracing(builder, &tracing_config.jaeger, trace_config)?;
         builder = setup_tracing(builder, &tracing_config.zipkin, trace_config)?;
         builder = setup_tracing(builder, &tracing_config.datadog, trace_config)?;
+        builder = setup_tracing(builder, &tracing_config.stackdriver, trace_config)?;
         builder = setup_tracing(builder, &tracing_config.otlp, trace_config)?;
         builder = setup_tracing(builder, &config.apollo, trace_config)?;
         // For metrics

--- a/apollo-router/src/plugins/telemetry/tracing/mod.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/mod.rs
@@ -28,6 +28,7 @@ pub(crate) mod datadog;
 pub(crate) mod jaeger;
 pub(crate) mod otlp;
 pub(crate) mod reload;
+pub(crate) mod stackdriver;
 pub(crate) mod zipkin;
 
 pub(crate) trait TracingConfigurator {

--- a/apollo-router/src/plugins/telemetry/tracing/stackdriver.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/stackdriver.rs
@@ -1,0 +1,81 @@
+//! Configuration for Stackdriver tracing.
+
+use futures::executor;
+use opentelemetry::sdk;
+use opentelemetry::sdk::trace::BatchSpanProcessor;
+use opentelemetry::sdk::trace::Builder;
+
+use opentelemetry_stackdriver::GcpAuthorizer;
+use opentelemetry_stackdriver::StackDriverExporter;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use tower::BoxError;
+
+use crate::plugins::telemetry::config::Trace;
+use crate::plugins::telemetry::tracing::BatchProcessorConfig;
+use crate::plugins::telemetry::tracing::TracingConfigurator;
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Config {
+    /// batch processor configuration
+    #[serde(default)]
+    pub(crate) batch_processor: BatchProcessorConfig,
+}
+
+impl TracingConfigurator for Config {
+    fn apply(&self, builder: Builder, trace: &Trace) -> Result<Builder, BoxError> {
+        tracing::info!("configuring Stackdriver tracing: {}", self.batch_processor);
+        let trace_config: sdk::trace::Config = trace.into();
+        tracing::info!("Stackdriver trace_config: {:#?}", trace_config);
+
+        // let res = init_stackdriver(&self, builder);
+        let res_future = async {
+            tracing::info!("Stackdriver authenticator before");
+
+            let authenticator_instance = GcpAuthorizer::new().await;
+
+            let authenticator = match authenticator_instance {
+                Ok(authenticator) => authenticator,
+                Err(error) => panic!("Stackdriver authenticator error: {:?}", error),
+            };
+            tracing::info!("Stackdriver authenticator after");
+
+            tracing::info!("Stackdriver exporter before");
+
+            let stackdriver_builder_instance =
+                StackDriverExporter::builder().build(authenticator).await;
+
+            let (exporter, whatevers_rest) = match stackdriver_builder_instance {
+                Ok((exporter, rest)) => (exporter, rest),
+                Err(error) => panic!(
+                    "Stackdriver stackdriver_builder_instance error: {:?}",
+                    error
+                ),
+            };
+
+            // let (exporter, _) = StackDriverExporter::builder()
+            //     .build(authenticator)
+            //     .await
+            //     .unwrap();
+
+            tracing::info!("Stackdriver driver: {:#?}", whatevers_rest.await);
+            tracing::info!("Stackdriver exporter: {:#?}", exporter);
+
+            builder.with_span_processor(
+                BatchSpanProcessor::builder(exporter, opentelemetry::runtime::Tokio)
+                    .with_batch_config(self.batch_processor.clone().into())
+                    .build(),
+            )
+        };
+
+        tracing::info!("Stackdriver res_future...");
+
+        let res = executor::block_on(res_future);
+
+        tracing::info!("Stackdriver res: {:#?}", res);
+
+        Ok(res)
+    }
+}

--- a/licenses.html
+++ b/licenses.html
@@ -1526,6 +1526,7 @@
                     <li><a href=" https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-proto ">opentelemetry-proto</a></li>
                     <li><a href=" https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-semantic-conventions ">opentelemetry-semantic-conventions</a></li>
                     <li><a href=" https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-zipkin ">opentelemetry-zipkin</a></li>
+                    <li><a href=" https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-stackdriver ">opentelemetry-stackdriver</a></li>
                     <li><a href=" https://github.com/open-telemetry/opentelemetry-rust ">opentelemetry_api</a></li>
                     <li><a href=" https://github.com/open-telemetry/opentelemetry-rust ">opentelemetry_sdk</a></li>
                     <li><a href=" https://github.com/TeXitoi/structopt ">structopt</a></li>


### PR DESCRIPTION
*Description here*

Fixes/implements #3357 

Hello Apollo router people, I know that you are still not accepting PRs from external contributors but I had to give it a try never the less.

I've attempted to implement the Stackdriver Opentelemetry Batch Trace exporter and push some traces to GCP but without success since I'm not a Rust developer and don't really know what I'm doing 😅

For some reason, the `opentelemetry-stackdriver` crate/package is fully `async` compared to the other ones and had some trouble initializing the exporter.

Also `StackDriverExporter` seems to be blocking instead of returning an exporter instance that can be passed to the `Builder`, which causes the router not to start.

Note: with debugging checked that `GcpAuthorizer` and `StackDriverExporter` are correctly initialized! 

Some guidance would be much appreciated about this one!

You can find me under the handle `@bojanches` on your community Discord server as well.

example output
```log
2023-08-08T15:18:37.356924Z  INFO Apollo Router v1.26.0 // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)
2023-08-08T15:18:37.357011Z  INFO Anonymous usage data collection is disabled.
2023-08-08T15:18:37.357089Z  DEBUG creating plugin factory plugin_factory_name=apollo.authorization
2023-08-08T15:18:37.357140Z  DEBUG creating plugin factory plugin_factory_name=experimental.broken
2023-08-08T15:18:37.357160Z  DEBUG creating plugin factory plugin_factory_name=apollo.traffic_shaping
2023-08-08T15:18:37.357183Z  DEBUG creating plugin factory plugin_factory_name=experimental.restricted
2023-08-08T15:18:37.357205Z  DEBUG creating plugin factory plugin_factory_name=apollo.subscription
2023-08-08T15:18:37.357225Z  DEBUG creating plugin factory plugin_factory_name=apollo.forbid_mutations
2023-08-08T15:18:37.357616Z  DEBUG creating plugin factory plugin_factory_name=apollo.authentication
2023-08-08T15:18:37.357645Z  DEBUG creating plugin factory plugin_factory_name=apollo.telemetry
2023-08-08T15:18:37.357666Z  DEBUG creating plugin factory plugin_factory_name=experimental.expose_query_plan
2023-08-08T15:18:37.357685Z  DEBUG creating plugin factory plugin_factory_name=apollo.override_subgraph_url
2023-08-08T15:18:37.357702Z  DEBUG creating plugin factory plugin_factory_name=apollo.include_subgraph_errors
2023-08-08T15:18:37.357720Z  DEBUG creating plugin factory plugin_factory_name=apollo.csrf
2023-08-08T15:18:37.357738Z  DEBUG creating plugin factory plugin_factory_name=apollo.headers
2023-08-08T15:18:37.360110Z  DEBUG creating plugin factory plugin_factory_name=apollo.rhai
2023-08-08T15:18:37.360146Z  DEBUG creating plugin factory plugin_factory_name=apollo.coprocessor
2023-08-08T15:18:37.522899Z  DEBUG starting
2023-08-08T15:18:37.523081Z  DEBUG state machine event: UpdateSchema(<redacted>), transitioned from: Startup to: Startup
2023-08-08T15:18:37.523119Z  DEBUG state machine event: UpdateLicense(Unlicensed), transitioned from: Startup to: Startup
2023-08-08T15:18:37.645766Z  TRACE recursion limit data recursion_limit=recursion limit: 4096, high: 0
2023-08-08T15:18:37.740999Z  DEBUG A valid Apollo license was not detected. However, no restricted features are in use.
2023-08-08T15:18:37.862085Z  TRACE recursion limit data recursion_limit=recursion limit: 4096, high: 0
2023-08-08T15:18:38.573858Z  TRACE recursion limit data recursion_limit=recursion limit: 4096, high: 0
2023-08-08T15:18:38.645210Z  DEBUG configuring Apollo metrics
2023-08-08T15:18:38.645484Z  INFO Prometheus endpoint exposed at http://0.0.0.0:9090/metrics
2023-08-08T15:18:38.645844Z  INFO configuring Stackdriver tracing: BatchConfig { scheduled_delay=100ms, max_queue_size=2048, max_export_batch_size=512, max_export_timeout=30s, max_concurrent_exports=1 }
2023-08-08T15:18:38.645897Z  INFO Stackdriver trace_config: Config {
    sampler: ParentBased(
        TraceIdRatioBased(
            1.0,
        ),
    ),
    id_generator: RandomIdGenerator {
        _private: (),
    },
    span_limits: SpanLimits {
        max_events_per_span: 128,
        max_attributes_per_span: 128,
        max_links_per_span: 128,
        max_attributes_per_event: 128,
        max_attributes_per_link: 128,
    },
    resource: Resource {
        attrs: {
            Static(
                "process.executable.name",
            ): String(
                Owned(
                    "router",
                ),
            ),
            Static(
                "service.version",
            ): String(
                Static(
                    "1.26.0",
                ),
            ),
            Static(
                "service.namespace",
            ): String(
                Owned(
                    "apollo",
                ),
            ),
            Static(
                "service.name",
            ): String(
                Owned(
                    "router-v2-gateway-svc",
                ),
            ),
            Owned(
                "some.config.attribute",
            ): String(
                Owned(
                    "config value",
                ),
            ),
        },
        schema_url: None,
    },
}
2023-08-08T15:18:38.646015Z  INFO Stackdriver res_future...
2023-08-08T15:18:38.646042Z  INFO Stackdriver authenticator before
2023-08-08 17:18:38.650301+0200 router[10878:67482] SecTaskLoadEntitlements failed error=22 cs_flags=20, pid=10878
2023-08-08 17:18:38.650668+0200 router[10878:67482] SecTaskCopyDebugDescription: router[10878]/0#-1 LF=0
2023-08-08T15:18:40.722723Z  INFO Stackdriver authenticator after
2023-08-08T15:18:48.821212Z  INFO Stackdriver exporter before
```


<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [*] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
