### PR TITLE
Improve uplink error/warning messages

### DIFF
--- a/.changesets/maint_uplink_message_tweaks.md
+++ b/.changesets/maint_uplink_message_tweaks.md
@@ -1,0 +1,5 @@
+### Improve uplink error/warning messages ([Issue #3877](https://github.com/apollographql/router/issues/3877))
+
+Adds a warning if the router is started with only a single Uplink URL, and improves the error messages shown when a fetch from Uplink fails.
+
+By [@bonnici](https://github.com/bonnici) in https://github.com/apollographql/router/pull/4250

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -27,8 +27,11 @@ pub(crate) enum Error {
     #[error("http error")]
     Http(#[from] reqwest::Error),
 
-    #[error("fetch failed from all endpoints")]
-    FetchFailed,
+    #[error("fetch failed from uplink endpoint, and there are no fallback endpoints configured")]
+    FetchFailedSingle,
+
+    #[error("fetch failed from all {url_count} uplink endpoints")]
+    FetchFailedMultiple { url_count: usize },
 
     #[error("uplink error: code={code} message={message}")]
     UplinkError { code: String, message: String },
@@ -121,6 +124,13 @@ impl Endpoints {
                         .take(urls.len()),
                 )
             }
+        }
+    }
+
+    pub fn url_count(&self) -> usize {
+        match self {
+            Endpoints::Fallback { urls } => urls.len(),
+            Endpoints::RoundRobin { urls, current: _ } => urls.len(),
         }
     }
 }
@@ -228,7 +238,7 @@ where
             match fetch::<Query, Response, TransformedResponse>(
                 &client,
                 &query_body,
-                &mut endpoints.iter(),
+                &mut endpoints,
                 &transform_new_response,
             )
             .await
@@ -306,7 +316,7 @@ where
 pub(crate) async fn fetch<Query, Response, TransformedResponse>(
     client: &reqwest::Client,
     request_body: &QueryBody<Query::Variables>,
-    urls: &mut impl Iterator<Item = &Url>,
+    endpoints: &mut Endpoints,
     // See stream_from_uplink_transforming_new_response for an explanation of
     // this argument.
     transform_new_response: &(impl Fn(
@@ -324,7 +334,7 @@ where
     TransformedResponse: Send + Debug + 'static,
 {
     let query = query_name::<Query>();
-    for url in urls {
+    for url in endpoints.iter() {
         let now = Instant::now();
         match http_request::<Query>(client, url.as_str(), request_body).await {
             Ok(response) => match response.data.map(Into::into) {
@@ -417,7 +427,13 @@ where
             }
         };
     }
-    Err(Error::FetchFailed)
+
+    let url_count = endpoints.url_count();
+    if url_count == 1 {
+        Err(Error::FetchFailedSingle)
+    } else {
+        Err(Error::FetchFailedMultiple { url_count })
+    }
 }
 
 fn query_name<Query>() -> &'static str {
@@ -863,6 +879,24 @@ mod test {
             .await;
         let results = stream_from_uplink::<TestQuery, QueryResult>(
             mock_uplink_config_with_round_robin_urls(vec![url1, url2]),
+        )
+        .take(1)
+        .collect::<Vec<_>>()
+        .await;
+        assert_yaml_snapshot!(results.into_iter().map(to_friendly).collect::<Vec<_>>());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn stream_from_uplink_failed_from_single() {
+        let (mock_server, url1, _url2, _url3) = init_mock_server().await;
+        MockResponses::builder()
+            .mock_server(&mock_server)
+            .endpoint(&url1)
+            .response(response_fetch_error_http())
+            .build()
+            .await;
+        let results = stream_from_uplink::<TestQuery, QueryResult>(
+            mock_uplink_config_with_fallback_urls(vec![url1]),
         )
         .take(1)
         .collect::<Vec<_>>()

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -127,7 +127,7 @@ impl Endpoints {
         }
     }
 
-    pub fn url_count(&self) -> usize {
+    pub(crate) fn url_count(&self) -> usize {
         match self {
             Endpoints::Fallback { urls } => urls.len(),
             Endpoints::RoundRobin { urls, current: _ } => urls.len(),

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_failed_from_single.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_failed_from_single.snap
@@ -2,5 +2,5 @@
 source: apollo-router/src/uplink/mod.rs
 expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
 ---
-- Err: fetch failed from all 2 uplink endpoints
+- Err: "fetch failed from uplink endpoint, and there are no fallback endpoints configured"
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_invalid.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__test__stream_from_uplink_invalid.snap
@@ -2,5 +2,5 @@
 source: apollo-router/src/uplink/mod.rs
 expression: "results.into_iter().map(to_friendly).collect::<Vec<_>>()"
 ---
-- Err: fetch failed from all endpoints
+- Err: fetch failed from all 3 uplink endpoints
 


### PR DESCRIPTION
Fixes #3877

* Adds a warning on startup if a single URL is provided in `APOLLO_UPLINK_ENDPOINTS`: "Only a single uplink endpoint is configured. We recommend specifying at least two endpoints so that a fallback exists." 
  * note that the existing behaviour is preserved if no valid URLs are set - the router fails to start up
* Updates the error messages that is shown if fetches fail to all uplink endpoints from "fetch failed from all endpoints" to either "fetch failed from all N uplink endpoints" or "fetch failed from uplink endpoint, and there are no fallback endpoints configured" depending on how many endpoints are configured

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

Performed manual testing by running a router with various `APOLLO_UPLINK_ENDPOINTS` config - single endpoint, multiple endpoints, endpoints that don't work.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
