### PR TITLE
fix(telemetry): do not display otel bug if the trace is sampled

### DIFF
--- a/apollo-router/src/plugins/telemetry/formatters/text.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/text.rs
@@ -17,6 +17,8 @@ use tracing_subscriber::fmt::time::SystemTime;
 use tracing_subscriber::fmt::FmtContext;
 use tracing_subscriber::registry::LookupSpan;
 
+use crate::plugins::telemetry::reload::IsSampled;
+
 #[derive(Debug, Clone)]
 pub(crate) struct TextFormatter {
     pub(crate) timer: SystemTime,
@@ -185,7 +187,11 @@ impl TextFormatter {
                     }
                     writer.write_char(' ')?;
                 }
-                None => eprintln!("Unable to find OtelData in extensions; this is a bug"),
+                None => {
+                    if span.is_sampled() {
+                        eprintln!("Unable to find OtelData in extensions; this is a bug");
+                    }
+                }
             }
         }
 

--- a/apollo-router/src/plugins/telemetry/reload.rs
+++ b/apollo-router/src/plugins/telemetry/reload.rs
@@ -21,6 +21,7 @@ use tracing_subscriber::layer::Layer;
 use tracing_subscriber::layer::Layered;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::registry::SpanRef;
 use tracing_subscriber::reload::Handle;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::EnvFilter;
@@ -220,10 +221,7 @@ where
             .id()
             .and_then(|id| cx.span(id))
         {
-            // if this extension is set, that means the parent span was accepted, and so the
-            // entire trace is accepted
-            let extensions = spanref.extensions();
-            return extensions.get::<SampledSpan>().is_some();
+            return spanref.is_sampled();
         }
 
         // we only make the sampling decision on the root span. If we reach here for any other span,
@@ -256,7 +254,23 @@ where
     }
 }
 
-struct SampledSpan;
+pub(crate) struct SampledSpan;
+
+pub(crate) trait IsSampled {
+    fn is_sampled(&self) -> bool;
+}
+
+impl<'a, T> IsSampled for SpanRef<'a, T>
+where
+    T: tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fn is_sampled(&self) -> bool {
+        // if this extension is set, that means the parent span was accepted, and so the
+        // entire trace is accepted
+        let extensions = self.extensions();
+        extensions.get::<SampledSpan>().is_some()
+    }
+}
 /// prevents span fields from being formatted to a string when writing logs
 pub(crate) struct NullFieldFormatter;
 


### PR DESCRIPTION
We changed the way we are sampling spans. If you had logs in an evicted span it displays that log `Unable to find OtelData in extensions; this is a bug` which is incorrect, it's not a bug, we just can't display the `trace_id` because there is no `trace_id` as the span has not been sampled.

Fixes #**issue_number**

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
