### PR TITLE
fix(subscription): add x-accel-buffering header for multipart response

### DIFF
--- a/apollo-router/tests/subscription_load_test.rs
+++ b/apollo-router/tests/subscription_load_test.rs
@@ -1,5 +1,6 @@
 //! This file is to load test subscriptions and should be launched manually, not in our CI
 use futures::StreamExt;
+use http::HeaderValue;
 use serde_json::json;
 use tower::BoxError;
 
@@ -22,6 +23,10 @@ async fn test_subscription_load() -> Result<(), BoxError> {
     for i in 0..1000000i64 {
         let (_, response) = router.run_subscription(UNFEDERATED_SUB_QUERY).await;
         assert!(response.status().is_success());
+        assert_eq!(
+            response.headers().get("x-accel-buffering").unwrap(),
+            &HeaderValue::from_static("no")
+        );
 
         tokio::spawn(async move {
             let mut stream = response.bytes_stream();


### PR DESCRIPTION
Set `x-accel-buffering` to `no` when it's a multipart response because proxies need this configuration.

Fixes #3683

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
