### PR TITLE
Temporarily allow webpki in deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -29,7 +29,10 @@ git-fetch-with-cli = true
 # while https://github.com/chronotope/chrono/issues/499 is open.
 # We need to keep track of this issue, and make sure `tracing-subscriber` is updated
 # We will then be able to remove this
-ignore = ["RUSTSEC-2020-0159", "RUSTSEC-2020-0071"]
+#
+# RUSTSEC-2023-0052 and RUSTSEC-2023-0053 are pending a webpki update that is tracked by https://github.com/apollographql/router/issues/3645
+# and will be fixed by https://github.com/apollographql/router/pull/3643
+ignore = ["RUSTSEC-2020-0159", "RUSTSEC-2020-0071", "RUSTSEC-2023-0053", "RUSTSEC-2023-0052"]
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:


### PR DESCRIPTION
Part of a fix for #3645

This changeset allows us to keep working on the router while #3643 deals with the issue. Note the initial issue is not critical for the router since operators have agency on which subgraphs they make https requests to.
