### PR TITLE
Adds new metrics for some apollo specific env variables

### DIFF
--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -127,7 +127,7 @@ impl InstrumentData {
             };
             ($($metric:ident).+, $path:literal, $($($attr:ident).+, $attr_path:literal),+) => {
                 let instrument_name = stringify!($($metric).+).to_string();
-                self.data.entry(instrument_name.clone()).or_insert_with(|| {
+                self.data.entry(instrument_name).or_insert_with(|| {
                     if let Some(value) = JsonPathInst::from_str($path).expect("json path must be valid").find_slice(yaml).first() {
                         paste!{
                             let mut attributes = HashMap::new();
@@ -370,7 +370,7 @@ impl From<InstrumentData> for Metrics {
                 .map(|(metric_name, (value, attributes))| {
                     let attributes: Vec<_> = attributes
                         .into_iter()
-                        .map(|(k, v)| KeyValue::new(k.replace("__", "."), v.clone()))
+                        .map(|(k, v)| KeyValue::new(k.replace("__", "."), v))
                         .collect();
                     data.meter
                         .u64_observable_gauge(metric_name)

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -343,22 +343,30 @@ impl InstrumentData {
         }
 
         let mut attributes = HashMap::new();
-        attributes.insert("env.apollo.key".to_string(), env_var_exists("APOLLO_KEY"));
+        attributes.insert("opt.apollo.key".to_string(), env_var_exists("APOLLO_KEY"));
         attributes.insert(
-            "env.apollo.graph_ref".to_string(),
+            "opt.apollo.graph_ref".to_string(),
             env_var_exists("APOLLO_GRAPH_REF"),
         );
         attributes.insert(
-            "env.apollo.license".to_string(),
+            "opt.apollo.license".to_string(),
             env_var_exists("APOLLO_ROUTER_LICENSE"),
         );
         attributes.insert(
-            "env.apollo.license.path".to_string(),
+            "opt.apollo.license.path".to_string(),
             env_var_exists("APOLLO_ROUTER_LICENSE_PATH"),
+        );
+        attributes.insert(
+            "opt.apollo.supergraph.urls".to_string(),
+            env_var_exists("APOLLO_ROUTER_SUPERGRAPH_URLS"),
+        );
+        attributes.insert(
+            "opt.apollo.supergraph.path".to_string(),
+            env_var_exists("APOLLO_ROUTER_SUPERGRAPH_PATH"),
         );
 
         self.data
-            .insert("apollo.router.env".to_string(), (1, attributes));
+            .insert("apollo.router.config.env".to_string(), (1, attributes));
     }
 }
 impl From<InstrumentData> for Metrics {

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -332,11 +332,14 @@ impl InstrumentData {
     fn populate_env_instrument(&mut self) {
         #[cfg(not(test))]
         fn env_var_exists(env_name: &str) -> opentelemetry::Value {
-            std::env::var(env_name).map(|_| 1).unwrap_or(0).into()
+            std::env::var(env_name)
+                .map(|_| true)
+                .unwrap_or(false)
+                .into()
         }
         #[cfg(test)]
         fn env_var_exists(_env_name: &str) -> opentelemetry::Value {
-            1.into()
+            true.into()
         }
 
         let mut attributes = HashMap::new();

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__env_metrics.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__env_metrics.snap
@@ -1,0 +1,14 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.non_zero()"
+---
+- name: apollo.router.env
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          env.apollo.graph_ref: 1
+          env.apollo.key: 1
+          env.apollo.license: 1
+          env.apollo.license.path: 1
+

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__env_metrics.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__env_metrics.snap
@@ -7,8 +7,8 @@ expression: "&metrics.non_zero()"
     datapoints:
       - value: 1
         attributes:
-          env.apollo.graph_ref: 1
-          env.apollo.key: 1
-          env.apollo.license: 1
-          env.apollo.license.path: 1
+          env.apollo.graph_ref: true
+          env.apollo.key: true
+          env.apollo.license: true
+          env.apollo.license.path: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__env_metrics.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__env_metrics.snap
@@ -2,13 +2,15 @@
 source: apollo-router/src/configuration/metrics.rs
 expression: "&metrics.non_zero()"
 ---
-- name: apollo.router.env
+- name: apollo.router.config.env
   data:
     datapoints:
       - value: 1
         attributes:
-          env.apollo.graph_ref: true
-          env.apollo.key: true
-          env.apollo.license: true
-          env.apollo.license.path: true
+          opt.apollo.graph_ref: true
+          opt.apollo.key: true
+          opt.apollo.license: true
+          opt.apollo.license.path: true
+          opt.apollo.supergraph.path: true
+          opt.apollo.supergraph.urls: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@apq.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@apq.router.yaml.snap
@@ -1,10 +1,13 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
-expression: "&metrics.metrics"
+expression: "&metrics.non_zero()"
 ---
-value.apollo.router.config.apq:
-  - 1
-  - opt__router__cache__in_memory__: true
-    opt__router__cache__redis__: true
-    opt__subgraph__: true
+- name: apollo.router.config.apq
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.router.cache.in_memory.: true
+          opt.router.cache.redis.: true
+          opt.subgraph.: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@authorization.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@authorization.router.yaml.snap
@@ -1,9 +1,12 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
-expression: "&metrics.metrics"
+expression: "&metrics.non_zero()"
 ---
-value.apollo.router.config.authorization:
-  - 1
-  - opt__directives__: false
-    opt__require_authentication__: true
+- name: apollo.router.config.authorization
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.directives.: false
+          opt.require_authentication.: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@authorization_directives.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@authorization_directives.router.yaml.snap
@@ -1,9 +1,12 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
-expression: "&metrics.metrics"
+expression: "&metrics.non_zero()"
 ---
-value.apollo.router.config.authorization:
-  - 1
-  - opt__directives__: true
-    opt__require_authentication__: false
+- name: apollo.router.config.authorization
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.directives.: true
+          opt.require_authentication.: false
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@batching.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@batching.router.yaml.snap
@@ -1,8 +1,11 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
-expression: "&metrics.metrics"
+expression: "&metrics.non_zero()"
 ---
-value.apollo.router.config.batching:
-  - 1
-  - opt__mode__: batch_http_link
+- name: apollo.router.config.batching
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.mode.: batch_http_link
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@coprocessor.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@coprocessor.router.yaml.snap
@@ -1,13 +1,16 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
-expression: "&metrics.metrics"
+expression: "&metrics.non_zero()"
 ---
-value.apollo.router.config.coprocessor:
-  - 1
-  - opt__router__request__: true
-    opt__router__response__: true
-    opt__subgraph__request__: true
-    opt__subgraph__response__: true
-    opt__supergraph__request__: true
-    opt__supergraph__response__: true
+- name: apollo.router.config.coprocessor
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.router.request.: true
+          opt.router.response.: true
+          opt.subgraph.request.: true
+          opt.subgraph.response.: true
+          opt.supergraph.request.: true
+          opt.supergraph.response.: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@defer.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@defer.router.yaml.snap
@@ -1,8 +1,10 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
-expression: "&metrics.metrics"
+expression: "&metrics.non_zero()"
 ---
-value.apollo.router.config.defer:
-  - 1
-  - {}
+- name: apollo.router.config.defer
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@entities.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@entities.router.yaml.snap
@@ -1,10 +1,13 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
-expression: "&metrics.metrics"
+expression: "&metrics.non_zero()"
 ---
-value.apollo.router.config.entity_cache:
-  - 1
-  - opt__enabled__: true
-    opt__subgraph__enabled__: true
-    opt__subgraph__ttl__: true
+- name: apollo.router.config.entity_cache
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.enabled.: true
+          opt.subgraph.enabled.: true
+          opt.subgraph.ttl.: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@jwt.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@jwt.router.yaml.snap
@@ -1,8 +1,10 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
-expression: "&metrics.metrics"
+expression: "&metrics.non_zero()"
 ---
-value.apollo.router.config.authentication.jwt:
-  - 1
-  - {}
+- name: apollo.router.config.authentication.jwt
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@limits.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@limits.router.yaml.snap
@@ -1,15 +1,18 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
-expression: "&metrics.metrics"
+expression: "&metrics.non_zero()"
 ---
-value.apollo.router.config.limits:
-  - 1
-  - opt__operation__max_aliases__: true
-    opt__operation__max_depth__: true
-    opt__operation__max_height__: true
-    opt__operation__max_root_fields__: true
-    opt__operation__warn_only__: true
-    opt__parser__max_recursion__: true
-    opt__parser__max_tokens__: true
-    opt__request__max_size__: true
+- name: apollo.router.config.limits
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.operation.max_aliases.: true
+          opt.operation.max_depth.: true
+          opt.operation.max_height.: true
+          opt.operation.max_root_fields.: true
+          opt.operation.warn_only.: true
+          opt.parser.max_recursion.: true
+          opt.parser.max_tokens.: true
+          opt.request.max_size.: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@persisted_queries.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@persisted_queries.router.yaml.snap
@@ -1,10 +1,13 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
-expression: "&metrics.metrics"
+expression: "&metrics.non_zero()"
 ---
-value.apollo.router.config.persisted_queries:
-  - 1
-  - opt__log_unknown__: true
-    opt__safelist__enabled__: true
-    opt__safelist__require_id__: true
+- name: apollo.router.config.persisted_queries
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.log_unknown.: true
+          opt.safelist.enabled.: true
+          opt.safelist.require_id.: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@sigv4.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@sigv4.router.yaml.snap
@@ -1,8 +1,10 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
-expression: "&metrics.metrics"
+expression: "&metrics.non_zero()"
 ---
-value.apollo.router.config.authentication.aws.sigv4:
-  - 1
-  - {}
+- name: apollo.router.config.authentication.aws.sigv4
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@subscriptions.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@subscriptions.router.yaml.snap
@@ -1,12 +1,15 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
-expression: "&metrics.metrics"
+expression: "&metrics.non_zero()"
 ---
-value.apollo.router.config.subscriptions:
-  - 1
-  - opt__deduplication__: false
-    opt__max_opened__: true
-    opt__mode__callback__: true
-    opt__mode__passthrough__: true
-    opt__queue_capacity__: true
+- name: apollo.router.config.subscriptions
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.deduplication.: false
+          opt.max_opened.: true
+          opt.mode.callback.: true
+          opt.mode.passthrough.: true
+          opt.queue_capacity.: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@telemetry.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@telemetry.router.yaml.snap
@@ -1,22 +1,25 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
-expression: "&metrics.metrics"
+expression: "&metrics.non_zero()"
 ---
-value.apollo.router.config.telemetry:
-  - 1
-  - opt__events__: false
-    opt__instruments__: false
-    opt__logging__experimental_when_header__: true
-    opt__metrics__otlp__: true
-    opt__metrics__prometheus__: true
-    opt__spans__: true
-    opt__spans__default_attribute_requirement_level__: recommended
-    opt__spans__mode__: spec_compliant
-    opt__spans__router__: true
-    opt__spans__subgraph__: true
-    opt__spans__supergraph__: true
-    opt__tracing__datadog__: true
-    opt__tracing__jaeger__: true
-    opt__tracing__otlp__: true
-    opt__tracing__zipkin__: true
+- name: apollo.router.config.telemetry
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.events.: false
+          opt.instruments.: false
+          opt.logging.experimental_when_header.: true
+          opt.metrics.otlp.: true
+          opt.metrics.prometheus.: true
+          opt.spans.: true
+          opt.spans.default_attribute_requirement_level.: recommended
+          opt.spans.mode.: spec_compliant
+          opt.spans.router.: true
+          opt.spans.subgraph.: true
+          opt.spans.supergraph.: true
+          opt.tracing.datadog.: true
+          opt.tracing.jaeger.: true
+          opt.tracing.otlp.: true
+          opt.tracing.zipkin.: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@tls.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@tls.router.yaml.snap
@@ -1,10 +1,13 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
-expression: "&metrics.metrics"
+expression: "&metrics.non_zero()"
 ---
-value.apollo.router.config.tls:
-  - 1
-  - opt__router__tls__server__: true
-    opt__router__tls__subgraph__ca_override__: true
-    opt__router__tls__subgraph__client_authentication__: true
+- name: apollo.router.config.tls
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.router.tls.server.: true
+          opt.router.tls.subgraph.ca_override.: true
+          opt.router.tls.subgraph.client_authentication.: true
 

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@traffic_shaping.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@traffic_shaping.router.yaml.snap
@@ -1,15 +1,18 @@
 ---
 source: apollo-router/src/configuration/metrics.rs
-expression: "&metrics.metrics"
+expression: "&metrics.non_zero()"
 ---
-value.apollo.router.config.traffic_shaping:
-  - 1
-  - opt__router__rate_limit__: true
-    opt__router__timeout__: true
-    opt__subgraph__compression__: true
-    opt__subgraph__deduplicate_query__: true
-    opt__subgraph__http2__: true
-    opt__subgraph__rate_limit__: true
-    opt__subgraph__retry__: true
-    opt__subgraph__timeout__: true
+- name: apollo.router.config.traffic_shaping
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.router.rate_limit.: true
+          opt.router.timeout.: true
+          opt.subgraph.compression.: true
+          opt.subgraph.deduplicate_query.: true
+          opt.subgraph.http2.: true
+          opt.subgraph.rate_limit.: true
+          opt.subgraph.retry.: true
+          opt.subgraph.timeout.: true
 

--- a/apollo-router/src/metrics/aggregation.rs
+++ b/apollo-router/src/metrics/aggregation.rs
@@ -539,7 +539,7 @@ mod test {
         let meter_provider = AggregateMeterProvider::default();
         meter_provider.set(
             MeterProviderType::Public,
-            Some(FilterMeterProvider::public_metrics(delegate)),
+            Some(FilterMeterProvider::public(delegate)),
         );
         let meter = meter_provider.meter("test");
 
@@ -590,7 +590,7 @@ mod test {
         let meter_provider = AggregateMeterProvider::default();
         meter_provider.set(
             MeterProviderType::Public,
-            Some(FilterMeterProvider::public_metrics(delegate)),
+            Some(FilterMeterProvider::public(delegate)),
         );
         let meter = meter_provider.meter("test");
 

--- a/apollo-router/src/metrics/filter.rs
+++ b/apollo-router/src/metrics/filter.rs
@@ -43,7 +43,7 @@ impl FilterMeterProvider {
         }
     }
 
-    pub(crate) fn private_metrics(delegate: opentelemetry::sdk::metrics::MeterProvider) -> Self {
+    pub(crate) fn private(delegate: opentelemetry::sdk::metrics::MeterProvider) -> Self {
         FilterMeterProvider::builder()
             .delegate(delegate)
             .allow(
@@ -55,7 +55,7 @@ impl FilterMeterProvider {
             .build()
     }
 
-    pub(crate) fn public_metrics(delegate: opentelemetry::sdk::metrics::MeterProvider) -> Self {
+    pub(crate) fn public(delegate: opentelemetry::sdk::metrics::MeterProvider) -> Self {
         FilterMeterProvider::builder()
             .delegate(delegate)
             .deny(
@@ -63,6 +63,11 @@ impl FilterMeterProvider {
                     .expect("regex should have been valid"),
             )
             .build()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn all(delegate: opentelemetry::sdk::metrics::MeterProvider) -> Self {
+        FilterMeterProvider::builder().delegate(delegate).build()
     }
 
     pub(crate) fn shutdown(&self) -> opentelemetry::metrics::Result<()> {
@@ -208,7 +213,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_private_metrics() {
         let exporter = InMemoryMetricsExporter::default();
-        let meter_provider = FilterMeterProvider::private_metrics(
+        let meter_provider = FilterMeterProvider::private(
             MeterProviderBuilder::default()
                 .with_reader(PeriodicReader::builder(exporter.clone(), runtime::Tokio).build())
                 .build(),
@@ -258,7 +263,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_public_metrics() {
         let exporter = InMemoryMetricsExporter::default();
-        let meter_provider = FilterMeterProvider::public_metrics(
+        let meter_provider = FilterMeterProvider::public(
             MeterProviderBuilder::default()
                 .with_reader(PeriodicReader::builder(exporter.clone(), runtime::Tokio).build())
                 .build(),
@@ -304,7 +309,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_description_and_unit() {
         let exporter = InMemoryMetricsExporter::default();
-        let meter_provider = FilterMeterProvider::private_metrics(
+        let meter_provider = FilterMeterProvider::private(
             MeterProviderBuilder::default()
                 .with_reader(PeriodicReader::builder(exporter.clone(), runtime::Tokio).build())
                 .build(),

--- a/apollo-router/src/metrics/mod.rs
+++ b/apollo-router/src/metrics/mod.rs
@@ -17,6 +17,8 @@ pub(crate) mod layer;
 
 #[cfg(test)]
 pub(crate) mod test_utils {
+    use std::cmp::Ordering;
+    use std::collections::BTreeMap;
     use std::fmt::Debug;
     use std::fmt::Display;
     use std::sync::Arc;
@@ -26,8 +28,11 @@ pub(crate) mod test_utils {
     use itertools::Itertools;
     use num_traits::NumCast;
     use num_traits::ToPrimitive;
+    use opentelemetry::sdk::metrics::data::DataPoint;
     use opentelemetry::sdk::metrics::data::Gauge;
     use opentelemetry::sdk::metrics::data::Histogram;
+    use opentelemetry::sdk::metrics::data::HistogramDataPoint;
+    use opentelemetry::sdk::metrics::data::Metric;
     use opentelemetry::sdk::metrics::data::ResourceMetrics;
     use opentelemetry::sdk::metrics::data::Sum;
     use opentelemetry::sdk::metrics::data::Temporality;
@@ -45,6 +50,7 @@ pub(crate) mod test_utils {
     use opentelemetry::KeyValue;
     use opentelemetry::Value;
     use opentelemetry_api::Context;
+    use serde::Serialize;
     use tokio::task_local;
 
     use crate::metrics::aggregation::AggregateMeterProvider;
@@ -102,7 +108,7 @@ pub(crate) mod test_utils {
 
             meter_provider.set(
                 MeterProviderType::Public,
-                Some(FilterMeterProvider::public_metrics(
+                Some(FilterMeterProvider::all(
                     MeterProviderBuilder::default()
                         .with_reader(reader.clone())
                         .build(),
@@ -176,132 +182,27 @@ pub(crate) mod test_utils {
             ty: MetricType,
             value: T,
             attributes: &[KeyValue],
-        ) {
+        ) -> bool {
             let attributes = AttributeSet::from(attributes);
             if let Some(value) = value.to_u64() {
                 if self.metric_exists(name, &ty, value, &attributes) {
-                    return;
+                    return true;
                 }
             }
 
             if let Some(value) = value.to_i64() {
                 if self.metric_exists(name, &ty, value, &attributes) {
-                    return;
+                    return true;
                 }
             }
 
             if let Some(value) = value.to_f64() {
                 if self.metric_exists(name, &ty, value, &attributes) {
-                    return;
+                    return true;
                 }
             }
 
-            self.panic_metric_not_found(name, value, &attributes);
-        }
-
-        fn panic_metric_not_found<T: Display + 'static>(
-            &self,
-            name: &str,
-            value: T,
-            attributes: &AttributeSet,
-        ) {
-            panic!(
-                "metric: {}, {}, {} not found.\nMetrics that were found:\n{}",
-                name,
-                value,
-                Self::pretty_attributes(attributes),
-                self.resource_metrics
-                    .scope_metrics
-                    .iter()
-                    .flat_map(|scope_metrics| { scope_metrics.metrics.iter() })
-                    .flat_map(|metric| { Self::pretty_metric(metric) })
-                    .map(|metric| { format!("  {}", metric) })
-                    .join("\n")
-            )
-        }
-
-        fn pretty_metric(metric: &opentelemetry::sdk::metrics::data::Metric) -> Vec<String> {
-            let mut results = Vec::new();
-            results.append(&mut Self::pretty_data_point::<u64>(metric));
-            results.append(&mut Self::pretty_data_point::<i64>(metric));
-            results.append(&mut Self::pretty_data_point::<f64>(metric));
-            results
-        }
-
-        fn pretty_data_point<T: Display + 'static>(
-            metric: &opentelemetry::sdk::metrics::data::Metric,
-        ) -> Vec<String> {
-            let mut results = Vec::new();
-            if let Some(gauge) = metric.data.as_any().downcast_ref::<Gauge<T>>() {
-                for datapoint in gauge.data_points.iter() {
-                    results.push(format!(
-                        "\"{}\", {}, {}",
-                        metric.name,
-                        datapoint.value,
-                        Self::pretty_attributes(&datapoint.attributes)
-                    ));
-                }
-            }
-            if let Some(sum) = metric.data.as_any().downcast_ref::<Sum<T>>() {
-                for datapoint in sum.data_points.iter() {
-                    results.push(format!(
-                        "\"{}\", {}, {}",
-                        metric.name,
-                        datapoint.value,
-                        Self::pretty_attributes(&datapoint.attributes)
-                    ));
-                }
-            }
-            if let Some(histogram) = metric.data.as_any().downcast_ref::<Histogram<T>>() {
-                for datapoint in histogram.data_points.iter() {
-                    results.push(format!(
-                        "\"{}\", {}, {}",
-                        metric.name,
-                        datapoint.sum,
-                        Self::pretty_attributes(&datapoint.attributes)
-                    ));
-                }
-            }
-
-            results
-        }
-
-        fn pretty_attributes(attributes: &AttributeSet) -> String {
-            attributes
-                .iter()
-                .map(|(key, value)| {
-                    format!(
-                        "\"{}\" => {}",
-                        key.as_str(),
-                        match value {
-                            Value::Bool(v) => {
-                                v.to_string()
-                            }
-                            Value::I64(v) => {
-                                v.to_string()
-                            }
-                            Value::F64(v) => {
-                                format!("{}f64", v)
-                            }
-                            Value::String(v) => {
-                                format!("\"{}\"", v)
-                            }
-                            Value::Array(Array::Bool(v)) => {
-                                format!("[{}]", v.iter().map(|v| v.to_string()).join(", "))
-                            }
-                            Value::Array(Array::F64(v)) => {
-                                format!("[{}]", v.iter().map(|v| format!("{}f64", v)).join(", "))
-                            }
-                            Value::Array(Array::I64(v)) => {
-                                format!("[{}]", v.iter().map(|v| v.to_string()).join(", "))
-                            }
-                            Value::Array(Array::String(v)) => {
-                                format!("[{}]", v.iter().map(|v| format!("\"{}\"", v)).join(", "))
-                            }
-                        }
-                    )
-                })
-                .join(", ")
+            false
         }
 
         fn metric_exists<T: Debug + PartialEq + Display + ToPrimitive + 'static>(
@@ -339,6 +240,171 @@ pub(crate) mod test_utils {
                 }
             }
             false
+        }
+
+        #[allow(dead_code)]
+        pub(crate) fn all(self) -> Vec<SerdeMetric> {
+            self.resource_metrics
+                .scope_metrics
+                .into_iter()
+                .flat_map(|scope_metrics| {
+                    scope_metrics.metrics.into_iter().map(|metric| {
+                        let serde_metric: SerdeMetric = metric.into();
+                        serde_metric
+                    })
+                })
+                .sorted()
+                .collect()
+        }
+
+        #[allow(dead_code)]
+        pub(crate) fn non_zero(self) -> Vec<SerdeMetric> {
+            self.all()
+                .into_iter()
+                .filter(|m| {
+                    m.data.datapoints.iter().any(|d| {
+                        d.value
+                            .as_ref()
+                            .map(|v| v.as_f64().unwrap_or_default() > 0.0)
+                            .unwrap_or_default()
+                            || d.sum
+                                .as_ref()
+                                .map(|v| v.as_f64().unwrap_or_default() > 0.0)
+                                .unwrap_or_default()
+                    })
+                })
+                .collect()
+        }
+    }
+
+    #[derive(Serialize, Eq, PartialEq)]
+    pub(crate) struct SerdeMetric {
+        pub(crate) name: String,
+        #[serde(skip_serializing_if = "String::is_empty")]
+        pub(crate) description: String,
+        #[serde(skip_serializing_if = "String::is_empty")]
+        pub(crate) unit: String,
+        pub(crate) data: SerdeMetricData,
+    }
+
+    impl Ord for SerdeMetric {
+        fn cmp(&self, other: &Self) -> Ordering {
+            self.name.cmp(&other.name)
+        }
+    }
+
+    impl PartialOrd for SerdeMetric {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+
+    #[derive(Serialize, Eq, PartialEq, Default)]
+    pub(crate) struct SerdeMetricData {
+        pub(crate) datapoints: Vec<SerdeMetricDataPoint>,
+    }
+
+    #[derive(Serialize, Eq, PartialEq)]
+    pub(crate) struct SerdeMetricDataPoint {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub(crate) value: Option<serde_json::Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub(crate) sum: Option<serde_json::Value>,
+        pub(crate) attributes: BTreeMap<String, serde_json::Value>,
+    }
+
+    impl SerdeMetricData {
+        fn extract_datapoints<T: Into<serde_json::Value> + Clone + 'static>(
+            metric_data: &mut SerdeMetricData,
+            value: &dyn opentelemetry::sdk::metrics::data::Aggregation,
+        ) {
+            if let Some(gauge) = value.as_any().downcast_ref::<Gauge<T>>() {
+                gauge.data_points.iter().for_each(|datapoint| {
+                    metric_data.datapoints.push(datapoint.into());
+                });
+            }
+            if let Some(sum) = value.as_any().downcast_ref::<Sum<T>>() {
+                sum.data_points.iter().for_each(|datapoint| {
+                    metric_data.datapoints.push(datapoint.into());
+                });
+            }
+            if let Some(histogram) = value.as_any().downcast_ref::<Histogram<T>>() {
+                histogram.data_points.iter().for_each(|datapoint| {
+                    metric_data.datapoints.push(datapoint.into());
+                });
+            }
+        }
+    }
+
+    impl From<Metric> for SerdeMetric {
+        fn from(value: Metric) -> Self {
+            SerdeMetric {
+                name: value.name.into_owned(),
+                description: value.description.into_owned(),
+                unit: value.unit.as_str().to_string(),
+                data: value.data.into(),
+            }
+        }
+    }
+
+    impl<T> From<&DataPoint<T>> for SerdeMetricDataPoint
+    where
+        T: Into<serde_json::Value> + Clone,
+    {
+        fn from(value: &DataPoint<T>) -> Self {
+            SerdeMetricDataPoint {
+                value: Some(value.value.clone().into()),
+                sum: None,
+                attributes: value
+                    .attributes
+                    .iter()
+                    .map(|(k, v)| (k.as_str().to_string(), Self::to_value(v)))
+                    .collect(),
+            }
+        }
+    }
+
+    impl SerdeMetricDataPoint {
+        pub(crate) fn to_value(v: &Value) -> serde_json::Value {
+            match v.clone() {
+                Value::Bool(v) => v.into(),
+                Value::I64(v) => v.into(),
+                Value::F64(v) => v.into(),
+                Value::String(v) => v.to_string().into(),
+                Value::Array(v) => match v {
+                    Array::Bool(v) => v.into(),
+                    Array::I64(v) => v.into(),
+                    Array::F64(v) => v.into(),
+                    Array::String(v) => v.iter().map(|v| v.to_string()).collect::<Vec<_>>().into(),
+                },
+            }
+        }
+    }
+
+    impl<T> From<&HistogramDataPoint<T>> for SerdeMetricDataPoint
+    where
+        T: Into<serde_json::Value> + Clone,
+    {
+        fn from(value: &HistogramDataPoint<T>) -> Self {
+            SerdeMetricDataPoint {
+                sum: Some(value.sum.clone().into()),
+                value: None,
+                attributes: value
+                    .attributes
+                    .iter()
+                    .map(|(k, v)| (k.as_str().to_string(), Self::to_value(v)))
+                    .collect(),
+            }
+        }
+    }
+
+    impl From<Box<dyn opentelemetry::sdk::metrics::data::Aggregation>> for SerdeMetricData {
+        fn from(value: Box<dyn opentelemetry::sdk::metrics::data::Aggregation>) -> Self {
+            let mut metric_data = SerdeMetricData::default();
+            Self::extract_datapoints::<u64>(&mut metric_data, value.as_ref());
+            Self::extract_datapoints::<f64>(&mut metric_data, value.as_ref());
+            Self::extract_datapoints::<i64>(&mut metric_data, value.as_ref());
+            metric_data
         }
     }
 
@@ -704,110 +770,206 @@ macro_rules! metric {
 }
 
 #[cfg(test)]
+macro_rules! assert_metric {
+    ($result:expr, $name:expr, $value:expr, $sum:expr, $attrs:expr) => {
+        if !$result {
+            let metric = crate::metrics::test_utils::SerdeMetric {
+                name: $name.to_string(),
+                description: "".to_string(),
+                unit: "".to_string(),
+                data: crate::metrics::test_utils::SerdeMetricData {
+                    datapoints: vec![crate::metrics::test_utils::SerdeMetricDataPoint {
+                        value: $value,
+                        sum: $sum,
+                        attributes: $attrs
+                            .iter()
+                            .map(|kv: &opentelemetry::KeyValue| {
+                                (
+                                    kv.key.to_string(),
+                                    crate::metrics::test_utils::SerdeMetricDataPoint::to_value(
+                                        &kv.value,
+                                    ),
+                                )
+                            })
+                            .collect(),
+                    }],
+                },
+            };
+            panic!(
+                "metric not found:\n{}\nmetrics present:\n{}",
+                serde_yaml::to_string(&metric).unwrap(),
+                serde_yaml::to_string(&crate::metrics::collect_metrics().all()).unwrap()
+            )
+        }
+    };
+}
+
+#[cfg(test)]
 macro_rules! assert_counter {
     ($($name:ident).+, $value: expr, $($attr_key:literal = $attr_value:expr),+) => {
+        let name = stringify!($($name).+);
         let attributes = vec![$(opentelemetry::KeyValue::new($attr_key, $attr_value)),+];
-        crate::metrics::collect_metrics().assert(stringify!($($name).+), crate::metrics::test_utils::MetricType::Counter, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert(name, crate::metrics::test_utils::MetricType::Counter, $value, &attributes);
+        assert_metric!(result, name, Some($value.into()), None, &attributes);
     };
 
     ($($name:ident).+, $value: expr, $($($attr_key:ident).+ = $attr_value:expr),+) => {
+        let name = stringify!($($name).+);
         let attributes = vec![$(opentelemetry::KeyValue::new(stringify!($($attr_key).+), $attr_value)),+];
-        crate::metrics::collect_metrics().assert(stringify!($($name).+), crate::metrics::test_utils::MetricType::Counter, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert(name, crate::metrics::test_utils::MetricType::Counter, $value, &attributes);
+        assert_metric!(result, name, Some($value.into()), None, &attributes);
     };
 
     ($name:literal, $value: expr, $($attr_key:literal = $attr_value:expr),+) => {
         let attributes = vec![$(opentelemetry::KeyValue::new($attr_key, $attr_value)),+];
-        crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Counter, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Counter, $value, &attributes);
+        assert_metric!(result, $name, Some($value.into()), None, &attributes);
     };
 
     ($name:literal, $value: expr, $($($attr_key:ident).+ = $attr_value:expr),+) => {
         let attributes = vec![$(opentelemetry::KeyValue::new(stringify!($($attr_key).+), $attr_value)),+];
-        crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Counter, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Counter, $value, &attributes);
+        assert_metric!(result, $name, Some($value.into()), None, attributes);
     };
 
     ($name:literal, $value: expr) => {
-        crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Counter, $value, &[]);
+        let result = crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Counter, $value, &[]);
+        assert_metric!(result, $name, Some($value.into()), None, &[]);
     };
 }
 
 #[cfg(test)]
 macro_rules! assert_up_down_counter {
-    ($($name:ident).+, $ty: expr, $value: expr, $($attr_key:literal = $attr_value:expr),+) => {
+
+    ($($name:ident).+, $value: expr, $($attr_key:literal = $attr_value:expr),+) => {
         let attributes = vec![$(opentelemetry::KeyValue::new($attr_key, $attr_value)),+];
-        crate::metrics::collect_metrics().assert(stringify!($($name).+), crate::metrics::test_utils::MetricType::UpDownCounter, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert(stringify!($($name).+), crate::metrics::test_utils::MetricType::UpDownCounter, $value, &attributes);
+        assert_metric!(result, $name, Some($value.into()), None, &attributes);
     };
 
     ($($name:ident).+, $value: expr, $($($attr_key:ident).+ = $attr_value:expr),+) => {
         let attributes = vec![$(opentelemetry::KeyValue::new(stringify!($($attr_key).+), $attr_value)),+];
-        crate::metrics::collect_metrics().assert(stringify!($($name).+), crate::metrics::test_utils::MetricType::UpDownCounter, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert(stringify!($($name).+), crate::metrics::test_utils::MetricType::UpDownCounter, $value, &attributes);
+        assert_metric!(result, $name, Some($value.into()), None, &attributes);
     };
 
     ($name:literal, $value: expr, $($attr_key:literal = $attr_value:expr),+) => {
         let attributes = vec![$(opentelemetry::KeyValue::new($attr_key, $attr_value)),+];
-        crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::UpDownCounter, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::UpDownCounter, $value, &attributes);
+        assert_metric!(result, $name, Some($value.into()), None, &attributes);
     };
 
     ($name:literal, $value: expr, $($($attr_key:ident).+ = $attr_value:expr),+) => {
         let attributes = vec![$(opentelemetry::KeyValue::new(stringify!($($attr_key).+), $attr_value)),+];
-        crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::UpDownCounter, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::UpDownCounter, $value, &attributes);
+        assert_metric!(result, $name, Some($value.into()), None, &attributes);
     };
 
     ($name:literal, $value: expr) => {
-        crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::UpDownCounter, $value, &[]);
+        let result = crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::UpDownCounter, $value, &[]);
+        assert_metric!(result, $name, Some($value.into()), None, &[]);
     };
 }
 
 #[cfg(test)]
 macro_rules! assert_gauge {
-    ($($name:ident).+, $ty: expr, $value: expr, $($attr_key:literal = $attr_value:expr),+) => {
+
+    ($($name:ident).+, $value: expr, $($attr_key:literal = $attr_value:expr),+) => {
         let attributes = vec![$(opentelemetry::KeyValue::new($attr_key, $attr_value)),+];
-        crate::metrics::collect_metrics().assert(stringify!($($name).+), crate::metrics::test_utils::MetricType::Gauge, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert(stringify!($($name).+), crate::metrics::test_utils::MetricType::Gauge, $value, &attributes);
+        assert_metric!(result, $name, Some($value.into()), None, &attributes);
     };
 
     ($($name:ident).+, $value: expr, $($($attr_key:ident).+ = $attr_value:expr),+) => {
         let attributes = vec![$(opentelemetry::KeyValue::new(stringify!($($attr_key).+), $attr_value)),+];
-        crate::metrics::collect_metrics().assert(stringify!($($name).+), crate::metrics::test_utils::MetricType::Gauge, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert(stringify!($($name).+), crate::metrics::test_utils::MetricType::Gauge, $value, &attributes);
+        assert_metric!(result, $name, Some($value.into()), None, &attributes);
     };
 
     ($name:literal, $value: expr, $($attr_key:literal = $attr_value:expr),+) => {
         let attributes = vec![$(opentelemetry::KeyValue::new($attr_key, $attr_value)),+];
-        crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Gauge, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Gauge, $value, &attributes);
+        assert_metric!(result, $name, Some($value.into()), None, &attributes);
     };
 
     ($name:literal, $value: expr, $($($attr_key:ident).+ = $attr_value:expr),+) => {
         let attributes = vec![$(opentelemetry::KeyValue::new(stringify!($($attr_key).+), $attr_value)),+];
-        crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Gauge, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Gauge, $value, &attributes);
+        assert_metric!(result, $name, Some($value.into()), None, &attributes);
     };
 
     ($name:literal, $value: expr) => {
-        crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Gauge, $value, &[]);
+        let result = crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Gauge, $value, &[]);
+        assert_metric!(result, $name, Some($value.into()), None, &[]);
     };
 }
 
 #[cfg(test)]
 macro_rules! assert_histogram {
-    ($($name:ident).+, $ty: expr, $value: expr, $($attr_key:literal = $attr_value:expr),+) => {
+
+    ($($name:ident).+, $value: expr, $($attr_key:literal = $attr_value:expr),+) => {
         let attributes = vec![$(opentelemetry::KeyValue::new($attr_key, $attr_value)),+];
-        crate::metrics::collect_metrics().assert(stringify!($($name).+), crate::metrics::test_utils::MetricType::Histogram, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert(stringify!($($name).+), crate::metrics::test_utils::MetricType::Histogram, $value, &attributes);
+        assert_metric!(result, $name, None, Some($value.into()), &attributes);
     };
 
     ($($name:ident).+, $value: expr, $($($attr_key:ident).+ = $attr_value:expr),+) => {
         let attributes = vec![$(opentelemetry::KeyValue::new(stringify!($($attr_key).+), $attr_value)),+];
-        crate::metrics::collect_metrics().assert(stringify!($($name).+), crate::metrics::test_utils::MetricType::Histogram, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert(stringify!($($name).+), crate::metrics::test_utils::MetricType::Histogram, $value, &attributes);
+        assert_metric!(result, $name, None, Some($value.into()), &attributes);
     };
 
     ($name:literal, $value: expr, $($attr_key:literal = $attr_value:expr),+) => {
         let attributes = vec![$(opentelemetry::KeyValue::new($attr_key, $attr_value)),+];
-        crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Histogram, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Histogram, $value, &attributes);
+        assert_metric!(result, $name, None, Some($value.into()), &attributes);
     };
 
     ($name:literal, $value: expr, $($($attr_key:ident).+ = $attr_value:expr),+) => {
         let attributes = vec![$(opentelemetry::KeyValue::new(stringify!($($attr_key).+), $attr_value)),+];
-        crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Histogram, $value, &attributes);
+        let result = crate::metrics::collect_metrics().assert($name, crate::metrics::test_utils::MetricType::Histogram, $value, &attributes);
+        assert_metric!(result, $name, None, Some($value.into()), &attributes);
     };
 
     ($name:literal, $value: expr) => {
-        crate::metrics::collect_metrics().assert($name, $value, &[]);
+        let result = crate::metrics::collect_metrics().assert($name, $value, &[]);
+        assert_metric!(result, $name, None, Some($value.into()), &[]);
+    };
+}
+
+#[cfg(test)]
+#[allow(unused_macros)]
+macro_rules! assert_metrics_snapshot {
+    ($file_name: expr) => {
+        insta::with_settings!({sort_maps => true, snapshot_suffix => $file_name}, {
+            let metrics = crate::metrics::collect_metrics();
+            insta::assert_yaml_snapshot!(&metrics.all());
+        });
+
+    };
+    () => {
+        insta::with_settings!({sort_maps => true}, {
+            let metrics = crate::metrics::collect_metrics();
+            insta::assert_yaml_snapshot!(&metrics.all());
+        });
+    };
+}
+
+#[cfg(test)]
+#[allow(unused_macros)]
+macro_rules! assert_non_zero_metrics_snapshot {
+    ($file_name: expr) => {
+        insta::with_settings!({sort_maps => true, snapshot_suffix => $file_name}, {
+            let metrics = crate::metrics::collect_metrics();
+            insta::assert_yaml_snapshot!(&metrics.non_zero());
+        });
+
+    };
+    () => {
+        insta::with_settings!({sort_maps => true}, {
+            let metrics = crate::metrics::collect_metrics();
+            insta::assert_yaml_snapshot!(&metrics.non_zero());
+        });
     };
 }
 
@@ -1044,7 +1206,7 @@ mod test {
     #[should_panic]
     async fn test_type_gauge() {
         async {
-            meter_provider()
+            let _gauge = meter_provider()
                 .meter("test")
                 .u64_observable_gauge("test")
                 .with_callback(|m| m.observe(5, &[]))

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -270,15 +270,15 @@ impl Plugin for Telemetry {
             apollo_metrics_sender: metrics_builder.apollo_metrics_sender,
             field_level_instrumentation_ratio,
             tracer_provider: Some(tracer_provider),
-            public_meter_provider: Some(FilterMeterProvider::public_metrics(
+            public_meter_provider: Some(FilterMeterProvider::public(
                 metrics_builder.public_meter_provider_builder.build(),
             )),
-            private_meter_provider: Some(FilterMeterProvider::private_metrics(
+            private_meter_provider: Some(FilterMeterProvider::private(
                 metrics_builder.apollo_meter_provider_builder.build(),
             )),
             public_prometheus_meter_provider: metrics_builder
                 .prometheus_meter_provider
-                .map(FilterMeterProvider::public_metrics),
+                .map(FilterMeterProvider::public),
             sampling_filter_ratio,
             config: Arc::new(config),
             counter,

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -28,7 +28,6 @@ use super::router::Event::UpdateConfiguration;
 use super::router::Event::UpdateSchema;
 use super::router::Event::{self};
 use crate::configuration::metrics::Metrics;
-use crate::configuration::metrics::MetricsHandle;
 use crate::configuration::Configuration;
 use crate::configuration::Discussed;
 use crate::configuration::ListenAddr;
@@ -60,7 +59,7 @@ enum State<FA: RouterSuperServiceFactory> {
     },
     Running {
         configuration: Arc<Configuration>,
-        _metrics_handle: MetricsHandle,
+        _metrics: Metrics,
         schema: Arc<String>,
         license: LicenseState,
         server_handle: Option<HttpServerHandle>,
@@ -415,11 +414,11 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
             discussed.log_preview_used(yaml);
         }
 
-        let metrics_handle = Metrics::spawn(&configuration).await;
+        let metrics_handle = Metrics::new(&configuration);
 
         Ok(Running {
             configuration,
-            _metrics_handle: metrics_handle,
+            _metrics: metrics_handle,
             schema,
             license,
             server_handle: Some(server_handle),


### PR DESCRIPTION
Adds some metrics for some specific apollo env variables to show if they are set or not.
Uses the new metrics macros rather than the hash map to exercise more of the stack.
As a bonus, the thread that was used to continuously update the gauges is gone. 

I had to make some changes to the asserting to allow asserting of all metrics rather than just specific ones hence all the snapshot changes. On the plus side they look better now.

Fixes #4290

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
