### PR TITLE
remove a cloned entity from response_at_path

### DIFF
--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -373,12 +373,12 @@ impl FetchNode {
                             if let Some(paths) = inverted_paths.get(&index) {
                                 if paths.len() > 1 {
                                     for path in &paths[1..] {
-                                        let _ = value.insert(&path, entity.clone());
+                                        let _ = value.insert(path, entity.clone());
                                     }
                                 }
 
                                 if let Some(path) = paths.first() {
-                                    let _ = value.insert(&path, entity);
+                                    let _ = value.insert(path, entity);
                                 }
                             }
                         }


### PR DESCRIPTION
there was always one additional clone before, even when the entity was used in only one place. In local benchmarks, I could see this remove 200μs from a query

*Description here*

Fixes #issue_number

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
