### PR TITLE
Tweak metrics for Rust/JS GraphQL validation mismatch

### DIFF
--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -86,9 +86,9 @@ impl BridgeQueryPlanner {
 
                     if has_validation_errors && !schema.has_errors() {
                         tracing::warn!(
-                            monotonic_counter.apollo.router.validation = 1,
-                            validation.source = VALIDATION_SOURCE_SCHEMA,
-                            validation.result = VALIDATION_FALSE_NEGATIVE,
+                            monotonic_counter.apollo.router.operations.schema.validation = 1,
+                            schema.validation.source = VALIDATION_SOURCE_SCHEMA,
+                            schema.validation.result = VALIDATION_FALSE_NEGATIVE,
                             "validation mismatch: JS query planner reported a schema validation error, but apollo-rs did not"
                         );
                     }
@@ -101,17 +101,17 @@ impl BridgeQueryPlanner {
         if configuration.experimental_graphql_validation_mode == GraphQLValidationMode::Both {
             if schema.has_errors() {
                 tracing::warn!(
-                    monotonic_counter.apollo.router.validation = 1,
-                    validation.source = VALIDATION_SOURCE_SCHEMA,
-                    validation.result = VALIDATION_FALSE_POSITIVE,
+                    monotonic_counter.apollo.router.operations.schema.validation = 1,
+                    schema.validation.source = VALIDATION_SOURCE_SCHEMA,
+                    schema.validation.result = VALIDATION_FALSE_POSITIVE,
                     "validation mismatch: apollo-rs reported a schema validation error, but JS query planner did not"
                 );
             } else {
                 // false_negative was an early return so we know it was correct here
                 tracing::info!(
-                    monotonic_counter.apollo.router.validation = 1,
-                    validation.source = VALIDATION_SOURCE_SCHEMA,
-                    validation.result = VALIDATION_MATCH
+                    monotonic_counter.apollo.router.operations.schema.validation = 1,
+                    schema.validation.source = VALIDATION_SOURCE_SCHEMA,
+                    schema.validation.result = VALIDATION_MATCH
                 );
             }
         }
@@ -273,25 +273,25 @@ impl BridgeQueryPlanner {
                 match (is_validation_error, &selections.validation_error) {
                     (false, Some(_)) => {
                         tracing::warn!(
-                            monotonic_counter.apollo.router.validation = 1,
-                            validation.source = VALIDATION_SOURCE_OPERATION,
-                            validation.result = VALIDATION_FALSE_POSITIVE,
+                            monotonic_counter.apollo.router.operations.schema.validation = 1,
+                            schema.validation.source = VALIDATION_SOURCE_OPERATION,
+                            schema.validation.result = VALIDATION_FALSE_POSITIVE,
                             "validation mismatch: JS query planner did not report query validation error, but apollo-rs did"
                         );
                     }
                     (true, None) => {
                         tracing::warn!(
-                            monotonic_counter.apollo.router.validation = 1,
-                            validation.source = VALIDATION_SOURCE_OPERATION,
-                            validation.result = VALIDATION_FALSE_NEGATIVE,
+                            monotonic_counter.apollo.router.operations.schema.validation = 1,
+                            schema.validation.source = VALIDATION_SOURCE_OPERATION,
+                            schema.validation.result = VALIDATION_FALSE_NEGATIVE,
                             "validation mismatch: apollo-rs did not report query validation error, but JS query planner did"
                         );
                     }
                     // if JS and Rust implementations agree, we return the JS result for now.
                     _ => tracing::info!(
-                            monotonic_counter.apollo.router.validation = 1,
-                            validation.source = VALIDATION_SOURCE_OPERATION,
-                            validation.result = VALIDATION_MATCH,
+                            monotonic_counter.apollo.router.operations.schema.validation = 1,
+                            schema.validation.source = VALIDATION_SOURCE_OPERATION,
+                            schema.validation.result = VALIDATION_MATCH,
                     ),
                 }
 

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -86,9 +86,9 @@ impl BridgeQueryPlanner {
 
                     if has_validation_errors && !schema.has_errors() {
                         tracing::warn!(
-                            monotonic_counter.apollo.router.operations.schema.validation = 1,
-                            schema.validation.source = VALIDATION_SOURCE_SCHEMA,
-                            schema.validation.result = VALIDATION_FALSE_NEGATIVE,
+                            monotonic_counter.apollo.router.validation = 1,
+                            validation.source = VALIDATION_SOURCE_SCHEMA,
+                            validation.result = VALIDATION_FALSE_NEGATIVE,
                             "validation mismatch: JS query planner reported a schema validation error, but apollo-rs did not"
                         );
                     }
@@ -101,17 +101,17 @@ impl BridgeQueryPlanner {
         if configuration.experimental_graphql_validation_mode == GraphQLValidationMode::Both {
             if schema.has_errors() {
                 tracing::warn!(
-                    monotonic_counter.apollo.router.operations.schema.validation = 1,
-                    schema.validation.source = VALIDATION_SOURCE_SCHEMA,
-                    schema.validation.result = VALIDATION_FALSE_POSITIVE,
+                    monotonic_counter.apollo.router.validation = 1,
+                    validation.source = VALIDATION_SOURCE_SCHEMA,
+                    validation.result = VALIDATION_FALSE_POSITIVE,
                     "validation mismatch: apollo-rs reported a schema validation error, but JS query planner did not"
                 );
             } else {
                 // false_negative was an early return so we know it was correct here
                 tracing::info!(
-                    monotonic_counter.apollo.router.operations.schema.validation = 1,
-                    schema.validation.source = VALIDATION_SOURCE_SCHEMA,
-                    schema.validation.result = VALIDATION_MATCH
+                    monotonic_counter.apollo.router.validation = 1,
+                    validation.source = VALIDATION_SOURCE_SCHEMA,
+                    validation.result = VALIDATION_MATCH
                 );
             }
         }
@@ -273,25 +273,25 @@ impl BridgeQueryPlanner {
                 match (is_validation_error, &selections.validation_error) {
                     (false, Some(_)) => {
                         tracing::warn!(
-                            monotonic_counter.apollo.router.operations.schema.validation = 1,
-                            schema.validation.source = VALIDATION_SOURCE_OPERATION,
-                            schema.validation.result = VALIDATION_FALSE_POSITIVE,
+                            monotonic_counter.apollo.router.validation = 1,
+                            validation.source = VALIDATION_SOURCE_OPERATION,
+                            validation.result = VALIDATION_FALSE_POSITIVE,
                             "validation mismatch: JS query planner did not report query validation error, but apollo-rs did"
                         );
                     }
                     (true, None) => {
                         tracing::warn!(
-                            monotonic_counter.apollo.router.operations.schema.validation = 1,
-                            schema.validation.source = VALIDATION_SOURCE_OPERATION,
-                            schema.validation.result = VALIDATION_FALSE_NEGATIVE,
+                            monotonic_counter.apollo.router.validation = 1,
+                            validation.source = VALIDATION_SOURCE_OPERATION,
+                            validation.result = VALIDATION_FALSE_NEGATIVE,
                             "validation mismatch: apollo-rs did not report query validation error, but JS query planner did"
                         );
                     }
                     // if JS and Rust implementations agree, we return the JS result for now.
                     _ => tracing::info!(
-                            monotonic_counter.apollo.router.operations.schema.validation = 1,
-                            schema.validation.source = VALIDATION_SOURCE_OPERATION,
-                            schema.validation.result = VALIDATION_MATCH,
+                            monotonic_counter.apollo.router.validation = 1,
+                            validation.source = VALIDATION_SOURCE_OPERATION,
+                            validation.result = VALIDATION_MATCH,
                     ),
                 }
 

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -79,8 +79,9 @@ impl BridgeQueryPlanner {
 
                     if has_validation_errors && !schema.has_errors() {
                         tracing::warn!(
-                            monotonic_counter.apollo_router_schema_validation = 1,
-                            result = "false_negative",
+                            monotonic_counter.apollo.router.validation = 1,
+                            validation.source = "schema",
+                            validation.result = "false_negative",
                             "validation mismatch: JS query planner reported a schema validation error, but apollo-rs did not"
                         );
                     }
@@ -93,15 +94,17 @@ impl BridgeQueryPlanner {
         if configuration.experimental_graphql_validation_mode == GraphQLValidationMode::Both {
             if schema.has_errors() {
                 tracing::warn!(
-                    monotonic_counter.apollo_router_schema_validation = 1,
-                    result = "false_positive",
+                    monotonic_counter.apollo.router.validation = 1,
+                    validation.source = "schema",
+                    validation.result = "false_positive",
                     "validation mismatch: apollo-rs reported a schema validation error, but JS query planner did not"
                 );
             } else {
                 // false_negative was an early return so we know it was correct here
                 tracing::info!(
-                    monotonic_counter.apollo_router_schema_validation = 1,
-                    result = "match"
+                    monotonic_counter.apollo.router.validation = 1,
+                    validation.source = "schema",
+                    validation.result = "match"
                 );
             }
         }
@@ -263,22 +266,25 @@ impl BridgeQueryPlanner {
                 match (is_validation_error, &selections.validation_error) {
                     (false, Some(_)) => {
                         tracing::warn!(
-                            monotonic_counter.apollo_router_query_validation = 1,
-                            result = "false_positive",
+                            monotonic_counter.apollo.router.validation = 1,
+                            validation.source = "operation",
+                            validation.result = "false_positive",
                             "validation mismatch: JS query planner did not report query validation error, but apollo-rs did"
                         );
                     }
                     (true, None) => {
                         tracing::warn!(
-                            monotonic_counter.apollo_router_query_validation = 1,
-                            result = "false_negative",
+                            monotonic_counter.apollo.router.validation = 1,
+                            validation.source = "operation",
+                            validation.result = "false_negative",
                             "validation mismatch: apollo-rs did not report query validation error, but JS query planner did"
                         );
                     }
                     // if JS and Rust implementations agree, we return the JS result for now.
                     _ => tracing::info!(
-                            monotonic_counter.apollo_router_query_validation = 1,
-                            result = "match",
+                            monotonic_counter.apollo.router.validation = 1,
+                            validation.source = "operation",
+                            validation.result = "match",
                     ),
                 }
 

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -79,7 +79,8 @@ impl BridgeQueryPlanner {
 
                     if has_validation_errors && !schema.has_errors() {
                         tracing::warn!(
-                            monotonic_counter.apollo_router_schema_validation_false_negative = 1,
+                            monotonic_counter.apollo_router_schema_validation = 1,
+                            result = "false_negative",
                             "validation mismatch: JS query planner reported a schema validation error, but apollo-rs did not"
                         );
                     }
@@ -89,13 +90,20 @@ impl BridgeQueryPlanner {
             }
         };
 
-        if configuration.experimental_graphql_validation_mode == GraphQLValidationMode::Both
-            && schema.has_errors()
-        {
-            tracing::warn!(
-                monotonic_counter.apollo_router_schema_validation_false_positive = 1,
-                "validation mismatch: apollo-rs reported a schema validation error, but JS query planner did not"
-            );
+        if configuration.experimental_graphql_validation_mode == GraphQLValidationMode::Both {
+            if schema.has_errors() {
+                tracing::warn!(
+                    monotonic_counter.apollo_router_schema_validation = 1,
+                    result = "false_positive",
+                    "validation mismatch: apollo-rs reported a schema validation error, but JS query planner did not"
+                );
+            } else {
+                // false_negative was an early return so we know it was correct here
+                tracing::info!(
+                    monotonic_counter.apollo_router_schema_validation = 1,
+                    result = "match"
+                );
+            }
         }
 
         let planner = Arc::new(planner);
@@ -255,18 +263,23 @@ impl BridgeQueryPlanner {
                 match (is_validation_error, &selections.validation_error) {
                     (false, Some(_)) => {
                         tracing::warn!(
-                            monotonic_counter.apollo_router_query_validation_false_positive = 1,
+                            monotonic_counter.apollo_router_query_validation = 1,
+                            result = "false_positive",
                             "validation mismatch: JS query planner did not report query validation error, but apollo-rs did"
                         );
                     }
                     (true, None) => {
                         tracing::warn!(
-                            monotonic_counter.apollo_router_query_validation_false_negative = 1,
+                            monotonic_counter.apollo_router_query_validation = 1,
+                            result = "false_negative",
                             "validation mismatch: apollo-rs did not report query validation error, but JS query planner did"
                         );
                     }
                     // if JS and Rust implementations agree, we return the JS result for now.
-                    _ => (),
+                    _ => tracing::info!(
+                            monotonic_counter.apollo_router_query_validation = 1,
+                            result = "match",
+                    ),
                 }
 
                 QueryPlannerError::from(err)

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -38,11 +38,11 @@ use crate::spec::SpecError;
 use crate::Configuration;
 
 // For reporting validation results with `experimental_graphql_validation_mode: both`.
-const VALIDATION_SOURCE_SCHEMA: &'static str = "schema";
-const VALIDATION_SOURCE_OPERATION: &'static str = "operation";
-const VALIDATION_FALSE_NEGATIVE: &'static str = "false_negative";
-const VALIDATION_FALSE_POSITIVE: &'static str = "false_positive";
-const VALIDATION_MATCH: &'static str = "match";
+const VALIDATION_SOURCE_SCHEMA: &str = "schema";
+const VALIDATION_SOURCE_OPERATION: &str = "operation";
+const VALIDATION_FALSE_NEGATIVE: &str = "false_negative";
+const VALIDATION_FALSE_POSITIVE: &str = "false_positive";
+const VALIDATION_MATCH: &str = "match";
 
 #[derive(Clone)]
 /// A query planner that calls out to the nodejs router-bridge query planner.

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -37,6 +37,13 @@ use crate::spec::Schema;
 use crate::spec::SpecError;
 use crate::Configuration;
 
+// For reporting validation results with `experimental_graphql_validation_mode: both`.
+const VALIDATION_SOURCE_SCHEMA: &'static str = "schema";
+const VALIDATION_SOURCE_OPERATION: &'static str = "operation";
+const VALIDATION_FALSE_NEGATIVE: &'static str = "false_negative";
+const VALIDATION_FALSE_POSITIVE: &'static str = "false_positive";
+const VALIDATION_MATCH: &'static str = "match";
+
 #[derive(Clone)]
 /// A query planner that calls out to the nodejs router-bridge query planner.
 ///
@@ -80,8 +87,8 @@ impl BridgeQueryPlanner {
                     if has_validation_errors && !schema.has_errors() {
                         tracing::warn!(
                             monotonic_counter.apollo.router.validation = 1,
-                            validation.source = "schema",
-                            validation.result = "false_negative",
+                            validation.source = VALIDATION_SOURCE_SCHEMA,
+                            validation.result = VALIDATION_FALSE_NEGATIVE,
                             "validation mismatch: JS query planner reported a schema validation error, but apollo-rs did not"
                         );
                     }
@@ -95,16 +102,16 @@ impl BridgeQueryPlanner {
             if schema.has_errors() {
                 tracing::warn!(
                     monotonic_counter.apollo.router.validation = 1,
-                    validation.source = "schema",
-                    validation.result = "false_positive",
+                    validation.source = VALIDATION_SOURCE_SCHEMA,
+                    validation.result = VALIDATION_FALSE_POSITIVE,
                     "validation mismatch: apollo-rs reported a schema validation error, but JS query planner did not"
                 );
             } else {
                 // false_negative was an early return so we know it was correct here
                 tracing::info!(
                     monotonic_counter.apollo.router.validation = 1,
-                    validation.source = "schema",
-                    validation.result = "match"
+                    validation.source = VALIDATION_SOURCE_SCHEMA,
+                    validation.result = VALIDATION_MATCH
                 );
             }
         }
@@ -267,24 +274,24 @@ impl BridgeQueryPlanner {
                     (false, Some(_)) => {
                         tracing::warn!(
                             monotonic_counter.apollo.router.validation = 1,
-                            validation.source = "operation",
-                            validation.result = "false_positive",
+                            validation.source = VALIDATION_SOURCE_OPERATION,
+                            validation.result = VALIDATION_FALSE_POSITIVE,
                             "validation mismatch: JS query planner did not report query validation error, but apollo-rs did"
                         );
                     }
                     (true, None) => {
                         tracing::warn!(
                             monotonic_counter.apollo.router.validation = 1,
-                            validation.source = "operation",
-                            validation.result = "false_negative",
+                            validation.source = VALIDATION_SOURCE_OPERATION,
+                            validation.result = VALIDATION_FALSE_NEGATIVE,
                             "validation mismatch: apollo-rs did not report query validation error, but JS query planner did"
                         );
                     }
                     // if JS and Rust implementations agree, we return the JS result for now.
                     _ => tracing::info!(
                             monotonic_counter.apollo.router.validation = 1,
-                            validation.source = "operation",
-                            validation.result = "match",
+                            validation.source = VALIDATION_SOURCE_OPERATION,
+                            validation.result = VALIDATION_MATCH,
                     ),
                 }
 


### PR DESCRIPTION
Instead of having 4 different counters for the different kinds of mismatches, and nothing for correct results, this PR uses a single counter `apollo.router.validation`. It tags the count with a `kind` for schema/operation validation, and a `result`: `match` if the Rust and JS results are the same, otherwise `false_positive` or `false_negative`. With the old count it only reported mismatches, which shouuuuuld never happen, but if this never sends any metrics we don't really know if there is some other issue causing the whole thing to be skipped.

<!-- start metadata -->
