### PR TITLE
fix: update telemetry config in helm chart

### DIFF
--- a/.changesets/maint_lb_helm_chart_deprecated_config.md
+++ b/.changesets/maint_lb_helm_chart_deprecated_config.md
@@ -1,0 +1,8 @@
+### fix: update telemetry config in helm chart ([PR #4360](https://github.com/apollographql/router/pull/4360))
+
+Before this change, if using the new `telemetry` configuration (notably `telemetry.exporters`), the helm chart would result in both old and new configuration at the same time. This is invalid and would prevent the router from starting up. With this change, the helm chart will output the appropriate structure based on user-provided configuration.
+
+<!-- start metadata -->
+---
+
+By [@lennyburdette](https://github.com/lennyburdette) in https://github.com/apollographql/router/pull/4360

--- a/helm/chart/router/templates/_helpers.tpl
+++ b/helm/chart/router/templates/_helpers.tpl
@@ -93,8 +93,8 @@ Usage:
 {{- end -}}
 
 {{- define "router.prometheusMetricsPath" -}}
-{{- if ((((.Values.router).configuration).telemetry).metrics).prometheus }}
-{{- .Values.router.configuration.telemetry.metrics.prometheus.path | quote }}
+{{- if (((((.Values.router).configuration).telemetry).exporters).metrics).prometheus }}
+{{- .Values.router.configuration.telemetry.exporters.metrics.prometheus.path | quote }}
 {{- else -}}
 "/metrics"
 {{- end }}

--- a/helm/chart/router/templates/_helpers.tpl
+++ b/helm/chart/router/templates/_helpers.tpl
@@ -93,8 +93,11 @@ Usage:
 {{- end -}}
 
 {{- define "router.prometheusMetricsPath" -}}
+{{/* NOTE: metrics configuration moved under telemetry.exporters in Router 1.35.0 */}}
 {{- if (((((.Values.router).configuration).telemetry).exporters).metrics).prometheus }}
 {{- .Values.router.configuration.telemetry.exporters.metrics.prometheus.path | quote }}
+{{- else if ((((.Values.router).configuration).telemetry).metrics).prometheus }}
+{{- .Values.router.configuration.telemetry.metrics.prometheus.path | quote }}
 {{- else -}}
 "/metrics"
 {{- end }}

--- a/helm/chart/router/templates/configmap.yaml
+++ b/helm/chart/router/templates/configmap.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.router.configuration }}
 {{- $routerFullName := include "router.fullname" .  -}}
-{{- $configuration := dict "telemetry" (dict "metrics" (dict "common" (dict "resources" (dict "service.name" $routerFullName)))) -}}
+{{- $configuration := dict "telemetry" (dict "exporters" (dict "metrics" (dict "common" (dict "resource" (dict "service.name" $routerFullName))))) -}}
 {{- $_ := mustMergeOverwrite $configuration .Values.router.configuration  -}}
 
 apiVersion: v1

--- a/helm/chart/router/templates/configmap.yaml
+++ b/helm/chart/router/templates/configmap.yaml
@@ -1,9 +1,11 @@
 {{- if .Values.router.configuration }}
 {{- $routerFullName := include "router.fullname" .  -}}
 {{/* NOTE: metrics configuration moved under telemetry.exporters in Router 1.35.0 */}}
-{{- $configuration := dict "telemetry" (dict "metrics" (dict "common" (dict "resources" (dict "service.name" $routerFullName)))) -}}
-{{- if (and .Values.router.configuration.telemetry .Values.router.configuration.telemetry.exporters) }}
+{{- $configuration := dict }}
+{{- if (.Values.router.configuration.telemetry).exporters }}
 {{- $configuration = dict "telemetry" (dict "exporters" (dict "metrics" (dict "common" (dict "resource" (dict "service.name" $routerFullName))))) -}}
+{{- else }}
+{{- $configuration := dict "telemetry" (dict "metrics" (dict "common" (dict "resources" (dict "service.name" $routerFullName)))) -}}
 {{- end }}
 {{- $_ := mustMergeOverwrite $configuration .Values.router.configuration  -}}
 

