### PR TITLE
docs: limitation of no request/response body access from router_service

### DIFF
--- a/docs/source/customizations/rhai.mdx
+++ b/docs/source/customizations/rhai.mdx
@@ -493,6 +493,10 @@ The Apollo Router requires that its Rhai engine implements the [sync feature](ht
 
 This is particularly risky when using closures within callbacks while referencing external data. Take particular care to avoid this kind of situation by making copies of data when required. The [examples/surrogate-cache-key directory](https://github.com/apollographql/router/tree/main/examples/surrogate-cache-key) contains an example of this, where "closing over" `response.headers` would cause a deadlock. To avoid this, a local copy of the required data is obtained and used in the closure.
 
+### Services
+
+Callbacks of `router_service` cannot access the body of a request or response. At the router service stage, a request or response body is an opaque sequence of bytes.
+
 ## Debugging
 
 ### Understanding errors


### PR DESCRIPTION
Until https://github.com/apollographql/router/issues/3642 is resolved and from [prior discussion](https://apollograph.slack.com/archives/C02UX05LF4K/p1695326294453519), document the limitation that a request or response body cannot be accessed from `router_service` callbacks.

Deploy previews:
- Added [new Services limitation](https://deploy-preview-4071--apollo-router-docs.netlify.app/customizations/rhai#services) 

