### PR TITLE
refactor(telemetry): use LinkedList instead of HashMap for custom attributes

### DIFF
--- a/apollo-router/src/plugins/telemetry/config_new/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/attributes.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt::Debug;
 use std::net::SocketAddr;
 
@@ -8,7 +7,7 @@ use http::header::USER_AGENT;
 use http::StatusCode;
 use http::Uri;
 use opentelemetry::Key;
-use opentelemetry::Value;
+use opentelemetry::KeyValue;
 use opentelemetry_semantic_conventions::trace::CLIENT_ADDRESS;
 use opentelemetry_semantic_conventions::trace::CLIENT_PORT;
 use opentelemetry_semantic_conventions::trace::GRAPHQL_DOCUMENT;
@@ -526,36 +525,36 @@ impl Selectors for RouterAttributes {
     type Request = router::Request;
     type Response = router::Response;
 
-    fn on_request(&self, request: &router::Request) -> HashMap<Key, opentelemetry::Value> {
+    fn on_request(&self, request: &router::Request) -> Vec<KeyValue> {
         let mut attrs = self.common.on_request(request);
         attrs.extend(self.server.on_request(request));
         if let Some(true) = &self.trace_id {
             if let Some(trace_id) = trace_id() {
-                attrs.insert(
+                attrs.push(KeyValue::new(
                     Key::from_static_str("trace_id"),
-                    trace_id.to_string().into(),
-                );
+                    trace_id.to_string(),
+                ));
             }
         }
         if let Some(true) = &self.datadog_trace_id {
             if let Some(trace_id) = trace_id() {
-                attrs.insert(
+                attrs.push(KeyValue::new(
                     Key::from_static_str("dd.trace_id"),
-                    trace_id.to_datadog().into(),
-                );
+                    trace_id.to_datadog(),
+                ));
             }
         }
 
         attrs
     }
 
-    fn on_response(&self, response: &router::Response) -> HashMap<Key, opentelemetry::Value> {
+    fn on_response(&self, response: &router::Response) -> Vec<KeyValue> {
         let mut attrs = self.common.on_response(response);
         attrs.extend(self.server.on_response(response));
         attrs
     }
 
-    fn on_error(&self, error: &BoxError) -> HashMap<Key, opentelemetry::Value> {
+    fn on_error(&self, error: &BoxError) -> Vec<KeyValue> {
         let mut attrs = self.common.on_error(error);
         attrs.extend(self.server.on_error(error));
         attrs
@@ -566,13 +565,13 @@ impl Selectors for HttpCommonAttributes {
     type Request = router::Request;
     type Response = router::Response;
 
-    fn on_request(&self, request: &router::Request) -> HashMap<Key, opentelemetry::Value> {
-        let mut attrs = HashMap::new();
+    fn on_request(&self, request: &router::Request) -> Vec<KeyValue> {
+        let mut attrs = Vec::new();
         if let Some(true) = &self.http_request_method {
-            attrs.insert(
+            attrs.push(KeyValue::new(
                 HTTP_REQUEST_METHOD,
-                request.router_request.method().as_str().to_string().into(),
-            );
+                request.router_request.method().as_str().to_string(),
+            ));
         }
 
         if let Some(true) = &self.http_request_body_size {
@@ -582,22 +581,25 @@ impl Selectors for HttpCommonAttributes {
                 .get(&CONTENT_LENGTH)
                 .and_then(|h| h.to_str().ok())
             {
-                attrs.insert(HTTP_REQUEST_BODY_SIZE, content_length.to_string().into());
+                attrs.push(KeyValue::new(
+                    HTTP_REQUEST_BODY_SIZE,
+                    content_length.to_string(),
+                ));
             }
         }
         if let Some(true) = &self.network_protocol_name {
             if let Some(scheme) = request.router_request.uri().scheme() {
-                attrs.insert(NETWORK_PROTOCOL_NAME, scheme.to_string().into());
+                attrs.push(KeyValue::new(NETWORK_PROTOCOL_NAME, scheme.to_string()));
             }
         }
         if let Some(true) = &self.network_protocol_version {
-            attrs.insert(
+            attrs.push(KeyValue::new(
                 NETWORK_PROTOCOL_VERSION,
-                format!("{:?}", request.router_request.version()).into(),
-            );
+                format!("{:?}", request.router_request.version()),
+            ));
         }
         if let Some(true) = &self.network_transport {
-            attrs.insert(NETWORK_TRANSPORT, "tcp".to_string().into());
+            attrs.push(KeyValue::new(NETWORK_TRANSPORT, "tcp".to_string()));
         }
         if let Some(true) = &self.network_type {
             if let Some(connection_info) =
@@ -605,9 +607,9 @@ impl Selectors for HttpCommonAttributes {
             {
                 if let Some(socket) = connection_info.server_address {
                     if socket.is_ipv4() {
-                        attrs.insert(NETWORK_TYPE, "ipv4".to_string().into());
+                        attrs.push(KeyValue::new(NETWORK_TYPE, "ipv4".to_string()));
                     } else if socket.is_ipv6() {
-                        attrs.insert(NETWORK_TYPE, "ipv6".to_string().into());
+                        attrs.push(KeyValue::new(NETWORK_TYPE, "ipv6".to_string()));
                     }
                 }
             }
@@ -616,8 +618,8 @@ impl Selectors for HttpCommonAttributes {
         attrs
     }
 
-    fn on_response(&self, response: &router::Response) -> HashMap<Key, opentelemetry::Value> {
-        let mut attrs = HashMap::new();
+    fn on_response(&self, response: &router::Response) -> Vec<KeyValue> {
+        let mut attrs = Vec::new();
         if let Some(true) = &self.http_response_body_size {
             if let Some(content_length) = response
                 .response
@@ -625,49 +627,50 @@ impl Selectors for HttpCommonAttributes {
                 .get(&CONTENT_LENGTH)
                 .and_then(|h| h.to_str().ok())
             {
-                attrs.insert(HTTP_RESPONSE_BODY_SIZE, content_length.to_string().into());
+                attrs.push(KeyValue::new(
+                    HTTP_RESPONSE_BODY_SIZE,
+                    content_length.to_string(),
+                ));
             }
         }
         if let Some(true) = &self.http_response_status_code {
-            attrs.insert(
+            attrs.push(KeyValue::new(
                 HTTP_RESPONSE_STATUS_CODE,
-                (response.response.status().as_u16() as i64).into(),
-            );
+                response.response.status().as_u16() as i64,
+            ));
         }
 
         if let Some(true) = &self.error_type {
             if !response.response.status().is_success() {
-                attrs.insert(
+                attrs.push(KeyValue::new(
                     ERROR_TYPE,
                     response
                         .response
                         .status()
                         .canonical_reason()
-                        .unwrap_or("unknown")
-                        .into(),
-                );
+                        .unwrap_or("unknown"),
+                ));
             }
         }
 
         attrs
     }
 
-    fn on_error(&self, _error: &BoxError) -> HashMap<Key, opentelemetry::Value> {
-        let mut attrs = HashMap::new();
+    fn on_error(&self, _error: &BoxError) -> Vec<KeyValue> {
+        let mut attrs = Vec::new();
         if let Some(true) = &self.error_type {
-            attrs.insert(
+            attrs.push(KeyValue::new(
                 ERROR_TYPE,
                 StatusCode::INTERNAL_SERVER_ERROR
                     .canonical_reason()
-                    .unwrap_or("unknown")
-                    .into(),
-            );
+                    .unwrap_or("unknown"),
+            ));
         }
         if let Some(true) = &self.http_response_status_code {
-            attrs.insert(
+            attrs.push(KeyValue::new(
                 HTTP_RESPONSE_STATUS_CODE,
-                (StatusCode::INTERNAL_SERVER_ERROR.as_u16() as i64).into(),
-            );
+                StatusCode::INTERNAL_SERVER_ERROR.as_u16() as i64,
+            ));
         }
 
         attrs
@@ -678,33 +681,33 @@ impl Selectors for HttpServerAttributes {
     type Request = router::Request;
     type Response = router::Response;
 
-    fn on_request(&self, request: &router::Request) -> HashMap<Key, opentelemetry::Value> {
-        let mut attrs: HashMap<Key, Value> = HashMap::new();
+    fn on_request(&self, request: &router::Request) -> Vec<KeyValue> {
+        let mut attrs = Vec::new();
         if let Some(true) = &self.http_route {
-            attrs.insert(
+            attrs.push(KeyValue::new(
                 HTTP_ROUTE,
-                request.router_request.uri().path().to_string().into(),
-            );
+                request.router_request.uri().path().to_string(),
+            ));
         }
         if let Some(true) = &self.client_address {
             if let Some(forwarded) = Self::forwarded_for(request) {
-                attrs.insert(CLIENT_ADDRESS, forwarded.ip().to_string().into());
+                attrs.push(KeyValue::new(CLIENT_ADDRESS, forwarded.ip().to_string()));
             } else if let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
             {
                 if let Some(socket) = connection_info.peer_address {
-                    attrs.insert(CLIENT_ADDRESS, socket.ip().to_string().into());
+                    attrs.push(KeyValue::new(CLIENT_ADDRESS, socket.ip().to_string()));
                 }
             }
         }
         if let Some(true) = &self.client_port {
             if let Some(forwarded) = Self::forwarded_for(request) {
-                attrs.insert(CLIENT_PORT, (forwarded.port() as i64).into());
+                attrs.push(KeyValue::new(CLIENT_PORT, forwarded.port() as i64));
             } else if let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
             {
                 if let Some(socket) = connection_info.peer_address {
-                    attrs.insert(CLIENT_PORT, (socket.port() as i64).into());
+                    attrs.push(KeyValue::new(CLIENT_PORT, socket.port() as i64));
                 }
             }
         }
@@ -713,23 +716,23 @@ impl Selectors for HttpServerAttributes {
             if let Some(forwarded) =
                 Self::forwarded_host(request).and_then(|h| h.host().map(|h| h.to_string()))
             {
-                attrs.insert(SERVER_ADDRESS, forwarded.into());
+                attrs.push(KeyValue::new(SERVER_ADDRESS, forwarded));
             } else if let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
             {
                 if let Some(socket) = connection_info.server_address {
-                    attrs.insert(SERVER_ADDRESS, socket.ip().to_string().into());
+                    attrs.push(KeyValue::new(SERVER_ADDRESS, socket.ip().to_string()));
                 }
             }
         }
         if let Some(true) = &self.server_port {
             if let Some(forwarded) = Self::forwarded_host(request).and_then(|h| h.port_u16()) {
-                attrs.insert(SERVER_PORT, (forwarded as i64).into());
+                attrs.push(KeyValue::new(SERVER_PORT, forwarded as i64));
             } else if let Some(connection_info) =
                 request.router_request.extensions().get::<ConnectionInfo>()
             {
                 if let Some(socket) = connection_info.server_address {
-                    attrs.insert(SERVER_PORT, (socket.port() as i64).into());
+                    attrs.push(KeyValue::new(SERVER_PORT, socket.port() as i64));
                 }
             }
         }
@@ -739,7 +742,10 @@ impl Selectors for HttpServerAttributes {
                 request.router_request.extensions().get::<ConnectionInfo>()
             {
                 if let Some(socket) = connection_info.server_address {
-                    attrs.insert(NETWORK_LOCAL_ADDRESS, socket.ip().to_string().into());
+                    attrs.push(KeyValue::new(
+                        NETWORK_LOCAL_ADDRESS,
+                        socket.ip().to_string(),
+                    ));
                 }
             }
         }
@@ -748,7 +754,7 @@ impl Selectors for HttpServerAttributes {
                 request.router_request.extensions().get::<ConnectionInfo>()
             {
                 if let Some(socket) = connection_info.server_address {
-                    attrs.insert(NETWORK_LOCAL_PORT, (socket.port() as i64).into());
+                    attrs.push(KeyValue::new(NETWORK_LOCAL_PORT, socket.port() as i64));
                 }
             }
         }
@@ -758,7 +764,7 @@ impl Selectors for HttpServerAttributes {
                 request.router_request.extensions().get::<ConnectionInfo>()
             {
                 if let Some(socket) = connection_info.peer_address {
-                    attrs.insert(NETWORK_PEER_ADDRESS, socket.ip().to_string().into());
+                    attrs.push(KeyValue::new(NETWORK_PEER_ADDRESS, socket.ip().to_string()));
                 }
             }
         }
@@ -767,23 +773,23 @@ impl Selectors for HttpServerAttributes {
                 request.router_request.extensions().get::<ConnectionInfo>()
             {
                 if let Some(socket) = connection_info.peer_address {
-                    attrs.insert(NETWORK_PEER_PORT, (socket.port() as i64).into());
+                    attrs.push(KeyValue::new(NETWORK_PEER_PORT, socket.port() as i64));
                 }
             }
         }
 
         let router_uri = request.router_request.uri();
         if let Some(true) = &self.url_path {
-            attrs.insert(URL_PATH, router_uri.path().to_string().into());
+            attrs.push(KeyValue::new(URL_PATH, router_uri.path().to_string()));
         }
         if let Some(true) = &self.url_query {
             if let Some(query) = router_uri.query() {
-                attrs.insert(URL_QUERY, query.to_string().into());
+                attrs.push(KeyValue::new(URL_QUERY, query.to_string()));
             }
         }
         if let Some(true) = &self.url_scheme {
             if let Some(scheme) = router_uri.scheme_str() {
-                attrs.insert(URL_SCHEME, scheme.to_string().into());
+                attrs.push(KeyValue::new(URL_SCHEME, scheme.to_string()));
             }
         }
         if let Some(true) = &self.user_agent_original {
@@ -793,19 +799,19 @@ impl Selectors for HttpServerAttributes {
                 .get(&USER_AGENT)
                 .and_then(|h| h.to_str().ok())
             {
-                attrs.insert(USER_AGENT_ORIGINAL, user_agent.to_string().into());
+                attrs.push(KeyValue::new(USER_AGENT_ORIGINAL, user_agent.to_string()));
             }
         }
 
         attrs
     }
 
-    fn on_response(&self, _response: &router::Response) -> HashMap<Key, opentelemetry::Value> {
-        HashMap::with_capacity(0)
+    fn on_response(&self, _response: &router::Response) -> Vec<KeyValue> {
+        Vec::with_capacity(0)
     }
 
-    fn on_error(&self, _error: &BoxError) -> HashMap<Key, opentelemetry::Value> {
-        HashMap::with_capacity(0)
+    fn on_error(&self, _error: &BoxError) -> Vec<KeyValue> {
+        Vec::with_capacity(0)
     }
 }
 
@@ -851,11 +857,11 @@ impl Selectors for SupergraphAttributes {
     type Request = supergraph::Request;
     type Response = supergraph::Response;
 
-    fn on_request(&self, request: &supergraph::Request) -> HashMap<Key, opentelemetry::Value> {
-        let mut attrs = HashMap::new();
+    fn on_request(&self, request: &supergraph::Request) -> Vec<KeyValue> {
+        let mut attrs = Vec::new();
         if let Some(true) = &self.graphql_document {
             if let Some(query) = &request.supergraph_request.body().query {
-                attrs.insert(GRAPHQL_DOCUMENT, query.clone().into());
+                attrs.push(KeyValue::new(GRAPHQL_DOCUMENT, query.clone()));
             }
         }
         if let Some(true) = &self.graphql_operation_name {
@@ -864,7 +870,10 @@ impl Selectors for SupergraphAttributes {
                 .get::<_, String>(OPERATION_NAME)
                 .unwrap_or_default()
             {
-                attrs.insert(GRAPHQL_OPERATION_NAME, operation_name.clone().into());
+                attrs.push(KeyValue::new(
+                    GRAPHQL_OPERATION_NAME,
+                    operation_name.clone(),
+                ));
             }
         }
         if let Some(true) = &self.graphql_operation_type {
@@ -873,19 +882,22 @@ impl Selectors for SupergraphAttributes {
                 .get::<_, String>(OPERATION_KIND)
                 .unwrap_or_default()
             {
-                attrs.insert(GRAPHQL_OPERATION_TYPE, operation_type.clone().into());
+                attrs.push(KeyValue::new(
+                    GRAPHQL_OPERATION_TYPE,
+                    operation_type.clone(),
+                ));
             }
         }
 
         attrs
     }
 
-    fn on_response(&self, _response: &supergraph::Response) -> HashMap<Key, opentelemetry::Value> {
-        HashMap::with_capacity(0)
+    fn on_response(&self, _response: &supergraph::Response) -> Vec<KeyValue> {
+        Vec::with_capacity(0)
     }
 
-    fn on_error(&self, _error: &BoxError) -> HashMap<Key, opentelemetry::Value> {
-        HashMap::with_capacity(0)
+    fn on_error(&self, _error: &BoxError) -> Vec<KeyValue> {
+        Vec::with_capacity(0)
     }
 }
 
@@ -893,16 +905,19 @@ impl Selectors for SubgraphAttributes {
     type Request = subgraph::Request;
     type Response = subgraph::Response;
 
-    fn on_request(&self, request: &subgraph::Request) -> HashMap<Key, opentelemetry::Value> {
-        let mut attrs = HashMap::new();
+    fn on_request(&self, request: &subgraph::Request) -> Vec<KeyValue> {
+        let mut attrs = Vec::new();
         if let Some(true) = &self.graphql_document {
             if let Some(query) = &request.subgraph_request.body().query {
-                attrs.insert(SUBGRAPH_GRAPHQL_DOCUMENT, query.clone().into());
+                attrs.push(KeyValue::new(SUBGRAPH_GRAPHQL_DOCUMENT, query.clone()));
             }
         }
         if let Some(true) = &self.graphql_operation_name {
             if let Some(op_name) = &request.subgraph_request.body().operation_name {
-                attrs.insert(SUBGRAPH_GRAPHQL_OPERATION_NAME, op_name.clone().into());
+                attrs.push(KeyValue::new(
+                    SUBGRAPH_GRAPHQL_OPERATION_NAME,
+                    op_name.clone(),
+                ));
             }
         }
         if let Some(true) = &self.graphql_operation_type {
@@ -912,27 +927,27 @@ impl Selectors for SubgraphAttributes {
                 .get::<_, String>(OPERATION_KIND)
                 .unwrap_or_default()
             {
-                attrs.insert(
+                attrs.push(KeyValue::new(
                     SUBGRAPH_GRAPHQL_OPERATION_TYPE,
-                    operation_type.clone().into(),
-                );
+                    operation_type.clone(),
+                ));
             }
         }
         if let Some(true) = &self.subgraph_name {
             if let Some(subgraph_name) = &request.subgraph_name {
-                attrs.insert(SUBGRAPH_NAME, subgraph_name.clone().into());
+                attrs.push(KeyValue::new(SUBGRAPH_NAME, subgraph_name.clone()));
             }
         }
 
         attrs
     }
 
-    fn on_response(&self, _response: &subgraph::Response) -> HashMap<Key, opentelemetry::Value> {
-        HashMap::with_capacity(0)
+    fn on_response(&self, _response: &subgraph::Response) -> Vec<KeyValue> {
+        Vec::with_capacity(0)
     }
 
-    fn on_error(&self, _error: &BoxError) -> HashMap<Key, opentelemetry::Value> {
-        HashMap::with_capacity(0)
+    fn on_error(&self, _error: &BoxError) -> Vec<KeyValue> {
+        Vec::with_capacity(0)
     }
 }
 
@@ -1027,11 +1042,19 @@ mod test {
             let attributes =
                 attributes.on_request(&router::Request::fake_builder().build().unwrap());
             assert_eq!(
-                attributes.get(&opentelemetry::Key::from_static_str("trace_id")),
+                attributes
+                    .iter()
+                    .find(|key_val| key_val.key == opentelemetry::Key::from_static_str("trace_id"))
+                    .map(|key_val| &key_val.value),
                 Some(&"0000000000000000000000000000002a".into())
             );
             assert_eq!(
-                attributes.get(&opentelemetry::Key::from_static_str("dd.trace_id")),
+                attributes
+                    .iter()
+                    .find(
+                        |key_val| key_val.key == opentelemetry::Key::from_static_str("dd.trace_id")
+                    )
+                    .map(|key_val| &key_val.value),
                 Some(&"42".into())
             );
         });
@@ -1050,7 +1073,10 @@ mod test {
                 .unwrap(),
         );
         assert_eq!(
-            attributes.get(&GRAPHQL_DOCUMENT),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == GRAPHQL_DOCUMENT)
+                .map(|key_val| &key_val.value),
             Some(&"query { __typename }".into())
         );
     }
@@ -1070,7 +1096,10 @@ mod test {
                 .unwrap(),
         );
         assert_eq!(
-            attributes.get(&GRAPHQL_OPERATION_NAME),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == GRAPHQL_OPERATION_NAME)
+                .map(|key_val| &key_val.value),
             Some(&"topProducts".into())
         );
     }
@@ -1090,7 +1119,10 @@ mod test {
                 .unwrap(),
         );
         assert_eq!(
-            attributes.get(&GRAPHQL_OPERATION_TYPE),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == GRAPHQL_OPERATION_TYPE)
+                .map(|key_val| &key_val.value),
             Some(&"query".into())
         );
     }
@@ -1116,7 +1148,10 @@ mod test {
                 .build(),
         );
         assert_eq!(
-            attributes.get(&SUBGRAPH_GRAPHQL_DOCUMENT),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == SUBGRAPH_GRAPHQL_DOCUMENT)
+                .map(|key_val| &key_val.value),
             Some(&"query { __typename }".into())
         );
     }
@@ -1143,7 +1178,10 @@ mod test {
                 .build(),
         );
         assert_eq!(
-            attributes.get(&SUBGRAPH_GRAPHQL_OPERATION_NAME),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == SUBGRAPH_GRAPHQL_OPERATION_NAME)
+                .map(|key_val| &key_val.value),
             Some(&"topProducts".into())
         );
     }
@@ -1169,7 +1207,10 @@ mod test {
                 .build(),
         );
         assert_eq!(
-            attributes.get(&SUBGRAPH_GRAPHQL_OPERATION_TYPE),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == SUBGRAPH_GRAPHQL_OPERATION_TYPE)
+                .map(|key_val| &key_val.value),
             Some(&"query".into())
         );
     }
@@ -1192,7 +1233,13 @@ mod test {
                 )
                 .build(),
         );
-        assert_eq!(attributes.get(&SUBGRAPH_NAME), Some(&"products".into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == SUBGRAPH_NAME)
+                .map(|key_val| &key_val.value),
+            Some(&"products".into())
+        );
     }
 
     #[test]
@@ -1209,7 +1256,10 @@ mod test {
                 .unwrap(),
         );
         assert_eq!(
-            attributes.get(&ERROR_TYPE),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == ERROR_TYPE)
+                .map(|key_val| &key_val.value),
             Some(
                 &StatusCode::BAD_REQUEST
                     .canonical_reason()
@@ -1220,7 +1270,10 @@ mod test {
 
         let attributes = common.on_error(&anyhow!("test error").into());
         assert_eq!(
-            attributes.get(&ERROR_TYPE),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == ERROR_TYPE)
+                .map(|key_val| &key_val.value),
             Some(
                 &StatusCode::INTERNAL_SERVER_ERROR
                     .canonical_reason()
@@ -1246,7 +1299,13 @@ mod test {
                 .build()
                 .unwrap(),
         );
-        assert_eq!(attributes.get(&HTTP_REQUEST_BODY_SIZE), Some(&"256".into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == HTTP_REQUEST_BODY_SIZE)
+                .map(|key_val| &key_val.value),
+            Some(&"256".into())
+        );
     }
 
     #[test]
@@ -1266,7 +1325,10 @@ mod test {
                 .unwrap(),
         );
         assert_eq!(
-            attributes.get(&HTTP_RESPONSE_BODY_SIZE),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == HTTP_RESPONSE_BODY_SIZE)
+                .map(|key_val| &key_val.value),
             Some(&"256".into())
         );
     }
@@ -1284,7 +1346,13 @@ mod test {
                 .build()
                 .unwrap(),
         );
-        assert_eq!(attributes.get(&HTTP_REQUEST_METHOD), Some(&"POST".into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == HTTP_REQUEST_METHOD)
+                .map(|key_val| &key_val.value),
+            Some(&"POST".into())
+        );
     }
 
     #[test]
@@ -1301,13 +1369,19 @@ mod test {
                 .unwrap(),
         );
         assert_eq!(
-            attributes.get(&HTTP_RESPONSE_STATUS_CODE),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == HTTP_RESPONSE_STATUS_CODE)
+                .map(|key_val| &key_val.value),
             Some(&(StatusCode::BAD_REQUEST.as_u16() as i64).into())
         );
 
         let attributes = common.on_error(&anyhow!("test error").into());
         assert_eq!(
-            attributes.get(&HTTP_RESPONSE_STATUS_CODE),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == HTTP_RESPONSE_STATUS_CODE)
+                .map(|key_val| &key_val.value),
             Some(&(StatusCode::INTERNAL_SERVER_ERROR.as_u16() as i64).into())
         );
     }
@@ -1326,7 +1400,10 @@ mod test {
                 .unwrap(),
         );
         assert_eq!(
-            attributes.get(&NETWORK_PROTOCOL_NAME),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == NETWORK_PROTOCOL_NAME)
+                .map(|key_val| &key_val.value),
             Some(&"https".into())
         );
     }
@@ -1345,7 +1422,10 @@ mod test {
                 .unwrap(),
         );
         assert_eq!(
-            attributes.get(&NETWORK_PROTOCOL_VERSION),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == NETWORK_PROTOCOL_VERSION)
+                .map(|key_val| &key_val.value),
             Some(&"HTTP/1.1".into())
         );
     }
@@ -1358,7 +1438,13 @@ mod test {
         };
 
         let attributes = common.on_request(&router::Request::fake_builder().build().unwrap());
-        assert_eq!(attributes.get(&NETWORK_TRANSPORT), Some(&"tcp".into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == NETWORK_TRANSPORT)
+                .map(|key_val| &key_val.value),
+            Some(&"tcp".into())
+        );
     }
 
     #[test]
@@ -1374,7 +1460,13 @@ mod test {
             server_address: Some(SocketAddr::from_str("192.168.0.1:8080").unwrap()),
         });
         let attributes = common.on_request(&req);
-        assert_eq!(attributes.get(&NETWORK_TYPE), Some(&"ipv4".into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == NETWORK_TYPE)
+                .map(|key_val| &key_val.value),
+            Some(&"ipv4".into())
+        );
     }
 
     #[test]
@@ -1390,7 +1482,13 @@ mod test {
             server_address: Some(SocketAddr::from_str("192.168.0.1:8080").unwrap()),
         });
         let attributes = server.on_request(&req);
-        assert_eq!(attributes.get(&CLIENT_ADDRESS), Some(&"192.168.0.8".into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == CLIENT_ADDRESS)
+                .map(|key_val| &key_val.value),
+            Some(&"192.168.0.8".into())
+        );
 
         let mut req = router::Request::fake_builder()
             .header(FORWARDED, "for=2.4.6.8:8000")
@@ -1401,7 +1499,13 @@ mod test {
             server_address: Some(SocketAddr::from_str("192.168.0.1:8080").unwrap()),
         });
         let attributes = server.on_request(&req);
