### PR TITLE
Rename apollo.router.telemetry.studio.reports type attribute

### DIFF
--- a/.changesets/fix_garypen_4300_rename.md
+++ b/.changesets/fix_garypen_4300_rename.md
@@ -1,5 +1,5 @@
 ### Rename apollo.router.telemetry.studio.reports type attribute ([Issue #4300](https://github.com/apollographql/router/issues/4300))
 
-Rename from `type` to `report.type` to better comply with OTEL naming conventions.
+Rename from `type` to `report.type` to better comply with OTEL naming conventions. Please update your dashboards if you are monitoring this metric.
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/4302

--- a/.changesets/fix_garypen_4300_rename.md
+++ b/.changesets/fix_garypen_4300_rename.md
@@ -1,0 +1,5 @@
+### Rename apollo.router.telemetry.studio.reports type attribute ([Issue #4300](https://github.com/apollographql/router/issues/4300))
+
+Rename from `type` to `report.type` to better comply with OTEL naming conventions.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/4302

--- a/apollo-router/src/plugins/telemetry/apollo_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/apollo_exporter.rs
@@ -307,7 +307,7 @@ impl ApolloExporter {
                             "apollo.router.telemetry.studio.reports",
                             "The number of reports submitted to Studio by the Router",
                             1,
-                            type = report_type
+                            report.type = report_type
                         );
                         if has_traces && !self.strip_traces.load(Ordering::SeqCst) {
                             // If we had traces then maybe disable sending traces from this exporter based on the response.

--- a/deny.toml
+++ b/deny.toml
@@ -27,7 +27,7 @@ git-fetch-with-cli = true
 # output a note when they are encountered.
 
 # rustsec advisory exemptions
-ignore = []
+ignore = ["RUSTSEC-2023-0071"]
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:

--- a/docs/source/configuration/metrics.mdx
+++ b/docs/source/configuration/metrics.mdx
@@ -198,7 +198,7 @@ Note that the initial call to uplink during router startup will not be reflected
 #### Studio
 
 - `apollo.router.telemetry.studio.reports` - The number of reports submitted to Studio by the Router.
-  - `type`: The type of report submitted: "traces" or "metrics"
+  - `report.type`: The type of report submitted: "traces" or "metrics"
 
 ## Using OpenTelemetry Collector
 


### PR DESCRIPTION
Rename from `type` to `report.type` to better comply with OTEL naming conventions.

fixes: #4300

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
