### PR TITLE
Activate query planner cache warm up by default

### DIFF
--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -827,11 +827,12 @@ impl Default for Apq {
 pub(crate) struct QueryPlanning {
     /// Cache configuration
     pub(crate) experimental_cache: Cache,
-    /// Warm up the cache on reloads by running the query plan over
-    /// a list of the most used queries
-    /// Defaults to 0 (do not warm up the cache)
+    /// Warms up the cache on reloads by running the query plan over
+    /// a list of the most used queries (from the in memory cache)
+    /// Configures the number of queries warmed up. Defaults to 1/3 of
+    /// the in memory cache
     #[serde(default)]
-    pub(crate) warmed_up_queries: usize,
+    pub(crate) warmed_up_queries: Option<usize>,
 }
 
 /// Cache configuration

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1801,7 +1801,7 @@ expression: "&schema"
             },
             "redis": null
           },
-          "warmed_up_queries": 0
+          "warmed_up_queries": null
         }
       },
       "type": "object",
@@ -1850,7 +1850,7 @@ expression: "&schema"
               },
               "redis": null
             },
-            "warmed_up_queries": 0
+            "warmed_up_queries": null
           },
           "type": "object",
           "properties": {
@@ -1907,11 +1907,12 @@ expression: "&schema"
               "additionalProperties": false
             },
             "warmed_up_queries": {
-              "description": "Warm up the cache on reloads by running the query plan over a list of the most used queries Defaults to 0 (do not warm up the cache)",
-              "default": 0,
+              "description": "Warms up the cache on reloads by running the query plan over a list of the most used queries (from the in memory cache) Configures the number of queries warmed up. Defaults to 1/3 of the in memory cache",
+              "default": null,
               "type": "integer",
               "format": "uint",
-              "minimum": 0.0
+              "minimum": 0.0,
+              "nullable": true
             }
           },
           "additionalProperties": false

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -92,7 +92,7 @@ where
 
     pub(crate) async fn cache_keys(&self, count: Option<usize>) -> Vec<WarmUpCachingQueryKey> {
         let keys = self.cache.in_memory_keys().await;
-        let count = count.unwrap_or_else(|| keys.len() / 3);
+        let count = count.unwrap_or(keys.len() / 3);
         keys.into_iter()
             .take(count)
             .map(|key| WarmUpCachingQueryKey {

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -90,8 +90,9 @@ where
         }
     }
 
-    pub(crate) async fn cache_keys(&self, count: usize) -> Vec<WarmUpCachingQueryKey> {
+    pub(crate) async fn cache_keys(&self, count: Option<usize>) -> Vec<WarmUpCachingQueryKey> {
         let keys = self.cache.in_memory_keys().await;
+        let count = count.unwrap_or_else(|| keys.len() / 3);
         keys.into_iter()
             .take(count)
             .map(|key| WarmUpCachingQueryKey {

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -552,7 +552,7 @@ impl RouterCreator {
 }
 
 impl RouterCreator {
-    pub(crate) async fn cache_keys(&self, count: usize) -> Vec<WarmUpCachingQueryKey> {
+    pub(crate) async fn cache_keys(&self, count: Option<usize>) -> Vec<WarmUpCachingQueryKey> {
         self.supergraph_creator.cache_keys(count).await
     }
 

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -752,7 +752,7 @@ impl SupergraphCreator {
             )
     }
 
-    pub(crate) async fn cache_keys(&self, count: usize) -> Vec<WarmUpCachingQueryKey> {
+    pub(crate) async fn cache_keys(&self, count: Option<usize>) -> Vec<WarmUpCachingQueryKey> {
         self.query_planner_service.cache_keys(count).await
     }
 


### PR DESCRIPTION
Fix #3766

Cache warm up has been in testing for long enough, and has proven highly ezffective in smoothing out latencies when updating a schema. So this will activate it by default. It can still be deactivated by configuring it to 0:

```yaml
supergraph:
  query_planning:
    warmed_up_queries: 0
```

By default, it will now warm up the cache with the 30% most used queries

*Description here*

Fixes #issue_number

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