-        assert_eq!(attributes.get(&CLIENT_ADDRESS), Some(&"2.4.6.8".into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == CLIENT_ADDRESS)
+                .map(|key_val| &key_val.value),
+            Some(&"2.4.6.8".into())
+        );
     }
 
     #[test]
@@ -1417,7 +1521,13 @@ mod test {
             server_address: Some(SocketAddr::from_str("192.168.0.1:8080").unwrap()),
         });
         let attributes = server.on_request(&req);
-        assert_eq!(attributes.get(&CLIENT_PORT), Some(&6060.into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == CLIENT_PORT)
+                .map(|key_val| &key_val.value),
+            Some(&6060.into())
+        );
 
         let mut req = router::Request::fake_builder()
             .header(FORWARDED, "for=2.4.6.8:8000")
@@ -1428,7 +1538,13 @@ mod test {
             server_address: Some(SocketAddr::from_str("192.168.0.1:8080").unwrap()),
         });
         let attributes = server.on_request(&req);
-        assert_eq!(attributes.get(&CLIENT_PORT), Some(&8000.into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == CLIENT_PORT)
+                .map(|key_val| &key_val.value),
+            Some(&8000.into())
+        );
     }
 
     #[test]
@@ -1447,7 +1563,13 @@ mod test {
             server_address: Some(SocketAddr::from_str("192.168.0.1:8080").unwrap()),
         });
         let attributes = server.on_request(&req);
