### PR TITLE
docs(telemetry): display docs for experimental_when_header

### DIFF
--- a/.changesets/docs_bnjjj_fix_4342.md
+++ b/.changesets/docs_bnjjj_fix_4342.md
@@ -1,5 +1,5 @@
-### docs(telemetry): display docs for `experimental_when_header` ([Issue #4342](https://github.com/apollographql/router/issues/4342))
+### Document `experimental_when_header` logging configuration option ([Issue #4342](https://github.com/apollographql/router/issues/4342))
 
-Put back the documentation about `experimental_when_header` configuration for logging.
+In the router v1.35.0, the experimental logging configuration option `experimental_when_header` was supported but not documented. Its documentation has been added [here](https://apollographql.com/docs/router/configuration/telemetry/exporters/logging/overview#requestresponse-logging).
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/4359

--- a/.changesets/docs_bnjjj_fix_4342.md
+++ b/.changesets/docs_bnjjj_fix_4342.md
@@ -1,0 +1,5 @@
+### docs(telemetry): display docs for `experimental_when_header` ([Issue #4342](https://github.com/apollographql/router/issues/4342))
+
+Put back the documentation about `experimental_when_header` configuration for logging.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/4359

--- a/docs/source/configuration/telemetry/exporters/logging/overview.mdx
+++ b/docs/source/configuration/telemetry/exporters/logging/overview.mdx
@@ -142,10 +142,10 @@ For OpenTelemetry conventions for resources, see [Resource Semantic Conventions]
 
 ### Request/Response logging
 
-> This is part of an experimental feature, it means any time until it's stabilized (without the prefix `experimental_`) we might change the configuration shape or adding/removing features.
-> If you want to give feedback or participate in that feature feel free to join [this discussion on GitHub](https://github.com/apollographql/router/discussions/1961).
+<ExperimentalFeature appendText="If you want to give feedback or participate in the feature, feel free to join [the discussion on GitHub](https://github.com/apollographql/router/discussions/1961)." />
 
-By default, the router _doesn't_ log certain values that might contain sensitive data, even if a sufficient log level is set:
+
+By default, the router _doesn't_ log the following values that might contain sensitive data, even if a sufficient log level is set:
 
  - Request bodies
  - Response bodies

--- a/docs/source/configuration/telemetry/exporters/logging/overview.mdx
+++ b/docs/source/configuration/telemetry/exporters/logging/overview.mdx
@@ -140,6 +140,35 @@ telemetry:
 
 For OpenTelemetry conventions for resources, see [Resource Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/resource/README.md).
 
+### Request/Response logging
+
+> This is part of an experimental feature, it means any time until it's stabilized (without the prefix `experimental_`) we might change the configuration shape or adding/removing features.
+> If you want to give feedback or participate in that feature feel free to join [this discussion on GitHub](https://github.com/apollographql/router/discussions/1961).
+
+By default, the router _doesn't_ log certain values that might contain sensitive data, even if a sufficient log level is set:
+
+ - Request bodies
+ - Response bodies
+ - Headers 
+
+You can enable selective logging of these values via the `experimental_when_header` option:
+
+```yaml title="router.yaml"
+telemetry:
+  exporters:
+    logging:
+      # If one of these headers matches we will log supergraph and subgraphs requests/responses
+      experimental_when_header:
+        - name: apollo-router-log-request
+          value: my_client
+          headers: true # default: false
+          body: true # default: false
+        # log request for all requests coming from Iphones
+        - name: user-agent
+          match: ^Mozilla/5.0 (iPhone*
+          headers: true
+```
+
 ## Logging common reference
 
 | Attribute           | Default                  | Description                                                   |


### PR DESCRIPTION
Put back the documentation about `experimental_when_header` configuration for logging.

Fixes #4342
