### PR TITLE
fix(cache): 📣 Do not cache query plan errors

### DIFF
--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -156,7 +156,7 @@ where
                     Err(error) => {
                         count += 1;
                         let e = Arc::new(error);
-                        entry.insert(Err(e.clone())).await;
+                        entry.send(Err(e.clone())).await;
                     }
                 }
             }
@@ -293,7 +293,7 @@ where
                             }
                             Err(error) => {
                                 let e = Arc::new(error);
-                                entry.insert(Err(e.clone())).await;
+                                entry.send(Err(e.clone())).await;
                                 Err(CacheResolverError::RetrievalError(e))
                             }
                         }


### PR DESCRIPTION
This fixes an issue where query plan errors live permanently in the cache. With this change the waiters are still notified, but the error is not added to the cache.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [-] Changes are compatible[^1]
- [-] Documentation[^2] completed
- [-] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [-] Unit Tests
    - [-] Integration Tests
    - [-] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
