### PR TITLE
Add note about otel endpoint param being only the base url

### DIFF
--- a/docs/source/configuration/telemetry/exporters/tracing/otlp.mdx
+++ b/docs/source/configuration/telemetry/exporters/tracing/otlp.mdx
@@ -57,7 +57,7 @@ Defaults to:
 
 <Note>
 
-Specify only the base URL in the endpoint parameter. The `/v1/traces` portion of the URL will be automatically added to match the [Open Telemetry specification](https://opentelemetry.io/docs/specs/otlp/#otlphttp-request).
+Specify only the base URL in the endpoint parameter. The router automatically adds the `/v1/traces` portion of the URL to match the [OpenTelemetry specification](https://opentelemetry.io/docs/specs/otlp/#otlphttp-request).
 
 </Note>
 

--- a/docs/source/configuration/telemetry/exporters/tracing/otlp.mdx
+++ b/docs/source/configuration/telemetry/exporters/tracing/otlp.mdx
@@ -55,6 +55,12 @@ Defaults to:
 * http://127.0.0.1:4317 for gRPC 
 * http://127.0.0.1:4318 for HTTP
 
+<Note>
+
+Specify only the base URL in the endpoint parameter. The `/v1/traces` portion of the URL will be automatically added to match the [Open Telemetry specification](https://opentelemetry.io/docs/specs/otlp/#otlphttp-request).
+
+</Note>
+
 ### `grpc`
 Settings specific to the gRPC protocol for setting a custom SSL certificate, domain name, and metadata.
 


### PR DESCRIPTION
Small documentation change after a customer question around the otel endpoint.