-        assert_eq!(attributes.get(&HTTP_ROUTE), Some(&"/graphql".into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == HTTP_ROUTE)
+                .map(|key_val| &key_val.value),
+            Some(&"/graphql".into())
+        );
     }
 
     #[test]
@@ -1467,7 +1589,10 @@ mod test {
         });
         let attributes = server.on_request(&req);
         assert_eq!(
-            attributes.get(&NETWORK_LOCAL_ADDRESS),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == NETWORK_LOCAL_ADDRESS)
+                .map(|key_val| &key_val.value),
             Some(&"192.168.0.1".into())
         );
     }
@@ -1488,7 +1613,13 @@ mod test {
             server_address: Some(SocketAddr::from_str("192.168.0.1:8080").unwrap()),
         });
         let attributes = server.on_request(&req);
-        assert_eq!(attributes.get(&NETWORK_LOCAL_PORT), Some(&8080.into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == NETWORK_LOCAL_PORT)
+                .map(|key_val| &key_val.value),
+            Some(&8080.into())
+        );
     }
 
     #[test]
@@ -1508,7 +1639,10 @@ mod test {
         });
         let attributes = server.on_request(&req);
         assert_eq!(
-            attributes.get(&NETWORK_PEER_ADDRESS),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == NETWORK_PEER_ADDRESS)
+                .map(|key_val| &key_val.value),
             Some(&"192.168.0.8".into())
         );
     }
