### PR TITLE
Fix memory leak caused by Arc circular reference in `Notify`

### DIFF
--- a/.changesets/fix_arc_config_mem_leak.md
+++ b/.changesets/fix_arc_config_mem_leak.md
@@ -1,4 +1,4 @@
-### Fix memory leak caused by Arc circular reference in `Notify` ([PR #3692](https://github.com/apollographql/router/pull/3692))
+### Fix memory leak caused by Arc circular reference in `Notify` ([Issue #3686](https://github.com/apollographql/router/issues/3686))
 
 A [memory leak](https://github.com/apollographql/router/issues/3686) caused by a [change](https://github.com/apollographql/router/pull/3341) to subscription handling was fixed.
 

--- a/.changesets/fix_arc_config_mem_leak.md
+++ b/.changesets/fix_arc_config_mem_leak.md
@@ -1,0 +1,5 @@
+### Fix memory leak caused by Arc circular reference in `Notify` ([PR #3692](https://github.com/apollographql/router/pull/3692))
+
+A [memory leak](https://github.com/apollographql/router/issues/3686) caused by a [change](https://github.com/apollographql/router/pull/3341) to subscription handling was fixed.
+
+By [@xuorig](https://github.com/xuorig) in https://github.com/apollographql/router/pull/3692

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -173,7 +173,7 @@ impl RouterSuperServiceFactory for YamlRouterFactory {
         if config_changed {
             configuration
                 .notify
-                .broadcast_configuration(configuration.clone());
+                .broadcast_configuration(Arc::downgrade(&configuration));
         }
 
         let schema = bridge_query_planner.schema();

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -427,22 +427,26 @@ async fn subscription_task(
                 }
             }
             Some(new_configuration) = configuration_updated_rx.next() => {
-                let plugins = match create_plugins(&new_configuration, &execution_service_factory.schema, None).await {
-                    Ok(plugins) => plugins,
-                    Err(err) => {
-                        tracing::error!("cannot re-create plugins with the new configuration (closing existing subscription): {err:?}");
-                        break;
-                    },
-                };
-                let subgraph_services = match create_subgraph_services(&plugins, &execution_service_factory.schema, &new_configuration).await {
-                    Ok(subgraph_services) => subgraph_services,
-                    Err(err) => {
-                        tracing::error!("cannot re-create subgraph service with the new configuration (closing existing subscription): {err:?}");
-                        break;
-                    },
-                };
-                let plugins = Arc::new(IndexMap::from_iter(plugins));
-                execution_service_factory = ExecutionServiceFactory { schema: execution_service_factory.schema.clone(), plugins: plugins.clone(), subgraph_service_factory: Arc::new(SubgraphServiceFactory::new(subgraph_services.into_iter().map(|(k, v)| (k, Arc::new(v) as Arc<dyn MakeSubgraphService>)).collect(), plugins.clone())) };
+                // If the configuration was dropped in the meantime, we ignore this update and will
+                // pick up the next one.
+                if let Some(conf) = new_configuration.upgrade() {
+                    let plugins = match create_plugins(&conf, &execution_service_factory.schema, None).await {
+                        Ok(plugins) => plugins,
+                        Err(err) => {
+                            tracing::error!("cannot re-create plugins with the new configuration (closing existing subscription): {err:?}");
+                            break;
+                        },
+                    };
+                    let subgraph_services = match create_subgraph_services(&plugins, &execution_service_factory.schema, &conf).await {
+                        Ok(subgraph_services) => subgraph_services,
+                        Err(err) => {
+                            tracing::error!("cannot re-create subgraph service with the new configuration (closing existing subscription): {err:?}");
+                            break;
+                        },
+                    };
+                    let plugins = Arc::new(IndexMap::from_iter(plugins));
+                    execution_service_factory = ExecutionServiceFactory { schema: execution_service_factory.schema.clone(), plugins: plugins.clone(), subgraph_service_factory: Arc::new(SubgraphServiceFactory::new(subgraph_services.into_iter().map(|(k, v)| (k, Arc::new(v) as Arc<dyn MakeSubgraphService>)).collect(), plugins.clone())) };
+                }
             }
             Some(new_schema) = schema_updated_rx.next() => {
                 if new_schema.raw_sdl != execution_service_factory.schema.raw_sdl {


### PR DESCRIPTION
The issue is described in detail here: https://github.com/apollographql/router/issues/3686

This PR uses `Weak` references to `Configuration` inside `Notify`'s broadcast channel. This was causing a memory leak on router reload.

If the `upgrade` in the `subscription_task` is not successful, we cannot update, so it is simply skipped this time, waiting for the next valid configuration broadcast.

I'm not sure what the best way to test this is within the router test suite. Happy to hear suggestions. I've validated it remediates the memory leak issue on our end.

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
