### PR TITLE
Geal/caching metrics

### DIFF
--- a/.changesets/maint_bnjjj_caching_metrics.md
+++ b/.changesets/maint_bnjjj_caching_metrics.md
@@ -1,0 +1,38 @@
+### Add experimental caching metrics ([PR #3532](https://github.com/apollographql/router/pull/3532))
+
+It adds a metric only if you configure `telemetry.metrics.common.experimental_enable_cache_metrics` to `true`. It will generate metrics to better know where and which data would benefit from caching.
+
+example
+
+```
+# HELP apollo_router_operations_entity_cachable apollo.router.operations.entity.cachable
+# TYPE apollo_router_operations_entity_cachable histogram
+apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.05"} 0
+apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.1"} 0
+apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.25"} 0
+apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.5"} 0
+apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="1"} 0
+apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="2.5"} 3
+apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="5"} 4
+apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="10"} 4
+apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="20"} 4
+apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="1000"} 4
+apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="+Inf"} 4
+apollo_router_operations_entity_cachable_sum{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version=""} 7
+apollo_router_operations_entity_cachable_count{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version=""} 4
+apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.05"} 0
+apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.1"} 0
+apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.25"} 0
+apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.5"} 0
+apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="1"} 0
+apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="2.5"} 1
+apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="5"} 1
+apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="10"} 1
+apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="20"} 1
+apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="1000"} 1
+apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="+Inf"} 1
+apollo_router_operations_entity_cachable_sum{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version=""} 1
+apollo_router_operations_entity_cachable_count{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version=""} 1
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/3532

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ dependencies = [
  "atty",
  "axum",
  "base64 0.20.0",
+ "bloom",
  "brotli",
  "buildstructor 0.5.3",
  "bytes",
@@ -763,8 +764,14 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.6.3",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
 
 [[package]]
 name = "bit-vec"
@@ -806,6 +813,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array 0.14.7",
+]
+
+[[package]]
+name = "bloom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00ac8e5056d6d65376a3c1aa5c7c34850d6949ace17f0266953a254eb3d6fe8"
+dependencies = [
+ "bit-vec 0.4.4",
 ]
 
 [[package]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -226,6 +226,7 @@ brotli = "3.3.4"
 zstd = "0.12.3"
 zstd-safe = "6.0.5"
 rand_core = "0.6.4"
+bloom = "0.3.2"
 
 [target.'cfg(macos)'.dependencies]
 uname = "0.1.1"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -3997,6 +3997,11 @@ expression: "&schema"
                     "format": "double"
                   }
                 },
+                "experimental_enable_cache_metrics": {
+                  "description": "Enable experimental metrics to know more about caching strategies",
+                  "default": false,
+                  "type": "boolean"
+                },
                 "resources": {
                   "description": "Resources",
                   "default": {},

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -94,6 +94,8 @@ pub(crate) struct MetricsCommon {
     /// Custom buckets for histograms
     #[serde(default = "default_buckets")]
     pub(crate) buckets: Vec<f64>,
+    /// Enable experimental metrics to know more about caching strategies
+    pub(crate) experimental_enable_cache_metrics: bool,
 }
 
 fn default_buckets() -> Vec<f64> {
@@ -110,6 +112,7 @@ impl Default for MetricsCommon {
             service_namespace: None,
             resources: HashMap::new(),
             buckets: default_buckets(),
+            experimental_enable_cache_metrics: false,
         }
     }
 }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -1602,13 +1602,7 @@ fn extract_cache_attributes(representations: &[Value]) -> Result<Vec<(String, Va
             .as_object()
             .and_then(|o| o.get(TYPENAME))
             .ok_or("missing __typename in representation")?;
-
         let typename = opt_type.as_str().unwrap_or("");
-
-        // // We have to have representation because it can contains PII
-        // let mut digest = Sha256::new();
-        // digest.update(serde_json::to_string(&representation).unwrap().as_bytes());
-        // let hashed_repr = hex::encode(digest.finalize().as_slice());
 
         res.push((typename.to_string(), representation.clone()));
     }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -1027,14 +1027,23 @@ impl Telemetry {
     }
 
     fn update_cache_metrics(sub_response: &SubgraphResponse, cache_attributes: CacheAttributes) {
-        let vary_headers = sub_response
+        let mut vary_headers = sub_response
             .response
             .headers()
             .get_all(header::VARY)
             .into_iter()
-            .filter_map(|val| val.to_str().ok().map(|v| v.to_string()))
-            .collect::<Vec<String>>()
-            .join(", ");
+            .filter_map(|val| {
+                val.to_str().ok().map(|v| {
+                    v.to_string()
+                        .split(", ")
+                        .map(|s| s.to_string())
+                        .collect::<Vec<String>>()
+                })
+            })
+            .flatten()
+            .collect::<Vec<String>>();
+        vary_headers.sort();
+        let vary_headers = vary_headers.join(", ");
 
         let hashed_headers = if vary_headers.is_empty() {
             String::new()

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -843,7 +843,7 @@ mod test {
     use opentelemetry::Value;
     use prost::Message;
     use serde_json::json;
-    use crate::plugins::telemetry::apollo::{ErrorConfiguration};
+    use crate::plugins::telemetry::apollo::ErrorConfiguration;
     use crate::plugins::telemetry::apollo_exporter::proto::reports::Trace;
     use crate::plugins::telemetry::apollo_exporter::proto::reports::trace::query_plan_node::{DeferNodePrimary, DeferredNode, ResponsePathElement};
     use crate::plugins::telemetry::apollo_exporter::proto::reports::trace::{QueryPlanNode, Node, Error};

--- a/apollo-router/src/plugins/traffic_shaping/cache.rs
+++ b/apollo-router/src/plugins/traffic_shaping/cache.rs
@@ -215,6 +215,7 @@ pub(crate) fn hash_request(body: &mut graphql::Request) -> String {
     digest.update(body.operation_name.as_deref().unwrap_or("-").as_bytes());
     digest.update(&[0u8; 1][..]);
     let repr_key = ByteString::from(REPRESENTATIONS);
+    // Removing the representations variable because it's already part of the cache key
     let representations = body.variables.remove(&repr_key);
     digest.update(&serde_json::to_vec(&body.variables).unwrap());
     if let Some(representations) = representations {

--- a/apollo-router/src/plugins/traffic_shaping/cache.rs
+++ b/apollo-router/src/plugins/traffic_shaping/cache.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 
 use futures::future::BoxFuture;
 use futures::FutureExt;
+use http::header;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json_bytes::Value;
@@ -24,6 +25,9 @@ use crate::graphql;
 use crate::json_ext::Object;
 use crate::services::subgraph;
 use crate::spec::TYPENAME;
+
+const ENTITIES: &str = "_entities";
+pub(crate) const REPRESENTATIONS: &str = "representations";
 
 #[derive(Clone)]
 pub(crate) struct SubgraphCacheLayer {
@@ -83,14 +87,14 @@ where
         Poll::Ready(Ok(()))
     }
 
-    fn call(&mut self, mut request: subgraph::Request) -> Self::Future {
+    fn call(&mut self, request: subgraph::Request) -> Self::Future {
         let service = self.service.clone();
 
         if !request
             .subgraph_request
-            .body_mut()
+            .body()
             .variables
-            .contains_key("representations")
+            .contains_key(REPRESENTATIONS)
         {
             return service.oneshot(request).boxed();
         }
@@ -118,9 +122,11 @@ where
     let body = request.subgraph_request.body_mut();
     let query_hash = hash_request(body);
 
+    // TODO: compute TTL with cacheControl directive on the subgraph
+
     let representations = body
         .variables
-        .get_mut("representations")
+        .get_mut(REPRESENTATIONS)
         .and_then(|value| value.as_array_mut())
         .expect("we already checked that representations exist");
 
@@ -132,11 +138,11 @@ where
         .unwrap_or_else(|| std::iter::repeat(None).take(keys.len()).collect());
 
     let (new_representations, mut result) =
-        filter_representations(representations, keys, cache_result)?;
+        filter_representations(&name, representations, keys, cache_result)?;
 
     if !new_representations.is_empty() {
         body.variables
-            .insert("representations", new_representations.into());
+            .insert(REPRESENTATIONS, new_representations.into());
 
         let mut response = service.oneshot(request).await?;
 
@@ -145,7 +151,7 @@ where
         if let Some(mut entities) = data
             .as_mut()
             .and_then(|v| v.as_object_mut())
-            .and_then(|o| o.remove("_entities"))
+            .and_then(|o| o.remove(ENTITIES))
         {
             let new_entities = insert_entities_in_result(
                 entities
@@ -160,7 +166,7 @@ where
 
             data.as_mut()
                 .and_then(|v| v.as_object_mut())
-                .map(|o| o.insert("_entities", new_entities.into()));
+                .map(|o| o.insert(ENTITIES, new_entities.into()));
             response.response.body_mut().data = data;
         }
 
@@ -168,7 +174,7 @@ where
     } else {
         let entities = insert_entities_in_result(&mut Vec::new(), &cache, &mut result).await?;
         let mut data = Object::default();
-        data.insert("_entities", entities.into());
+        data.insert(ENTITIES, entities.into());
 
         Ok(subgraph::Response::builder()
             .data(data)
@@ -178,7 +184,30 @@ where
     }
 }
 
-fn hash_request(body: &graphql::Request) -> String {
+pub(crate) fn hash_vary_headers(headers: &http::HeaderMap) -> String {
+    let mut digest = Sha256::new();
+
+    for vary_header_value in headers.get_all(header::VARY).into_iter() {
+        if vary_header_value == "*" {
+            return String::from("*");
+        } else {
+            let header_names = match vary_header_value.to_str() {
+                Ok(header_val) => header_val.split(", "),
+                Err(_) => continue,
+            };
+            header_names.for_each(|header_name| {
+                if let Some(header_value) = headers.get(header_name).and_then(|h| h.to_str().ok()) {
+                    digest.update(header_value);
+                    digest.update(&[0u8; 1][..]);
+                }
+            });
+        }
+    }
+
+    hex::encode(digest.finalize().as_slice())
+}
+
+pub(crate) fn hash_request(body: &graphql::Request) -> String {
     let mut digest = Sha256::new();
     digest.update(body.query.as_deref().unwrap_or("-").as_bytes());
     digest.update(&[0u8; 1][..]);
@@ -204,19 +233,21 @@ fn extract_cache_keys(
                 reason: "missing __typename in representation".to_string(),
             })?;
 
-        let typename = opt_type.as_str().unwrap_or("-").to_string();
+        let typename = opt_type.as_str().unwrap_or("-");
+
+        // We have to have representation because it can contains PII
+        let mut digest = Sha256::new();
+        digest.update(serde_json::to_string(&representation).unwrap().as_bytes());
+        let hashed_repr = hex::encode(digest.finalize().as_slice());
 
         let key = format!(
             "subgraph.{}|{}|{}|{}",
-            subgraph_name,
-            &typename,
-            serde_json::to_string(&representation).unwrap(),
-            query_hash
+            subgraph_name, &typename, hashed_repr, query_hash
         );
 
         representation
             .as_object_mut()
-            .map(|o| o.insert("__typename", opt_type));
+            .map(|o| o.insert(TYPENAME, opt_type));
         res.push(key);
     }
     Ok(res)
@@ -230,6 +261,7 @@ struct IntermediateResult {
 
 // build a new list of representations without the ones we got from the cache
 fn filter_representations(
+    subgraph_name: &str,
     representations: &mut Vec<Value>,
     keys: Vec<String>,
     mut cache_result: Vec<Option<Value>>,
@@ -245,7 +277,7 @@ fn filter_representations(
     {
         let opt_type = representation
             .as_object_mut()
-            .and_then(|o| o.remove("__typename"))
+            .and_then(|o| o.remove(TYPENAME))
             .ok_or_else(|| FetchError::MalformedRequest {
                 reason: "missing __typename in representation".to_string(),
             })?;
@@ -257,7 +289,7 @@ fn filter_representations(
 
             representation
                 .as_object_mut()
-                .map(|o| o.insert("__typename", opt_type));
+                .map(|o| o.insert(TYPENAME, opt_type));
             new_representations.push(representation);
         } else {
             cache_hit.entry(typename.clone()).or_default().0 += 1;
@@ -270,11 +302,15 @@ fn filter_representations(
     }
 
     for (ty, (hit, miss)) in cache_hit {
-        tracing::event!(
-            Level::INFO,
+        tracing::info!(
+            monotonic_counter.apollo_router_cache_hit = hit as u64,
             entity_type = ty.as_str(),
-            cache_hit = hit,
-            cache_miss = miss
+            %subgraph_name
+        );
+        tracing::info!(
+            monotonic_counter.apollo_router_cache_miss = miss as u64,
+            entity_type = ty.as_str(),
+            %subgraph_name
         );
     }
 
@@ -317,6 +353,7 @@ async fn insert_entities_in_result(
     }
 
     if !to_insert.is_empty() {
+        // TODO use insert_multiple_with_ttl
         cache.insert_multiple(&to_insert).await;
     }
 

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -6,7 +6,7 @@
 //! * Compression
 //! * Rate limiting
 //!
-mod cache;
+pub(crate) mod cache;
 mod deduplication;
 pub(crate) mod rate;
 mod retry;
@@ -379,10 +379,9 @@ impl TrafficShaping {
         let all_config = self.config.all.as_ref();
         let subgraph_config = self.config.subgraphs.get(name);
         let final_config = Self::merge_config(all_config, subgraph_config);
-
         let entity_caching = if let (Some(storage), Some(caching_config)) = (
             self.storage.clone(),
-            subgraph_config
+            final_config
                 .as_ref()
                 .and_then(|c| c.experimental_entity_caching.as_ref()),
         ) {


### PR DESCRIPTION
Fix #3554
Replaces #3532

This is a new metric recorded only if we enable that feature setting `telemetry.metrics.common.experimental_enable_cache_metrics` to `true`. It will generate metrics to better know where and which data would benefit from caching.

example

```
# HELP apollo_router_operations_entity_cachable apollo.router.operations.entity.cachable
# TYPE apollo_router_operations_entity_cachable histogram
apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.05"} 0
apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.1"} 0
apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.25"} 0
apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.5"} 0
apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="1"} 0
apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="2.5"} 3
apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="5"} 4
apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="10"} 4
apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="20"} 4
apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="1000"} 4
apollo_router_operations_entity_cachable_bucket{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="+Inf"} 4
apollo_router_operations_entity_cachable_sum{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version=""} 7
apollo_router_operations_entity_cachable_count{entity_type="Product",service_name="apollo-router",subgraph="products",vary="",otel_scope_name="apollo/router",otel_scope_version=""} 4
apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.05"} 0
apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.1"} 0
apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.25"} 0
apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="0.5"} 0
apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="1"} 0
apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="2.5"} 1
apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="5"} 1
apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="10"} 1
apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="20"} 1
apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="1000"} 1
apollo_router_operations_entity_cachable_bucket{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version="",le="+Inf"} 1
apollo_router_operations_entity_cachable_sum{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version=""} 1
apollo_router_operations_entity_cachable_count{entity_type="User",service_name="apollo-router",subgraph="users",vary="",otel_scope_name="apollo/router",otel_scope_version=""} 1
``` 
<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
