### PR TITLE
docs: Clarify that hot-reload does not affect Uplink-delivered config/schema

### DIFF
--- a/.changesets/docs_abernix_hot_reload_clarify.md
+++ b/.changesets/docs_abernix_hot_reload_clarify.md
@@ -1,4 +1,4 @@
-### docs: Clarify that hot-reload does not affect Uplink-delivered config/schema ([PR #3596](https://github.com/apollographql/router/pull/3596))
+### Clarify that hot-reload does not affect Uplink-delivered config/schema ([PR #3596](https://github.com/apollographql/router/pull/3596))
 
 This documentation adjustment (and small CLI help change) tries to clarify some confusion around the `--hot-reload` command line argument and the scope of it's operation.
 

--- a/.changesets/docs_abernix_hot_reload_clarify.md
+++ b/.changesets/docs_abernix_hot_reload_clarify.md
@@ -1,0 +1,14 @@
+### docs: Clarify that hot-reload does not affect Uplink-delivered config/schema ([PR #3596](https://github.com/apollographql/router/pull/3596))
+
+This documentation adjustment (and small CLI help change) tries to clarify some confusion around the `--hot-reload` command line argument and the scope of it's operation.
+
+Concretely, the supergraph and configuration that is delivered through a [GraphOS Launch](https://www.apollographql.com/docs/graphos/delivery/launches/) (and delivered through Uplink) is _always_ loaded immediately and will take effect as soon as possible.
+
+On the other hand, files that are provided locally - e.g., `--config ./file.yaml` and `--supergraph ./supergraph.graphql` - are only reloaded:
+
+- If `--hot-reload` is passed (or if another flag infers `--hot-reload`, as is the case with `--dev`) and a supergraph or configuration is changed; or
+- When the router process is sent a SIGHUP.
+
+Otherwise, files provided locally to the router are only re-started if the router process is completely restarted.
+
+By [@abernix](https://github.com/abernix) in https://github.com/apollographql/router/pull/3596

--- a/README.md
+++ b/README.md
@@ -26,44 +26,37 @@ specified via flag, either by an absolute path, or a path relative to the curren
 directory.
 
 ```
-USAGE:
-    router [OPTIONS] [SUBCOMMAND]
+Usage:
 
-OPTIONS:
-        --apollo-uplink-endpoints <APOLLO_UPLINK_ENDPOINTS>
-            The endpoints (comma separated) polled to fetch the latest supergraph schema [env:
-            APOLLO_UPLINK_ENDPOINTS=]
+Commands:
+  config  Configuration subcommands
+  help    Print this message or the help of the given subcommand(s)
 
-        --apollo-uplink-poll-interval <APOLLO_UPLINK_POLL_INTERVAL>
-            The time between polls to Apollo uplink. Minimum 10s [env: APOLLO_UPLINK_POLL_INTERVAL=]
-            [default: 10s]
-
-        --apollo-uplink-timeout <APOLLO_UPLINK_TIMEOUT>
-            The timeout for each of the polls to Apollo Uplink. [env: APOLLO_UPLINK_TIMEOUT=]
-            [default: 30s]
-
-    -c, --config <CONFIG_PATH>
-            Configuration location relative to the project directory [env:
-            APOLLO_ROUTER_CONFIG_PATH=]
-
-    -h, --help
-            Print help information
-
-        --hot-reload
-            Reload configuration and schema files automatically [env: APOLLO_ROUTER_HOT_RELOAD=]
-
-        --log <LOG_LEVEL>
-            Log level (off|error|warn|info|debug|trace) [env: APOLLO_ROUTER_LOG=] [default: info]
-
-    -s, --supergraph <SUPERGRAPH_PATH>
-            Schema location relative to the project directory [env: APOLLO_ROUTER_SUPERGRAPH_PATH=]
-
-    -V, --version
-            Display version and exit
-
-SUBCOMMANDS:
-    config    Configuration subcommands
-    help      Print this message or the help of the given subcommand(s)
+Options:
+      --log <LOG_LEVEL>
+          Log level (off|error|warn|info|debug|trace) [env: APOLLO_ROUTER_LOG=] [default: info]
+      --hot-reload
+          Reload locally provided configuration and supergraph files automatically.  This only affects watching of local files and does not affect supergraphs and configuration provided by GraphOS through Uplink, which is always reloaded immediately [env: APOLLO_ROUTER_HOT_RELOAD=]
+  -c, --config <CONFIG_PATH>
+          Configuration location relative to the project directory [env: APOLLO_ROUTER_CONFIG_PATH=]
+      --dev
+          Enable development mode [env: APOLLO_ROUTER_DEV=]
+  -s, --supergraph <SUPERGRAPH_PATH>
+          Schema location relative to the project directory [env: APOLLO_ROUTER_SUPERGRAPH_PATH=]
+      --apollo-uplink-endpoints <APOLLO_UPLINK_ENDPOINTS>
+          The endpoints (comma separated) polled to fetch the latest supergraph schema [env: APOLLO_UPLINK_ENDPOINTS=]
+      --apollo-uplink-poll-interval <APOLLO_UPLINK_POLL_INTERVAL>
+          The time between polls to Apollo uplink. Minimum 10s [env: APOLLO_UPLINK_POLL_INTERVAL=] [default: 10s]
+      --anonymous-telemetry-disabled
+          Disable sending anonymous usage information to Apollo [env: APOLLO_TELEMETRY_DISABLED=]
+      --apollo-uplink-timeout <APOLLO_UPLINK_TIMEOUT>
+          The timeout for an http call to Apollo uplink. Defaults to 30s [env: APOLLO_UPLINK_TIMEOUT=] [default: 30s]
+      --listen <LISTEN_ADDRESS>
+          The listen address for the router. Overrides `supergraph.listen` in router.yaml [env: APOLLO_ROUTER_LISTEN_ADDRESS=]
+  -V, --version
+          Display version and exit
+  -h, --help
+          Print help
 ```
 
 ## Who is Apollo?

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -159,7 +159,7 @@ pub struct Opt {
     )]
     log_level: String,
 
-    /// Reload configuration and schema files automatically.
+    /// Reload locally provided configuration and supergraph files automatically.  This only affects watching of local files and does not affect supergraphs and configuration provided by GraphOS through Uplink, which is always reloaded immediately.
     #[clap(
         alias = "hr",
         long = "hot-reload",

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -139,7 +139,7 @@ If set, the Apollo Router runs in dev mode to help with local development.
 </td>
 <td>
 
-If set, the router watches for changes to its schema and configuration files and reloads them automatically without downtime.
+If set, the router watches for changes to its configuration file, and any supergraph file passed with `--supergraph` and reloads them automatically without downtime.  This only affects local files provided to the Router.  The supergraph and configuration provided from GraphOS via Launches (and delivered via Uplink) are _always_ loaded automatically, irregardless of this setting.
 
 </td>
 </tr>

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -139,7 +139,7 @@ If set, the Apollo Router runs in dev mode to help with local development.
 </td>
 <td>
 
-If set, the router watches for changes to its configuration file, and any supergraph file passed with `--supergraph` and reloads them automatically without downtime.  This only affects local files provided to the Router.  The supergraph and configuration provided from GraphOS via Launches (and delivered via Uplink) are _always_ loaded automatically, irregardless of this setting.
+If set, the router watches for changes to its configuration file and any supergraph file passed with `--supergraph` and reloads them automatically without downtime.  This setting only affects local files provided to the router.  The supergraph and configuration provided from GraphOS via Launches (and delivered via Uplink) are _always_ loaded automatically, regardless of this setting.
 
 </td>
 </tr>


### PR DESCRIPTION
The supergraph and configuration that is deliverd by Uplink is always delivered to a running Router and will result in a hot-reload.  Files that are provided locally - e.g., `--config ./file.yaml` and `--supergraph ./supergraph.graphql` are ONLY reloaded via file-watching mechanisms if the `--hot-reload` is passed, or if another flag infers `--hot-reload` (as is the case with `--dev`).
