### PR TITLE
chore: Enable checking for kubernetes 1.28.0 in kubeconform

### DIFF
--- a/.changesets/maint_garypen_3587_enable_1_28_0.md
+++ b/.changesets/maint_garypen_3587_enable_1_28_0.md
@@ -1,0 +1,7 @@
+### Enable checking for kubernetes 1.28.0 in kubeconform ([Issue #3587](https://github.com/apollographql/router/issues/3587))
+
+Support has now been added for kubernetes `1.28.0` and we can re-enable checking.
+
+This is reverting the change from #3584.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3638

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,10 +373,6 @@ commands:
             # Use helm to template our chart against all kube versions
             TEMPLATE_DIR=$(mktemp -d)
             for kube_version in ${CURRENT_KUBE_VERSIONS}; do
-              # Skip 1.28.0 until supported by kubeconform
-              if [[ "${kube_version}" == "1.28.0" ]]; then
-                  continue
-              fi
               # Use helm to template our chart against kube_version
               helm template --kube-version "${kube_version}" router helm/chart/router --set autoscaling.enabled=true > "${TEMPLATE_DIR}/router-${kube_version}.yaml"
 


### PR DESCRIPTION
Support has now been added for kubernetes `1.28.0` and we can re-enable checking.

This is reverting the change from #3584.

fixes: #3587

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
