### PR TITLE
Rewrite config migrations

### DIFF
--- a/apollo-router/src/configuration/migrations/0011-experimental-http2.yaml
+++ b/apollo-router/src/configuration/migrations/0011-experimental-http2.yaml
@@ -13,13 +13,14 @@ actions:
     to: traffic_shaping.all.experimental_http2
 
   - type: change
-    path: traffic_shaping.subgraphs..experimental_enable_http2
+    path: traffic_shaping.subgraphs.*.experimental_enable_http2
     from: true
     to: enable
   - type: change
-    path: traffic_shaping.subgraphs..experimental_enable_http2
+    path: traffic_shaping.subgraphs.*.experimental_enable_http2
     from: false
     to: disable
-  - type: move
-    from: traffic_shaping.subgraphs..experimental_enable_http2
-    to: traffic_shaping.subgraphs..experimental_http2
+  - type: rename
+    path: traffic_shaping.subgraphs.*
+    name: experimental_enable_http2
+    to: experimental_http2

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@http2.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@http2.yaml.snap
@@ -1,0 +1,12 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+---
+---
+traffic_shaping:
+  all:
+    experimental_http2: disable
+  subgraphs:
+    products:
+      experimental_http2: enable
+

--- a/apollo-router/src/configuration/testdata/migrations/http2.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/http2.yaml
@@ -1,0 +1,6 @@
+traffic_shaping:
+  all:
+    experimental_enable_http2: false
+  subgraphs:
+    products:
+      experimental_enable_http2: true

--- a/apollo-router/src/configuration/upgrade.rs
+++ b/apollo-router/src/configuration/upgrade.rs
@@ -51,6 +51,11 @@ enum Action {
         from: Value,
         to: Value,
     },
+    Rename {
+        path: String,
+        name: String,
+        to: String,
+    },
 }
 
 const REMOVAL_VALUE: &str = "__PLEASE_DELETE_ME";
@@ -261,6 +266,24 @@ fn apply_migration(config: &Value, migration: &Migration) -> Result<Value, Confi
                             .expect("migration must be valid"),
                     );
                 }*/
+            }
+            Action::Rename { path, name, to } => {
+                let path: Path = Path::from_json_path(path);
+
+                println!("from path: {path:?}");
+
+                serde_json_iterate_path_mut(
+                    &mut Path::default(),
+                    &path.0,
+                    &mut new_config,
+                    &mut |_path, value| {
+                        if let Some(o) = value.as_object_mut() {
+                            if let Some(v) = o.remove(name) {
+                                o.insert(to.to_string(), v);
+                            }
+                        }
+                    },
+                );
             }
         }
     }

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -629,17 +629,7 @@ pub(crate) fn serde_json_iterate_path_mut<'a, F>(
                 }
             }
         }
-        Some(PathElement::Fragment(name)) => {
-            /*if data.is_object_of_type(schema, name) {
-                iterate_path_mut(schema, parent, &path[1..], data, f);
-            } else if let Value::Array(array) = data {
-                for (i, value) in array.iter_mut().enumerate() {
-                    parent.push(PathElement::Index(i));
-                    iterate_path_mut(schema, parent, path, value, f);
-                    parent.pop();
-                }
-            }*/
-        }
+        Some(PathElement::Fragment(_name)) => {}
         Some(PathElement::Glob) => {
             if let serde_json::Value::Object(o) = data {
                 for (k, value) in o.iter_mut() {

--- a/apollo-router/src/spec/selection.rs
+++ b/apollo-router/src/spec/selection.rs
@@ -231,6 +231,7 @@ impl Selection {
 
     pub(crate) fn contains_error_path(&self, path: &[PathElement], fragments: &Fragments) -> bool {
         match (path.get(0), self) {
+            (Some(PathElement::Glob), _) => false,
             (None, _) => true,
             (
                 Some(PathElement::Key(key)),


### PR DESCRIPTION
Fix #3869

This rewrites the configuration migration code to use our own JSON selection and modification code. This adds `iterate_path_mut` and `insert_at_path` methods specific to `serde_json::Value` (the rest of the code targets `serde_json_bytes::Value`) and adds a "Glob" (*) path element to target all fields of an object.
That glob is not implemented for the serde_json_bytes type and should not affect the rest of execution, but it might be better to separate the `Path` type for config migrations, and have it match JSON path syntax.
This also adds a `rename` migration action, that selects a key at a path, and renames it to another key.
 
<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
