### PR TITLE
fewer header manipulations and allocations

### DIFF
--- a/apollo-router/src/http_ext.rs
+++ b/apollo-router/src/http_ext.rs
@@ -13,10 +13,10 @@ use bytes::Bytes;
 use http::header;
 use http::header::HeaderName;
 use http::HeaderValue;
-use mime::APPLICATION_JSON;
 use multimap::MultiMap;
 
 use crate::graphql;
+use crate::services::APPLICATION_JSON_HEADER_VALUE;
 
 /// Delayed-fallibility wrapper for conversion to [`http::header::HeaderName`].
 ///
@@ -441,10 +441,9 @@ impl IntoResponse for Response<graphql::Response> {
         let (mut parts, body) = http::Response::from(self).into_parts();
         let json_body_bytes =
             Bytes::from(serde_json::to_vec(&body).expect("body should be serializable; qed"));
-        parts.headers.insert(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static(APPLICATION_JSON.essence_str()),
-        );
+        parts
+            .headers
+            .insert(header::CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE);
 
         axum::response::Response::from_parts(parts, boxed(http_body::Full::new(json_body_bytes)))
     }

--- a/apollo-router/src/http_ext.rs
+++ b/apollo-router/src/http_ext.rs
@@ -443,7 +443,7 @@ impl IntoResponse for Response<graphql::Response> {
             Bytes::from(serde_json::to_vec(&body).expect("body should be serializable; qed"));
         parts
             .headers
-            .insert(header::CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE);
+            .insert(header::CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE.clone());
 
         axum::response::Response::from_parts(parts, boxed(http_body::Full::new(json_body_bytes)))
     }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -152,11 +152,11 @@ pub(crate) const LOGGING_DISPLAY_BODY: &str = "apollo_telemetry::logging::displa
 const DEFAULT_SERVICE_NAME: &str = "apollo-router";
 const GLOBAL_TRACER_NAME: &str = "apollo-router";
 const DEFAULT_EXPOSE_TRACE_ID_HEADER: &str = "apollo-trace-id";
-const DEFAULT_EXPOSE_TRACE_ID_HEADER_NAME: HeaderName =
+static DEFAULT_EXPOSE_TRACE_ID_HEADER_NAME: HeaderName =
     HeaderName::from_static(DEFAULT_EXPOSE_TRACE_ID_HEADER);
+static FTV1_HEADER_NAME: HeaderName = HeaderName::from_static("apollo-federation-include-trace");
+static FTV1_HEADER_VALUE: HeaderValue = HeaderValue::from_static("ftv1");
 
