### PR TITLE
Add more packages to our diy debug images

### DIFF
--- a/dockerfiles/diy/dockerfiles/Dockerfile.repo
+++ b/dockerfiles/diy/dockerfiles/Dockerfile.repo
@@ -1,6 +1,6 @@
 # Use the rust build image from docker as our base
 # renovate-automation: rustc version
-FROM rust:1.71.1 as build
+FROM rust:1.72.0 as build
 
 # Set our working directory for the build
 WORKDIR /usr/src/router
@@ -31,7 +31,7 @@ RUN mkdir -p /dist/config && \
 COPY dockerfiles/router.yaml /dist/config
 
 # Build our final image
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG DEBUG_IMAGE=false
 
@@ -46,10 +46,17 @@ RUN \
 # Copy in the required files from our build image
 COPY --from=build --chown=root:root /dist /dist
 
-# If debug image, install heaptrack and make a data directory
+# If debug image, install a bunch of useful debugging stuff and make a data directory
 RUN \
   if [ "${DEBUG_IMAGE}" = "true" ]; then \
-    apt-get install -y heaptrack && \
+    apt-get install -y \
+    dnsutils \
+    procps \
+    heaptrack \
+    gdb \
+    heaptrack-gui \
+    x11-apps \
+    iputils-ping && \
     mkdir data; \
   fi
 


### PR DESCRIPTION
To make debugging easier. Also update from bullseye to bookworm to align with update to rust 1.72.0.