### PR TITLE
fix(telemetry): support more types for metric counters

### DIFF
--- a/.changesets/maint_bnjjj_fix_3865.md
+++ b/.changesets/maint_bnjjj_fix_3865.md
@@ -1,0 +1,19 @@
+### fix(telemetry): support more types for metric counters ([Issue #3865](https://github.com/apollographql/router/issues/3865))
+
+Add more supported types for metric counters in `MetricsLayer`.
+
+Now it's not mandatory and won't panic in debug mode if you don't specify `1u64` in this example:
+
+```rust
+tracing::info!(
+    monotonic_counter
+        .apollo
+        .router
+        .operations
+        .authentication
+        .jwt = 1,
+    authentication.jwt.failed = true
+)
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/3868

--- a/apollo-router/src/plugins/telemetry/metrics/layer.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/layer.rs
@@ -26,7 +26,7 @@ use super::METRIC_PREFIX_VALUE;
 
 macro_rules! log_and_panic_in_debug_build {
     ($($tokens:tt)+) => {{
-        tracing::debug!($($tokens)+);
+        tracing::error!($($tokens)+);
         #[cfg(debug_assertions)]
         panic!("metric type error, see DEBUG log for details. Release builds will not panic but will still emit a debug log message");
     }};
@@ -205,19 +205,27 @@ impl<'a> Visit for MetricVisitor<'a> {
 
     fn record_i64(&mut self, field: &Field, value: i64) {
         if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_MONOTONIC_COUNTER) {
-            log_and_panic_in_debug_build!(
-                metric_name,
-                "monotonic counter must be u64 or f64. This metric will be ignored"
-            );
+            if value < 0 {
+                log_and_panic_in_debug_build!(
+                    metric_name,
+                    "monotonic counter must be u64 or f64. This metric will be ignored"
+                );
+            } else {
+                self.set_metric(metric_name, InstrumentType::CounterU64(value as u64));
+            }
         } else if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_COUNTER) {
             self.set_metric(metric_name, InstrumentType::UpDownCounterI64(value));
         } else if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_HISTOGRAM) {
             self.set_metric(metric_name, InstrumentType::HistogramI64(value));
         } else if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_VALUE) {
-            log_and_panic_in_debug_build!(
-                metric_name,
-                "gauge must be u64. This metric will be ignored"
-            );
+            if value < 0 {
+                log_and_panic_in_debug_build!(
+                    metric_name,
+                    "gauge must be u64. This metric will be ignored"
+                );
+            } else {
+                self.set_metric(metric_name, InstrumentType::GaugeU64(value as u64));
+            }
         } else if self.metric.is_some() {
             self.custom_attributes.push(KeyValue::new(
                 Key::from_static_str(field.name()),
@@ -232,10 +240,7 @@ impl<'a> Visit for MetricVisitor<'a> {
         if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_MONOTONIC_COUNTER) {
             self.set_metric(metric_name, InstrumentType::CounterU64(value));
         } else if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_COUNTER) {
-            log_and_panic_in_debug_build!(
-                metric_name,
-                "counter must be i64. This metric will be ignored"
-            );
+            self.set_metric(metric_name, InstrumentType::UpDownCounterI64(value as i64));
         } else if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_HISTOGRAM) {
             self.set_metric(metric_name, InstrumentType::HistogramU64(value));
         } else if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_VALUE) {


### PR DESCRIPTION
Add more supported types for metric counters in `MetricsLayer`.

Now it's not mandatory and won't panic in debug mode if you don't specify `1u64` in this example:

```rust
tracing::info!(
    monotonic_counter
        .apollo
        .router
        .operations
        .authentication
        .jwt = 1,
    authentication.jwt.failed = true
)
```

Fixes #3865 

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
