### PR TITLE
feat(apollo-router): add `QueryPlan.subgraph_fetches`

### DIFF
--- a/.changesets/feat_nicolas_subgraph_fetches.md
+++ b/.changesets/feat_nicolas_subgraph_fetches.md
@@ -1,0 +1,5 @@
+### Expose the number of subgraph fetches in `QueryPlan` ([#3658](https://github.com/apollographql/router/issues/3658))
+
+Add a new `subgraph_fetches` method for the `QueryPlan` type that exposes the number of expected subgraph fetches for a given query plan.
+
+By [@nmoutschen](https://github.com/nmoutschen) in https://github.com/apollographql/router/pull/3659

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -85,6 +85,10 @@ impl QueryPlan {
     pub fn contains_mutations(&self) -> bool {
         self.root.contains_mutations()
     }
+
+    pub fn subgraph_fetches(&self) -> usize {
+        self.root.subgraph_fetches()
+    }
 }
 
 // holds the query plan executon arguments that do not change between calls

--- a/apollo-router/src/query_planner/plan.rs
+++ b/apollo-router/src/query_planner/plan.rs
@@ -199,8 +199,9 @@ impl PlanNode {
                         .map(|n| n.node.as_ref().map_or(0, |n| n.subgraph_fetches()))
                         .sum::<usize>()
             }
+            // A `SubscriptionNode` makes a request to a subgraph, so counting it as 1
             PlanNode::Subscription { rest, .. } => {
-                rest.as_ref().map_or(0, |n| n.subgraph_fetches())
+                rest.as_ref().map_or(0, |n| n.subgraph_fetches()) + 1
             }
             // Compute the highest possible value for condition nodes
             PlanNode::Condition {

--- a/apollo-router/src/query_planner/plan.rs
+++ b/apollo-router/src/query_planner/plan.rs
@@ -186,6 +186,40 @@ impl PlanNode {
         }
     }
 
+    pub(crate) fn subgraph_fetches(&self) -> usize {
+        match self {
+            PlanNode::Sequence { nodes } => nodes.iter().map(|n| n.subgraph_fetches()).sum(),
+            PlanNode::Parallel { nodes } => nodes.iter().map(|n| n.subgraph_fetches()).sum(),
+            PlanNode::Fetch(_) => 1,
+            PlanNode::Flatten(node) => node.node.subgraph_fetches(),
+            PlanNode::Defer { primary, deferred } => {
+                primary.node.as_ref().map_or(0, |n| n.subgraph_fetches())
+                    + deferred
+                        .iter()
+                        .map(|n| n.node.as_ref().map_or(0, |n| n.subgraph_fetches()))
+                        .sum::<usize>()
+            }
+            PlanNode::Subscription { rest, .. } => {
+                rest.as_ref().map_or(0, |n| n.subgraph_fetches())
+            }
+            // Compute the highest possible value for condition nodes
+            PlanNode::Condition {
+                if_clause,
+                else_clause,
+                ..
+            } => std::cmp::max(
+                if_clause
+                    .as_ref()
+                    .map(|n| n.subgraph_fetches())
+                    .unwrap_or(0),
+                else_clause
+                    .as_ref()
+                    .map(|n| n.subgraph_fetches())
+                    .unwrap_or(0),
+            ),
+        }
+    }
+
     #[cfg(test)]
     /// Retrieves all the services used across all plan nodes.
     ///


### PR DESCRIPTION
*Description here*

Fixes #3658

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

Right now, I've set it to take the max possible value for `PlanNode::Condition`. An alternative would be to return the min-max possible values for the number of subgraph fetches instead. Let me know what you folks prefer.

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
