### PR TITLE
prep release: v1.33.2

### DIFF
--- a/.changesets/fix_bryn_fix_metrics_2.md
+++ b/.changesets/fix_bryn_fix_metrics_2.md
@@ -1,7 +1,0 @@
-### Ensure `apollo_router_http_requests_total` metrics match ([Issue #4047](https://github.com/apollographql/router/issues/4047))
-Identically _named_ metrics were being emitted for `apollo_router_http_requests_total` (as intended) but with different _descriptions_ (not intended) resulting in occasional, but noisy, log warnings:
-```
-OpenTelemetry metric error occurred: Metrics error: Instrument description conflict, using existing.
-```
-The metrics' descriptions have been brought into alignment to resolve the log warnings and we will follow-up with additional work to think holistically about a more durable pattern that will prevent this from occurring in the future.
-By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/4089

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 
+# [1.33.2] - 2023-10-26
+
+## 🐛 Fixes
+
+### Ensure `apollo_router_http_requests_total` metrics match ([Issue #4047](https://github.com/apollographql/router/issues/4047))
+Identically _named_ metrics were being emitted for `apollo_router_http_requests_total` (as intended) but with different _descriptions_ (not intended) resulting in occasional, but noisy, log warnings:
+```
+OpenTelemetry metric error occurred: Metrics error: Instrument description conflict, using existing.
+```
+The metrics' descriptions have been brought into alignment to resolve the log warnings and we will follow-up with additional work to think holistically about a more durable pattern that will prevent this from occurring in the future.
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/4089
+
+
+
 # [1.33.1] - 2023-10-20
 
 ## 🐛 Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "1.33.1"
