### PR TITLE
Update cors.mdx

### DIFF
--- a/docs/source/configuration/cors.mdx
+++ b/docs/source/configuration/cors.mdx
@@ -25,7 +25,7 @@ By default, the Apollo Router enables _only_ Apollo Studio to initiate browser c
 
 * If clients need to [authenticate their requests with cookies](#passing-credentials), you _must_ use either `origins`, `match_origins`, or the combination of both options. When using both options, note that `origins` is evaluated before `match_origins`.
 
-The following snippet includes an example of each option (use either `allow_any_origin`, or `origins + match_origins`):
+The following snippet includes an example of each option (use either `allow_any_origin`, or `origins` and/or `match_origins`):
 
 ```yaml title="router.yaml"
 cors:

--- a/docs/source/configuration/cors.mdx
+++ b/docs/source/configuration/cors.mdx
@@ -23,7 +23,7 @@ By default, the Apollo Router enables _only_ Apollo Studio to initiate browser c
     * Use this option if your supergraph is a public API with arbitrarily many web app consumers.
     * With this option enabled, the router sends the [wildcard (`*`)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#directives) value for the `Access-Control-Allow-Origin` header. This enables _any_ website to initiate browser connections to it (but they can't provide cookies or other credentials).
 
-* You _must_ use the `origins` + `match_origins` option if clients need to [authenticate their requests with cookies](#passing-credentials).
+* You _must_ use either `origins`, `match_origins`, or the combination of both options if clients need to [authenticate their requests with cookies](#passing-credentials). Note that `origins` will be evaluated before `match_origins`.
 
 The following snippet includes an example of each option (use either `allow_any_origin`, or `origins + match_origins`):
 

--- a/docs/source/configuration/cors.mdx
+++ b/docs/source/configuration/cors.mdx
@@ -23,7 +23,7 @@ By default, the Apollo Router enables _only_ Apollo Studio to initiate browser c
     * Use this option if your supergraph is a public API with arbitrarily many web app consumers.
     * With this option enabled, the router sends the [wildcard (`*`)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin#directives) value for the `Access-Control-Allow-Origin` header. This enables _any_ website to initiate browser connections to it (but they can't provide cookies or other credentials).
 
-* You _must_ use either `origins`, `match_origins`, or the combination of both options if clients need to [authenticate their requests with cookies](#passing-credentials). Note that `origins` will be evaluated before `match_origins`.
+* If clients need to [authenticate their requests with cookies](#passing-credentials), you _must_ use either `origins`, `match_origins`, or the combination of both options. When using both options, note that `origins` is evaluated before `match_origins`.
 
 The following snippet includes an example of each option (use either `allow_any_origin`, or `origins + match_origins`):
 


### PR DESCRIPTION
Current documentation on CORS `origins` and `match_origins` is a little unclear. Minor changes in language to clear them up and establish order of evaluation.