### PR TITLE
docs(kubernetes/docker): Update relative path for configuration links

### DIFF
--- a/docs/source/containerization/docker.mdx
+++ b/docs/source/containerization/docker.mdx
@@ -22,7 +22,7 @@ The exact image version to use depends on which release you wish to use. In the 
 
 ## Basic example running router in Docker
 
-To run the router, your Docker container must have the [`APOLLO_GRAPH_REF`](../../configuration/overview#apollo_graph_ref) and [`APOLLO_KEY`](configuration/overview#apollo_key) environment variables set to your graph ref and API key, respectively.
+To run the router, your Docker container must have the [`APOLLO_GRAPH_REF`](../configuration/overview#apollo_graph_ref) and [`APOLLO_KEY`](configuration/overview#apollo_key) environment variables set to your graph ref and API key, respectively.
 
 Here's a basic example of running a router image in Docker. Make sure to replace `<router-image-version>` with whichever version you want to use, such as `v1.32.0`.
 

--- a/docs/source/containerization/kubernetes.mdx
+++ b/docs/source/containerization/kubernetes.mdx
@@ -46,7 +46,7 @@ The path to the OCI router chart is `oci://ghcr.io/apollographql/helm-charts/rou
 
 </Note>
 
-You customize a deployed router with the same [command-line options and YAML configuration](../../configuration/overview) but under different Helm CLI options and YAML keys.  
+You customize a deployed router with the same [command-line options and YAML configuration](../configuration/overview) but under different Helm CLI options and YAML keys.  
 
 ## Basic deployment
 
@@ -54,8 +54,8 @@ Follow this guide to deploy the Apollo Router using Helm to install the basic ch
 
 Each router chart has a `values.yaml` file with router and deployment settings. The released, unedited file has a few explicit settings, including:
 
-* Default container ports for the router's [HTTP server](../../configuration/overview/#listen-address), [health check endpoint](../../configuration/health-checks), and [metrics endpoint](../../configuration/metrics).
-* A command-line argument to enable [hot reloading of the router](../../configuration/overview/#--hr----hot-reload).
+* Default container ports for the router's [HTTP server](../configuration/overview/#listen-address), [health check endpoint](../configuration/health-checks), and [metrics endpoint](../configuration/metrics).
+* A command-line argument to enable [hot reloading of the router](../configuration/overview/#--hr----hot-reload).
 * A single replica.
 
 <ExpansionPanel title="Click to expand values.yaml for router v1.31.0">
@@ -104,7 +104,7 @@ For an example, see the [Setup from Apollo's Build a Supergraph tutorial](https:
 
 ### Set up graph
 
-Set up your self-hosted graph and get its [graph ref](../../configuration/overview/#apollo_graph_ref) and [API key](../../configuration/overview/#apollo_graph_ref).
+Set up your self-hosted graph and get its [graph ref](../configuration/overview/#apollo_graph_ref) and [API key](../configuration/overview/#apollo_graph_ref).
 
 If you need a guide to set up your graph, you can follow [the self-hosted router quickstart](/graphos/quickstart/self-hosted) and complete [step 1 (Set up Apollo tools)](/graphos/quickstart/self-hosted/#1-set-up-apollo-tools), [step 4 (Obtain your subgraph schemas)](/graphos/quickstart/self-hosted/#4-obtain-your-subgraph-schemas), and [step 5 (Publish your subgraph schemas)](/graphos/quickstart/self-hosted/#5-publish-your-subgraph-schemas).
 
@@ -117,8 +117,8 @@ helm install --namespace <router-namespace> --set managedFederation.apiKey="<gra
 ```
 The necessary arguments for specific configuration values:
 
-* `--set managedFederation.graphRef="<graph-ref>"`. The reference to your managed graph (`id@variant`), the same value as the [`APOLLO_GRAPH_REF` environment variable](../../configuration/overview/#apollo_graph_ref).
-* `--set managedFederation.apiKey="<graph-api-key>"`. The API key to your managed graph, the same value as the [`APOLLO_KEY` environment variable](../../configuration/overview/#apollo_key).
+* `--set managedFederation.graphRef="<graph-ref>"`. The reference to your managed graph (`id@variant`), the same value as the [`APOLLO_GRAPH_REF` environment variable](../configuration/overview/#apollo_graph_ref).
+* `--set managedFederation.apiKey="<graph-api-key>"`. The API key to your managed graph, the same value as the [`APOLLO_KEY` environment variable](../configuration/overview/#apollo_key).
 
 Some optional but recommended arguments:
 
@@ -137,7 +137,7 @@ helm list --namespace <router-namespace>
 
 ## Deploy with metrics endpoints 
 
-The router supports [metrics endpoints for Prometheus and OpenTelemetry protocol (OTLP)](../../configuration/metrics). A [basic deployment](#basic-deployment) doesn't enable metrics endpoints, because the router chart disables both Prometheus (explicitly) and OTLP (by omission).
+The router supports [metrics endpoints for Prometheus and OpenTelemetry protocol (OTLP)](../configuration/metrics). A [basic deployment](#basic-deployment) doesn't enable metrics endpoints, because the router chart disables both Prometheus (explicitly) and OTLP (by omission).
 
 To enable metrics endpoints in your deployed router through a YAML configuration file:
 


### PR DESCRIPTION
*Description here*

Some of the links on the [kubernetes](https://www.apollographql.com/docs/router/containerization/kubernetes/) and [docker](https://www.apollographql.com/docs/router/containerization/docker/) pages refer to [a configuration page](https://www.apollographql.com/docs/configuration/overview) two levels up resulting in a 404

<img width="675" alt="image" src="https://github.com/apollographql/router/assets/146107359/b3d1c260-4977-4153-b255-fe82744bbb9a">

Quickest way to find one is go to the Kubernetes page and click on `command-line options and YAML configuration`

Fixes #**issue_number**

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
