### PR TITLE
Fixup: update helm chart common label to apollographql.

### DIFF
--- a/helm/chart/router/templates/configmap.yaml
+++ b/helm/chart/router/templates/configmap.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     {{- include "router.labels" . | nindent 4 }}
     {{- if .Values.extraLabels }}
-    {{- include "common.templatizeExtraLabels" . | trim | nindent 4 }}
+    {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 4 }}
     {{- end }}
 data:
   configuration.yaml: |

--- a/helm/chart/router/templates/hpa.yaml
+++ b/helm/chart/router/templates/hpa.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     {{- include "router.labels" . | nindent 4 }}
     {{- if .Values.extraLabels }}
-    {{- include "common.templatizeExtraLabels" . | trim | nindent 4 }}
+    {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 4 }}
     {{- end }}
 spec:
   scaleTargetRef:

--- a/helm/chart/router/templates/ingress.yaml
+++ b/helm/chart/router/templates/ingress.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     {{- include "router.labels" . | nindent 4 }}
     {{- if .Values.extraLabels }}
-    {{- include "common.templatizeExtraLabels" . | trim | nindent 4 }}
+    {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 4 }}
     {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:

--- a/helm/chart/router/templates/pdb.yaml
+++ b/helm/chart/router/templates/pdb.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "router.labels" . | nindent 4 }}
     {{- if .Values.extraLabels }}
-    {{- include "common.templatizeExtraLabels" . | trim | nindent 4 }}
+    {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 4 }}
     {{- end }}
 spec:
 {{- if .Values.podDisruptionBudget.minAvailable }}

--- a/helm/chart/router/templates/secret.yaml
+++ b/helm/chart/router/templates/secret.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "router.labels" . | nindent 4 }}
     {{- if .Values.extraLabels }}
-    {{- include "common.templatizeExtraLabels" . | trim | nindent 4 }}
+    {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 4 }}
     {{- end }}
 data:
   managedFederationApiKey: {{ default "MISSING" .Values.managedFederation.apiKey | b64enc | quote }}

--- a/helm/chart/router/templates/service.yaml
+++ b/helm/chart/router/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "router.labels" . | nindent 4 }}
     {{- if .Values.extraLabels }}
-    {{- include "common.templatizeExtraLabels" . | trim | nindent 4 }}
+    {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 4 }}
     {{- end }}
   {{- with .Values.service.annotations }}
   annotations:

--- a/helm/chart/router/templates/serviceaccount.yaml
+++ b/helm/chart/router/templates/serviceaccount.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "router.labels" . | nindent 4 }}
     {{- if .Values.extraLabels }}
-    {{- include "common.templatizeExtraLabels" . | trim | nindent 4 }}
+    {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 4 }}
     {{- end }}
   {{- with .Values.serviceAccount.annotations }}
   annotations:

--- a/helm/chart/router/templates/serviceentry.yaml
+++ b/helm/chart/router/templates/serviceentry.yaml
@@ -13,7 +13,7 @@ metadata:
     app.fullName: {{ $fullName }}
     {{- include "router.labels" . | nindent 4 }}
     {{- if .Values.extraLabels }}
-    {{- include "common.templatizeExtraLabels" . | trim | nindent 4 }}
+    {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 4 }}
     {{- end }}
   {{- with .Values.serviceentry.annotations }}
   annotations:

--- a/helm/chart/router/templates/servicemonitor.yaml
+++ b/helm/chart/router/templates/servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "router.labels" . | nindent 4 }}
     {{- if .Values.extraLabels }}
-    {{- include "common.templatizeExtraLabels" . | trim | nindent 4 }}
+    {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 4 }}
     {{- end }}
 spec:
   endpoints:

--- a/helm/chart/router/templates/supergraph-cm.yaml
+++ b/helm/chart/router/templates/supergraph-cm.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     {{- include "router.labels" . | nindent 4 }}
     {{- if .Values.extraLabels }}
-    {{- include "common.templatizeExtraLabels" . | trim | nindent 4 }}
+    {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 4 }}
     {{- end }}
 data:
   supergraph-schema.graphql: |-

--- a/helm/chart/router/templates/tests/test-connection.yaml
+++ b/helm/chart/router/templates/tests/test-connection.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "router.labels" . | nindent 4 }}
     {{- if .Values.extraLabels }}
-    {{- include "common.templatizeExtraLabels" . | trim | nindent 4 }}
+    {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 4 }}
     {{- end }}
   annotations:
     "helm.sh/hook": test

--- a/helm/chart/router/templates/virtualservice.yaml
+++ b/helm/chart/router/templates/virtualservice.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
     {{- include "router.labels" . | nindent 4 }}
     {{- if .Values.extraLabels }}
-    {{- include "common.templatizeExtraLabels" . | trim | nindent 4 }}
+    {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 4 }}
     {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:


### PR DESCRIPTION
Followup to #4005 , this updates the name where we forgot to, so we can cut an other alpha and deploy the chart.
