### PR TITLE
fix: Studio Reporting when it is not configured

### DIFF
--- a/.changesets/fix_geal_fix_studio_reporting2.md
+++ b/.changesets/fix_geal_fix_studio_reporting2.md
@@ -1,0 +1,12 @@
+### Fix Studio reporting when it is not configured ([Issue #3871](https://github.com/apollographql/router/issues/3871))
+
+Apollo Studio reporting was broken in 1.30.0 if the Apollo exporter was not configured. If the configuration file contained anything under:
+
+```yaml
+telemetry:
+  apollo:
+```
+
+then it would have been working properly. It is now working in all cases by properly detecting the presence of the Apollo key and graph reference
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/3881

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -110,7 +110,6 @@ use crate::plugins::telemetry::utils::TracingUtils;
 use crate::query_planner::OperationKind;
 use crate::register_plugin;
 use crate::router_factory::Endpoint;
-use crate::services::apollo_key;
 use crate::services::execution;
 use crate::services::router;
 use crate::services::subgraph;
@@ -666,13 +665,6 @@ impl Telemetry {
         // should be accepted
         trace_config.sampler = SamplerOption::Always(Sampler::AlwaysOn);
 
-        // if APOLLO_KEY was set, the Studio exporter must be active
-        let apollo_config = if config.apollo.is_none() && apollo_key().is_some() {
-            Some(Default::default())
-        } else {
-            config.apollo.clone()
-        };
-
         let mut builder = opentelemetry::sdk::trace::TracerProvider::builder()
             .with_config((&trace_config).into());
 
@@ -680,13 +672,13 @@ impl Telemetry {
         builder = setup_tracing(builder, &tracing_config.zipkin, &trace_config)?;
         builder = setup_tracing(builder, &tracing_config.datadog, &trace_config)?;
         builder = setup_tracing(builder, &tracing_config.otlp, &trace_config)?;
-        builder = setup_tracing(builder, &apollo_config, &trace_config)?;
+        builder = setup_tracing(builder, &config.apollo, &trace_config)?;
 
         if tracing_config.jaeger.is_none()
             && tracing_config.zipkin.is_none()
             && tracing_config.datadog.is_none()
             && tracing_config.otlp.is_none()
-            && apollo_config.is_none()
+            && config.apollo.is_none()
         {
             sampler = SamplerOption::Always(Sampler::AlwaysOff);
         }

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -34,6 +34,8 @@ use crate::plugins::traffic_shaping::RetryPolicy;
 use crate::plugins::traffic_shaping::TrafficShaping;
 use crate::plugins::traffic_shaping::APOLLO_TRAFFIC_SHAPING;
 use crate::query_planner::BridgeQueryPlanner;
+use crate::services::apollo_graph_reference;
+use crate::services::apollo_key;
 use crate::services::layers::query_analysis::QueryAnalysisLayer;
 use crate::services::new_service::ServiceFactory;
 use crate::services::router;
@@ -573,11 +575,14 @@ pub(crate) async fn create_plugins(
 
 fn inject_schema_id(schema: &Schema, configuration: &mut Value) {
     if configuration.get("apollo").is_none() {
-        /*FIXME: do we really need to set a default configuration for telemetry.apollo ?
-        if let Some(telemetry) = configuration.as_object_mut() {
-            telemetry.insert("apollo".to_string(), Value::Object(Default::default()));
-        }*/
-        return;
+        // Warning: this must be done here, otherwise studio reporting will not work
+        if apollo_key().is_some() && apollo_graph_reference().is_some() {
+            if let Some(telemetry) = configuration.as_object_mut() {
+                telemetry.insert("apollo".to_string(), Value::Object(Default::default()));
+            }
+        } else {
+            return;
+        }
     }
     if let (Some(schema_id), Some(apollo)) = (
         &schema.api_schema().schema_id,

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -36,7 +36,6 @@ use crate::plugins::traffic_shaping::APOLLO_TRAFFIC_SHAPING;
 use crate::query_planner::BridgeQueryPlanner;
 use crate::services::apollo_graph_reference;
 use crate::services::apollo_key;
-use crate::services::layers::persisted_queries::PersistedQueryLayer;
 use crate::services::layers::query_analysis::QueryAnalysisLayer;
 use crate::services::new_service::ServiceFactory;
 use crate::services::router;

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -36,6 +36,7 @@ use crate::plugins::traffic_shaping::APOLLO_TRAFFIC_SHAPING;
 use crate::query_planner::BridgeQueryPlanner;
 use crate::services::apollo_graph_reference;
 use crate::services::apollo_key;
+use crate::services::layers::persisted_queries::PersistedQueryLayer;
 use crate::services::layers::query_analysis::QueryAnalysisLayer;
 use crate::services::new_service::ServiceFactory;
 use crate::services::router;


### PR DESCRIPTION
Fix https://github.com/apollographql/router/issues/3871

The sampling filter introduced in
https://github.com/apollographql/router/commit/b58a67c92d65b00c6c11c246e220dce9e2755de1 was making sure that the Apollo exporter was configured when the key is present, but not in the right place: that configuration is used in various places to set up information in the spans and the context, and that is used to create the Studio report and injecting the traces there.
In previous versions, the code was relying on the inject_schema_id function in router_factory.rs to always insert a configuration for the Apollo exporter.
This commit adds back the code that creates that configuration, but only if the Apollo key and graph reference are present

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
