### PR TITLE
Introduce OneShotAsyncCheckpoint

### DIFF
--- a/.changesets/feat_garypen_one_shot_async_check.md
+++ b/.changesets/feat_garypen_one_shot_async_check.md
@@ -1,0 +1,11 @@
+### Introduce OneShotAsyncCheckpoint ([PR #3819](https://github.com/apollographql/router/pull/3819))
+
+The existing AsynCheckpoint requires `Clone` and thus introduces a need for Service Buffering which reduces the performance and resiliance of the router.
+
+This new set of Services, Layers and utility functions removes the requirement for `Clone` and thus the requirement for service buffering.
+
+Existing uses of AsyncCheckpoint within the router are replaced with OneShotAsyncCheckpoint along with the requirement to `buffer()` such services.
+
+If you have a custom plugin that makes use of `AsyncCheckpoint`, we encourage you to migrate to `OneShotAsyncCheckpoint` and thus reduce the requirement for service buffering from your router.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3819

--- a/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
+++ b/apollo-router-scaffold/templates/plugin/src/plugins/{{snake_name}}.rs
@@ -113,11 +113,10 @@ impl Plugin for {{pascal_name}} {
     ) -> supergraph::BoxService {
 
         ServiceBuilder::new()
-                    .checkpoint_async(|request : supergraph::Request| async {
+                    .oneshot_checkpoint_async(|request : supergraph::Request| async {
                         // Do some async call here to auth, and decide if to continue or not.
                         Ok(ControlFlow::Continue(request))
                     })
-                    .buffered()
                     .service(service)
                     .boxed()
     }

--- a/apollo-router/src/layers/async_checkpoint.rs
+++ b/apollo-router/src/layers/async_checkpoint.rs
@@ -67,6 +67,82 @@ where
     }
 }
 
+/// [`Service`] for OneShot (single use) Asynchronous Checkpoints. See [`ServiceBuilderExt::oneshot_checkpoint_async()`](crate::layers::ServiceBuilderExt::oneshot_checkpoint_async()).
+#[allow(clippy::type_complexity)]
+pub struct OneShotAsyncCheckpointService<S, Fut, Request>
+where
+    Request: Send + 'static,
+    S: Service<Request, Error = BoxError> + Send + 'static,
+    <S as Service<Request>>::Response: Send + 'static,
+    <S as Service<Request>>::Future: Send + 'static,
+    Fut: Future<Output = Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>>,
+{
+    inner: Option<S>,
+    checkpoint_fn: Arc<Pin<Box<dyn Fn(Request) -> Fut + Send + Sync + 'static>>>,
+}
+
+impl<S, Fut, Request> OneShotAsyncCheckpointService<S, Fut, Request>
+where
+    Request: Send + 'static,
+    S: Service<Request, Error = BoxError> + Send + 'static,
+    <S as Service<Request>>::Response: Send + 'static,
+    <S as Service<Request>>::Future: Send + 'static,
+    Fut: Future<Output = Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>>,
+{
+    /// Create an `OneShotAsyncCheckpointLayer` from a function that takes a Service Request and returns a `ControlFlow`
+    pub fn new<F>(checkpoint_fn: F, service: S) -> Self
+    where
+        F: Fn(Request) -> Fut + Send + Sync + 'static,
+    {
+        Self {
+            checkpoint_fn: Arc::new(Box::pin(checkpoint_fn)),
+            inner: Some(service),
+        }
+    }
+}
+
+impl<S, Fut, Request> Service<Request> for OneShotAsyncCheckpointService<S, Fut, Request>
+where
+    Request: Send + 'static,
+    S: Service<Request, Error = BoxError> + Send + 'static,
+    <S as Service<Request>>::Response: Send + 'static,
+    <S as Service<Request>>::Future: Send + 'static,
+    Fut: Future<Output = Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>>
+        + Send
+        + 'static,
+{
+    type Response = <S as Service<Request>>::Response;
+
+    type Error = BoxError;
+
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner
+            .as_mut()
+            .expect("One shot must only be called once")
+            .poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request) -> Self::Future {
+        let checkpoint_fn = Arc::clone(&self.checkpoint_fn);
+        let inner = self
+            .inner
+            .take()
+            .expect("One shot must only be called once");
+        Box::pin(async move {
+            match (checkpoint_fn)(req).await {
+                Ok(ControlFlow::Break(response)) => Ok(response),
+                Ok(ControlFlow::Continue(request)) => inner.oneshot(request).await,
+                Err(error) => Err(error),
+            }
+        })
+    }
+}
+
 /// [`Service`] for Asynchronous Checkpoints. See [`ServiceBuilderExt::checkpoint_async()`](crate::layers::ServiceBuilderExt::checkpoint_async()).
 #[allow(clippy::type_complexity)]
 pub struct AsyncCheckpointService<S, Fut, Request>
@@ -134,6 +210,52 @@ where
                 Err(error) => Err(error),
             }
         })
