### PR TITLE
adding the ability to define extraLabels for the kubernetes Service object

### DIFF
--- a/.changesets/feat_add_service_extraLabels_to_helm_chart.md
+++ b/.changesets/feat_add_service_extraLabels_to_helm_chart.md
@@ -1,0 +1,5 @@
+### Helm: exposes extraLabels object for Service labels
+
+You can now set extraLabels on the Service object in the helm chart.
+
+By [@bjoernw](https://github.com/bjoernw) in https://github.com/apollographql/router/pull/3600

--- a/helm/chart/router/templates/_helpers.tpl
+++ b/helm/chart/router/templates/_helpers.tpl
@@ -112,7 +112,9 @@ extraLabels:
 ```
 */}}
 {{- define "common.templatizeExtraLabels" -}}
-{{- range $key, $value := .Values.extraLabels }}
-{{ printf "%s: %s" $key (include  "common.tplvalues.render" ( dict "value" $value "context" $))}}
+{{- $extraLabels := .extraLabels -}}
+{{- $ctx := .context -}}
+{{- range $key, $value := $extraLabels }}
+{{ printf "%s: %s" $key (include "common.tplvalues.render" (dict "value" $value "context" $ctx)) }}
 {{- end -}}
 {{- end -}}

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "router.labels" . | nindent 4 }}
     {{- if .Values.extraLabels }}
-    {{- include "common.templatizeExtraLabels" . | nindent 4 }}
+    {{ include "common.templatizeExtraLabels" (dict "extraLabels" .Values.extraLabels "context" $) | nindent 4 }}
     {{- end }}
   {{/* There may not be much configuration so check that there is something */}}
   {{- if (((((.Values.router).configuration).telemetry).metrics).prometheus).enabled }}
@@ -35,7 +35,7 @@ spec:
       labels:
         {{- include "router.selectorLabels" . | nindent 8 }}
         {{- if .Values.extraLabels }}
-        {{- include "common.templatizeExtraLabels" . | nindent 8 }}
+        {{ include "common.templatizeExtraLabels" (dict "extraLabels" .Values.extraLabels "context" $) | nindent 8 }}
         {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/helm/chart/router/templates/service.yaml
+++ b/helm/chart/router/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "router.labels" . | nindent 4 }}
     {{- if .Values.service.extraLabels }}
-    {{ include "common.templatizeExtraLabels" (dict "extraLabels" .Values.service.extraLabels "context" $) | indent 4 }}
+    {{ include "common.templatizeExtraLabels" (dict "extraLabels" .Values.service.extraLabels "context" $) | nindent 4 }}
     {{- end }}
   {{- with .Values.service.annotations }}
   annotations:

--- a/helm/chart/router/templates/service.yaml
+++ b/helm/chart/router/templates/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "router.fullname" . }}
   labels:
     {{- include "router.labels" . | nindent 4 }}
+    {{- if .Values.service.extraLabels }}
+    {{ include "common.templatizeExtraLabels" (dict "extraLabels" .Values.service.extraLabels "context" $) | indent 4 }}
+    {{- end }}
   {{- with .Values.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/helm/chart/router/values.yaml
+++ b/helm/chart/router/values.yaml
@@ -139,6 +139,7 @@ service:
   type: ClusterIP
   port: 80
   annotations: {}
+  extraLabels: {}
 
 serviceMonitor:
   enabled: false


### PR DESCRIPTION
*Description here*
I have a use-case where I need to set specific labels on the Service object. Had to refactor the helper method a bit to make it take a dict instead of hardcoding it to `.Values.extraLabels`.

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
