### PR TITLE
Make release a step that is performed after tests have passed.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -839,6 +839,9 @@ workflows:
                 [ macos_test, windows_test, amd_linux_test, arm_linux_test ]
       - release_approval:
           type: approval
+          requires:
+            - test
+            - test_updated
 
       - pre_verify_release:
           requires: [ release_approval ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -846,6 +846,8 @@ workflows:
             parameters:
               platform: [ amd_linux_build ]
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /v.*/
       # Anything that tagged is deemed a nightly
@@ -860,7 +862,7 @@ workflows:
                 [ macos_build, windows_build, amd_linux_build, arm_linux_build ]
           filters:
             branches:
-              ignore: /.*/
+              only: /.*/
             tags:
               ignore: /v.*/
       # Releases are tagged

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -848,6 +848,8 @@ workflows:
             parameters:
               platform: [ amd_linux_build ]
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /v.*/
       # Anything that tagged is deemed a nightly
@@ -861,6 +863,8 @@ workflows:
               platform:
                 [ macos_build, windows_build, amd_linux_build, arm_linux_build ]
           filters:
+            branches:
+              ignore: /.*/
             tags:
               ignore: /v.*/
       # Releases are tagged
@@ -873,10 +877,14 @@ workflows:
               platform:
                 [ macos_build, windows_build, amd_linux_build, arm_linux_build ]
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /v.*/
       - publish_github_release:
           requires: [ build_release ]
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -806,37 +806,37 @@ jobs:
 workflows:
   ci_checks:
     jobs:
-#      - lint:
-#          matrix:
-#            parameters:
-#              platform: [ amd_linux_build ]
-#      - check_helm:
-#          matrix:
-#            parameters:
-#              platform: [ amd_linux_helm ]
-#      - check_compliance:
-#          matrix:
-#            parameters:
-#              platform: [ amd_linux_build ]
-#
-#      - test_updated:
-#          requires:
-#            - lint
-#            - check_helm
-#            - check_compliance
-#          matrix:
-#            parameters:
-#              platform:
-#                [ amd_linux_test ]
-#      - test:
-#          requires:
-#            - lint
-#            - check_helm
-#            - check_compliance
-#          matrix:
-#            parameters:
-#              platform:
-#                [ macos_test, windows_test, amd_linux_test, arm_linux_test ]
+      - lint:
+          matrix:
+            parameters:
+              platform: [ amd_linux_build ]
+      - check_helm:
+          matrix:
+            parameters:
+              platform: [ amd_linux_helm ]
+      - check_compliance:
+          matrix:
+            parameters:
+              platform: [ amd_linux_build ]
+
+      - test_updated:
+          requires:
+            - lint
+            - check_helm
+            - check_compliance
+          matrix:
+            parameters:
+              platform:
+                [ amd_linux_test ]
+      - test:
+          requires:
+            - lint
+            - check_helm
+            - check_compliance
+          matrix:
+            parameters:
+              platform:
+                [ macos_test, windows_test, amd_linux_test, arm_linux_test ]
       - release_approval:
           type: approval
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -805,43 +805,42 @@ jobs:
 
 workflows:
   ci_checks:
-    jobs:
-      - lint:
-          matrix:
-            parameters:
-              platform: [ amd_linux_build ]
-      - check_helm:
-          matrix:
-            parameters:
-              platform: [ amd_linux_helm ]
-      - check_compliance:
-          matrix:
-            parameters:
-              platform: [ amd_linux_build ]
-
-      - test_updated:
-          requires:
-            - lint
-            - check_helm
-            - check_compliance
-          matrix:
-            parameters:
-              platform:
-                [ amd_linux_test ]
-      - test:
-          requires:
-            - lint
-            - check_helm
-            - check_compliance
-          matrix:
-            parameters:
-              platform:
-                [ macos_test, windows_test, amd_linux_test, arm_linux_test ]
+#    jobs:
+#      - lint:
+#          matrix:
+#            parameters:
+#              platform: [ amd_linux_build ]
+#      - check_helm:
+#          matrix:
+#            parameters:
+#              platform: [ amd_linux_helm ]
+#      - check_compliance:
+#          matrix:
+#            parameters:
+#              platform: [ amd_linux_build ]
+#
+#      - test_updated:
+#          requires:
+#            - lint
+#            - check_helm
+#            - check_compliance
+#          matrix:
+#            parameters:
+#              platform:
+#                [ amd_linux_test ]
+#      - test:
+#          requires:
+#            - lint
+#            - check_helm
+#            - check_compliance
+#          matrix:
+#            parameters:
+#              platform:
+#                [ macos_test, windows_test, amd_linux_test, arm_linux_test ]
       - release_approval:
           type: approval
           requires:
-            - test
-            - test_updated
+
       - pre_verify_release:
           requires: [ release_approval ]
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -805,7 +805,7 @@ jobs:
 
 workflows:
   ci_checks:
-#    jobs:
+    jobs:
 #      - lint:
 #          matrix:
 #            parameters:
@@ -839,7 +839,6 @@ workflows:
 #                [ macos_test, windows_test, amd_linux_test, arm_linux_test ]
       - release_approval:
           type: approval
-          requires:
 
       - pre_verify_release:
           requires: [ release_approval ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -852,6 +852,7 @@ workflows:
               only: /v.*/
       # Anything that tagged is deemed a nightly
       - build_release:
+          name: build nightly release << matrix.platform >>
           nightly: true
           requires: [ release_approval ]
           matrix:
@@ -864,6 +865,7 @@ workflows:
               ignore: /v.*/
       # Releases are tagged
       - build_release:
+          name: build release << matrix.platform >>
           nightly: false
           requires: [ pre_verify_release ]
           matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,9 +80,6 @@ parameters:
   protoc_version:
     type: string
     default: "21.8"
-  nightly:
-    type: boolean
-    default: false
 
 # These are common environment variables that we want to set on on all jobs.
 # While these could conceivably be set on the CircleCI project settings'
@@ -808,8 +805,6 @@ jobs:
 
 workflows:
   ci_checks:
-    when:
-      not: << pipeline.parameters.nightly >>
     jobs:
       - lint:
           matrix:
@@ -842,46 +837,44 @@ workflows:
             parameters:
               platform:
                 [ macos_test, windows_test, amd_linux_test, arm_linux_test ]
-
-  nightly:
-    when: << pipeline.parameters.nightly >>
-    jobs:
-      - build_release:
-          nightly: true
-          context: router
-          matrix:
-            parameters:
-              platform:
-                [ macos_build, windows_build, amd_linux_build, arm_linux_build ]
-
-  release:
-    when:
-      not: << pipeline.parameters.nightly >>
-    jobs:
+      - release_approval:
+          type: approval
+          requires:
+            - test
+            - test_updated
       - pre_verify_release:
+          requires: [ release_approval ]
           matrix:
             parameters:
               platform: [ amd_linux_build ]
           filters:
-            branches:
-              ignore: /.*/
             tags:
               only: /v.*/
+      # Anything that tagged is deemed a nightly
       - build_release:
+          nightly: true
+          requires: [ release_approval ]
+          matrix:
+            alias: build_release_nightly
+            parameters:
+              platform:
+                [ macos_build, windows_build, amd_linux_build, arm_linux_build ]
+          filters:
+            tags:
+              ignore: /v.*/
+      # Releases are tagged
+      - build_release:
+          nightly: false
           requires: [ pre_verify_release ]
           matrix:
             parameters:
               platform:
                 [ macos_build, windows_build, amd_linux_build, arm_linux_build ]
           filters:
-            branches:
-              ignore: /.*/
             tags:
               only: /v.*/
       - publish_github_release:
           requires: [ build_release ]
           filters:
-            branches:
-              ignore: /.*/
             tags:
               only: /v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -846,8 +846,6 @@ workflows:
             parameters:
               platform: [ amd_linux_build ]
           filters:
-            branches:
-              ignore: /.*/
             tags:
               only: /v.*/
       # Anything that tagged is deemed a nightly


### PR DESCRIPTION
A new `release_approval` step is added which requires that tests have been run. Once approved either a nightly or regular release will take place depending on if the branch is tagged or not.
