### PR TITLE
Docs recommend an untested Dockerfile (which broke at some point)

### DIFF
--- a/apollo-router-scaffold/templates/base/Dockerfile
+++ b/apollo-router-scaffold/templates/base/Dockerfile
@@ -28,7 +28,7 @@ RUN mkdir -p /dist/config && \
 # Copy configuration for docker image
 COPY router.yaml /dist/config.yaml
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update
 RUN apt-get -y install \


### PR DESCRIPTION
Reportedly, using Dockerfile very similar to the one before this PR yields a successful build a binary that errors on startup with:

```
error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory
```

This change seems to fix the issue. Per https://packages.debian.org/search?keywords=libssl Bullseye is on OpenSSL v1.1 while Bookworm is on v3.0. I suspect the `rust:1.72.0` image is based on something that has v3.0 and the Router binary ends up depending on the version that exists in the build environment.

Beyond this immediate fix, it seems this Dockerfile is not being tested even though [we recommend it for custom binaries](https://www.apollographql.com/docs/router/customizations/custom-binary/#docker). I’m not sure what the right solution is here. Having CircleCI rebuild an image for every PR may be excessive since the file changes so rarely.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