--- a/helm/chart/router/templates/configmap.yaml
+++ b/helm/chart/router/templates/configmap.yaml
@@ -2,7 +2,7 @@
 {{- $routerFullName := include "router.fullname" .  -}}
 {{/* NOTE: metrics configuration moved under telemetry.exporters in Router 1.35.0 */}}
 {{- $configuration := dict "telemetry" (dict "metrics" (dict "common" (dict "resources" (dict "service.name" $routerFullName)))) -}}
-{{- if .Values.router.configuration.telemetry.exporters }}
+{{- if (and .Values.router.configuration.telemetry .Values.router.configuration.telemetry.exporters) }}
 {{- $configuration = dict "telemetry" (dict "exporters" (dict "metrics" (dict "common" (dict "resource" (dict "service.name" $routerFullName))))) -}}
 {{- end }}
 {{- $_ := mustMergeOverwrite $configuration .Values.router.configuration  -}}

--- a/helm/chart/router/templates/configmap.yaml
+++ b/helm/chart/router/templates/configmap.yaml
@@ -1,6 +1,10 @@
 {{- if .Values.router.configuration }}
 {{- $routerFullName := include "router.fullname" .  -}}
-{{- $configuration := dict "telemetry" (dict "exporters" (dict "metrics" (dict "common" (dict "resource" (dict "service.name" $routerFullName))))) -}}
+{{/* NOTE: metrics configuration moved under telemetry.exporters in Router 1.35.0 */}}
+{{- $configuration := dict "telemetry" (dict "metrics" (dict "common" (dict "resources" (dict "service.name" $routerFullName)))) -}}
+{{- if .Values.router.configuration.telemetry.exporters }}
+{{- $configuration = dict "telemetry" (dict "exporters" (dict "metrics" (dict "common" (dict "resource" (dict "service.name" $routerFullName))))) -}}
+{{- end }}
 {{- $_ := mustMergeOverwrite $configuration .Values.router.configuration  -}}
 
 apiVersion: v1

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -8,10 +8,10 @@ metadata:
     {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 4 }}
     {{- end }}
   {{/* There may not be much configuration so check that there is something */}}
-  {{- if (((((.Values.router).configuration).telemetry).metrics).prometheus).enabled }}
+  {{- if ((((((.Values.router).configuration).telemetry).exporters).metrics).prometheus).enabled }}
   annotations:
-    prometheus.io/path: {{ .Values.router.configuration.telemetry.metrics.prometheus.path | default "/metrics" }}
-    prometheus.io/port: {{ (splitList ":" .Values.router.configuration.telemetry.metrics.prometheus.listen | last) | default "9090" | quote }}
+    prometheus.io/path: {{ .Values.router.configuration.telemetry.exporters.metrics.prometheus.path | default "/metrics" }}
+    prometheus.io/port: {{ (splitList ":" .Values.router.configuration.telemetry.exporters.metrics.prometheus.listen | last) | default "9090" | quote }}
     prometheus.io/scrape: "true"
   {{- end }}
 spec:

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -8,10 +8,16 @@ metadata:
     {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 4 }}
     {{- end }}
   {{/* There may not be much configuration so check that there is something */}}
+  {{/* NOTE: metrics configuration moved under telemetry.exporters in Router 1.35.0 */}}
   {{- if ((((((.Values.router).configuration).telemetry).exporters).metrics).prometheus).enabled }}
   annotations:
     prometheus.io/path: {{ .Values.router.configuration.telemetry.exporters.metrics.prometheus.path | default "/metrics" }}
     prometheus.io/port: {{ (splitList ":" .Values.router.configuration.telemetry.exporters.metrics.prometheus.listen | last) | default "9090" | quote }}
+    prometheus.io/scrape: "true"
+  {{- else if (((((.Values.router).configuration).telemetry).metrics).prometheus).enabled }}
+  annotations:
+    prometheus.io/path: {{ .Values.router.configuration.telemetry.metrics.prometheus.path | default "/metrics" }}
+    prometheus.io/port: {{ (splitList ":" .Values.router.configuration.telemetry.metrics.prometheus.listen | last) | default "9090" | quote }}
     prometheus.io/scrape: "true"
   {{- end }}
 spec:

