### PR TITLE
docs: remove outdated preview note for request limits

### DIFF
--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -633,10 +633,6 @@ tls:
 
 ### Request limits
 
-> **Request limits are currently in [preview](/resources/product-launch-stages#preview).**
->
-> To set request limits, you must run v1.17 or later of the Apollo Router. [Download the latest version.](../quickstart#download-options)
-
 The Apollo Router supports enforcing three types of request limits for enhanced security:
 
 - Network-based limits


### PR DESCRIPTION
Remove outdated note about Request Limits being in Preview