### PR TITLE
[multipart-subscriptions-protocol.md] Let the server decide the boundary

### DIFF
--- a/dev-docs/multipart-subscriptions-protocol.md
+++ b/dev-docs/multipart-subscriptions-protocol.md
@@ -4,10 +4,10 @@ Instead of relying on WebSockets, the subscriptions protocol supported by the ro
 
 ## Communication
 
-When sending a request containing a subscription to the router, clients MUST support the `multipart/mixed; subscriptionSpec="1.0"` content-type in addition to the `application/graphql-response+json` content-type:
+When sending a request containing a subscription to the router, clients MUST support the `multipart/mixed; subscriptionSpec="1.0"` content-type in addition to the `application/json` content-type:
 
 ```
-Accept: multipart/mixed; subscriptionSpec="1.0", application/graphql-response+json
+Accept: multipart/mixed; subscriptionSpec="1.0", application/json
 ```
 
 The router will then respond with a stream of body parts, following the [definition of multipart content specified in RFC1341](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html).

--- a/dev-docs/multipart-subscriptions-protocol.md
+++ b/dev-docs/multipart-subscriptions-protocol.md
@@ -4,12 +4,11 @@ Instead of relying on WebSockets, the subscriptions protocol supported by the ro
 
 ## Communication
 
-When sending a request containing a subscription to the router, clients should include the following `Accept` header to indicate their support for the multipart subscriptions protocol:
-```
-Accept: multipart/mixed; boundary="graphql"; subscriptionSpec="1.0", application/json
-```
+When sending a request containing a subscription to the router, clients MUST support the `multipart/mixed; subscriptionSpec="1.0"` content-type in addition to the `application/graphql-response+json` content-type:
 
-> Note that `boundary` should always be `graphql` for now, and `subscriptionSpec` is `1.0` for the current version of the protocol.
+```
+Accept: multipart/mixed; subscriptionSpec="1.0", application/graphql-response+json
+```
 
 The router will then respond with a stream of body parts, following the [definition of multipart content specified in RFC1341](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html).
 
@@ -26,6 +25,9 @@ Content-Type: application/json
 {"payload": {"data": { "newPost": { "id": 123, "title": "Hello!"}}}}
 --graphql--
 ```
+
+> Note: because the parts are always JSON, it is never possible for `\r\n--graphql` to appear in the contents of a part. For convenience, servers MAY use `graphql` as a boundary.
+> Clients MUST accomodate any boundary returned by the server in `Content-Type`.
 
 When HTTP/1 is used, the response will use `Transfer-Encoding: chunked`, but this is not needed for HTTP/2 (which has built-in support for data streaming) and actually [disallowed](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding).
 


### PR DESCRIPTION
Remove the multipart boundary from the client `Accept` header. Typically, the boundary is decided by the server in order to avoid nameclashes with the parts contents. It just happens that `--graphql` works all the time for us because the part contents are JSON.

Keep `--graphql` as a "may" for convenience but mandate that clients support any boundary sent by the server. I _think_ this is already the case for web/ios/kotlin? Ping @alessbell @calvincestari 

ping @bnjjj @abernix 