### PR TITLE
Update coprocessor.mdx to fix typo

### DIFF
--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -54,7 +54,7 @@ As shown in the diagram above, the `RouterService`, `SupergraphService` and `Sub
 
 Each supported service can send its coprocessor requests at two different **stages**:
 
-- As excecution proceeds "down" from the client to individual subgraphs
+- As execution proceeds "down" from the client to individual subgraphs
     - Here, the coprocessor can inspect and modify details of requests before  GraphQL operations are processed.
     - The coprocessor can also instruct the router to [_terminate_ a client request](#terminating-a-client-request) immediately.
 - As execution proceeds back "up" from subgraphs to the client


### PR DESCRIPTION
This PR fixes a typo in coprocessor.mdx by replacing "excecution" with "execution".

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
