### PR TITLE
Fix subgraph query hashing with fragment reuse

### DIFF
--- a/apollo-router/src/spec/query/change.rs
+++ b/apollo-router/src/spec/query/change.rs
@@ -222,6 +222,7 @@ impl<'a> QueryHashVisitor<'a> {
                                 Some(condition) => self.inline_fragment(condition.as_str(), f)?,
                             };
                         }
+                        Selection::FragmentSpread(f) => self.fragment_spread(f)?,
                         _ => return Err("expected inline fragment".into()),
                     }
                 }


### PR DESCRIPTION
the hasher was assuming only inline fragments under _entities queries, but as an optimisation, named fragments can be reused

*Description here*

Fixes #**issue_number**

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
