### PR TITLE
GraphQL response processing must happen under the execution span

### DIFF
--- a/.changesets/fix_geal_fix_execution_span_attribution.md
+++ b/.changesets/fix_geal_fix_execution_span_attribution.md
@@ -1,0 +1,5 @@
+### GraphQL response processing must happen under the execution span ([PR #3732](https://github.com/apollographql/router/pull/3732))
+
+Previously, any event in processing would be reported under the supergraph span, or any plugin span (like rhai) happening in between
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3732

--- a/apollo-router/src/services/execution_service.rs
+++ b/apollo-router/src/services/execution_service.rs
@@ -23,6 +23,7 @@ use tower::ServiceExt;
 use tower_service::Service;
 use tracing::event;
 use tracing::Instrument;
+use tracing::Span;
 use tracing_core::Level;
 
 use super::new_service::ServiceFactory;
@@ -171,17 +172,21 @@ impl ExecutionService {
         let schema = self.schema.clone();
         let mut nullified_paths: Vec<Path> = vec![];
 
+        let execution_span = Span::current();
+
         let stream = stream
             .filter_map(move |response: Response| {
-                ready(Self::process_graphql_response(
-                    &query,
-                    operation_name.as_deref(),
-                    &variables,
-                    is_deferred,
-                    &schema,
-                    &mut nullified_paths,
-                    response,
-                ))
+                ready(execution_span.in_scope(|| {
+                    Self::process_graphql_response(
+                        &query,
+                        operation_name.as_deref(),
+                        &variables,
+                        is_deferred,
+                        &schema,
+                        &mut nullified_paths,
+                        response,
+                    )
+                }))
             })
             .boxed();
 

--- a/apollo-router/tests/snapshots/tracing_tests__traced_basic_composition.snap
+++ b/apollo-router/tests/snapshots/tracing_tests__traced_basic_composition.snap
@@ -707,24 +707,24 @@ expression: get_spans()
                           }
                         }
                       }
+                    },
+                    "apollo_router::services::execution_service::format_response": {
+                      "name": "apollo_router::services::execution_service::format_response",
+                      "record": {
+                        "entries": [],
+                        "metadata": {
+                          "name": "format_response",
+                          "target": "apollo_router::services::execution_service",
+                          "level": "DEBUG",
+                          "module_path": "apollo_router::services::execution_service",
+                          "fields": {
+                            "names": []
+                          }
+                        }
+                      },
+                      "children": {}
                     }
                   }
-                },
-                "apollo_router::services::execution_service::format_response": {
-                  "name": "apollo_router::services::execution_service::format_response",
-                  "record": {
-                    "entries": [],
-                    "metadata": {
-                      "name": "format_response",
-                      "target": "apollo_router::services::execution_service",
-                      "level": "DEBUG",
-                      "module_path": "apollo_router::services::execution_service",
-                      "fields": {
-                        "names": []
-                      }
-                    }
-                  },
-                  "children": {}
                 }
               }
             }

--- a/apollo-router/tests/snapshots/tracing_tests__traced_basic_request.snap
+++ b/apollo-router/tests/snapshots/tracing_tests__traced_basic_request.snap
@@ -422,24 +422,24 @@ expression: get_spans()
                           "children": {}
                         }
                       }
+                    },
+                    "apollo_router::services::execution_service::format_response": {
+                      "name": "apollo_router::services::execution_service::format_response",
+                      "record": {
+                        "entries": [],
+                        "metadata": {
+                          "name": "format_response",
+                          "target": "apollo_router::services::execution_service",
+                          "level": "DEBUG",
+                          "module_path": "apollo_router::services::execution_service",
+                          "fields": {
+                            "names": []
+                          }
+                        }
+                      },
+                      "children": {}
                     }
                   }
-                },
-                "apollo_router::services::execution_service::format_response": {
-                  "name": "apollo_router::services::execution_service::format_response",
-                  "record": {
-                    "entries": [],
-                    "metadata": {
-                      "name": "format_response",
-                      "target": "apollo_router::services::execution_service",
-                      "level": "DEBUG",
-                      "module_path": "apollo_router::services::execution_service",
-                      "fields": {
-                        "names": []
-                      }
-                    }
-                  },
-                  "children": {}
                 }
               }
             }


### PR DESCRIPTION
Previously, any event in processing would be reported under the supergraph span, or any plugin span (like rhai) happening in between

*Description here*

Fixes #issue_number

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
