### PR TITLE
chore(deps): update jsonschema to 0.17.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2357,9 +2357,9 @@ dependencies = [
 
 [[package]]
 name = "fancy-regex"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0678ab2d46fa5195aaf59ad034c083d351377d4af57f3e073c074d0da3e3c766"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set",
  "regex",
@@ -2503,9 +2503,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.12.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa5de57a62c2440ece64342ea59efb7171aa7d016faf8dfcb8795066a17146b"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
 dependencies = [
  "lazy_static",
  "num",
@@ -3344,9 +3344,9 @@ dependencies = [
 
 [[package]]
 name = "iso8601"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296af15e112ec6dc38c9fd3ae027b5337a75466e8eed757bd7d5cf742ea85eb6"
+checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
 dependencies = [
  "nom",
 ]
@@ -3418,21 +3418,22 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca9e2b45609132ae2214d50482c03aeee78826cd6fd53a8940915b81acedf16"
+checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
 dependencies = [
  "ahash",
  "anyhow",
- "base64 0.13.1",
+ "base64 0.21.2",
  "bytecount",
  "fancy-regex",
  "fraction",
+ "getrandom 0.2.10",
  "iso8601",
  "itoa",
- "lazy_static",
  "memchr",
  "num-cmp",
+ "once_cell",
  "parking_lot 0.12.1",
  "percent-encoding",
  "regex",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -103,7 +103,7 @@ indexmap = { version = "2.0.0", features = ["serde"] }
 itertools = "0.11.0"
 jsonpath_lib = "0.3.0"
 jsonpath-rust = "0.3.1"
-jsonschema = { version = "0.16.1", default-features = false }
+jsonschema = { version = "0.17.1", default-features = false }
 jsonwebtoken = "8.3.0"
 lazy_static = "1.4.0"
 libc = "0.2.147"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_bad_type.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__line_precise_config_errors_bad_type.snap
@@ -10,6 +10,6 @@ configuration had errors:
     # The socket address and port to listen on
     # Defaults to 127.0.0.1:4000
     listen: true
-            ^----- true is not valid under any of the given schemas
+            ^----- true is not valid under any of the schemas listed in the 'anyOf' keyword
 
 


### PR DESCRIPTION
This follows up my https://github.com/apollographql/router/pull/3624, which
is related to bumping dependencies as is the case with
https://github.com/apollographql/router/pull/3628 and
https://github.com/apollographql/router/pull/2665 before that.

My previous PR didn't bump some of the dependency changes that required
additional changes, but this starts chipping away at that.

This PR updates `jsonschema`
