### PR TITLE
docs: add persisted query configuration options info

### DIFF
--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -488,6 +488,12 @@ You can configure certain caching behaviors for generated query plans and APQ (b
 
 **If you have a GraphOS Enterprise plan,** you can also configure a Redis-backed _distributed_ cache that enables multiple router instances to share cached values. For details, see [Distributed caching in the Apollo Router](./distributed-caching/).
 
+### Safelisting with persisted queries
+
+You can enhance your graph's security by maintaining a persisted query list (PQL), an operation safelist made by your first-party apps. As opposed to automatic persisted queries (APQ) where operations are automatically cached, operations must be preregistered to the PQL. The router than checks incoming requests against the PQL.
+
+See [Safelisting with persisted queries](./persisted-queries) for more information.
+
 ### HTTP header rules
 
 See [Sending HTTP headers to subgraphs](./header-propagation/).
@@ -683,10 +689,6 @@ fragment ProductVariation on Product {
 Note that the router calculates the recursion depth for each operation and fragment _separately_.  Even if a fragment is included in an operation, that fragment's recursion depth does not contribute to the _operation's_ recursion depth.
 
 > In versions of the Apollo Router prior to 1.17, this limit was defined via the config option `experimental_parser_recursion_limit`.
-
-### Safelisting
-
-See [Safelisting with persisted queries](./persisted-queries).
 
 ### GraphQL Validation Mode
 

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -684,6 +684,10 @@ Note that the router calculates the recursion depth for each operation and fragm
 
 > In versions of the Apollo Router prior to 1.17, this limit was defined via the config option `experimental_parser_recursion_limit`.
 
+### Safelisting
+
+See [Safelisting with persisted queries](./persisted-queries).
+
 ### GraphQL Validation Mode
 
 We are experimenting with a new GraphQL validation implementation written in Rust. The legacy implementation is part of the JavaScript query planner. This is part of a project to remove JavaScript from the Router to improve performance and memory behavior.

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -490,7 +490,7 @@ You can configure certain caching behaviors for generated query plans and APQ (b
 
 ### Safelisting with persisted queries
 
-You can enhance your graph's security by maintaining a persisted query list (PQL), an operation safelist made by your first-party apps. As opposed to automatic persisted queries (APQ) where operations are automatically cached, operations must be preregistered to the PQL. The router than checks incoming requests against the PQL.
+You can enhance your graph's security by maintaining a persisted query list (PQL), an operation safelist made by your first-party apps. As opposed to automatic persisted queries (APQ) where operations are automatically cached, operations must be preregistered to the PQL. Once configured, the router checks incoming requests against the PQL.
 
 See [Safelisting with persisted queries](./persisted-queries) for more information.
 

--- a/docs/source/configuration/persisted-queries.mdx
+++ b/docs/source/configuration/persisted-queries.mdx
@@ -38,7 +38,7 @@ For more information on other configuration aspects, see the [GraphOS persisted 
 
 ### Configuration options
 
-The router provides four configuration options that you can combine to create the recommended [security levels](#router-security-levels). This section details each configuration option. Refer to the [security levels](#router-security-levels) section for sample YAML configurations.
+The router provides four configuration options that you can combine to create the recommended [security levels](#router-security-levels). This section details each configuration option. Refer to the [security levels](#router-security-levels) section for recommended combinations.
 
 #### `preview_persisted_queries`
 

--- a/docs/source/configuration/persisted-queries.mdx
+++ b/docs/source/configuration/persisted-queries.mdx
@@ -70,7 +70,11 @@ preview_persisted_queries:
   enabled: true
   safelist:
     enabled: true
+apq:
+  enabled: false
 ```
+
+> **Note:** To enable safelisting, you _must_ turn off [automatic persisted queries](./in-memory-caching#caching-automatic-persisted-queries-apq) (APQs). APQs let clients [register arbitrary operations at runtime](/graphos/operations/persisted-queries/#differences-from-automatic-persisted-queries) while safelisting restricts operations to those that have been explicitly preregistered.
 
 By default, the [`require_id`](#required_id) suboption is `false`, meaning the router accepts both operation IDs and operation strings as long as the operation is preregistered.
 
@@ -86,4 +90,8 @@ preview_persisted_queries:
   safelist:
     enabled: true
     require_id: true
+apq:
+  enabled: false
 ```
+
+> **Note:** To enable safelisting, you _must_ turn off [automatic persisted queries](./in-memory-caching#caching-automatic-persisted-queries-apq) (APQs). APQs let clients [register arbitrary operations at runtime](/graphos/operations/persisted-queries/#differences-from-automatic-persisted-queries) while safelisting restricts operations to those that have been explicitly preregistered.

--- a/docs/source/configuration/persisted-queries.mdx
+++ b/docs/source/configuration/persisted-queries.mdx
@@ -6,7 +6,7 @@ minVersion: 1.25.0
 
 <GraphOSEnterpriseRequired />
 
-<PreviewFeature contactLink="https://discordapp.com/channels/1022972389463687228/1143901714173407342">
+<PreviewFeature discordLink="https://discordapp.com/channels/1022972389463687228/1143901714173407342"/>
 
 <PQIntro />
 

--- a/docs/source/configuration/persisted-queries.mdx
+++ b/docs/source/configuration/persisted-queries.mdx
@@ -6,7 +6,7 @@ minVersion: 1.25.0
 
 <GraphOSEnterpriseRequired />
 
-<FeatureInPreview />
+<PreviewFeature contactLink="https://discordapp.com/channels/1022972389463687228/1143901714173407342">
 
 <PQIntro />
 

--- a/docs/source/configuration/persisted-queries.mdx
+++ b/docs/source/configuration/persisted-queries.mdx
@@ -51,7 +51,7 @@ preview_persisted_queries:
 
 #### `log_unknown`
 
-Adding `log_unknown: true` to `preview_persisted_queries` causes the router to log any operations not preregistered to the PQL.
+Adding `log_unknown: true` to `preview_persisted_queries` configures the router to log any incoming operations not preregistered to the PQL.
 
 ```yaml title="router.yaml"
 preview_persisted_queries:
@@ -59,7 +59,7 @@ preview_persisted_queries:
   log_unknown: true
 ```
 
-If used with the [`safelist`](#safelist) option, the router logs unregistered and rejected operations. If [`safelist.required_id`](#require_id) is turned on, operations can be rejected even when preregistered because they use operation IDs rather than operation strings.
+If used with the [`safelist`](#safelist) option, the router logs unregistered and rejected operations. With [`safelist.required_id`](#require_id) off, the only rejected operations are unregistered ones. If [`safelist.required_id`](#require_id) is turned on, operations can be rejected even when preregistered because they use operation IDs rather than operation strings.
 
 #### `safelist`
 
@@ -72,7 +72,7 @@ preview_persisted_queries:
     enabled: true
 ```
 
-By default, the [`require_id`](#required_id) suboption is `false`, meaning both operation IDs and operation strings are accepted.
+By default, the [`require_id`](#required_id) suboption is `false`, meaning the router accepts both operation IDs and operation strings as long as the operation is preregistered.
 
 #### `require_id`
 

--- a/docs/source/configuration/persisted-queries.mdx
+++ b/docs/source/configuration/persisted-queries.mdx
@@ -35,3 +35,55 @@ For more information on other configuration aspects, see the [GraphOS persisted 
 ### Router security levels
 
 <PQSecurityLevels />
+
+### Configuration options
+
+The router provides four configuration options that you can combine to create the recommended [security levels](#router-security-levels). This section details each configuration option. Refer to the [security levels](#router-security-levels) section for sample YAML configurations.
+
+#### `preview_persisted_queries`
+
+This base configuration enables the feature. All other configuration options build off this one.
+
+```yaml title="router.yaml"
+preview_persisted_queries:
+  enabled: true
+```
+
+#### `log_unknown`
+
+Adding `log_unknown: true` to `preview_persisted_queries` causes the router to log any operations not preregistered to the PQL.
+
+```yaml title="router.yaml"
+preview_persisted_queries:
+  enabled: true
+  log_unknown: true
+```
+
+If used with the [`safelist`](#safelist) option, the router logs unregistered and rejected operations. If [`safelist.required_id`](#require_id) is turned on, operations can be rejected even when preregistered because they use operation IDs rather than operation strings.
+
+#### `safelist`
+
+Adding `safelist: true` to `preview_persisted_queries` causes the router to reject any operations that haven't been preregistered to your PQL.
+
+```yaml title="router.yaml"
+preview_persisted_queries:
+  enabled: true
+  safelist:
+    enabled: true
+```
+
+By default, the [`require_id`](#required_id) suboption is `false`, meaning both operation IDs and operation strings are accepted.
+
+#### `require_id`
+
+Adding `require_id: true` to the `safelist` option causes the router to reject any operations that either:
+- haven't been preregistered to your PQL
+- use a full operation string rather than the operation ID
+
+```yaml title="router.yaml"
+preview_persisted_queries:
+  enabled: true
+  safelist:
+    enabled: true
+    require_id: true
+```


### PR DESCRIPTION
This PR adds information about persisted queries router configuration options. The "security levels" or "modes" were already documented, but this adds reference information about the individual options. I've purposefully put them after the modes, since those are likely to be more useful to readers.

I'm targeting `main` since this is only a docs change. LMK if that's not right.
