### PR TITLE
Require the main (GraphQL) server to shutdown before other servers

### DIFF
--- a/.changesets/fix_garypen_3521_keep_listening.md
+++ b/.changesets/fix_garypen_3521_keep_listening.md
@@ -1,0 +1,7 @@
+### Require the main (GraphQL) route to shutdown before other routes ([Issue #3521](https://github.com/apollographql/router/issues/3521))
+
+This changes router execution so that there is more control over the sequencing of server shutdown. In particular, this modifies how different routes are shutdown so that the main (GraphQL) route is shutdown before other routes are shutdown. Prior to this change all routes shut down in parallel and this would mean that, for example, health checks stopped responding prematurely.
+    
+This is particularly undesirable when the router is executing in Kubernetes, since continuing to report live/ready checks during shutdown is a requirement.
+    
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3557

--- a/apollo-router/src/http_server_factory.rs
+++ b/apollo-router/src/http_server_factory.rs
@@ -29,7 +29,7 @@ pub(crate) trait HttpServerFactory {
         service_factory: RF,
         configuration: Arc<Configuration>,
         main_listener: Option<Listener>,
-        previous_listeners: Vec<(ListenAddr, Listener)>,
+        previous_listeners: ExtraListeners,
         extra_endpoints: MultiMap<ListenAddr, Endpoint>,
         license: LicenseState,
         all_connections_stopped_sender: mpsc::Sender<()>,
@@ -40,7 +40,8 @@ pub(crate) trait HttpServerFactory {
     fn ready(&self, ready: bool);
 }
 
-type MainAndExtraListeners = (Listener, Vec<(ListenAddr, Listener)>);
+type ExtraListeners = Vec<(ListenAddr, Listener)>;
+
 /// A handle with with a client can shut down the server gracefully.
 /// This relies on the underlying server implementation doing the right thing.
 /// There are various ways that a user could prevent this working, including holding open connections
@@ -51,10 +52,16 @@ pub(crate) struct HttpServerHandle {
     /// Sender to use to notify of shutdown
     shutdown_sender: oneshot::Sender<()>,
 
+    /// Sender to use to notify extras of shutdown
+    extra_shutdown_sender: oneshot::Sender<()>,
+
     /// Future to wait on for graceful shutdown
     #[derivative(Debug = "ignore")]
-    server_future:
-        Pin<Box<dyn Future<Output = Result<MainAndExtraListeners, ApolloRouterError>> + Send>>,
+    main_future: Pin<Box<dyn Future<Output = Result<Listener, ApolloRouterError>> + Send>>,
+
+    /// More futures to wait on for graceful shutdown
+    #[derivative(Debug = "ignore")]
+    extra_futures: Pin<Box<dyn Future<Output = Result<ExtraListeners, ApolloRouterError>> + Send>>,
 
     /// The listen addresses that the server is actually listening on.
     /// This includes the `graphql_listen_address` as well as any other address a plugin listens on.
@@ -72,12 +79,12 @@ pub(crate) struct HttpServerHandle {
 impl HttpServerHandle {
     pub(crate) fn new(
         shutdown_sender: oneshot::Sender<()>,
-        server_future: Pin<
-            Box<
-                dyn Future<Output = Result<MainAndExtraListeners, ApolloRouterError>>
-                    + Send
-                    + 'static,
-            >,
+        extra_shutdown_sender: oneshot::Sender<()>,
+        main_future: Pin<
+            Box<dyn Future<Output = Result<Listener, ApolloRouterError>> + Send + 'static>,
+        >,
+        extra_futures: Pin<
+            Box<dyn Future<Output = Result<ExtraListeners, ApolloRouterError>> + Send + 'static>,
         >,
         graphql_listen_address: Option<ListenAddr>,
         listen_addresses: Vec<ListenAddr>,
@@ -85,7 +92,9 @@ impl HttpServerHandle {
     ) -> Self {
         Self {
             shutdown_sender,
-            server_future,
+            extra_shutdown_sender,
+            main_future,
+            extra_futures,
             graphql_listen_address,
             listen_addresses,
             all_connections_stopped_sender,
@@ -96,7 +105,13 @@ impl HttpServerHandle {
         if let Err(_err) = self.shutdown_sender.send(()) {
             tracing::error!("Failed to notify http thread of shutdown")
         };
-        let _listener = self.server_future.await?;
+        let _listener = self.main_future.await?;
+        // FOR TESTING IDEA PRETEND IT TAKES A LONG TIME TO SHUT DOWN MAIN
+        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+        if let Err(_err) = self.extra_shutdown_sender.send(()) {
+            tracing::error!("Failed to notify http thread of shutdown")
+        };
+        let _listener = self.extra_futures.await?;
         #[cfg(unix)]
         // listen_addresses includes the main graphql_address
         for listen_address in self.listen_addresses {
@@ -128,7 +143,8 @@ impl HttpServerHandle {
         // connections, and returns the TCP listener, to reuse it in the next server
         // it is necessary to keep the queue of new TCP sockets associated with
         // the listener instead of dropping them
-        let (main_listener, extra_listeners) = self.server_future.await?;
+        let main_listener = self.main_future.await?;
+        let extra_listeners = self.extra_futures.await?;
         tracing::debug!("previous server stopped");
 
         // we give the listeners to the new configuration, they'll clean up whatever needs to
@@ -254,12 +270,15 @@ mod tests {
     // TODO [igni]: add a check with extra endpoints
     async fn sanity() {
         let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+        let (extra_shutdown_sender, extra_shutdown_receiver) = oneshot::channel();
         let listener = Listener::Tcp(tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap());
         let (all_connections_stopped_sender, _) = mpsc::channel::<()>(1);
 
         HttpServerHandle::new(
             shutdown_sender,
-            futures::future::ready(Ok((listener, vec![]))).boxed(),
+            extra_shutdown_sender,
+            futures::future::ready(Ok(listener)).boxed(),
+            futures::future::ready(Ok(vec![])).boxed(),
             Some(SocketAddr::from_str("127.0.0.1:0").unwrap().into()),
             Default::default(),
             all_connections_stopped_sender,
@@ -271,6 +290,9 @@ mod tests {
         shutdown_receiver
             .await
             .expect("Should have been send notification to shutdown");
+        extra_shutdown_receiver
+            .await
+            .expect("Should have been send notification to shutdown");
     }
 
     #[test(tokio::test)]
@@ -280,12 +302,15 @@ mod tests {
         let temp_dir = tempfile::tempdir().unwrap();
         let sock = temp_dir.as_ref().join("sock");
         let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+        let (extra_shutdown_sender, extra_shutdown_receiver) = oneshot::channel();
         let listener = Listener::Unix(tokio::net::UnixListener::bind(&sock).unwrap());
         let (all_connections_stopped_sender, _) = mpsc::channel::<()>(1);
 
         HttpServerHandle::new(
             shutdown_sender,
-            futures::future::ready(Ok((listener, vec![]))).boxed(),
+            extra_shutdown_sender,
+            futures::future::ready(Ok(listener)).boxed(),
+            futures::future::ready(Ok(vec![])).boxed(),
             Some(ListenAddr::UnixSocket(sock)),
             Default::default(),
             all_connections_stopped_sender,
@@ -295,6 +320,10 @@ mod tests {
         .expect("Should have waited for shutdown");
 
         shutdown_receiver
+            .await
+            .expect("Should have sent notification to shutdown");
+
+        extra_shutdown_receiver
             .await
             .expect("Should have sent notification to shutdown");
     }

--- a/apollo-router/src/http_server_factory.rs
+++ b/apollo-router/src/http_server_factory.rs
@@ -106,12 +106,12 @@ impl HttpServerHandle {
             tracing::error!("Failed to notify http thread of shutdown")
         };
         let _listener = self.main_future.await?;
-        // FOR TESTING IDEA PRETEND IT TAKES A LONG TIME TO SHUT DOWN MAIN
-        tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+
         if let Err(_err) = self.extra_shutdown_sender.send(()) {
             tracing::error!("Failed to notify http thread of shutdown")
         };
         let _listener = self.extra_futures.await?;
+
         #[cfg(unix)]
         // listen_addresses includes the main graphql_address
         for listen_address in self.listen_addresses {


### PR DESCRIPTION
We'd like to have more control over the sequencing of server shutdown so that the main (GraphQL) server is required to complete before other servers are shutdown.
    
This is particularly desirable when the router is executing in Kubernetes, since continuing to report live/ready checks during shutdown is a requirement.
    
fixes: #3521

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

Difficult to assess the impact with automated testing. All existing tests pass and I performed manual testing as follows:

1. Run a router
```
cargo run -- -s examples/graphql/local.graphql -c router.yaml --hot-reload
```
Note: Config doesn't matter, I'm just passing one to have a `touch` target. `--hot-reload` is to enable reloading

2. Exercise the health with this script:
```
while true; do curl "http://localhost:8088/health?ready" || {echo "curl failed"; break}; done
```
3. In a separate terminal force reloads by `touch`ing the config file.

Observe that the curl loop keeps working and doesn't exit through multiple reloads of the router before the router is actually shutdown.

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