@@ -1529,7 +1663,13 @@ mod test {
             server_address: Some(SocketAddr::from_str("192.168.0.1:8080").unwrap()),
         });
         let attributes = server.on_request(&req);
-        assert_eq!(attributes.get(&NETWORK_PEER_PORT), Some(&6060.into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == NETWORK_PEER_PORT)
+                .map(|key_val| &key_val.value),
+            Some(&6060.into())
+        );
     }
 
     #[test]
@@ -1545,7 +1685,13 @@ mod test {
             server_address: Some(SocketAddr::from_str("192.168.0.1:8080").unwrap()),
         });
         let attributes = server.on_request(&req);
-        assert_eq!(attributes.get(&SERVER_ADDRESS), Some(&"192.168.0.1".into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == SERVER_ADDRESS)
+                .map(|key_val| &key_val.value),
+            Some(&"192.168.0.1".into())
+        );
 
         let mut req = router::Request::fake_builder()
             .header(FORWARDED, "host=2.4.6.8:8000")
@@ -1556,7 +1702,13 @@ mod test {
             server_address: Some(SocketAddr::from_str("192.168.0.1:8080").unwrap()),
         });
         let attributes = server.on_request(&req);
-        assert_eq!(attributes.get(&SERVER_ADDRESS), Some(&"2.4.6.8".into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == SERVER_ADDRESS)
+                .map(|key_val| &key_val.value),
+            Some(&"2.4.6.8".into())
+        );
     }
 
     #[test]
