### PR TITLE
Apollo metrics exporter and config metrics

### DIFF
--- a/.changesets/maint_frog_deejay_motorcar_planetarium.md
+++ b/.changesets/maint_frog_deejay_motorcar_planetarium.md
@@ -1,7 +1,8 @@
 ### Add OTLP exporter for Apollo metrics ([PR #3354](https://github.com/apollographql/router/pull/3354))
 
-This PR adds an OTLP metrics exporter for a future Apollo pipeline that can compliment the existing protobuf format.
+This PR adds an OTLP metrics exporter for a future Apollo pipeline that can compliment the existing protobuf format. It is currently disabled by default.
 
-It is currently disabled by default.
+Note that new metrics of the format `apollo.router.*` are currently not stable.
+Once we have added enough metrics to ensure that we are consistent then they will be stabilized and documented.
 
 By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3354

--- a/.changesets/maint_frog_deejay_motorcar_planetarium.md
+++ b/.changesets/maint_frog_deejay_motorcar_planetarium.md
@@ -1,0 +1,6 @@
+### Add OTLP exporter for Apollo metrics ([PR #3354](https://github.com/apollographql/router/pull/3354))
+
+This PR adds an OTLP metrics exporter for a future Apollo pipeline that can compliment the existing protobuf format.
+It is currently disabled by default.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3354

--- a/.changesets/maint_frog_deejay_motorcar_planetarium.md
+++ b/.changesets/maint_frog_deejay_motorcar_planetarium.md
@@ -1,6 +1,7 @@
 ### Add OTLP exporter for Apollo metrics ([PR #3354](https://github.com/apollographql/router/pull/3354))
 
 This PR adds an OTLP metrics exporter for a future Apollo pipeline that can compliment the existing protobuf format.
