### PR TITLE
preverify release version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -869,6 +869,11 @@ workflows:
           matrix:
             parameters:
               platform: [ amd_linux_build ]
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v.*/
       - build_release:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -380,18 +380,7 @@ commands:
                   - target
   xtask_release_preverify:
     steps:
-      - restore_cache:
-          keys:
-            - "<< pipeline.parameters.merge_version >>-preverify"
       - run: xtask release pre-verify
-      - when:
-          condition:
-            equal: [ "dev", "<< pipeline.git.branch >>" ]
-          steps:
-            - save_cache:
-                key: "<< pipeline.parameters.merge_version >>-preverify"
-                paths:
-                  - target
 
   xtask_check_helm:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -378,6 +378,20 @@ commands:
                 key: "<< pipeline.parameters.merge_version >>-lint"
                 paths:
                   - target
+  xtask_release_preverify:
+    steps:
+      - restore_cache:
+          keys:
+            - "<< pipeline.parameters.merge_version >>-preverify"
+      - run: xtask release pre-verify
+      - when:
+          condition:
+            equal: [ "dev", "<< pipeline.git.branch >>" ]
+          steps:
+            - save_cache:
+                key: "<< pipeline.parameters.merge_version >>-preverify"
+                paths:
+                  - target
 
   xtask_check_helm:
     steps:
@@ -525,6 +539,18 @@ jobs:
             cargo fetch
       - xtask_test:
           variant: "updated"
+  pre_verify_release:
+    environment:
+      <<: *common_job_environment
+    parameters:
+      platform:
+        type: executor
+    executor: << parameters.platform >>
+    steps:
+      - checkout
+      - setup_environment:
+          platform: << parameters.platform >>
+      - xtask_release_preverify
 
   build_release:
     parameters:
@@ -839,6 +865,10 @@ workflows:
     when:
       not: << pipeline.parameters.nightly >>
     jobs:
+      - pre_verify_release:
+          matrix:
+            parameters:
+              platform: [ amd_linux_build ]
       - build_release:
           matrix:
             parameters:

--- a/xtask/src/commands/release.rs
+++ b/xtask/src/commands/release.rs
@@ -419,18 +419,7 @@ struct PreVerify();
 
 impl PreVerify {
     fn run() -> Result<()> {
-        // Get the version out of Cargo.toml
-        let metadata = MetadataCommand::new()
-            .manifest_path("./apollo-router/Cargo.toml")
-            .exec()?;
-        let version = format!(
-            "v{}",
-            metadata
-                .root_package()
-                .expect("expected root")
-                .version
-                .to_string()
-        );
+        let version = format!("v{}", *PKG_VERSION);
 
         // Get the git tag name as a string
         let tags_output = std::process::Command::new("git")


### PR DESCRIPTION
Adds a new `xtask release pre-verify`

Adds a check that the cargo toml matches the local tagged tree.

Fixes #3664

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
