### PR TITLE
Add support for downloading supergraph schema from a list of URLs.

### DIFF
--- a/.changesets/feat_bryn_supergraph_urls.md
+++ b/.changesets/feat_bryn_supergraph_urls.md
@@ -1,0 +1,8 @@
+### Add support for downloading supergraph schema from a list of URLs. ([Issue #4219](https://github.com/apollographql/router/issues/4219))
+
+`APOLLO_ROUTER_SUPERGRAPH_URLS` takes a comma separated list of URLs which will be polled in order to try and retrieve the supergraph schema.
+
+This is useful for users who require supergraph deployments to be synchronized via gitops workflow.
+Poll interval is controlled by `APOLLO_UPLINK_POLL_INTERVAL` and defaults to 10s.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/4377

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -195,6 +195,10 @@ pub struct Opt {
     )]
     supergraph_path: Option<PathBuf>,
 
+    /// Locations (comma separated) to fetch the supergraph from. These will be queried in order.
+    #[clap(env = "APOLLO_ROUTER_SUPERGRAPH_URLS", value_delimiter = ',')]
+    supergraph_urls: Option<Vec<Url>>,
+
     /// Prints the configuration schema.
     #[clap(long, action(ArgAction::SetTrue), hide(true))]
     schema: bool,
@@ -525,14 +529,19 @@ impl Executable {
 
         let apollo_router_msg = format!("Apollo Router v{} // (c) Apollo Graph, Inc. // Licensed as ELv2 (https://go.apollo.dev/elv2)", std::env!("CARGO_PKG_VERSION"));
 
-        let schema_source = match (schema, &opt.supergraph_path, &opt.apollo_key) {
-            (Some(_), Some(_), _) => {
+        // Schema source will be in order of precedence:
+        // 1. Cli --supergraph
+        // 2. Env APOLLO_ROUTER_SUPERGRAPH_PATH
+        // 3. Env APOLLO_ROUTER_SUPERGRAPH_URLS
+        // 4. Env APOLLO_KEY and APOLLO_GRAPH_REF
+        let schema_source = match (schema, &opt.supergraph_path, &opt.supergraph_urls, &opt.apollo_key) {
+            (Some(_), Some(_), _, _) | (Some(_), _, Some(_), _) => {
                 return Err(anyhow!(
                     "--supergraph and APOLLO_ROUTER_SUPERGRAPH_PATH cannot be used when a custom schema source is in use"
                 ))
             }
-            (Some(source), None, _) => source,
-            (_, Some(supergraph_path), _) => {
+            (Some(source), None, None,_) => source,
+            (_, Some(supergraph_path), _, _) => {
                 tracing::info!("{apollo_router_msg}");
                 tracing::info!("{apollo_telemetry_msg}");
 
@@ -547,7 +556,17 @@ impl Executable {
                     delay: None,
                 }
             }
-            (_, None, Some(_apollo_key)) => {
+            (_, _, Some(supergraph_urls), _) => {
+                tracing::info!("{apollo_router_msg}");
+                tracing::info!("{apollo_telemetry_msg}");
+
+                SchemaSource::URLs {
+                    urls: supergraph_urls.clone(),
+                    watch: opt.hot_reload,
+                    period: opt.apollo_uplink_poll_interval
+                }
+            }
+            (_, None, None, Some(_apollo_key)) => {
                 tracing::info!("{apollo_router_msg}");
                 tracing::info!("{apollo_telemetry_msg}");
                 SchemaSource::Registry(opt.uplink_config()?)

--- a/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__tests__typename_propagation2.snap
+++ b/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__tests__typename_propagation2.snap
@@ -4,24 +4,12 @@ expression: "serde_json::to_value(&response).unwrap()"
 ---
 {
   "data": {
-    "book": null
-  },
-  "errors": [
-    {
-      "message": "couldn't find mock for query {\"query\":\"query QueryBook__node_relay_subgraph__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename id}}}\",\"operationName\":\"QueryBook__node_relay_subgraph__2\",\"variables\":{\"representations\":[{\"__typename\":\"Book\",\"bookId\":\"book1\",\"author\":null}]}}",
-      "extensions": {
-        "code": "FETCH_ERROR"
+    "book": {
+      "__typename": "Book",
+      "id": "1",
+      "author": {
+        "__typename": "Author"
       }
     }
-  ],
-  "extensions": {
-    "valueCompletion": [
-      {
-        "message": "Cannot return null for non-nullable field Book.id",
-        "path": [
-          "book"
-        ]
-      }
-    ]
   }
 }

--- a/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__tests__typename_propagation2.snap
+++ b/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__tests__typename_propagation2.snap
@@ -4,12 +4,24 @@ expression: "serde_json::to_value(&response).unwrap()"
 ---
 {
   "data": {
-    "book": {
-      "__typename": "Book",
-      "id": "1",
-      "author": {
-        "__typename": "Author"
+    "book": null
+  },
+  "errors": [
+    {
+      "message": "couldn't find mock for query {\"query\":\"query QueryBook__node_relay_subgraph__2($representations:[_Any!]!){_entities(representations:$representations){...on Book{__typename id}}}\",\"operationName\":\"QueryBook__node_relay_subgraph__2\",\"variables\":{\"representations\":[{\"__typename\":\"Book\",\"bookId\":\"book1\",\"author\":null}]}}",
+      "extensions": {
+        "code": "FETCH_ERROR"
       }
     }
+  ],
+  "extensions": {
+    "valueCompletion": [
+      {
+        "message": "Cannot return null for non-nullable field Book.id",
+        "path": [
+          "book"
+        ]
+      }
+    ]
   }
 }

--- a/apollo-router/src/router/event/schema.rs
+++ b/apollo-router/src/router/event/schema.rs
@@ -6,6 +6,7 @@ use derivative::Derivative;
 use derive_more::Display;
 use derive_more::From;
 use futures::prelude::*;
+use url::Url;
 
 use crate::router::Event;
 use crate::router::Event::NoMoreSchema;
@@ -47,6 +48,17 @@ pub enum SchemaSource {
     /// Apollo managed federation.
     #[display(fmt = "Registry")]
     Registry(UplinkConfig),
+
+    /// A list of URLs to fetch the schema from.
+    #[display(fmt = "URLs")]
+    URLs {
+        /// The URLs to fetch the schema from.
+        urls: Vec<Url>,
+        /// `true` to watch the URLs for changes and hot apply them.
+        watch: bool,
+        /// When watching, the delay to wait between each poll.
+        period: Duration,
+    },
 }
 
 impl From<&'_ str> for SchemaSource {
@@ -74,7 +86,7 @@ impl SchemaSource {
                 // Sanity check, does the schema file exists, if it doesn't then bail.
                 if !path.exists() {
                     tracing::error!(
-                        "Schema file at path '{}' does not exist.",
+                        "Supergraph schema at path '{}' does not exist.",
                         path.to_string_lossy()
                     );
                     stream::empty().boxed()
@@ -90,7 +102,7 @@ impl SchemaSource {
                                             match tokio::fs::read_to_string(&path).await {
                                                 Ok(schema) => Some(UpdateSchema(schema)),
                                                 Err(err) => {
-                                                    tracing::error!("{}", err);
+                                                    tracing::error!(reason = %err, "failed to read supergraph schema");
                                                     None
                                                 }
                                             }
@@ -102,7 +114,7 @@ impl SchemaSource {
                             }
                         }
                         Err(err) => {
-                            tracing::error!("Failed to read schema: {}", err);
+                            tracing::error!(reason = %err, "failed to read supergraph schema");
                             stream::empty().boxed()
                         }
                     }
@@ -121,8 +133,117 @@ impl SchemaSource {
                     })
                     .boxed()
             }
+            SchemaSource::URLs {
+                urls,
+                watch,
+                period,
+            } => {
+                let mut fetcher = match Fetcher::new(urls, period) {
+                    Ok(fetcher) => fetcher,
+                    Err(err) => {
+                        tracing::error!(reason = %err, "failed to fetch supergraph schema");
+                        return stream::empty().boxed();
+                    }
+                };
+
+                if watch {
+                    stream::unfold(fetcher, |mut state| async move {
+                        if state.first_call {
+                            // First call we may terminate the stream if there are no viable urls, None may be returned
+                            state
+                                .fetch_supergraph_from_first_viable_url()
+                                .await
+                                .map(|event| (Some(event), state))
+                        } else {
+                            // Subsequent calls we don't want to terminate the stream, so we always return Some
+                            Some(match state.fetch_supergraph_from_first_viable_url().await {
+                                None => (None, state),
+                                Some(event) => (Some(event), state),
+                            })
+                        }
+                    })
+                    .filter_map(|s| async move { s })
+                    .boxed()
+                } else {
+                    futures::stream::once(async move {
+                        fetcher.fetch_supergraph_from_first_viable_url().await
+                    })
+                    .filter_map(|s| async move { s })
+                    .boxed()
+                }
+            }
         }
         .chain(stream::iter(vec![NoMoreSchema]))
+        .boxed()
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+enum FetcherError {
+    #[error("failed to build http client")]
+    InitializationError(#[from] reqwest::Error),
+}
+
+// Encapsulates fetching the schema from the first viable url.
+// It will try each url in order until it finds one that works.
+// On the second and subsequent calls it will wait for the period before making the call.
+struct Fetcher {
+    client: reqwest::Client,
+    urls: Vec<Url>,
+    period: Duration,
+    first_call: bool,
+}
+
+impl Fetcher {
+    fn new(urls: Vec<Url>, period: Duration) -> Result<Self, FetcherError> {
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .map_err(FetcherError::InitializationError)?,
+            urls,
+            period,
+            first_call: true,
+        })
+    }
+    async fn fetch_supergraph_from_first_viable_url(&mut self) -> Option<Event> {
+        // If this is not the first call then we need to wait for the period before trying again.
+        if !self.first_call {
+            tokio::time::sleep(self.period).await;
+        }
+        self.first_call = false;
+
+        for url in &self.urls {
+            match self
+                .client
+                .get(reqwest::Url::parse(url.as_ref()).unwrap())
+                .send()
+                .await
+            {
+                Ok(res) if res.status().is_success() => match res.text().await {
+                    Ok(schema) => return Some(UpdateSchema(schema)),
+                    Err(err) => {
+                        tracing::warn!(
+                            url.full = %url,
+                            reason = %err,
+                            "failed to fetch supergraph schema"
+                        )
+                    }
+                },
+                Ok(res) => tracing::warn!(
+                    http.response.status_code = res.status().as_u16(),
+                    url.full = %url,
+                    "failed to fetch supergraph schema"
+                ),
+                Err(err) => tracing::warn!(
+                    url.full = %url,
+                    reason = %err,
+                    "failed to fetch supergraph schema"
+                ),
+            }
+        }
+        tracing::error!("failed to fetch supergraph schema from all urls");
+        None
     }
 }
 
@@ -130,9 +251,17 @@ impl SchemaSource {
 mod tests {
     use std::env::temp_dir;
 
+    use futures::select;
     use test_log::test;
+    use tracing_futures::WithSubscriber;
+    use wiremock::matchers::method;
+    use wiremock::matchers::path;
+    use wiremock::Mock;
+    use wiremock::MockServer;
+    use wiremock::ResponseTemplate;
 
     use super::*;
+    use crate::assert_snapshot_subscriber;
     use crate::files::tests::create_temp_file;
     use crate::files::tests::write_and_flush;
 
@@ -186,5 +315,192 @@ mod tests {
 
         // First update fails because the file is invalid.
         assert!(matches!(stream.next().await.unwrap(), NoMoreSchema));
+    }
+
+    const SCHEMA_1: &str = "schema1";
+    const SCHEMA_2: &str = "schema2";
+    #[test(tokio::test)]
+    async fn schema_by_url() {
+        async {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/schema1"))
+                .respond_with(ResponseTemplate::new(200).set_body_string(SCHEMA_1))
+                .mount(&mock_server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/schema2"))
+                .respond_with(ResponseTemplate::new(200).set_body_string(SCHEMA_2))
+                .mount(&mock_server)
+                .await;
+
+            let mut stream = SchemaSource::URLs {
+                urls: vec![
+                    Url::parse(&format!("http://{}/schema1", mock_server.address())).unwrap(),
+                    Url::parse(&format!("http://{}/schema2", mock_server.address())).unwrap(),
+                ],
+                watch: true,
+                period: Duration::from_secs(1),
+            }
+            .into_stream();
+
+            assert!(
+                matches!(stream.next().await.unwrap(), UpdateSchema(schema) if schema == SCHEMA_1)
+            );
+            assert!(
+                matches!(stream.next().await.unwrap(), UpdateSchema(schema) if schema == SCHEMA_1)
+            );
+        }
+        .with_subscriber(assert_snapshot_subscriber!())
+        .await;
+    }
+
+    #[test(tokio::test)]
+    async fn schema_by_url_fallback() {
+        async {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/schema1"))
+                .respond_with(ResponseTemplate::new(400))
+                .mount(&mock_server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/schema2"))
+                .respond_with(ResponseTemplate::new(200).set_body_string(SCHEMA_2))
+                .mount(&mock_server)
+                .await;
+
+            let mut stream = SchemaSource::URLs {
+                urls: vec![
+                    Url::parse(&format!("http://{}/schema1", mock_server.address())).unwrap(),
+                    Url::parse(&format!("http://{}/schema2", mock_server.address())).unwrap(),
+                ],
+                watch: true,
+                period: Duration::from_secs(1),
+            }
+            .into_stream();
+
+            assert!(
+                matches!(stream.next().await.unwrap(), UpdateSchema(schema) if schema == SCHEMA_2)
+            );
+            assert!(
+                matches!(stream.next().await.unwrap(), UpdateSchema(schema) if schema == SCHEMA_2)
+            );
+        }
+        .with_subscriber(assert_snapshot_subscriber!({
+            "[].fields[\"url.full\"]" => "[url.full]"
+        }))
+        .await;
+    }
+
+    #[test(tokio::test)]
+    async fn schema_by_url_all_fail() {
+        async {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/schema1"))
+                .respond_with(ResponseTemplate::new(400))
+                .mount(&mock_server)
+                .await;
+            Mock::given(method("GET"))
+                .and(path("/schema2"))
+                .respond_with(ResponseTemplate::new(400))
+                .mount(&mock_server)
+                .await;
+
+            let mut stream = SchemaSource::URLs {
+                urls: vec![
+                    Url::parse(&format!("http://{}/schema1", mock_server.address())).unwrap(),
+                    Url::parse(&format!("http://{}/schema2", mock_server.address())).unwrap(),
+                ],
+                watch: true,
+                period: Duration::from_secs(1),
+            }
+            .into_stream();
+
+            assert!(matches!(stream.next().await.unwrap(), NoMoreSchema));
+        }
+        .with_subscriber(assert_snapshot_subscriber!({
+            "[].fields[\"url.full\"]" => "[url.full]"
+        }))
+        .await;
+    }
+    #[test(tokio::test)]
+    async fn schema_success_fail_success() {
+        async {
+            let mock_server = MockServer::start().await;
+            let mut stream = SchemaSource::URLs {
+                urls: vec![
+                    Url::parse(&format!("http://{}/schema1", mock_server.address())).unwrap(),
+                ],
+                watch: true,
+                period: Duration::from_secs(1),
+            }
+            .into_stream()
+            .boxed()
+            .fuse();
+
+            let success = Mock::given(method("GET"))
+                .and(path("/schema1"))
+                .respond_with(ResponseTemplate::new(200).set_body_string(SCHEMA_1))
+                .mount_as_scoped(&mock_server)
+                .await;
+
+            assert!(
+                matches!(stream.next().await.unwrap(), UpdateSchema(schema) if schema == SCHEMA_1)
+            );
+
+            drop(success);
+
+            // Next call will timeout
+            assert!(select! {
+                _res = stream.next() => false,
+                _res = tokio::time::sleep(Duration::from_secs(2)).boxed().fuse() => true,
+
+            });
+
+            // Now we should get the schema again if the endpoint is back
+            Mock::given(method("GET"))
+                .and(path("/schema1"))
+                .respond_with(ResponseTemplate::new(200).set_body_string(SCHEMA_1))
+                .mount(&mock_server)
+                .await;
+
+            assert!(
+                matches!(stream.next().await.unwrap(), UpdateSchema(schema) if schema == SCHEMA_1)
+            );
+        }
+        .with_subscriber(assert_snapshot_subscriber!({
+            "[].fields[\"url.full\"]" => "[url.full]"
+        }))
+        .await;
+    }
+
+    #[test(tokio::test)]
+    async fn schema_no_watch() {
+        async {
+            let mock_server = MockServer::start().await;
+            Mock::given(method("GET"))
+                .and(path("/schema1"))
+                .respond_with(ResponseTemplate::new(200).set_body_string(SCHEMA_1))
+                .mount(&mock_server)
+                .await;
+
+            let mut stream = SchemaSource::URLs {
+                urls: vec![
+                    Url::parse(&format!("http://{}/schema1", mock_server.address())).unwrap(),
+                ],
+                watch: false,
+                period: Duration::from_secs(1),
+            }
+            .into_stream();
+
+            assert!(
+                matches!(stream.next().await.unwrap(), UpdateSchema(schema) if schema == SCHEMA_1)
+            );
+            assert!(matches!(stream.next().await.unwrap(), NoMoreSchema));
+        }
+        .with_subscriber(assert_snapshot_subscriber!())
+        .await;
     }
 }

--- a/apollo-router/src/router/event/snapshots/apollo_router__router__event__schema__tests__schema_by_url.snap
+++ b/apollo-router/src/router/event/snapshots/apollo_router__router__event__schema__tests__schema_by_url.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-router/src/router/event/schema.rs
+expression: yaml
+---
+[]
+

--- a/apollo-router/src/router/event/snapshots/apollo_router__router__event__schema__tests__schema_by_url_all_fail.snap
+++ b/apollo-router/src/router/event/snapshots/apollo_router__router__event__schema__tests__schema_by_url_all_fail.snap
@@ -1,0 +1,18 @@
+---
+source: apollo-router/src/router/event/schema.rs
+expression: yaml
+---
+- fields:
+    http.response.status_code: 400
+    url.full: "[url.full]"
+  level: WARN
+  message: failed to fetch supergraph schema
+- fields:
+    http.response.status_code: 400
+    url.full: "[url.full]"
+  level: WARN
+  message: failed to fetch supergraph schema
+- fields: {}
+  level: ERROR
+  message: failed to fetch supergraph schema from all urls
+

--- a/apollo-router/src/router/event/snapshots/apollo_router__router__event__schema__tests__schema_by_url_fallback.snap
+++ b/apollo-router/src/router/event/snapshots/apollo_router__router__event__schema__tests__schema_by_url_fallback.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-router/src/router/event/schema.rs
+expression: yaml
+---
+- fields:
+    http.response.status_code: 400
+    url.full: "[url.full]"
+  level: WARN
+  message: failed to fetch supergraph schema
+- fields:
+    http.response.status_code: 400
+    url.full: "[url.full]"
+  level: WARN
+  message: failed to fetch supergraph schema
+

--- a/apollo-router/src/router/event/snapshots/apollo_router__router__event__schema__tests__schema_no_watch.snap
+++ b/apollo-router/src/router/event/snapshots/apollo_router__router__event__schema__tests__schema_no_watch.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-router/src/router/event/schema.rs
+expression: yaml
+---
+[]
+

--- a/apollo-router/src/router/event/snapshots/apollo_router__router__event__schema__tests__schema_success_fail_success.snap
+++ b/apollo-router/src/router/event/snapshots/apollo_router__router__event__schema__tests__schema_success_fail_success.snap
@@ -1,0 +1,13 @@
+---
+source: apollo-router/src/router/event/schema.rs
+expression: yaml
+---
+- fields:
+    http.response.status_code: 404
+    url.full: "[url.full]"
+  level: WARN
+  message: failed to fetch supergraph schema
+- fields: {}
+  level: ERROR
+  message: failed to fetch supergraph schema from all urls
+

--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -291,7 +291,6 @@ mod test {
     use tracing::instrument::WithSubscriber;
 
     use crate::assert_snapshot_subscriber;
-    use crate::logging::test::SnapshotSubscriber;
     use crate::router::Event;
     use crate::uplink::license_enforcement::Audience;
     use crate::uplink::license_enforcement::Claims;

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_stream__test__validate_audience_multiple_filtered.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_stream__test__validate_audience_multiple_filtered.snap
@@ -4,6 +4,6 @@ expression: yaml
 ---
 - fields:
     code: APOLLO_ROUTER_LICENSE_OFFLINE_UNSUPPORTED
-    message: "the license file was valid, but was not enabled offline use"
   level: ERROR
+  message: "the license file was valid, but was not enabled offline use"
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_stream__test__validate_audience_single_filtered.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_stream__test__validate_audience_single_filtered.snap
@@ -4,6 +4,6 @@ expression: yaml
 ---
 - fields:
     code: APOLLO_ROUTER_LICENSE_OFFLINE_UNSUPPORTED
-    message: "the license file was valid, but was not enabled offline use"
   level: ERROR
+  message: "the license file was valid, but was not enabled offline use"
 


### PR DESCRIPTION
APOLLO_ROUTER_SUPERGRAPH_URLS takes a comma separated list of URLs which will be polled in order to try and retrieve the supergraph schema.

The regular `apollo_uplink_poll_interval` is used for duration between polls.

Fixes #4219



<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
