### PR TITLE
docs: clarify coprocessor router stage responses

### DIFF
--- a/.changesets/docs_lb_coprocessor_break_router_stages.md
+++ b/.changesets/docs_lb_coprocessor_break_router_stages.md
@@ -1,0 +1,9 @@
+### docs: clarify coprocessor router stage responses ([PR #4189](https://github.com/apollographql/router/pull/4189))
+
+The coprocessor RouterRequest and RouterResponse stages fully supports `control: { break: 500 }` but the response body must be a string. This change provides examples in the "Terminating a client request" section.
+
+
+<!-- start metadata -->
+---
+
+By [@lennyburdette](https://github.com/lennyburdette) in https://github.com/apollographql/router/pull/4189

--- a/.changesets/docs_lb_coprocessor_break_router_stages.md
+++ b/.changesets/docs_lb_coprocessor_break_router_stages.md
@@ -1,6 +1,6 @@
 ### docs: clarify coprocessor router stage responses ([PR #4189](https://github.com/apollographql/router/pull/4189))
 
-The coprocessor RouterRequest and RouterResponse stages fully supports `control: { break: 500 }` but the response body must be a string. This change provides examples in the "Terminating a client request" section.
+The coprocessor RouterRequest and RouterResponse stages fully support `control: { break: 500 }` but the response body must be a string. This change provides examples in the "Terminating a client request" section.
 
 
 <!-- start metadata -->

--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -891,7 +891,30 @@ You can _also_ use this mechanism to immediately return a _successful_ response:
   }
 }
 ```
+
+<Tip>
+
+The `body` in the `RouterRequest` and `RouterResponse` stages is always a string, but you can still `break` with a GraphQL response if it's encoded as JSON.
+
+</Tip>
+
+<ExpansionPanel title="Examples of coprocessor responses for Router stages">
+
+```json
+{
+  "control": { "break": 500 },
+  "body": "{ \"errors\": [ { \"message\": \"Something went wrong\", \"extensions\": { \"code\": \"INTERNAL_SERVER_ERRROR\" } } ] }"
+}
 ```
+
+```json
+{
+  "control": { "break": 200 },
+  "body": "{ \"data\": { \"currentUser\": { \"name\": \"Ada Lovelace\" } }"
+}
+```
+
+</ExpansionPanel>
 
 <Note>
 

--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -892,6 +892,12 @@ You can _also_ use this mechanism to immediately return a _successful_ response:
 }
 ```
 
+<Note>
+
+If you return a successful response, make sure the structure of the `data` property matches the structure expected by the client query.
+
+</Note>
+
 <Tip>
 
 The `body` in the `RouterRequest` and `RouterResponse` stages is always a string, but you can still `break` with a GraphQL response if it's encoded as JSON.

--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -891,6 +891,7 @@ You can _also_ use this mechanism to immediately return a _successful_ response:
   }
 }
 ```
+```
 
 <Note>
 


### PR DESCRIPTION
The coprocessor RouterRequest and RouterResponse stages fully supports `control: { break: 500 }` but the response body must be a string. This change provides examples in the "Terminating a client request" section.

*Description here*

Fixes #**issue_number**

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
