### PR TITLE
Fix TLS session ticket retries

### DIFF
--- a/.changesets/fix_geal_update_rustls.md
+++ b/.changesets/fix_geal_update_rustls.md
@@ -1,0 +1,5 @@
+### Fix TLS session ticket retries ([Issue #4305](https://github.com/apollographql/router/issues/4305))
+
+In some cases, the router could retry TLS connections indefinitely with an invalid session ticket, making it impossible to contact a subgraph. rustls 0.21.10 contains a fix for that
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4362

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5908,9 +5908,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.9"
+version = "0.21.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629648aced5775d558af50b2b4c7b02983a04b312126d45eeead26e7caa498b9"
+checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
  "ring 0.17.5",


### PR DESCRIPTION
Fix #4305 
replace https://github.com/apollographql/router/pull/4344

In some cases, the router could retry TLS connection indefinitely with an invalid session ticket, making it impossible to contact a subgraph. rustls 0.21.10 contains a fix for that

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
