### PR TITLE
Chore: Refactor selection set

### DIFF
--- a/apollo-router/src/spec/fragments.rs
+++ b/apollo-router/src/spec/fragments.rs
@@ -5,7 +5,6 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use crate::spec::query::DeferStats;
-use crate::spec::Schema;
 use crate::spec::Selection;
 use crate::spec::SpecError;
 
@@ -17,7 +16,6 @@ pub(crate) struct Fragments {
 impl Fragments {
     pub(crate) fn from_hir(
         doc: &ExecutableDocument,
-        schema: &Schema,
         defer_stats: &mut DeferStats,
     ) -> Result<Self, SpecError> {
         let map = doc
@@ -32,7 +30,7 @@ impl Fragments {
                         .selections
                         .iter()
                         .filter_map(|selection| {
-                            Selection::from_hir(selection, type_condition, schema, 0, defer_stats)
+                            Selection::from_hir(selection, type_condition, 0, defer_stats)
                                 .transpose()
                         })
                         .collect::<Result<Vec<_>, _>>()?,

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -332,7 +332,7 @@ impl Query {
             has_unconditional_defer: false,
             conditional_defer_variable_names: IndexSet::new(),
         };
-        let fragments = Fragments::from_hir(document, schema, &mut defer_stats)?;
+        let fragments = Fragments::from_hir(document, &mut defer_stats)?;
         let operations = document
             .all_operations()
             .map(|operation| Operation::from_hir(operation, schema, &mut defer_stats))
@@ -1093,7 +1093,7 @@ impl Operation {
             .selections
             .iter()
             .filter_map(|selection| {
-                Selection::from_hir(selection, &type_name, schema, 0, defer_stats).transpose()
+                Selection::from_hir(selection, &type_name, 0, defer_stats).transpose()
             })
             .collect::<Result<_, _>>()?;
         let variables = operation

--- a/apollo-router/src/spec/query/snapshots/apollo_router__spec__query__tests__fragment_type.snap
+++ b/apollo-router/src/spec/query/snapshots/apollo_router__spec__query__tests__fragment_type.snap
@@ -1,0 +1,13 @@
+---
+source: apollo-router/src/spec/query/tests.rs
+expression: response
+---
+{
+  "data": {
+    "node": {
+      "__typename": "Game",
+      "_id": "1",
+      "__isVideo": "Game"
+    }
+  }
+}

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -168,40 +168,6 @@ impl Schema {
         self.definitions.is_subtype(abstract_type, maybe_subtype)
     }
 
-    pub(crate) fn is_implementation(&self, interface: &str, implementor: &str) -> bool {
-        self.definitions
-            .get_interface(interface)
-            .map(|interface| {
-                // FIXME: this looks backwards
-                interface.implements_interfaces.contains(implementor)
-            })
-            .unwrap_or(false)
-    }
-
-    pub(crate) fn is_interface(&self, abstract_type: &str) -> bool {
-        self.definitions.get_interface(abstract_type).is_some()
-    }
-
-    // given two field, returns the one that implements the other, if applicable
-    pub(crate) fn most_precise<'f>(&self, a: &'f str, b: &'f str) -> Option<&'f str> {
-        let typename_a = a;
-        let typename_b = b;
-        if typename_a == typename_b {
-            return Some(a);
-        }
-        if self.is_subtype(typename_a, typename_b) || self.is_implementation(typename_a, typename_b)
-        {
-            Some(b)
-        } else if self.is_subtype(typename_b, typename_a)
-            || self.is_implementation(typename_b, typename_a)
-        {
-            Some(a)
-        } else {
-            // No relationship between a and b
-            None
-        }
-    }
-
     /// Return an iterator over subgraphs that yields the subgraph name and its URL.
     pub(crate) fn subgraphs(&self) -> impl Iterator<Item = (&String, &Uri)> {
         self.subgraphs.iter()


### PR DESCRIPTION
Recent compiler updates make a lot of workarounds we have written not necessary anymore.

This change removes them, so we can tidy the code up a bit.

No changelog since this has no user impact.