@@ -1572,7 +1724,13 @@ mod test {
             server_address: Some(SocketAddr::from_str("192.168.0.1:8080").unwrap()),
         });
         let attributes = server.on_request(&req);
-        assert_eq!(attributes.get(&SERVER_PORT), Some(&8080.into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == SERVER_PORT)
+                .map(|key_val| &key_val.value),
+            Some(&8080.into())
+        );
 
         let mut req = router::Request::fake_builder()
             .header(FORWARDED, "host=2.4.6.8:8000")
@@ -1583,7 +1741,13 @@ mod test {
             server_address: Some(SocketAddr::from_str("192.168.0.1:8080").unwrap()),
         });
         let attributes = server.on_request(&req);
-        assert_eq!(attributes.get(&SERVER_PORT), Some(&8000.into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == SERVER_PORT)
+                .map(|key_val| &key_val.value),
+            Some(&8000.into())
+        );
     }
     #[test]
     fn test_http_server_url_path() {
@@ -1598,7 +1762,13 @@ mod test {
                 .build()
                 .unwrap(),
         );
-        assert_eq!(attributes.get(&URL_PATH), Some(&"/graphql".into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == URL_PATH)
+                .map(|key_val| &key_val.value),
+            Some(&"/graphql".into())
+        );
     }
     #[test]
     fn test_http_server_query() {
@@ -1613,7 +1783,13 @@ mod test {
                 .build()
                 .unwrap(),
         );
-        assert_eq!(attributes.get(&URL_QUERY), Some(&"hi=5".into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == URL_QUERY)
+                .map(|key_val| &key_val.value),
+            Some(&"hi=5".into())
+        );
     }
     #[test]
     fn test_http_server_scheme() {
@@ -1628,7 +1804,13 @@ mod test {
                 .build()
                 .unwrap(),
         );
-        assert_eq!(attributes.get(&URL_SCHEME), Some(&"https".into()));
+        assert_eq!(
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == URL_SCHEME)
+                .map(|key_val| &key_val.value),
+            Some(&"https".into())
+        );
     }
 
     #[test]
@@ -1645,7 +1827,10 @@ mod test {
                 .unwrap(),
         );
         assert_eq!(
-            attributes.get(&USER_AGENT_ORIGINAL),
+            attributes
+                .iter()
+                .find(|key_val| key_val.key == USER_AGENT_ORIGINAL)
+                .map(|key_val| &key_val.value),
             Some(&"my-agent".into())
         );
     }

--- a/apollo-router/src/plugins/telemetry/config_new/extendable.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/extendable.rs
@@ -1,5 +1,6 @@
 use std::any::type_name;
 use std::collections::HashMap;
+use std::collections::LinkedList;
 use std::fmt::Debug;
 
 use opentelemetry::KeyValue;
@@ -153,7 +154,7 @@ where
     type Request = Request;
     type Response = Response;
 
