### PR TITLE
Update Changelog for #3586

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,7 +146,7 @@ By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/p
 This exposes a new key in the `Context`, `apollo_operation_id`, which identifies operation you can find in studio:
 
 ```
-https://studio.apollographql.com/graph/<your_graph_variant>/variant/<your_graph_variant>/operations?query=<apollo_operation_id>
+https://studio.apollographql.com/graph/<your_graph_id>/variant/<your_graph_variant>/operations?query=<apollo_operation_id>
 ```
 
 The `apollo_operation_id` context key is exposed during:


### PR DESCRIPTION
This corrects the CHANGELOG entry for #3586 which inadvertently suggested using `<your_graph_variant>` twice instead of `<your_graph_id>` and (separately) `<your_graph_variant>`:

```
https://studio.apollographql.com/graph/<your_graph_id>/variant/<your_graph_variant>/operations?query=<apollo_operation_id>
```

This doesn't replace the need to document this in https://github.com/apollographql/router/issues/3803. 😄