### PR TITLE
test fragment reuse

### DIFF
--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__fragment_reuse.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__fragment_reuse.snap
@@ -1,0 +1,17 @@
+---
+source: apollo-router/src/services/supergraph/tests.rs
+expression: response
+---
+{
+  "data": {
+    "me": {
+      "name": "Ada",
+      "organizations": [
+        {
+          "id": "2",
+          "name": "Apollo"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
As an optimization, query fragments can be reused in subgraph _entities queries, and this case was not handled in some parts of the router

This adds a test for https://github.com/apollographql/router/pull/4387 and https://github.com/apollographql/router/pull/4388 where subgraph query hashing only supported inline fragments

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
