### PR TITLE
Subscriptions: Correct v1.28.x regression allowing panic via un-namedsubscription operation (#3738)

### DIFF
--- a/.changesets/fix_dragonfly_ship_win_folder.md
+++ b/.changesets/fix_dragonfly_ship_win_folder.md
@@ -1,0 +1,9 @@
+### Subscriptions: Correct v1.28.x regression allowing panic via un-named subscription operation
+
+Correct a regression that was introduced in Router v1.28.0 which made a Router **panic** possible when the following _three_ conditions are _all_ met:
+
+1. When sending an un-named (i.e., "anonymous") `subscription` operation (e.g., `subscription { ... }`); **and**;
+2. The Router has a `subscription` type defined in the Supergraph schema; **and**
+3. Have subscriptions enabled (they are disabled by default) in the Router's YAML configuration, either by setting `enabled: true` _or_ by setting a `mode` within the `subscriptions` object (as seen in [the subscriptions documentation](https://www.apollographql.com/docs/router/executing-operations/subscription-support/#router-setup).
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/3738

--- a/apollo-router/src/context/mod.rs
+++ b/apollo-router/src/context/mod.rs
@@ -70,13 +70,6 @@ impl Context {
 }
 
 impl Context {
-    pub(crate) fn operation_name(&self) -> Option<String> {
-        // This method should be removed once we have a proper way to get the operation name.
-        self.entries
-            .get(OPERATION_NAME)
-            .map(|v| v.value().as_str().unwrap().to_string())
-    }
-
     /// Returns true if the context contains a value for the specified key.
     pub fn contains_key<K>(&self, key: K) -> bool
     where

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -431,6 +431,13 @@ async fn call_websocket(
     subgraph_cfg: &WebSocketConfiguration,
     subscription_hash: String,
 ) -> Result<SubgraphResponse, BoxError> {
+    let operation_name = request
+        .subgraph_request
+        .body()
+        .operation_name
+        .clone()
+        .unwrap_or_default();
+
     let SubgraphRequest {
         subgraph_request,
         subscription_stream,
@@ -445,7 +452,6 @@ async fn call_websocket(
     let (handle, created) = notify
         .create_or_subscribe(subscription_hash.clone(), false)
         .await?;
-    let operation_name = context.operation_name().unwrap_or_default();
     tracing::info!(
         monotonic_counter.apollo.router.operations.subscriptions = 1u64,
         subscriptions.mode = %"passthrough",


### PR DESCRIPTION
### Subscriptions: Correct v1.28.x regression allowing panic via un-named subscription operation

Correct a regression that was introduced in Router v1.28.0 which made a Router **panic** possible when the following _three_ conditions are _all_ met:

1. When sending an un-named (i.e., "anonymous") `subscription` operation (e.g., `subscription { ... }`); **and**;
2. The Router has a `subscription` type defined in the Supergraph schema; **and**
3. Have subscriptions enabled (they are disabled by default) in the Router's YAML configuration, either by setting `enabled: true` _or_ by setting a `mode` within the `subscriptions` object (as seen in [the subscriptions documentation]