### PR TITLE
feat(redis): add configuration to set the timeout

### DIFF
--- a/.changesets/feat_bnjjj_fix_3621.md
+++ b/.changesets/feat_bnjjj_fix_3621.md
@@ -1,0 +1,15 @@
+### feat(redis): add configuration to set the timeout ([Issue #3621](https://github.com/apollographql/router/issues/3621))
+
+It adds a configuration to set another timeout than the default one (2ms) for redis requests. It also change the default timeout to 2ms (previously set to 1ms)
+
+Example for APQ:
+```yaml
+apq:
+  router:
+    cache:
+      redis:
+        urls: ["redis://..."] 
+        timeout: 5ms
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/3817

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -115,14 +115,18 @@ where
 }
 
 impl RedisCacheStorage {
-    pub(crate) async fn new(urls: Vec<Url>, ttl: Option<Duration>) -> Result<Self, RedisError> {
+    pub(crate) async fn new(
+        urls: Vec<Url>,
+        ttl: Option<Duration>,
+        timeout: Option<Duration>,
+    ) -> Result<Self, RedisError> {
         let url = Self::preprocess_urls(urls)?;
         let config = RedisConfig::from_url(url.as_str())?;
 
         let client = RedisClient::new(
             config,
             Some(PerformanceConfig {
-                default_command_timeout_ms: 1,
+                default_command_timeout_ms: timeout.map(|t| t.as_millis() as u64).unwrap_or(2),
                 ..Default::default()
             }),
             Some(ReconnectPolicy::new_exponential(0, 1, 2000, 5)),

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -3,6 +3,7 @@ use std::fmt::{self};
 use std::hash::Hash;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::time::Duration;
 
 use lru::LruCache;
 use serde::de::DeserializeOwned;
@@ -57,14 +58,15 @@ where
 {
     pub(crate) async fn new(
         max_capacity: NonZeroUsize,
-        _redis_urls: Option<Vec<url::Url>>,
+        redis_urls: Option<Vec<url::Url>>,
+        timeout: Option<Duration>,
         caller: &str,
     ) -> Self {
         Self {
             caller: caller.to_string(),
             inner: Arc::new(Mutex::new(LruCache::new(max_capacity))),
-            redis: if let Some(urls) = _redis_urls {
-                match RedisCacheStorage::new(urls, None).await {
+            redis: if let Some(urls) = redis_urls {
+                match RedisCacheStorage::new(urls, None, timeout).await {
                     Err(e) => {
                         tracing::error!(
                             "could not open connection to Redis for {} caching: {:?}",

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -866,8 +866,8 @@ pub(crate) struct RedisCache {
     /// List of URLs to the Redis cluster
     pub(crate) urls: Vec<url::Url>,
 
-    #[serde(deserialize_with = "humantime_serde::deserialize")]
-    #[schemars(with = "Option<String>")]
+    #[serde(deserialize_with = "humantime_serde::deserialize", default)]
+    #[schemars(with = "Option<String>", default)]
     /// Redis request timeout (default: 2ms)
     pub(crate) timeout: Option<Duration>,
 }

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -867,7 +867,7 @@ pub(crate) struct RedisCache {
     pub(crate) urls: Vec<url::Url>,
 
     #[serde(deserialize_with = "humantime_serde::deserialize")]
-    #[schemars(with = "String")]
+    #[schemars(with = "Option<String>")]
     /// Redis request timeout (default: 2ms)
     pub(crate) timeout: Option<Duration>,
 }

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -20,7 +20,6 @@ use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::str::FromStr;
 use std::sync::Arc;
-#[cfg(not(test))]
 use std::time::Duration;
 
 use derivative::Derivative;
@@ -866,6 +865,11 @@ impl Default for InMemoryCache {
 pub(crate) struct RedisCache {
     /// List of URLs to the Redis cluster
     pub(crate) urls: Vec<url::Url>,
+
+    #[serde(deserialize_with = "humantime_serde::deserialize")]
+    #[schemars(with = "String")]
+    /// Redis request timeout (default: 2ms)
+    pub(crate) timeout: Option<Duration>,
 }
 
 /// TLS related configuration options.

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -85,6 +85,7 @@ expression: "&schema"
                   "properties": {
                     "timeout": {
                       "description": "Redis request timeout (default: 2ms)",
+                      "default": null,
                       "type": "string",
                       "nullable": true
                     },
@@ -1898,6 +1899,7 @@ expression: "&schema"
                   "properties": {
                     "timeout": {
                       "description": "Redis request timeout (default: 2ms)",
+                      "default": null,
                       "type": "string",
                       "nullable": true
                     },
@@ -5504,6 +5506,7 @@ expression: "&schema"
           "properties": {
             "timeout": {
               "description": "Redis request timeout (default: 2ms)",
+              "default": null,
               "type": "string",
               "nullable": true
             },

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -80,9 +80,14 @@ expression: "&schema"
                   "default": null,
                   "type": "object",
                   "required": [
+                    "timeout",
                     "urls"
                   ],
                   "properties": {
+                    "timeout": {
+                      "description": "Redis request timeout (default: 2ms)",
+                      "type": "string"
+                    },
                     "urls": {
                       "description": "List of URLs to the Redis cluster",
                       "type": "array",
@@ -1888,9 +1893,14 @@ expression: "&schema"
                   "default": null,
                   "type": "object",
                   "required": [
+                    "timeout",
                     "urls"
                   ],
                   "properties": {
+                    "timeout": {
+                      "description": "Redis request timeout (default: 2ms)",
+                      "type": "string"
+                    },
                     "urls": {
                       "description": "List of URLs to the Redis cluster",
                       "type": "array",
@@ -5489,9 +5499,14 @@ expression: "&schema"
           "default": null,
           "type": "object",
           "required": [
+            "timeout",
             "urls"
           ],
           "properties": {
+            "timeout": {
+              "description": "Redis request timeout (default: 2ms)",
+              "type": "string"
+            },
             "urls": {
               "description": "List of URLs to the Redis cluster",
               "type": "array",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -80,13 +80,13 @@ expression: "&schema"
                   "default": null,
                   "type": "object",
                   "required": [
-                    "timeout",
                     "urls"
                   ],
                   "properties": {
                     "timeout": {
                       "description": "Redis request timeout (default: 2ms)",
-                      "type": "string"
+                      "type": "string",
+                      "nullable": true
                     },
                     "urls": {
                       "description": "List of URLs to the Redis cluster",
@@ -1893,13 +1893,13 @@ expression: "&schema"
                   "default": null,
                   "type": "object",
                   "required": [
-                    "timeout",
                     "urls"
                   ],
                   "properties": {
                     "timeout": {
                       "description": "Redis request timeout (default: 2ms)",
-                      "type": "string"
+                      "type": "string",
+                      "nullable": true
                     },
                     "urls": {
                       "description": "List of URLs to the Redis cluster",
@@ -5499,13 +5499,13 @@ expression: "&schema"
           "default": null,
           "type": "object",
           "required": [
-            "timeout",
             "urls"
           ],
           "properties": {
             "timeout": {
               "description": "Redis request timeout (default: 2ms)",
-              "type": "string"
+              "type": "string",
+              "nullable": true
             },
             "urls": {
               "description": "List of URLs to the Redis cluster",

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -25,7 +25,7 @@ impl Introspection {
         capacity: NonZeroUsize,
     ) -> Self {
         Self {
-            cache: CacheStorage::new(capacity, None, "introspection").await,
+            cache: CacheStorage::new(capacity, None, None, "introspection").await,
             planner,
         }
     }

--- a/apollo-router/src/plugins/traffic_shaping/mod.rs
+++ b/apollo-router/src/plugins/traffic_shaping/mod.rs
@@ -280,7 +280,17 @@ impl Plugin for TrafficShaping {
                 .as_ref()
                 .map(|cache| cache.urls.clone())
             {
-                Some(RedisCacheStorage::new(urls, None).await?)
+                Some(
+                    RedisCacheStorage::new(
+                        urls,
+                        None,
+                        init.config
+                            .experimental_cache
+                            .as_ref()
+                            .and_then(|c| c.timeout),
+                    )
+                    .await?,
+                )
             } else {
                 None
             };

--- a/docs/source/configuration/distributed-caching.mdx
+++ b/docs/source/configuration/distributed-caching.mdx
@@ -88,6 +88,7 @@ supergraph:
     experimental_cache:
       redis: #highlight-line
         urls: ["redis://..."] #highlight-line
+        timeout: 5ms # Optional, by default: 2ms
 ```
 
 The value of `urls` is a list of URLs for all Redis instances in your cluster.
@@ -104,6 +105,7 @@ apq:
     cache:
       redis: #highlight-line
         urls: ["redis://..."] #highlight-line
+        timeout: 5ms # Optional, by default: 2ms
 ```
 
 The value of `urls` is a list of URLs for all Redis instances in your cluster.


### PR DESCRIPTION
It adds a configuration to set another timeout than the default one (2ms) for redis requests. It also change the default timeout to 2ms (previously set to 1ms)

Example for APQ:
```yaml
apq:
  router:
    cache:
      redis:
        urls: ["redis://..."] 
        timeout: 5ms
```

Fixes #3621

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
