### PR TITLE
docs: Fix incorrect formatting in authn-subgraph.mdx

### DIFF
--- a/docs/source/configuration/authn-subgraph.mdx
+++ b/docs/source/configuration/authn-subgraph.mdx
@@ -17,33 +17,30 @@ Subgraph requests are signed using [HTTP Authorization headers](https://docs.aws
 
 ### Configuration example
 
-
-
 The example below shows how to use a default credentials chain for all subgraphs, except for the `products` subgraph, which uses  hardcoded credentials:
 
-    ```yaml title="router.yaml"
-    authentication:
-      subgraph:
-        all: # configuration that will apply to all subgraphs
-          aws_sig_v4:
-            default_chain:
-              profile_name: "my-test-profile" # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#ec2-instance-profile
-              region: "us-east-1" # https://docs.aws.amazon.com/general/latest/gr/rande.html
-              service_name: "lambda" # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-services-that-work-with-iam.html
-              assume_role: # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
-                role_arn: "test-arn"
-                session_name: "test-session"
-                external_id: "test-id"
-        subgraphs:
-          products:
-            aws_sig_v4:
-              hardcoded: # Not recommended, prefer using default_chain as shown above
-                access_key_id: "my-access-key"
-                secret_access_key: "my-secret-access-key"
-                region: "us-east-1"
-                service_name: "vpc-lattice-svcs" # "s3", "lambda" etc.
-    ```
-
+```yaml title="router.yaml"
+authentication:
+  subgraph:
+    all: # configuration that will apply to all subgraphs
+      aws_sig_v4:
+        default_chain:
+          profile_name: "my-test-profile" # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#ec2-instance-profile
+          region: "us-east-1" # https://docs.aws.amazon.com/general/latest/gr/rande.html
+          service_name: "lambda" # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-services-that-work-with-iam.html
+          assume_role: # https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html
+            role_arn: "test-arn"
+            session_name: "test-session"
+            external_id: "test-id"
+    subgraphs:
+      products:
+        aws_sig_v4:
+          hardcoded: # Not recommended, prefer using default_chain as shown above
+            access_key_id: "my-access-key"
+            secret_access_key: "my-secret-access-key"
+            region: "us-east-1"
+            service_name: "vpc-lattice-svcs" # "s3", "lambda" etc.
+```
 
 ### Default chain authentication
 


### PR DESCRIPTION
It appears that the YAML was indented a bit too much causing the YAML itself to be a code-fence (based on markdown indentation rules 🤣 )

Fixes #3619
