### PR TITLE
docs: add links for authorization directive docs

### DIFF
--- a/docs/source/configuration/authorization.mdx
+++ b/docs/source/configuration/authorization.mdx
@@ -6,7 +6,7 @@ minVersion: 1.29.0
 
 <GraphOSEnterpriseRequired />
 
-<FeatureInPreview />
+<PreviewFeature discordLink="https://discord.com/channels/1022972389463687228/1148623262104965120"/>
 
 APIs provide access to business-critical data. Unrestricted access can result in data breaches, monetary losses, or potential denial of service. Even for internal services, checks can be essential to limit data to authorized parties.
 

--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -901,7 +901,7 @@ Subsequent response chunks omit the `headers` and `statusCode` fields:
 
 ## Adding authorization claims via coprocessor
 
-For authorization purposes, your requests may need to include **claims**—the details of its authentication and scope. The most straightforward way to add claims is with [JWT authentication](../configuration/./authn-jwt). You can also add claims with a [`RouterService` coprocessor](#how-it-works) since it hooks into the request lifecycle directly after the router has received a client request.
+To use the [authorization directives](../configuration/authorization#authorization-directives), a request needs to include **claims**—the details of its authentication and scope. The most straightforward way to add claims is with [JWT authentication](../configuration/./authn-jwt). You can also add claims with a [`RouterService` coprocessor](#how-it-works) since it hooks into the request lifecycle directly after the router has received a client request.
 
 The router configuration needs to include at least these settings:
 
@@ -930,7 +930,7 @@ This configuration prompts the router to send an HTTP POST request to your copro
 }
 ```
 
-When your coprocessor receives this request from the router, it should add claims to the request's [`context`](#context) and return them in the response to the router. Specifically, the coprocessor should add an entry with a claims object. The key must be `apollo_authentication::JWT::claims`, and the value should be the claims required for authorization. For example:
+When your coprocessor receives this request from the router, it should add claims to the request's [`context`](#context) and return them in the response to the router. Specifically, the coprocessor should add an entry with a claims object. The key must be `apollo_authentication::JWT::claims`, and the value should be the claims required by the authorization directives you intend to use. For example, if you want to use [`@requireScopes`](../configuration/authorization#requiresscopes), the response may look something like this:
 
 ```json
 {


### PR DESCRIPTION
This PR adds back links to the auth docs, which were [removed](https://github.com/apollographql/router/pull/3711/files) when those docs weren't published yet. It also adds a link to the Discord post for feedback.

Fixes #issue_number

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
