### PR TITLE
use a more modern golang with helm-docs

### DIFF
--- a/.changesets/maint_garypen_4025_helm_docs.md
+++ b/.changesets/maint_garypen_4025_helm_docs.md
@@ -1,9 +1,0 @@
-### Use a more modern golang with helm-docs ([Issue #4025](https://github.com/apollographql/router/issues/4025))
-
-Recent updates to helm-docs mean that the golang on the Operating System is too old.
-
-Download a version from the golang website and use that.
-
-fixes: #4025 
-
-By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/4027

--- a/.changesets/maint_garypen_4025_helm_docs.md
+++ b/.changesets/maint_garypen_4025_helm_docs.md
@@ -1,0 +1,9 @@
+### Use a more modern golang with helm-docs ([Issue #4025](https://github.com/apollographql/router/issues/4025))
+
+Recent updates to helm-docs mean that the golang on the Operating System is too old.
+
+Download a version from the golang website and use that.
+
+fixes: #4025 
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/4027

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -597,9 +597,11 @@ jobs:
             - run:
                 name: helm-docs install
                 command: |
-                  sudo apt update
-                  sudo apt install golang
-                  GOPATH="${HOME}/.local" GO111MODULE=on go get github.com/norwoodj/helm-docs/cmd/helm-docs
+                  # install golang (to ${HOME}/go)
+                  curl -OLs https://go.dev/dl/go1.21.3.linux-amd64.tar.gz
+                  tar -C "${HOME}" -xf go1.21.3.linux-amd64.tar.gz
+                  # install helm-docs
+                  PATH="${HOME}/go/bin" GOPATH="${HOME}/.local" GO111MODULE=on go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
       - when:
           condition:
             or:


### PR DESCRIPTION
Recent updates to helm-docs mean that the golang on the OS is too old.

Download a version from the golang website and use that.

fixes: #4025 

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
