### PR TITLE
Disable RSA advisory check

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -27,7 +27,7 @@ git-fetch-with-cli = true
 # output a note when they are encountered.
 
 # rustsec advisory exemptions
-ignore = []
+ignore = ["RUSTSEC-2023-0071"]
 
 # This section is considered when running `cargo deny check licenses`
 # More documentation for the licenses section can be found here:


### PR DESCRIPTION
We believe this only impacts the router-bridge and we don't do RSA private key related operations in the router-bridge.