### PR TITLE
add a flag to disable authorization error logs

### DIFF
--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -28,6 +28,7 @@ use crate::json_ext::Object;
 use crate::json_ext::Path;
 use crate::plugins::authorization::AuthorizationPlugin;
 use crate::plugins::authorization::CacheKeyMetadata;
+use crate::plugins::authorization::UnauthorizedPaths;
 use crate::query_planner::labeler::add_defer_labels;
 use crate::services::layers::query_analysis::ParsedDocument;
 use crate::services::layers::query_analysis::ParsedDocumentInner;
@@ -231,7 +232,10 @@ impl BridgeQueryPlanner {
             fragments,
             operations,
             filtered_query: None,
-            unauthorized_paths: vec![],
+            unauthorized: UnauthorizedPaths {
+                paths: vec![],
+                log_errors: AuthorizationPlugin::log_errors(&self.configuration),
+            },
             subselections,
             defer_stats,
             is_original: true,
@@ -547,7 +551,7 @@ impl BridgeQueryPlanner {
                 executable: new_doc.to_executable(&self.schema.api_schema().definitions),
                 ast: new_doc,
             });
-            selections.unauthorized_paths = unauthorized_paths;
+            selections.unauthorized.paths = unauthorized_paths;
         }
 
         if selections.contains_introspection() {

--- a/apollo-router/src/services/execution_service.rs
+++ b/apollo-router/src/services/execution_service.rs
@@ -237,8 +237,9 @@ impl ExecutionService {
         tracing::debug_span!("format_response").in_scope(|| {
             let mut paths = Vec::new();
             if let Some(filtered_query) = query.filtered_query.as_ref() {
-                let unauthorized_paths = query.unauthorized_paths.iter().map(|path| path.to_string()).collect::<Vec<_>>();
-                if !unauthorized_paths.is_empty() {
+                if query.unauthorized.log_errors && !query.unauthorized.paths.is_empty() {
+                    let unauthorized_paths = query.unauthorized.paths.iter().map(|path| path.to_string()).collect::<Vec<_>>();
+
                     event!(Level::ERROR, unauthorized_query_paths = ?unauthorized_paths, "Authorization error",);
                 }
 
@@ -250,7 +251,7 @@ impl ExecutionService {
                     variables_set,
                 );
 
-                for path in &query.unauthorized_paths {
+                for path in &query.unauthorized.paths {
                     response.errors.push(Error::builder()
                     .message("Unauthorized field or type")
                     .path(path.clone())

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -30,6 +30,7 @@ use crate::json_ext::Object;
 use crate::json_ext::Path;
 use crate::json_ext::ResponsePathElement;
 use crate::json_ext::Value;
+use crate::plugins::authorization::UnauthorizedPaths;
 use crate::query_planner::fetch::OperationKind;
 use crate::services::layers::query_analysis::ParsedDocument;
 use crate::services::layers::query_analysis::ParsedDocumentInner;
@@ -59,7 +60,7 @@ pub(crate) struct Query {
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub(crate) subselections: HashMap<SubSelectionKey, SubSelectionValue>,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
-    pub(crate) unauthorized_paths: Vec<Path>,
+    pub(crate) unauthorized: UnauthorizedPaths,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub(crate) filtered_query: Option<Arc<Query>>,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
@@ -97,7 +98,7 @@ impl Query {
             },
             operations: Vec::new(),
             subselections: HashMap::new(),
-            unauthorized_paths: Vec::new(),
+            unauthorized: UnauthorizedPaths::default(),
             filtered_query: None,
             defer_stats: DeferStats {
                 has_defer: false,
@@ -296,7 +297,7 @@ impl Query {
             fragments,
             operations,
             subselections: HashMap::new(),
-            unauthorized_paths: Vec::new(),
+            unauthorized: UnauthorizedPaths::default(),
             filtered_query: None,
             defer_stats,
             is_original: true,

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -5660,7 +5660,7 @@ fn filtered_defer_fragment() {
         subselections,
         defer_stats,
         is_original: true,
-        unauthorized_paths: vec![],
+        unauthorized: vec![],
         validation_error: None,
     };
 
@@ -5688,7 +5688,7 @@ fn filtered_defer_fragment() {
         subselections,
         defer_stats,
         is_original: false,
-        unauthorized_paths: vec![],
+        unauthorized: vec![],
         validation_error: None,
     };
 


### PR DESCRIPTION
Authorization errors can be seen as common usage of the service when filtering fields from queries depending on the client's rights, so they might not warrant error logs to be analyzed by the router operators

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
