### PR TITLE
Add dependency so that release is preverified before builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -868,6 +868,7 @@ workflows:
             tags:
               only: /v.*/
       - build_release:
+          requires: [ pre_verify_release ]
           matrix:
             parameters:
               platform:


### PR DESCRIPTION
Adds dependency to preverify release version before releases are built
Fixes https://github.com/apollographql/router/issues/3664

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
