### PR TITLE
Make observable metrics clean up once they are dropped

### DIFF
--- a/apollo-router/src/metrics/aggregation.rs
+++ b/apollo-router/src/metrics/aggregation.rs
@@ -214,12 +214,12 @@ impl<T: Copy> SyncCounter<T> for AggregateCounter<T> {
 }
 
 pub(crate) struct AggregateObservableCounter<T> {
-    delegates: Vec<ObservableCounter<T>>,
+    delegates: Vec<(ObservableCounter<T>, Option<DroppingUnregister>)>,
 }
 
 impl<T: Copy> AsyncInstrument<T> for AggregateObservableCounter<T> {
     fn observe(&self, value: T, attributes: &[KeyValue]) {
-        for counter in &self.delegates {
+        for (counter, _) in &self.delegates {
             counter.observe(value, attributes)
         }
     }
@@ -254,12 +254,12 @@ impl<T: Copy> SyncUpDownCounter<T> for AggregateUpDownCounter<T> {
 }
 
 pub(crate) struct AggregateObservableUpDownCounter<T> {
-    delegates: Vec<ObservableUpDownCounter<T>>,
+    delegates: Vec<(ObservableUpDownCounter<T>, Option<DroppingUnregister>)>,
 }
 
 impl<T: Copy> AsyncInstrument<T> for AggregateObservableUpDownCounter<T> {
     fn observe(&self, value: T, attributes: &[KeyValue]) {
-        for counter in &self.delegates {
+        for (counter, _) in &self.delegates {
             counter.observe(value, attributes)
         }
     }
@@ -270,12 +270,12 @@ impl<T: Copy> AsyncInstrument<T> for AggregateObservableUpDownCounter<T> {
 }
 
 pub(crate) struct AggregateObservableGauge<T> {
-    delegates: Vec<ObservableGauge<T>>,
+    delegates: Vec<(ObservableGauge<T>, Option<DroppingUnregister>)>,
 }
 
 impl<T: Copy> AsyncInstrument<T> for AggregateObservableGauge<T> {
     fn observe(&self, measurement: T, attributes: &[KeyValue]) {
-        for gauge in &self.delegates {
+        for (gauge, _) in &self.delegates {
             gauge.observe(measurement, attributes)
         }
     }
@@ -284,6 +284,60 @@ impl<T: Copy> AsyncInstrument<T> for AggregateObservableGauge<T> {
         unreachable!()
     }
 }
+// Observable instruments don't need to have a ton of optimisation because they are only read on demand.
+macro_rules! aggregate_observable_instrument_fn {
+    ($name:ident, $ty:ty, $wrapper:ident, $implementation:ident) => {
+        fn $name(
+            &self,
+            name: Cow<'static, str>,
+            description: Option<Cow<'static, str>>,
+            unit: Option<Unit>,
+            callback: Vec<Callback<$ty>>,
+        ) -> opentelemetry::metrics::Result<$wrapper<$ty>> {
+            let callback: Vec<Arc<Callback<$ty>>> =
+                callback.into_iter().map(|c| Arc::new(c)).collect_vec();
+            let delegates = self
+                .meters
+                .iter()
+                .map(|meter| {
+                    let mut builder = meter.$name(name.clone());
+                    if let Some(description) = &description {
+                        builder = builder.with_description(description.clone());
+                    }
+                    if let Some(unit) = &unit {
+                        builder = builder.with_unit(unit.clone());
+                    }
+                    // We must not set callback in the builder as it will leak memory.
+                    // Instead we use callback registration on the meter provider as it allows unregistration
+                    // Also we need to filter out no-op instruments as passing these to the meter provider as these will fail witha crptic message about different implementation.
+                    // Confusingly the implementation of as_any() on an instrument will return 'other stuff'. In particular no-ops return Arc<()>. This is why we need to check for this.
+                    let delegate: $wrapper<$ty> = builder.try_init()?;
+                    let registration = if delegate.clone().as_any().downcast_ref::<()>().is_some() {
+                        // This is a no-op instrument, so we don't need to register a callback.
+                        None
+                    } else {
+                        let delegate = delegate.clone();
+                        let callback = callback.clone();
+                        Some(
+                            meter.register_callback(&[delegate.clone().as_any()], move |_| {
+                                for callback in &callback {
+                                    callback(&delegate);
+                                }
+                            })?,
+                        )
+                    };
+                    let result: opentelemetry::metrics::Result<_> =
+                        Ok((delegate, registration.map(DroppingUnregister)));
+                    result
+                })
+                .try_collect()?;
+            Ok($wrapper::new(Arc::new($implementation { delegates })))
+        }
+    };
+}
+
+struct DroppingUnregister(Box<dyn CallbackRegistration>);
+
 macro_rules! aggregate_instrument_fn {
     ($name:ident, $ty:ty, $wrapper:ident, $implementation:ident) => {
         fn $name(
@@ -310,40 +364,12 @@ macro_rules! aggregate_instrument_fn {
         }
     };
 }
-
-// Observable instruments don't need to have a ton of optimisation because they are only read on demand.
-macro_rules! aggregate_observable_instrument_fn {
-    ($name:ident, $ty:ty, $wrapper:ident, $implementation:ident) => {
-        fn $name(
-            &self,
-            name: Cow<'static, str>,
-            description: Option<Cow<'static, str>>,
-            unit: Option<Unit>,
-            callback: Vec<Callback<$ty>>,
-        ) -> opentelemetry::metrics::Result<$wrapper<$ty>> {
-            let callback: Vec<Arc<Callback<$ty>>> =
-                callback.into_iter().map(|c| Arc::new(c)).collect_vec();
-            let delegates = self
-                .meters
-                .iter()
-                .map(|p| {
-                    let mut b = p.$name(name.clone());
-                    if let Some(description) = &description {
-                        b = b.with_description(description.clone());
-                    }
-                    if let Some(unit) = &unit {
-                        b = b.with_unit(unit.clone());
-                    }
-                    for callback in &callback {
-                        let callback = callback.clone();
-                        b = b.with_callback(move |c| (*callback)(c));
-                    }
-                    b.try_init()
-                })
-                .try_collect()?;
-            Ok($wrapper::new(Arc::new($implementation { delegates })))
+impl Drop for DroppingUnregister {
+    fn drop(&mut self) {
+        if let Err(e) = self.0.unregister() {
+            ::tracing::error!(error = %e, "failed to unregister callback")
         }
-    };
+    }
 }
 
 impl InstrumentProvider for AggregateInstrumentProvider {
@@ -414,22 +440,11 @@ impl InstrumentProvider for AggregateInstrumentProvider {
 
     fn register_callback(
         &self,
-        instruments: &[Arc<dyn Any>],
-        callbacks: Box<dyn Fn(&dyn Observer) + Send + Sync>,
+        _instruments: &[Arc<dyn Any>],
+        _callbacks: Box<dyn Fn(&dyn Observer) + Send + Sync>,
     ) -> opentelemetry_api::metrics::Result<Box<dyn CallbackRegistration>> {
-        // The reason that this is OK is that calling observe outside of a callback is a no-op.
-        // So the callback is called, an observable is updated, but only the observable associated with the correct meter will take effect
-
-        let callback = Arc::new(callbacks);
-        let mut callback_registrations = Vec::with_capacity(self.meters.len());
-        for meter in &self.meters {
-            let callback = callback.clone();
-            // If this fails there is no recovery as some callbacks may be registered
-            callback_registrations.push(meter.register_callback(instruments, move |c| callback(c))?)
-        }
-        Ok(Box::new(AggregatedCallbackRegistrations(
-            callback_registrations,
-        )))
+        // We may implement this in future, but for now we don't need it and it's a pain to implement because we need to unwrap the aggregate instruments and pass them to the meter provider that owns them.
+        unimplemented!("register_callback is not supported on AggregateInstrumentProvider");
     }
 }
 
@@ -448,5 +463,214 @@ impl CallbackRegistration for AggregatedCallbackRegistrations {
         } else {
             Err(MetricsError::Other(format!("{errors:?}")))
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::atomic::AtomicI64;
+    use std::sync::Arc;
+    use std::sync::Weak;
+
+    use opentelemetry::sdk::metrics::data::Gauge;
+    use opentelemetry::sdk::metrics::data::ResourceMetrics;
+    use opentelemetry::sdk::metrics::data::Temporality;
+    use opentelemetry::sdk::metrics::reader::AggregationSelector;
+    use opentelemetry::sdk::metrics::reader::MetricProducer;
+    use opentelemetry::sdk::metrics::reader::MetricReader;
+    use opentelemetry::sdk::metrics::reader::TemporalitySelector;
+    use opentelemetry::sdk::metrics::Aggregation;
+    use opentelemetry::sdk::metrics::InstrumentKind;
+    use opentelemetry::sdk::metrics::ManualReader;
+    use opentelemetry::sdk::metrics::MeterProviderBuilder;
+    use opentelemetry::sdk::metrics::Pipeline;
+    use opentelemetry_api::metrics::MeterProvider;
+    use opentelemetry_api::metrics::Result;
+    use opentelemetry_api::Context;
+
+    use crate::metrics::aggregation::AggregateMeterProvider;
+    use crate::metrics::aggregation::MeterProviderType;
+    use crate::metrics::filter::FilterMeterProvider;
+
+    #[derive(Clone, Debug)]
+    struct SharedReader(Arc<ManualReader>);
+
+    impl TemporalitySelector for SharedReader {
+        fn temporality(&self, kind: InstrumentKind) -> Temporality {
+            self.0.temporality(kind)
+        }
+    }
+
+    impl AggregationSelector for SharedReader {
+        fn aggregation(&self, kind: InstrumentKind) -> Aggregation {
+            self.0.aggregation(kind)
+        }
+    }
+
+    impl MetricReader for SharedReader {
+        fn register_pipeline(&self, pipeline: Weak<Pipeline>) {
+            self.0.register_pipeline(pipeline)
+        }
+
+        fn register_producer(&self, producer: Box<dyn MetricProducer>) {
+            self.0.register_producer(producer)
+        }
+
+        fn collect(&self, rm: &mut ResourceMetrics) -> Result<()> {
+            self.0.collect(rm)
+        }
+
+        fn force_flush(&self, cx: &Context) -> Result<()> {
+            self.0.force_flush(cx)
+        }
+
+        fn shutdown(&self) -> Result<()> {
+            self.0.shutdown()
+        }
+    }
+
+    #[test]
+    fn test_i64_gauge_drop() {
+        let reader = SharedReader(Arc::new(ManualReader::builder().build()));
+
+        let delegate = MeterProviderBuilder::default()
+            .with_reader(reader.clone())
+            .build();
+        let meter_provider = AggregateMeterProvider::default();
+        meter_provider.set(
+            MeterProviderType::Public,
+            Some(FilterMeterProvider::public_metrics(delegate)),
+        );
+        let meter = meter_provider.meter("test");
+
+        let observe_counter = Arc::new(AtomicI64::new(0));
+        let callback_observe_counter = observe_counter.clone();
+        let gauge = meter
+            .i64_observable_gauge("test")
+            .with_callback(move |i| {
+                let count =
+                    callback_observe_counter.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                i.observe(count + 1, &[])
+            })
+            .init();
+
+        let mut result = ResourceMetrics {
+            resource: Default::default(),
+            scope_metrics: Default::default(),
+        };
+
+        // Fetching twice will call the observer twice
+        reader
+            .collect(&mut result)
+            .expect("metrics must be collected");
+        reader
+            .collect(&mut result)
+            .expect("metrics must be collected");
+
+        assert_eq!(get_gauge_value(&mut result), 2);
+
+        // Dropping the gauge should remove the observer registration
+        drop(gauge);
+
+        // No further increment will happen
+        reader
+            .collect(&mut result)
+            .expect("metrics must be collected");
+
+        assert_eq!(observe_counter.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn test_i64_gauge_lifecycle() {
+        let reader = SharedReader(Arc::new(ManualReader::builder().build()));
+
+        let delegate = MeterProviderBuilder::default()
+            .with_reader(reader.clone())
+            .build();
+        let meter_provider = AggregateMeterProvider::default();
+        meter_provider.set(
+            MeterProviderType::Public,
+            Some(FilterMeterProvider::public_metrics(delegate)),
+        );
+        let meter = meter_provider.meter("test");
+
+        let observe_counter = Arc::new(AtomicI64::new(0));
+        let callback_observe_counter1 = observe_counter.clone();
+        let callback_observe_counter2 = observe_counter.clone();
+        let gauge1 = meter
+            .i64_observable_gauge("test")
+            .with_callback(move |i| {
+                let count =
+                    callback_observe_counter1.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                i.observe(count + 1, &[])
+            })
+            .init();
+
+        let mut result = ResourceMetrics {
+            resource: Default::default(),
+            scope_metrics: Default::default(),
+        };
+
+        // Fetching metrics will call the observer
+        reader
+            .collect(&mut result)
+            .expect("metrics must be collected");
+
+        assert_eq!(get_gauge_value(&mut result), 1);
+        drop(gauge1);
+
+        // The first gauge is dropped, let's create a new one
+        let gauge2 = meter
+            .i64_observable_gauge("test")
+            .with_callback(move |i| {
+                let count =
+                    callback_observe_counter2.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                i.observe(count + 1, &[])
+            })
+            .init();
+
+        // Fetching metrics will call the observer ONLY on the remaining gauge
+        reader
+            .collect(&mut result)
+            .expect("metrics must be collected");
+
+        assert_eq!(get_gauge_value(&mut result), 2);
+        drop(gauge2);
+    }
+
+    fn get_gauge_value(result: &mut ResourceMetrics) -> i64 {
+        assert_eq!(result.scope_metrics.len(), 1);
+        assert_eq!(result.scope_metrics.get(0).unwrap().metrics.len(), 1);
+        assert_eq!(
+            result
+                .scope_metrics
+                .get(0)
+                .unwrap()
+                .metrics
+                .get(0)
+                .unwrap()
+                .data
+                .as_any()
+                .downcast_ref::<Gauge<i64>>()
+                .unwrap()
+                .data_points
+                .len(),
+            1
+        );
+        result
+            .scope_metrics
+            .get(0)
+            .unwrap()
+            .metrics
+            .get(0)
+            .unwrap()
+            .data
+            .as_any()
+            .downcast_ref::<Gauge<i64>>()
+            .unwrap()
+            .data_points
+            .get(0)
+            .unwrap()
+            .value
     }
 }

--- a/apollo-router/src/metrics/mod.rs
+++ b/apollo-router/src/metrics/mod.rs
@@ -855,7 +855,8 @@ mod test {
 
     #[test]
     fn test_gauge() {
-        meter_provider()
+        // Observables are cleaned up when they dropped, so keep this around.
+        let _gauge = meter_provider()
             .meter("test")
             .u64_observable_gauge("test")
             .with_callback(|m| m.observe(5, &[]))


### PR DESCRIPTION
When observable metrics are created any callbacks are registered with the metrics pipeline. They are never cleaned up. This means that we may slowly leak memory if this feature is ever used.

Currently the metrics layer does NOT use this and instead calls `observe` directly on gauges. This means that we don't currently leak, but this shouldn't actually work as according to the rust docs for `observe`:

```
Records the state of the instrument.
It is only valid to call this within a callback. If called outside of the registered callback it should have no effect on the instrument, and an error will be reported via the error handler.
```

Fixing this means that we get rid of the thread that is constantly refreshing gauges between exports.

Fixes #4352

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
