### PR TITLE
Expose Context Id to Rhai scripts

### DIFF
--- a/.changesets/feat_garypen_4370_rhai_request_id.md
+++ b/.changesets/feat_garypen_4370_rhai_request_id.md
@@ -1,0 +1,22 @@
+### Expose Context Id to Rhai scripts ([Issue #4370](https://github.com/apollographql/router/issues/4370))
+
+We recently added an ID to Context which uniquely identifies the context for the duration of a request/response lifecycle. This is now accessible on Request or Response objects from Rhai scripts.
+
+For example:
+
+```rhai
+// Map Request for the Supergraph Service
+fn supergraph_service(service) {
+    const request_callback = Fn("process_request");
+    service.map_request(request_callback);
+}
+
+// Generate a log for each Supergraph request with the request ID
+fn process_request(request) {
+    print(`request id : ${request.id}`);
+}
+```
+
+Note: We have chosen to expose this Context data directly from Request/Response objects rather than on the Context object to avoid the possibility of name collisions (with "id") in the context data.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/4374

--- a/apollo-router/src/plugins/rhai/engine.rs
+++ b/apollo-router/src/plugins/rhai/engine.rs
@@ -413,6 +413,12 @@ mod router_context {
     ) -> Result<Context, Box<EvalAltResult>> {
         Ok(obj.with_mut(|response| response.context.clone()))
     }
