### PR TITLE
Move `apollo.router.operations` to the outer layer of the router pipeline.

### DIFF
--- a/.changesets/fix_bryn_move_telemetry.md
+++ b/.changesets/fix_bryn_move_telemetry.md
@@ -1,0 +1,12 @@
+### Ensure that telemetry happens first ([Issue #3915](https://github.com/apollographql/router/issues/3915))
+
+Telemetry related logic is now moved to the first thing in the router pipeline.
+
+Previously the metric `apollo.router.operations` may have missed some requests if they were failed at the router stage.
+In addition, some logic happened before root spans were created, which would have caused missing traces.
+
+`apollo.router.operations` and root spans are now the first thing that happens in the router pipeline for graphql requests.
+
+
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3919

--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -404,6 +404,8 @@ where
         ))
         .layer(Extension(service_factory))
         .layer(cors)
+        // Telemetry layers MUST be last. This means that they will be hit first during execution of the pipeline
+        // Adding layers after telemetry will cause us to lose metrics and spans.
         .layer(TraceLayer::new_for_http().make_span_with(PropagatingMakeSpan { license }))
         .layer(middleware::from_fn(metrics_handler));
 

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -833,12 +833,6 @@ impl Telemetry {
                 if !parts.status.is_success() {
                     metric_attrs.push(KeyValue::new("error", parts.status.to_string()));
                 }
-                u64_counter!(
-                    "apollo.router.operations",
-                    "The number of graphql operations performed by the Router",
-                    1,
-                    "http.response.status_code" = parts.status.as_u16() as i64
-                );
                 let response = http::Response::from_parts(
                     parts,
                     once(ready(first_response.unwrap_or_default()))
@@ -850,12 +844,6 @@ impl Telemetry {
             }
             Err(err) => {
                 metric_attrs.push(KeyValue::new("status", "500"));
-                u64_counter!(
-                    "apollo.router.operations",
-                    "The number of graphql operations performed by the Router",
-                    1,
-                    "http.response.status_code" = 500
-                );
                 Err(err)
             }
         };

--- a/apollo-router/tests/metrics_tests.rs
+++ b/apollo-router/tests/metrics_tests.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use serde_json::json;
-use tower::BoxError;
 
 use crate::common::IntegrationTest;
 


### PR DESCRIPTION
Our metrics are currently mutated at the supergraph service. 
This is a throwback from when the router service did not exist.

Move operation count metrics to the first thing that happens in the pipeline. Note that this won't catch disconnects because they are reliant on the status code of the response, which will stop processing before the metric is incremented.

This also move the creation of the root span to the just after so that cors and extensions are traced.

Fixes #3915


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
