### PR TITLE
docs: update otel conventions link

### DIFF
--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -37,7 +37,7 @@ telemetry:
         "environment.namespace": "{env.MY_K8_NAMESPACE_ENV_VARIABLE}"
 ```
 
-> [See OpenTelemetry conventions for resources.](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md)
+> [See OpenTelemetry conventions for resources.](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md)
 
 ## Using Prometheus
 

--- a/docs/source/configuration/tracing.mdx
+++ b/docs/source/configuration/tracing.mdx
@@ -59,7 +59,7 @@ telemetry:
         "environment.namespace": "{env.MY_K8_NAMESPACE_ENV_VARIABLE}"
 ```
 
-[See OpenTelemetry conventions for resources.](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md)
+[See OpenTelemetry conventions for resources.](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md)
 
 ### Sampling
 


### PR DESCRIPTION
The previous location (https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/README.md) appears to have changed to https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md.