### PR TITLE
[docs] Update subgraph-error-inclusion to link to other docs

### DIFF
--- a/.changesets/docs_subgraph_error_inclusion.md
+++ b/.changesets/docs_subgraph_error_inclusion.md
@@ -1,0 +1,5 @@
+### [docs] Update subgraph-error-inclusion to link to other docs ([PR #4206](https://github.com/apollographql/router/pull/4206))
+
+Update docs sets to link to other info on on why you might not be seeing error message in logs or GraphOS and where you can go to configure those
+
+By [@smyrick](https://github.com/smyrick) in https://github.com/apollographql/router/pull/4206

--- a/docs/source/configuration/subgraph-error-inclusion.mdx
+++ b/docs/source/configuration/subgraph-error-inclusion.mdx
@@ -24,7 +24,7 @@ include_subgraph_errors:
 Any configuration under the `subgraphs` key takes precedence over configuration under the `all` key. In the example above, subgraph errors are included from all subgraphs _except_ the `products` subgraph.
 
 ## Sending errors to GraphOS
-To report the subgraph errors to GraphOS that is a separate configuration that is not affected by client subgraph error inclusion. See more in the [GraphOS reporting docs](./apollo-telemetry).
+To report the subgraph errors to GraphOS that is a separate configuration that is not affected by client subgraph error inclusion, see the [GraphOS reporting docs](./apollo-telemetry).
 
 ## Logging GraphQL request errors
 To log the GraphQL error responses (i.e. messages returned in the GraphQL `errors` array) from the router, see the [logging configuration documentation](./logging).

--- a/docs/source/configuration/subgraph-error-inclusion.mdx
+++ b/docs/source/configuration/subgraph-error-inclusion.mdx
@@ -24,8 +24,8 @@ include_subgraph_errors:
 Any configuration under the `subgraphs` key takes precedence over configuration under the `all` key. In the example above, subgraph errors are included from all subgraphs _except_ the `products` subgraph.
 
 ## Sending errors to GraphOS
-To report the subgraph errors to GraphOS that is a separate configuration that is not affected by client subgraph error inclusion, see the [GraphOS reporting docs](./apollo-telemetry).
+To report the subgraph errors to GraphOS that is a separate configuration that is not affected by client subgraph error inclusion, see the [GraphOS reporting docs](./../telemetry/apollo-telemetry.mdx).
 
 ## Logging GraphQL request errors
-To log the GraphQL error responses (i.e. messages returned in the GraphQL `errors` array) from the router, see the [logging configuration documentation](./logging).
+To log the GraphQL error responses (i.e. messages returned in the GraphQL `errors` array) from the router, see the [logging configuration documentation](./../telemetry/exporters/logging/overview).
 

--- a/docs/source/configuration/subgraph-error-inclusion.mdx
+++ b/docs/source/configuration/subgraph-error-inclusion.mdx
@@ -22,3 +22,10 @@ include_subgraph_errors:
 ```
 
 Any configuration under the `subgraphs` key takes precedence over configuration under the `all` key. In the example above, subgraph errors are included from all subgraphs _except_ the `products` subgraph.
+
+## Sending errors to GraphOS
+To report the subgraph errors to GraphOS that is a separate configuration that is not affected by client subgraph error inclusion. See more in the [GraphOS reporting docs](./apollo-telemetry).
+
+## Logging GraphQL request errors
+To log the GraphQL error responses (i.e. messages returned in the GraphQL `errors` array) from the router, see the [logging configuration documentation](./logging).
+

--- a/docs/source/configuration/telemetry/apollo-telemetry.mdx
+++ b/docs/source/configuration/telemetry/apollo-telemetry.mdx
@@ -313,6 +313,7 @@ Your subgraph libraries must support federated tracing (also known as FTV1 traci
 To confirm support:
 - Check the `FEDERATED TRACING` entry for your library on [the supported subgraphs page](/federation/building-supergraphs/supported-subgraphs).
 - If federated tracing isn't enabled automatically for your library, consult its documentation to learn how to enable it.
+- Note that federated tracing can also be sampled (see above) so error messages might not be available for all your operations if you have sampled to a lower level.
 
 See the example below:
 

--- a/docs/source/executing-operations/subscription-support.mdx
+++ b/docs/source/executing-operations/subscription-support.mdx
@@ -119,7 +119,7 @@ flowchart LR;
     - You can _skip_ modifying subgraph schemas that don't define any `Subscription` fields.
 
 1. If you're using Apollo Server to implement subgraphs, [update your Apollo Server instances to version 4 or later](/apollo-server/migration).
-    - Follow the Apollo Server 4 [guide for enabling subscriptions](/apollo-server/data/subscriptions#enabling-subscriptions). 
+    - Follow the Apollo Server 4 [guide for enabling subscriptions](/apollo-server/data/subscriptions#enabling-subscriptions).
     - Update [`@apollo/subgraph`](/apollo-server/using-federation/apollo-subgraph-setup/#1-install-and-import-apollosubgraph).
 
 After you complete these prerequisites, you can safely [configure your router](#router-setup) for subscriptions.
@@ -155,7 +155,7 @@ The router supports the following WebSocket subprotocols, specified via the `pro
   - Used by the [graphql-ws](https://github.com/enisdenjo/graphql-ws) library
   - This subprotocol is the **default value** and is recommended for GraphQL server libraries implementing WebSocket-based subscriptions.
 - `graphql_transport_ws`
-  - Legacy subprotocol used by the [`subscriptions-transport-ws` library](https://github.com/apollographql/subscriptions-transport-ws), which is **unmaintained** but provided for backward compatibility. 
+  - Legacy subprotocol used by the [`subscriptions-transport-ws` library](https://github.com/apollographql/subscriptions-transport-ws), which is **unmaintained** but provided for backward compatibility.
 
 By default, the router uses the `graphql_ws` protocol option for all subgraphs. You can change this global default and/or override it for individual subgraphs by setting the `protocol` key as shown above.
 
@@ -164,14 +164,14 @@ Your router creates a separate WebSocket connection for each client subscription
 ### HTTP callback setup
 
 <Note>
-  
+
 * Your router must use whichever subprotocol is expected by each of your subgraphs.
 * To disambiguate between `graph-ws` and `graph_ws`:
-  * `graph-ws` (with a hyphen `-`) is the name of the [library](https://github.com/enisdenjo/graphql-ws) that uses the recommended `graphql_ws` (with un underscore `_`) WebSocket subprotocol. 
+  * `graph-ws` (with a hyphen `-`) is the name of the [library](https://github.com/enisdenjo/graphql-ws) that uses the recommended `graphql_ws` (with un underscore `_`) WebSocket subprotocol.
 * Each `path` must be set as an _absolute path_. For example, given `http://localhost:8080/foo/bar/graphql/ws`, set the absolute path as `path: "/foo/bar/graphql/ws"`.
 * The `public_url` must include the configured `path` on the router. For example, given a server URL of `http://localhost:8080` and the router's `path` = `/my_callback`, then your `public_url` must append the `path` to the server: `http://localhost:8080/my_callback`.
 * If you have a proxy in front of the router that redirects queries to the `path` configured in the router, you can specify another path for the `public_url`, for example `http://localhost:8080/external_path`.
-* Given a `public_url`, the router appends a subscription id to the `public_url` to get `http://localhost:8080/external_access/{subscription_id}` then passes it directly to your subgraphs.
+* Given a `public_url`, the router appends a subscription id to the `public_url` to get {`http://localhost:8080/external_access/{subscription_id}`} then passes it directly to your subgraphs.
 * If you don't specify the `path`, its default value is `/callback`, so you'll have to specify it in `public_url`.
 
 </Note>
@@ -208,7 +208,7 @@ You can disable the heartbeat by setting `heartbeat_interval_ms: disabled`. This
 
 <Caution>
 
-Once the heartbeat is disabled, you must manage how a subscription is closed from the server side. 
+Once the heartbeat is disabled, you must manage how a subscription is closed from the server side.
 
 If something crashes on your side for a specific subscription on specific events, but you don't manage closing the subscription, you can end up with a subscription still opened on the client but without any events to notify you on the client side that the subscription has crashed.
 


### PR DESCRIPTION
Update docs sets to link to other info on on why you might not be seeing error message in logs or GraphOS and where you can go to configure those
