### PR TITLE
fix: graphql operation attributes on spec_compliant spans

### DIFF
--- a/apollo-router/src/plugins/telemetry/span_factory.rs
+++ b/apollo-router/src/plugins/telemetry/span_factory.rs
@@ -108,6 +108,8 @@ impl SpanMode {
                     "apollo_private.http.request_headers" = ::tracing::field::Empty,
                     "apollo_private.http.response_headers" = ::tracing::field::Empty,
                     "apollo_private.request" = true,
+                    "graphql.operation.name" = ::tracing::field::Empty,
+                    "graphql.operation.type" = ::tracing::field::Empty,
                 )
             }
         }


### PR DESCRIPTION
The root router span must be initialized with empty values for graphql.operation.name and graphal.operation.type in order to set them later.

Reported by a customer, no issue filed yet.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
