### PR TITLE
Enable Apollo OTLP metrics export

### DIFF
--- a/.changesets/maint_frog_deejay_motorcar_planetarium.md
+++ b/.changesets/maint_frog_deejay_motorcar_planetarium.md
@@ -1,8 +1,8 @@
-### Add OTLP exporter for Apollo metrics ([PR #3354](https://github.com/apollographql/router/pull/3354))
+### Add OTLP exporter for Apollo metrics ([PR #3354](https://github.com/apollographql/router/pull/3354), [PR #3651](https://github.com/apollographql/router/pull/3651))
 
-This PR adds an OTLP metrics exporter for a future Apollo pipeline that can compliment the existing protobuf format. It is currently disabled by default.
+This PR adds an OTLP metrics exporter for a Apollo pipeline that can compliment the existing protobuf format.
 
 Note that new metrics of the format `apollo.router.*` are currently not stable.
 Once we have added enough metrics to ensure that we are consistent then they will be stabilized and documented.
 
-By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3354
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3354 and https://github.com/apollographql/router/pull/3651

--- a/apollo-router/src/plugins/telemetry/metrics/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo.rs
@@ -62,9 +62,9 @@ impl MetricsConfigurator for Config {
                     batch_processor,
                 )?;
                 // env variable EXPERIMENTAL_APOLLO_OTLP_METRICS_ENABLED will disappear without warning in future
-                if let Some("true") = std::env::var("EXPERIMENTAL_APOLLO_OTLP_METRICS_ENABLED")
-                    .ok()
-                    .as_deref()
+                if std::env::var("EXPERIMENTAL_APOLLO_OTLP_METRICS_ENABLED")
+                    .unwrap_or_else(|_| "true".to_string())
+                    == "true"
                 {
                     builder = Self::configure_apollo_otlp_metrics(
                         builder,


### PR DESCRIPTION
We're creating an OTLP metrics pipeline to compliment the existing Protobuf based metrics.
This flips the switch to enable this by default.
It uses the existing endpoint, so should require no extra config for users, and will allow us to add useful metrics faster in future.


<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
