### PR TITLE
Tidy up various thread interactions

### DIFF
--- a/.changesets/fix_garypen_fewer_threads.md
+++ b/.changesets/fix_garypen_fewer_threads.md
@@ -1,0 +1,11 @@
+### Tidy up various thread interactions ([Issue #4121](https://github.com/apollographql/router/issues/4121))
+
+Introduce the DropWatch utility struct which can be used to watch a closure and either:
+ - execute the closure and then wait for the DropWatch struct to be dropped
+ - or wait for the struct to be dropped and then execute the closure
+
+It's primarily useful when dealing with Drops that are triggered from an async context, but could be useful wherever we have a thread that we'd like to have a managed lifetime associated with a Drop.
+
+We use it to clean up thread interactions in Telemetry and Rhai file watching.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/4127

--- a/apollo-router/src/drop_watch.rs
+++ b/apollo-router/src/drop_watch.rs
@@ -1,0 +1,71 @@
+//! Provide a [`DropWatch`] utility.
+//!
+//! Accept a FnOnce and carefully watch over it until we are dropped.
+//!
+//! Useful when we want to join threads which will ultimately be terminated within an asynchronous
+//! context.
+
+use std::mem::ManuallyDrop;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::thread::JoinHandle;
+
+pub(crate) struct DropWatch {
+    watcher_handle: ManuallyDrop<JoinHandle<()>>,
+    park_flag: Arc<AtomicBool>,
+}
+
+impl DropWatch {
+    /// Create a DropWatch which will execute the supplied closure then wait for notification
+    pub(crate) fn new_notify_after<F: FnOnce() + Send + 'static>(watched: F) -> Self {
+        let park_flag = Arc::new(AtomicBool::new(false));
+        let watching_flag = park_flag.clone();
+        let watcher_handle = std::thread::spawn(move || {
+            watched();
+            // Park the thread until this instance is dropped (see Drop impl)
+            // We may actually unpark() before this code executes or exit from park() spuriously.
+            // Use the watching_flag to control a loop which waits for the flag to be updated
+            // from Drop.
+            while !watching_flag.load(Ordering::Acquire) {
+                std::thread::park();
+            }
+        });
+        Self {
+            park_flag,
+            watcher_handle: ManuallyDrop::new(watcher_handle),
+        }
+    }
+
+    /// Create a DropWatch which will wait for notification before executing the supplied closure
+    pub(crate) fn new_notify_before<F: FnOnce() + Send + 'static>(watched: F) -> Self {
+        let park_flag = Arc::new(AtomicBool::new(false));
+        let watching_flag = park_flag.clone();
+        let watcher_handle = std::thread::spawn(move || {
+            // Park the thread until this instance is dropped (see Drop impl)
+            // We may actually unpark() before this code executes or exit from park() spuriously.
+            // Use the watching_flag to control a loop which waits for the flag to be updated
+            // from Drop.
+            while !watching_flag.load(Ordering::Acquire) {
+                std::thread::park();
+            }
+            watched();
+        });
+        Self {
+            park_flag,
+            watcher_handle: ManuallyDrop::new(watcher_handle),
+        }
+    }
+}
+
+impl Drop for DropWatch {
+    fn drop(&mut self) {
+        // Safety: watcher_handle is taken, and must not be accessed again
+        // Since this is in Drop::drop, it is not possible to access it afterwards.
+        // https://doc.rust-lang.org/stable/std/mem/struct.ManuallyDrop.html#method.into_inner
+        let wh = unsafe { ManuallyDrop::<JoinHandle<()>>::take(&mut self.watcher_handle) };
+        self.park_flag.store(true, Ordering::Release);
+        wh.thread().unpark();
+        wh.join().expect("drop watcher thread terminating");
+    }
+}

--- a/apollo-router/src/drop_watch.rs
+++ b/apollo-router/src/drop_watch.rs
@@ -72,7 +72,8 @@ impl Drop for DropWatch {
 
 #[cfg(test)]
 mod test {
-    use std::sync::atomic::{AtomicU8, Ordering};
+    use std::sync::atomic::AtomicU8;
+    use std::sync::atomic::Ordering;
     use std::sync::mpsc;
     use std::sync::Arc;
 

--- a/apollo-router/src/drop_watch.rs
+++ b/apollo-router/src/drop_watch.rs
@@ -18,7 +18,7 @@ pub(crate) struct DropWatch {
 
 impl DropWatch {
     /// Create a DropWatch which will execute the supplied closure then wait for notification
-    pub(crate) fn new_notify_after<F: FnOnce() + Send + 'static>(watched: F) -> Self {
+    pub(crate) fn run_and_wait<F: FnOnce() + Send + 'static>(watched: F) -> Self {
         let park_flag = Arc::new(AtomicBool::new(false));
         let watching_flag = park_flag.clone();
         let watcher_handle = std::thread::spawn(move || {
@@ -38,7 +38,7 @@ impl DropWatch {
     }
 
     /// Create a DropWatch which will wait for notification before executing the supplied closure
-    pub(crate) fn new_notify_before<F: FnOnce() + Send + 'static>(watched: F) -> Self {
+    pub(crate) fn wait_and_run<F: FnOnce() + Send + 'static>(watched: F) -> Self {
         let park_flag = Arc::new(AtomicBool::new(false));
         let watching_flag = park_flag.clone();
         let watcher_handle = std::thread::spawn(move || {

--- a/apollo-router/src/drop_watch.rs
+++ b/apollo-router/src/drop_watch.rs
@@ -2,8 +2,8 @@
 //!
 //! Accept a FnOnce and carefully watch over it until we are dropped.
 //!
-//! Useful when we want to join threads which will ultimately be terminated within an asynchronous
-//! context.
+//! Useful when we want to join threads which will ultimately be terminated
+//! within an asynchronous context.
 
 use std::mem::ManuallyDrop;
 use std::sync::atomic::AtomicBool;

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -54,6 +54,7 @@ pub(crate) mod axum_factory;
 mod cache;
 mod configuration;
 mod context;
+mod drop_watch;
 mod error;
 mod executable;
 mod files;

--- a/apollo-router/src/plugins/rhai/mod.rs
+++ b/apollo-router/src/plugins/rhai/mod.rs
@@ -205,7 +205,7 @@ impl Plugin for Rhai {
                 .unwrap_or_else(|_| panic!("could not watch: {watched_path:?}"));
         };
 
-        let watcher = DropWatch::new_notify_after(watcher_handle);
+        let watcher = DropWatch::run_and_wait(watcher_handle);
 
         Ok(Self { block, watcher })
     }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -574,7 +574,7 @@ impl Telemetry {
             );
             hot_tracer.reload(tracer);
 
-            // To ensure we don't hang, tracing providers are dropped in a blocking task.
+            // To ensure we don't hang, tracing providers are dropped in a thread.
             // https://github.com/open-telemetry/opentelemetry-rust/issues/868#issuecomment-1250387989
             // We don't have to worry about timeouts as every exporter is batched, which has a timeout on it already.
             // Note: It's safe to join our thread here, since we are not in an async context.


### PR DESCRIPTION
Introduce the DropWatch utility struct which can be used to watch a closure and either:
 - execute the closure and then wait for the DropWatch struct to be dropped
 - or wait for the struct to be dropped and then execute the closure

It's primarily useful when dealing with Drops that are triggered from an async context, but could be useful wherever we have a thread that we'd like to have a managed lifetime associated with a Drop.

fixes: #4121

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
