### PR TITLE
fix(telemetry): use the right conventions for batching metrics

### DIFF
--- a/.changesets/fix_bnjjj_fix_metric_name.md
+++ b/.changesets/fix_bnjjj_fix_metric_name.md
@@ -1,0 +1,5 @@
+### Use the right conventions for batching metrics ([PR #4424](https://github.com/apollographql/router/pull/4424))
+
+Rename `apollo_router.operations.batching` to  `apollo.router.operations.batching` because it doesn't follow our conventions with `apollo.router.` prefix.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/4424

--- a/apollo-router/src/request.rs
+++ b/apollo-router/src/request.rs
@@ -198,12 +198,12 @@ impl Request {
 
         if value.is_array() {
             tracing::info!(
-                histogram.apollo_router.operations.batching.size = result.len() as f64,
+                histogram.apollo.router.operations.batching.size = result.len() as f64,
                 mode = %BatchingMode::BatchHttpLink // Only supported mode right now
             );
 
             tracing::info!(
-                monotonic_counter.apollo_router.operations.batching = 1u64,
+                monotonic_counter.apollo.router.operations.batching = 1u64,
                 mode = %BatchingMode::BatchHttpLink // Only supported mode right now
             );
             for entry in value
@@ -225,12 +225,12 @@ impl Request {
 
         if value.is_array() {
             tracing::info!(
-                histogram.apollo_router.operations.batching.size = result.len() as f64,
+                histogram.apollo.router.operations.batching.size = result.len() as f64,
                 mode = "batch_http_link" // Only supported mode right now
             );
 
             tracing::info!(
-                monotonic_counter.apollo_router.operations.batching = 1u64,
+                monotonic_counter.apollo.router.operations.batching = 1u64,
                 mode = "batch_http_link" // Only supported mode right now
             );
             for entry in value

--- a/docs/source/configuration/telemetry/instrumentation/standard-instruments.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/standard-instruments.mdx
@@ -97,8 +97,8 @@ The initial call to Uplink during router startup is not reflected in metrics.
 
 ### Batching
 
-- `apollo_router.operations.batching` - A counter of the number of query batches received by the router.
-- `apollo_router.operations.batching.size` - A histogram tracking the number of queries contained within a query batch.
+- `apollo.router.operations.batching` - A counter of the number of query batches received by the router.
+- `apollo.router.operations.batching.size` - A histogram tracking the number of queries contained within a query batch.
 
 ### GraphOS Studio
 


### PR DESCRIPTION
Rename `apollo_router.operations.batching` to  `apollo.router.operations.batching` because it doesn't follow our conventions with `apollo.router.` prefix.

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