+
 It is currently disabled by default.
 
 By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3354

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,7 @@ dependencies = [
  "insta",
  "introspector-gadget",
  "itertools",
+ "jsonpath-rust",
  "jsonpath_lib",
  "jsonschema",
  "jsonwebtoken",
@@ -3411,6 +3412,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonpath-rust"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b55563e28c54b1cc0d7eb92475cf9e210cd58e2fce9fabbc0cb5bb1136b4ab3"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
 ]
 
 [[package]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -102,6 +102,7 @@ hyper-rustls = { version = "0.23.2", features = ["http1", "http2"] }
 indexmap = { version = "1.9.3", features = ["serde-1"] }
 itertools = "0.10.5"
 jsonpath_lib = "0.3.0"
+jsonpath-rust = "0.3.1"
 jsonschema = { version = "0.16.1", default-features = false }
 jsonwebtoken = "8.3.0"
 lazy_static = "1.4.0"

--- a/apollo-router/src/configuration/expansion.rs
+++ b/apollo-router/src/configuration/expansion.rs
@@ -100,6 +100,14 @@ impl Expansion {
                     .value_type(ValueType::String)
                     .build(),
             )
+            // Note that APOLLO_USAGE_REPORTING_OTLP_INGRESS_URL is experimental and subject to change without notice
+            .override_config(
+                Override::builder()
+                    .config_path("telemetry.apollo.experimental_otlp_endpoint")
+                    .env_name("APOLLO_USAGE_REPORTING_OTLP_INGRESS_URL")
+                    .value_type(ValueType::String)
+                    .build(),
+            )
             .override_config(
                 Override::builder()
                     .config_path("supergraph.listen")

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -1,0 +1,300 @@
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use jsonpath_rust::JsonPathInst;
+use paste::paste;
+use serde_json::Value;
+use tokio::sync::OwnedSemaphorePermit;
+
+use crate::Configuration;
+
+pub(crate) struct MetricsHandle {
+    _guard: OwnedSemaphorePermit,
+}
+
+pub(crate) struct Metrics {
+    yaml: Value,
+    metrics: HashMap<String, (u64, HashMap<String, String>)>,
+}
+
+impl Metrics {
+    /// Spawn a task that will log configuration usage metrics every second.
+    /// This task has to run more frequently than that of the apollo otlp exporter otherwise the gauges will flap.
+    /// Dropping the MetricsHandle stops the task.  
+    pub(crate) async fn spawn(configuration: &Configuration) -> MetricsHandle {
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+        let guard = semaphore.clone().acquire_owned().await.unwrap();
+        let yaml = configuration
+            .validated_yaml
+            .as_ref()
+            .cloned()
+            .unwrap_or(Value::Object(Default::default()));
+        tokio::task::spawn(async move {
+            let mut metrics = Metrics {
+                yaml,
+                metrics: HashMap::new(),
+            };
+            let mut interval = tokio::time::interval(Duration::from_secs(30));
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => {
+                        metrics.log_usage_metrics();
+                    }
+                    _ = semaphore.acquire() => {
+                        // The semaphore was dropped so we can stop logging this config. The next config (if any) will take over.
+                        break;
+                    }
+
+                }
+            }
+        });
+
+        MetricsHandle { _guard: guard }
+    }
+}
+
+impl Metrics {
+    pub(crate) fn log_usage_metrics(&mut self) {
+        // We have to have a macro here because tracing requires it. However, we also need to cache the metrics as json path is slow.
+        // This macro will query the config json for a primary metric and optionally metric attributes.
+        // The results will be cached for the next iteration.
+
+        // The reason we use jsonpath_rust is that jsonpath_lib has correctness issues and looks abandoned.
+        // We should consider converting the rest of the codebase to use jsonpath_rust.
+        // The only issue is that jsonpath_rust's API takes ownership of the json Value. It has lower level APIs that don't but for some reason they don't get exposed.
+
+        // Example usage:
+        // log_usage_metrics!(
+        //             value.apollo.router.config.authorization, // The metric name
+        //             "$.authorization", // The path into the config
+        //             opt.require_authentication, // The name of the attribute
+        //             "$[?(@.require_authentication == true)]" // The path for the attribute relative to the metric
+        //         );
+
+        macro_rules! log_usage_metrics {
+            ($($metric:ident).+, $path:literal) => {
+                let metric_name = stringify!($($metric).+).to_string();
+                let metric = self.metrics.entry(metric_name.clone()).or_insert_with(|| {
+                    if JsonPathInst::from_str($path).expect("json path must be valid").find_slice(&self.yaml).first().is_some() {
+                        (1, HashMap::new())
+                    }
+                    else {
+                        (0, HashMap::new())
+                    }
+                });
+
+                // Now log the metric
+                tracing::info!($($metric).+ = metric.0);
+
+            };
+            ($($metric:ident).+, $path:literal, $($($attr:ident).+, $attr_path:literal),+) => {
+                let metric_name = stringify!($($metric).+).to_string();
+                let metric = self.metrics.entry(metric_name.clone()).or_insert_with(|| {
+                    if let Some(value) = JsonPathInst::from_str($path).expect("json path must be valid").find_slice(&self.yaml).first() {
+                        paste!{
+                            let mut attributes = HashMap::new();
+                            $(
+                            let attr_name = stringify!([<$($attr __ )+>]).to_string();
+                            match JsonPathInst::from_str($attr_path).expect("json path must be valid").find_slice(value).into_iter().next().as_deref() {
+                                // If the value is an object we can only state that it is set, but not what it is set to.
+                                Some(Value::Object(_value)) => {attributes.insert(attr_name, "true".to_string());},
+                                Some(Value::Array(value)) if !value.is_empty() => {attributes.insert(attr_name, "true".to_string());},
+                                // Scalars can be logged as is.
+                                Some(value) => {attributes.insert(attr_name, value.to_string());},
+                                // If the value is not set we don't specify the attribute.
+                                None => {attributes.insert(attr_name, "false".to_string());},
+                            };)+
+                            (1, attributes)
+                        }
+                    }
+                    else {
+                        paste!{
+                            let mut attributes = HashMap::new();
+                            $(
+                                let attr_name = stringify!([<$($attr __ )+>]).to_string();
+                                attributes.insert(attr_name, "false".to_string());
+                            )+
+                            (0, attributes)
+                        }
+                    }
+                });
+
+                // Now log the metric
+                paste!{
+                    tracing::info!($($metric).+ = metric.0, $($($attr).+ = metric.1.get(stringify!([<$($attr __ )+>])).expect("attribute must be in map")),+);
+                }
+            };
+        }
+
+        log_usage_metrics!(
+            value.apollo.router.config.defer,
+            "$.supergraph[?(@.defer_support == true)]"
+        );
+        log_usage_metrics!(
+            value.apollo.router.config.authentication.jwt,
+            "$.authentication[?(@..jwt)]"
+        );
+        log_usage_metrics!(
+            value.apollo.router.config.authentication.aws.sigv4,
+            "$.authentication[?(@.subgraph..aws_sig_v4)]"
+        );
+        log_usage_metrics!(
+            value.apollo.router.config.authorization,
+            "$.authorization",
+            opt.require_authentication,
+            "$[?(@.require_authentication == true)]"
+        );
+        log_usage_metrics!(
+            value.apollo.router.config.coprocessor,
+            "$.coprocessor",
+            opt.router.request,
+            "$.router.request",
+            opt.router.response,
+            "$.router.response",
+            // Note that supergraph is not supported yet so these will always be empty
+            opt.supergraph.request,
+            "$.supergraph.response",
+            opt.supergraph.response,
+            "$.supergraph.request",
+            opt.subgraph.request,
+            "$.subgraph..request",
+            opt.subgraph.response,
+            "$.subgraph..response"
+        );
+        log_usage_metrics!(
+            value.apollo.router.config.persisted_queries,
+            "$.preview_persisted_queries[?(@.enabled == true)]",
+            opt.log_unknown,
+            "$[?(@.log_unknown == true)]",
+            opt.safelist.require_id,
+            "$[?(@.safelist.require_id == true)]",
+            opt.safelist.enabled,
+            "$[?(@.safelist.enabled == true)]"
+        );
+
+        log_usage_metrics!(
+            value.apollo.router.config.subscriptions,
+            "$.subscription[?(@.enabled == true)]",
+            opt.mode.passthrough,
+            "$.mode.passthrough",
+            opt.mode.callback,
+            "$.mode.callback",
+            opt.deduplication,
+            "$[?(@.enable_deduplication == true)]",
+            opt.max_opened,
+            "$[?(@.max_opened_subscriptions)]",
+            opt.queue_capacity,
+            "$[?(@.queue_capacity)]"
+        );
+
+        log_usage_metrics!(
+            value.apollo.router.config.limits,
+            "$.limits",
+            opt.operation.max_depth,
+            "$[?(@.max_depth)]",
+            opt.operation.max_aliases,
+            "$[?(@.max_aliases)]",
+            opt.operation.max_height,
+            "$[?(@.max_height)]",
+            opt.operation.max_root_fields,
+            "$[?(@.max_root_fields)]",
+            opt.operation.warn_only,
+            "$[?(@.warn_only)]",
+            opt.parser.max_recursion,
+            "$[?(@.parser_max_recursion)]",
+            opt.parser.max_tokens,
+            "$[?(@.parser_max_tokens)]",
+            opt.request.max_size,
+            "$[?(@.experimental_http_max_request_bytes)]"
+        );
+        log_usage_metrics!(
+            value.apollo.router.config.apq,
+            "$.apq[?(@.enabled==true)]",
+            opt.router.cache.redis,
+            "$.router.cache.redis",
+            opt.router.cache.in_memory,
+            "$.router.cache.in_memory",
+            opt.subgraph,
+            "$.subgraph..enabled[?(@ == true)]"
+        );
+        log_usage_metrics!(
+            value.apollo.router.config.traffic_shaping,
+            "$.traffic_shaping",
+            opt.router.timout,
+            "$$[?(@.router.timeout)]",
+            opt.router.rate_limit,
+            "$.router.global_rate_limit",
+            opt.subgraph.timeout,
+            "$[?(@.all.timeout || @.subgraphs..timeout)]",
+            opt.subgraph.rate_limit,
+            "$[?(@.all.global_rate_limit || @.subgraphs..global_rate_limit)]",
+            opt.subgraph.http2,
+            "$[?(@.all.experimental_enable_http2 == true || @.subgraphs..experimental_enable_http2 == true)]",
+            opt.subgraph.compression,
+            "$[?(@.all.compression || @.subgraphs..compression)]",
+            opt.subgraph.deduplicate_query,
+            "$[?(@.all.deduplicate_query == true || @.subgraphs..deduplicate_query == true)]",
+            opt.subgraph.retry,
+            "$[?(@.all.experimental_retry || @.subgraphs..experimental_retry)]"
+        );
+
+        log_usage_metrics!(
+            value.apollo.router.config.entities,
+            "$[?(@.traffic_shaping..experimental_entity_caching)]",
+            opt.cache,
+            "$[?(@.traffic_shaping..experimental_entity_caching)]"
+        );
+        log_usage_metrics!(
+            value.apollo.router.config.telemetry,
+            "$.telemetry[?(@..endpoint || @.metrics.prometheus.enabled == true)]",
+            opt.metrics.otlp,
+            "$.metrics.otlp[?(@.endpoint)]",
+            opt.metrics.prometheus,
+            "$.metrics.prometheus[?(@.enabled==true)]",
+            opt.tracing.otlp,
+            "$.tracing.otlp[?(@.endpoint)]",
+            opt.tracing.datadog,
+            "$.tracing.datadog[?(@.endpoint)]",
+            opt.tracing.jaeger,
+            "$.tracing.jaeger[?(@..endpoint)]",
+            opt.tracing.zipkin,
+            "$.tracing.zipkin[?(@.endpoint)]"
+        );
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use insta::assert_yaml_snapshot;
+    use rust_embed::RustEmbed;
+
+    use crate::configuration::metrics::Metrics;
+
+    #[derive(RustEmbed)]
+    #[folder = "src/configuration/testdata/metrics"]
+    struct Asset;
+
+    #[test]
+    fn test_metrics() {
+        for file_name in Asset::iter() {
+            let source = Asset::get(&file_name).expect("test file must exist");
+            let input = std::str::from_utf8(&source.data)
+                .expect("expected utf8")
+                .to_string();
+            let yaml = &serde_yaml::from_str::<serde_json::Value>(&input)
+                .expect("config must be valid yaml");
+
+            let mut metrics = Metrics {
+                yaml: yaml.clone(),
+                metrics: Default::default(),
+            };
+            metrics.log_usage_metrics();
+            metrics.metrics.retain(|_, v| v.0 > 0);
+            insta::with_settings!({sort_maps => true, snapshot_suffix => file_name}, {
+                assert_yaml_snapshot!(&metrics.metrics);
+            });
+        }
+    }
+}

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -2,6 +2,7 @@
 pub(crate) mod cors;
 pub(crate) mod expansion;
 mod experimental;
+pub(crate) mod metrics;
 mod persisted_queries;
 mod schema;
 pub(crate) mod subgraph;

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@apq.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@apq.router.yaml.snap
@@ -1,0 +1,10 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.metrics"
+---
+value.apollo.router.config.apq:
+  - 1
+  - opt__router__cache__in_memory__: "true"
+    opt__router__cache__redis__: "true"
+    opt__subgraph__: "true"
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@authorization.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@authorization.router.yaml.snap
@@ -1,0 +1,8 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.metrics"
+---
+value.apollo.router.config.authorization:
+  - 1
+  - opt__require_authentication__: "true"
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@coprocessor.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@coprocessor.router.yaml.snap
@@ -1,0 +1,13 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.metrics"
+---
+value.apollo.router.config.coprocessor:
+  - 1
+  - opt__router__request__: "true"
+    opt__router__response__: "true"
+    opt__subgraph__request__: "true"
+    opt__subgraph__response__: "true"
+    opt__supergraph__request__: "false"
+    opt__supergraph__response__: "false"
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@defer.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@defer.router.yaml.snap
@@ -1,0 +1,8 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.metrics"
+---
+value.apollo.router.config.defer:
+  - 1
+  - {}
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@entities.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@entities.router.yaml.snap
@@ -1,0 +1,18 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.metrics"
+---
+value.apollo.router.config.entities:
+  - 1
+  - opt__cache__: "true"
+value.apollo.router.config.traffic_shaping:
+  - 1
+  - opt__router__rate_limit__: "false"
+    opt__router__timout__: "false"
+    opt__subgraph__compression__: "false"
+    opt__subgraph__deduplicate_query__: "false"
+    opt__subgraph__http2__: "false"
+    opt__subgraph__rate_limit__: "false"
+    opt__subgraph__retry__: "false"
+    opt__subgraph__timeout__: "false"
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@jwt.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@jwt.router.yaml.snap
@@ -1,0 +1,8 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.metrics"
+---
+value.apollo.router.config.authentication.jwt:
+  - 1
+  - {}
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@limits.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@limits.router.yaml.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.metrics"
+---
+value.apollo.router.config.limits:
+  - 1
+  - opt__operation__max_aliases__: "true"
+    opt__operation__max_depth__: "true"
+    opt__operation__max_height__: "true"
+    opt__operation__max_root_fields__: "true"
+    opt__operation__warn_only__: "true"
+    opt__parser__max_recursion__: "true"
+    opt__parser__max_tokens__: "true"
+    opt__request__max_size__: "true"
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@persisted_queries.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@persisted_queries.router.yaml.snap
@@ -1,0 +1,10 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.metrics"
+---
+value.apollo.router.config.persisted_queries:
+  - 1
+  - opt__log_unknown__: "true"
+    opt__safelist__enabled__: "true"
+    opt__safelist__require_id__: "true"
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@sigv4.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@sigv4.router.yaml.snap
@@ -1,0 +1,8 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.metrics"
+---
+value.apollo.router.config.authentication.aws.sigv4:
+  - 1
+  - {}
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@subscriptions.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@subscriptions.router.yaml.snap
@@ -1,0 +1,12 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.metrics"
+---
+value.apollo.router.config.subscriptions:
+  - 1
+  - opt__deduplication__: "false"
+    opt__max_opened__: "true"
+    opt__mode__callback__: "false"
+    opt__mode__passthrough__: "true"
+    opt__queue_capacity__: "true"
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@telemetry.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@telemetry.router.yaml.snap
@@ -1,0 +1,13 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.metrics"
+---
+value.apollo.router.config.telemetry:
+  - 1
+  - opt__metrics__otlp__: "true"
+    opt__metrics__prometheus__: "true"
+    opt__tracing__datadog__: "true"
+    opt__tracing__jaeger__: "true"
+    opt__tracing__otlp__: "true"
+    opt__tracing__zipkin__: "true"
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@traffic_shaping.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@traffic_shaping.router.yaml.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.metrics"
+---
+value.apollo.router.config.traffic_shaping:
+  - 1
+  - opt__router__rate_limit__: "true"
+    opt__router__timout__: "true"
+    opt__subgraph__compression__: "true"
+    opt__subgraph__deduplicate_query__: "true"
+    opt__subgraph__http2__: "true"
+    opt__subgraph__rate_limit__: "true"
+    opt__subgraph__retry__: "true"
+    opt__subgraph__timeout__: "true"
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -2159,6 +2159,11 @@ expression: "&schema"
               },
               "additionalProperties": false
             },
