### PR TITLE
create a nightly noop release publish step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -764,6 +764,14 @@ jobs:
     steps:
       - when:
           condition:
+            not:
+              equal: [ "https://github.com/apollographql/router", << pipeline.project.git_url >> ]
+          steps:
+             - run:
+                command: >
+                  echo "Not publishing any github release."
+      - when:
+          condition:
             equal: [ "https://github.com/apollographql/router", << pipeline.project.git_url >> ]
           steps:
             - checkout


### PR DESCRIPTION
Followup to https://github.com/apollographql/router/pull/4419, this makes the circleci file valid on any repository