### PR TITLE
Fix validation error with ID variable values overflowing i32

### DIFF
--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -103,6 +103,9 @@ pub(crate) trait ValueExt {
     #[track_caller]
     fn is_valid_int_input(&self) -> bool;
 
+    #[track_caller]
+    fn is_valid_id_input(&self) -> bool;
+
     /// Returns whether this value is an object that matches the provided type.
     ///
     /// More precisely, this checks that this value is an object, looks at
@@ -392,6 +395,17 @@ impl ValueExt for Value {
         F: FnMut(&Path, &'a mut Value),
     {
         iterate_path_mut(schema, &mut Path::default(), &path.0, self, &mut f)
+    }
+
+    #[track_caller]
+    fn is_valid_id_input(&self) -> bool {
+        // https://spec.graphql.org/October2021/#sec-ID.Input-Coercion
+        match self {
+            // Any string and integer values are accepted
+            Value::String(_) => true,
+            Value::Number(n) => n.is_i64() || n.is_u64(),
+            _ => false,
+        }
     }
 
     #[track_caller]

--- a/apollo-router/src/services/supergraph_service.rs
+++ b/apollo-router/src/services/supergraph_service.rs
@@ -778,8 +778,11 @@ mod tests {
     use std::collections::HashMap;
     use std::time::Duration;
 
+    use tower::ServiceExt;
+
     use super::*;
     use crate::plugin::test::MockSubgraph;
+    use crate::services::subgraph;
     use crate::services::supergraph;
     use crate::test_harness::MockedSubgraphs;
     use crate::Notify;
@@ -3307,5 +3310,59 @@ mod tests {
         let mut stream = service.clone().oneshot(request).await.unwrap();
         let response = stream.next_response().await.unwrap();
         assert_eq!(serde_json_bytes::Value::Null, response.data.unwrap());
+    }
+
+    #[tokio::test]
+    async fn id_scalar_can_overflow_i32() {
+        // Hack to let the first subgraph fetch contain an ID variable:
+        // ```
+        // type Query {
+        //     user(id: ID!): User @join__field(graph: USER)
+        // }
+        // ```
+        assert!(SCHEMA.contains("currentUser:"));
+        let schema = SCHEMA.replace("currentUser:", "user(id: ID!):");
+
+        let service = TestHarness::builder()
+            .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true } }))
+            .unwrap()
+            .schema(&schema)
+            .subgraph_hook(|_subgraph_name, _service| {
+                tower::service_fn(|request: subgraph::Request| async move {
+                    let id = &request.subgraph_request.body().variables["id"];
+                    Err(format!("$id = {id}").into())
+                })
+                .boxed()
+            })
+            .build_supergraph()
+            .await
+            .unwrap();
+
+        let large: i64 = 1 << 53;
+        let large_plus_one = large + 1;
+        // f64 rounds since it doesn’t have enough mantissa bits
+        assert!(large_plus_one as f64 as i64 == large);
+        // i64 of course doesn’t round
+        assert!(large_plus_one != large);
+
+        let request = supergraph::Request::fake_builder()
+            .query("query($id: ID!) { user(id: $id) { name }}")
+            .variable("id", large_plus_one)
+            .build()
+            .unwrap();
+        let response = service
+            .oneshot(request)
+            .await
+            .unwrap()
+            .next_response()
+            .await
+            .unwrap();
+        // The router did not panic or respond with an early validation error.
+        // Instead it did a subgraph fetch, which recieved the correct ID variable without rounding:
+        assert_eq!(
+            response.errors[0].extensions["reason"].as_str().unwrap(),
+            "$id = 9007199254740993"
+        );
+        assert_eq!(large_plus_one.to_string(), "9007199254740993");
     }
 }

--- a/apollo-router/src/spec/field_type.rs
+++ b/apollo-router/src/spec/field_type.rs
@@ -109,8 +109,8 @@ fn validate_input_value(
         //
         // In practice it seems Int works too
         (hir::Type::Named { name, .. }, Value::String(_)) if name == "ID" => Ok(()),
-        (hir::Type::Named { name, .. }, maybe_int) if name == "ID" => {
-            if maybe_int == &Value::Null || maybe_int.is_valid_int_input() {
+        (hir::Type::Named { name, .. }, value) if name == "ID" => {
+            if value == &Value::Null || value.is_valid_id_input() {
                 Ok(())
             } else {
                 Err(InvalidValue)


### PR DESCRIPTION
Fixes #3873

Input values for variables of type `ID` were previously validated as "either like a GraphQL `Int` or like a GraphQL `String`". GraphQL `Int` is specified as a signed 32-bit integer, such that values that overflow fail validation. Applying this range restriction to `ID` values was incorrect. Instead, validation for `ID` now accepts any JSON integer or JSON string value, so that IDs larger than 32 bits can be used.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
