### PR TITLE
chore(deps): separate out apollo-rs packages from renovations

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -117,7 +117,7 @@
       "groupSlug": "rust-apollo-rs-updates",
       "matchManagers": ["cargo"],
       "automerge": false
-    }
+    },
     // We'll review these in a PR of their own since it has the most direct runtime
     // implications on users that we'd like to be very intentional about.
     {

--- a/renovate.json5
+++ b/renovate.json5
@@ -106,6 +106,18 @@
       "groupSlug": "cargo-tracing-packages",
       "dependencyDashboardApproval": true
     },
+    // Our own `apollo-` packages deserve to get front-and-center treatment.
+    // We'll put them in their own PR to facilitate workflows that surface
+    // their changes earlier, and get us dog-fooding them quicker.
+    // They also have a small proclivity to require more hands-on changes
+    // since they're pre-0.x and we use them so extensively.
+    {
+      "matchPackagePatterns": ["^apollo-"],
+      "groupName": "apollo-rs crates",
+      "groupSlug": "rust-apollo-rs-updates",
+      "matchManagers": ["cargo"],
+      "automerge": false
+    }
     // We'll review these in a PR of their own since it has the most direct runtime
     // implications on users that we'd like to be very intentional about.
     {


### PR DESCRIPTION
Our own `apollo-` packages deserve to get front-and-center treatment.  This changes them  to be in their own PR — just like router-bridge — to facilitate workflows that surface their changes earlier, and get us dog-fooding them quicker.  (At the very least, become aware of their updates!).

They also have a small proclivity to require more hands-on changes since they're pre-0.x and we use them so extensively, so this will avoid them blocking the other dep bumps landing.