-const FTV1_HEADER_NAME: HeaderName = HeaderName::from_static("apollo-federation-include-trace");
-const FTV1_HEADER_VALUE: HeaderValue = HeaderValue::from_static("ftv1");
 #[doc(hidden)] // Only public for integration tests
 pub(crate) struct Telemetry {
     config: Arc<config::Conf>,
@@ -416,7 +416,7 @@ impl Plugin for Telemetry {
                         t.response_trace_id
                             .header_name
                             .clone()
-                            .unwrap_or(DEFAULT_EXPOSE_TRACE_ID_HEADER_NAME)
+                            .unwrap_or_else(||DEFAULT_EXPOSE_TRACE_ID_HEADER_NAME.clone())
                     })
                 });
                 if let (Some(header_name), Some(trace_id)) = (
@@ -1898,7 +1898,7 @@ fn request_ftv1(mut req: SubgraphRequest) -> SubgraphRequest {
     {
         req.subgraph_request
             .headers_mut()
-            .insert(FTV1_HEADER_NAME, FTV1_HEADER_VALUE);
+            .insert(FTV1_HEADER_NAME.clone(), FTV1_HEADER_VALUE.clone());
     }
     req
 }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -152,7 +152,11 @@ pub(crate) const LOGGING_DISPLAY_BODY: &str = "apollo_telemetry::logging::displa
 const DEFAULT_SERVICE_NAME: &str = "apollo-router";
 const GLOBAL_TRACER_NAME: &str = "apollo-router";
 const DEFAULT_EXPOSE_TRACE_ID_HEADER: &str = "apollo-trace-id";
+const DEFAULT_EXPOSE_TRACE_ID_HEADER_NAME: HeaderName =
+    HeaderName::from_static(DEFAULT_EXPOSE_TRACE_ID_HEADER);
 
+const FTV1_HEADER_NAME: HeaderName = HeaderName::from_static("apollo-federation-include-trace");
+const FTV1_HEADER_VALUE: HeaderValue = HeaderValue::from_static("ftv1");
 #[doc(hidden)] // Only public for integration tests
 pub(crate) struct Telemetry {
     config: Arc<config::Conf>,
@@ -316,21 +320,21 @@ impl Plugin for Telemetry {
                     .unwrap_or_default();
                 let router_request = &request.router_request;
                 let headers = router_request.headers();
-                let client_name = headers
+                let client_name: &str = headers
                     .get(&apollo.client_name_header)
-                    .cloned()
-                    .unwrap_or_else(|| HeaderValue::from_static(""));
+                    .and_then(|h| h.to_str().ok())
+                    .unwrap_or("");
                 let client_version = headers
                     .get(&apollo.client_version_header)
-                    .cloned()
-                    .unwrap_or_else(|| HeaderValue::from_static(""));
+                    .and_then(|h| h.to_str().ok())
+                    .unwrap_or("");
                 let span = ::tracing::info_span!(ROUTER_SPAN_NAME,
                     "http.method" = %router_request.method(),
                     "http.route" = %router_request.uri(),
                     "http.flavor" = ?router_request.version(),
                     "trace_id" = %trace_id,
-                    "client.name" = client_name.to_str().unwrap_or_default(),
-                    "client.version" = client_version.to_str().unwrap_or_default(),
+                    "client.name" = client_name,
+                    "client.version" = client_version,
                     "otel.kind" = "INTERNAL",
                     "otel.status_code" = ::tracing::field::Empty,
                     "apollo_private.duration_ns" = ::tracing::field::Empty,
@@ -412,7 +416,7 @@ impl Plugin for Telemetry {
                         t.response_trace_id
                             .header_name
                             .clone()
-                            .unwrap_or(HeaderName::from_static(DEFAULT_EXPOSE_TRACE_ID_HEADER))
+                            .unwrap_or(DEFAULT_EXPOSE_TRACE_ID_HEADER_NAME)
                     })
                 });
                 if let (Some(header_name), Some(trace_id)) = (
@@ -942,26 +946,22 @@ impl Telemetry {
         let headers = http_request.headers();
         let client_name_header = &apollo_config.client_name_header;
         let client_version_header = &apollo_config.client_version_header;
-        let _ = context.insert(
-            CLIENT_NAME,
-            headers
-                .get(client_name_header)
-                .cloned()
-                .unwrap_or_else(|| HeaderValue::from_static(""))
-                .to_str()
-                .unwrap_or_default()
-                .to_string(),
-        );
-        let _ = context.insert(
-            CLIENT_VERSION,
-            headers
-                .get(client_version_header)
-                .cloned()
-                .unwrap_or_else(|| HeaderValue::from_static(""))
-                .to_str()
-                .unwrap_or_default()
-                .to_string(),
-        );
+        if let Some(name) = headers
+            .get(client_name_header)
+            .and_then(|h| h.to_str().ok())
+            .map(|s| s.to_owned())
+        {
+            let _ = context.insert(CLIENT_NAME, name);
+        }
+
+        if let Some(version) = headers
+            .get(client_version_header)
+            .and_then(|h| h.to_str().ok())
+            .map(|s| s.to_owned())
+        {
+            let _ = context.insert(CLIENT_VERSION, version);
+        }
+
         let (should_log_headers, should_log_body) = config.logging.should_log(req);
         if should_log_headers {
             ::tracing::info!(http.request.headers = ?req.supergraph_request.headers(), "Supergraph request headers");
@@ -1896,10 +1896,9 @@ fn request_ftv1(mut req: SubgraphRequest) -> SubgraphRequest {
         .contains_key::<EnableSubgraphFtv1>()
         && Span::current().context().span().span_context().is_sampled()
     {
-        req.subgraph_request.headers_mut().insert(
-            "apollo-federation-include-trace",
-            HeaderValue::from_static("ftv1"),
-        );
+        req.subgraph_request
+            .headers_mut()
+            .insert(FTV1_HEADER_NAME, FTV1_HEADER_VALUE);
     }
     req
 }

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -382,7 +382,7 @@ impl Exporter {
             SUBGRAPH_SPAN_NAME => {
                 let subgraph_name = span
                     .attributes
-                    .get(&Key::from_static_str("apollo.subgraph.name"))
+                    .get(&SUBGRAPH_NAME)
                     .and_then(extract_string)
                     .unwrap_or_default();
                 let error_configuration = self

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -17,6 +17,7 @@ use crate::services::SupergraphRequest;
 use crate::services::SupergraphResponse;
 
 const DONT_CACHE_RESPONSE_VALUE: &str = "private, no-cache, must-revalidate";
+const DONT_CACHE_HEADER_VALUE: HeaderValue = HeaderValue::from_static(DONT_CACHE_RESPONSE_VALUE);
 
 /// A persisted query.
 #[derive(Deserialize, Clone, Debug)]
@@ -134,10 +135,7 @@ async fn apq_request(
                     // Persisted query errors (especially "not found") need to be uncached, because
                     // hopefully we're about to fill in the APQ cache and the same request will
                     // succeed next time.
-                    .header(
-                        CACHE_CONTROL,
-                        HeaderValue::from_static(DONT_CACHE_RESPONSE_VALUE),
-                    )
+                    .header(CACHE_CONTROL, DONT_CACHE_HEADER_VALUE)
                     .context(request.context)
                     .build()
                     .expect("response is valid");

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -17,7 +17,7 @@ use crate::services::SupergraphRequest;
 use crate::services::SupergraphResponse;
 
 const DONT_CACHE_RESPONSE_VALUE: &str = "private, no-cache, must-revalidate";
-const DONT_CACHE_HEADER_VALUE: HeaderValue = HeaderValue::from_static(DONT_CACHE_RESPONSE_VALUE);
+static DONT_CACHE_HEADER_VALUE: HeaderValue = HeaderValue::from_static(DONT_CACHE_RESPONSE_VALUE);
 
 /// A persisted query.
 #[derive(Deserialize, Clone, Debug)]
@@ -135,7 +135,7 @@ async fn apq_request(
                     // Persisted query errors (especially "not found") need to be uncached, because
                     // hopefully we're about to fill in the APQ cache and the same request will
                     // succeed next time.
-                    .header(CACHE_CONTROL, DONT_CACHE_HEADER_VALUE)
+                    .header(CACHE_CONTROL, DONT_CACHE_HEADER_VALUE.clone())
                     .context(request.context)
                     .build()
                     .expect("response is valid");

--- a/apollo-router/src/services/layers/content_negotiation.rs
+++ b/apollo-router/src/services/layers/content_negotiation.rs
@@ -142,15 +142,15 @@ where
                 if !res.has_next.unwrap_or_default() && (accepts_json || accepts_wildcard) {
                     parts
                         .headers
-                        .insert(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE);
+                        .insert(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE.clone());
                 } else if accepts_multipart_defer {
                     parts
                         .headers
-                        .insert(CONTENT_TYPE, MULTIPART_DEFER_HEADER_VALUE);
+                        .insert(CONTENT_TYPE, MULTIPART_DEFER_HEADER_VALUE.clone());
                 } else if accepts_multipart_subscription {
                     parts
                         .headers
-                        .insert(CONTENT_TYPE, MULTIPART_SUBSCRIPTION_HEADER_VALUE);
+                        .insert(CONTENT_TYPE, MULTIPART_SUBSCRIPTION_HEADER_VALUE.clone());
                 }
                 (parts, res)
             })

--- a/apollo-router/src/services/layers/content_negotiation.rs
+++ b/apollo-router/src/services/layers/content_negotiation.rs
@@ -3,7 +3,6 @@ use std::ops::ControlFlow;
 use http::header::ACCEPT;
 use http::header::CONTENT_TYPE;
 use http::HeaderMap;
-use http::HeaderValue;
 use http::Method;
 use http::StatusCode;
 use mediatype::names::APPLICATION;
@@ -24,7 +23,10 @@ use crate::layers::sync_checkpoint::CheckpointService;
 use crate::layers::ServiceExt as _;
 use crate::services::router;
 use crate::services::router::ClientRequestAccepts;
+use crate::services::router_service::MULTIPART_DEFER_HEADER_VALUE;
+use crate::services::router_service::MULTIPART_SUBSCRIPTION_HEADER_VALUE;
 use crate::services::supergraph;
+use crate::services::APPLICATION_JSON_HEADER_VALUE;
 use crate::services::MULTIPART_DEFER_CONTENT_TYPE;
 use crate::services::MULTIPART_DEFER_SPEC_PARAMETER;
 use crate::services::MULTIPART_DEFER_SPEC_VALUE;
@@ -138,20 +140,17 @@ where
                     .unwrap_or_default();
 
                 if !res.has_next.unwrap_or_default() && (accepts_json || accepts_wildcard) {
-                    parts.headers.insert(
-                        CONTENT_TYPE,
-                        HeaderValue::from_static(APPLICATION_JSON.essence_str()),
-                    );
+                    parts
+                        .headers
+                        .insert(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE);
                 } else if accepts_multipart_defer {
-                    parts.headers.insert(
-                        CONTENT_TYPE,
-                        HeaderValue::from_static(MULTIPART_DEFER_CONTENT_TYPE),
-                    );
+                    parts
+                        .headers
+                        .insert(CONTENT_TYPE, MULTIPART_DEFER_HEADER_VALUE);
                 } else if accepts_multipart_subscription {
-                    parts.headers.insert(
-                        CONTENT_TYPE,
-                        HeaderValue::from_static(MULTIPART_SUBSCRIPTION_CONTENT_TYPE),
-                    );
+                    parts
+                        .headers
+                        .insert(CONTENT_TYPE, MULTIPART_SUBSCRIPTION_HEADER_VALUE);
                 }
                 (parts, res)
             })
@@ -236,6 +235,8 @@ fn parse_accept(headers: &HeaderMap) -> ClientRequestAccepts {
 
 #[cfg(test)]
 mod tests {
+    use http::HeaderValue;
+
     use super::*;
 
     #[test]

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -17,9 +17,9 @@ use serde_json_bytes::Value;
 use static_assertions::assert_impl_all;
 use tower::BoxError;
 
+use super::router_service::MULTIPART_DEFER_HEADER_VALUE;
+use super::router_service::MULTIPART_SUBSCRIPTION_HEADER_VALUE;
 use super::supergraph;
-use super::MULTIPART_DEFER_CONTENT_TYPE;
-use super::MULTIPART_SUBSCRIPTION_CONTENT_TYPE;
 use crate::graphql;
 use crate::json_ext::Path;
 use crate::services::TryIntoHeaderName;
@@ -220,8 +220,8 @@ impl Response {
                 .get(CONTENT_TYPE)
                 .iter()
                 .any(|value| {
-                    *value == HeaderValue::from_static(MULTIPART_DEFER_CONTENT_TYPE)
-                        || *value == HeaderValue::from_static(MULTIPART_SUBSCRIPTION_CONTENT_TYPE)
+                    *value == MULTIPART_DEFER_HEADER_VALUE
+                        || *value == MULTIPART_SUBSCRIPTION_HEADER_VALUE
                 })
             {
                 let multipart = Multipart::new(self.response.into_body(), "graphql");

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -42,6 +42,7 @@ use super::HasPlugins;
 #[cfg(test)]
 use super::HasSchema;
 use super::SupergraphCreator;
+use super::APPLICATION_JSON_HEADER_VALUE;
 use super::MULTIPART_DEFER_CONTENT_TYPE;
 use super::MULTIPART_SUBSCRIPTION_CONTENT_TYPE;
 use crate::cache::DeduplicatingCache;
@@ -62,6 +63,14 @@ use crate::services::SupergraphResponse;
 use crate::Configuration;
 use crate::Endpoint;
 use crate::ListenAddr;
+
+pub(crate) const MULTIPART_DEFER_HEADER_VALUE: HeaderValue =
+    HeaderValue::from_static(MULTIPART_DEFER_CONTENT_TYPE);
+pub(crate) const MULTIPART_SUBSCRIPTION_HEADER_VALUE: HeaderValue =
+    HeaderValue::from_static(MULTIPART_SUBSCRIPTION_CONTENT_TYPE);
+const ACCEL_BUFFERING_HEADER_NAME: HeaderName = HeaderName::from_static("x-accel-buffering");
+const ACCEL_BUFFERING_HEADER_VALUE: HeaderValue = HeaderValue::from_static("no");
+const ORIGIN_HEADER_VALUE: HeaderValue = HeaderValue::from_static("origin");
 
 /// Containing [`Service`] in the request lifecyle.
 #[derive(Clone)]
@@ -284,10 +293,9 @@ impl RouterService {
                     && !response.subscribed.unwrap_or(false)
                     && (accepts_json || accepts_wildcard)
                 {
-                    parts.headers.insert(
-                        CONTENT_TYPE,
-                        HeaderValue::from_static(APPLICATION_JSON.essence_str()),
-                    );
+                    parts
+                        .headers
+                        .insert(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE);
                     tracing::trace_span!("serialize_response").in_scope(|| {
                         let body = serde_json::to_string(&response)?;
                         Ok(router::Response {
@@ -297,21 +305,18 @@ impl RouterService {
                     })
                 } else if accepts_multipart_defer || accepts_multipart_subscription {
                     if accepts_multipart_defer {
-                        parts.headers.insert(
-                            CONTENT_TYPE,
-                            HeaderValue::from_static(MULTIPART_DEFER_CONTENT_TYPE),
-                        );
+                        parts
+                            .headers
+                            .insert(CONTENT_TYPE, MULTIPART_DEFER_HEADER_VALUE);
                     } else if accepts_multipart_subscription {
-                        parts.headers.insert(
-                            CONTENT_TYPE,
-                            HeaderValue::from_static(MULTIPART_SUBSCRIPTION_CONTENT_TYPE),
-                        );
+                        parts
+                            .headers
+                            .insert(CONTENT_TYPE, MULTIPART_SUBSCRIPTION_HEADER_VALUE);
                     }
                     // Useful when you're using a proxy like nginx which enable proxy_buffering by default (http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering)
-                    parts.headers.insert(
-                        HeaderName::from_static("x-accel-buffering"),
-                        HeaderValue::from_static("no"),
-                    );
+                    parts
+                        .headers
+                        .insert(ACCEL_BUFFERING_HEADER_NAME, ACCEL_BUFFERING_HEADER_VALUE);
                     let multipart_stream = match response.subscribed {
                         Some(true) => {
                             StreamBody::new(Multipart::new(body, ProtocolMode::Subscription))
@@ -454,7 +459,7 @@ impl RouterService {
 fn process_vary_header(headers: &mut HeaderMap<HeaderValue>) {
     if headers.get(VARY).is_none() {
         // We don't have a VARY header, add one with value "origin"
-        headers.insert(VARY, HeaderValue::from_static("origin"));
+        headers.insert(VARY, ORIGIN_HEADER_VALUE);
     }
 }
 

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -64,13 +64,13 @@ use crate::Configuration;
 use crate::Endpoint;
 use crate::ListenAddr;
 
-pub(crate) const MULTIPART_DEFER_HEADER_VALUE: HeaderValue =
+pub(crate) static MULTIPART_DEFER_HEADER_VALUE: HeaderValue =
     HeaderValue::from_static(MULTIPART_DEFER_CONTENT_TYPE);
-pub(crate) const MULTIPART_SUBSCRIPTION_HEADER_VALUE: HeaderValue =
+pub(crate) static MULTIPART_SUBSCRIPTION_HEADER_VALUE: HeaderValue =
     HeaderValue::from_static(MULTIPART_SUBSCRIPTION_CONTENT_TYPE);
-const ACCEL_BUFFERING_HEADER_NAME: HeaderName = HeaderName::from_static("x-accel-buffering");
-const ACCEL_BUFFERING_HEADER_VALUE: HeaderValue = HeaderValue::from_static("no");
-const ORIGIN_HEADER_VALUE: HeaderValue = HeaderValue::from_static("origin");
+static ACCEL_BUFFERING_HEADER_NAME: HeaderName = HeaderName::from_static("x-accel-buffering");
+static ACCEL_BUFFERING_HEADER_VALUE: HeaderValue = HeaderValue::from_static("no");
+static ORIGIN_HEADER_VALUE: HeaderValue = HeaderValue::from_static("origin");
 
 /// Containing [`Service`] in the request lifecyle.
 #[derive(Clone)]
@@ -295,7 +295,7 @@ impl RouterService {
                 {
                     parts
                         .headers
-                        .insert(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE);
+                        .insert(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE.clone());
                     tracing::trace_span!("serialize_response").in_scope(|| {
                         let body = serde_json::to_string(&response)?;
                         Ok(router::Response {
@@ -307,16 +307,17 @@ impl RouterService {
                     if accepts_multipart_defer {
                         parts
                             .headers
-                            .insert(CONTENT_TYPE, MULTIPART_DEFER_HEADER_VALUE);
+                            .insert(CONTENT_TYPE, MULTIPART_DEFER_HEADER_VALUE.clone());
                     } else if accepts_multipart_subscription {
                         parts
                             .headers
-                            .insert(CONTENT_TYPE, MULTIPART_SUBSCRIPTION_HEADER_VALUE);
+                            .insert(CONTENT_TYPE, MULTIPART_SUBSCRIPTION_HEADER_VALUE.clone());
                     }
                     // Useful when you're using a proxy like nginx which enable proxy_buffering by default (http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering)
-                    parts
-                        .headers
-                        .insert(ACCEL_BUFFERING_HEADER_NAME, ACCEL_BUFFERING_HEADER_VALUE);
+                    parts.headers.insert(
+                        ACCEL_BUFFERING_HEADER_NAME.clone(),
+                        ACCEL_BUFFERING_HEADER_VALUE.clone(),
+                    );
                     let multipart_stream = match response.subscribed {
                         Some(true) => {
                             StreamBody::new(Multipart::new(body, ProtocolMode::Subscription))
@@ -459,7 +460,7 @@ impl RouterService {
 fn process_vary_header(headers: &mut HeaderMap<HeaderValue>) {
     if headers.get(VARY).is_none() {
         // We don't have a VARY header, add one with value "origin"
-        headers.insert(VARY, ORIGIN_HEADER_VALUE);
+        headers.insert(VARY, ORIGIN_HEADER_VALUE.clone());
     }
 }
 

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -92,10 +92,10 @@ const POOL_IDLE_TIMEOUT_DURATION: Option<Duration> = Some(Duration::from_secs(5)
 
 // interior mutability is not a concern here, the value is never modified
 #[allow(clippy::declare_interior_mutable_const)]
-const ACCEPTED_ENCODINGS: HeaderValue = HeaderValue::from_static("gzip, br, deflate");
-pub(crate) const APPLICATION_JSON_HEADER_VALUE: HeaderValue =
+static ACCEPTED_ENCODINGS: HeaderValue = HeaderValue::from_static("gzip, br, deflate");
+pub(crate) static APPLICATION_JSON_HEADER_VALUE: HeaderValue =
     HeaderValue::from_static("application/json");
-const APP_GRAPHQL_JSON: HeaderValue = HeaderValue::from_static(GRAPHQL_JSON_RESPONSE_HEADER_VALUE);
+static APP_GRAPHQL_JSON: HeaderValue = HeaderValue::from_static(GRAPHQL_JSON_RESPONSE_HEADER_VALUE);
 
 enum APQError {
     PersistedQueryNotSupported,
@@ -649,14 +649,16 @@ async fn call_http(
 
     request
         .headers_mut()
-        .insert(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE);
+        .insert(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE.clone());
     request
         .headers_mut()
-        .insert(ACCEPT, APPLICATION_JSON_HEADER_VALUE);
-    request.headers_mut().append(ACCEPT, APP_GRAPHQL_JSON);
+        .insert(ACCEPT, APPLICATION_JSON_HEADER_VALUE.clone());
     request
         .headers_mut()
-        .insert(ACCEPT_ENCODING, ACCEPTED_ENCODINGS);
+        .append(ACCEPT, APP_GRAPHQL_JSON.clone());
+    request
+        .headers_mut()
+        .insert(ACCEPT_ENCODING, ACCEPTED_ENCODINGS.clone());
 
     let schema_uri = request.uri();
     let host = schema_uri.host().unwrap_or_default();

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -93,6 +93,9 @@ const POOL_IDLE_TIMEOUT_DURATION: Option<Duration> = Some(Duration::from_secs(5)
 // interior mutability is not a concern here, the value is never modified
 #[allow(clippy::declare_interior_mutable_const)]
 const ACCEPTED_ENCODINGS: HeaderValue = HeaderValue::from_static("gzip, br, deflate");
+pub(crate) const APPLICATION_JSON_HEADER_VALUE: HeaderValue =
+    HeaderValue::from_static("application/json");
+const APP_GRAPHQL_JSON: HeaderValue = HeaderValue::from_static(GRAPHQL_JSON_RESPONSE_HEADER_VALUE);
 
 enum APQError {
     PersistedQueryNotSupported,
@@ -643,12 +646,14 @@ async fn call_http(
         })?;
 
     let mut request = http::request::Request::from_parts(parts, compressed_body.into());
-    let app_json: HeaderValue = HeaderValue::from_static(APPLICATION_JSON.essence_str());
-    let app_graphql_json: HeaderValue =
-        HeaderValue::from_static(GRAPHQL_JSON_RESPONSE_HEADER_VALUE);
-    request.headers_mut().insert(CONTENT_TYPE, app_json.clone());
-    request.headers_mut().insert(ACCEPT, app_json);
-    request.headers_mut().append(ACCEPT, app_graphql_json);
+
+    request
+        .headers_mut()
+        .insert(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE);
+    request
+        .headers_mut()
+        .insert(ACCEPT, APPLICATION_JSON_HEADER_VALUE);
+    request.headers_mut().append(ACCEPT, APP_GRAPHQL_JSON);
     request
         .headers_mut()
         .insert(ACCEPT_ENCODING, ACCEPTED_ENCODINGS);


### PR DESCRIPTION
`HeaderName::from_static` and `HeaderValue::from_static` can avoid allocations, but we do not get the full benefit from this function by calling them directly in the code: They are const functions, so their result should be stored in a const or static value, then reused elsewhere.
This also removes some unneeded header allocations when handling client name and client version

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
