### PR TITLE
fix: build entity representations with inline fragments correctly

### DIFF
--- a/.changesets/fix_lb_requires_selection_set_abstract_types.md
+++ b/.changesets/fix_lb_requires_selection_set_abstract_types.md
@@ -1,0 +1,5 @@
+### fix: build entity representations with inline fragments correctly ([PR #4441](https://github.com/apollographql/router/pull/4441))
+
+This uses a more flexible abstract type / concrete type check when applying a selection set to an entity reference before it's used in a fetch node. Previous to this change, we would drop data from the reference when it selected using an inline fragment (e.g. `@requires(fields: "... on Foo { a } ... on Bar { b }")`).
+
+By [@lennyburdette](https://github.com/lennyburdette) in https://github.com/apollographql/router/pull/4441

--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__abstract_types_in_requires.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__abstract_types_in_requires.snap
@@ -1,0 +1,11 @@
+---
+source: apollo-router/src/services/supergraph/tests.rs
+expression: stream.next_response().await.unwrap()
+---
+{
+  "data": {
+    "entity": {
+      "fieldWithDependencies": "success"
+    }
+  }
+}

--- a/apollo-router/src/services/supergraph/tests.rs
+++ b/apollo-router/src/services/supergraph/tests.rs
@@ -2989,3 +2989,173 @@ async fn fragment_reuse() {
 
     insta::assert_json_snapshot!(response);
 }
+
+#[tokio::test]
+async fn abstract_types_in_requires() {
+    let schema = r#"schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  {
+    query: Query
+  }
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    A @join__graph(name: "A", url: "https://localhost:4001")
+    B @join__graph(name: "B", url: "https://localhost:4002")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    """
+    `SECURITY` features provide metadata necessary to securely resolve fields.
+    """
+    SECURITY
+
+    """
+    `EXECUTION` features provide metadata necessary for operation execution.
+    """
+    EXECUTION
+  }
+
+  type Query
+    @join__type(graph: A)
+  {
+    entity: Entity @join__field(graph: A)
+  }
+
+  type Entity
+    @join__type(graph: A, key: "id")
+    @join__type(graph: B, key: "id")
+  {
+    id: ID
+    if: If @join__field(graph: A) @join__field(graph: B, external: true)
+    un: Un @join__field(graph: A) @join__field(graph: B, external: true)
+    fieldWithDependencies: String
+      @join__field(graph: B, requires: "if { i ... on IfA { a } } un { ... on UnZ { z } }")
+  }
+
+  interface If @join__type(graph: A) @join__type(graph: B) {
+    i: ID
+  }
+
+  type IfA implements If
+    @join__type(graph: A)
+    @join__type(graph: B)
+    @join__implements(graph: A, interface: "If")
+    @join__implements(graph: B, interface: "If")
+  {
+    i: ID
+    a: ID
+  }
+
+  type UnZ @join__type(graph: A) @join__type(graph: B) {
+    z: ID
+  }
+
+  union Un
+    @join__type(graph: A)
+    @join__type(graph: B)
+    @join__unionMember(graph: A, member: "UnZ")
+    @join__unionMember(graph: B, member: "UnZ") =
+      UnZ
+      "#;
+
+    let subgraphs = MockedSubgraphs(
+        [
+            (
+                "A",
+                MockSubgraph::builder().with_json(
+                    serde_json::json!({"query":"{entity{__typename id if{__typename i ...on IfA{a}}un{__typename ...on UnZ{z}}}}"}),
+                    serde_json::json!{{"data": {
+                        "entity": {
+                            "__typename": "Entity",
+                            "id": "1",
+                            "if": {
+                              "__typename": "IfA",
+                              "i": "i",
+                              "a": "a"
+                            },
+                            "un": {
+                              "__typename": "UnZ",
+                              "z": "z"
+                            }
+                        }
+                    } }}
+                ).build(),
+            ),
+            (
+                "B",
+                MockSubgraph::builder().with_json(
+                    serde_json::json!{{
+                        "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on Entity{fieldWithDependencies}}}",
+                        "variables": {
+                          "representations": [
+                            {
+                              "__typename": "Entity",
+                              "id": "1",
+                              "if": {
+                                "i": "i",
+                                "a": "a"
+                              },
+                              "un": {
+                                "z": "z"
+                              }
+                            }
+                          ]
+                        }
+                    }},
+                    serde_json::json!{{"data": {
+                        "_entities": [{
+                            "__typename":"Entity",
+                            "fieldWithDependencies": "success"
+                        }]
+                    } }}
+                ).build(),
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true } }))
+        .unwrap()
+        .schema(schema)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .context(defer_context())
+        .query(
+            "query {
+            entity {
+              fieldWithDependencies
+            }
+          }
+          ",
+        )
+        .build()
+        .unwrap();
+
+    let mut stream = service.oneshot(request).await.unwrap();
+    insta::assert_json_snapshot!(stream.next_response().await.unwrap());
+}


### PR DESCRIPTION
This uses a more flexible abstract type / concrete type check when applying a selection set to an entity reference before it's used in a fetch node. Previous to this change, we would drop data from the reference when it selected using an inline fragment (e.g. `@requires(fields: "... on Foo { a } ... on Bar { b }")`).

This addresses a customer issue.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
