### PR TITLE
use __typename as current type if present in requires selection

### DIFF
--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -7,6 +7,7 @@ use crate::json_ext::Object;
 use crate::json_ext::Value;
 use crate::json_ext::ValueExt;
 use crate::spec::Schema;
+use crate::spec::TYPENAME;
 
 /// A selection that is part of a fetch.
 /// Selections are used to propagate data to subgraph fetches.
@@ -60,7 +61,7 @@ pub(crate) fn execute_selection_set<'a>(
     };
 
     current_type = content
-        .get("__typename")
+        .get(TYPENAME)
         .and_then(|v| v.as_str())
         .or(current_type);
 
@@ -87,7 +88,7 @@ pub(crate) fn execute_selection_set<'a>(
 
                 match content.get_key_value(selection_name) {
                     None => {
-                        if name == "__typename" {
+                        if name == TYPENAME {
                             // if the __typename field was missing but we can infer it, fill it
                             if let Some(ty) = current_type {
                                 output.insert(

--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -59,7 +59,10 @@ pub(crate) fn execute_selection_set<'a>(
         None => return Value::Null,
     };
 
-    current_type = current_type.or_else(|| content.get("__typename").and_then(|v| v.as_str()));
+    current_type = content
+        .get("__typename")
+        .and_then(|v| v.as_str())
+        .or(current_type);
 
     let mut output = Object::with_capacity(selections.len());
     for selection in selections {

--- a/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__tests__missing_typename_and_fragments_in_requires2.snap
+++ b/apollo-router/src/query_planner/snapshots/apollo_router__query_planner__tests__missing_typename_and_fragments_in_requires2.snap
@@ -1,0 +1,12 @@
+---
+source: apollo-router/src/query_planner/tests.rs
+expression: "serde_json::to_value(&response).unwrap()"
+---
+{
+  "data": {
+    "stuff": {
+      "id": "1",
+      "isEnabled": true
+    }
+  }
+}

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -1242,7 +1242,8 @@ async fn missing_typename_and_fragments_in_requires2() {
                         "__typename": "Stuff",
                         "id": "1",
                         "thing": {
-                        "__typename": "Thing1"
+                        "__typename": "Thing1",
+                        "text1": "aaa"
                         }
                     }
                 ]}}},

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -1134,6 +1134,153 @@ async fn missing_typename_and_fragments_in_requires() {
 }
 
 #[tokio::test]
+async fn missing_typename_and_fragments_in_requires2() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+  
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+  
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+  
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+  
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+  
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+  
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+  
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+  
+  scalar join__FieldSet
+  
+  enum join__Graph {
+    SUB1 @join__graph(name: "sub1", url: "http://localhost:4002/test")
+    SUB2 @join__graph(name: "sub2", url: "http://localhost:4002/test2")
+  }
+  
+  scalar link__Import
+  
+  enum link__Purpose {
+    """
+    `SECURITY` features provide metadata necessary to securely resolve fields.
+    """
+    SECURITY
+  
+    """
+    `EXECUTION` features provide metadata necessary for operation execution.
+    """
+    EXECUTION
+  }
+  
+  type Query
+    @join__type(graph: SUB1)
+    @join__type(graph: SUB2)
+  {
+    stuff: Stuff @join__field(graph: SUB1)
+  }
+  
+  type Stuff
+    @join__type(graph: SUB1, key: "id")
+    @join__type(graph: SUB2, key: "id", extension: true)
+  {
+    id: ID
+    thing: PossibleThing @join__field(graph: SUB1) @join__field(graph: SUB2, external: true) 
+    isEnabled: Boolean @join__field(graph: SUB2, requires: "thing { ... on Thing1 { __typename text1 } ... on Thing2 { __typename text2 } }")
+  }
+  
+  union PossibleThing @join__type(graph: SUB1) @join__type(graph: SUB2)
+  @join__unionMember(graph: SUB1, member: "Thing1") @join__unionMember(graph: SUB1, member: "Thing2")
+  @join__unionMember(graph: SUB2, member: "Thing1") @join__unionMember(graph: SUB2, member: "Thing2")
+    = Thing1 | Thing2
+
+  type Thing1
+  @join__type(graph: SUB1, key: "id")
+  @join__type(graph: SUB2, key: "id") {
+    id: ID
+    text1: String @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+  }
+
+  type Thing2
+  @join__type(graph: SUB1, key: "id")
+  @join__type(graph: SUB2, key: "id") {
+    id: ID
+    text2: String @join__field(graph: SUB1) @join__field(graph: SUB2, external: true)
+  }
+  "#;
+
+    let query = "query {
+        stuff {
+          id
+          isEnabled
+        }
+      }";
+
+    let subgraphs = MockedSubgraphs([
+        ("sub1", MockSubgraph::builder().with_json(
+            serde_json::json!{{"query": "{stuff{__typename id thing{__typename ...on Thing1{__typename text1}...on Thing2{__typename text2}}}}",}},
+            serde_json::json!{{"data": {
+                "stuff": {
+                  "__typename": "Stuff",
+                  "id": "1",
+                  "thing": {
+                    "__typename": "Thing1",
+                    "text1": "aaa"
+                  }
+                }
+            } }}
+        ).build()),
+        ("sub2", MockSubgraph::builder().with_json(
+            serde_json::json!{{
+                "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on Stuff{isEnabled}}}",
+                "variables":{"representations": [
+                    {
+                        "__typename": "Stuff",
+                        "id": "1",
+                        "thing": {
+                        "__typename": "Thing1"
+                        }
+                    }
+                ]}}},
+            serde_json::json!{{"data": {
+                "_entities": [{
+                    "isEnabled": true
+                }]
+            } }}
+        ).build()),
+        ].into_iter().collect());
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true } }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(Context::new())
+        .query(query)
+        .variables(
+            serde_json_bytes::json! {{ "tId": "1"}}
+                .as_object()
+                .unwrap()
+                .clone(),
+        )
+        .build()
+        .unwrap();
+
+    let mut stream = service.clone().oneshot(request).await.unwrap();
+    let response = stream.next_response().await.unwrap();
+    insta::assert_json_snapshot!(serde_json::to_value(&response).unwrap());
+}
+
+#[tokio::test]
 async fn null_in_requires() {
     let schema = r#"schema
     @link(url: "https://specs.apollo.dev/link/v1.0")


### PR DESCRIPTION
Investigation as a follow up to https://github.com/apollographql/router/commit/4a592f4933b7b9e46f14c7a98404b9e067687f09

 If the field we are selecting from is a union, when going into  `execute_selection_set`, `current_type` will be the name of the union. If we already have a `__typename` field, it will be more precise than `current_type` and should be used instead

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
