### PR TITLE
Relax JWKS requirements

### DIFF
--- a/.changesets/fix_geal_relax_jwks_requirements.md
+++ b/.changesets/fix_geal_relax_jwks_requirements.md
@@ -1,0 +1,5 @@
+### Relax JWKS requirements ([PR #4234](https://github.com/apollographql/router/pull/4234))
+
+We had a bug where if `use` and `key_ops` were absent, the key was not selected for verification
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4234

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -962,3 +962,33 @@ async fn it_rejects_and_accepts_keys_with_restricted_algorithms_and_unknown_jwks
 
     assert!(search_jwks(&jwks_manager, &criteria).is_some());
 }
+
+#[tokio::test]
+async fn it_accepts_key_without_use_or_keyops() {
+    let mut sets = vec![];
+    let mut urls = vec![];
+
+    let jwks_url = create_an_url("jwks-no-use.json");
+
+    sets.push(jwks_url);
+
+    for s_url in &sets {
+        let url: Url = Url::from_str(s_url).expect("created a valid url");
+        urls.push(JwksConfig {
+            url,
+            issuer: None,
+            algorithms: None,
+            poll_interval: Duration::from_secs(60),
+        });
+    }
+
+    let jwks_manager = JwksManager::new(urls).await.unwrap();
+
+    // the JWT contains a HMAC key but we configured a restriction to RSA signing
+    let criteria = JWTCriteria {
+        kid: None,
+        alg: Algorithm::ES256,
+    };
+
+    assert!(search_jwks(&jwks_manager, &criteria).is_some());
+}

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -992,3 +992,63 @@ async fn it_accepts_key_without_use_or_keyops() {
 
     assert!(search_jwks(&jwks_manager, &criteria).is_some());
 }
+
+#[tokio::test]
+async fn it_accepts_elliptic_curve_key_without_alg() {
+    let mut sets = vec![];
+    let mut urls = vec![];
+
+    let jwks_url = create_an_url("jwks-ec-no-alg.json");
+
+    sets.push(jwks_url);
+
+    for s_url in &sets {
+        let url: Url = Url::from_str(s_url).expect("created a valid url");
+        urls.push(JwksConfig {
+            url,
+            issuer: None,
+            algorithms: None,
+            poll_interval: Duration::from_secs(60),
+        });
+    }
+
+    let jwks_manager = JwksManager::new(urls).await.unwrap();
+
+    // the JWT contains a HMAC key but we configured a restriction to RSA signing
+    let criteria = JWTCriteria {
+        kid: None,
+        alg: Algorithm::ES256,
+    };
+
+    assert!(search_jwks(&jwks_manager, &criteria).is_some());
+}
+
+#[tokio::test]
+async fn it_accepts_rsa_key_without_alg() {
+    let mut sets = vec![];
+    let mut urls = vec![];
+
+    let jwks_url = create_an_url("jwks-rsa-no-alg.json");
+
+    sets.push(jwks_url);
+
+    for s_url in &sets {
+        let url: Url = Url::from_str(s_url).expect("created a valid url");
+        urls.push(JwksConfig {
+            url,
+            issuer: None,
+            algorithms: None,
+            poll_interval: Duration::from_secs(60),
+        });
+    }
+
+    let jwks_manager = JwksManager::new(urls).await.unwrap();
+
+    // the JWT contains a HMAC key but we configured a restriction to RSA signing
+    let criteria = JWTCriteria {
+        kid: None,
+        alg: Algorithm::RS384,
+    };
+
+    assert!(search_jwks(&jwks_manager, &criteria).is_some());
+}

--- a/apollo-router/tests/fixtures/jwks-ec-no-alg.json
+++ b/apollo-router/tests/fixtures/jwks-ec-no-alg.json
@@ -1,0 +1,10 @@
+{
+    "keys": [
+        {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "N9mNZYXyvhyzy5Xq3bD7aJp6R6I2SekVL2kE6byV5Z8",
+            "y": "wQiY8AKPoWevbeedRa93WdOr9O71GpszF888u6lI9w8"
+        }
+    ]
+}

--- a/apollo-router/tests/fixtures/jwks-no-use.json
+++ b/apollo-router/tests/fixtures/jwks-no-use.json
@@ -1,0 +1,11 @@
+{
+    "keys": [
+        {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "N9mNZYXyvhyzy5Xq3bD7aJp6R6I2SekVL2kE6byV5Z8",
+            "y": "wQiY8AKPoWevbeedRa93WdOr9O71GpszF888u6lI9w8",
+            "alg": "ES256"
+        }
+    ]
+}

--- a/apollo-router/tests/fixtures/jwks-rsa-no-alg.json
+++ b/apollo-router/tests/fixtures/jwks-rsa-no-alg.json
@@ -1,0 +1,10 @@
+{
+    "keys": [
+        {
+            "kty": "RSA",
+            "e": "AQAB",
+            "use": "sig",
+            "n": "pCDUC2mgQfh2FDLINmm4jyBMAIQMQuB5RyK5HO3KFqDSA3noTtgSCzKXEceyt6VLnWKYD_XOkr8ZUvTPRSLm3oz4uY1mfaF5BtkYO9WHjBKU3ioqFcYCtHZajg3WZeNih4cuppQB4E-xVi8BVzxHrQfPLcO8Pe9Y0jwkpMdkHB1mvdkA3nYOEHag3AfZFtZYkcpOe2c-4tM_fXKYHMoIkFkmgWTUYH9RoOWEoHpWeJqAbESZG0kuB6eohH8xOQScrQe9cOQEdGzp80C7jKCZ1EOP1rYVy7G2UQZOonjc8nOFgGoFKAvGrxLU5innnpJCWWSzoVW-FsB2F9Rdp5yrQw"
+        }
+    ]
+}


### PR DESCRIPTION
Fix https://github.com/apollographql/router/issues/3986

We had a bug where if `use` and `key_ops` are absent, we do not consider a key for verification. As shown in the tests, there is no issue if `alg` is not present, we still detect the key correctly

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