+            "experimental_otlp_endpoint": {
+              "description": "The Apollo Studio endpoint for exporting traces and metrics.",
+              "default": "http://0.0.0.0:4317/",
+              "type": "string"
+            },
             "field_level_instrumentation_sampler": {
               "description": "Field level instrumentation for subgraphs via ftv1. ftv1 tracing can cause performance issues as it is transmitted in band with subgraph responses.",
               "anyOf": [

--- a/apollo-router/src/configuration/testdata/metrics/apq.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/apq.router.yaml
@@ -1,0 +1,12 @@
+apq:
+  enabled: true
+  router:
+    cache:
+      in_memory:
+        limit: 10000
+      redis:
+        urls:
+          - "http://example.com"
+  subgraph:
+    all:
+      enabled: true

--- a/apollo-router/src/configuration/testdata/metrics/authorization.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/authorization.router.yaml
@@ -1,0 +1,2 @@
+authorization:
+  require_authentication: true

--- a/apollo-router/src/configuration/testdata/metrics/coprocessor.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/coprocessor.router.yaml
@@ -1,0 +1,31 @@
+coprocessor:
+  timeout: 10s
+  url: http://example.com
+  router:
+    request:
+      headers: true
+      body: true
+      context: true
+      method: true
+      path: true
+      sdl: true
+    response:
+      sdl: true
+      context: true
+      body: true
+      headers: true
+      status_code: true
+  subgraph:
+    all:
+      request:
+        headers: true
+        body: true
+        context: true
+        method: true
+      response:
+        status_code: true
+        headers: true
+        body: true
+        context: true
+        service_name: true
+

--- a/apollo-router/src/configuration/testdata/metrics/defer.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/defer.router.yaml
@@ -1,0 +1,3 @@
+supergraph:
+  defer_support: true
+

--- a/apollo-router/src/configuration/testdata/metrics/entities.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/entities.router.yaml
@@ -1,0 +1,5 @@
+traffic_shaping:
+  all:
+    experimental_entity_caching:
+      ttl: 10s
+

--- a/apollo-router/src/configuration/testdata/metrics/jwt.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/jwt.router.yaml
@@ -1,0 +1,7 @@
+authentication:
+  router:
+    jwt:
+      jwks:
+        - url: https://example.com
+
+

--- a/apollo-router/src/configuration/testdata/metrics/limits.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/limits.router.yaml
@@ -1,0 +1,9 @@
+limits:
+  max_depth: 1
+  experimental_http_max_request_bytes: 2000000
+  warn_only: true
+  max_root_fields: 1
+  parser_max_tokens: 15000
+  parser_max_recursion: 4096
+  max_height: 2
+  max_aliases: 2

--- a/apollo-router/src/configuration/testdata/metrics/persisted_queries.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/persisted_queries.router.yaml
@@ -1,0 +1,7 @@
+preview_persisted_queries:
+  enabled: true
+  log_unknown: true
+  safelist:
+    require_id: true
+    enabled: true
+

--- a/apollo-router/src/configuration/testdata/metrics/sigv4.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/sigv4.router.yaml
@@ -1,0 +1,7 @@
+authentication:
+  subgraph:
+    all:
+      aws_sig_v4:
+        default_chain:
+            service_name: "Foo"
+            region: "us-east-1"

--- a/apollo-router/src/configuration/testdata/metrics/subscriptions.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/subscriptions.router.yaml
@@ -1,0 +1,13 @@
+subscription:
+  enabled: true
+  mode:
+    passthrough:
+      all:
+        protocol: graphql_ws
+    preview_callback:
+      path: /graphql
+      public_url: https://example.com
+  enable_deduplication: false
+  queue_capacity: 2
+  max_opened_subscriptions: 3
+

--- a/apollo-router/src/configuration/testdata/metrics/telemetry.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/telemetry.router.yaml
@@ -1,0 +1,17 @@
+telemetry:
+  metrics:
+    prometheus:
+      enabled: true
+    otlp:
+      endpoint: default
+  tracing:
+    otlp:
+      endpoint: default
+    zipkin:
+      endpoint: default
+    datadog:
+      endpoint: default
+    jaeger:
+      agent:
+        endpoint: default
+

--- a/apollo-router/src/configuration/testdata/metrics/traffic_shaping.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/traffic_shaping.router.yaml
@@ -1,0 +1,20 @@
+traffic_shaping:
+  router:
+    timeout: 10s
+    global_rate_limit:
+      capacity: 100
+      interval: 1s
+  all:
+    deduplicate_query: true
+    compression: br
+    timeout: 10s
+    global_rate_limit:
+      capacity: 100
+      interval: 1s
+    experimental_enable_http2: true
+    experimental_retry:
+      ttl: 1s
+      min_per_sec: 2
+      retry_mutations: true
+      retry_percent: 2
+

--- a/apollo-router/src/plugins/telemetry/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/apollo.rs
@@ -33,6 +33,8 @@ use crate::services::apollo_key;
 pub(crate) const ENDPOINT_DEFAULT: &str =
     "https://usage-reporting.api.apollographql.com/api/ingress/traces";
 
+pub(crate) const OTLP_ENDPOINT_DEFAULT: &str = "http://0.0.0.0:4317";
+
 #[derive(Derivative)]
 #[derivative(Debug)]
 #[derive(Clone, Deserialize, JsonSchema)]
@@ -41,6 +43,10 @@ pub(crate) struct Config {
     /// The Apollo Studio endpoint for exporting traces and metrics.
     #[schemars(with = "String", default = "endpoint_default")]
     pub(crate) endpoint: Url,
+
+    /// The Apollo Studio endpoint for exporting traces and metrics.
+    #[schemars(with = "String", default = "otlp_endpoint_default")]
+    pub(crate) experimental_otlp_endpoint: Url,
 
     /// The Apollo Studio API key.
     #[schemars(skip)]
@@ -145,6 +151,10 @@ fn endpoint_default() -> Url {
     Url::parse(ENDPOINT_DEFAULT).expect("must be valid url")
 }
 
+fn otlp_endpoint_default() -> Url {
+    Url::parse(OTLP_ENDPOINT_DEFAULT).expect("must be valid url")
+}
+
 const fn client_name_header_default_str() -> &'static str {
     "apollographql-client-name"
 }
@@ -169,6 +179,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             endpoint: endpoint_default(),
+            experimental_otlp_endpoint: otlp_endpoint_default(),
             apollo_key: apollo_key(),
             apollo_graph_ref: apollo_graph_reference(),
             client_name_header: client_name_header_default(),

--- a/apollo-router/src/plugins/telemetry/metrics/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo.rs
@@ -1,22 +1,40 @@
 //! Apollo metrics
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
+use std::time::Duration;
 
+use opentelemetry::sdk::export::metrics::aggregation;
+use opentelemetry::sdk::metrics::selectors;
+use opentelemetry::sdk::Resource;
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::WithExportConfig;
+use sys_info::hostname;
+use tonic::metadata::MetadataMap;
 use tower::BoxError;
+use url::Url;
 
 use crate::plugins::telemetry::apollo::Config;
+use crate::plugins::telemetry::apollo_exporter::get_uname;
 use crate::plugins::telemetry::apollo_exporter::ApolloExporter;
 use crate::plugins::telemetry::config::MetricsCommon;
+use crate::plugins::telemetry::metrics::filter::FilterMeterProvider;
 use crate::plugins::telemetry::metrics::MetricsBuilder;
 use crate::plugins::telemetry::metrics::MetricsConfigurator;
+use crate::plugins::telemetry::tracing::BatchProcessorConfig;
 
 mod duration_histogram;
 pub(crate) mod studio;
 
+fn default_buckets() -> Vec<f64> {
+    vec![
+        0.001, 0.005, 0.015, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 5.0, 10.0,
+    ]
+}
+
 impl MetricsConfigurator for Config {
     fn apply(
         &self,
-        builder: MetricsBuilder,
+        mut builder: MetricsBuilder,
         _metrics_config: &MetricsCommon,
     ) -> Result<MetricsBuilder, BoxError> {
         tracing::debug!("configuring Apollo metrics");
@@ -24,6 +42,7 @@ impl MetricsConfigurator for Config {
         Ok(match self {
             Config {
                 endpoint,
+                experimental_otlp_endpoint: otlp_endpoint,
                 apollo_key: Some(key),
                 apollo_graph_ref: Some(reference),
                 schema_id,
@@ -33,23 +52,101 @@ impl MetricsConfigurator for Config {
                 if !ENABLED.swap(true, Ordering::Relaxed) {
                     tracing::info!("Apollo Studio usage reporting is enabled. See https://go.apollo.dev/o/data for details");
                 }
-                let batch_processor_config = batch_processor;
-                tracing::debug!("creating metrics exporter");
-                let exporter = ApolloExporter::new(
+
+                builder = Self::configure_apollo_metrics(
+                    builder,
                     endpoint,
-                    batch_processor_config,
                     key,
                     reference,
                     schema_id,
+                    batch_processor,
                 )?;
-
-                builder.with_apollo_metrics_collector(exporter.start())
+                // env variable EXPERIMENTAL_APOLLO_OTLP_METRICS_ENABLED will disappear without warning in future
+                if let Some("true") = std::env::var("EXPERIMENTAL_APOLLO_OTLP_METRICS_ENABLED")
+                    .ok()
+                    .as_deref()
+                {
+                    builder = Self::configure_apollo_otlp_metrics(
+                        builder,
+                        otlp_endpoint,
+                        key,
+                        reference,
+                        schema_id,
+                        batch_processor,
+                    )?;
+                }
+                builder
             }
             _ => {
                 ENABLED.swap(false, Ordering::Relaxed);
                 builder
             }
         })
+    }
+}
+
+impl Config {
+    fn configure_apollo_otlp_metrics(
+        mut builder: MetricsBuilder,
+        endpoint: &Url,
+        key: &str,
+        reference: &str,
+        schema_id: &str,
+        batch_processor: &BatchProcessorConfig,
+    ) -> Result<MetricsBuilder, BoxError> {
+        tracing::debug!("creating otlp metrics exporter");
+        let mut metadata = MetadataMap::new();
+        metadata.insert("apollo.api.key", key.parse()?);
+
+        let exporter = opentelemetry_otlp::new_pipeline()
+            .metrics(
+                selectors::simple::histogram(default_buckets()),
+                aggregation::delta_temporality_selector(),
+                opentelemetry::runtime::Tokio,
+            )
+            .with_resource(Resource::new([
+                KeyValue::new("apollo.graph.ref", reference.to_string()),
+                KeyValue::new("apollo.schema.id", schema_id.to_string()),
+                KeyValue::new(
+                    "apollo.user.agent",
+                    format!(
+                        "{}@{}",
+                        std::env!("CARGO_PKG_NAME"),
+                        std::env!("CARGO_PKG_VERSION")
+                    ),
+                ),
+                KeyValue::new("apollo.client.host", hostname()?),
+                KeyValue::new("apollo.client.uname", get_uname()?),
+            ]))
+            .with_period(Duration::from_secs(60))
+            .with_exporter(
+                opentelemetry_otlp::new_exporter()
+                    .tonic()
+                    .with_endpoint(endpoint.as_str())
+                    .with_timeout(batch_processor.max_export_timeout)
+                    .with_metadata(metadata),
+            )
+            .build()?;
+        builder =
+            builder.with_meter_provider(FilterMeterProvider::apollo_metrics(exporter.clone()));
+        builder = builder.with_exporter(exporter);
+        Ok(builder)
+    }
+
+    fn configure_apollo_metrics(
+        builder: MetricsBuilder,
+        endpoint: &Url,
+        key: &str,
+        reference: &str,
+        schema_id: &str,
+        batch_processor: &BatchProcessorConfig,
+    ) -> Result<MetricsBuilder, BoxError> {
+        let batch_processor_config = batch_processor;
+        tracing::debug!("creating metrics exporter");
+        let exporter =
+            ApolloExporter::new(endpoint, batch_processor_config, key, reference, schema_id)?;
+
+        Ok(builder.with_apollo_metrics_collector(exporter.start()))
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/metrics/filter.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/filter.rs
@@ -50,6 +50,9 @@ impl<T: MeterProvider> FilterMeterProvider<T> {
                 Regex::new(r"apollo\.router\.(operations?|config)(\..*|$)")
                     .expect("regex should have been valid"),
             )
+            // You can add exceptions to the deny list here. Eventually we will want to allow most metrics to be public, but the rationale for
+            // making metrics public gradually is that we can make sure that we have got the naming conventions right.
+            // Our previous metrics suffered from inconsistency, and we don't want to repeat that mistake.
             .allow(
                 Regex::new(r"apollo\.router\.operations\.authentication")
                     .expect("regex should have been valid"),

--- a/apollo-router/src/plugins/telemetry/metrics/filter.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/filter.rs
@@ -1,0 +1,302 @@
+use std::sync::Arc;
+
+use buildstructor::buildstructor;
+use opentelemetry::metrics::noop::NoopMeterProvider;
+use opentelemetry::metrics::Counter;
+use opentelemetry::metrics::Histogram;
+use opentelemetry::metrics::InstrumentProvider;
+use opentelemetry::metrics::Meter;
+use opentelemetry::metrics::MeterProvider;
+use opentelemetry::metrics::ObservableCounter;
+use opentelemetry::metrics::ObservableGauge;
+use opentelemetry::metrics::ObservableUpDownCounter;
+use opentelemetry::metrics::Unit;
+use opentelemetry::metrics::UpDownCounter;
+use opentelemetry::Context;
+use opentelemetry::InstrumentationLibrary;
+use regex::Regex;
+
+pub(crate) struct FilterMeterProvider<T: MeterProvider> {
+    delegate: T,
+    deny: Option<Regex>,
+    allow: Option<Regex>,
+}
+
+#[buildstructor]
+impl<T: MeterProvider> FilterMeterProvider<T> {
+    #[builder]
+    fn new(delegate: T, deny: Option<Regex>, allow: Option<Regex>) -> Self {
+        FilterMeterProvider {
+            delegate,
+            deny,
+            allow,
+        }
+    }
+
+    pub(crate) fn apollo_metrics(delegate: T) -> Self {
+        FilterMeterProvider::builder()
+            .delegate(delegate)
+            .allow(
+                Regex::new(r"apollo\.router\.(operations?|config)(\..*|$)")
+                    .expect("regex should have been valid"),
+            )
+            .build()
+    }
+
+    pub(crate) fn public_metrics(delegate: T) -> Self {
+        FilterMeterProvider::builder()
+            .delegate(delegate)
+            .deny(
+                Regex::new(r"apollo\.router\.(operations?|config)(\..*|$)")
+                    .expect("regex should have been valid"),
+            )
+            .allow(
+                Regex::new(r"apollo\.router\.operations\.authentication")
+                    .expect("regex should have been valid"),
+            )
+            .build()
+    }
+}
+
+struct FilteredInstrumentProvider {
+    noop: Meter,
+    delegate: Meter,
+    deny: Option<Regex>,
+    allow: Option<Regex>,
+}
+macro_rules! filter_meter_fn {
+    ($name:ident, $ty:ty, $wrapper:ident) => {
+        fn $name(
+            &self,
+            name: String,
+            description: Option<String>,
+            unit: Option<Unit>,
+        ) -> opentelemetry::metrics::Result<$wrapper<$ty>> {
+            let mut builder = match (&self.deny, &self.allow) {
+                (Some(deny), Some(allow)) if deny.is_match(&name) && !allow.is_match(&name) => {
+                    self.noop.$name(name)
+                }
+                (Some(deny), None) if deny.is_match(&name) => self.noop.$name(name),
+                (None, Some(allow)) if !allow.is_match(&name) => self.noop.$name(name),
+                (_, _) => self.delegate.$name(name),
+            };
+            if let Some(description) = &description {
+                builder = builder.with_description(description);
+            }
+            if let Some(unit) = &unit {
+                builder = builder.with_unit(unit.clone());
+            }
+            builder.try_init()
+        }
+    };
+}
+
+impl InstrumentProvider for FilteredInstrumentProvider {
+    filter_meter_fn!(u64_counter, u64, Counter);
+    filter_meter_fn!(f64_counter, f64, Counter);
+
+    filter_meter_fn!(f64_observable_counter, f64, ObservableCounter);
+    filter_meter_fn!(u64_observable_counter, u64, ObservableCounter);
+
+    filter_meter_fn!(u64_histogram, u64, Histogram);
+    filter_meter_fn!(f64_histogram, f64, Histogram);
+    filter_meter_fn!(i64_histogram, i64, Histogram);
+
+    filter_meter_fn!(i64_up_down_counter, i64, UpDownCounter);
+    filter_meter_fn!(f64_up_down_counter, f64, UpDownCounter);
+
+    filter_meter_fn!(i64_observable_up_down_counter, i64, ObservableUpDownCounter);
+    filter_meter_fn!(f64_observable_up_down_counter, f64, ObservableUpDownCounter);
+
+    filter_meter_fn!(f64_observable_gauge, f64, ObservableGauge);
+    filter_meter_fn!(i64_observable_gauge, i64, ObservableGauge);
+    filter_meter_fn!(u64_observable_gauge, u64, ObservableGauge);
+
+    fn register_callback(
+        &self,
+        callback: Box<dyn Fn(&Context) + Send + Sync>,
+    ) -> opentelemetry::metrics::Result<()> {
+        self.delegate.register_callback(callback)
+    }
+}
+
+impl<T: MeterProvider> MeterProvider for FilterMeterProvider<T> {
+    fn versioned_meter(
+        &self,
+        name: &'static str,
+        version: Option<&'static str>,
+        schema_url: Option<&'static str>,
+    ) -> Meter {
+        let delegate = self.delegate.versioned_meter(name, version, schema_url);
+        Meter::new(
+            InstrumentationLibrary::new(name, version, schema_url),
+            Arc::new(FilteredInstrumentProvider {
+                noop: NoopMeterProvider::new().versioned_meter(name, version, schema_url),
+                delegate,
+                deny: self.deny.clone(),
+                allow: self.allow.clone(),
+            }),
+        )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashSet;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::Ordering;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use opentelemetry::metrics::noop;
+    use opentelemetry::metrics::Counter;
+    use opentelemetry::metrics::InstrumentProvider;
+    use opentelemetry::metrics::Meter;
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry::metrics::Unit;
+    use opentelemetry::Context;
+    use opentelemetry::InstrumentationLibrary;
+
+    use crate::plugins::telemetry::metrics::filter::FilterMeterProvider;
+
+    #[derive(Default, Clone)]
+    struct MockInstrumentProvider {
+        #[allow(clippy::type_complexity)]
+        counters_created: Arc<Mutex<HashSet<(String, Option<String>, Option<Unit>)>>>,
+        callbacks_registered: Arc<AtomicU64>,
+    }
+
+    impl InstrumentProvider for MockInstrumentProvider {
+        // We're only going to bother with testing counters and callbacks because the code is implemented as a macro and if it's right for counters it's right for everything else.
+        fn u64_counter(
+            &self,
+            name: String,
+            description: Option<String>,
+            unit: Option<Unit>,
+        ) -> opentelemetry::metrics::Result<Counter<u64>> {
+            self.counters_created
+                .lock()
+                .expect("lock should not be poisoned")
+                .insert((name, description, unit));
+            Ok(Counter::new(Arc::new(noop::NoopSyncInstrument::new())))
+        }
+
+        fn register_callback(
+            &self,
+            _callback: Box<dyn Fn(&Context) + Send + Sync>,
+        ) -> opentelemetry::metrics::Result<()> {
+            self.callbacks_registered.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[derive(Default, Clone)]
+    struct MockMeterProvider {
+        instrument_provider: Arc<MockInstrumentProvider>,
+    }
+
+    impl MeterProvider for MockMeterProvider {
+        fn versioned_meter(
+            &self,
+            name: &'static str,
+            version: Option<&'static str>,
+            schema_url: Option<&'static str>,
+        ) -> Meter {
+            Meter::new(
+                InstrumentationLibrary::new(name, version, schema_url),
+                self.instrument_provider.clone(),
+            )
+        }
+    }
+
+    #[test]
+    fn test_apollo_metrics() {
+        let delegate = MockMeterProvider::default();
+        let filtered = FilterMeterProvider::apollo_metrics(delegate.clone())
+            .versioned_meter("filtered", None, None);
+        filtered.u64_counter("apollo.router.operations").init();
+        filtered.u64_counter("apollo.router.operations.test").init();
+        filtered.u64_counter("apollo.router.unknown.test").init();
+        assert!(delegate
+            .instrument_provider
+            .counters_created
+            .lock()
+            .unwrap()
+            .contains(&("apollo.router.operations.test".to_string(), None, None)));
+        assert!(delegate
+            .instrument_provider
+            .counters_created
+            .lock()
+            .unwrap()
+            .contains(&("apollo.router.operations".to_string(), None, None)));
+        assert!(!delegate
+            .instrument_provider
+            .counters_created
+            .lock()
+            .unwrap()
+            .contains(&("apollo.router.unknown.test".to_string(), None, None)));
+    }
+
+    #[test]
+    fn test_public_metrics() {
+        let delegate = MockMeterProvider::default();
+        let filtered = FilterMeterProvider::public_metrics(delegate.clone())
+            .versioned_meter("filtered", None, None);
+        filtered.u64_counter("apollo.router.operations").init();
+        filtered.u64_counter("apollo.router.operations.test").init();
+        filtered.u64_counter("apollo.router.unknown.test").init();
+        filtered
+            .u64_counter("apollo.router.operations.authentication.aws.sigv4")
+            .init();
+        assert!(!delegate
+            .instrument_provider
+            .counters_created
+            .lock()
+            .unwrap()
+            .contains(&("apollo.router.operations.test".to_string(), None, None)));
+        assert!(!delegate
+            .instrument_provider
+            .counters_created
+            .lock()
+            .unwrap()
+            .contains(&("apollo.router.operations".to_string(), None, None)));
+        assert!(delegate
+            .instrument_provider
+            .counters_created
+            .lock()
+            .unwrap()
+            .contains(&("apollo.router.unknown.test".to_string(), None, None)));
+        assert!(delegate
+            .instrument_provider
+            .counters_created
+            .lock()
+            .unwrap()
+            .contains(&(
+                "apollo.router.operations.authentication.aws.sigv4".to_string(),
+                None,
+                None
+            )));
+    }
+
+    #[test]
+    fn test_description_and_unit() {
+        let delegate = MockMeterProvider::default();
+        let filtered = FilterMeterProvider::apollo_metrics(delegate.clone())
+            .versioned_meter("filtered", None, None);
+        filtered
+            .u64_counter("apollo.router.operations")
+            .with_description("desc")
+            .with_unit(Unit::new("ms"))
+            .init();
+        assert!(delegate
+            .instrument_provider
+            .counters_created
+            .lock()
+            .unwrap()
+            .contains(&(
+                "apollo.router.operations".to_string(),
+                Some("desc".to_string()),
+                Some(Unit::new("ms"))
+            )));
+    }
+}

--- a/apollo-router/src/plugins/telemetry/metrics/mod.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/mod.rs
@@ -32,6 +32,7 @@ use crate::ListenAddr;
 
 pub(crate) mod aggregation;
 pub(crate) mod apollo;
+pub(crate) mod filter;
 pub(crate) mod layer;
 pub(crate) mod otlp;
 pub(crate) mod prometheus;

--- a/apollo-router/src/plugins/telemetry/metrics/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/otlp.rs
@@ -7,6 +7,7 @@ use opentelemetry_otlp::TonicExporterBuilder;
 use tower::BoxError;
 
 use crate::plugins::telemetry::config::MetricsCommon;
+use crate::plugins::telemetry::metrics::filter::FilterMeterProvider;
 use crate::plugins::telemetry::metrics::MetricsBuilder;
 use crate::plugins::telemetry::metrics::MetricsConfigurator;
 use crate::plugins::telemetry::otlp::Temporality;
@@ -74,7 +75,8 @@ impl MetricsConfigurator for super::super::otlp::Config {
                         ))
                         .build()?,
                 };
-                builder = builder.with_meter_provider(exporter.clone());
+                builder = builder
+                    .with_meter_provider(FilterMeterProvider::public_metrics(exporter.clone()));
                 builder = builder.with_exporter(exporter);
                 Ok(builder)
             }

--- a/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/prometheus.rs
@@ -22,6 +22,7 @@ use tower::ServiceExt;
 use tower_service::Service;
 
 use crate::plugins::telemetry::config::MetricsCommon;
+use crate::plugins::telemetry::metrics::filter::FilterMeterProvider;
 use crate::plugins::telemetry::metrics::MetricsBuilder;
 use crate::plugins::telemetry::metrics::MetricsConfigurator;
 use crate::router_factory::Endpoint;
@@ -123,7 +124,9 @@ impl MetricsConfigurator for Config {
                     .boxed(),
                 ),
             );
-            builder = builder.with_meter_provider(exporter.meter_provider()?);
+            builder = builder.with_meter_provider(FilterMeterProvider::public_metrics(
+                exporter.meter_provider()?,
+            ));
             builder = builder.with_exporter(exporter);
             tracing::info!(
                 "Prometheus endpoint exposed at {}{}",

--- a/apollo-router/src/plugins/telemetry/utils.rs
+++ b/apollo-router/src/plugins/telemetry/utils.rs
@@ -1,0 +1,15 @@
+use tracing_core::field::Value;
+
+pub(crate) trait TracingUtils {
+    fn or_empty(&self) -> &dyn Value;
+}
+
+impl TracingUtils for bool {
+    fn or_empty(&self) -> &dyn Value {
+        if *self {
+            self as &dyn Value
+        } else {
+            &::tracing::field::Empty
+        }
+    }
+}

--- a/apollo-router/tests/snapshots/tracing_tests__traced_basic_composition.snap
+++ b/apollo-router/tests/snapshots/tracing_tests__traced_basic_composition.snap
@@ -200,14 +200,6 @@ expression: get_spans()
                   [
                     "apollo_private.operation_signature",
                     "# -\n{topProducts{name reviews{author{id name}id product{name}}upc}}"
-                  ],
-                  [
-                    "monotonic_counter.apollo.router.operations",
-                    1
-                  ],
-                  [
-                    "http.response.status_code",
-                    200
                   ]
                 ],
                 "metadata": {

--- a/apollo-router/tests/snapshots/tracing_tests__traced_basic_composition.snap
+++ b/apollo-router/tests/snapshots/tracing_tests__traced_basic_composition.snap
@@ -200,6 +200,14 @@ expression: get_spans()
                   [
                     "apollo_private.operation_signature",
                     "# -\n{topProducts{name reviews{author{id name}id product{name}}upc}}"
+                  ],
+                  [
+                    "monotonic_counter.apollo.router.operations",
+                    1
+                  ],
+                  [
+                    "http.response.status_code",
+                    200
                   ]
                 ],
                 "metadata": {

--- a/apollo-router/tests/snapshots/tracing_tests__traced_basic_request.snap
+++ b/apollo-router/tests/snapshots/tracing_tests__traced_basic_request.snap
@@ -200,14 +200,6 @@ expression: get_spans()
                   [
                     "apollo_private.operation_signature",
                     "# -\n{topProducts{name name}}"
-                  ],
-                  [
-                    "monotonic_counter.apollo.router.operations",
-                    1
-                  ],
-                  [
-                    "http.response.status_code",
-                    200
                   ]
                 ],
                 "metadata": {

--- a/apollo-router/tests/snapshots/tracing_tests__traced_basic_request.snap
+++ b/apollo-router/tests/snapshots/tracing_tests__traced_basic_request.snap
@@ -200,6 +200,14 @@ expression: get_spans()
                   [
                     "apollo_private.operation_signature",
                     "# -\n{topProducts{name name}}"
+                  ],
+                  [
+                    "monotonic_counter.apollo.router.operations",
+                    1
+                  ],
+                  [
+                    "http.response.status_code",
+                    200
                   ]
                 ],
                 "metadata": {

--- a/apollo-router/tests/snapshots/tracing_tests__variables.snap
+++ b/apollo-router/tests/snapshots/tracing_tests__variables.snap
@@ -188,14 +188,6 @@ expression: get_spans()
                   [
                     "apollo_private.operation_signature",
                     "# ExampleQuery\nquery ExampleQuery($reviewsForAuthorAuthorId:ID!,$topProductsFirst:Int){topProducts(first:$topProductsFirst){name reviewsForAuthor(authorID:$reviewsForAuthorAuthorId){author{id name}body}}}"
-                  ],
-                  [
-                    "monotonic_counter.apollo.router.operations",
-                    1
-                  ],
-                  [
-                    "http.response.status_code",
-                    400
                   ]
                 ],
                 "metadata": {

--- a/apollo-router/tests/snapshots/tracing_tests__variables.snap
+++ b/apollo-router/tests/snapshots/tracing_tests__variables.snap
@@ -188,6 +188,14 @@ expression: get_spans()
                   [
                     "apollo_private.operation_signature",
                     "# ExampleQuery\nquery ExampleQuery($reviewsForAuthorAuthorId:ID!,$topProductsFirst:Int){topProducts(first:$topProductsFirst){name reviewsForAuthor(authorID:$reviewsForAuthorAuthorId){author{id name}body}}}"
+                  ],
+                  [
+                    "monotonic_counter.apollo.router.operations",
+                    1
+                  ],
+                  [
+                    "http.response.status_code",
+                    400
                   ]
                 ],
                 "metadata": {

--- a/licenses.html
+++ b/licenses.html
@@ -44,8 +44,8 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#MIT">MIT License</a> (95)</li>
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (59)</li>
+            <li><a href="#MIT">MIT License</a> (96)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (61)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (10)</li>
             <li><a href="#ISC">ISC License</a> (9)</li>
             <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (3)</li>
@@ -58,6 +58,203 @@
 
         <h2>All license text:</h2>
         <ul class="licenses-list">
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-config</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-credential-types</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-endpoint</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-http</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-sig-auth</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-sigv4</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-async</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-client</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-http</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-http-tower</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-json</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-query</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-types</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-xml</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-types</a></li>
+                </ul>
+                <pre class="license-text">
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+</pre>
+            </li>
             <li class="license">
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
@@ -3186,6 +3383,217 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts</a></li>
+                </ul>
+                <pre class="license-text">                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;{}&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/tmiasko/shell-words ">shell-words</a></li>
                 </ul>
                 <pre class="license-text">                               Apache License
@@ -3397,7 +3805,6 @@ limitations under the License.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/soc/directories-rs ">directories</a></li>
                     <li><a href=" https://github.com/soc/dirs-rs ">dirs</a></li>
-                    <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys</a></li>
                     <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -6750,7 +7157,6 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/vorner/bytes-utils ">bytes-utils</a></li>
                     <li><a href=" https://github.com/rust-lang/cc-rs ">cc</a></li>
                     <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if</a></li>
-                    <li><a href=" https://github.com/sagiegurari/ci_info.git ">ci_info</a></li>
                     <li><a href=" https://github.com/smol-rs/concurrent-queue ">concurrent-queue</a></li>
                     <li><a href=" https://github.com/tkaitchuck/constrandom ">const-random</a></li>
                     <li><a href=" https://github.com/tkaitchuck/constrandom ">const-random-macro</a></li>
@@ -6767,6 +7173,7 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/sagiegurari/envmnt.git ">envmnt</a></li>
                     <li><a href=" https://github.com/cuviper/equivalent ">equivalent</a></li>
                     <li><a href=" https://github.com/smol-rs/event-listener ">event-listener</a></li>
+                    <li><a href=" https://github.com/smol-rs/fastrand ">fastrand</a></li>
                     <li><a href=" https://github.com/smol-rs/fastrand ">fastrand</a></li>
                     <li><a href=" https://github.com/alexcrichton/filetime ">filetime</a></li>
                     <li><a href=" https://github.com/petgraph/fixedbitset ">fixedbitset</a></li>
@@ -6796,7 +7203,6 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/bluss/indexmap ">indexmap</a></li>
                     <li><a href=" https://github.com/bluss/indexmap ">indexmap</a></li>
                     <li><a href=" https://github.com/dtolnay/inventory ">inventory</a></li>
-                    <li><a href=" https://github.com/sunfishcode/io-lifetimes ">io-lifetimes</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools</a></li>
                     <li><a href=" https://github.com/alexcrichton/jobserver-rs ">jobserver</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/js-sys ">js-sys</a></li>
@@ -6805,7 +7211,6 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/rust-lang/git2-rs ">libgit2-sys</a></li>
                     <li><a href=" https://github.com/rust-lang/libm ">libm</a></li>
                     <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys</a></li>
-                    <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys</a></li>
                     <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api</a></li>
                     <li><a href=" https://github.com/bluss/maplit ">maplit</a></li>
@@ -6856,7 +7261,6 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/Kimundi/rustc-version-rs ">rustc_version</a></li>
                     <li><a href=" https://github.com/Kimundi/rustc-version-rs ">rustc_version</a></li>
                     <li><a href=" https://github.com/bytecodealliance/rustix ">rustix</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/rustix ">rustix</a></li>
                     <li><a href=" https://github.com/rustls/rustls ">rustls</a></li>
                     <li><a href=" https://github.com/rustls/rustls ">rustls</a></li>
                     <li><a href=" https://github.com/ctz/rustls-native-certs ">rustls-native-certs</a></li>
@@ -6877,6 +7281,7 @@ limitations under the License.</pre>
                     <li><a href=" https://gitlab.com/ijackson/rust-shellexpand ">shellexpand</a></li>
                     <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry</a></li>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec</a></li>
+                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2</a></li>
                     <li><a href=" https://github.com/rust-lang/socket2 ">socket2</a></li>
                     <li><a href=" https://github.com/dtolnay/syn ">syn</a></li>
                     <li><a href=" https://github.com/Stebalien/tempfile ">tempfile</a></li>
@@ -6914,6 +7319,7 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared</a></li>
                     <li><a href=" https://github.com/rustwasm/wasm-bindgen/tree/master/crates/web-sys ">web-sys</a></li>
                     <li><a href=" https://github.com/LukeMathWalker/wiremock-rs ">wiremock</a></li>
+                    <li><a href=" https://github.com/RazrFalcon/xmlparser ">xmlparser</a></li>
                     <li><a href=" https://github.com/chyh1990/yaml-rust ">yaml-rust</a></li>
                     <li><a href=" https://github.com/SergioBenitez/yansi ">yansi</a></li>
                 </ul>
@@ -11580,9 +11986,9 @@ these terms.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/apollographql/federation/ ">router-bridge</a></li>
                 </ul>
-                <pre class="license-text">Copyright 2021 Apollo Graph, Inc.
+                <pre class="license-text">Elastic License 2.0
 
-Elastic License 2.0
+URL: https://www.elastic.co/licensing/elastic-license
 
 ## Acceptance
 
@@ -11673,8 +12079,6 @@ these terms.
 **use** means anything you do with the software requiring one of your licenses.
 
 **trademark** means trademarks, service marks, and similar rights.
-
---------------------------------------------------------------------------------
 </pre>
             </li>
             <li class="license">
@@ -13682,6 +14086,34 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRES
                 <pre class="license-text">MIT License
 
 Copyright (c) [2019] [Changseok Han]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/besok/jsonpath-rust ">jsonpath-rust</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) [2021] [Boris Zhguchev]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal


### PR DESCRIPTION
This PR adds an OTLP metrics exporter for a future Apollo pipeline that can compliment the existing protobuf format.
It is currently disabled by default.

It is a slimmed down version of #3354 that hopefully is not controversial.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
