### PR TITLE
chore(deps): Update `base64` package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
  "aws-sigv4",
  "aws-types",
  "axum",
- "base64 0.20.0",
+ "base64 0.21.2",
  "brotli",
  "buildstructor 0.5.3",
  "bytes",
@@ -1025,12 +1025,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -66,7 +66,7 @@ async-compression = { version = "0.4.1", features = [
 async-trait = "0.1.73"
 atty = "0.2.14"
 axum = { version = "0.6.20", features = ["headers", "json", "original-uri"] }
-base64 = "0.20.0"
+base64 = "0.21.2"
 buildstructor = "0.5.3"
 bytes = "1.4.0"
 clap = { version = "4.3.23", default-features = false, features = [

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
 
+use base64::prelude::BASE64_URL_SAFE_NO_PAD;
+use base64::Engine as _;
 use jsonwebtoken::encode;
 use jsonwebtoken::get_current_timestamp;
 use jsonwebtoken::jwk::CommonParameters;
@@ -723,10 +725,6 @@ async fn issuer_check() {
 
     let encoding_key = EncodingKey::from_ec_der(&signing_key.to_pkcs8_der().unwrap().to_bytes());
 
-    let url_safe_engine = base64::engine::fast_portable::FastPortable::from(
-        &base64::alphabet::URL_SAFE,
-        base64::engine::fast_portable::NO_PAD,
-    );
     let jwk = Jwk {
         common: CommonParameters {
             public_key_use: Some(PublicKeyUse::Signature),
@@ -738,8 +736,8 @@ async fn issuer_check() {
         algorithm: AlgorithmParameters::EllipticCurve(EllipticCurveKeyParameters {
             key_type: EllipticCurveKeyType::EC,
             curve: EllipticCurve::P256,
-            x: base64::encode_engine(point.x().unwrap(), &url_safe_engine),
-            y: base64::encode_engine(point.y().unwrap(), &url_safe_engine),
+            x: BASE64_URL_SAFE_NO_PAD.encode(point.x().unwrap()),
+            y: BASE64_URL_SAFE_NO_PAD.encode(point.y().unwrap()),
         }),
     };
 

--- a/apollo-router/src/plugins/rhai/engine.rs
+++ b/apollo-router/src/plugins/rhai/engine.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::SystemTime;
 
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine as _;
 use http::header::InvalidHeaderName;
 use http::uri::Authority;
 use http::uri::Parts;
@@ -84,13 +86,17 @@ impl<T> OptionDance<T> for SharedMut<T> {
 mod router_base64 {
     #[rhai_fn(pure, return_raw)]
     pub(crate) fn decode(input: &mut ImmutableString) -> Result<String, Box<EvalAltResult>> {
-        String::from_utf8(base64::decode(input.as_bytes()).map_err(|e| e.to_string())?)
-            .map_err(|e| e.to_string().into())
+        String::from_utf8(
+            BASE64_STANDARD
+                .decode(input.as_bytes())
+                .map_err(|e| e.to_string())?,
+        )
+        .map_err(|e| e.to_string().into())
     }
 
     #[rhai_fn(pure)]
     pub(crate) fn encode(input: &mut ImmutableString) -> String {
-        base64::encode(input.as_bytes())
+        BASE64_STANDARD.encode(input.as_bytes())
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -7,6 +7,8 @@ use std::time::SystemTime;
 use std::time::SystemTimeError;
 
 use async_trait::async_trait;
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine as _;
 use derivative::Derivative;
 use futures::future::BoxFuture;
 use futures::FutureExt;
@@ -642,7 +644,7 @@ fn preprocess_errors(t: &mut proto::reports::trace::Node, error_config: &ErrorCo
 }
 
 pub(crate) fn decode_ftv1_trace(string: &str) -> Option<proto::reports::Trace> {
-    let bytes = base64::decode(string).ok()?;
+    let bytes = BASE64_STANDARD.decode(string).ok()?;
     proto::reports::Trace::decode(Cursor::new(bytes)).ok()
 }
 
@@ -840,6 +842,8 @@ impl ChildNodes for Vec<TreeData> {
 
 #[cfg(test)]
 mod test {
+    use base64::prelude::BASE64_STANDARD;
+    use base64::Engine as _;
     use opentelemetry::Value;
     use prost::Message;
     use serde_json::json;
@@ -1001,7 +1005,7 @@ mod test {
     #[test]
     fn test_extract_ftv1_trace() {
         let trace = Trace::default();
-        let encoded = base64::encode(trace.encode_to_vec());
+        let encoded = BASE64_STANDARD.encode(trace.encode_to_vec());
         assert_eq!(
             *extract_ftv1_trace(
                 &Value::String(encoded.into()),

--- a/apollo-router/tests/apollo_reports.rs
+++ b/apollo-router/tests/apollo_reports.rs
@@ -13,6 +13,8 @@ use axum::body::Bytes;
 use axum::routing::post;
 use axum::Extension;
 use axum::Json;
+use base64::prelude::BASE64_STANDARD;
+use base64::Engine as _;
 use flate2::read::GzDecoder;
 use http::header::ACCEPT;
 use once_cell::sync::Lazy;
@@ -113,7 +115,7 @@ async fn get_router_service(mocked: bool) -> BoxCloneService {
 }
 
 fn encode_ftv1(trace: Trace) -> String {
-    base64::encode(trace.encode_to_vec())
+    BASE64_STANDARD.encode(trace.encode_to_vec())
 }
 
 macro_rules! assert_report {


### PR DESCRIPTION
This follows up my https://github.com/apollographql/router/pull/3624, which is related to bumping dependencies as is the case with https://github.com/apollographql/router/pull/3628 and https://github.com/apollographql/router/pull/2665 before that.

My previous PR didn't bump some of the dependency changes that required additional changes, but this starts chipping away at that, first with `base64`!

(Also improving my own Rust abilities. ;))
