### PR TITLE
Add `enabled` field for telemetry exporters

### DIFF
--- a/.changesets/config_bryn_telemetry_enabled_field.md
+++ b/.changesets/config_bryn_telemetry_enabled_field.md
@@ -1,0 +1,20 @@
+### Add `enabled` field for telemetry exporters ([PR #3952](https://github.com/apollographql/router/pull/3952))
+
+Telemetry configuration now supports `enabled` on all exporters. This allows exporters to be disabled without removing them from the configuration and in addition allows for a more streamlined default configuration.
+
+```diff
+telemetry:
+  tracing: 
+    datadog:
++      enabled: true
+    jaeger:
++      enabled: true
+    otlp:
++      enabled: true
+    zipkin:
++      enabled: true
+```
+
+Existing configurations will be migrated to the new format automatically on startup. However, you should update your configuration to use the new format as soon as possible. 
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/3952

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -305,13 +305,13 @@ impl Metrics {
             opt.metrics.prometheus,
             "$.metrics.prometheus[?(@.enabled==true)]",
             opt.tracing.otlp,
-            "$.tracing.otlp[?(@.endpoint)]",
+            "$.tracing.otlp[?(@.enabled==true)]",
             opt.tracing.datadog,
-            "$.tracing.datadog[?(@.endpoint)]",
+            "$.tracing.datadog[?(@.enabled==true)]",
             opt.tracing.jaeger,
-            "$.tracing.jaeger[?(@..endpoint)]",
+            "$.tracing.jaeger[?(@.enabled==true)]",
             opt.tracing.zipkin,
-            "$.tracing.zipkin[?(@.endpoint)]"
+            "$.tracing.zipkin[?(@.enabled==true)]"
         );
         log_usage_metrics!(
             value.apollo.router.config.batching,

--- a/apollo-router/src/configuration/migrations/0012-telemetry-exporters-enabled.yaml
+++ b/apollo-router/src/configuration/migrations/0012-telemetry-exporters-enabled.yaml
@@ -1,0 +1,22 @@
+description: Telemetry exporters now have an enabled field
+actions:
+  - type: add
+    path: telemetry.tracing.jaeger
+    name: enabled
+    value: true
+  - type: add
+    path: telemetry.tracing.otlp
+    name: enabled
+    value: true
+  - type: add
+    path: telemetry.tracing.zipkin
+    name: enabled
+    value: true
+  - type: add
+    path: telemetry.tracing.datadog
+    name: enabled
+    value: true
+  - type: add
+    path: telemetry.metrics.otlp
+    name: enabled
+    value: true

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -2073,19 +2073,6 @@ expression: "&schema"
           "properties": {
             "batch_processor": {
               "description": "Configuration for batch processing.",
-              "default": {
-                "scheduled_delay": {
-                  "secs": 5,
-                  "nanos": 0
-                },
-                "max_queue_size": 2048,
-                "max_export_batch_size": 512,
-                "max_export_timeout": {
-                  "secs": 30,
-                  "nanos": 0
-                },
-                "max_concurrent_exports": 1
-              },
               "type": "object",
               "properties": {
                 "max_concurrent_exports": {
@@ -4501,24 +4488,11 @@ expression: "&schema"
               "description": "Open Telemetry native exporter configuration",
               "type": "object",
               "required": [
-                "endpoint"
+                "enabled"
               ],
               "properties": {
                 "batch_processor": {
                   "description": "Batch processor settings",
-                  "default": {
-                    "scheduled_delay": {
-                      "secs": 5,
-                      "nanos": 0
-                    },
-                    "max_queue_size": 2048,
-                    "max_export_batch_size": 512,
-                    "max_export_timeout": {
-                      "secs": 30,
-                      "nanos": 0
-                    },
-                    "max_concurrent_exports": 1
-                  },
                   "type": "object",
                   "properties": {
                     "max_concurrent_exports": {
@@ -4559,6 +4533,10 @@ expression: "&schema"
                       "type": "string"
                     }
                   }
+                },
+                "enabled": {
+                  "description": "Enable otlp",
+                  "type": "boolean"
                 },
                 "endpoint": {
                   "description": "The endpoint to send data to",
@@ -4705,24 +4683,11 @@ expression: "&schema"
               "description": "Datadog exporter configuration",
               "type": "object",
               "required": [
-                "endpoint"
+                "enabled"
               ],
               "properties": {
                 "batch_processor": {
                   "description": "batch processor configuration",
-                  "default": {
-                    "scheduled_delay": {
-                      "secs": 5,
-                      "nanos": 0
-                    },
-                    "max_queue_size": 2048,
-                    "max_export_batch_size": 512,
-                    "max_export_timeout": {
-                      "secs": 30,
-                      "nanos": 0
-                    },
-                    "max_concurrent_exports": 1
-                  },
                   "type": "object",
                   "properties": {
                     "max_concurrent_exports": {
@@ -4769,6 +4734,10 @@ expression: "&schema"
                   "default": false,
                   "type": "boolean"
                 },
+                "enabled": {
+                  "description": "Enable datadog",
+                  "type": "boolean"
+                },
                 "endpoint": {
                   "description": "The endpoint to send to",
                   "type": "string"
@@ -4800,103 +4769,11 @@ expression: "&schema"
                 {
                   "type": "object",
                   "required": [
-                    "agent"
-                  ],
-                  "properties": {
-                    "agent": {
-                      "description": "Agent configuration",
-                      "type": "object",
-                      "required": [
-                        "endpoint"
-                      ],
-                      "properties": {
-                        "endpoint": {
-                          "description": "The endpoint to send to",
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "batch_processor": {
-                      "description": "Batch processor configuration",
-                      "default": {
-                        "scheduled_delay": {
-                          "secs": 5,
-                          "nanos": 0
-                        },
-                        "max_queue_size": 2048,
-                        "max_export_batch_size": 512,
-                        "max_export_timeout": {
-                          "secs": 30,
-                          "nanos": 0
-                        },
-                        "max_concurrent_exports": 1
-                      },
-                      "type": "object",
-                      "properties": {
-                        "max_concurrent_exports": {
-                          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
-                          "default": 1,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "max_export_batch_size": {
-                          "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
-                          "default": 512,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "max_export_timeout": {
-                          "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
-                          "default": {
-                            "secs": 30,
-                            "nanos": 0
-                          },
-                          "type": "string"
-                        },
-                        "max_queue_size": {
-                          "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
-                          "default": 2048,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "scheduled_delay": {
-                          "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
-                          "default": {
-                            "secs": 5,
-                            "nanos": 0
-                          },
-                          "type": "string"
-                        }
-                      }
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "required": [
-                    "collector"
+                    "enabled"
                   ],
                   "properties": {
                     "batch_processor": {
                       "description": "Batch processor configuration",
-                      "default": {
-                        "scheduled_delay": {
-                          "secs": 5,
-                          "nanos": 0
-                        },
-                        "max_queue_size": 2048,
-                        "max_export_batch_size": 512,
-                        "max_export_timeout": {
-                          "secs": 30,
-                          "nanos": 0
-                        },
-                        "max_concurrent_exports": 1
-                      },
                       "type": "object",
                       "properties": {
                         "max_concurrent_exports": {
@@ -4941,9 +4818,6 @@ expression: "&schema"
                     "collector": {
                       "description": "Collector configuration",
                       "type": "object",
-                      "required": [
-                        "endpoint"
-                      ],
                       "properties": {
                         "endpoint": {
                           "description": "The endpoint to send reports to",
@@ -4951,16 +4825,89 @@ expression: "&schema"
                         },
                         "password": {
                           "description": "The optional password",
+                          "default": null,
                           "type": "string",
                           "nullable": true
                         },
                         "username": {
                           "description": "The optional username",
+                          "default": null,
                           "type": "string",
                           "nullable": true
                         }
                       },
                       "additionalProperties": false
+                    },
+                    "enabled": {
+                      "description": "Enable Jaeger",
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "enabled"
+                  ],
+                  "properties": {
+                    "agent": {
+                      "description": "Agent configuration",
+                      "type": "object",
+                      "properties": {
+                        "endpoint": {
+                          "description": "The endpoint to send to",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "batch_processor": {
+                      "description": "Batch processor configuration",
+                      "type": "object",
+                      "properties": {
+                        "max_concurrent_exports": {
+                          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
+                          "default": 1,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_batch_size": {
+                          "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
+                          "default": 512,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_timeout": {
+                          "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
+                          "default": {
+                            "secs": 30,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        },
+                        "max_queue_size": {
+                          "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
+                          "default": 2048,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "scheduled_delay": {
+                          "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
+                          "default": {
+                            "secs": 5,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "enabled": {
+                      "description": "Enable Jaeger",
+                      "type": "boolean"
                     }
                   },
                   "additionalProperties": false
@@ -4972,24 +4919,11 @@ expression: "&schema"
               "description": "OpenTelemetry native exporter configuration",
               "type": "object",
               "required": [
-                "endpoint"
+                "enabled"
               ],
               "properties": {
                 "batch_processor": {
                   "description": "Batch processor settings",
-                  "default": {
-                    "scheduled_delay": {
-                      "secs": 5,
-                      "nanos": 0
-                    },
-                    "max_queue_size": 2048,
-                    "max_export_batch_size": 512,
-                    "max_export_timeout": {
-                      "secs": 30,
-                      "nanos": 0
-                    },
-                    "max_concurrent_exports": 1
-                  },
                   "type": "object",
                   "properties": {
                     "max_concurrent_exports": {
@@ -5030,6 +4964,10 @@ expression: "&schema"
                       "type": "string"
                     }
                   }
+                },
+                "enabled": {
+                  "description": "Enable otlp",
+                  "type": "boolean"
                 },
                 "endpoint": {
                   "description": "The endpoint to send data to",
@@ -5334,24 +5272,11 @@ expression: "&schema"
               "description": "Zipkin exporter configuration",
               "type": "object",
               "required": [
-                "endpoint"
+                "enabled"
               ],
               "properties": {
                 "batch_processor": {
                   "description": "Batch processor configuration",
-                  "default": {
-                    "scheduled_delay": {
-                      "secs": 5,
-                      "nanos": 0
-                    },
-                    "max_queue_size": 2048,
-                    "max_export_batch_size": 512,
-                    "max_export_timeout": {
-                      "secs": 30,
-                      "nanos": 0
-                    },
-                    "max_concurrent_exports": 1
-                  },
                   "type": "object",
                   "properties": {
                     "max_concurrent_exports": {
@@ -5392,6 +5317,10 @@ expression: "&schema"
                       "type": "string"
                     }
                   }
+                },
+                "enabled": {
+                  "description": "Enable zipkin",
+                  "type": "boolean"
                 },
                 "endpoint": {
                   "description": "The endpoint to send to",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -4772,6 +4772,73 @@ expression: "&schema"
                     "enabled"
                   ],
                   "properties": {
+                    "agent": {
+                      "description": "Agent configuration",
+                      "type": "object",
+                      "properties": {
+                        "endpoint": {
+                          "description": "The endpoint to send to",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "batch_processor": {
+                      "description": "Batch processor configuration",
+                      "type": "object",
+                      "properties": {
+                        "max_concurrent_exports": {
+                          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
+                          "default": 1,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_batch_size": {
+                          "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
+                          "default": 512,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "max_export_timeout": {
+                          "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
+                          "default": {
+                            "secs": 30,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        },
+                        "max_queue_size": {
+                          "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
+                          "default": 2048,
+                          "type": "integer",
+                          "format": "uint",
+                          "minimum": 0.0
+                        },
+                        "scheduled_delay": {
+                          "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
+                          "default": {
+                            "secs": 5,
+                            "nanos": 0
+                          },
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "enabled": {
+                      "description": "Enable Jaeger",
+                      "type": "boolean"
+                    }
+                  },
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "required": [
+                    "enabled"
+                  ],
+                  "properties": {
                     "batch_processor": {
                       "description": "Batch processor configuration",
                       "type": "object",
@@ -4837,73 +4904,6 @@ expression: "&schema"
                         }
                       },
                       "additionalProperties": false
-                    },
-                    "enabled": {
-                      "description": "Enable Jaeger",
-                      "type": "boolean"
-                    }
-                  },
-                  "additionalProperties": false
-                },
-                {
-                  "type": "object",
-                  "required": [
-                    "enabled"
-                  ],
-                  "properties": {
-                    "agent": {
-                      "description": "Agent configuration",
-                      "type": "object",
-                      "properties": {
-                        "endpoint": {
-                          "description": "The endpoint to send to",
-                          "type": "string"
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "batch_processor": {
-                      "description": "Batch processor configuration",
-                      "type": "object",
-                      "properties": {
-                        "max_concurrent_exports": {
-                          "description": "Maximum number of concurrent exports\n\nLimits the number of spawned tasks for exports and thus memory consumed by an exporter. A value of 1 will cause exports to be performed synchronously on the BatchSpanProcessor task. The default is 1.",
-                          "default": 1,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "max_export_batch_size": {
-                          "description": "The maximum number of spans to process in a single batch. If there are more than one batch worth of spans then it processes multiple batches of spans one batch after the other without any delay. The default value is 512.",
-                          "default": 512,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "max_export_timeout": {
-                          "description": "The maximum duration to export a batch of data. The default value is 30 seconds.",
-                          "default": {
-                            "secs": 30,
-                            "nanos": 0
-                          },
-                          "type": "string"
-                        },
-                        "max_queue_size": {
-                          "description": "The maximum queue size to buffer spans for delayed processing. If the queue gets full it drops the spans. The default value of is 2048.",
-                          "default": 2048,
-                          "type": "integer",
-                          "format": "uint",
-                          "minimum": 0.0
-                        },
-                        "scheduled_delay": {
-                          "description": "The delay interval in milliseconds between two consecutive processing of batches. The default value is 5 seconds.",
-                          "default": {
-                            "secs": 5,
-                            "nanos": 0
-                          },
-                          "type": "string"
-                        }
-                      }
                     },
                     "enabled": {
                       "description": "Enable Jaeger",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@datadog_enabled.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@datadog_enabled.router.yaml.snap
@@ -1,0 +1,11 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+---
+---
+telemetry:
+  tracing:
+    datadog:
+      endpoint: default
+      enabled: true
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@jaeger_enabled.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@jaeger_enabled.router.yaml.snap
@@ -1,0 +1,12 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+---
+---
+telemetry:
+  tracing:
+    jaeger:
+      agent:
+        endpoint: default
+      enabled: true
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@jaeger_scheduled_delay.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@jaeger_scheduled_delay.router.yaml.snap
@@ -10,4 +10,5 @@ telemetry:
         endpoint: default
       batch_processor:
         scheduled_delay: 100ms
+      enabled: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@otlp_enabled.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@otlp_enabled.router.yaml.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+---
+---
+telemetry:
+  tracing:
+    otlp:
+      endpoint: default
+      enabled: true
+  metrics:
+    otlp:
+      endpoint: default
+      enabled: true
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@telemetry_otlp_timeout.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@telemetry_otlp_timeout.router.yaml.snap
@@ -9,4 +9,5 @@ telemetry:
       endpoint: default
       batch_processor:
         max_export_timeout: 5s
+      enabled: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@zipkin_enabled.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@zipkin_enabled.router.yaml.snap
@@ -1,0 +1,11 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+---
+---
+telemetry:
+  tracing:
+    zipkin:
+      endpoint: default
+      enabled: true
+

--- a/apollo-router/src/configuration/testdata/metrics/telemetry.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/telemetry.router.yaml
@@ -3,15 +3,20 @@ telemetry:
     prometheus:
       enabled: true
     otlp:
+      enabled: true
       endpoint: default
   tracing:
     otlp:
+      enabled: true
       endpoint: default
     zipkin:
+      enabled: true
       endpoint: default
     datadog:
+      enabled: true
       endpoint: default
     jaeger:
+      enabled: true
       agent:
         endpoint: default
 

--- a/apollo-router/src/configuration/testdata/migrations/datadog_enabled.router.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/datadog_enabled.router.yaml
@@ -1,8 +1,4 @@
-supergraph:
-  listen: 1.2.3.4:5
 telemetry:
   tracing:
     datadog:
-      enabled: true
       endpoint: default
-

--- a/apollo-router/src/configuration/testdata/migrations/jaeger_enabled.router.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/jaeger_enabled.router.yaml
@@ -1,8 +1,5 @@
-supergraph:
-  listen: 1.2.3.4:5
 telemetry:
   tracing:
     jaeger:
-      enabled: true
       agent:
         endpoint: default

--- a/apollo-router/src/configuration/testdata/migrations/otlp_enabled.router.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/otlp_enabled.router.yaml
@@ -1,0 +1,7 @@
+telemetry:
+  tracing:
+    otlp:
+      endpoint: default
+  metrics:
+    otlp:
+      endpoint: default

--- a/apollo-router/src/configuration/testdata/migrations/zipkin_enabled.router.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/zipkin_enabled.router.yaml
@@ -1,0 +1,4 @@
+telemetry:
+  tracing:
+    zipkin:
+      endpoint: default

--- a/apollo-router/src/configuration/testdata/tracing_datadog_env.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_datadog_env.router.yaml
@@ -3,5 +3,6 @@ supergraph:
 telemetry:
   tracing:
     datadog:
+      enabled: true
       endpoint: ${env.TEST_CONFIG_ENDPOINT}
 

--- a/apollo-router/src/configuration/testdata/tracing_jaeger_collector.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_jaeger_collector.router.yaml
@@ -3,5 +3,6 @@ supergraph:
 telemetry:
   tracing:
     jaeger:
+      enabled: true
       collector:
         endpoint: http://example.com

--- a/apollo-router/src/configuration/testdata/tracing_jaeger_collector_env.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_jaeger_collector_env.router.yaml
@@ -3,5 +3,6 @@ supergraph:
 telemetry:
   tracing:
     jaeger:
+      enabled: true
       collector:
         endpoint: ${env.TEST_CONFIG_COLLECTOR_ENDPOINT}

--- a/apollo-router/src/configuration/testdata/tracing_jaeger_full.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_jaeger_full.router.yaml
@@ -3,6 +3,7 @@ supergraph:
 telemetry:
   tracing:
     jaeger:
+      enabled: true
       collector:
         endpoint: "http://foo"
         password: ""

--- a/apollo-router/src/configuration/testdata/tracing_otlp_full.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_otlp_full.router.yaml
@@ -3,6 +3,7 @@ supergraph:
 telemetry:
   tracing:
     otlp:
+      enabled: true
       endpoint: default
       grpc:
         ca: ""

--- a/apollo-router/src/configuration/testdata/tracing_otlp_grpc_basic.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_otlp_grpc_basic.router.yaml
@@ -3,5 +3,6 @@ supergraph:
 telemetry:
   tracing:
     otlp:
+      enabled: true
       endpoint: default
       protocol: http

--- a/apollo-router/src/configuration/testdata/tracing_otlp_grpc_basic_env.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_otlp_grpc_basic_env.router.yaml
@@ -3,5 +3,6 @@ supergraph:
 telemetry:
   tracing:
     otlp:
+      enabled: true
       endpoint: ${env.TEST_CONFIG_ENDPOINT}
       protocol: http

--- a/apollo-router/src/configuration/testdata/tracing_otlp_http_basic.router.yaml
+++ b/apollo-router/src/configuration/testdata/tracing_otlp_http_basic.router.yaml
@@ -3,5 +3,6 @@ supergraph:
 telemetry:
   tracing:
     otlp:
+      enabled: true
       endpoint: default
       protocol: http

--- a/apollo-router/src/configuration/testdata/zipkin-address.router.yaml
+++ b/apollo-router/src/configuration/testdata/zipkin-address.router.yaml
@@ -3,4 +3,5 @@ telemetry:
     trace_config:
       service_name: router
     zipkin:
+      enabled: true
       endpoint: zipkin:9411

--- a/apollo-router/src/configuration/testdata/zipkin-url.router.yaml
+++ b/apollo-router/src/configuration/testdata/zipkin-url.router.yaml
@@ -3,4 +3,5 @@ telemetry:
     trace_config:
       service_name: router
     zipkin:
+      enabled: true
       endpoint: http://zipkin:9411/api/v2/spans

--- a/apollo-router/src/configuration/testdata/zipkin-url_env.router.yaml
+++ b/apollo-router/src/configuration/testdata/zipkin-url_env.router.yaml
@@ -3,4 +3,5 @@ telemetry:
     trace_config:
       service_name: router
     zipkin:
+      enabled: true
       endpoint: ${env.TEST_CONFIG_ENDPOINT}

--- a/apollo-router/src/configuration/testdata/zipkin.router.yaml
+++ b/apollo-router/src/configuration/testdata/zipkin.router.yaml
@@ -3,5 +3,5 @@ telemetry:
     trace_config:
       service_name: router
     zipkin:
-      enabled: false
+      enabled: true
       endpoint: default

--- a/apollo-router/src/configuration/testdata/zipkin.router.yaml
+++ b/apollo-router/src/configuration/testdata/zipkin.router.yaml
@@ -3,4 +3,5 @@ telemetry:
     trace_config:
       service_name: router
     zipkin:
+      enabled: false
       endpoint: default

--- a/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__create_report.snap
+++ b/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__create_report.snap
@@ -21,6 +21,7 @@ usage:
   configuration.override_subgraph_url.len: 1
   configuration.plugins.len: 0
   configuration.telemetry.apollo.send_headers.len: 1
+  configuration.telemetry.tracing.otlp.enabled.true: 1
   configuration.telemetry.tracing.otlp.endpoint.<redacted>: 1
   configuration.telemetry.tracing.otlp.grpc.metadata.len: 2
   configuration.telemetry.tracing.otlp.protocol.<redacted>: 1

--- a/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__visit_config.snap
+++ b/apollo-router/src/orbiter/snapshots/apollo_router__orbiter__test__visit_config.snap
@@ -14,6 +14,7 @@ configuration.headers.subgraphs.<redacted>.request.remove.len: 1
 configuration.headers.subgraphs.<redacted>.request.remove.named.<redacted>: 1
 configuration.override_subgraph_url.len: 1
 configuration.telemetry.apollo.send_headers.len: 1
+configuration.telemetry.tracing.otlp.enabled.true: 1
 configuration.telemetry.tracing.otlp.endpoint.<redacted>: 1
 configuration.telemetry.tracing.otlp.grpc.metadata.len: 2
 configuration.telemetry.tracing.otlp.protocol.<redacted>: 1

--- a/apollo-router/src/orbiter/testdata/redaction.router.yaml
+++ b/apollo-router/src/orbiter/testdata/redaction.router.yaml
@@ -25,6 +25,7 @@ telemetry:
         - "bar"
   tracing:
     otlp:
+      enabled: true
       protocol: grpc
       endpoint: default
       grpc:

--- a/apollo-router/src/plugins/telemetry/metrics/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/otlp.rs
@@ -38,7 +38,9 @@ impl MetricsConfigurator for super::super::otlp::Config {
         metrics_config: &MetricsCommon,
     ) -> Result<MetricsBuilder, BoxError> {
         let exporter: MetricExporterBuilder = self.exporter()?;
-
+        if !self.enabled {
+            return Ok(builder);
+        }
         match exporter.exporter {
             Some(exporter) => {
                 let exporter = MetricsExporterBuilder::Tonic(exporter).build_metrics_exporter(

--- a/apollo-router/src/plugins/telemetry/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/otlp.rs
@@ -30,10 +30,14 @@ lazy_static! {
     static ref DEFAULT_HTTP_ENDPOINT: Uri = Uri::from_static("http://127.0.0.1:4318");
 }
 
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, JsonSchema, Default)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
+    /// Enable otlp
+    pub(crate) enabled: bool,
+
     /// The endpoint to send data to
+    #[serde(default)]
     pub(crate) endpoint: UriEndpoint,
 
     /// The protocol to use when sending data

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -35,10 +35,14 @@ lazy_static! {
     static ref DEFAULT_ENDPOINT: Uri = Uri::from_static("http://localhost:8126/v0.4/traces");
 }
 
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, JsonSchema, Default)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
+    /// Enable datadog
+    pub(crate) enabled: bool,
+
     /// The endpoint to send to
+    #[serde(default)]
     pub(crate) endpoint: UriEndpoint,
 
     /// batch processor configuration
@@ -52,6 +56,9 @@ pub(crate) struct Config {
 
 impl TracingConfigurator for Config {
     fn apply(&self, builder: Builder, trace: &Trace) -> Result<Builder, BoxError> {
+        if !self.enabled {
+            return Ok(builder);
+        }
         tracing::info!("Configuring Datadog tracing: {}", self.batch_processor);
         let enable_span_mapping = self.enable_span_mapping.then_some(true);
         let trace_config: sdk::trace::Config = trace.into();

--- a/apollo-router/src/plugins/telemetry/tracing/jaeger.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/jaeger.rs
@@ -19,7 +19,7 @@ use crate::plugins::telemetry::tracing::SpanProcessorExt;
 use crate::plugins::telemetry::tracing::TracingConfigurator;
 
 lazy_static! {
-    static ref DEFAULT_ENDPOINT: Uri = Uri::from_static("http://localhost:14268/api/traces");
+    static ref DEFAULT_ENDPOINT: Uri = Uri::from_static("http://127.0.0.1:14268/api/traces");
 }
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields, untagged)]
@@ -76,7 +76,7 @@ impl TracingConfigurator for Config {
                 agent,
                 batch_processor,
             } if *enabled => {
-                tracing::info!("Configuring Jaeger tracing: {}", batch_processor);
+                tracing::info!("Configuring Jaeger tracing: {} (agent)", batch_processor);
                 let exporter = opentelemetry_jaeger::new_agent_pipeline()
                     .with_trace_config(trace_config.into())
                     .with_service_name(trace_config.service_name.clone())
@@ -94,7 +94,10 @@ impl TracingConfigurator for Config {
                 collector,
                 batch_processor,
             } if *enabled => {
-                tracing::info!("Configuring Jaeger tracing: {}", batch_processor);
+                tracing::info!(
+                    "Configuring Jaeger tracing: {} (collector)",
+                    batch_processor
+                );
 
                 let exporter = opentelemetry_jaeger::new_collector_pipeline()
                     .with_trace_config(trace_config.into())

--- a/apollo-router/src/plugins/telemetry/tracing/mod.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/mod.rs
@@ -13,7 +13,6 @@ use opentelemetry::Context;
 use opentelemetry::KeyValue;
 use schemars::JsonSchema;
 use serde::Deserialize;
-use serde::Serialize;
 use tower::BoxError;
 
 use crate::plugins::telemetry::config::Trace;
@@ -96,7 +95,7 @@ where
 }
 
 /// Batch processor configuration
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(default)]
 pub(crate) struct BatchProcessorConfig {
     #[serde(deserialize_with = "humantime_serde::deserialize")]

--- a/apollo-router/src/plugins/telemetry/tracing/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/otlp.rs
@@ -12,6 +12,9 @@ use crate::plugins::telemetry::tracing::TracingConfigurator;
 
 impl TracingConfigurator for super::super::otlp::Config {
     fn apply(&self, builder: Builder, _trace_config: &Trace) -> Result<Builder, BoxError> {
+        if !self.enabled {
+            return Ok(builder);
+        }
         tracing::info!("Configuring Otlp tracing: {}", self.batch_processor);
         let exporter: SpanExporterBuilder = self.exporter()?;
         Ok(builder.with_span_processor(

--- a/apollo-router/src/plugins/telemetry/tracing/zipkin.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/zipkin.rs
@@ -18,10 +18,14 @@ lazy_static! {
     static ref DEFAULT_ENDPOINT: Uri = Uri::from_static("http://localhost:9411/api/v2/spans");
 }
 
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, JsonSchema, Default)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
+    /// Enable zipkin
+    pub(crate) enabled: bool,
+
     /// The endpoint to send to
+    #[serde(default)]
     pub(crate) endpoint: UriEndpoint,
 
     /// Batch processor configuration
@@ -31,6 +35,9 @@ pub(crate) struct Config {
 
 impl TracingConfigurator for Config {
     fn apply(&self, builder: Builder, trace_config: &Trace) -> Result<Builder, BoxError> {
+        if !self.enabled {
+            return Ok(builder);
+        }
         tracing::info!("configuring Zipkin tracing: {}", self.batch_processor);
 
         let exporter = opentelemetry_zipkin::new_pipeline()

--- a/apollo-router/src/plugins/telemetry/tracing/zipkin.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/zipkin.rs
@@ -15,7 +15,7 @@ use crate::plugins::telemetry::tracing::SpanProcessorExt;
 use crate::plugins::telemetry::tracing::TracingConfigurator;
 
 lazy_static! {
-    static ref DEFAULT_ENDPOINT: Uri = Uri::from_static("http://localhost:9411/api/v2/spans");
+    static ref DEFAULT_ENDPOINT: Uri = Uri::from_static("http://127.0.0.1:9411/api/v2/spans");
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema, Default)]

--- a/apollo-router/src/testdata/datadog.router.yaml
+++ b/apollo-router/src/testdata/datadog.router.yaml
@@ -3,4 +3,5 @@ telemetry:
     trace_config:
       service_name: router
     datadog:
+      enabled: true
       endpoint: default

--- a/apollo-router/src/testdata/jaeger.router.yaml
+++ b/apollo-router/src/testdata/jaeger.router.yaml
@@ -13,6 +13,7 @@ telemetry:
     trace_config:
       service_name: router
     jaeger:
+      enabled: true
       batch_processor:
         scheduled_delay: 100ms
       agent:

--- a/apollo-router/src/testdata/otlp.router.yaml
+++ b/apollo-router/src/testdata/otlp.router.yaml
@@ -3,4 +3,5 @@ telemetry:
     trace_config:
       service_name: router
     otlp:
+      enabled: true
       endpoint: default

--- a/apollo-router/src/testdata/zipkin.router.yaml
+++ b/apollo-router/src/testdata/zipkin.router.yaml
@@ -3,4 +3,5 @@ telemetry:
     trace_config:
       service_name: router
     zipkin:
+      enabled: true
       endpoint: default

--- a/apollo-router/tests/fixtures/broken_plugin.router.yaml
+++ b/apollo-router/tests/fixtures/broken_plugin.router.yaml
@@ -13,6 +13,7 @@ telemetry:
     trace_config:
       service_name: router
     jaeger:
+      enabled: true
       batch_processor:
         scheduled_delay: 100ms
       agent:

--- a/apollo-router/tests/fixtures/datadog.router.yaml
+++ b/apollo-router/tests/fixtures/datadog.router.yaml
@@ -3,4 +3,5 @@ telemetry:
     trace_config:
       service_name: router
     datadog:
+      enabled: true
       endpoint: default

--- a/apollo-router/tests/fixtures/jaeger-0.5-sample.router.yaml
+++ b/apollo-router/tests/fixtures/jaeger-0.5-sample.router.yaml
@@ -9,6 +9,7 @@ telemetry:
       service_name: router
       sampler: 0.5
     jaeger:
+      enabled: true
       batch_processor:
         scheduled_delay: 100ms
       agent:

--- a/apollo-router/tests/fixtures/jaeger-no-sample.router.yaml
+++ b/apollo-router/tests/fixtures/jaeger-no-sample.router.yaml
@@ -12,6 +12,7 @@ telemetry:
       service_name: router
       sampler: always_off
     jaeger:
+      enabled: true
       batch_processor:
         scheduled_delay: 100ms
       agent:

--- a/apollo-router/tests/fixtures/jaeger.router.yaml
+++ b/apollo-router/tests/fixtures/jaeger.router.yaml
@@ -9,6 +9,7 @@ telemetry:
       service_name: router
       sampler: always_on
     jaeger:
+      enabled: true
       batch_processor:
         scheduled_delay: 100ms
       agent:

--- a/apollo-router/tests/fixtures/otlp.router.yaml
+++ b/apollo-router/tests/fixtures/otlp.router.yaml
@@ -3,4 +3,5 @@ telemetry:
     trace_config:
       service_name: router
     otlp:
+      enabled: true
       endpoint: default

--- a/apollo-router/tests/fixtures/zipkin.router.yaml
+++ b/apollo-router/tests/fixtures/zipkin.router.yaml
@@ -3,5 +3,5 @@ telemetry:
     trace_config:
       service_name: router
     zipkin:
-      enabled: false
+      enabled: true
       endpoint: default

--- a/apollo-router/tests/fixtures/zipkin.router.yaml
+++ b/apollo-router/tests/fixtures/zipkin.router.yaml
@@ -3,4 +3,5 @@ telemetry:
     trace_config:
       service_name: router
     zipkin:
+      enabled: false
       endpoint: default

--- a/dockerfiles/tracing/router/datadog.router.yaml
+++ b/dockerfiles/tracing/router/datadog.router.yaml
@@ -9,6 +9,7 @@ telemetry:
     trace_config:
       service_name: router
     datadog:
+      enabled: true
       endpoint: datadog-agent:8126
     propagation:
       datadog: true

--- a/dockerfiles/tracing/router/jaeger.router.yaml
+++ b/dockerfiles/tracing/router/jaeger.router.yaml
@@ -9,6 +9,7 @@ telemetry:
     trace_config:
       service_name: router
     jaeger:
+      enabled: true
       agent:
         endpoint: jaeger:6831
     propagation:

--- a/dockerfiles/tracing/router/zipkin.router.yaml
+++ b/dockerfiles/tracing/router/zipkin.router.yaml
@@ -9,6 +9,7 @@ telemetry:
     trace_config:
       service_name: router
     zipkin:
+      enabled: true
       endpoint: http://zipkin:9411/api/v2/spans
     propagation:
       zipkin: true 

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -141,6 +141,9 @@ You can send metrics to [OpenTelemetry Collector](https://opentelemetry.io/docs/
 telemetry:
   metrics:
     otlp:
+      # Enable the OpenTelemetry exporter
+      enabled: true
+      
       # Either 'default' or a URL
       endpoint: default
 

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -143,8 +143,8 @@ telemetry:
     otlp:
       # Enable the OpenTelemetry exporter
       enabled: true
-      
-      # Either 'default' or a URL
+
+      # Optional endpoint, either 'default' or a URL (Defaults to http://127.0.0.1:4317 for gRPC and http://127.0.0.1:4318 for HTTP)
       endpoint: default
 
       # Optional protocol. Only grpc is supported currently.

--- a/docs/source/configuration/tracing.mdx
+++ b/docs/source/configuration/tracing.mdx
@@ -134,6 +134,7 @@ telemetry:
   tracing:
     # Datadog
     datadog:
+      enabled: true
       batch_processor:
         scheduled_delay: 100ms
         max_concurrent_exports: 1000
@@ -156,6 +157,7 @@ The Apollo Router can be configured to connect to either the default agent addre
 telemetry:
   tracing:
     datadog:
+      enabled: true
       # Either 'default' or a URL (example: 'http://127.0.0.1:8126')
       endpoint: default
 ```
@@ -168,6 +170,7 @@ To fix this, you can configure the Apollo Router to perform a mapping for the sp
 telemetry:
   tracing:
     datadog:
+      enabled: true
       endpoint: default
       enable_span_mapping: true
 ```
@@ -218,6 +221,7 @@ The Apollo Router can be configured to export tracing data to Jaeger either via 
 telemetry:
   tracing:
     jaeger:
+      enabled: true
       agent:
         # Either 'default' or a URL
         endpoint: docker_jaeger:14268
@@ -231,6 +235,7 @@ If you're using Kubernetes, you can inject your secrets into configuration via e
 telemetry:
   tracing:
     jaeger:
+      enabled: true
       collector:
         endpoint: "http://my-jaeger-collector"
         username: "${env.JAEGER_USERNAME}"
@@ -247,6 +252,8 @@ If you find that the built-in telemetry features of the Apollo Router are missin
 telemetry:
   tracing:
     otlp:
+      enabled: true
+      
       # Either 'default' or a URL
       endpoint: default
 
@@ -278,6 +285,8 @@ The Apollo Router can be configured to export tracing data to either the default
 telemetry:
   tracing:
     zipkin:
+      enabled: true
+      
       # Either 'default' or a URL
       endpoint: http://my_zipkin_collector.dev
 ```

--- a/docs/source/configuration/tracing.mdx
+++ b/docs/source/configuration/tracing.mdx
@@ -215,6 +215,8 @@ Instead when `enable_span_mapping` is set to `true` the following trace will be 
 
 The Apollo Router can be configured to export tracing data to Jaeger either via an agent or http collector.
 
+Unless explicitly configured to use a collector, Jaeger will use an agent by default.
+
 ### Agent config
 
 ```yaml title="router.yaml"
@@ -222,9 +224,10 @@ telemetry:
   tracing:
     jaeger:
       enabled: true
+      # Optional agent configuration,
       agent:
-        # Either 'default' or a URL
-        endpoint: docker_jaeger:14268
+        # Optional endpoint, either 'default' or a socket address (Defaults to 127.0.0.1:6831)
+        endpoint: docker_jaeger:14268  
 ```
 
 ### Collector config
@@ -236,8 +239,10 @@ telemetry:
   tracing:
     jaeger:
       enabled: true
+      # Optional collector configuration,
       collector:
-        endpoint: "http://my-jaeger-collector"
+        # Optional endpoint, either 'default' or a URL (Defaults to http://127.0.0.1:14268/api/traces)
+        endpoint: "http://my-jaeger-collector" 
         username: "${env.JAEGER_USERNAME}"
         password: "${env.JAEGER_PASSWORD}"
 ```
@@ -254,7 +259,7 @@ telemetry:
     otlp:
       enabled: true
       
-      # Either 'default' or a URL
+      # Optional endpoint, either 'default' or a URL (Defaults to http://127.0.0.1:4317 for gRPC and http://127.0.0.1:4318 for HTTP)
       endpoint: default
 
       # Optional protocol (Defaults to grpc)
@@ -286,7 +291,7 @@ telemetry:
   tracing:
     zipkin:
       enabled: true
-      
-      # Either 'default' or a URL
-      endpoint: http://my_zipkin_collector.dev
+
+      # Optional endpoint, either 'default' or a URL (Defaults to http://127.0.0.1:9411/api/v2/spans)
+      endpoint: http://my_zipkin_collector.dev   
 ```

--- a/examples/telemetry/datadog.router.yaml
+++ b/examples/telemetry/datadog.router.yaml
@@ -3,4 +3,5 @@ telemetry:
     trace_config:
       service_name: router
     datadog:
+      enabled: true
       endpoint: default

--- a/examples/telemetry/jaeger-agent.router.yaml
+++ b/examples/telemetry/jaeger-agent.router.yaml
@@ -3,5 +3,6 @@ telemetry:
     trace_config:
       service_name: router
     jaeger:
+      enabled: true
       agent:
         endpoint: default

--- a/examples/telemetry/jaeger-collector.router.yaml
+++ b/examples/telemetry/jaeger-collector.router.yaml
@@ -3,6 +3,7 @@ telemetry:
     trace_config:
       service_name: router
     jaeger:
+      enabled: true
       collector:
         endpoint: "https://example.com"
         username: "username"

--- a/examples/telemetry/otlp.router.yaml
+++ b/examples/telemetry/otlp.router.yaml
@@ -3,4 +3,5 @@ telemetry:
     trace_config:
       service_name: router
     otlp:
+      enabled: true
       endpoint: default

--- a/examples/telemetry/zipkin-agent.router.yaml
+++ b/examples/telemetry/zipkin-agent.router.yaml
@@ -3,4 +3,5 @@ telemetry:
     trace_config:
       service_name: router
     zipkin:
+      enabled: true
       endpoint: default

--- a/examples/telemetry/zipkin-collector.router.yaml
+++ b/examples/telemetry/zipkin-collector.router.yaml
@@ -3,5 +3,6 @@ telemetry:
     trace_config:
       service_name: router
     zipkin:
+      enabled: true
       endpoint: "https://example.com"
 


### PR DESCRIPTION
Adds an enabled field to all the telemetry endpoint. This means that we can move away from use of Optional in the telemetry config structures.

Part of #3226

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
