### PR TITLE
test(subscription): add integration test for subscription

### DIFF
--- a/.changesets/maint_bnjjj_fix_3740.md
+++ b/.changesets/maint_bnjjj_fix_3740.md
@@ -1,0 +1,5 @@
+### Add integration test for subscription ([Issue #3740](https://github.com/apollographql/router/issues/3740))
+
+Add a regression test that ensures an unnamed subscription makes it through the request pipeline.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/3752

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -168,7 +168,7 @@ impl IntegrationTest {
             std::env::var("TEST_APOLLO_GRAPH_REF"),
         ) {
             router
-                .env("APOLLO_GRAPH_KEY", apollo_key)
+                .env("APOLLO_KEY", apollo_key)
                 .env("APOLLO_GRAPH_REF", apollo_graph_ref);
         }
 

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -179,6 +179,7 @@ impl IntegrationTest {
             std::env::var("TEST_APOLLO_KEY"),
             std::env::var("TEST_APOLLO_GRAPH_REF"),
         ) {
+            dbg!(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> SET");
             router.env("APOLLO_GRAPH_KEY", apollo_key);
             router.env("APOLLO_GRAPH_REF", apollo_graph_ref);
         }

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -162,7 +162,8 @@ impl IntegrationTest {
 
     #[allow(dead_code)]
     pub async fn start(&mut self) {
-        let mut router = Command::new(&self.router_location)
+        let mut router = Command::new(&self.router_location);
+        router
             .args([
                 "--hr",
                 "--config",
@@ -173,9 +174,16 @@ impl IntegrationTest {
                 "--log",
                 "error,apollo_router=info",
             ])
-            .stdout(Stdio::piped())
-            .spawn()
-            .expect("router should start");
+            .stdout(Stdio::piped());
+        if let (Ok(apollo_key), Ok(apollo_graph_ref)) = (
+            std::env::var("TEST_APOLLO_KEY"),
+            std::env::var("TEST_APOLLO_GRAPH_REF"),
+        ) {
+            router.env("APOLLO_GRAPH_KEY", apollo_key);
+            router.env("APOLLO_GRAPH_REF", apollo_graph_ref);
+        }
+
+        let mut router = router.spawn().expect("router should start");
         let reader = BufReader::new(router.stdout.take().expect("out"));
         let stdio_tx = self.stdio_tx.clone();
         let collect_stdio = self.collect_stdio.take();

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -163,6 +163,15 @@ impl IntegrationTest {
     #[allow(dead_code)]
     pub async fn start(&mut self) {
         let mut router = Command::new(&self.router_location);
+        if let (Ok(apollo_key), Ok(apollo_graph_ref)) = (
+            std::env::var("TEST_APOLLO_KEY"),
+            std::env::var("TEST_APOLLO_GRAPH_REF"),
+        ) {
+            router
+                .env("APOLLO_GRAPH_KEY", apollo_key)
+                .env("APOLLO_GRAPH_REF", apollo_graph_ref);
+        }
+
         router
             .args([
                 "--hr",
@@ -175,14 +184,6 @@ impl IntegrationTest {
                 "error,apollo_router=info",
             ])
             .stdout(Stdio::piped());
-        if let (Ok(apollo_key), Ok(apollo_graph_ref)) = (
-            std::env::var("TEST_APOLLO_KEY"),
-            std::env::var("TEST_APOLLO_GRAPH_REF"),
-        ) {
-            println!(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> SET");
-            router.env("APOLLO_GRAPH_KEY", apollo_key);
-            router.env("APOLLO_GRAPH_REF", apollo_graph_ref);
-        }
 
         let mut router = router.spawn().expect("router should start");
         let reader = BufReader::new(router.stdout.take().expect("out"));

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -179,7 +179,7 @@ impl IntegrationTest {
             std::env::var("TEST_APOLLO_KEY"),
             std::env::var("TEST_APOLLO_GRAPH_REF"),
         ) {
-            dbg!(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> SET");
+            println!(">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> SET");
             router.env("APOLLO_GRAPH_KEY", apollo_key);
             router.env("APOLLO_GRAPH_REF", apollo_graph_ref);
         }

--- a/apollo-router/tests/fixtures/subscription.router.yaml
+++ b/apollo-router/tests/fixtures/subscription.router.yaml
@@ -7,7 +7,7 @@ homepage:
 sandbox:
   enabled: true
 override_subgraph_url:
-  accounts: "http://localhost:4041"
+  products: http://localhost:4005
 include_subgraph_errors:
   all: true
 subscription:

--- a/apollo-router/tests/subscription_load_test.rs
+++ b/apollo-router/tests/subscription_load_test.rs
@@ -16,15 +16,20 @@ const UNFEDERATED_SUB_QUERY: &str = r#"subscription {  userWasCreated { name use
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscription() -> Result<(), BoxError> {
-    let mut router = create_router(SUBSCRIPTION_CONFIG).await?;
-    router.start().await;
-    router.assert_started().await;
+    if let (Ok(apollo_key), Ok(apollo_graph_ref)) = (
+        std::env::var("TEST_APOLLO_KEY"),
+        std::env::var("TEST_APOLLO_GRAPH_REF"),
+    ) {
+        let mut router = create_router(SUBSCRIPTION_CONFIG).await?;
+        router.start().await;
+        router.assert_started().await;
 
-    let (_, response) = router.run_subscription(SUB_QUERY).await;
-    assert!(response.status().is_success());
+        let (_, response) = router.run_subscription(SUB_QUERY).await;
+        assert!(response.status().is_success());
 
-    let mut stream = response.bytes_stream();
-    while let Some(_chunk) = stream.next().await {}
+        let mut stream = response.bytes_stream();
+        while let Some(_chunk) = stream.next().await {}
+    }
 
     Ok(())
 }

--- a/apollo-router/tests/subscription_load_test.rs
+++ b/apollo-router/tests/subscription_load_test.rs
@@ -16,19 +16,18 @@ const UNFEDERATED_SUB_QUERY: &str = r#"subscription {  userWasCreated { name use
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscription() -> Result<(), BoxError> {
-    if let (Ok(apollo_key), Ok(apollo_graph_ref)) = (
-        std::env::var("TEST_APOLLO_KEY"),
-        std::env::var("TEST_APOLLO_GRAPH_REF"),
-    ) {
-        let mut router = create_router(SUBSCRIPTION_CONFIG).await?;
-        router.start().await;
-        router.assert_started().await;
+    let mut router = create_router(SUBSCRIPTION_CONFIG).await?;
+    router.start().await;
+    router.assert_started().await;
 
-        let (_, response) = router.run_subscription(SUB_QUERY).await;
-        assert!(response.status().is_success());
+    let (_, response) = router.run_subscription(SUB_QUERY).await;
+    assert!(response.status().is_success());
 
-        let mut stream = response.bytes_stream();
-        while let Some(_chunk) = stream.next().await {}
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.unwrap();
+        assert!(chunk.starts_with(b"\r\n--graphql\r\ncontent-type: application/json\r\n\r\n"));
+        assert!(chunk.ends_with(b"\r\n--graphql--\r\n"));
     }
 
     Ok(())


### PR DESCRIPTION
Add a regression test that ensures an unnamed subscription makes it through the request pipeline.

Fixes #3740
