### PR TITLE
Add missing schemas for redis connections

### DIFF
--- a/.changesets/fix_garypen_4173_redis_config.md
+++ b/.changesets/fix_garypen_4173_redis_config.md
@@ -1,0 +1,5 @@
+### Add missing schemas for redis connections ([Issue #4173](https://github.com/apollographql/router/issues/4173))
+
+We have supported additional schemas in our redis configuration since we fixed: https://github.com/apollographql/router/issues/3534, but we never updated our redis connection logic to process the new schema options. This is now fixed.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/4174

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -204,7 +204,7 @@ impl RedisCacheStorage {
                     ));
                 }
 
-                while let Some(mut url) = urls_iter.next() {
+                for mut url in urls_iter {
                     if url.username() != username {
                         return Err(RedisError::new(
                             RedisErrorKind::Config,

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -214,6 +214,15 @@ impl RedisCacheStorage {
                             "incompatible passwords between Redis URLs",
                         ));
                     }
+
+                    // Backwords compatibility with old redis client
+                    if url.scheme() == "redis" {
+                        let _ = result.set_scheme("redis-cluster");
+                    }
+                    if url.scheme() == "rediss" {
+                        let _ = result.set_scheme("rediss-cluster");
+                    }
+
                     if url.scheme() != scheme {
                         return Err(RedisError::new(
                             RedisErrorKind::Config,

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -226,7 +226,8 @@ impl RedisCacheStorage {
                         if result.scheme() == "redis" {
                             let _ = result.set_scheme("redis-cluster");
                         }
-                    } else if url.scheme() == "rediss" {
+                    }
+                    if url.scheme() == "rediss" {
                         let _ = url.set_scheme("rediss-cluster");
                         if result.scheme() == "rediss" {
                             let _ = result.set_scheme("rediss-cluster");

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -221,15 +221,17 @@ impl RedisCacheStorage {
                         ));
                     }
 
-                    let _host = url.host_str().ok_or_else(|| {
+                    let host = url.host_str().ok_or_else(|| {
                         RedisError::new(RedisErrorKind::Config, "missing host in Redis URL")
                     })?;
 
-                    let _port = url.port().ok_or_else(|| {
+                    let port = url.port().ok_or_else(|| {
                         RedisError::new(RedisErrorKind::Config, "missing port in Redis URL")
                     })?;
 
-                    // We don't perform further preprocessing on Cluster/Sentinel urls
+                    result
+                        .query_pairs_mut()
+                        .append_pair("node", &format!("{host}:{port}"));
                 }
 
                 Ok(result)


### PR DESCRIPTION
We have supported additional schemas in our redis configuration for a while, but we never updated our redis connection logic to process the new schemas. This is now fixed.

fixes: #4173

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
