### PR TITLE
Additional benign positive allowlisting

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,17 +14,25 @@
     [ rules.allowlist ]
         commits = [
             "7fdb0a5a0831d309524e98503760c16bd3de160c",
-            # Example private key for test cases
+            # Example private keys for test cases
             "9d6464b96eed3a20c48d5ec653bf9986757c89e5",
-            
+            "74ebb0269933c703efd9143c029f69e30330478b",
         ]
 
 [[ rules ]]
     id = "jwt"
     [ rules.allowlist ]
         commits = [
-            # Example jwt
+            # Example jwts
             "f12bcddc663aa4c4d90218a1bb718fe74e0e7be3",
+            "6ff43869e0cf8ab0de8dd0e898f80c08ad135552",
+            "b11412918d58db34693488b29495e148dbb27cc2",
+            "a4ceefc8d51879330f10861438401a3a3deb316e",
+            "d19de3cbca36981676ff03c7f3cab113609772b1",
+            "3ee3d4bda9efcf4f175fdcfd59abc16cb9a4657e",
+            "76aaa5ec21d4fbde65676c6cf0dc265dd6daee99",
+            "d2b85acee5cf94120b47093f87ae80a7365d7b28",
+            "f107c2a42292d0c8068395f5cb8f491377559a42",
         ]
 
 [[ rules ]]


### PR DESCRIPTION
This implements additional allowlisting for benign positive "secret" detection. The values allowlisted in this PR are test/sample JWTs and private keys. 

Apologies for repeated PRs on this. These detections appeared after my last PR for allowlisting secrets. I believe that gitleaks (the project we're using to scan for secrets) updated their signatures to better detect JWTs, causing more detections. I've run gitleaks on this repo by hand and after this change, there are currently no additional detections generated. 

<!-- start metadata -->

**Checklist**

Complete the checklist (and note appropriate exceptions) before a final PR is raised.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]. It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]. Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]. Tick whichever testing boxes are applicable. If you are adding Manual Tests:
    - please document the manual testing (extensively) in the Exceptions.
    - please raise a separate issue to automate the test and label it (or ask for it to be labeled) as `manual test`
