### PR TITLE
Add apollo.router.id to otlp metrics metadata

### DIFF
--- a/apollo-router/src/plugins/telemetry/metrics/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo.rs
@@ -1,6 +1,7 @@
 //! Apollo metrics
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use opentelemetry::sdk::export::metrics::aggregation;
@@ -12,6 +13,7 @@ use sys_info::hostname;
 use tonic::metadata::MetadataMap;
 use tower::BoxError;
 use url::Url;
+use uuid::Uuid;
 
 use crate::plugins::telemetry::apollo::Config;
 use crate::plugins::telemetry::apollo_exporter::get_uname;
@@ -30,6 +32,9 @@ fn default_buckets() -> Vec<f64> {
         0.001, 0.005, 0.015, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 1.0, 5.0, 10.0,
     ]
 }
+
+// Random unique UUID fot the Router. This doesn't actually identify the router, it just allows disambiguation between multiple routers with the same metadata.
+static ROUTER_ID: OnceLock<Uuid> = OnceLock::new();
 
 impl MetricsConfigurator for Config {
     fn apply(
@@ -105,6 +110,10 @@ impl Config {
                 opentelemetry::runtime::Tokio,
             )
             .with_resource(Resource::new([
+                KeyValue::new(
+                    "apollo.router.id",
+                    ROUTER_ID.get_or_init(Uuid::new_v4).to_string(),
+                ),
                 KeyValue::new("apollo.graph.ref", reference.to_string()),
                 KeyValue::new("apollo.schema.id", schema_id.to_string()),
                 KeyValue::new(

--- a/apollo-router/src/plugins/telemetry/metrics/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo.rs
@@ -33,7 +33,7 @@ fn default_buckets() -> Vec<f64> {
     ]
 }
 
-// Random unique UUID fot the Router. This doesn't actually identify the router, it just allows disambiguation between multiple routers with the same metadata.
+// Random unique UUID for the Router. This doesn't actually identify the router, it just allows disambiguation between multiple routers with the same metadata.
 static ROUTER_ID: OnceLock<Uuid> = OnceLock::new();
 
 impl MetricsConfigurator for Config {


### PR DESCRIPTION
Currently apollo metrics may have the same metadata between multiple routers. This means that we can't disambiguate when multiple routers are sending data.

Add a random UUID to the metadata.

This has no user facing impact.


Note: there is no unit test or integration test for this. We need to take a broader look at how we do telemetry testing, and the solution should probably involve otel collector. However that is beyond the scope of this ticket.


<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
