### PR TITLE
Improve the robustness of our kubeconform processing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,13 +395,35 @@ commands:
             curl -L https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz | tar xz -C "${KUBECONFORM_INSTALL}"
 
             # Create list of kube versions
-            CURRENT_KUBE_VERSIONS=$(curl -L https://raw.githubusercontent.com/kubernetes/website/main/data/releases/schedule.yaml \
+            CURRENT_KUBE_VERSIONS=$(curl -s -L https://raw.githubusercontent.com/kubernetes/website/main/data/releases/schedule.yaml \
               | yq -o json '.' \
-              | jq --raw-output '.schedules[] | select((now | strftime("%Y-%m-%dT00:00:00Z")) as $date | .releaseDate < $date and .endOfLifeDate > $date) | .previousPatches[0].release')
+              | jq --raw-output '.schedules[] | select((now | strftime("%Y-%m-%dT00:00:00Z")) as $date | .releaseDate < $date and .endOfLifeDate > $date) | .previousPatches[].release')
 
-            # Use helm to template our chart against all kube versions
             TEMPLATE_DIR=$(mktemp -d)
+            MINOR_VERSION="${kube_version%.*}"
+            SUCCEEDED=false
+
+            # For each k8s minor version (e.g.: 1.28) we will try to validate against the most recent patch release (e.g. 1.28.3)
+            # We use curl --head to check if support is available. If it isn't we then try the next most recent release.
+            # As soon as we find an available release we try to use it. If we don't find an available release for a minor version, then we will ignore that silently
             for kube_version in ${CURRENT_KUBE_VERSIONS}; do
+              if [[ "${kube_version%.*}" == "${MINOR_VERSION}" ]]; then
+                if [[ ${SUCCEEDED} == true ]]; then
+                  continue
+                fi
+              else
+                MINOR_VERSION="${kube_version%.*}"
+                SUCCEEDED=false
+              fi
+
+              # Sometimes the database has not been updated with schema details. If that happens, just skip the kubeconform checks until the database is updated"
+              if ! curl --head --silent --output /dev/null  --fail "https://github.com/yannh/kubernetes-json-schema/tree/master/v${kube_version}"; then
+                echo "Skipping validation for kubernetes version: ${kube_version} until the schema database is updated."
+                continue
+              fi
+
+              echo "Validating against schema version: ${kube_version}"
+
               # Use helm to template our chart against kube_version
               helm template --kube-version "${kube_version}" router helm/chart/router --set autoscaling.enabled=true > "${TEMPLATE_DIR}/router-${kube_version}.yaml"
 
@@ -412,6 +434,7 @@ commands:
                 --schema-location default \
                 --verbose \
                 "${TEMPLATE_DIR}/router-${kube_version}.yaml"
+              SUCCEEDED=true
             done
 
   xtask_check_compliance:


### PR DESCRIPTION
Sometimes a new release of kubernetes becomes available well in advance of kubeconform support. Because we always use the latest patch release of a kubernetes to validate our Helm files, we can end up with a broken CI pipeline.

This changes the logic so that we always try all of the patch releases for a minor release using the first one we find before moving on to the next minor release. This is fine, since it's more important to keep our CI pipeline working than to be verifying our Helm templates against the very latest patch release of kubernetes.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
