### PR TITLE
docs: fix broken links

### DIFF
--- a/.changesets/docs_fix_broken_links.md
+++ b/.changesets/docs_fix_broken_links.md
@@ -1,0 +1,5 @@
+### Fix broken links ([Issue #ISSUE_NUMBER](https://github.com/apollographql/router/issues/ISSUE_NUMBER))
+
+This documentation change fixes an incorrect anchor link in the [CORS documentation](https://www.apollographql.com/docs/router/configuration/cors/) and removes links to authorization docs which have not yet been released. 
+
+By [@Meschreiber](https://github.com/Meschreiber) in https://github.com/apollographql/router/pull/3711

--- a/.changesets/docs_fix_broken_links.md
+++ b/.changesets/docs_fix_broken_links.md
@@ -1,4 +1,4 @@
-### Fix broken links ([Issue #ISSUE_NUMBER](https://github.com/apollographql/router/issues/ISSUE_NUMBER))
+### Fix broken links
 
 This documentation change fixes an incorrect anchor link in the [CORS documentation](https://www.apollographql.com/docs/router/configuration/cors/) and removes links to authorization docs which have not yet been released. 
 

--- a/docs/source/configuration/cors.mdx
+++ b/docs/source/configuration/cors.mdx
@@ -19,7 +19,7 @@ By default, the Apollo Router enables _only_ Apollo Studio to initiate browser c
     * Use this option if your supergraph is a public API with arbitrarily many web app consumers.
     * With this option enabled, the router sends the [wildcard (`*`)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#directives) value for the `Access-Control-Allow-Origin` header. This enables _any_ website to initiate browser connections to it (but they can't provide cookies or other credentials).
 
-* You _must_ use the `origins` + `match_origins` option if clients need to [authenticate their requests with cookies](#passing-credentials-with-cors).
+* You _must_ use the `origins` + `match_origins` option if clients need to [authenticate their requests with cookies](#passing-credentials).
 
 The following snippet includes an example of each option (use either `allow_any_origin`, or `origins + match_origins`):
 

--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -901,7 +901,7 @@ Subsequent response chunks omit the `headers` and `statusCode` fields:
 
 ## Adding authorization claims via coprocessor
 
-To use the [authorization directives](../configuration/authorization#authorization-directives), a request needs to include **claims**—the details of its authentication and scope. The most straightforward way to add claims is with [JWT authentication](../configuration/./authn-jwt). You can also add claims with a [`RouterService` coprocessor](#how-it-works) since it hooks into the request lifecycle directly after the router has received a client request.
+For authorization purposes, your requests may need to include **claims**—the details of its authentication and scope. The most straightforward way to add claims is with [JWT authentication](../configuration/./authn-jwt). You can also add claims with a [`RouterService` coprocessor](#how-it-works) since it hooks into the request lifecycle directly after the router has received a client request.
 
 The router configuration needs to include at least these settings:
 
@@ -930,7 +930,7 @@ This configuration prompts the router to send an HTTP POST request to your copro
 }
 ```
 
-When your coprocessor receives this request from the router, it should add claims to the request's [`context`](#context) and return them in the response to the router. Specifically, the coprocessor should add an entry with a claims object. The key must be `apollo_authentication::JWT::claims`, and the value should be the claims required by the authorization directives you intend to use. For example, if you want to use [`@requireScopes`](../configuration/authorization#requiresscopes), the response may look something like this:
+When your coprocessor receives this request from the router, it should add claims to the request's [`context`](#context) and return them in the response to the router. Specifically, the coprocessor should add an entry with a claims object. The key must be `apollo_authentication::JWT::claims`, and the value should be the claims required for authorization. For example:
 
 ```json
 {


### PR DESCRIPTION
This PR removes a broken anchor link [reported by Zillow](https://apollograph.slack.com/archives/C0721M2F6/p1693434962231179) and removes some links about authorization directives. (The changes were originally intended to launch with the authorization directive docs. I will revert the changes in [that PR](https://github.com/apollographql/router/pull/3673).)
