### PR TITLE
docs: callback should create heartbeat per subscription

### DIFF
--- a/docs/source/executing-operations/subscription-callback-protocol.mdx
+++ b/docs/source/executing-operations/subscription-callback-protocol.mdx
@@ -222,45 +222,25 @@ Otherwise, **Router** should respond with an error.
 
 ### `heartbeat`
 
-As long as at least one subscription is active, **Emitter** must send a `heartbeat` message to **Router** every five seconds. This enables **Emitter** to confirm both that it can still reach **Router**'s callback endpoint, and that all known subscriptions are still active.
-
-The `heartbeat` message includes an `ids` field, which is an array of **Emitter**'s active subscription IDs:
+**Emitter** must send a `heartbeat` message to **Router** every five seconds. This enables **Emitter** to confirm both that it can still reach **Router**'s callback endpoint, and that subscription is still active.
 
 ```json
 {
     "kind": "subscription",
     "action": "heartbeat",
     "id": "c4a9d1b8-dc57-44ab-9e5a-6e6189b2b945",
-    "verifier": "XXX",
-    "ids": ["c4a9d1b8-dc57-44ab-9e5a-6e6189b2b945", "c4a9d1b8-dc57-44ab-9e5a-6e6189b2b254"] // highlight-line
-}
-```
-
-> **This message still includes an `id` field!** Even though this value is also present in the `ids` list, **Emitter** must specify whichever subscription is associated with the `verifier` it's providing.
-
-On receiving a `heartbeat` message, **Router** checks whether all subscriptions listed in `ids` are indeed still active on _its_ end.
-
-- If _all_ listed subscriptions are active, **Router** should respond with the following details:
-  - A 204 HTTP status code
-  - An empty response body
-- If the list includes both active _and_ inactive subscriptions, **Router** should respond with the following details:
-  - A 400 HTTP status code
-  - A JSON response body containing:
-    - An `invalid_ids` field. This is a list containing all IDs of _inactive_ subscriptions.
-    - A `verifier` field. This value _replaces_ the value of `verifier` provided by **Emitter**.
-- If _all_ listed subscriptions are _inactive_, **Router** should respond with the following details:
-  - A 404 HTTP status code
-  - An empty response body
-
-Here's an example payload sent with a 400 HTTP status code if `ids` contains both active and inactive subscription IDs:
-
-```json
-{
-    "id": "c4a9d1b8-dc57-44ab-9e5a-6e6189b2b945",
-    "invalid_ids": ["c4a9d1b8-dc57-44ab-9e5a-6e6189b2b254"],
     "verifier": "XXX"
 }
 ```
+
+On receiving a `heartbeat` message, **Router** checks whether subscription is still active on _its_ end.
+
+- If subscription is active, **Router** should respond with the following details:
+  - A 204 HTTP status code
+  - An empty response body
+- If subscription is _inactive_, **Router** should respond with the following details:
+  - A 404 HTTP status code
+  - An empty response body
 
 ### `next`
 
@@ -316,6 +296,5 @@ The following are common error states that can occur with this protcol:
 - **Emitter** can't communicate with **Router**'s callback endpoint, either because the endpoint isn't available or because its provided credentials (`id` and/or `verifier`) are invalid.
 - **Emitter** receives an error HTTP status code from **Router**'s callback endpoint. 
   - If the error code is 404, **Emitter** should consider the associated subscription terminated by **Router**.
-  - If the error code is 400 in response to a [`heartbeat`](#heartbeat) message, **Emitter** should terminate all subscriptions listed in the response body's `invalid_ids` field.
   - In other error cases, **Emitter** should consider the subscription terminated due to an unexpected error.
 - **Emitter** fails to send **Router** a [`heartbeat`](#heartbeat) or [`check`](#check) message for an active subscription every five seconds, causing **Router** to terminate that subscription.


### PR DESCRIPTION
*Description here*

While trying to optimize the number of heartbeats is great, it had a side effect that it would require some error prone logic on the subgraph level to correctly group subscriptions per router (and it also complicates the logic of cancelling sibling subscriptions which may be running in separate threads). By requiring a heartbeat per subscription we can keep the logic simple and make it easier to adopt. Further optimizations to the protocol might be added at some later date.