+    #[rhai_fn(get = "id", pure)]
+    pub(crate) fn router_first_response_id_get(
+        obj: &mut SharedMut<router::FirstResponse>,
+    ) -> String {
+        obj.with_mut(|response| response.context.id.clone())
+    }
     #[rhai_fn(set = "context", return_raw)]
     pub(crate) fn router_first_response_context_set(
         obj: &mut SharedMut<router::FirstResponse>,
@@ -428,6 +434,12 @@ mod router_context {
     ) -> Result<Context, Box<EvalAltResult>> {
         Ok(obj.with_mut(|response| response.context.clone()))
     }
+    #[rhai_fn(get = "id", pure)]
+    pub(crate) fn supergraph_first_response_id_get(
+        obj: &mut SharedMut<supergraph::FirstResponse>,
+    ) -> String {
+        obj.with_mut(|response| response.context.id.clone())
+    }
     #[rhai_fn(set = "context", return_raw)]
     pub(crate) fn supergraph_first_response_context_set(
         obj: &mut SharedMut<supergraph::FirstResponse>,
@@ -442,6 +454,12 @@ mod router_context {
         obj: &mut SharedMut<execution::FirstResponse>,
     ) -> Result<Context, Box<EvalAltResult>> {
         Ok(obj.with_mut(|response| response.context.clone()))
+    }
+    #[rhai_fn(get = "id", pure)]
+    pub(crate) fn execution_first_response_id_get(
+        obj: &mut SharedMut<execution::FirstResponse>,
+    ) -> String {
+        obj.with_mut(|response| response.context.id.clone())
     }
     #[rhai_fn(set = "context", return_raw)]
     pub(crate) fn execution_first_response_context_set(
@@ -459,6 +477,12 @@ mod router_context {
     ) -> Result<Context, Box<EvalAltResult>> {
         Ok(obj.with_mut(|response| response.context.clone()))
     }
+    #[rhai_fn(get = "id", pure)]
+    pub(crate) fn router_deferred_response_id_get(
+        obj: &mut SharedMut<router::DeferredResponse>,
+    ) -> String {
+        obj.with_mut(|response| response.context.id.clone())
+    }
     #[rhai_fn(set = "context", return_raw)]
     pub(crate) fn router_deferred_response_context_set(
         obj: &mut SharedMut<router::DeferredResponse>,
@@ -474,6 +498,12 @@ mod router_context {
     ) -> Result<Context, Box<EvalAltResult>> {
         Ok(obj.with_mut(|response| response.context.clone()))
     }
+    #[rhai_fn(get = "id", pure)]
+    pub(crate) fn supergraph_deferred_response_id_get(
+        obj: &mut SharedMut<supergraph::DeferredResponse>,
+    ) -> String {
+        obj.with_mut(|response| response.context.id.clone())
+    }
     #[rhai_fn(set = "context", return_raw)]
     pub(crate) fn supergraph_deferred_response_context_set(
         obj: &mut SharedMut<supergraph::DeferredResponse>,
@@ -488,6 +518,12 @@ mod router_context {
         obj: &mut SharedMut<execution::DeferredResponse>,
     ) -> Result<Context, Box<EvalAltResult>> {
         Ok(obj.with_mut(|response| response.context.clone()))
+    }
+    #[rhai_fn(get = "id", pure)]
+    pub(crate) fn execution_deferred_response_id_get(
+        obj: &mut SharedMut<execution::DeferredResponse>,
+    ) -> String {
+        obj.with_mut(|response| response.context.id.clone())
     }
     #[rhai_fn(set = "context", return_raw)]
     pub(crate) fn execution_deferred_response_context_set(
@@ -1267,6 +1303,32 @@ macro_rules! register_rhai_router_interface {
                 }
             );
 
+            // Id
+            $engine.register_get(
+                "id",
+                |obj: &mut SharedMut<$base::FirstRequest>| -> String {
+                    obj.with_mut(|request| request.context.id.clone())
+                }
+            )
+            .register_get(
+                "id",
+                |obj: &mut SharedMut<$base::ChunkedRequest>| -> String {
+                    obj.with_mut(|request| request.context.id.clone())
+                }
+            )
+            .register_get(
+                "id",
+                |obj: &mut SharedMut<$base::Response>| -> String {
+                    obj.with_mut(|response| response.context.id.clone())
+                }
+            )
+            .register_get(
+                "id",
+                |obj: &mut SharedMut<$base::DeferredResponse>| -> String {
+                    obj.with_mut(|response| response.context.id.clone())
+                }
+            );
+
             // Originating Request
             $engine.register_get(
                 "headers",
@@ -1386,6 +1448,20 @@ macro_rules! register_rhai_interface {
                 |obj: &mut SharedMut<$base::Response>, context: Context| {
                     obj.with_mut(|response| response.context = context);
                     Ok(())
+                }
+            );
+
+            // Id
+            $engine.register_get(
+                "id",
+                |obj: &mut SharedMut<$base::Request>| -> String {
+                    obj.with_mut(|request| request.context.id.clone())
+                }
+            )
+            .register_get(
+                "id",
+                |obj: &mut SharedMut<$base::Response>| -> String {
+                    obj.with_mut(|response| response.context.id.clone())
                 }
             );
 

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -714,7 +714,7 @@ async fn it_can_process_string_subgraph_forbidden() {
     if let Err(error) = base_process_function("process_subgraph_response_string").await {
         let processed_error = process_error(error);
         assert_eq!(processed_error.status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(processed_error.message, Some("rhai execution error: 'Runtime error: I have raised an error (line 155, position 5)\nin call to function 'process_subgraph_response_string''".to_string()));
+        assert_eq!(processed_error.message, Some("rhai execution error: 'Runtime error: I have raised an error (line 161, position 5)\nin call to function 'process_subgraph_response_string''".to_string()));
     } else {
         // Test failed
         panic!("error processed incorrectly");
@@ -740,7 +740,7 @@ async fn it_cannot_process_om_subgraph_missing_message_and_body() {
     {
         let processed_error = process_error(error);
         assert_eq!(processed_error.status, StatusCode::BAD_REQUEST);
-        assert_eq!(processed_error.message, Some("rhai execution error: 'Runtime error: #{\"status\": 400} (line 166, position 5)\nin call to function 'process_subgraph_response_om_missing_message''".to_string()));
+        assert_eq!(processed_error.message, Some("rhai execution error: 'Runtime error: #{\"status\": 400} (line 172, position 5)\nin call to function 'process_subgraph_response_om_missing_message''".to_string()));
     } else {
         // Test failed
         panic!("error processed incorrectly");

--- a/apollo-router/tests/fixtures/request_response_test.rhai
+++ b/apollo-router/tests/fixtures/request_response_test.rhai
@@ -3,13 +3,16 @@
 // If any of the tests fail, the thrown error will cause the respective rust
 // unit test to fail.
 
-fn process_common_request(check_context_and_method, request) {
-    if check_context_and_method {
+fn process_common_request(check_context_method_and_id, request) {
+    if check_context_method_and_id {
         if request.context.entries != () {
             throw(`context entries: expected: (), actual: ${request.context.entries}`);
         }
         if request.method != "GET" {
             throw(`query: expected: "GET", actual: ${request.method}`);
+        }
+        if type_of(request.id) != "string" {
+            throw(`query: expected: "string", actual: ${type_of(request.id)}`);
         }
     }
     if request.body.operation_name != () {
@@ -104,6 +107,9 @@ fn process_common_response(response) {
     }
     if response.body.extensions != #{} {
         throw(`query: expected: #{}, actual: ${response.body.extensions}`);
+    }
+    if type_of(response.id) != "string" {
+        throw(`query: expected: "string", actual: ${type_of(response.id)}`);
     }
 }
 

--- a/docs/source/customizations/rhai-api.mdx
+++ b/docs/source/customizations/rhai-api.mdx
@@ -325,6 +325,7 @@ All callback functions registered via `map_request` are passed a `request` objec
 
 ```
 request.context
+request.id
 request.headers
 request.method
 request.body.query
@@ -395,6 +396,14 @@ let resolver = |current| {
 
 // Upsert our context with our resolver
 response.context.upsert("surrogate-cache-key", resolver);
+```
+
+### `request.id`
+
+The id is a string which uniquely identifies a request/response context for its entire lifespan. If you have a request (or a response) you can access the ID as follows.
+
+```rhai
+print(`request id is: ${request.id}`);
 ```
 
 ### `request.headers`
@@ -512,6 +521,7 @@ The `response` object includes the following fields:
 
 ```
 response.context
+response.id
 response.headers
 response.body.label
 response.body.data
@@ -524,6 +534,7 @@ All of the above fields are read/write.
 The following fields are identical in behavior to their `request` counterparts:
 
 * [`context`](#requestcontext)
+* [`id`](#requestid)
 * [`headers`](#requestheaders)
 * [`body`](#requestbody)
 * [`body.extensions`](#requestbodyextensions)


### PR DESCRIPTION
We recently added an ID to Context which uniquely identifies the context for the duration of a request/response lifecycle. This is now accessible on Request or Response objects from Rhai scripts.

For example:

```rhai
// Map Request for the Supergraph Service
fn supergraph_service(service) {
    const request_callback = Fn("process_request");
    service.map_request(request_callback);
}

// Generate a log for each Supergraph request with the request ID
fn process_request(request) {
    print(`request id : ${request.id}`);
}
```

Note: We have chosen to expose this Context data directly from Request/Response objects rather than on the Context object to avoid the possibility of name collisions (with "id") in the context data.

fixes: #4370

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

I tested this manually by modifying various example logging scripts and logging out the ID for all supported services with non deferred queries and deferred queries.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
