### PR TITLE
Add support for has_next in coprocessors `SupergraphResponse`

### DIFF
--- a/apollo-router/src/services/external.rs
+++ b/apollo-router/src/services/external.rs
@@ -87,6 +87,8 @@ pub(crate) struct Externalizable<T> {
     pub(crate) service_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) status_code: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) has_next: Option<bool>,
 }
 
 #[buildstructor::buildstructor]
@@ -128,6 +130,7 @@ where
             path,
             method,
             service_name: None,
+            has_next: None,
         }
     }
 
@@ -145,6 +148,7 @@ where
         status_code: Option<u16>,
         method: Option<String>,
         sdl: Option<String>,
+        has_next: Option<bool>,
     ) -> Self {
         assert!(matches!(
             stage,
@@ -164,6 +168,7 @@ where
             path: None,
             method,
             service_name: None,
+            has_next,
         }
     }
 
@@ -201,6 +206,7 @@ where
             path: None,
             method,
             service_name,
+            has_next: None,
         }
     }
 

--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -602,7 +602,7 @@ If your coprocessor [returns a _different_ value](#responding-to-coprocessor-req
 </td>
 <td>
 
-When `stage` is `SupergraphRequest`, if present and `true` then there may be subsequent `SupergraphRequest` calls to the co-processor for each multi-part (@defer/subscriptions) response.
+When `stage` is `SupergraphResponse`, if present and `true` then there may be subsequent `SupergraphResponse` calls to the co-processor for each multi-part (`@defer`/subscriptions) response.
 
 </td>
 </tr>

--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -602,7 +602,7 @@ If your coprocessor [returns a _different_ value](#responding-to-coprocessor-req
 </td>
 <td>
 
-When `stage` is `SupergraphResponse`, if present and `true` then there may be subsequent `SupergraphResponse` calls to the co-processor for each multi-part (`@defer`/subscriptions) response.
+When `stage` is `SupergraphResponse`, if present and `true` then there will be subsequent `SupergraphResponse` calls to the co-processor for each multi-part (`@defer`/subscriptions) response.
 
 </td>
 </tr>

--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -595,6 +595,21 @@ If your coprocessor [returns a _different_ value](#responding-to-coprocessor-req
 <tr>
 <td>
 
+##### `has_next`
+
+`bool`
+
+</td>
+<td>
+
+When `stage` is `SupergraphRequest`, if present and `true` then there may be subsequent `SupergraphRequest` calls to the co-processor for each multi-part (@defer/subscriptions) response.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 ##### `headers`
 
 `object`
@@ -711,6 +726,7 @@ When `stage` is `SubgraphRequest`, this is the full URI of the subgraph the rout
 
 </tbody>
 </table>
+
 
 ## Responding to coprocessor requests
 


### PR DESCRIPTION
Add a new field in SupergraphResponse that can be used to determine when a request has finished.

Fixes #4016

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
