### PR TITLE
Make all `apollo_router_http_requests_total` metrics match

### DIFF
--- a/.changesets/fix_bryn_prom_differing_descriptions.md
+++ b/.changesets/fix_bryn_prom_differing_descriptions.md
@@ -1,11 +1,11 @@
-### Make all apollo_router_http_requests_total metrics match ([Issue #4047](https://github.com/apollographql/router/issues/4047))
+### Ensure `apollo_router_http_requests_total` metrics match ([Issue #4047](https://github.com/apollographql/router/issues/4047))
 
-The Router emitted identical metrics events with different descriptions causing an error to be emitted to the logs.
+Identically _named_ metrics were being emitted for `apollo_router_http_requests_total` (as intended) but with different _descriptions_ (not intended) resulting in occasional, but noisy, log warnings:
 
-```log
+```
 OpenTelemetry metric error occurred: Metrics error: Instrument description conflict, using existing.
 ```
 
-The metrics description have been brought into alignment.
+The metrics' descriptions have been brought into alignment to resolve the log warnings and we will follow-up with additional work to think holistically about a more durable pattern that will prevent this from occurring in the future.
 
 By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/4065

--- a/.changesets/fix_bryn_prom_differing_descriptions.md
+++ b/.changesets/fix_bryn_prom_differing_descriptions.md
@@ -1,0 +1,11 @@
+### Make all apollo_router_http_requests_total metrics match ([Issue #4047](https://github.com/apollographql/router/issues/4047))
+
+The Router emitted identical metrics events with different descriptions causing an error to be emitted to the logs.
+
+```log
+OpenTelemetry metric error occurred: Metrics error: Instrument description conflict, using existing.
+```
+
+The metrics description have been brought into alignment.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/4065

--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -437,12 +437,13 @@ async fn license_handler<B>(
         license,
         LicenseState::LicensedHalt | LicenseState::LicensedWarn
     ) {
-        ::tracing::error!(
-           monotonic_counter.apollo_router_http_requests_total = 1u64,
-           status = %500u16,
-           error = LICENSE_EXPIRED_SHORT_MESSAGE,
+        u64_counter!(
+            "apollo_router_http_requests_total",
+            "Total number of HTTP requests made.",
+            1,
+            status = StatusCode::INTERNAL_SERVER_ERROR.as_u16() as i64,
+            error = LICENSE_EXPIRED_SHORT_MESSAGE
         );
-
         // This will rate limit logs about license to 1 a second.
         // The way it works is storing the delta in seconds from a starting instant.
         // If the delta is over one second from the last time we logged then try and do a compare_exchange and if successfull log.

--- a/apollo-router/src/axum_factory/utils.rs
+++ b/apollo-router/src/axum_factory/utils.rs
@@ -70,10 +70,12 @@ pub(super) async fn decompress_request_body(
                 unknown => {
                     let message = format!("unknown content-encoding header value {unknown:?}");
                     tracing::error!(message);
-                    ::tracing::error!(
-                       monotonic_counter.apollo_router_http_requests_total = 1u64,
-                       status = %400u16,
-                       error = %message,
+                    u64_counter!(
+                        "apollo_router_http_requests_total",
+                        "Total number of HTTP requests made.",
+                        1,
+                        status = StatusCode::BAD_REQUEST.as_u16() as i64,
+                        error = message.clone()
                     );
 
                     Err((StatusCode::BAD_REQUEST, message).into_response())
@@ -82,10 +84,12 @@ pub(super) async fn decompress_request_body(
 
             Err(err) => {
                 let message = format!("cannot read content-encoding header: {err}");
-                ::tracing::error!(
-                   monotonic_counter.apollo_router_http_requests_total = 1u64,
-                   status = %400u16,
-                   error = %message,
+                u64_counter!(
+                    "apollo_router_http_requests_total",
+                    "Total number of HTTP requests made.",
+                    1,
+                    status = 400,
+                    error = message.clone()
                 );
                 Err((StatusCode::BAD_REQUEST, message).into_response())
             }

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -66,11 +66,12 @@ impl QueryAnalysisLayer {
                 .message("Must provide query string.".to_string())
                 .extension_code("MISSING_QUERY_STRING")
                 .build()];
-            tracing::error!(
-                monotonic_counter.apollo_router_http_requests_total = 1u64,
-                status = %StatusCode::BAD_REQUEST.as_u16(),
-                error = "Must provide query string",
-                "Must provide query string"
+            u64_counter!(
+                "apollo_router_http_requests_total",
+                "Total number of HTTP requests made.",
+                1,
+                status = StatusCode::BAD_REQUEST.as_u16() as i64,
+                error = "Must provide query string"
             );
 
             return Err(SupergraphResponse::builder()

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -10,6 +10,7 @@ use std::time::SystemTime;
 
 use buildstructor::buildstructor;
 use http::header::ACCEPT;
+use http::header::CONTENT_ENCODING;
 use http::header::CONTENT_TYPE;
 use http::HeaderValue;
 use jsonpath_lib::Selector;
@@ -334,7 +335,10 @@ impl IntegrationTest {
     pub fn execute_default_query(
         &self,
     ) -> impl std::future::Future<Output = (String, reqwest::Response)> {
-        self.execute_query_internal(&json!({"query":"query {topProducts{name}}","variables":{}}))
+        self.execute_query_internal(
+            &json!({"query":"query {topProducts{name}}","variables":{}}),
+            None,
+        )
     }
 
     #[allow(dead_code)]
@@ -342,19 +346,27 @@ impl IntegrationTest {
         &self,
         query: &Value,
     ) -> impl std::future::Future<Output = (String, reqwest::Response)> {
-        self.execute_query_internal(query)
+        self.execute_query_internal(query, None)
     }
 
     #[allow(dead_code)]
     pub fn execute_bad_query(
         &self,
     ) -> impl std::future::Future<Output = (String, reqwest::Response)> {
-        self.execute_query_internal(&json!({"garbage":{}}))
+        self.execute_query_internal(&json!({"garbage":{}}), None)
+    }
+
+    #[allow(dead_code)]
+    pub fn execute_bad_content_encoding(
+        &self,
+    ) -> impl std::future::Future<Output = (String, reqwest::Response)> {
+        self.execute_query_internal(&json!({"garbage":{}}), Some("garbage"))
     }
 
     fn execute_query_internal(
         &self,
         query: &Value,
+        content_encoding: Option<&'static str>,
     ) -> impl std::future::Future<Output = (String, reqwest::Response)> {
         assert!(
             self.router.is_some(),
@@ -372,6 +384,7 @@ impl IntegrationTest {
                 let mut request = client
                     .post("http://localhost:4000")
                     .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                    .header(CONTENT_ENCODING, content_encoding.unwrap_or("identity"))
                     .header("apollographql-client-name", "custom_name")
                     .header("apollographql-client-version", "1.0")
                     .json(&query)
@@ -560,6 +573,20 @@ impl IntegrationTest {
         }
         self.dump_stack_traces();
         panic!("'{msg}' not detected in logs");
+    }
+
+    #[allow(dead_code)]
+    pub async fn assert_log_not_contains(&mut self, msg: &str) {
+        let now = Instant::now();
+        while now.elapsed() < Duration::from_secs(5) {
+            if let Ok(line) = self.stdio_rx.try_recv() {
+                if line.contains(msg) {
+                    self.dump_stack_traces();
+                    panic!("'{msg}' detected in logs");
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 
     #[allow(dead_code)]

--- a/apollo-router/tests/metrics_tests.rs
+++ b/apollo-router/tests/metrics_tests.rs
@@ -120,3 +120,41 @@ async fn test_metrics_bad_query() {
     router.execute_bad_query().await;
     router.assert_metrics_contains(r#"apollo_router_operations_total{http_response_status_code="400",otel_scope_name="apollo/router"} 1"#, None).await;
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_bad_queries() {
+    let mut router = IntegrationTest::builder()
+        .config(PROMETHEUS_CONFIG)
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+    router.execute_default_query().await;
+    router
+        .assert_metrics_contains(
+            r#"apollo_router_http_requests_total{status="200",otel_scope_name="apollo/router"}"#,
+            None,
+        )
+        .await;
+    router.execute_bad_content_encoding().await;
+    router
+            .assert_metrics_contains(
+                r#"apollo_router_http_requests_total{error="unknown content-encoding header value \"garbage\"",status="400",otel_scope_name="apollo/router"}"#,
+                None,
+            )
+            .await;
+
+    router.execute_bad_query().await;
+    router
+        .assert_metrics_contains(
+            r#"apollo_router_http_requests_total{error="Must provide query string",status="400",otel_scope_name="apollo/router"}"#,
+            None,
+        )
+        .await;
+    router
+        .assert_log_not_contains(
+            "OpenTelemetry metric error occurred: Metrics error: Instrument description conflict",
+        )
+        .await;
+}


### PR DESCRIPTION
Metrics definitions must match, including descriptions.

Currently we have the same metric scattered across the codebase. This is not ideal, but we are refactoring metrics callsites. 
In the meantime, let's just make things match so that users don't see an error in the logs.


I tries to pull stuff out to consts, but I don't think this is possible without changing the macros, and we don't actually want people to have multiple callsites for metrics. The golden rule is one metric one callsite.

Fixes #4047