### PR TITLE
Fred doesn't seem to return an is_not_found error if the record does not exist

### DIFF
--- a/.changesets/fix_bryn_redis_cache_miss_log.md
+++ b/.changesets/fix_bryn_redis_cache_miss_log.md
@@ -1,8 +1,5 @@
-### Fred doesn't seem to return an is_not_found error if the error does not exist ([Issue #2876](https://github.com/apollographql/router/issues/2876))
+### Error no longer reported on Redis cache misses ([Issue #2876](https://github.com/apollographql/router/issues/2876))
 
-The Redis Fred client doesn't seem to deal with `nil` responses correctly returning a parse error instead of not found.
-This means that if there was a cache miss for a key, the Router would log a parse error.
-
-We now manually detect `nil` responses and treat them as a cache miss.
+The Router will no longer log an error in when fetching from Redis and the record doesn't exist. This affected APQ, QueryPlanning and experimental entity caching.
 
 By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3661

--- a/.changesets/fix_bryn_redis_cache_miss_log.md
+++ b/.changesets/fix_bryn_redis_cache_miss_log.md
@@ -1,0 +1,8 @@
+### Fred doesn't seem to return an is_not_found error if the error does not exist ([Issue #2876](https://github.com/apollographql/router/issues/2876))
+
+The Redis Fred client doesn't seem to deal with `nil` responses correctly returning a parse error instead of not found.
+This means that if there was a cache miss for a key, the Router would log a parse error.
+
+We now manually detect `nil` responses and treat them as a cache miss.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3661

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -1,3 +1,4 @@
+use fred::interfaces::RedisResult;
 use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
@@ -241,14 +242,26 @@ impl RedisCacheStorage {
     ) -> Option<RedisValue<V>> {
         tracing::trace!("getting from redis: {:?}", key);
 
-        self.inner
-            .get(key.to_string())
-            .await
-            .map_err(|e| {
-                tracing::error!("mget error: {}", e);
-                e
-            })
-            .ok()
+        let result: RedisResult<String> = self.inner.get(key.to_string()).await;
+        match result.as_ref().map(|s| s.as_str()) {
+            // Fred returns nil rather than an error with not_found
+            // See `RedisErrorKind::NotFound` for why this should work
+            // To work around this we first read the value as a string and then deal with the value explicitly
+            Ok("nil") => None,
+            Ok(value) => serde_json::from_str(value)
+                .map(RedisValue)
+                .map_err(|e| {
+                    tracing::error!("couldn't deserialize value from redis: {}", e);
+                    e
+                })
+                .ok(),
+            Err(e) => {
+                if !e.is_not_found() {
+                    tracing::error!("mget error: {}", e);
+                }
+                None
+            }
+        }
     }
 
     pub(crate) async fn get_multiple<K: KeyType, V: ValueType>(

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -1,8 +1,8 @@
-use fred::interfaces::RedisResult;
 use std::fmt;
 use std::sync::Arc;
 use std::time::Duration;
 
+use fred::interfaces::RedisResult;
 use fred::prelude::ClientLike;
 use fred::prelude::KeysInterface;
 use fred::prelude::RedisClient;


### PR DESCRIPTION
The fred client doesn't seem to deal with nil values correctly, and as opposed to returning an error for `is_not_found` it returns a parse error

Fixes #2876

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
