### PR TITLE
Remove the most significant memory leaks caused by HashMap::into_iter()

### DIFF
--- a/.changesets/fix_233_no_cloned_metrics.md
+++ b/.changesets/fix_233_no_cloned_metrics.md
@@ -1,6 +1,6 @@
 ### Remove the memory leaks from apollo telemetry ([PR #4094](https://github.com/apollographql/router/pull/4094))
 
-A memory leak in HashMap::into_iter() causes issues for the router.
+A memory leak in `HashMap::into_iter()` causes issues for the router.
 
 The relevant rust issues are:
 
@@ -9,6 +9,6 @@ https://github.com/rust-lang/hashbrown/issues/438
 Update in rust-lang:
 https://github.com/rust-lang/rust/pull/116956
 
-The fix will not be available in rust unti mid-November. In the meantime, this fix mitigates the impact on the router in the area most frequently exercising HashMap::into_iter().
+The fix will not be available in rust unti mid-November. In the meantime, this fix mitigates the impact on the router in the area most frequently exercising `HashMap::into_iter()`.
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/4094

--- a/.changesets/fix_233_no_cloned_metrics.md
+++ b/.changesets/fix_233_no_cloned_metrics.md
@@ -1,0 +1,14 @@
+### Remove the memory leaks from apollo telemetry ([PR #4094](https://github.com/apollographql/router/pull/4094))
+
+A memory leak in HashMap::into_iter() causes issues for the router.
+
+The relevant rust issues are:
+
+Original issue in HashBrown
+https://github.com/rust-lang/hashbrown/issues/438
+Update in rust-lang:
+https://github.com/rust-lang/rust/pull/116956
+
+The fix will not be available in rust unti mid-November. In the meantime, this fix mitigates the impact on the router in the area most frequently exercising HashMap::into_iter().
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/4094

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -780,13 +780,13 @@ impl Telemetry {
                 .private_entries
                 .lock()
                 .get::<MetricsAttributes>()
-                .cloned()
+                .as_ref()
         }
         .map(|attrs| {
             attrs
                 .0
-                .into_iter()
-                .map(|(attr_name, attr_value)| KeyValue::new(attr_name, attr_value))
+                .iter()
+                .map(|(attr_name, attr_value)| KeyValue::new(attr_name.clone(), attr_value.clone()))
                 .collect::<Vec<KeyValue>>()
         })
         .unwrap_or_default();
@@ -1039,13 +1039,13 @@ impl Telemetry {
                 .private_entries
                 .lock()
                 .get::<SubgraphMetricsAttributes>()
-                .cloned()
+                .as_ref()
         }
         .map(|attrs| {
             attrs
                 .0
-                .into_iter()
-                .map(|(attr_name, attr_value)| KeyValue::new(attr_name, attr_value))
+                .iter()
+                .map(|(attr_name, attr_value)| KeyValue::new(attr_name.clone(), attr_value.clone()))
                 .collect::<Vec<KeyValue>>()
         })
         .unwrap_or_default();
@@ -1266,7 +1266,7 @@ impl Telemetry {
             .private_entries
             .lock()
             .get::<UsageReporting>()
-            .cloned()
+            .as_ref()
         {
             let licensed_operation_count =
                 licensed_operation_count(&usage_reporting.stats_report_key);
@@ -1340,8 +1340,8 @@ impl Telemetry {
                             },
                             referenced_fields_by_type: usage_reporting
                                 .referenced_fields_by_type
-                                .into_iter()
-                                .map(|(k, v)| (k, convert(v)))
+                                .iter()
+                                .map(|(k, v)| (k.clone(), convert(v.clone())))
                                 .collect(),
                         },
                     )]),


### PR DESCRIPTION
Cloning the full metrics entries results in leaks.

The root cause is a memory leak in the rust standard HashMap (see changelog for more details).

This PR mitigates the impact of the leak on the router by replacing our use of `into_iter()` with `iter()` in the area of the router greatest impacted by this problem.

When rust 1.74.0 is available this problem will be fixed since the issue was fixed 2 days ago.

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
