### PR TITLE
Add dev mode to the env metrics reported to apollo.

### DIFF
--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -367,6 +367,11 @@ impl InstrumentData {
             env_var_exists("APOLLO_ROUTER_SUPERGRAPH_PATH"),
         );
 
+        attributes.insert(
+            "opt.apollo.dev".to_string(),
+            env_var_exists("APOLLO_ROUTER_DEV_ENV"),
+        );
+
         self.data
             .insert("apollo.router.config.env".to_string(), (1, attributes));
     }

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__env_metrics.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__env_metrics.snap
@@ -7,6 +7,7 @@ expression: "&metrics.non_zero()"
     datapoints:
       - value: 1
         attributes:
+          opt.apollo.dev: true
           opt.apollo.graph_ref: true
           opt.apollo.key: true
           opt.apollo.license: true


### PR DESCRIPTION
Adding dev mode so that we can filter out particularly router developers from our usage metrics.
<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
