### PR TITLE
fix: support multi-value headers

### DIFF
--- a/.changesets/fix_nicolas_multi_value_headers.md
+++ b/.changesets/fix_nicolas_multi_value_headers.md
@@ -1,0 +1,5 @@
+### Propagate multi-value headers to subgraphs ([Issue #4153](https://github.com/apollographql/router/issues/4153))
+
+Use `HeaderMap.append` instead of `insert` to prevent erasing previous values when using multiple headers with the same name.
+
+By [@nmoutschen](https://github.com/nmoutschen) in https://github.com/apollographql/router/pull/4154

--- a/apollo-router/src/plugins/headers.rs
+++ b/apollo-router/src/plugins/headers.rs
@@ -373,9 +373,15 @@ where
                     default,
                 }) => {
                     let headers = req.subgraph_request.headers_mut();
-                    let value = req.supergraph_request.headers().get(named);
-                    if let Some(value) = value.or(default.as_ref()) {
-                        headers.insert(rename.as_ref().unwrap_or(named), value.clone());
+                    let values = req.supergraph_request.headers().get_all(named);
+                    if values.iter().count() == 0 {
+                        if let Some(default) = default {
+                            headers.append(rename.as_ref().unwrap_or(named), default.clone());
+                        }
+                    } else {
+                        for value in values {
+                            headers.append(rename.as_ref().unwrap_or(named), value.clone());
+                        }
                     }
                 }
                 Operation::Propagate(Propagate::Matching { matching }) => {
@@ -387,7 +393,7 @@ where
                             !RESERVED_HEADERS.contains(name) && matching.is_match(name.as_str())
                         })
                         .for_each(|(name, value)| {
-                            headers.insert(name, value.clone());
+                            headers.append(name, value.clone());
                         });
                 }
             }
@@ -650,6 +656,7 @@ mod test {
                     ("ac", "vac"),
                     ("da", "vda"),
                     ("db", "vdb"),
+                    ("db", "vdb2"),
                 ])
             })
             .returning(example_response);
@@ -762,6 +769,7 @@ mod test {
                     .header("da", "vda")
                     .header("db", "vdb")
                     .header("db", "vdb")
+                    .header("db", "vdb2")
                     .header(HOST, "host")
                     .header(CONTENT_LENGTH, "2")
                     .header(CONTENT_TYPE, "graphql")


### PR DESCRIPTION
Uses `HeaderMap.append` instead of `insert` to prevent removing values from multi-value headers.

__Note__: This might break implementations that require on a single header value being passed.

Fixes #4153

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
