### PR TITLE
Fix serde deserialization for Extendable.

### DIFF
--- a/apollo-router/src/plugins/telemetry/config_new/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/events.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -77,7 +79,8 @@ pub(crate) enum EventLevel {
 #[derive(Deserialize, JsonSchema, Clone, Debug)]
 pub(crate) struct Event<A, E>
 where
-    A: Default,
+    A: Default + Debug,
+    E: Debug,
 {
     /// The log level of the event.
     level: EventLevel,

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -1,3 +1,5 @@
+use std::fmt::Debug;
+
 use schemars::JsonSchema;
 use serde::Deserialize;
 
@@ -76,7 +78,8 @@ struct SubgraphInstruments {
 #[derive(Clone, Deserialize, JsonSchema, Debug)]
 pub(crate) struct Instrument<A, E>
 where
-    A: Default,
+    A: Default + Debug,
+    E: Debug,
 {
     /// The type of instrument.
     #[serde(rename = "type")]

--- a/apollo-router/src/plugins/telemetry/config_new/snapshots/apollo_router__plugins__telemetry__config_new__attributes__test__extendable_serde.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/snapshots/apollo_router__plugins__telemetry__config_new__attributes__test__extendable_serde.snap
@@ -1,0 +1,18 @@
+---
+source: apollo-router/src/plugins/telemetry/config_new/attributes.rs
+expression: o
+---
+attributes:
+  graphql.document: ~
+  graphql.operation.name: true
+  graphql.operation.type: true
+custom:
+  custom_1:
+    operation_name: string
+    redact: ~
+    default: ~
+  custom_2:
+    operation_name: string
+    redact: ~
+    default: ~
+


### PR DESCRIPTION
Serde `flatten` doesn't do what we want it to do.
Custom `Deserializer` that will to the right thing, first trying a custom attribute and then a standard attribute.

Part of #3226 

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
