### PR TITLE
supergraph coprocessor followup, with docs update and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ Supergraph request contains:
 * variables
 * extensions
 
-Supergraph reqponse contains:
+Supergraph response contains:
 * label
 * data
 * path

--- a/apollo-router/src/plugins/coprocessor/supergraph.rs
+++ b/apollo-router/src/plugins/coprocessor/supergraph.rs
@@ -31,8 +31,6 @@ pub(super) struct SupergraphRequestConf {
     pub(super) body: bool,
     /// Send the SDL
     pub(super) sdl: bool,
-    /// Send the path
-    pub(super) path: bool,
     /// Send the method
     pub(super) method: bool,
 }
@@ -190,6 +188,8 @@ where
         .then(|| serde_json::from_slice::<serde_json::Value>(&bytes))
         .transpose()?;
     let context_to_send = request_config.context.then(|| request.context.clone());
+    let sdl_to_send = request_config.sdl.then(|| sdl.clone().to_string());
+    let method = request_config.method.then(|| parts.method.to_string());
 
     let payload = Externalizable::supergraph_builder()
         .stage(PipelineStep::SupergraphRequest)
@@ -198,8 +198,8 @@ where
         .and_headers(headers_to_send)
         .and_body(body_to_send)
         .and_context(context_to_send)
-        .method(parts.method.to_string())
-        .sdl(sdl.to_string())
+        .and_method(method)
+        .and_sdl(sdl_to_send)
         .build();
 
     tracing::debug!(?payload, "externalized output");

--- a/apollo-router/src/plugins/coprocessor/supergraph.rs
+++ b/apollo-router/src/plugins/coprocessor/supergraph.rs
@@ -551,7 +551,6 @@ mod tests {
                 body: true,
                 sdl: false,
                 method: false,
-                path: false,
             },
             response: Default::default(),
         };
@@ -685,7 +684,6 @@ mod tests {
                 body: true,
                 sdl: false,
                 method: false,
-                path: false,
             },
             response: Default::default(),
         };

--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -98,7 +98,6 @@ coprocessor:
       body: false
       context: false
       sdl: false
-      path: false
       method: false
     response: # By including this key, the `SupergraphService` sends a coprocessor request whenever it's about to send response data to a client (including incremental data via @defer).
       headers: true


### PR DESCRIPTION
This is a followup to #3408 that:
- removes the path variable,
- makes sure we only send the sdl and method if they're enabled in the configuration
- updates the documentation to reflect that.

This doesn't need a changelog entry because it is covered by the previous PR.