### PR TITLE
Remove unused crates from the project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,7 +372,6 @@ dependencies = [
  "proteus",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "redis",
  "regex",
  "reqwest",
  "rhai",
@@ -388,10 +387,9 @@ dependencies = [
  "serde_json_bytes",
  "serde_urlencoded",
  "serde_yaml",
- "sha1 0.10.6",
+ "sha1",
  "sha2",
  "shellexpand",
- "similar-asserts",
  "static_assertions",
  "strum_macros",
  "sys-info",
@@ -1137,7 +1135,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1 0.10.6",
+ "sha1",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -1312,17 +1310,6 @@ checksum = "da74e2b81409b1b743f8f0c62cc6254afefb8b8e50bbfe3735550f7aeefa3448"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
-]
-
-[[package]]
-name = "bstr"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
-dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1580,20 +1567,6 @@ dependencies = [
  "either",
  "memchr",
  "unreachable",
-]
-
-[[package]]
-name = "combine"
-version = "4.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ed6e9d84f0b51a7f52daf1c7d71dd136fd7a3f41a8462b8cdb8c78d920fad4"
-dependencies = [
- "bytes",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -2140,7 +2113,7 @@ dependencies = [
  "sec1",
  "serde",
  "serde_bytes",
- "sha1 0.10.6",
+ "sha1",
  "sha2",
  "signature 1.6.4",
  "spki",
@@ -3006,7 +2979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "759c97c1e17c55525b57192c06a267cda0ac5210b222d6b82189a2338fa1c13d"
 dependencies = [
  "aho-corasick",
- "bstr 1.6.0",
+ "bstr",
  "fnv",
  "log",
  "regex",
@@ -3039,7 +3012,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ebc8013b4426d5b81a4364c419a95ed0b404af2b82e2457de52d9348f0e474"
 dependencies = [
- "combine 3.8.1",
+ "combine",
  "thiserror",
 ]
 
@@ -3174,7 +3147,7 @@ dependencies = [
  "http",
  "httpdate",
  "mime",
- "sha1 0.10.6",
+ "sha1",
 ]
 
 [[package]]
@@ -5241,26 +5214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redis"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152f3863635cbb76b73bc247845781098302c6c9ad2060e1a9a7de56840346b6"
-dependencies = [
- "async-trait",
- "bytes",
- "combine 4.6.6",
- "futures-util",
- "itoa",
- "percent-encoding",
- "pin-project-lite",
- "ryu",
- "sha1 0.6.1",
- "tokio",
- "tokio-util",
- "url",
-]
-
-[[package]]
 name = "redis-protocol"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6067,15 +6020,6 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
-]
-
-[[package]]
-name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
@@ -6084,12 +6028,6 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.7",
 ]
-
-[[package]]
-name = "sha1_smol"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
 name = "sha2"
@@ -6160,20 +6098,6 @@ name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "420acb44afdae038210c99e69aae24109f32f15500aa708e81d46c9f29d55fcf"
-dependencies = [
- "bstr 0.2.17",
- "unicode-segmentation",
-]
-
-[[package]]
-name = "similar-asserts"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e041bb827d1bfca18f213411d51b665309f1afb37a04a5d1464530e13779fc0f"
-dependencies = [
- "console 0.15.7",
- "similar",
-]
 
 [[package]]
 name = "simple_asn1"
@@ -7204,7 +7128,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustls",
- "sha1 0.10.6",
+ "sha1",
  "thiserror",
  "url",
  "utf-8",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -172,7 +172,6 @@ prost = "0.11.9"
 prost-types = "0.11.9"
 proteus = "0.5.0"
 rand = "0.8.5"
-rand_core = "0.6.4"
 rhai = { version = "1.16.2", features = ["sync", "serde", "internals"] }
 regex = "1.10.2"
 reqwest = { version = "0.11.22", default-features = false, features = [
@@ -283,7 +282,6 @@ once_cell = "1.18.0"
 opentelemetry-stdout = { version = "0.1.0", features = ["trace"] }
 p256 = "0.12.0"
 rand_core = "0.6.4"
-redis = { version = "0.21.7", features = ["tokio-comp"] }
 reqwest = { version = "0.11.22", default-features = false, features = [
     "json",
     "stream",
@@ -294,7 +292,6 @@ rhai = { version = "1.16.2", features = [
     "internals",
     "testing-environ",
 ] }
-similar-asserts = "1.5.0"
 tempfile = "3.8.0"
 test-log = { version = "0.2.13", default-features = false, features = [
     "trace",

--- a/apollo-router/src/http_server_factory.rs
+++ b/apollo-router/src/http_server_factory.rs
@@ -102,6 +102,7 @@ impl HttpServerHandle {
     }
 
     pub(crate) async fn shutdown(mut self) -> Result<(), ApolloRouterError> {
+        #[cfg(unix)]
         let listen_addresses = std::mem::take(&mut self.listen_addresses);
 
         let (_main_listener, _extra_listener) = self.wait_for_servers().await?;

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -1,4 +1,3 @@
-#![deny(unused_crate_dependencies)]
 //! Components of a federated GraphQL Server.
 //!
 //! Most of these modules are of varying interest to different audiences.
@@ -110,13 +109,3 @@ pub mod _private {
     // For tests
     pub use crate::router_factory::create_test_service_factory_from_yaml;
 }
-
-// Prevent false positives from unused crate dependencies. If any more
-// arise, add them here
-
-#[cfg(test)]
-use ecdsa as _;
-#[cfg(all(target_os = "linux", test))]
-use rstack as _;
-#[cfg(test)]
-use test_span as _;

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -116,5 +116,7 @@ pub mod _private {
 
 #[cfg(test)]
 use ecdsa as _;
+#[cfg(all(target_os = "linux", test))]
+use rstack as _;
 #[cfg(test)]
 use test_span as _;

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unused_crate_dependencies)]
 //! Components of a federated GraphQL Server.
 //!
 //! Most of these modules are of varying interest to different audiences.
@@ -109,3 +110,11 @@ pub mod _private {
     // For tests
     pub use crate::router_factory::create_test_service_factory_from_yaml;
 }
+
+// Prevent false positives from unused crate dependencies. If any more
+// arise, add them here
+
+#[cfg(test)]
+use ecdsa as _;
+#[cfg(test)]
+use test_span as _;


### PR DESCRIPTION
Remove some unused crates and convert our redis tests to use the `fred` crate. That means we can remove our dev dependency on the `redis` crate.

This yielded a 1.5% reduction in test build time on my laptop.

Note: This is an exploratory PR, since it's fairly tricky to get unused crates information across multiple platforms with various conditional compilations in play.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
