### PR TITLE
Fix: deal with interface inheritance when retrieving selectionset

### DIFF
--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -200,6 +200,7 @@ impl Schema {
         {
             Some(a)
         } else {
+            // No relationship between a and b
             None
         }
     }

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -187,8 +187,8 @@ impl Schema {
         a: &'f FieldType,
         b: &'f FieldType,
     ) -> Option<&'f FieldType> {
-        let typename_a = dbg!(a.inner_type_name().unwrap_or_default());
-        let typename_b = dbg!(b.inner_type_name().unwrap_or_default());
+        let typename_a = a.inner_type_name().unwrap_or_default();
+        let typename_b = b.inner_type_name().unwrap_or_default();
         if typename_a == typename_b {
             return Some(a);
         }

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -160,6 +160,20 @@ impl Schema {
             .unwrap_or(false)
     }
 
+    pub(crate) fn is_implementation(&self, interface: &str, implementor: &str) -> bool {
+        self.type_system
+            .definitions
+            .interfaces
+            .get(interface)
+            .map(|interface| {
+                interface
+                    .implements_interfaces()
+                    .find(|i| i.interface() == implementor)
+                    .is_some()
+            })
+            .unwrap_or(false)
+    }
+
     pub(crate) fn is_interface(&self, abstract_type: &str) -> bool {
         self.type_system
             .definitions

--- a/apollo-router/src/spec/selection.rs
+++ b/apollo-router/src/spec/selection.rs
@@ -162,8 +162,8 @@ impl Selection {
                     // Query validation should have already verified that current type implements that interface
                     debug_assert!(
                         schema.is_subtype(
-                            dbg!(type_condition.as_str()),
-                            dbg!(current_type.inner_type_name().unwrap_or(""))
+                            type_condition.as_str(),
+                            current_type.inner_type_name().unwrap_or("")
                         ) || schema.is_implementation(
                             type_condition.as_str(),
                             current_type.inner_type_name().unwrap_or(""))

--- a/apollo-router/src/spec/selection.rs
+++ b/apollo-router/src/spec/selection.rs
@@ -162,8 +162,8 @@ impl Selection {
                     // Query validation should have already verified that current type implements that interface
                     debug_assert!(
                         schema.is_subtype(
-                            type_condition.as_str(),
-                            current_type.inner_type_name().unwrap_or("")
+                            dbg!(type_condition.as_str()),
+                            dbg!(current_type.inner_type_name().unwrap_or(""))
                         ) || schema.is_implementation(
                             type_condition.as_str(),
                             current_type.inner_type_name().unwrap_or(""))
@@ -172,7 +172,9 @@ impl Selection {
                         type_condition.as_str()
                             == current_type.inner_type_name().unwrap_or("")
                     );
-                    current_type
+                    let relevant_type = schema.most_precise(current_type, &fragment_type);
+                    debug_assert!(relevant_type.is_some());
+                    relevant_type.unwrap_or(&fragment_type)
                 } else {
                     &fragment_type
                 };

--- a/apollo-router/src/spec/selection.rs
+++ b/apollo-router/src/spec/selection.rs
@@ -164,7 +164,10 @@ impl Selection {
                         schema.is_subtype(
                             type_condition.as_str(),
                             current_type.inner_type_name().unwrap_or("")
-                        ) ||
+                        ) || schema.is_implementation(
+                            type_condition.as_str(),
+                            current_type.inner_type_name().unwrap_or(""))
+                     ||
                         // if the current type and the type condition are both the same interface, it is still valid
                         type_condition.as_str()
                             == current_type.inner_type_name().unwrap_or("")


### PR DESCRIPTION
Followup to #3718, this changeset makes sure we're able to generate the most concrete selection set for a given operation.

This means finding the most concrete type we can when we're dealing with interfaces:
  - If InterfaceA implements InterfaceB, use InterfaceA as current_type to generate an inline fragment's selection set
  
Given the following invariants:
```graphql
  interface OperationItemStuff implements OperationItem
```

For
```graphql
fragment OperationItemFragment on OperationItem {
  ... on OperationItemStuff {
     stuff
  }
}
```

The most concrete interface to generate fields for `OperationItemStuff` is not `OperationItem`, so we narrow down the selection to `OperationItemStuff`.

The fixes for #3718 still apply, IE:

Given the following invariants:
```graphql
  type Dog implements Animal
```
For
```graphql
...on Animal {
  id
  ...on Dog {
    name
  }
}
```
The most concrete type to generate a selection set for `Dog` is not `Animal`, so we narrow down the selection to `Dog`.

