### PR TITLE
fix(callback): change accept header value for callback mode with subscriptions

### DIFF
--- a/.changesets/feat_bnjjj_chore_4269.md
+++ b/.changesets/feat_bnjjj_chore_4269.md
@@ -59,7 +59,7 @@ The subscription specification has been updated with the following observable ch
 }
 ```
 
-* When the router is sending a subscription to a subgraph in callback mode, it now includes a specific `accept` header set to `application/json+graphql+callback/1.0` that let's you automatically detect if it's using callback mode or not.
+* When the router is sending a subscription to a subgraph in callback mode, it now includes a specific `accept` header set to `application/json;callbackSpec=1.0` that let's you automatically detect if it's using callback mode or not.
 
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/4272

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -2079,7 +2079,10 @@ expression: "&schema"
                   "default": "5s",
                   "anyOf": [
                     {
-                      "type": "null"
+                      "type": "string",
+                      "enum": [
+                        "disabled"
+                      ]
                     },
                     {
                       "type": "string"

--- a/apollo-router/src/plugins/subscription.rs
+++ b/apollo-router/src/plugins/subscription.rs
@@ -171,10 +171,16 @@ pub(crate) struct CallbackMode {
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case", untagged)]
 pub(crate) enum HeartbeatInterval {
-    Disabled,
+    Disabled(Disabled),
     #[serde(with = "humantime_serde")]
     #[schemars(with = "String")]
     Duration(Duration),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Disabled {
+    Disabled,
 }
 
 impl Default for HeartbeatInterval {
@@ -233,7 +239,7 @@ impl Plugin for Subscription {
                 HeartbeatInterval::Duration(duration) => {
                     init.notify.set_ttl(Some(duration)).await?;
                 }
-                HeartbeatInterval::Disabled => {
+                HeartbeatInterval::Disabled(_) => {
                     init.notify.set_ttl(None).await?;
                 }
             }

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -429,7 +429,7 @@ impl tower::Service<SubgraphRequest> for SubgraphService {
                             callback_url,
                             verifier,
                             heartbeat_interval_ms: match heartbeat_interval {
-                                HeartbeatInterval::Disabled => 0,
+                                HeartbeatInterval::Disabled(_) => 0,
                                 HeartbeatInterval::Duration(duration) => {
                                     duration.as_millis() as u64
                                 }
@@ -1252,6 +1252,7 @@ mod tests {
     use crate::graphql::Error;
     use crate::graphql::Request;
     use crate::graphql::Response;
+    use crate::plugins::subscription::Disabled;
     use crate::plugins::subscription::SubgraphPassthroughMode;
     use crate::plugins::subscription::SubscriptionModeConfig;
     use crate::plugins::subscription::SUBSCRIPTION_CALLBACK_HMAC_KEY;
@@ -1882,7 +1883,7 @@ mod tests {
                     listen: None,
                     path: Some("/testcallback".to_string()),
                     subgraphs: vec![String::from("testbis")].into_iter().collect(),
-                    heartbeat_interval: HeartbeatInterval::Disabled,
+                    heartbeat_interval: HeartbeatInterval::Disabled(Disabled::Disabled),
                 }),
                 passthrough: Some(SubgraphPassthroughMode {
                     all: None,

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -365,7 +365,6 @@ async fn subscription_task(
     let mut receiver = sub_params.stream_rx;
     let sender = sub_params.client_sender;
 
-    let graphql_document = &query_plan.query.string;
     // Get the rest of the query_plan to execute for subscription events
     let query_plan = match &query_plan.root {
         crate::query_planner::PlanNode::Subscription { rest, .. } => rest.clone().map(|r| {

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -457,7 +457,6 @@ async fn subscription_task(
                         val.created_at = Some(Instant::now());
                         let res = dispatch_event(&supergraph_req, &execution_service_factory, query_plan.as_ref(), context.clone(), val, sender.clone())
                             .instrument(tracing::info_span!(SUBSCRIPTION_EVENT_SPAN_NAME,
-                                graphql.document = graphql_document,
                                 graphql.operation.name = %operation_name,
                                 otel.kind = "INTERNAL",
                                 apollo_private.operation_signature = %operation_signature,

--- a/docs/source/executing-operations/subscription-callback-protocol.mdx
+++ b/docs/source/executing-operations/subscription-callback-protocol.mdx
@@ -30,7 +30,7 @@ All actions described in these steps are performed by one of **Router**, **Subgr
 
 1. Before it executes a subscription operation, **Router** generates a unique ID to represent that operation.
 
-2. **Router** sends a GraphQL subscription operation to **Subgraph** via HTTP POST using the standard [GraphQL request payload](https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#request-parameters) with `Accept` header containing `application/json+graphql+callback/1.0`:
+2. **Router** sends a GraphQL subscription operation to **Subgraph** via HTTP POST using the standard [GraphQL request payload](https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#request-parameters) with `Accept` header containing `application/json;callbackSpec=1.0`:
 
     ```json
     {


### PR DESCRIPTION
Previously we had an accept header value that could not be compliant with media type RFC so I updated the value to be more like the one we use from client to router with multipart protocol.

I also added the way to display the body even if `content-type` is not accepted.