-    fn on_request(&self, request: &Self::Request) -> Vec<KeyValue> {
+    fn on_request(&self, request: &Self::Request) -> LinkedList<KeyValue> {
         let mut attrs = self.attributes.on_request(request);
         let custom_attributes = self.custom.iter().filter_map(|(key, value)| {
             value
@@ -165,7 +166,7 @@ where
         attrs
     }
 
-    fn on_response(&self, response: &Self::Response) -> Vec<KeyValue> {
+    fn on_response(&self, response: &Self::Response) -> LinkedList<KeyValue> {
         let mut attrs = self.attributes.on_response(response);
         let custom_attributes = self.custom.iter().filter_map(|(key, value)| {
             value
@@ -177,7 +178,7 @@ where
         attrs
     }
 
-    fn on_error(&self, error: &BoxError) -> Vec<KeyValue> {
+    fn on_error(&self, error: &BoxError) -> LinkedList<KeyValue> {
         self.attributes.on_error(error)
     }
 }

--- a/apollo-router/src/plugins/telemetry/config_new/extendable.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/extendable.rs
@@ -2,7 +2,7 @@ use std::any::type_name;
 use std::collections::HashMap;
 use std::fmt::Debug;
 
-use opentelemetry::Key;
+use opentelemetry::KeyValue;
 use schemars::gen::SchemaGenerator;
 use schemars::schema::Schema;
 use schemars::JsonSchema;
@@ -153,31 +153,31 @@ where
     type Request = Request;
     type Response = Response;
 
-    fn on_request(&self, request: &Self::Request) -> HashMap<Key, opentelemetry::Value> {
+    fn on_request(&self, request: &Self::Request) -> Vec<KeyValue> {
         let mut attrs = self.attributes.on_request(request);
         let custom_attributes = self.custom.iter().filter_map(|(key, value)| {
             value
                 .on_request(request)
-                .map(|v| (Key::from(key.clone()), v))
+                .map(|v| KeyValue::new(key.clone(), v))
         });
         attrs.extend(custom_attributes);
 
         attrs
     }
 
-    fn on_response(&self, response: &Self::Response) -> HashMap<Key, opentelemetry::Value> {
+    fn on_response(&self, response: &Self::Response) -> Vec<KeyValue> {
         let mut attrs = self.attributes.on_response(response);
         let custom_attributes = self.custom.iter().filter_map(|(key, value)| {
             value
                 .on_response(response)
-                .map(|v| (Key::from(key.clone()), v))
+                .map(|v| KeyValue::new(key.clone(), v))
         });
         attrs.extend(custom_attributes);
 
         attrs
     }
 
-    fn on_error(&self, error: &BoxError) -> HashMap<Key, opentelemetry::Value> {
+    fn on_error(&self, error: &BoxError) -> Vec<KeyValue> {
         self.attributes.on_error(error)
     }
 }

--- a/apollo-router/src/plugins/telemetry/config_new/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::LinkedList;
+
 use opentelemetry::baggage::BaggageExt;
 use opentelemetry::trace::TraceContextExt;
 use opentelemetry::trace::TraceId;
@@ -25,9 +27,9 @@ pub(crate) mod spans;
 pub(crate) trait Selectors {
     type Request;
     type Response;
-    fn on_request(&self, request: &Self::Request) -> Vec<KeyValue>;
-    fn on_response(&self, response: &Self::Response) -> Vec<KeyValue>;
-    fn on_error(&self, error: &BoxError) -> Vec<KeyValue>;
+    fn on_request(&self, request: &Self::Request) -> LinkedList<KeyValue>;
+    fn on_response(&self, response: &Self::Response) -> LinkedList<KeyValue>;
+    fn on_error(&self, error: &BoxError) -> LinkedList<KeyValue>;
 }
 
 pub(crate) trait Selector {

--- a/apollo-router/src/plugins/telemetry/config_new/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/mod.rs
@@ -1,9 +1,7 @@
-use std::collections::HashMap;
-
 use opentelemetry::baggage::BaggageExt;
 use opentelemetry::trace::TraceContextExt;
 use opentelemetry::trace::TraceId;
-use opentelemetry::Key;
+use opentelemetry::KeyValue;
 use paste::paste;
 use tower::BoxError;
 use tracing::Span;
@@ -27,9 +25,9 @@ pub(crate) mod spans;
 pub(crate) trait Selectors {
     type Request;
     type Response;
-    fn on_request(&self, request: &Self::Request) -> HashMap<Key, opentelemetry::Value>;
-    fn on_response(&self, response: &Self::Response) -> HashMap<Key, opentelemetry::Value>;
-    fn on_error(&self, error: &BoxError) -> HashMap<Key, opentelemetry::Value>;
+    fn on_request(&self, request: &Self::Request) -> Vec<KeyValue>;
+    fn on_response(&self, response: &Self::Response) -> Vec<KeyValue>;
+    fn on_error(&self, error: &BoxError) -> Vec<KeyValue>;
 }
 
 pub(crate) trait Selector {

--- a/apollo-router/src/plugins/telemetry/config_new/spans.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/spans.rs
@@ -120,10 +120,16 @@ mod test {
                 .build()
                 .unwrap(),
         );
-        assert!(values.get(&HTTP_REQUEST_METHOD).is_none());
-        assert!(values.get(&NETWORK_PROTOCOL_VERSION).is_none());
-        assert!(values.get(&URL_PATH).is_none());
-        assert!(values.get(&USER_AGENT_ORIGINAL).is_none());
+        assert!(!values
+            .iter()
+            .any(|key_val| key_val.key == HTTP_REQUEST_METHOD));
+        assert!(!values
+            .iter()
+            .any(|key_val| key_val.key == NETWORK_PROTOCOL_VERSION));
+        assert!(!values.iter().any(|key_val| key_val.key == URL_PATH));
+        assert!(!values
+            .iter()
+            .any(|key_val| key_val.key == USER_AGENT_ORIGINAL));
     }
 
     #[test]
@@ -137,10 +143,16 @@ mod test {
                 .build()
                 .unwrap(),
         );
-        assert!(values.get(&HTTP_REQUEST_METHOD).is_some());
-        assert!(values.get(&NETWORK_PROTOCOL_VERSION).is_none());
-        assert!(values.get(&URL_PATH).is_some());
-        assert!(values.get(&USER_AGENT_ORIGINAL).is_none());
+        assert!(values
+            .iter()
+            .any(|key_val| key_val.key == HTTP_REQUEST_METHOD));
+        assert!(!values
+            .iter()
+            .any(|key_val| key_val.key == NETWORK_PROTOCOL_VERSION));
+        assert!(values.iter().any(|key_val| key_val.key == URL_PATH));
+        assert!(!values
+            .iter()
+            .any(|key_val| key_val.key == USER_AGENT_ORIGINAL));
     }
 
     #[test]
@@ -154,10 +166,16 @@ mod test {
                 .build()
                 .unwrap(),
         );
-        assert!(values.get(&HTTP_REQUEST_METHOD).is_some());
-        assert!(values.get(&NETWORK_PROTOCOL_VERSION).is_some());
-        assert!(values.get(&URL_PATH).is_some());
-        assert!(values.get(&USER_AGENT_ORIGINAL).is_some());
+        assert!(values
+            .iter()
+            .any(|key_val| key_val.key == HTTP_REQUEST_METHOD));
+        assert!(values
+            .iter()
+            .any(|key_val| key_val.key == NETWORK_PROTOCOL_VERSION));
+        assert!(values.iter().any(|key_val| key_val.key == URL_PATH));
+        assert!(values
+            .iter()
+            .any(|key_val| key_val.key == USER_AGENT_ORIGINAL));
     }
 
     #[test]
@@ -170,7 +188,7 @@ mod test {
                 .build()
                 .unwrap(),
         );
-        assert!(values.get(&GRAPHQL_DOCUMENT).is_none());
+        assert!(!values.iter().any(|key_val| key_val.key == GRAPHQL_DOCUMENT));
     }
 
     #[test]
@@ -183,7 +201,7 @@ mod test {
                 .build()
                 .unwrap(),
         );
-        assert!(values.get(&GRAPHQL_DOCUMENT).is_none());
+        assert!(!values.iter().any(|key_val| key_val.key == GRAPHQL_DOCUMENT));
     }
 
     #[test]
@@ -196,7 +214,7 @@ mod test {
                 .build()
                 .unwrap(),
         );
-        assert!(values.get(&GRAPHQL_DOCUMENT).is_some());
+        assert!(values.iter().any(|key_val| key_val.key == GRAPHQL_DOCUMENT));
     }
 
     #[test]
@@ -217,7 +235,7 @@ mod test {
                 )
                 .build(),
         );
-        assert!(values.get(&GRAPHQL_DOCUMENT).is_none());
+        assert!(!values.iter().any(|key_val| key_val.key == GRAPHQL_DOCUMENT));
     }
 
     #[test]
@@ -238,7 +256,7 @@ mod test {
                 )
                 .build(),
         );
-        assert!(values.get(&GRAPHQL_DOCUMENT).is_none());
+        assert!(!values.iter().any(|key_val| key_val.key == GRAPHQL_DOCUMENT));
     }
 
     #[test]
@@ -259,7 +277,9 @@ mod test {
                 )
                 .build(),
         );
-        assert!(values.get(&SUBGRAPH_GRAPHQL_DOCUMENT).is_some());
+        assert!(values
+            .iter()
+            .any(|key_val| key_val.key == SUBGRAPH_GRAPHQL_DOCUMENT));
     }
 
     #[test]
@@ -281,8 +301,8 @@ mod test {
                 .unwrap(),
         );
         assert!(values
-            .get(&opentelemetry::Key::from_static_str("test"))
-            .is_some());
+            .iter()
+            .any(|key_val| key_val.key == opentelemetry::Key::from_static_str("test")));
     }
 
     #[test]
@@ -303,8 +323,8 @@ mod test {
                 .unwrap(),
         );
         assert!(values
-            .get(&opentelemetry::Key::from_static_str("test"))
-            .is_some());
+            .iter()
+            .any(|key_val| key_val.key == opentelemetry::Key::from_static_str("test")));
     }
 
     #[test]
@@ -326,8 +346,8 @@ mod test {
                 .unwrap(),
         );
         assert!(values
-            .get(&opentelemetry::Key::from_static_str("test"))
-            .is_some());
+            .iter()
+            .any(|key_val| key_val.key == opentelemetry::Key::from_static_str("test")));
     }
 
     #[test]
@@ -348,8 +368,8 @@ mod test {
                 .unwrap(),
         );
         assert!(values
-            .get(&opentelemetry::Key::from_static_str("test"))
-            .is_some());
+            .iter()
+            .any(|key_val| key_val.key == opentelemetry::Key::from_static_str("test")));
     }
 
     #[test]
@@ -379,8 +399,8 @@ mod test {
                 .build(),
         );
         assert!(values
-            .get(&opentelemetry::Key::from_static_str("test"))
-            .is_some());
+            .iter()
+            .any(|key_val| key_val.key == opentelemetry::Key::from_static_str("test")));
     }
 
     #[test]
@@ -401,7 +421,7 @@ mod test {
                 .unwrap(),
         );
         assert!(values
-            .get(&opentelemetry::Key::from_static_str("test"))
-            .is_some());
+            .iter()
+            .any(|key_val| key_val.key == opentelemetry::Key::from_static_str("test")));
     }
 }

