### PR TITLE
disable self-signed certificate tls test

### DIFF
--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -2781,6 +2781,7 @@ mod tests {
         server.await.unwrap()
     }
 
+    #[ignore]
     #[tokio::test(flavor = "multi_thread")]
     async fn tls_self_signed() {
         let certificate_pem = include_str!("./testdata/server_self_signed.crt");


### PR DESCRIPTION
until we figure out a fix for: https://github.com/apollographql/router/issues/3998
