### PR TITLE
persisted queries: improve Uplink failover and error handling

### DIFF
--- a/.changesets/fix_persisted_queries_failover_and_error_handling.md
+++ b/.changesets/fix_persisted_queries_failover_and_error_handling.md
@@ -1,0 +1,5 @@
+### Improve multi-cloud failover and error handling for Persisted Queries
+
+Improves the resilience of the Persisted Queries feature to Uplink outages, and makes errors fetching Persisted Query Manifests from Uplink more visible.
+
+By [@glasser](https://github.com/glasser) in https://github.com/apollographql/router/pull/3863

--- a/apollo-router/src/services/layers/persisted_queries/manifest_poller.rs
+++ b/apollo-router/src/services/layers/persisted_queries/manifest_poller.rs
@@ -19,7 +19,7 @@ use tower::BoxError;
 use crate::uplink::persisted_queries_manifest_stream::MaybePersistedQueriesManifestChunks;
 use crate::uplink::persisted_queries_manifest_stream::PersistedQueriesManifestChunk;
 use crate::uplink::persisted_queries_manifest_stream::PersistedQueriesManifestQuery;
-use crate::uplink::stream_from_uplink;
+use crate::uplink::stream_from_uplink_transforming_new_response;
 use crate::uplink::UplinkConfig;
 use crate::Configuration;
 
@@ -347,23 +347,32 @@ async fn poll_uplink(
     mut drop_receiver: mpsc::Receiver<()>,
     http_client: Client,
 ) {
+    let http_client = http_client.clone();
     let mut uplink_executor = stream::select_all(vec![
-        stream_from_uplink::<PersistedQueriesManifestQuery, MaybePersistedQueriesManifestChunks>(
-            uplink_config.clone(),
-        )
-        .filter_map(|res| {
+        stream_from_uplink_transforming_new_response::<
+            PersistedQueriesManifestQuery,
+            MaybePersistedQueriesManifestChunks,
+            Option<PersistedQueryManifest>,
+        >(uplink_config.clone(), move |response| {
             let http_client = http_client.clone();
-            let graph_ref = uplink_config.apollo_graph_ref.clone();
-            async move {
-                match res {
-                    Ok(Some(chunks)) => match manifest_from_chunks(chunks, http_client).await {
-                        Ok(new_manifest) => Some(ManifestPollEvent::NewManifest(new_manifest)),
-                        Err(e) => Some(ManifestPollEvent::FetchError(e)),
-                    },
-                    Ok(None) => Some(ManifestPollEvent::NoPersistedQueryList { graph_ref }),
-                    Err(e) => Some(ManifestPollEvent::Err(e.into())),
+            Box::new(Box::pin(async move {
+                match response {
+                    Some(chunks) => manifest_from_chunks(chunks, http_client)
+                        .await
+                        .map(Some)
+                        .map_err(|err| {
+                            format!("could not download persisted query lists: {}", err).into()
+                        }),
+                    None => Ok(None),
                 }
-            }
+            }))
+        })
+        .map(|res| match res {
+            Ok(Some(new_manifest)) => ManifestPollEvent::NewManifest(new_manifest),
+            Ok(None) => ManifestPollEvent::NoPersistedQueryList {
+                graph_ref: uplink_config.apollo_graph_ref.clone(),
+            },
+            Err(e) => ManifestPollEvent::Err(e.into()),
         })
         .boxed(),
         drop_receiver
@@ -373,7 +382,8 @@ async fn poll_uplink(
                 future::ready(match res {
                     None => Some(ManifestPollEvent::Shutdown),
                     Some(()) => Some(ManifestPollEvent::Err(
-                        "received message on drop channel in persisted query layer, which never gets sent"
+                        "received message on drop channel in persisted query layer, which never \
+                         gets sent"
                             .into(),
                     )),
                 })
@@ -383,7 +393,7 @@ async fn poll_uplink(
     .take_while(|msg| future::ready(!matches!(msg, ManifestPollEvent::Shutdown)))
     .boxed();
 
-    let mut resolved_first_pq_manifest = false;
+    let mut ready_sender_once = Some(ready_sender);
 
     while let Some(event) = uplink_executor.next().await {
         match event {
@@ -423,30 +433,22 @@ async fn poll_uplink(
                     })
                     .expect("could not acquire write lock on persisted query manifest state");
 
-                if !resolved_first_pq_manifest {
-                    send_startup_event(
-                        &ready_sender,
-                        ManifestPollResultOnStartup::LoadedOperations,
-                    )
-                    .await;
-                    resolved_first_pq_manifest = true;
-                }
+                send_startup_event_or_log_error(
+                    &mut ready_sender_once,
+                    ManifestPollResultOnStartup::LoadedOperations,
+                )
+                .await;
             }
-            ManifestPollEvent::FetchError(e) => {
-                send_startup_event(
-                    &ready_sender,
-                    ManifestPollResultOnStartup::Err(
-                        format!("could not fetch persisted queries: {e}").into(),
-                    ),
+            ManifestPollEvent::Err(e) => {
+                send_startup_event_or_log_error(
+                    &mut ready_sender_once,
+                    ManifestPollResultOnStartup::Err(e),
                 )
                 .await
             }
-            ManifestPollEvent::Err(e) => {
-                send_startup_event(&ready_sender, ManifestPollResultOnStartup::Err(e)).await
-            }
             ManifestPollEvent::NoPersistedQueryList { graph_ref } => {
-                send_startup_event(
-                    &ready_sender,
+                send_startup_event_or_log_error(
+                    &mut ready_sender_once,
                     ManifestPollResultOnStartup::Err(
                         format!("no persisted query list found for graph ref {}", &graph_ref)
                             .into(),
@@ -459,12 +461,28 @@ async fn poll_uplink(
         }
     }
 
-    async fn send_startup_event(
-        ready_sender: &mpsc::Sender<ManifestPollResultOnStartup>,
+    async fn send_startup_event_or_log_error(
+        ready_sender: &mut Option<mpsc::Sender<ManifestPollResultOnStartup>>,
         message: ManifestPollResultOnStartup,
     ) {
-        if let Err(e) = ready_sender.send(message).await {
-            tracing::debug!("could not send startup event for the persisted query layer: {e}");
+        match (ready_sender.take(), message) {
+            (Some(ready_sender), message) => {
+                if let Err(e) = ready_sender.send(message).await {
+                    tracing::debug!(
+                        "could not send startup event for the persisted query layer: {e}"
+                    );
+                }
+            }
+            (None, ManifestPollResultOnStartup::Err(err)) => {
+                // We've already successfully started up, but we received some sort of error. This doesn't
+                // need to break our functional router, but we can log in case folks are interested.
+                tracing::error!(
+                    "error while polling uplink for persisted query manifests: {}",
+                    err
+                )
+            }
+            // Do nothing in the normal background "new manifest" case.
+            (None, ManifestPollResultOnStartup::LoadedOperations) => {}
         }
     }
 }
@@ -498,46 +516,69 @@ async fn add_chunk_to_operations(
     operations: &mut PersistedQueryManifest,
     http_client: Client,
 ) -> Result<(), BoxError> {
-    // TODO: chunk URLs will eventually respond with fallback URLs, when it does, implement falling back here
-    if let Some(chunk_url) = chunk.urls.get(0) {
-        let chunk = http_client
-            .get(chunk_url.clone())
-            .send()
-            .await
-            .and_then(|r| r.error_for_status())
-            .map_err(|e| -> BoxError {
-                format!(
-                    "error fetching persisted queries manifest chunk from {}: {}",
-                    chunk_url, e
-                )
-                .into()
-            })?
-            .json::<SignedUrlChunk>()
-            .await
-            .map_err(|e| -> BoxError {
-                format!(
-                    "error reading body of persisted queries manifest chunk from {}: {}",
-                    chunk_url, e
-                )
-                .into()
-            })?;
-
-        if chunk.format != "apollo-persisted-query-manifest" {
-            return Err("chunk format is not 'apollo-persisted-query-manifest'".into());
+    let mut it = chunk.urls.iter().peekable();
+    while let Some(chunk_url) = it.next() {
+        match fetch_chunk(http_client.clone(), chunk_url).await {
+            Ok(chunk) => {
+                for operation in chunk.operations {
+                    operations.insert(operation.id, operation.body);
+                }
+                return Ok(());
+            }
+            Err(e) => {
+                if it.peek().is_some() {
+                    // There's another URL to try, so log as debug and move on.
+                    tracing::debug!(
+                        "failed to fetch persisted query list chunk from {}: {}. \
+                         Other endpoints will be tried",
+                        chunk_url,
+                        e
+                    );
+                    continue;
+                } else {
+                    // No more URLs; fail the function.
+                    return Err(e);
+                }
+            }
         }
-
-        if chunk.version != 1 {
-            return Err("persisted query manifest chunk version is not 1".into());
-        }
-
-        for operation in chunk.operations {
-            operations.insert(operation.id, operation.body);
-        }
-
-        Ok(())
-    } else {
-        Err("persisted query chunk did not include any URLs to fetch operations from".into())
     }
+    // The loop always returns unless there's another iteration after it, so the
+    // only way we can fall off the loop is if we never entered it.
+    Err("persisted query chunk did not include any URLs to fetch operations from".into())
+}
+
+async fn fetch_chunk(http_client: Client, chunk_url: &String) -> Result<SignedUrlChunk, BoxError> {
+    let chunk = http_client
+        .get(chunk_url.clone())
+        .send()
+        .await
+        .and_then(|r| r.error_for_status())
+        .map_err(|e| -> BoxError {
+            format!(
+                "error fetching persisted queries manifest chunk from {}: {}",
+                chunk_url, e
+            )
+            .into()
+        })?
+        .json::<SignedUrlChunk>()
+        .await
+        .map_err(|e| -> BoxError {
+            format!(
+                "error reading body of persisted queries manifest chunk from {}: {}",
+                chunk_url, e
+            )
+            .into()
+        })?;
+
+    if chunk.format != "apollo-persisted-query-manifest" {
+        return Err("chunk format is not 'apollo-persisted-query-manifest'".into());
+    }
+
+    if chunk.version != 1 {
+        return Err("persisted query manifest chunk version is not 1".into());
+    }
+
+    Ok(chunk)
 }
 
 /// Types of events produced by the manifest poller.
@@ -546,7 +587,6 @@ pub(crate) enum ManifestPollEvent {
     NewManifest(PersistedQueryManifest),
     NoPersistedQueryList { graph_ref: String },
     Err(BoxError),
-    FetchError(BoxError),
     Shutdown,
 }
 
@@ -608,6 +648,24 @@ mod tests {
         )
         .await
         .is_err());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn poller_fails_over_on_gcs_failure() {
+        let (_mock_server1, url1) = mock_pq_uplink_bad_gcs().await;
+        let (id, body, manifest) = fake_manifest();
+        let (_mock_guard2, url2) = mock_pq_uplink_one_endpoint(&manifest, None).await;
+        let manifest_manager = PersistedQueryManifestPoller::new(
+            Configuration::fake_builder()
+                .uplink(UplinkConfig::for_tests(Endpoints::fallback(vec![
+                    url1, url2,
+                ])))
+                .build()
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(manifest_manager.get_operation_body(&id), Some(body))
     }
 
     #[test]

--- a/apollo-router/src/test_harness/mocks/persisted_queries.rs
+++ b/apollo-router/src/test_harness/mocks/persisted_queries.rs
@@ -32,12 +32,20 @@ pub async fn mock_pq_uplink_with_delay(
     manifest: &HashMap<String, String>,
     delay: Duration,
 ) -> (UplinkMockGuard, UplinkConfig) {
-    do_mock_pq_uplink(manifest, Some(delay)).await
+    let (guard, url) = mock_pq_uplink_one_endpoint(manifest, Some(delay)).await;
+    (
+        guard,
+        UplinkConfig::for_tests(Endpoints::fallback(vec![url])),
+    )
 }
 
 /// Mocks an uplink server with a persisted query list containing operations passed to this function.
 pub async fn mock_pq_uplink(manifest: &HashMap<String, String>) -> (UplinkMockGuard, UplinkConfig) {
-    do_mock_pq_uplink(manifest, None).await
+    let (guard, url) = mock_pq_uplink_one_endpoint(manifest, None).await;
+    (
+        guard,
+        UplinkConfig::for_tests(Endpoints::fallback(vec![url])),
+    )
 }
 
 /// Guards for the uplink and GCS mock servers, dropping these structs shuts down the server.
@@ -52,10 +60,12 @@ struct Operation {
     body: String,
 }
 
-async fn do_mock_pq_uplink(
+/// Mocks an uplink server; returns a single Url rather than a full UplinkConfig, so you
+/// can combine it with another one to test failover.
+pub async fn mock_pq_uplink_one_endpoint(
     manifest: &HashMap<String, String>,
     delay: Option<Duration>,
-) -> (UplinkMockGuard, UplinkConfig) {
+) -> (UplinkMockGuard, Url) {
     let operations: Vec<Operation> = manifest
         // clone the manifest so the caller can still make assertions about it
         .clone()
@@ -80,7 +90,7 @@ async fn do_mock_pq_uplink(
 
     let mock_uplink_server = MockServer::start().await;
 
-    let mut gcs_response = ResponseTemplate::new(200).set_body_json(json!({
+    let mut uplink_response = ResponseTemplate::new(200).set_body_json(json!({
           "data": {
             "persistedQueries": {
               "__typename": "PersistedQueriesResult",
@@ -90,7 +100,8 @@ async fn do_mock_pq_uplink(
                 {
                   "id": "graph-id/889406a1-b4f8-44df-a499-6c1e3c1bea09/ec8ae3ae3eb00c738031dbe81603489b5d24fbf58f15bdeec1587282ee4e6eea",
                   "urls": [
-                    mock_gcs_server_uri
+                    "https://a.broken.gcs.url.that.will.get.fetched.and.skipped.unknown/",
+                    mock_gcs_server_uri,
                   ]
                 }
               ]
@@ -99,11 +110,11 @@ async fn do_mock_pq_uplink(
         }));
 
     if let Some(delay) = delay {
-        gcs_response = gcs_response.set_delay(delay);
+        uplink_response = uplink_response.set_delay(delay);
     }
 
     Mock::given(method("POST"))
-        .respond_with(gcs_response)
+        .respond_with(uplink_response)
         .mount(&mock_uplink_server)
         .await;
 
@@ -113,6 +124,37 @@ async fn do_mock_pq_uplink(
             _uplink_mock_guard: mock_uplink_server,
             _gcs_mock_guard: mock_gcs_server,
         },
-        UplinkConfig::for_tests(Endpoints::fallback(vec![url])),
+        url,
     )
+}
+
+/// Mocks an uplink server which returns bad GCS URLs.
+pub async fn mock_pq_uplink_bad_gcs() -> (MockServer, Url) {
+    let mock_uplink_server = MockServer::start().await;
+
+    let  uplink_response = ResponseTemplate::new(200).set_body_json(json!({
+          "data": {
+            "persistedQueries": {
+              "__typename": "PersistedQueriesResult",
+              "id": "889406d7-b4f8-44df-a499-6c1e3c1bea09:1",
+              "minDelaySeconds": 60,
+              "chunks": [
+                {
+                  "id": "graph-id/889406a1-b4f8-44df-a499-6c1e3c1bea09/ec8ae3ae3eb00c738031dbe81603489b5d24fbf58f15bdeec1587282ee4e6eea",
+                  "urls": [
+                    "https://definitely.not.gcs.unknown"
+                  ]
+                }
+              ]
+            }
+          }
+        }));
+
+    Mock::given(method("POST"))
+        .respond_with(uplink_response)
+        .mount(&mock_uplink_server)
+        .await;
+
+    let url = mock_uplink_server.uri().parse().unwrap();
+    (mock_uplink_server, url)
 }

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -3,12 +3,14 @@ use std::fmt::Debug;
 use std::time::Duration;
 use std::time::Instant;
 
+use futures::Future;
 use futures::Stream;
 use futures::StreamExt;
 use graphql_client::QueryBody;
 use thiserror::Error;
 use tokio::sync::mpsc::channel;
 use tokio_stream::wrappers::ReceiverStream;
+use tower::BoxError;
 use tracing::instrument::WithSubscriber;
 use url::Url;
 
@@ -160,13 +162,40 @@ impl UplinkConfig {
 /// Regularly fetch from Uplink
 /// If urls are supplied then they will be called round robin
 pub(crate) fn stream_from_uplink<Query, Response>(
-    mut uplink_config: UplinkConfig,
+    uplink_config: UplinkConfig,
 ) -> impl Stream<Item = Result<Response, Error>>
 where
     Query: graphql_client::GraphQLQuery,
     <Query as graphql_client::GraphQLQuery>::ResponseData: Into<UplinkResponse<Response>> + Send,
     <Query as graphql_client::GraphQLQuery>::Variables: From<UplinkRequest> + Send + Sync,
     Response: Send + 'static + Debug,
+{
+    stream_from_uplink_transforming_new_response::<Query, Response, Response>(
+        uplink_config,
+        |response| Box::new(Box::pin(async { Ok(response) })),
+    )
+}
+
+/// Like stream_from_uplink, but applies an async transformation function to the
+/// result of the HTTP fetch if the response is an UplinkResponse::New. If this
+/// function returns Err, we fail over to the next Uplink endpoint, just like if
+/// the HTTP fetch itself failed. This serves the use case where an Uplink
+/// endpoint's response includes another URL located close to the Uplink
+/// endpoint; if that second URL is down, we want to try the next Uplink
+/// endpoint rather than fully giving up.
+pub(crate) fn stream_from_uplink_transforming_new_response<Query, Response, SomethingElse>(
+    mut uplink_config: UplinkConfig,
+    transform_new_response: impl Fn(Response) -> Box<dyn Future<Output = Result<SomethingElse, BoxError>> + Send + Unpin>
+        + Send
+        + Sync
+        + 'static,
+) -> impl Stream<Item = Result<SomethingElse, Error>>
+where
+    Query: graphql_client::GraphQLQuery,
+    <Query as graphql_client::GraphQLQuery>::ResponseData: Into<UplinkResponse<Response>> + Send,
+    <Query as graphql_client::GraphQLQuery>::Variables: From<UplinkRequest> + Send + Sync,
+    Response: Send + 'static + Debug,
+    SomethingElse: Send + 'static + Debug,
 {
     let query = query_name::<Query>();
     let (sender, receiver) = channel(2);
@@ -193,7 +222,14 @@ where
 
             let query_body = Query::build_query(variables.into());
 
-            match fetch::<Query, Response>(&client, &query_body, &mut endpoints.iter()).await {
+            match fetch::<Query, Response, SomethingElse>(
+                &client,
+                &query_body,
+                &mut endpoints.iter(),
+                &transform_new_response,
+            )
+            .await
+            {
                 Ok(response) => {
                     tracing::info!(
                         monotonic_counter.apollo_router_uplink_fetch_count_total = 1u64,
@@ -264,68 +300,100 @@ where
     ReceiverStream::new(receiver).boxed()
 }
 
-pub(crate) async fn fetch<Query, Response>(
+pub(crate) async fn fetch<Query, Response, SomethingElse>(
     client: &reqwest::Client,
     request_body: &QueryBody<Query::Variables>,
     urls: &mut impl Iterator<Item = &Url>,
-) -> Result<UplinkResponse<Response>, Error>
+    // See stream_from_uplink_transforming_new_response for an explanation of
+    // this argument.
+    transform_new_response: &(impl Fn(Response) -> Box<dyn Future<Output = Result<SomethingElse, BoxError>> + Send + Unpin>
+          + Send
+          + Sync
+          + 'static),
+) -> Result<UplinkResponse<SomethingElse>, Error>
 where
     Query: graphql_client::GraphQLQuery,
     <Query as graphql_client::GraphQLQuery>::ResponseData: Into<UplinkResponse<Response>> + Send,
     <Query as graphql_client::GraphQLQuery>::Variables: From<UplinkRequest> + Send + Sync,
     Response: Send + Debug + 'static,
+    SomethingElse: Send + Debug + 'static,
 {
     let query = query_name::<Query>();
     for url in urls {
         let now = Instant::now();
         match http_request::<Query>(client, url.as_str(), request_body).await {
-            Ok(response) => {
-                let response = response.data.map(Into::into);
-                match &response {
-                    None => {
-                        tracing::info!(
-                            histogram.apollo_router_uplink_fetch_duration_seconds =
-                                now.elapsed().as_secs_f64(),
-                            query,
-                            url = url.to_string(),
-                            "kind" = "uplink_error",
-                            error = "empty response from uplink",
-                        );
-                    }
-                    Some(UplinkResponse::New { .. }) => {
-                        tracing::info!(
-                            histogram.apollo_router_uplink_fetch_duration_seconds =
-                                now.elapsed().as_secs_f64(),
-                            query,
-                            url = url.to_string(),
-                            "kind" = "new"
-                        );
-                        return Ok(response.expect("we are in the some branch, qed"));
-                    }
-                    Some(UplinkResponse::Unchanged { .. }) => {
-                        tracing::info!(
-                            histogram.apollo_router_uplink_fetch_duration_seconds =
-                                now.elapsed().as_secs_f64(),
-                            query,
-                            url = url.to_string(),
-                            "kind" = "unchanged"
-                        );
-                        return Ok(response.expect("we are in the some branch, qed"));
-                    }
-                    Some(UplinkResponse::Error { message, code, .. }) => {
-                        tracing::info!(
-                            histogram.apollo_router_uplink_fetch_duration_seconds =
-                                now.elapsed().as_secs_f64(),
-                            query,
-                            url = url.to_string(),
-                            "kind" = "uplink_error",
-                            error = message,
-                            code
-                        );
-                        return Ok(response.expect("we are in the some branch, qed"));
+            Ok(response) => match response.data.map(Into::into) {
+                None => {
+                    tracing::info!(
+                        histogram.apollo_router_uplink_fetch_duration_seconds =
+                            now.elapsed().as_secs_f64(),
+                        query,
+                        url = url.to_string(),
+                        "kind" = "uplink_error",
+                        error = "empty response from uplink",
+                    );
+                }
+                Some(UplinkResponse::New {
+                    response,
+                    id,
+                    delay,
+                }) => {
+                    tracing::info!(
+                        histogram.apollo_router_uplink_fetch_duration_seconds =
+                            now.elapsed().as_secs_f64(),
+                        query,
+                        url = url.to_string(),
+                        "kind" = "new"
+                    );
+                    match transform_new_response(response).await {
+                        Ok(res) => {
+                            return Ok(UplinkResponse::New {
+                                response: res,
+                                id,
+                                delay,
+                            })
+                        }
+                        Err(err) => {
+                            tracing::debug!(
+                                    "failed to process results of Uplink response from {}: {}. Other endpoints will be tried",
+                                    url,
+                                    err
+                                );
+                            continue;
+                        }
                     }
                 }
-            }
+                Some(UplinkResponse::Unchanged { id, delay }) => {
+                    tracing::info!(
+                        histogram.apollo_router_uplink_fetch_duration_seconds =
+                            now.elapsed().as_secs_f64(),
+                        query,
+                        url = url.to_string(),
+                        "kind" = "unchanged"
+                    );
+                    return Ok(UplinkResponse::Unchanged { id, delay });
+                }
+                Some(UplinkResponse::Error {
+                    message,
+                    code,
+                    retry_later,
+                }) => {
+                    tracing::info!(
+                        histogram.apollo_router_uplink_fetch_duration_seconds =
+                            now.elapsed().as_secs_f64(),
+                        query,
+                        url = url.to_string(),
+                        "kind" = "uplink_error",
+                        error = message,
+                        code
+                    );
+                    return Ok(UplinkResponse::Error {
+                        message,
+                        code,
+                        retry_later,
+                    });
+                }
+            },
             Err(e) => {
                 tracing::info!(
                     histogram.apollo_router_uplink_fetch_duration_seconds =
@@ -415,6 +483,7 @@ mod test {
     use wiremock::ResponseTemplate;
 
     use crate::uplink::stream_from_uplink;
+    use crate::uplink::stream_from_uplink_transforming_new_response;
     use crate::uplink::Endpoints;
     use crate::uplink::Error;
     use crate::uplink::UplinkConfig;
@@ -435,6 +504,13 @@ mod test {
     struct QueryResult {
         name: String,
         ordering: i64,
+    }
+
+    #[allow(dead_code)]
+    #[derive(Debug)]
+    struct TransformedQueryResult {
+        name: String,
+        halved_ordering: i64,
     }
 
     impl From<UplinkRequest> for test_query::Variables {
@@ -789,7 +865,50 @@ mod test {
         assert_yaml_snapshot!(results.into_iter().map(to_friendly).collect::<Vec<_>>());
     }
 
-    fn to_friendly(r: Result<QueryResult, Error>) -> Result<String, String> {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_from_uplink_transforming_new_response_first_response_transform_fails() {
+        let (mock_server, url1, url2, _url3) = init_mock_server().await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url1)
+            .response(response_ok(15))
+            .build()
+            .await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url2)
+            .response(response_ok(100))
+            .build()
+            .await;
+        let results = stream_from_uplink_transforming_new_response::<
+            TestQuery,
+            QueryResult,
+            TransformedQueryResult,
+        >(
+            mock_uplink_config_with_fallback_urls(vec![url1, url2]),
+            |result| {
+                Box::new(Box::pin(async move {
+                    let QueryResult { name, ordering } = result;
+                    if ordering % 2 == 0 {
+                        // This will trigger on url2's response.
+                        Ok(TransformedQueryResult {
+                            name,
+                            halved_ordering: ordering / 2,
+                        })
+                    } else {
+                        // This will trigger on url1's response.
+                        Err("cannot halve an odd number".into())
+                    }
+                }))
+            },
+        )
+        .take(1)
+        .collect::<Vec<_>>()
+        .await;
+        assert_yaml_snapshot!(results.into_iter().map(to_friendly).collect::<Vec<_>>());
+    }
+
+    fn to_friendly<R: std::fmt::Debug>(r: Result<R, Error>) -> Result<String, String> {
         match r {
             Ok(e) => Ok(format!("result {:?}", e)),
             Err(e) => Err(e.to_string()),

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_transforming_new_response_first_response_transform_fails.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_transforming_new_response_first_response_transform_fails.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-router/src/uplink/mod.rs
+expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
+---
+- Ok: "result TransformedQueryResult { name: \"ok\", halved_ordering: 50 }"
+


### PR DESCRIPTION
If an Uplink request fails, the `stream_from_uplink` function automatically tries the next configured Uplink endpoint. However, in the case of the persisted queries feature, the Uplink response contains an URL located in the same cloud provider as the Uplink endpoint (which is used to fetch the full PQ list chunk). Before this PR, the PQ code fetched this second URL "outside" of `stream_from_uplink`, so an error downloading this file would *not* result in re-trying the Uplink request itself on the next endpoint.

This PR factors out the body of `stream_from_uplink` into `stream_from_uplink_transforming_new_response`, which takes an async function that is called on any `UplinkResponse::New` to transform the response. (`stream_from_uplink` passes the identity function here, so its API is not affected.) If this function returns `Err`, the uplink code moves on to the next endpoint URL, just like if the initial Uplink fetch had failed. The PQ layer now fetches the PQ manifest chunk bodies inside this async function instead of by mapping the uplink stream.

This means that if our GCP Uplink server is up but the GCS servers that serve manifests from GCP are down, we will fail over to the AWS Uplink server instead of just failing to fetch PQs.

Additionally, the response from Uplink can specify multiple valid URLs for each chunk. (Uplink does not currently do this, but the protocol allows for it.) Before this PR, Router would only look at the first URL listed; after this PR, it tries each URL in order until finding one that does not fail.

Additionally, before this PR, any errors fetching PQs from Uplink or GCS after a successful startup were ignored. (They would be sent on the `ready_sender` channel whose receiver is dropped, which could lead to a `debug`-level logged message about how the channel wasn't open, but they were not *directly* logged.) After this PR, we don't try to send these errors on the channel after the channel was used once; instead, we log them at the `error` level (similarly to how schema and license uplink errors work).  Note that this only occurs if Router fails to fetch PQs from all configured Uplink endpoints; a failure to fetch from a single endpoint is still only logged at the `debug` level.

Co-authored-by: Jeremy Lempereur <jeremy.lempereur@iomentum.com>
