### PR TITLE
Removing from template the `/` as it will always come with the `/` as…

### DIFF
--- a/apollo-router/src/axum_factory/axum_http_server_factory.rs
+++ b/apollo-router/src/axum_factory/axum_http_server_factory.rs
@@ -104,7 +104,7 @@ where
 
     if configuration.health_check.enabled {
         tracing::info!(
-            "Health check exposed at {}/{}",
+            "Health check exposed at {}{}",
             configuration.health_check.listen,
             configuration.health_check.path
         );


### PR DESCRIPTION
Removing from the template the `/` as it will always come with the `/` as gives and incorrect health check URL the logs

*Description here*

Fixes https://github.com/apollographql/router/issues/4270

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
