### PR TITLE
Disable running doctests

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -15,6 +15,13 @@ build = "build/main.rs"
 [[bin]]
 name = "router"
 path = "src/main.rs"
+# Don’t recompile main.rs to run unit tests, there aren’t any there:
+test = false
+
+[lib]
+# Disabled as they are low value compared to the pathological amount of time and RAM
+# needed to link an executable for each individual doctest:
+doctest = false
 
 [features]
 default = ["global-allocator"]
@@ -136,10 +143,7 @@ once_cell = "1.18.0"
 # groups `^tracing` and `^opentelemetry*` dependencies together as of
 # https://github.com/apollographql/router/pull/1509.  A comment which exists
 # there (and on `tracing` packages below) should be updated should this change.
-opentelemetry = { version = "0.20.0", features = [
-    "trace",
-    "metrics",
-] }
+opentelemetry = { version = "0.20.0", features = ["trace", "metrics"] }
 opentelemetry_api = "0.20.0"
 opentelemetry-aws = "0.8.0"
 opentelemetry-datadog = { version = "0.8.0", features = ["reqwest-client"] }
@@ -282,9 +286,7 @@ mockall = "0.11.4"
 num-traits = "0.2.17"
 once_cell = "1.18.0"
 opentelemetry-stdout = { version = "0.1.0", features = ["trace"] }
-opentelemetry = { version = "0.20.0", features = [
-    "testing",
-] }
+opentelemetry = { version = "0.20.0", features = ["testing"] }
 p256 = "0.13.2"
 rand_core = "0.6.4"
 reqwest = { version = "0.11.22", default-features = false, features = [


### PR DESCRIPTION
They are usually low value: demonstrating basic usage of API that is already execised in parts of other tests. However they are costly since each doctest is compiled as a separate executable that depends on the apollo_router crate. For reasons we don’t fully understand, linking takes a pathologically long time and, especially on Linux, large amount of memory. Many linker running in parallel can run out of memory. For example:

https://app.circleci.com/pipelines/github/apollographql/router/17749/workflows/5e2cd87a-c10b-41b8-900e-e5d517b8abe8/jobs/116288?invite=true#step-116-326592_69

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
