### PR TITLE
Fix monotonic counter type

### DIFF
--- a/apollo-router/src/plugins/authentication/mod.rs
+++ b/apollo-router/src/plugins/authentication/mod.rs
@@ -627,7 +627,7 @@ fn authenticate(
             monotonic_counter.apollo_authentication_success_count = 1u64,
             kind = %AUTHENTICATION_KIND
         );
-        tracing::info!(monotonic_counter.apollo.router.operations.jwt = 1);
+        tracing::info!(monotonic_counter.apollo.router.operations.jwt = 1u64);
         return Ok(ControlFlow::Continue(request));
     }
 

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -76,7 +76,7 @@ impl QueryPlan {
             )
             .await;
         if !deferred_fetches.is_empty() {
-            tracing::info!(monotonic_counter.apollo.router.operations.defer = 1);
+            tracing::info!(monotonic_counter.apollo.router.operations.defer = 1u64);
         }
 
         Response::builder().data(value).errors(errors).build()

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -290,7 +290,7 @@ impl FetchNode {
             self.response_at_path(parameters.schema, current_dir, paths, response);
         if let Some(id) = &self.id {
             if let Some(sender) = parameters.deferred_fetches.get(id.as_str()) {
-                tracing::info!(monotonic_counter.apollo.router.operations.defer.fetch = 1);
+                tracing::info!(monotonic_counter.apollo.router.operations.defer.fetch = 1u64);
                 if let Err(e) = sender.clone().send((value.clone(), errors.clone())) {
                     tracing::error!("error sending fetch result at path {} and id {:?} for deferred response building: {}", current_dir, self.id, e);
                 }


### PR DESCRIPTION
This fixes a bug where you would encounter error logs: monotonic counter must be u64 or f64. This metric will be ignored.