+    }
+}
+
+/// [`Layer`] for OneShot (single use) Asynchronous Checkpoints. See [`ServiceBuilderExt::oneshot_checkpoint_async()`](crate::layers::ServiceBuilderExt::oneshot_checkpoint_async()).
+#[allow(clippy::type_complexity)]
+pub struct OneShotAsyncCheckpointLayer<S, Fut, Request>
+where
+    S: Service<Request, Error = BoxError> + Send + 'static,
+    Fut: Future<Output = Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>>,
+{
+    checkpoint_fn: Arc<Pin<Box<dyn Fn(Request) -> Fut + Send + Sync + 'static>>>,
+    phantom: PhantomData<S>, // XXX: The compiler can't detect that S is used in the Future...
+}
+
+impl<S, Fut, Request> OneShotAsyncCheckpointLayer<S, Fut, Request>
+where
+    S: Service<Request, Error = BoxError> + Send + 'static,
+    Fut: Future<Output = Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>>,
+{
+    /// Create an `OneShotAsyncCheckpointLayer` from a function that takes a Service Request and returns a `ControlFlow`
+    pub fn new<F>(checkpoint_fn: F) -> Self
+    where
+        F: Fn(Request) -> Fut + Send + Sync + 'static,
+    {
+        Self {
+            checkpoint_fn: Arc::new(Box::pin(checkpoint_fn)),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<S, Fut, Request> Layer<S> for OneShotAsyncCheckpointLayer<S, Fut, Request>
+where
+    S: Service<Request, Error = BoxError> + Send + 'static,
+    <S as Service<Request>>::Future: Send,
+    Request: Send + 'static,
+    <S as Service<Request>>::Response: Send + 'static,
+    Fut: Future<Output = Result<ControlFlow<<S as Service<Request>>::Response, Request>, BoxError>>,
+{
+    type Service = OneShotAsyncCheckpointService<S, Fut, Request>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        OneShotAsyncCheckpointService {
+            checkpoint_fn: Arc::clone(&self.checkpoint_fn),
+            inner: Some(service),
+        }
     }
 }
 
@@ -274,6 +396,128 @@ mod async_checkpoint_tests {
                 move |_req| async move { Err(BoxError::from(expected_error)) },
             )
             .layer(router_service);
+
+        let request = ExecutionRequest::fake_builder().build();
+
+        let actual_error = service_stack
+            .oneshot(request)
+            .await
+            .map(|_| unreachable!())
+            .unwrap_err()
+            .to_string();
+
+        assert_eq!(actual_error, expected_error)
+    }
+
+    #[tokio::test]
+    async fn test_service_builder_oneshot() {
+        let expected_label = "from_mock_service";
+
+        let mut execution_service = MockExecutionService::new();
+        execution_service
+            .expect_call()
+            .times(1)
+            .returning(move |req: ExecutionRequest| {
+                Ok(ExecutionResponse::fake_builder()
+                    .label(expected_label.to_string())
+                    .context(req.context)
+                    .build()
+                    .unwrap())
+            });
+
+        let service_stack = ServiceBuilder::new()
+            .oneshot_checkpoint_async(|req: ExecutionRequest| async {
+                Ok(ControlFlow::Continue(req))
+            })
+            .service(execution_service);
+
+        let request = ExecutionRequest::fake_builder().build();
+
+        let actual_label = service_stack
+            .oneshot(request)
+            .await
+            .unwrap()
+            .next_response()
+            .await
+            .unwrap()
+            .label
+            .unwrap();
+
+        assert_eq!(actual_label, expected_label)
+    }
+
+    #[tokio::test]
+    async fn test_continue_oneshot() {
+        let expected_label = "from_mock_service";
+        let mut router_service = MockExecutionService::new();
+        router_service
+            .expect_call()
+            .times(1)
+            .returning(move |_req| {
+                Ok(ExecutionResponse::fake_builder()
+                    .label(expected_label.to_string())
+                    .build()
+                    .unwrap())
+            });
+
+        let service_stack =
+            OneShotAsyncCheckpointLayer::new(|req| async { Ok(ControlFlow::Continue(req)) })
+                .layer(router_service);
+
+        let request = ExecutionRequest::fake_builder().build();
+
+        let actual_label = service_stack
+            .oneshot(request)
+            .await
+            .unwrap()
+            .next_response()
+            .await
+            .unwrap()
+            .label
+            .unwrap();
+
+        assert_eq!(actual_label, expected_label)
+    }
+
+    #[tokio::test]
+    async fn test_return_oneshot() {
+        let expected_label = "returned_before_mock_service";
+        let router_service = MockExecutionService::new();
+
+        let service_stack = OneShotAsyncCheckpointLayer::new(|_req| async {
+            Ok(ControlFlow::Break(
+                ExecutionResponse::fake_builder()
+                    .label("returned_before_mock_service".to_string())
+                    .build()
+                    .unwrap(),
+            ))
+        })
+        .layer(router_service);
+
+        let request = ExecutionRequest::fake_builder().build();
+
+        let actual_label = service_stack
+            .oneshot(request)
+            .await
+            .unwrap()
+            .next_response()
+            .await
+            .unwrap()
+            .label
+            .unwrap();
+
+        assert_eq!(actual_label, expected_label)
+    }
+
+    #[tokio::test]
+    async fn test_error_oneshot() {
+        let expected_error = "checkpoint_error";
+        let router_service = MockExecutionService::new();
+
+        let service_stack = OneShotAsyncCheckpointLayer::new(move |_req| async move {
+            Err(BoxError::from(expected_error))
+        })
+        .layer(router_service);
 
         let request = ExecutionRequest::fake_builder().build();
 

--- a/apollo-router/src/plugins/coprocessor.rs
+++ b/apollo-router/src/plugins/coprocessor.rs
@@ -31,7 +31,7 @@ use tower::ServiceBuilder;
 use tower::ServiceExt;
 
 use crate::error::Error;
-use crate::layers::async_checkpoint::AsyncCheckpointLayer;
+use crate::layers::async_checkpoint::OneShotAsyncCheckpointLayer;
 use crate::layers::ServiceBuilderExt;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
@@ -280,7 +280,7 @@ impl RouterStage {
             let http_client = http_client.clone();
             let sdl = sdl.clone();
 
-            AsyncCheckpointLayer::new(move |request: router::Request| {
+            OneShotAsyncCheckpointLayer::new(move |request: router::Request| {
                 let request_config = request_config.clone();
                 let coprocessor_url = coprocessor_url.clone();
                 let http_client = http_client.clone();
@@ -366,7 +366,6 @@ impl RouterStage {
             .instrument(external_service_span())
             .option_layer(request_layer)
             .option_layer(response_layer)
-            .buffered()
             .service(service)
             .boxed()
     }
@@ -413,7 +412,7 @@ impl SubgraphStage {
             let http_client = http_client.clone();
             let coprocessor_url = coprocessor_url.clone();
             let service_name = service_name.clone();
-            AsyncCheckpointLayer::new(move |request: subgraph::Request| {
+            OneShotAsyncCheckpointLayer::new(move |request: subgraph::Request| {
                 let http_client = http_client.clone();
                 let coprocessor_url = coprocessor_url.clone();
                 let service_name = service_name.clone();
@@ -500,7 +499,6 @@ impl SubgraphStage {
             .instrument(external_service_span())
             .option_layer(request_layer)
             .option_layer(response_layer)
-            .buffered()
             .service(service)
             .boxed()
     }

--- a/apollo-router/src/plugins/coprocessor/supergraph.rs
+++ b/apollo-router/src/plugins/coprocessor/supergraph.rs
@@ -13,7 +13,7 @@ use tower_service::Service;
 use super::externalize_header_map;
 use super::*;
 use crate::graphql;
-use crate::layers::async_checkpoint::AsyncCheckpointLayer;
+use crate::layers::async_checkpoint::OneShotAsyncCheckpointLayer;
 use crate::layers::ServiceBuilderExt;
 use crate::plugins::coprocessor::EXTERNAL_SPAN_NAME;
 use crate::response;
@@ -82,7 +82,7 @@ impl SupergraphStage {
             let http_client = http_client.clone();
             let sdl = sdl.clone();
 
-            AsyncCheckpointLayer::new(move |request: supergraph::Request| {
+            OneShotAsyncCheckpointLayer::new(move |request: supergraph::Request| {
                 let request_config = request_config.clone();
                 let coprocessor_url = coprocessor_url.clone();
                 let http_client = http_client.clone();
@@ -169,7 +169,6 @@ impl SupergraphStage {
             .instrument(external_service_span())
             .option_layer(request_layer)
             .option_layer(response_layer)
-            .buffered()
             .service(service)
             .boxed()
     }

--- a/docs/source/customizations/native.mdx
+++ b/docs/source/customizations/native.mdx
@@ -164,6 +164,7 @@ Some notable layers are:
 * **buffered** - Make a service `Clone`. Typically required for any `async` layers.
 * **checkpoint** - Perform a sync call to decide if a request should proceed or not. Useful for validation.
 * **checkpoint_async** - Perform an async call to decide if the request should proceed or not. e.g. for Authentication. Requires `buffered`.
+* **oneshot_checkpoint_async** - Perform an async call to decide if the request should proceed or not. e.g. for Authentication. Does not require `buffered` and should be preferred to `checkpoint_async` for that reason.
 * **instrument** - Add a tracing span around a service.
 * **map_request** - Transform the request before proceeding. e.g. for header manipulation.
 * **map_response** - Transform the response before proceeding. e.g. for header manipulation.


### PR DESCRIPTION
The existing AsynCheckpoint requires `Clone` and thus introduces a need for Service Buffering that reduces the performance and resiliance of the router.

This new service set of Services, Layers and utility functions removes the requirement for `Clone` and thus the requirement for service buffering.

Existing uses of AsyncCheckpoint within the router are replaced with OneShotAsyncCheckpoint along with the requirement to `buffer()` such services.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
