### PR TITLE
Fix config metrics path and test for subscription callbacks

### DIFF
--- a/.changesets/fix_bryn_fix_config_metrics.md
+++ b/.changesets/fix_bryn_fix_config_metrics.md
@@ -1,0 +1,5 @@
+### Fix config metrics path and test for subscription callbacks ([Issue #3687](https://github.com/apollographql/router/issues/3687))
+
+Detection of subscription callbacks has been fixed for internal Apollo metrics. This has no user facing impact.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3688

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -181,7 +181,7 @@ impl Metrics {
             opt.mode.passthrough,
             "$.mode.passthrough",
             opt.mode.callback,
-            "$.mode.callback",
+            "$.mode.preview_callback",
             opt.deduplication,
             "$[?(@.enable_deduplication == true)]",
             opt.max_opened,

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@subscriptions.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@subscriptions.router.yaml.snap
@@ -6,7 +6,7 @@ value.apollo.router.config.subscriptions:
   - 1
   - opt__deduplication__: "false"
     opt__max_opened__: "true"
-    opt__mode__callback__: "false"
+    opt__mode__callback__: "true"
     opt__mode__passthrough__: "true"
     opt__queue_capacity__: "true"
 


### PR DESCRIPTION
Fix Apollo metrics for detection of subscription callbacks.
Fixes #3687

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