--- a/helm/chart/router/templates/service.yaml
+++ b/helm/chart/router/templates/service.yaml
@@ -23,10 +23,18 @@ spec:
       protocol: TCP
       name: health
     {{- if .Values.serviceMonitor.enabled }}
+    {{/* NOTE: metrics configuration moved under telemetry.exporters in Router 1.35.0 */}}
+    {{- if .Values.router.configuration.telemetry.exporters.metrics.prometheus.listen }}
     - port: {{ (splitList ":" .Values.router.configuration.telemetry.exporters.metrics.prometheus.listen | last) | default "9090" }}
       targetPort: metrics
       protocol: TCP
       name: metrics
+    {{- else if .Values.router.configuration.telemetry.metrics.prometheus.listen }}
+    - port: {{ (splitList ":" .Values.router.configuration.telemetry.metrics.prometheus.listen | last) | default "9090" }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
     {{- end }}
   selector:
     {{- include "router.selectorLabels" . | nindent 4 }}

--- a/helm/chart/router/templates/service.yaml
+++ b/helm/chart/router/templates/service.yaml
@@ -23,11 +23,10 @@ spec:
       protocol: TCP
       name: health
     {{- if .Values.serviceMonitor.enabled }}
-    - port: {{ (splitList ":" .Values.router.configuration.telemetry.metrics.prometheus.listen | last) | default "9090" }}
+    - port: {{ (splitList ":" .Values.router.configuration.telemetry.exporters.metrics.prometheus.listen | last) | default "9090" }}
       targetPort: metrics
       protocol: TCP
       name: metrics
     {{- end }}
   selector:
     {{- include "router.selectorLabels" . | nindent 4 }}
-

--- a/helm/chart/router/values.yaml
+++ b/helm/chart/router/values.yaml
@@ -12,14 +12,15 @@ router:
     health_check:
       listen: 0.0.0.0:8088
     telemetry:
-      metrics:
-        prometheus:
-          enabled: false
-          listen: 0.0.0.0:9090
-          path: "/metrics"
+      exporters:
+        metrics:
+          prometheus:
+            enabled: false
+            listen: 0.0.0.0:9090
+            path: "/metrics"
 
   args:
-  - --hot-reload
+    - --hot-reload
 
 managedFederation:
   # -- If using managed federation, the graph API key to identify router to Studio
@@ -43,8 +44,8 @@ supergraphFile:
 #     value: debug
 #
 extraEnvVars: []
-extraEnvVarsCM: ''
-extraEnvVarsSecret: ''
+extraEnvVarsCM: ""
+extraEnvVarsSecret: ""
 
 # An array of extra VolumeMounts
 # Example:
@@ -124,10 +125,12 @@ serviceAccount:
 
 podAnnotations: {}
 
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -146,7 +149,8 @@ serviceMonitor:
 ingress:
   enabled: false
   className: ""
-  annotations: {}
+  annotations:
+    {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   hosts:
@@ -191,7 +195,8 @@ serviceentry:
   # a list of external hosts you want to be able to make https calls to
   #   - api.example.com
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following

--- a/helm/chart/router/values.yaml
+++ b/helm/chart/router/values.yaml
@@ -11,13 +11,6 @@ router:
       listen: 0.0.0.0:4000
     health_check:
       listen: 0.0.0.0:8088
-    telemetry:
-      exporters:
-        metrics:
-          prometheus:
-            enabled: false
-            listen: 0.0.0.0:9090
-            path: "/metrics"
 
   args:
     - --hot-reload


### PR DESCRIPTION
This patch updates the generated router config to avoid a "router configuration contains deprecated options" warning on router startup.

I tested this change against the in house router's chart in three ways:

* As it currently is, using the deprecated shape. The results are the same and the router can start up with it.
* Without any telemetry at all. The resulting config no longer contains `telemetry`.
* After updating telemetry configuration to the new structure. The resulting config is correct and the router no longer spits out deprecation warnings.


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