+version = "1.33.2"
 dependencies = [
  "access-json",
  "anyhow",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "1.33.1"
+version = "1.33.2"
 dependencies = [
  "apollo-parser 0.6.3",
  "apollo-router",
@@ -431,7 +431,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-scaffold"
-version = "1.33.1"
+version = "1.33.2"
 dependencies = [
  "anyhow",
  "cargo-scaffold",

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "1.33.1"
+version = "1.33.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-scaffold"
-version = "1.33.1"
+version = "1.33.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -22,7 +22,7 @@ apollo-router = { path ="{{integration_test}}apollo-router" }
 apollo-router = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
 # Note if you update these dependencies then also update xtask/Cargo.toml
-apollo-router = "1.33.1"
+apollo-router = "1.33.2"
 {{/if}}
 {{/if}}
 async-trait = "0.1.52"

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -13,7 +13,7 @@ apollo-router-scaffold = { path ="{{integration_test}}apollo-router-scaffold" }
 {{#if branch}}
 apollo-router-scaffold = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
-apollo-router-scaffold = { git = "https://github.com/apollographql/router.git", tag = "v1.33.1" }
+apollo-router-scaffold = { git = "https://github.com/apollographql/router.git", tag = "v1.33.2" }
 {{/if}}
 {{/if}}
 anyhow = "1.0.58"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "1.33.1"
+version = "1.33.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 repository = "https://github.com/apollographql/router/"
 documentation = "https://docs.rs/apollo-router"

--- a/dockerfiles/tracing/docker-compose.datadog.yml
+++ b/dockerfiles/tracing/docker-compose.datadog.yml
@@ -3,7 +3,7 @@ services:
 
   apollo-router:
     container_name: apollo-router
-    image: ghcr.io/apollographql/router:v1.33.1
+    image: ghcr.io/apollographql/router:v1.33.2
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/datadog.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.jaeger.yml
+++ b/dockerfiles/tracing/docker-compose.jaeger.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     #build: ./router
-    image: ghcr.io/apollographql/router:v1.33.1
+    image: ghcr.io/apollographql/router:v1.33.2
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/jaeger.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.zipkin.yml
+++ b/dockerfiles/tracing/docker-compose.zipkin.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     build: ./router
-    image: ghcr.io/apollographql/router:v1.33.1
+    image: ghcr.io/apollographql/router:v1.33.2
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/zipkin.router.yaml:/etc/config/configuration.yaml

--- a/helm/chart/router/Chart.yaml
+++ b/helm/chart/router/Chart.yaml
@@ -20,10 +20,10 @@ type: application
 # so it matches the shape of our release process and release automation.
 # By proxy of that decision, this version uses SemVer 2.0.0, though the prefix
 # of "v" is not included.
-version: 1.33.1
+version: 1.33.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.33.1"
+appVersion: "v1.33.2"

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -2,7 +2,7 @@
 
 [router](https://github.com/apollographql/router) Rust Graph Routing runtime for Apollo Federation
 
-![Version: 1.33.1](https://img.shields.io/badge/Version-1.33.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.33.1](https://img.shields.io/badge/AppVersion-v1.33.1-informational?style=flat-square)
+![Version: 1.33.2](https://img.shields.io/badge/Version-1.33.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.33.2](https://img.shields.io/badge/AppVersion-v1.33.2-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@
 ## Get Repo Info
 
 ```console
-helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.33.1
+helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.33.2
 ```
 
 ## Install Chart
@@ -19,7 +19,7 @@ helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.33.1
 **Important:** only helm3 is supported
 
 ```console
-helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 1.33.1 --values my-values.yaml
+helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 1.33.2 --values my-values.yaml
 ```
 
 _See [configuration](#configuration) below._

--- a/licenses.html
+++ b/licenses.html
@@ -7572,7 +7572,6 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/vorner/bytes-utils ">bytes-utils</a></li>
                     <li><a href=" https://github.com/rust-lang/cc-rs ">cc</a></li>
                     <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if</a></li>
-                    <li><a href=" https://github.com/sagiegurari/ci_info.git ">ci_info</a></li>
                     <li><a href=" https://github.com/rust-lang/cmake-rs ">cmake</a></li>
                     <li><a href=" https://github.com/smol-rs/concurrent-queue ">concurrent-queue</a></li>
                     <li><a href=" https://github.com/tkaitchuck/constrandom ">const-random</a></li>
@@ -11149,6 +11148,7 @@ additional terms or conditions.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/sagiegurari/ci_info.git ">ci_info</a></li>
                     <li><a href=" https://github.com/sagiegurari/envmnt.git ">envmnt</a></li>
                     <li><a href=" https://github.com/sagiegurari/fsio.git ">fsio</a></li>
                 </ul>
@@ -12517,9 +12517,9 @@ these terms.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/apollographql/federation/ ">router-bridge</a></li>
                 </ul>
-                <pre class="license-text">Copyright 2021 Apollo Graph, Inc.
+                <pre class="license-text">Elastic License 2.0
 
-Elastic License 2.0
+URL: https://www.elastic.co/licensing/elastic-license
 
 ## Acceptance
 
@@ -12610,8 +12610,6 @@ these terms.
 **use** means anything you do with the software requiring one of your licenses.
 
 **trademark** means trademarks, service marks, and similar rights.
-
---------------------------------------------------------------------------------
 </pre>
             </li>
             <li class="license">

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/router/releases/downloa
 
 # Router version defined in apollo-router's Cargo.toml
 # Note: Change this line manually during the release steps.
-PACKAGE_VERSION="v1.33.1"
+PACKAGE_VERSION="v1.33.2"
 
 download_binary() {
     downloader --check


### PR DESCRIPTION
> **Note**
>
> When approved, this PR will merge into **the `1.33.2` branch** which will — upon being approved itself — merge into `main`.
>
> **Things to review in this PR**:
>  - Changelog correctness (There is a preview below, but it is not necessarily the most up to date.  See the _Files Changed_ for the true reality.)
>  - Version bumps
>  - That it targets the right release branch (`1.33.2` in this case!).
>
---
## 🐛 Fixes

### Ensure `apollo_router_http_requests_total` metrics match ([Issue #4047](https://github.com/apollographql/router/issues/4047))
Identically _named_ metrics were being emitted for `apollo_router_http_requests_total` (as intended) but with different _descriptions_ (not intended) resulting in occasional, but noisy, log warnings:
```
OpenTelemetry metric error occurred: Metrics error: Instrument description conflict, using existing.
```
The metrics' descriptions have been brought into alignment to resolve the log warnings and we will follow-up with additional work to think holistically about a more durable pattern that will prevent this from occurring in the future.
By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/4089
