### PR TITLE
docs: add links to router configuration overview

### DIFF
--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -435,6 +435,12 @@ supergraph:
   introspection: true
 ```
 
+### Debugging
+
+- To configure logging, see [Logging in the Apollo Router](./logging).
+
+- To configure the inclusion of subgraph errors, see [Subgraph error inclusion](./subgraph-error-inclusion).
+
 ### Landing pages
 
 The Apollo Router can serve any of the following landing pages to browsers that visit its [endpoint path](#endpoint-path):
@@ -517,6 +523,10 @@ See [Safelisting with persisted queries](./persisted-queries) for more informati
 
 See [Sending HTTP headers to subgraphs](./header-propagation/).
 
+### Traffic shaping
+
+To configure the shape of traffic between clients, routers, and subgraphs, see [Traffic shaping in the Apollo Router](./traffic-shaping).
+
 ### Cross-Origin Resource Sharing (CORS)
 
 See [Configuring CORS in the Apollo Router](./cors).
@@ -533,9 +543,23 @@ See [Apollo Router's _experimental_ support for query batching](../executing-ope
 
 See [GraphQL subscriptions in the Apollo Router](../executing-operations/subscription-support/#router-setup).
 
-### Authorization directives support
+### Authorization support
 
-See [Authorization in the Apollo Router](./authorization#authorization-directives).
+- To configure authorization directives, see [Authorization directives](./authorization/#authorization-directives).
+
+- To configure the authorization plugin, see [Configuration options](./authorization/#configuration-options).
+
+### JWT authentication
+
+To enable and configure JWT authentication, see [JWT authentication in the Apollo Router](./authn-jwt).
+
+### Cross-site request forgery (CSRF) prevention
+
+To configure CSRF prevention, see [CSRF prevention in the Apollo Router](./csrf).
+
+### Subgraph authentication
+
+To configure subgraph authentication with AWS SigV4, see a [configuration example](./authn-subgraph/#configuration-example).
 
 ### External coprocessing
 


### PR DESCRIPTION
Add links to features with config properties that were missing from the [router configuration overview](https://deploy-preview-4141--apollo-router-docs.netlify.app/configuration/overview) 