### PR TITLE
detect lists properly in error paths for authorization

### DIFF
--- a/apollo-router/src/plugins/authorization/policy.rs
+++ b/apollo-router/src/plugins/authorization/policy.rs
@@ -20,6 +20,7 @@ use crate::json_ext::Path;
 use crate::json_ext::PathElement;
 use crate::spec::query::transform;
 use crate::spec::query::transform::get_field_type;
+use crate::spec::query::transform::is_list;
 use crate::spec::query::traverse;
 
 pub(crate) struct PolicyExtractionVisitor<'a> {
@@ -380,7 +381,7 @@ impl<'a> transform::Visitor for PolicyFilteringVisitor<'a> {
             .get(parent_type)
             .is_some_and(|def| {
                 if let Some(field) = def.field(&self.compiler.db, field_name) {
-                    if field.ty().is_list() {
+                    if is_list(field.ty()) {
                         is_field_list = true;
                     }
                     self.is_field_authorized(field)

--- a/apollo-router/src/plugins/authorization/scopes.rs
+++ b/apollo-router/src/plugins/authorization/scopes.rs
@@ -20,6 +20,7 @@ use crate::json_ext::Path;
 use crate::json_ext::PathElement;
 use crate::spec::query::transform;
 use crate::spec::query::transform::get_field_type;
+use crate::spec::query::transform::is_list;
 use crate::spec::query::traverse;
 
 pub(crate) struct ScopeExtractionVisitor<'a> {
@@ -435,7 +436,7 @@ impl<'a> transform::Visitor for ScopeFilteringVisitor<'a> {
             .get(parent_type)
             .is_some_and(|def| {
                 if let Some(field) = def.field(&self.compiler.db, field_name) {
-                    if field.ty().is_list() {
+                    if is_list(field.ty()) {
                         is_field_list = true;
                     }
                     self.is_field_authorized(field)

--- a/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__authenticated__tests__non_null.snap
+++ b/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__authenticated__tests__non_null.snap
@@ -1,0 +1,23 @@
+---
+source: apollo-router/src/plugins/authorization/authenticated.rs
+expression: "TestResult { query: QUERY, result: doc, paths }"
+---
+query:
+
+        query {
+            me {
+                id
+                addresses {
+                    city
+                }
+            }
+        }
+        
+filtered:
+query {
+  me {
+    id
+  }
+}
+
+paths: ["/me/addresses/@"]

--- a/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__authenticated__tests__non_null_list.snap
+++ b/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__authenticated__tests__non_null_list.snap
@@ -1,0 +1,23 @@
+---
+source: apollo-router/src/plugins/authorization/authenticated.rs
+expression: "TestResult { query: QUERY, result: doc, paths }"
+---
+query:
+
+        query {
+            me {
+                id
+                addresses {
+                    city
+                }
+            }
+        }
+        
+filtered:
+query {
+  me {
+    id
+  }
+}
+
+paths: ["/me/addresses/@"]

--- a/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__authenticated__tests__unauthenticated_request_list.snap
+++ b/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__authenticated__tests__unauthenticated_request_list.snap
@@ -1,0 +1,77 @@
+---
+source: apollo-router/src/plugins/authorization/authenticated.rs
+expression: response
+---
+{
+  "data": {
+    "orga": {
+      "id": 1,
+      "members": [
+        {
+          "id": 0,
+          "name": "Ada",
+          "phone": null,
+          "addresses": null
+        },
+        {
+          "id": 1,
+          "name": "A",
+          "phone": null,
+          "addresses": null
+        }
+      ]
+    }
+  },
+  "errors": [
+    {
+      "message": "Unauthorized field or type",
+      "path": [
+        "orga",
+        "members",
+        0,
+        "phone"
+      ],
+      "extensions": {
+        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
+      }
+    },
+     {
+      "message": "Unauthorized field or type",
+      "path": [
+        "orga",
+        "members",
+        1,
+        "phone"
+      ],
+      "extensions": {
+        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
+      }
+    },
+    {
+      "message": "Unauthorized field or type",
+      "path": [
+        "orga",
+        "members",
+        "0",
+        "addresses",
+        "@"
+      ],
+      "extensions": {
+        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
+      }
+    }
+    {
+      "message": "Unauthorized field or type",
+      "path": [
+        "orga",
+        "members",
+        "1",
+        "addresses",
+        "@"
+      ],
+      "extensions": {
+        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
+      }
+    }
+  ]
+}

--- a/apollo-router/src/spec/query/transform.rs
+++ b/apollo-router/src/spec/query/transform.rs
@@ -276,6 +276,14 @@ pub(crate) fn get_field_type(
     })
 }
 
+pub(crate) fn is_list(ty: &hir::Type) -> bool {
+    match ty {
+        hir::Type::NonNull { ty, .. } => is_list(ty),
+        hir::Type::List { .. } => true,
+        hir::Type::Named { .. } => false,
+    }
+}
+
 pub(crate) fn selection_set(
     visitor: &mut impl Visitor,
     hir: &hir::SelectionSet,


### PR DESCRIPTION
The lists were not correctly recognized when building the error path in the authorization plugin. This has no impact on actual authorization, types that require authorization are still properly recognized even in a list or non null


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
