### PR TITLE
Fix another instance of conflicting metrics definitions.

### DIFF
--- a/.changesets/fix_bryn_fix_metrics_2.md
+++ b/.changesets/fix_bryn_fix_metrics_2.md
@@ -1,0 +1,7 @@
+### Ensure `apollo_router_http_requests_total` metrics match ([Issue #4047](https://github.com/apollographql/router/issues/4047))
+Identically _named_ metrics were being emitted for `apollo_router_http_requests_total` (as intended) but with different _descriptions_ (not intended) resulting in occasional, but noisy, log warnings:
+```
+OpenTelemetry metric error occurred: Metrics error: Instrument description conflict, using existing.
+```
+The metrics' descriptions have been brought into alignment to resolve the log warnings and we will follow-up with additional work to think holistically about a more durable pattern that will prevent this from occurring in the future.
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/4089

--- a/apollo-router/src/services/router_service.rs
+++ b/apollo-router/src/services/router_service.rs
@@ -363,10 +363,12 @@ impl RouterService {
         let supergraph_requests = match self.translate_request(req).await {
             Ok(requests) => requests,
             Err(err) => {
-                ::tracing::error!(
-                    monotonic_counter.apollo_router_http_requests_total = 1u64,
-                    status = %err.status.as_u16(),
-                    error = %err.error,
+                u64_counter!(
+                    "apollo_router_http_requests_total",
+                    "Total number of HTTP requests made.",
+                    1,
+                    status = err.status.as_u16() as i64,
+                    error = err.error.to_string()
                 );
 
                 return router::Response::error_builder()

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -357,6 +357,13 @@ impl IntegrationTest {
     }
 
     #[allow(dead_code)]
+    pub fn execute_huge_query(
+        &self,
+    ) -> impl std::future::Future<Output = (String, reqwest::Response)> {
+        self.execute_query_internal(&json!({"query":"query {topProducts{name, name, name, name, name, name, name, name, name, name}}","variables":{}}), None)
+    }
+
+    #[allow(dead_code)]
     pub fn execute_bad_content_encoding(
         &self,
     ) -> impl std::future::Future<Output = (String, reqwest::Response)> {

--- a/apollo-router/tests/fixtures/prometheus.router.yaml
+++ b/apollo-router/tests/fixtures/prometheus.router.yaml
@@ -1,3 +1,5 @@
+limits:
+  experimental_http_max_request_bytes: 60
 telemetry:
   metrics:
     prometheus:

--- a/apollo-router/tests/metrics_tests.rs
+++ b/apollo-router/tests/metrics_tests.rs
@@ -152,6 +152,14 @@ async fn test_bad_queries() {
             None,
         )
         .await;
+
+    router.execute_huge_query().await;
+    router
+        .assert_metrics_contains(
+            r#"apollo_router_http_requests_total{error="payload too large for the `experimental_http_max_request_bytes` configuration",status="413",otel_scope_name="apollo/router"} 1"#,
+            None,
+        )
+        .await;
     router
         .assert_log_not_contains(
             "OpenTelemetry metric error occurred: Metrics error: Instrument description conflict",


### PR DESCRIPTION
There was another instance of a metric that was missed that used the old metrics layer. Update this and add a test

Fixes #4047


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
