### PR TITLE
Make Jaeger tests run without APOLLO_KEY and APOLLO_GRAPH_REF

### DIFF
--- a/apollo-router/tests/fixtures/jaeger-advanced.router.yaml
+++ b/apollo-router/tests/fixtures/jaeger-advanced.router.yaml
@@ -8,7 +8,7 @@ telemetry:
         jaeger: true
       common:
         service_name: router
-        sampler: 0.5
+        sampler: always_on
       jaeger:
         enabled: true
         batch_processor:
@@ -25,6 +25,29 @@ telemetry:
         - name: custom-header
           match: ^foo.*
           headers: true
+  instrumentation:
+    spans:
+      mode: deprecated
+      router:
+        attributes:
+          http.request.method: true
+          http.response.status_code: true
+          url.path: true
+          "http.request.header.x-my-header":
+            request_header: "x-my-header"
+          "http.request.header.x-not-present":
+            request_header: "x-not-present"
+            default: nope
+      supergraph:
+        attributes:
+          graphql.operation.name: true
+          graphql.operation.type: true
+          graphql.document: true
+      subgraph:
+        attributes:
+          subgraph.graphql.operation.type: true
+          subgraph.name: true
+          
 override_subgraph_url:
   products: http://localhost:4005
 include_subgraph_errors:

--- a/apollo-router/tests/fixtures/jaeger-no-sample.router.yaml
+++ b/apollo-router/tests/fixtures/jaeger-no-sample.router.yaml
@@ -28,28 +28,6 @@ telemetry:
         - name: custom-header
           match: ^foo.*
           headers: true
-  instrumentation:
-    spans:
-      mode: deprecated
-      router:
-        attributes:
-          http.request.method: true
-          http.response.status_code: true
-          url.path: true
-          "http.request.header.x-my-header":
-            request_header: "x-my-header"
-          "http.request.header.x-not-present":
-            request_header: "x-not-present"
-            default: nope
-      supergraph:
-        attributes:
-          graphql.operation.name: true
-          graphql.operation.type: true
-          graphql.document: true
-      subgraph:
-        attributes:
-          subgraph.graphql.operation.type: true
-          subgraph.name: true
 override_subgraph_url:
   products: http://localhost:4005
 include_subgraph_errors:

--- a/apollo-router/tests/fixtures/jaeger.router.yaml
+++ b/apollo-router/tests/fixtures/jaeger.router.yaml
@@ -25,28 +25,6 @@ telemetry:
         - name: custom-header
           match: ^foo.*
           headers: true
-  instrumentation:
-    spans:
-      mode: deprecated
-      router:
-        attributes:
-          http.request.method: true
-          http.response.status_code: true
-          url.path: true
-          "http.request.header.x-my-header":
-            request_header: "x-my-header"
-          "http.request.header.x-not-present":
-            request_header: "x-not-present"
-            default: nope
-      supergraph:
-        attributes:
-          graphql.operation.name: true
-          graphql.operation.type: true
-          graphql.document: true
-      subgraph:
-        attributes:
-          subgraph.graphql.operation.type: true
-          subgraph.name: true
           
 override_subgraph_url:
   products: http://localhost:4005


### PR DESCRIPTION
#4102 Introduced some changes to tests that would result in failures if the developer did not have an enterprise account. This is now gated on the appropriate env variables being present.

Changes:
Revert configuration of existing jaeger tests for not use custom span attributes.
Add a new test specifically for this.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
