### PR TITLE
document guidance for request and response buffering

### DIFF
--- a/.changesets/docs_garypen_3838_document_buffering.md
+++ b/.changesets/docs_garypen_3838_document_buffering.md
@@ -1,0 +1,5 @@
+### Document guidance for request and response buffering ([Issue #3838](https://github.com/apollographql/router/issues/3838))
+
+Provides specific guidance on request and response buffering within the router.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/3970

--- a/docs/source/customizations/overview.mdx
+++ b/docs/source/customizations/overview.mdx
@@ -280,18 +280,15 @@ Additionally, some requests and responses may happen multiple times for the same
 
 The router expects to execute on a stream of data. In order to work correctly and provide high performance, the following expectations must be met:
 
-##### Request Path
-__No buffering before the end of the `router_service` processing step__
+* **Request Path**: No buffering before the end of the `router_service` processing step
+* **Response Path**: No buffering
 
-##### Response Path
-__No buffering__
-
-> In general, it's best to avoid buffering where possible. It is "ok" to do so on the request path once the `router_service` step is complete.
+> In general, it's best to avoid buffering where possible. If necessary, it is ok to do so on the request path once the `router_service` step is complete.
 
 This guidance applies if you are:
- - modifying the router
- - creating a native Rust plugin
- - creating a custom binary
+ - Modifying the router
+ - Creating a native Rust plugin
+ - Creating a custom binary
 
 ## Customization creation
 

--- a/docs/source/customizations/overview.mdx
+++ b/docs/source/customizations/overview.mdx
@@ -276,6 +276,23 @@ flowchart LR;
 
 Additionally, some requests and responses may happen multiple times for the same operation. With subscriptions, for example, a subgraph sends a new `SubgraphResponse` whenever data is updated. Each response object travels through all the services in the response path and interacts with any customizations you've created.
 
+### Request and Response Buffering
+
+The router expects to execute on a stream of data. In order to work correctly and provide high performance, the following expectations must be met:
+
+##### Request Path
+__No buffering before the end of the `router_service` processing step__
+
+##### Response Path
+__No buffering__
+
+> In general, it's best to avoid buffering where possible. It is "ok" to do so on the request path once the `router_service` step is complete.
+
+This guidance applies if you are:
+ - modifying the router
+ - creating a native Rust plugin
+ - creating a custom binary
+
 ## Customization creation
 
 To learn how to hook in to the various lifecycle stages, including examples customizations, refer to the [Rhai scripts](./rhai/) and [external coprocessing](./coprocessor/) docs.

--- a/docs/source/customizations/overview.mdx
+++ b/docs/source/customizations/overview.mdx
@@ -276,7 +276,7 @@ flowchart LR;
 
 Additionally, some requests and responses may happen multiple times for the same operation. With subscriptions, for example, a subgraph sends a new `SubgraphResponse` whenever data is updated. Each response object travels through all the services in the response path and interacts with any customizations you've created.
 
-### Request and Response Buffering
+### Request and Response buffering
 
 The router expects to execute on a stream of data. In order to work correctly and provide high performance, the following expectations must be met:
 


### PR DESCRIPTION
Provides specific guidance on request and response buffering within the router.

fixes: #3838

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