--- a/apollo-router/src/plugins/telemetry/dynamic_attribute.rs
+++ b/apollo-router/src/plugins/telemetry/dynamic_attribute.rs
@@ -11,17 +11,9 @@ use tracing_subscriber::Registry;
 use super::reload::IsSampled;
 use super::tracing::APOLLO_PRIVATE_PREFIX;
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub(crate) struct LogAttributes {
     attributes: LinkedList<KeyValue>,
-}
-
-impl Default for LogAttributes {
-    fn default() -> Self {
-        Self {
-            attributes: LinkedList::new(),
-        }
-    }
 }
 
 impl LogAttributes {

--- a/apollo-router/src/plugins/telemetry/dynamic_attribute.rs
+++ b/apollo-router/src/plugins/telemetry/dynamic_attribute.rs
@@ -85,7 +85,7 @@ impl DynAttribute for ::tracing::Span {
                                         otel_data
                                             .builder
                                             .attributes
-                                            .as_mut() 
+                                            .as_mut()
                                             .expect("we checked the attributes value in the condition above")
                                             .push(KeyValue::new(key, value));
                                     }

--- a/apollo-router/src/plugins/telemetry/dynamic_attribute.rs
+++ b/apollo-router/src/plugins/telemetry/dynamic_attribute.rs
@@ -1,3 +1,5 @@
+use std::collections::LinkedList;
+
 use opentelemetry::Key;
 use opentelemetry::KeyValue;
 use tracing_opentelemetry::OtelData;
@@ -11,24 +13,24 @@ use super::tracing::APOLLO_PRIVATE_PREFIX;
 
 #[derive(Debug)]
 pub(crate) struct LogAttributes {
-    attributes: Vec<KeyValue>,
+    attributes: LinkedList<KeyValue>,
 }
 
 impl Default for LogAttributes {
     fn default() -> Self {
         Self {
-            attributes: Vec::with_capacity(0),
+            attributes: LinkedList::new(),
         }
     }
 }
 
 impl LogAttributes {
-    pub(crate) fn attributes(&self) -> &Vec<KeyValue> {
+    pub(crate) fn attributes(&self) -> &LinkedList<KeyValue> {
         &self.attributes
     }
 
     fn insert(&mut self, kv: KeyValue) {
-        self.attributes.push(kv);
+        self.attributes.push_back(kv);
     }
 
     pub(crate) fn extend(&mut self, other: impl IntoIterator<Item = KeyValue>) {

--- a/apollo-router/src/plugins/telemetry/fmt_layer.rs
+++ b/apollo-router/src/plugins/telemetry/fmt_layer.rs
@@ -319,8 +319,8 @@ mod tests {
             let _enter = nested_test_span.enter();
 
             nested_test_span.set_dyn_attributes([
-                ("inner".into(), (-42).into()),
-                ("graphql.operation.kind".into(), "Subscription".into()),
+                KeyValue::new("inner", -42_i64),
+                KeyValue::new("graphql.operation.kind", "Subscription"),
             ]);
 
             error!(http.method = "GET", "Hello from nested test");

--- a/apollo-router/src/plugins/telemetry/formatters/json.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/json.rs
@@ -1,7 +1,3 @@
-#[cfg(test)]
-use std::collections::BTreeMap;
-#[cfg(not(test))]
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
 use std::io;
@@ -25,25 +21,19 @@ use super::APOLLO_PRIVATE_PREFIX;
 use super::EXCLUDED_ATTRIBUTES;
 use crate::plugins::telemetry::config_new::logging::JsonFormat;
 use crate::plugins::telemetry::dynamic_attribute::LogAttributes;
-use crate::plugins::telemetry::formatters::to_map;
+use crate::plugins::telemetry::formatters::to_vec;
 
 #[derive(Debug)]
 pub(crate) struct Json {
     config: JsonFormat,
-    #[cfg(not(test))]
-    resource: HashMap<String, serde_json::Value>,
-    #[cfg(test)]
-    resource: BTreeMap<String, serde_json::Value>,
+    resource: Vec<(String, serde_json::Value)>,
     excluded_attributes: HashSet<&'static str>,
 }
 
 impl Json {
     pub(crate) fn new(resource: Resource, config: JsonFormat) -> Self {
         Self {
-            #[cfg(not(test))]
-            resource: to_map(resource),
-            #[cfg(test)]
-            resource: to_map(resource).into_iter().collect(),
+            resource: to_vec(resource),
             config,
             excluded_attributes: EXCLUDED_ATTRIBUTES.into(),
         }

--- a/apollo-router/src/plugins/telemetry/formatters/mod.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/mod.rs
@@ -2,7 +2,6 @@
 pub(crate) mod json;
 pub(crate) mod text;
 
-use std::collections::HashMap;
 use std::fmt;
 
 use opentelemetry_sdk::Resource;
@@ -109,7 +108,7 @@ pub(crate) fn filter_metric_events(event: &tracing::Event<'_>) -> bool {
     })
 }
 
-pub(crate) fn to_map(resource: Resource) -> HashMap<String, serde_json::Value> {
+pub(crate) fn to_vec(resource: Resource) -> Vec<(String, serde_json::Value)> {
     resource
         .into_iter()
         .map(|(k, v)| {
@@ -156,6 +155,54 @@ pub(crate) fn to_map(resource: Resource) -> HashMap<String, serde_json::Value> {
         })
         .collect()
 }
+
+// pub(crate) fn to_vec(resource: Resource) -> Vec<(String, serde_json::Value)> {
+//     resource
+//         .into_iter()
+//         .map(|(k, v)| {
+//             (
+//                 k.into(),
+//                 match v {
+//                     opentelemetry::Value::Bool(value) => serde_json::Value::Bool(value),
+//                     opentelemetry::Value::I64(value) => {
+//                         serde_json::Value::Number(Number::from(value))
+//                     }
+//                     opentelemetry::Value::F64(value) => serde_json::Value::Number(
+//                         Number::from_f64(value).unwrap_or(Number::from(0)),
+//                     ),
+//                     opentelemetry::Value::String(value) => serde_json::Value::String(value.into()),
+//                     opentelemetry::Value::Array(value) => match value {
+//                         opentelemetry::Array::Bool(array) => serde_json::Value::Array(
+//                             array.into_iter().map(serde_json::Value::Bool).collect(),
+//                         ),
+//                         opentelemetry::Array::I64(array) => serde_json::Value::Array(
+//                             array
+//                                 .into_iter()
+//                                 .map(|value| serde_json::Value::Number(Number::from(value)))
+//                                 .collect(),
+//                         ),
+//                         opentelemetry::Array::F64(array) => serde_json::Value::Array(
+//                             array
+//                                 .into_iter()
+//                                 .map(|value| {
+//                                     serde_json::Value::Number(
+//                                         Number::from_f64(value).unwrap_or(Number::from(0)),
+//                                     )
+//                                 })
+//                                 .collect(),
+//                         ),
+//                         opentelemetry::Array::String(array) => serde_json::Value::Array(
+//                             array
+//                                 .into_iter()
+//                                 .map(|s| serde_json::Value::String(s.to_string()))
+//                                 .collect(),
+//                         ),
+//                     },
+//                 },
+//             )
+//         })
+//         .collect()
+// }
 
 pub(crate) trait EventFormatter<S> {
     fn format_event<W>(

--- a/apollo-router/src/plugins/telemetry/formatters/mod.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/mod.rs
@@ -156,54 +156,6 @@ pub(crate) fn to_vec(resource: Resource) -> Vec<(String, serde_json::Value)> {
         .collect()
 }
 
-// pub(crate) fn to_vec(resource: Resource) -> Vec<(String, serde_json::Value)> {
-//     resource
-//         .into_iter()
-//         .map(|(k, v)| {
-//             (
-//                 k.into(),
-//                 match v {
-//                     opentelemetry::Value::Bool(value) => serde_json::Value::Bool(value),
-//                     opentelemetry::Value::I64(value) => {
-//                         serde_json::Value::Number(Number::from(value))
-//                     }
-//                     opentelemetry::Value::F64(value) => serde_json::Value::Number(
-//                         Number::from_f64(value).unwrap_or(Number::from(0)),
-//                     ),
-//                     opentelemetry::Value::String(value) => serde_json::Value::String(value.into()),
-//                     opentelemetry::Value::Array(value) => match value {
-//                         opentelemetry::Array::Bool(array) => serde_json::Value::Array(
-//                             array.into_iter().map(serde_json::Value::Bool).collect(),
-//                         ),
-//                         opentelemetry::Array::I64(array) => serde_json::Value::Array(
-//                             array
-//                                 .into_iter()
-//                                 .map(|value| serde_json::Value::Number(Number::from(value)))
-//                                 .collect(),
-//                         ),
-//                         opentelemetry::Array::F64(array) => serde_json::Value::Array(
-//                             array
-//                                 .into_iter()
-//                                 .map(|value| {
-//                                     serde_json::Value::Number(
-//                                         Number::from_f64(value).unwrap_or(Number::from(0)),
-//                                     )
-//                                 })
-//                                 .collect(),
-//                         ),
-//                         opentelemetry::Array::String(array) => serde_json::Value::Array(
-//                             array
-//                                 .into_iter()
-//                                 .map(|s| serde_json::Value::String(s.to_string()))
-//                                 .collect(),
-//                         ),
-//                     },
-//                 },
-//             )
-//         })
-//         .collect()
-// }
-
 pub(crate) trait EventFormatter<S> {
     fn format_event<W>(
         &self,

--- a/apollo-router/src/plugins/telemetry/formatters/mod.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/mod.rs
@@ -2,6 +2,7 @@
 pub(crate) mod json;
 pub(crate) mod text;
 
+use std::collections::LinkedList;
 use std::fmt;
 
 use opentelemetry_sdk::Resource;
@@ -108,7 +109,7 @@ pub(crate) fn filter_metric_events(event: &tracing::Event<'_>) -> bool {
     })
 }
 
-pub(crate) fn to_vec(resource: Resource) -> Vec<(String, serde_json::Value)> {
+pub(crate) fn to_vec(resource: Resource) -> LinkedList<(String, serde_json::Value)> {
     resource
         .into_iter()
         .map(|(k, v)| {

--- a/apollo-router/src/plugins/telemetry/formatters/text.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/text.rs
@@ -1,7 +1,3 @@
-#[cfg(test)]
-use std::collections::BTreeMap;
-#[cfg(not(test))]
-use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
 
@@ -28,16 +24,13 @@ use super::EventFormatter;
 use super::EXCLUDED_ATTRIBUTES;
 use crate::plugins::telemetry::config_new::logging::TextFormat;
 use crate::plugins::telemetry::dynamic_attribute::LogAttributes;
-use crate::plugins::telemetry::formatters::to_map;
+use crate::plugins::telemetry::formatters::to_vec;
 use crate::plugins::telemetry::tracing::APOLLO_PRIVATE_PREFIX;
 
 pub(crate) struct Text {
     #[allow(dead_code)]
     timer: SystemTime,
-    #[cfg(not(test))]
-    resource: HashMap<String, Value>,
-    #[cfg(test)]
-    resource: BTreeMap<String, Value>,
+    resource: Vec<(String, Value)>,
     config: TextFormat,
     excluded_attributes: HashSet<&'static str>,
 }
@@ -64,10 +57,7 @@ impl Text {
         Self {
             timer: Default::default(),
             config,
-            #[cfg(not(test))]
-            resource: to_map(resource),
-            #[cfg(test)]
-            resource: to_map(resource).into_iter().collect(),
+            resource: to_vec(resource),
             excluded_attributes: EXCLUDED_ATTRIBUTES.into(),
         }
     }
@@ -274,8 +264,7 @@ impl Text {
     pub(crate) fn format_resource(
         &self,
         writer: &mut Writer,
-        #[cfg(test)] resource: &BTreeMap<String, Value>,
-        #[cfg(not(test))] resource: &HashMap<String, Value>,
+        resource: &[(String, Value)],
     ) -> fmt::Result {
         if !resource.is_empty() {
             let style = Style::new().dimmed();

--- a/apollo-router/src/plugins/telemetry/formatters/text.rs
+++ b/apollo-router/src/plugins/telemetry/formatters/text.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::collections::LinkedList;
 use std::fmt;
 
 use nu_ansi_term::Color;
@@ -30,7 +31,7 @@ use crate::plugins::telemetry::tracing::APOLLO_PRIVATE_PREFIX;
 pub(crate) struct Text {
     #[allow(dead_code)]
     timer: SystemTime,
-    resource: Vec<(String, Value)>,
+    resource: LinkedList<(String, Value)>,
     config: TextFormat,
     excluded_attributes: HashSet<&'static str>,
 }
@@ -264,7 +265,7 @@ impl Text {
     pub(crate) fn format_resource(
         &self,
         writer: &mut Writer,
-        resource: &[(String, Value)],
+        resource: &LinkedList<(String, Value)>,
     ) -> fmt::Result {
         if !resource.is_empty() {
             let style = Style::new().dimmed();

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -1,6 +1,7 @@
 //! Telemetry plugin.
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::collections::LinkedList;
 use std::fmt;
 use std::sync::Arc;
 use std::thread;
@@ -363,7 +364,7 @@ impl Plugin for Telemetry {
 
                     custom_attributes
                 },
-                move |custom_attributes: Vec<KeyValue>, fut| {
+                move |custom_attributes: LinkedList<KeyValue>, fut| {
                     let start = Instant::now();
                     let config = config_later.clone();
 
@@ -487,7 +488,7 @@ impl Plugin for Telemetry {
                     Self::populate_context(config.clone(), field_level_instrumentation_ratio, req);
                     (req.context.clone(), custom_attributes)
                 },
-                move |(ctx, custom_attributes): (Context, Vec<KeyValue>), fut| {
+                move |(ctx, custom_attributes): (Context, LinkedList<KeyValue>), fut| {
                     let config = config_map_res.clone();
                     let sender = metrics_sender.clone();
                     let start = Instant::now();
@@ -591,7 +592,7 @@ impl Plugin for Telemetry {
                 move |(context, cache_attributes, custom_attributes): (
                     Context,
                     Option<CacheAttributes>,
-                    Vec<KeyValue>,
+                    LinkedList<KeyValue>,
                 ),
                       f: BoxFuture<'static, Result<SubgraphResponse, BoxError>>| {
                     let subgraph_attribute = subgraph_attribute.clone();

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -350,21 +350,20 @@ impl Plugin for Telemetry {
                         .attributes
                         .on_request(request);
                     custom_attributes.extend([
-                        (CLIENT_NAME_KEY, client_name.to_string().into()),
-                        (CLIENT_VERSION_KEY, client_version.to_string().into()),
-                        (
+                        KeyValue::new(CLIENT_NAME_KEY, client_name.to_string()),
+                        KeyValue::new(CLIENT_VERSION_KEY, client_version.to_string()),
+                        KeyValue::new(
                             Key::from_static_str("apollo_private.http.request_headers"),
                             filter_headers(
                                 request.router_request.headers(),
                                 &config_request.apollo.send_headers,
-                            )
-                            .into(),
+                            ),
                         ),
                     ]);
 
                     custom_attributes
                 },
-                move |custom_attributes: HashMap<opentelemetry::Key, opentelemetry::Value>, fut| {
+                move |custom_attributes: Vec<KeyValue>, fut| {
                     let start = Instant::now();
                     let config = config_later.clone();
 
@@ -488,7 +487,7 @@ impl Plugin for Telemetry {
                     Self::populate_context(config.clone(), field_level_instrumentation_ratio, req);
                     (req.context.clone(), custom_attributes)
                 },
-                move |(ctx, custom_attributes): (Context, HashMap<Key, opentelemetry::Value>), fut| {
+                move |(ctx, custom_attributes): (Context, Vec<KeyValue>), fut| {
                     let config = config_map_res.clone();
                     let sender = metrics_sender.clone();
                     let start = Instant::now();
@@ -592,7 +591,7 @@ impl Plugin for Telemetry {
                 move |(context, cache_attributes, custom_attributes): (
                     Context,
                     Option<CacheAttributes>,
-                    HashMap<Key, opentelemetry::Value>,
+                    Vec<KeyValue>,
                 ),
                       f: BoxFuture<'static, Result<SubgraphResponse, BoxError>>| {
                     let subgraph_attribute = subgraph_attribute.clone();


### PR DESCRIPTION
Only use `LinkedList` and get rid of `HashMap` for the custom attributes.

Fixes #4251 


**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
