### PR TITLE
Uplink connections now reuse reqwest client

### DIFF
--- a/.changesets/maint_bryn_uplink_client.md
+++ b/.changesets/maint_bryn_uplink_client.md
@@ -1,0 +1,6 @@
+### Uplink connections now reuse reqwest client ([Issue #3333](https://github.com/apollographql/router/issues/3333))
+
+Previously uplink requests created a new reqwest client each time, this may cause CPU spikes especially on OSX.
+A single client will now be shared between requests of the same type. 
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3703


### PR DESCRIPTION
Previously uplink requests created a new reqwest client each time, this may cause CPU spikes especially on OSX.

Fixes #3333

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
