### PR TITLE
Remove races in plugins::telemetry::resource::test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -402,6 +402,7 @@ dependencies = [
  "serde_json_bytes",
  "serde_urlencoded",
  "serde_yaml",
+ "serial_test",
  "sha1",
  "sha2",
  "shellexpand",
@@ -6092,6 +6093,31 @@ dependencies = [
  "ryu",
  "serde",
  "yaml-rust",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot 0.12.1",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2 1.0.66",
+ "quote 1.0.33",
+ "syn 2.0.29",
 ]
 
 [[package]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -298,6 +298,7 @@ rhai = { version = "1.16.3", features = [
     "internals",
     "testing-environ",
 ] }
+serial_test = { version = "2.0.0" }
 tempfile = "3.8.1"
 test-log = { version = "0.2.13", default-features = false, features = [
     "trace",

--- a/apollo-router/src/plugins/telemetry/resource.rs
+++ b/apollo-router/src/plugins/telemetry/resource.rs
@@ -136,6 +136,7 @@ mod test {
     use std::env;
 
     use opentelemetry::Key;
+    use serial_test::serial;
 
     use crate::plugins::telemetry::config::AttributeValue;
     use crate::plugins::telemetry::resource::ConfigResource;
@@ -157,7 +158,11 @@ mod test {
         }
     }
 
+    // All of the tests in this module must execute serially wrt each other because they rely on
+    // env settings and one of the tests modifies the env for the duration of the test. We enforce
+    // this with the #[serial] derive.
     #[test]
+    #[serial]
     fn test_empty() {
         let test_config = TestConfig {
             service_name: None,
@@ -186,6 +191,7 @@ mod test {
     }
 
     #[test]
+    #[serial]
     fn test_config_resources() {
         let test_config = TestConfig {
             service_name: None,
@@ -221,6 +227,7 @@ mod test {
     }
 
     #[test]
+    #[serial]
     fn test_service_name_service_namespace() {
         let test_config = TestConfig {
             service_name: Some("override-service-name".to_string()),
@@ -239,6 +246,7 @@ mod test {
     }
 
     #[test]
+    #[serial]
     fn test_service_name_override() {
         // Order of precedence
         // OTEL_SERVICE_NAME env


### PR DESCRIPTION
These tests manipulated the environment and thus cannot execute in parallel with each other. The fix forces these tests to execute serially with respect to each other.

fixes: #4067

Note: No changeset as this doesn't have any meaningful user-facing impact.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
