### PR TITLE
Coprocessors: Discard content-length sent by coprocessors.

### DIFF
--- a/.changesets/fix_igni_coprocessors_discard_content_length.md
+++ b/.changesets/fix_igni_coprocessors_discard_content_length.md
@@ -1,0 +1,6 @@
+### Coprocessors: Discard content-length sent by coprocessors. ([PR #3802](https://github.com/apollographql/router/pull/3802))
+
+The content-length of an HTTP response can only be computed when a router response is being sent.
+We now discard coprocessors "content-length" header to make sure the value is computed correctly.
+
+By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/3802

--- a/.changesets/fix_igni_coprocessors_discard_content_length.md
+++ b/.changesets/fix_igni_coprocessors_discard_content_length.md
@@ -1,6 +1,6 @@
 ### Coprocessors: Discard content-length sent by coprocessors. ([PR #3802](https://github.com/apollographql/router/pull/3802))
 
-The content-length of an HTTP response can only be computed when a router response is being sent.
-We now discard coprocessors "content-length" header to make sure the value is computed correctly.
+The `content-length` of an HTTP response can only be computed when a router response is being sent.
+We now discard coprocessors `content-length` header to make sure the value is computed correctly.
 
 By [@o0Ignition0o](https://github.com/o0Ignition0o) in https://github.com/apollographql/router/pull/3802

--- a/apollo-router/src/plugins/coprocessor.rs
+++ b/apollo-router/src/plugins/coprocessor.rs
@@ -12,6 +12,7 @@ use futures::future::ready;
 use futures::stream::once;
 use futures::StreamExt;
 use futures::TryStreamExt;
+use http::header;
 use http::HeaderMap;
 use http::HeaderName;
 use http::HeaderValue;
@@ -1117,7 +1118,7 @@ pub(super) fn internalize_header_map(
     // better than nothing even though it doesnt account for the values len
     let mut output = HeaderMap::with_capacity(input.len());
     for (k, values) in input {
-        if k.as_str() != "content-length" {
+        if k == header::CONTENT_LENGTH.as_str() {
             for v in values {
                 let key = HeaderName::from_str(k.as_ref())?;
                 let value = HeaderValue::from_str(v.as_ref())?;

--- a/apollo-router/src/plugins/coprocessor.rs
+++ b/apollo-router/src/plugins/coprocessor.rs
@@ -1119,11 +1119,12 @@ pub(super) fn internalize_header_map(
     let mut output = HeaderMap::with_capacity(input.len());
     for (k, values) in input {
         if k == header::CONTENT_LENGTH.as_str() {
-            for v in values {
-                let key = HeaderName::from_str(k.as_ref())?;
-                let value = HeaderValue::from_str(v.as_ref())?;
-                output.append(key, value);
-            }
+            continue;
+        }
+        for v in values {
+            let key = HeaderName::from_str(k.as_ref())?;
+            let value = HeaderValue::from_str(v.as_ref())?;
+            output.append(key, value);
         }
     }
     Ok(output)

--- a/apollo-router/src/plugins/coprocessor.rs
+++ b/apollo-router/src/plugins/coprocessor.rs
@@ -1117,10 +1117,9 @@ pub(super) fn internalize_header_map(
 ) -> Result<HeaderMap<HeaderValue>, BoxError> {
     // better than nothing even though it doesnt account for the values len
     let mut output = HeaderMap::with_capacity(input.len());
-    for (k, values) in input {
-        if k == header::CONTENT_LENGTH.as_str() {
-            continue;
-        }
+    for (k, values) in input
+        .into_iter()
+        .filter(|(k, _)| k != header::CONTENT_LENGTH.as_str()) {
         for v in values {
             let key = HeaderName::from_str(k.as_ref())?;
             let value = HeaderValue::from_str(v.as_ref())?;

--- a/apollo-router/src/plugins/coprocessor.rs
+++ b/apollo-router/src/plugins/coprocessor.rs
@@ -12,8 +12,8 @@ use futures::future::ready;
 use futures::stream::once;
 use futures::StreamExt;
 use futures::TryStreamExt;
-use http::header::HeaderName;
 use http::HeaderMap;
+use http::HeaderName;
 use http::HeaderValue;
 use hyper::client::HttpConnector;
 use hyper::Body;
@@ -1114,12 +1114,15 @@ pub(super) fn externalize_header_map(
 pub(super) fn internalize_header_map(
     input: HashMap<String, Vec<String>>,
 ) -> Result<HeaderMap<HeaderValue>, BoxError> {
-    let mut output = HeaderMap::new();
+    // better than nothing even though it doesnt account for the values len
+    let mut output = HeaderMap::with_capacity(input.len());
     for (k, values) in input {
-        for v in values {
-            let key = HeaderName::from_str(k.as_ref())?;
-            let value = HeaderValue::from_str(v.as_ref())?;
-            output.append(key, value);
+        if k.as_str() != "content-length" {
+            for v in values {
+                let key = HeaderName::from_str(k.as_ref())?;
+                let value = HeaderValue::from_str(v.as_ref())?;
+                output.append(key, value);
+            }
         }
     }
     Ok(output)

--- a/apollo-router/src/plugins/coprocessor.rs
+++ b/apollo-router/src/plugins/coprocessor.rs
@@ -1119,7 +1119,8 @@ pub(super) fn internalize_header_map(
     let mut output = HeaderMap::with_capacity(input.len());
     for (k, values) in input
         .into_iter()
-        .filter(|(k, _)| k != header::CONTENT_LENGTH.as_str()) {
+        .filter(|(k, _)| k != header::CONTENT_LENGTH.as_str())
+    {
         for v in values {
             let key = HeaderName::from_str(k.as_ref())?;
             let value = HeaderValue::from_str(v.as_ref())?;

--- a/apollo-router/src/plugins/coprocessor_test.rs
+++ b/apollo-router/src/plugins/coprocessor_test.rs
@@ -1159,6 +1159,9 @@ mod tests {
             ],
         );
 
+        // This header should be stripped
+        external_form.insert("content-length".to_string(), vec!["1024".to_string()]);
+
         let actual = internalize_header_map(external_form).expect("internalized header map");
 
         assert_eq!(expected, actual);

--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -636,6 +636,7 @@ If your coprocessor [returns a _different_ value](#responding-to-coprocessor-req
 An object mapping of all HTTP header names and values for the corresponding request or response.
 
 If your coprocessor [returns a _different_ value](#responding-to-coprocessor-requests) for `headers`, the router replaces the existing headers with that value.
+⚠️ `content-length` sent by Coprocessors are discarded by the router. (Wrong `content-length` values could lead to failure for HTTP requests to be sent)
 
 </td>
 </tr>


### PR DESCRIPTION
ControlFlow::Break in coprocessors would lead to all response headers being directly forwarded back to the router, which would lead to content-length missmatch. This changeset discards content-length sent by the coprocessor.
