### PR TITLE
chore: Fix formatting in `pull_request_template.md`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,13 @@
 *Description here*
 
-Fixes #issue_number
+Fixes #**issue_number**
 
 <!-- start metadata -->
+---
 
 **Checklist**
 
-Complete the checklist (and note appropriate exceptions) before a final PR is raised.
+Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.
 
 - [ ] Changes are compatible[^1]
 - [ ] Documentation[^2] completed
@@ -22,8 +23,6 @@ Complete the checklist (and note appropriate exceptions) before a final PR is ra
 
 **Notes**
 
-[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
-[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
-[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
-    - please document the manual testing (extensively) in the Exceptions.
-    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
+[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
+[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
+[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


### PR DESCRIPTION
This has looked pretty funny to me for a while now and the fix was as simple as using `:` instead of `.`!  Inspired by @nathanmarcos doing it as a one-off in https://github.com/apollographql/router/pull/3805. 😸 

I also took the opportunity to add a nice horizontal rule that improves the ascetics of the rendered result and made some other small tweaks to text/formatting.  Most notably though, I removed the suggestion to open a issue labeled `manual test`.  It takes up a lot of real-estate in the text, and not a single issue has been opened or labeled as such. (Nor does the label even exist. 😅 )