### PR TITLE
Entity cache: link cache and authorization

### DIFF
--- a/apollo-router/src/plugins/authorization/scopes.rs
+++ b/apollo-router/src/plugins/authorization/scopes.rs
@@ -291,11 +291,6 @@ impl<'a> ScopeFilteringVisitor<'a> {
         field_def: &ast::FieldDefinition,
         node: &ast::Field,
     ) -> bool {
-        println!(
-            "implementors with different requirements for {:?}, node name={}",
-            field_def.name,
-            node.name.as_str()
-        );
         // we can request __typename outside of fragments even if the types have different
         // authorization requirements
         if node.name.as_str() == TYPENAME {

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -343,19 +343,17 @@ async fn cache_store_root_from_response(
             .map(|secs| Duration::from_secs(secs as u64))
             .or(subgraph_ttl);
 
-        if response.response.body().errors.is_empty() {
-            if cache_control.should_store() {
-                cache
-                    .insert(
-                        RedisKey(cache_key),
-                        RedisValue(CacheEntry {
-                            control: cache_control,
-                            data: data.clone(),
-                        }),
-                        ttl,
-                    )
-                    .await;
-            }
+        if response.response.body().errors.is_empty() && cache_control.should_store() {
+            cache
+                .insert(
+                    RedisKey(cache_key),
+                    RedisValue(CacheEntry {
+                        control: cache_control,
+                        data: data.clone(),
+                    }),
+                    ttl,
+                )
+                .await;
         }
     }
 

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -173,7 +173,13 @@ async fn cache_lookup_root(
 ) -> Result<ControlFlow<subgraph::Response, subgraph::Request>, BoxError> {
     let body = request.subgraph_request.body_mut();
 
-    let key = extract_cache_key_root(&name, &request.query_hash, body, &request.context);
+    let key = extract_cache_key_root(
+        &name,
+        &request.query_hash,
+        body,
+        &request.context,
+        &request.authorization,
+    );
 
     let cache_result: Option<RedisValue<CacheEntry>> = cache.get(RedisKey(key.clone())).await;
 
@@ -214,7 +220,13 @@ async fn cache_lookup_entities(
 ) -> Result<ControlFlow<subgraph::Response, subgraph::Request>, BoxError> {
     let body = request.subgraph_request.body_mut();
 
-    let keys = extract_cache_keys(&name, &request.query_hash, body, &request.context)?;
+    let keys = extract_cache_keys(
+        &name,
+        &request.query_hash,
+        body,
+        &request.context,
+        &request.authorization,
+    )?;
 
     let cache_result: Vec<Option<CacheEntry>> = cache
         .get_multiple(keys.iter().map(|k| RedisKey(k.clone())).collect::<Vec<_>>())
@@ -416,7 +428,11 @@ pub(crate) fn hash_query(query_hash: &QueryHash, body: &graphql::Request) -> Str
     hex::encode(digest.finalize().as_slice())
 }
 
-pub(crate) fn hash_additional_data(body: &mut graphql::Request, context: &Context) -> String {
+pub(crate) fn hash_additional_data(
+    body: &mut graphql::Request,
+    context: &Context,
+    cache_key: &CacheKeyMetadata,
+) -> String {
     let mut digest = Sha256::new();
 
     let repr_key = ByteString::from(REPRESENTATIONS);
@@ -427,13 +443,7 @@ pub(crate) fn hash_additional_data(body: &mut graphql::Request, context: &Contex
         body.variables.insert(repr_key, representations);
     }
 
-    let cache_key = context
-        .private_entries
-        .lock()
-        .get::<CacheKeyMetadata>()
-        .cloned()
-        .unwrap_or_default();
-    digest.update(&serde_json::to_vec(&cache_key).unwrap());
+    digest.update(&serde_json::to_vec(cache_key).unwrap());
 
     if let Ok(Some(cache_data)) = context.get::<&str, Object>(CONTEXT_CACHE_KEY) {
         if let Some(v) = cache_data.get("all") {
@@ -457,11 +467,12 @@ fn extract_cache_key_root(
     query_hash: &QueryHash,
     body: &mut graphql::Request,
     context: &Context,
+    cache_key: &CacheKeyMetadata,
 ) -> String {
     // hash the query and operation name
     let query_hash = hash_query(query_hash, body);
     // hash more data like variables and authorization status
-    let additional_data_hash = hash_additional_data(body, context);
+    let additional_data_hash = hash_additional_data(body, context, cache_key);
 
     // the cache key is written to easily find keys matching a prefix for deletion:
     // - subgraph name: caching is done per subgraph
@@ -479,11 +490,12 @@ fn extract_cache_keys(
     query_hash: &QueryHash,
     body: &mut graphql::Request,
     context: &Context,
+    cache_key: &CacheKeyMetadata,
 ) -> Result<Vec<String>, BoxError> {
     // hash the query and operation name
     let query_hash = hash_query(query_hash, body);
     // hash more data like variables and authorization status
-    let additional_data_hash = hash_additional_data(body, context);
+    let additional_data_hash = hash_additional_data(body, context, cache_key);
 
     let representations = body
         .variables

--- a/apollo-router/tests/fixtures/supergraph-auth.graphql
+++ b/apollo-router/tests/fixtures/supergraph-auth.graphql
@@ -1,0 +1,102 @@
+
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/requiresScopes/v0.1", for: SECURITY)
+{
+  query: Query
+  mutation: Mutation
+}
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet) repeatable on OBJECT | INTERFACE
+
+directive @join__owner(graph: join__Graph!) on OBJECT | INTERFACE
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION
+
+directive @inaccessible on OBJECT | FIELD_DEFINITION | INTERFACE | UNION
+
+scalar link__Import
+
+enum link__Purpose {
+    """
+    `SECURITY` features provide metadata necessary to securely resolve fields.
+    """
+    SECURITY
+  
+    """
+    `EXECUTION` features provide metadata necessary for operation execution.
+    """
+    EXECUTION
+  }
+
+scalar join__FieldSet
+
+scalar federation__Scope
+
+directive @requiresScopes(scopes: [[federation__Scope!]!]!) on OBJECT | FIELD_DEFINITION | INTERFACE | SCALAR | ENUM
+
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "https://accounts.demo.starstuff.dev")
+  INVENTORY @join__graph(name: "inventory", url: "https://inventory.demo.starstuff.dev")
+  PRODUCTS @join__graph(name: "products", url: "https://products.demo.starstuff.dev")
+  REVIEWS @join__graph(name: "reviews", url: "https://reviews.demo.starstuff.dev")
+}
+type Mutation
+  @join__type(graph: PRODUCTS)
+  @join__type(graph: REVIEWS)
+{
+  createProduct(name: String, upc: ID!): Product @join__field(graph: PRODUCTS)
+  createReview(body: String, id: ID!, upc: ID!): Review @join__field(graph: REVIEWS)
+}
+
+type Product
+  @join__type(graph: PRODUCTS, key: "upc")
+  @join__type(graph: INVENTORY, key: "upc")
+  @join__type(graph: REVIEWS, key: "upc")
+{
+  inStock: Boolean @join__field(graph: INVENTORY) @tag(name: "private") @inaccessible
+  name: String @join__field(graph: PRODUCTS)
+  price: Int @join__field(graph: PRODUCTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  reviewsForAuthor(authorID: ID!): [Review] @join__field(graph: REVIEWS)
+  upc: String! @join__field(graph: PRODUCTS) @join__field(graph: INVENTORY, external: true) @join__field(graph: REVIEWS, external: true)
+  weight: Int @join__field(graph: PRODUCTS)
+}
+
+type Query
+  @join__type(graph: ACCOUNTS)
+  @join__type(graph: PRODUCTS) {
+  me: User @join__field(graph: ACCOUNTS) @requiresScopes(scopes: [["profile"]])
+  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCTS)
+}
+
+type Review
+  @join__owner(graph: REVIEWS)
+  @join__type(graph: REVIEWS, key: "id")
+{
+  author: User @join__field(graph: REVIEWS)
+  body: String @join__field(graph: REVIEWS)
+  id: ID!
+  product: Product @join__field(graph: REVIEWS)
+}
+
+type User
+  @join__owner(graph: ACCOUNTS)
+  @join__type(graph: ACCOUNTS, key: "id")
+  @join__type(graph: REVIEWS, key: "id")
+  @requiresScopes(scopes: [["read:user"]])
+{
+  id: ID!
+  name: String @join__field(graph: ACCOUNTS) @requiresScopes(scopes: [["read:name"]])
+  reviews: [Review] @join__field(graph: REVIEWS)
+  username: String @join__field(graph: ACCOUNTS)
+}

--- a/apollo-router/tests/redis_test.rs
+++ b/apollo-router/tests/redis_test.rs
@@ -312,7 +312,6 @@ mod test {
           .get("subgraph.products|530d594c46b838e725b87d64fd6384b82f6ff14bd902b57bba9dcc34ce684b76|d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
           .await
           .unwrap();
-        println!("got res: {s}");
         let v: Value = serde_json::from_str(&s).unwrap();
         insta::assert_json_snapshot!(v.as_object().unwrap().get("data").unwrap());
 
@@ -627,7 +626,6 @@ mod test {
           .get("subgraph.products|530d594c46b838e725b87d64fd6384b82f6ff14bd902b57bba9dcc34ce684b76|d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
           .await
           .unwrap();
-        println!("got res: {s}");
         let v: Value = serde_json::from_str(&s).unwrap();
         assert_eq!(
             v.as_object().unwrap().get("data").unwrap(),
@@ -645,11 +643,10 @@ mod test {
             }}
         );
 
-        let s:String = client
+        let s: String = client
         .get("subgraph.reviews|Product|4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66|98424704ece0e377929efa619bce2cbd5246281199c72a0902da863270f5839c|d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
         .await
         .unwrap();
-        println!("got res: {s}");
         let v: Value = serde_json::from_str(&s).unwrap();
         assert_eq!(
             v.as_object().unwrap().get("data").unwrap(),
@@ -660,10 +657,6 @@ mod test {
             }}
         );
 
-        //insta::assert_json_snapshot!(v.as_object().unwrap().get("data").unwrap());
-
-        println!("\n\n///////////////////////////////////\n\n");
-        ///////////////////////////
         let context = Context::new();
         context
             .insert(
@@ -698,7 +691,6 @@ mod test {
           .get("subgraph.reviews|Product|4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66|dc8e1fb584d7ad114b3e836a5fe4f642732b82eb39bb8d6dff000d844d0e3baf|f1d914240cfd0c60d5388f3f2d2ae00b5f1e2400ef2c9320252439f354515ce9")
           .await
           .unwrap();
-        println!("got res: {s}");
         let v: Value = serde_json::from_str(&s).unwrap();
         assert_eq!(
             v.as_object().unwrap().get("data").unwrap(),
@@ -710,8 +702,6 @@ mod test {
             }}
         );
 
-        println!("\n\n///////////////////////////////////\n\n");
-        ///////////////////////////
         let context = Context::new();
         context
             .insert(

--- a/apollo-router/tests/redis_test.rs
+++ b/apollo-router/tests/redis_test.rs
@@ -308,14 +308,15 @@ mod test {
         insta::assert_json_snapshot!(response);
 
         let s:String = client
-          .get("subgraph.products|3c25d82024f1e8f457912c103a4217469132851090e3ced085a4aac05bdc415d|d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+          .get("subgraph.products|530d594c46b838e725b87d64fd6384b82f6ff14bd902b57bba9dcc34ce684b76|d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
           .await
           .unwrap();
+        println!("got res: {s}");
         let v: Value = serde_json::from_str(&s).unwrap();
         insta::assert_json_snapshot!(v.as_object().unwrap().get("data").unwrap());
 
         let s:String = client
-        .get("subgraph.reviews|Product|4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66|51b48bcac2fe71c01543e6e4ce115a5142193d885162ddf5d299f5ed59dc2341|d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+        .get("subgraph.reviews|Product|4911f7a9dbad8a47b8900d65547503a2f3c0359f65c0bc5652ad9b9843281f66|98424704ece0e377929efa619bce2cbd5246281199c72a0902da863270f5839c|d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
         .await
         .unwrap();
         let v: Value = serde_json::from_str(&s).unwrap();
@@ -412,7 +413,7 @@ mod test {
         insta::assert_json_snapshot!(response);
 
         let s:String = client
-        .get("subgraph.reviews|Product|d9a4cd73308dd13ca136390c10340823f94c335b9da198d2339c886c738abf0d|51b48bcac2fe71c01543e6e4ce115a5142193d885162ddf5d299f5ed59dc2341|d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
+        .get("subgraph.reviews|Product|d9a4cd73308dd13ca136390c10340823f94c335b9da198d2339c886c738abf0d|98424704ece0e377929efa619bce2cbd5246281199c72a0902da863270f5839c|d9d84a3c7ffc27b0190a671212f3740e5b8478e84e23825830e97822e25cf05c")
         .await
         .unwrap();
         let v: Value = serde_json::from_str(&s).unwrap();

--- a/apollo-router/tests/redis_test.rs
+++ b/apollo-router/tests/redis_test.rs
@@ -289,7 +289,7 @@ mod test {
                 }
             }))?
             .extra_plugin(subgraphs)
-            .schema(include_str!("fixtures/supergraph.graphql"))
+            .schema(include_str!("fixtures/supergraph-auth.graphql"))
             .build_supergraph()
             .await
             .unwrap();
@@ -393,7 +393,7 @@ mod test {
                 }
             }))?
             .extra_plugin(subgraphs)
-            .schema(include_str!("fixtures/supergraph.graphql"))
+            .schema(include_str!("fixtures/supergraph-auth.graphql"))
             .build_supergraph()
             .await
             .unwrap();

--- a/apollo-router/tests/snapshots/redis_test__test__entity_cache_authorization-2.snap
+++ b/apollo-router/tests/snapshots/redis_test__test__entity_cache_authorization-2.snap
@@ -1,0 +1,50 @@
+---
+source: apollo-router/tests/redis_test.rs
+expression: response
+---
+{
+  "data": {
+    "me": null,
+    "topProducts": [
+      {
+        "name": "chair",
+        "reviews": [
+          {
+            "body": "I can sit on it",
+            "author": {
+              "username": "ada"
+            }
+          }
+        ]
+      },
+      {
+        "name": "table",
+        "reviews": [
+          {
+            "body": "I can sit on it",
+            "author": {
+              "username": "ada"
+            }
+          },
+          {
+            "body": "I can eat on it",
+            "author": {
+              "username": "charles"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "errors": [
+    {
+      "message": "Unauthorized field or type",
+      "path": [
+        "me"
+      ],
+      "extensions": {
+        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
+      }
+    }
+  ]
+}

--- a/apollo-router/tests/snapshots/redis_test__test__entity_cache_authorization-3.snap
+++ b/apollo-router/tests/snapshots/redis_test__test__entity_cache_authorization-3.snap
@@ -1,0 +1,54 @@
+---
+source: apollo-router/tests/redis_test.rs
+expression: response
+---
+{
+  "data": {
+    "me": {
+      "id": "1",
+      "name": null
+    },
+    "topProducts": [
+      {
+        "name": "chair",
+        "reviews": [
+          {
+            "body": "I can sit on it",
+            "author": {
+              "username": "ada"
+            }
+          }
+        ]
+      },
+      {
+        "name": "table",
+        "reviews": [
+          {
+            "body": "I can sit on it",
+            "author": {
+              "username": "ada"
+            }
+          },
+          {
+            "body": "I can eat on it",
+            "author": {
+              "username": "charles"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "errors": [
+    {
+      "message": "Unauthorized field or type",
+      "path": [
+        "me",
+        "name"
+      ],
+      "extensions": {
+        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
+      }
+    }
+  ]
+}

--- a/apollo-router/tests/snapshots/redis_test__test__entity_cache_authorization.snap
+++ b/apollo-router/tests/snapshots/redis_test__test__entity_cache_authorization.snap
@@ -1,0 +1,57 @@
+---
+source: apollo-router/tests/redis_test.rs
+expression: response
+---
+{
+  "data": {
+    "me": null,
+    "topProducts": [
+      {
+        "name": "chair",
+        "reviews": [
+          {
+            "body": "I can sit on it",
+            "author": null
+          }
+        ]
+      },
+      {
+        "name": "table",
+        "reviews": [
+          {
+            "body": "I can sit on it",
+            "author": null
+          },
+          {
+            "body": "I can eat on it",
+            "author": null
+          }
+        ]
+      }
+    ]
+  },
+  "errors": [
+    {
+      "message": "Unauthorized field or type",
+      "path": [
+        "me"
+      ],
+      "extensions": {
+        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
+      }
+    },
+    {
+      "message": "Unauthorized field or type",
+      "path": [
+        "topProducts",
+        "@",
+        "reviews",
+        "@",
+        "author"
+      ],
+      "extensions": {
+        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This builds upon #4208 to use subgraph level authorization status in  the cache key, to split cache entries per authorization contexts

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
