### PR TITLE
Fix `telemetry.instrumentation.spans.span_mode`

### DIFF
--- a/.changesets/fix_bryn_span_mode.md
+++ b/.changesets/fix_bryn_span_mode.md
@@ -1,0 +1,13 @@
+### `span_mode: spec_complient` not applied correctly ([Issue #4335](https://github.com/apollographql/router/issues/4335))
+
+`telemetry.instrumentation.spans.span_mode` was not being correctly applied, resulting in extra request spans that should not have been present in spec compliant mode.
+
+In spec compliant mode the spans should have the hierarchy:
+
+`router.supergraph.subgraph`
+
+but were instead output as:
+
+`request.router.supergraph.subgraph`
+
+By [@bryncooke](https://github.com/bryncooke) in https://github.com/apollographql/router/pull/4341

--- a/apollo-router/src/axum_factory/testdata/span_mode_default.router.yaml
+++ b/apollo-router/src/axum_factory/testdata/span_mode_default.router.yaml
@@ -1,0 +1,4 @@
+telemetry:
+  instrumentation:
+    spans:
+      default_attribute_requirement_level: required

--- a/apollo-router/src/axum_factory/testdata/span_mode_deprecated.router.yaml
+++ b/apollo-router/src/axum_factory/testdata/span_mode_deprecated.router.yaml
@@ -1,0 +1,4 @@
+telemetry:
+  instrumentation:
+    spans:
+      mode: deprecated

--- a/apollo-router/src/axum_factory/testdata/span_mode_spec_compliant.router.yaml
+++ b/apollo-router/src/axum_factory/testdata/span_mode_spec_compliant.router.yaml
@@ -1,0 +1,4 @@
+telemetry:
+  instrumentation:
+    spans:
+      mode: spec_compliant


### PR DESCRIPTION
`telemetry.instrumentation.spans.span_mode` was not being correctly applied, resulting in extra request spans that should not have been present in spec compliant mode.

Fixes #4335


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
