### PR TITLE
chore: removes unused introspector-gadget crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -232,16 +232,6 @@ dependencies = [
 
 [[package]]
 name = "apollo-encoder"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a67cf5282faa8a66c848e1f4aef139c3cfe307025029983d05b80f8360f41e8"
-dependencies = [
- "apollo-parser 0.5.3",
- "thiserror",
-]
-
-[[package]]
-name = "apollo-encoder"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b323dfc43b95a8806a401aed913e84db297162c6295bca620c0f57956cdb52cf"
@@ -278,7 +268,7 @@ dependencies = [
  "access-json",
  "anyhow",
  "apollo-compiler 0.11.1",
- "apollo-encoder 0.7.0",
+ "apollo-encoder",
  "apollo-parser 0.6.1",
  "arc-swap",
  "askama",
@@ -322,7 +312,6 @@ dependencies = [
  "hyper-rustls",
  "indexmap 2.0.0",
  "insta",
- "introspector-gadget",
  "itertools 0.11.0",
  "jsonpath-rust",
  "jsonpath_lib",
@@ -453,7 +442,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13ed94bb9de9f24da12ca2122b8eeaa7484d17b090dc84daaaba6b6ac2bee89b"
 dependencies = [
- "apollo-encoder 0.7.0",
+ "apollo-encoder",
  "apollo-parser 0.6.1",
  "arbitrary",
  "once_cell",
@@ -1003,17 +992,6 @@ dependencies = [
  "rustversion",
  "tower-layer",
  "tower-service",
-]
-
-[[package]]
-name = "backoff"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
-dependencies = [
- "getrandom 0.2.10",
- "instant",
- "rand 0.8.5",
 ]
 
 [[package]]
@@ -3324,23 +3302,6 @@ name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
-name = "introspector-gadget"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07e629cb6382fac6e1fb1560123f81438556e6fe4219fec939ad5ff4345d9fa"
-dependencies = [
- "apollo-encoder 0.5.1",
- "backoff",
- "graphql_client",
- "hyper",
- "reqwest",
- "serde",
- "serde_json",
- "thiserror",
- "tracing",
-]
 
 [[package]]
 name = "inventory"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -263,7 +263,6 @@ ecdsa = { version = "0.15.1", features = ["signing", "pem", "pkcs8"] }
 fred = { version = "6.3.1", features = ["enable-rustls", "no-client-setname"] }
 futures-test = "0.3.28"
 insta = { version = "1.31.0", features = ["json", "redactions", "yaml"] }
-introspector-gadget = "0.2.2"
 maplit = "1.0.2"
 memchr = { version = "2.6.2", default-features = false }
 mockall = "0.11.4"


### PR DESCRIPTION
This PR removes the `introspector-gadget` dependency from the `Cargo.toml` as I don't believe it's used by this crate anymore. If this passes I think I'd like to deprecate that crate and move it fully back into the Rover repository so it's easier to make changes to its implementation.