### PR TITLE
Promote HTTP request size limit from experimental to general availability

### DIFF
--- a/.changesets/feat_simon_http_max_request_bytes_ga.md
+++ b/.changesets/feat_simon_http_max_request_bytes_ga.md
@@ -1,0 +1,24 @@
+### Promote HTTP request size limit from experimental to general availability ([PR #4442](https://github.com/apollographql/router/pull/4442))
+
+By default Apollo Router limits the size of the HTTP request body it will read from the network to 2 MB. In this version, the YAML configuration to change the limit is promoted from experimental to general availability.
+
+For more information about launch stages, please see the documentation here: https://www.apollographql.com/docs/resources/product-launch-stages/
+
+Before increasing this limit significantly consider testing performance in an environment similar to your production,
+especially if some clients are untrusted. Many concurrent large requests could cause the Router to run out of memory.
+
+Previous configuration will warn but still work:
+
+```yaml
+limits:
+  experimental_http_max_request_bytes: 2000000 # Default value: 2 MB
+```
+
+The warning can be fixed by removing the `experimental_` prefix:
+
+```yaml
+limits:
+  http_max_request_bytes: 2000000 # Default value: 2 MB
+```
+
+By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/4442

--- a/apollo-router/feature_discussions.json
+++ b/apollo-router/feature_discussions.json
@@ -3,9 +3,7 @@
     "experimental_retry": "https://github.com/apollographql/router/discussions/2241",
     "experimental_response_trace_id": "https://github.com/apollographql/router/discussions/2147",
     "experimental_when_header": "https://github.com/apollographql/router/discussions/1961",
-    "experimental_http_max_request_bytes": "https://github.com/apollographql/router/discussions/3220",
     "experimental_batching": "https://github.com/apollographql/router/discussions/3840"
   },
-  "preview": {
-  }
+  "preview": {}
 }

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -235,7 +235,7 @@ impl InstrumentData {
             opt.parser.max_tokens,
             "$[?(@.parser_max_tokens)]",
             opt.request.max_size,
-            "$[?(@.experimental_http_max_request_bytes)]"
+            "$[?(@.http_max_request_bytes)]"
         );
         populate_config_instrument!(
             apollo.router.config.apq,

--- a/apollo-router/src/configuration/migrations/0021-http-max-request-bytes-ga.yaml
+++ b/apollo-router/src/configuration/migrations/0021-http-max-request-bytes-ga.yaml
@@ -1,0 +1,5 @@
+description: HTTP request size limit is no longer experimental, `experimental_http_max_request_bytes` is renamed `http_max_request_bytes`
+actions:
+  - type: move
+    from: limits.experimental_http_max_request_bytes
+    to: limits.http_max_request_bytes

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -766,7 +766,7 @@ pub(crate) struct Limits {
 
     /// Limit the size of incoming HTTP requests read from the network,
     /// to protect against running out of memory. Default: 2000000 (2 MB)
-    pub(crate) experimental_http_max_request_bytes: usize,
+    pub(crate) http_max_request_bytes: usize,
 }
 
 impl Default for Limits {
@@ -778,7 +778,7 @@ impl Default for Limits {
             max_root_fields: None,
             max_aliases: None,
             warn_only: false,
-            experimental_http_max_request_bytes: 2_000_000,
+            http_max_request_bytes: 2_000_000,
             parser_max_tokens: 15_000,
 
             // This is `apollo-parser`’s default, which protects against stack overflow

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1799,11 +1799,11 @@ expression: "&schema"
         "warn_only": false,
         "parser_max_recursion": 500,
         "parser_max_tokens": 15000,
-        "experimental_http_max_request_bytes": 2000000
+        "http_max_request_bytes": 2000000
       },
       "type": "object",
       "properties": {
-        "experimental_http_max_request_bytes": {
+        "http_max_request_bytes": {
           "description": "Limit the size of incoming HTTP requests read from the network, to protect against running out of memory. Default: 2000000 (2 MB)",
           "default": 2000000,
           "type": "integer",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@http_max_request_bytes.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__upgrade_old_configuration@http_max_request_bytes.router.yaml.snap
@@ -1,0 +1,8 @@
+---
+source: apollo-router/src/configuration/tests.rs
+expression: new_config
+---
+---
+limits:
+  http_max_request_bytes: 4000000
+

--- a/apollo-router/src/configuration/testdata/metrics/limits.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/limits.router.yaml
@@ -1,6 +1,6 @@
 limits:
   max_depth: 1
-  experimental_http_max_request_bytes: 2000000
+  http_max_request_bytes: 2000000
   warn_only: true
   max_root_fields: 1
   parser_max_tokens: 15000

--- a/apollo-router/src/configuration/testdata/migrations/http_max_request_bytes.router.yaml
+++ b/apollo-router/src/configuration/testdata/migrations/http_max_request_bytes.router.yaml
@@ -1,0 +1,2 @@
+limits:
+  experimental_http_max_request_bytes: 4000000

--- a/apollo-router/src/services/router/tests.rs
+++ b/apollo-router/src/services/router/tests.rs
@@ -183,12 +183,12 @@ async fn it_fails_on_no_query() {
 }
 
 #[tokio::test]
-async fn test_experimental_http_max_request_bytes() {
+async fn test_http_max_request_bytes() {
     /// Size of the JSON serialization of the request created by `fn canned_new`
     /// in `apollo-router/src/services/supergraph.rs`
     const CANNED_REQUEST_LEN: usize = 391;
 
-    async fn with_config(experimental_http_max_request_bytes: usize) -> router::Response {
+    async fn with_config(http_max_request_bytes: usize) -> router::Response {
         let http_request = supergraph::Request::canned_builder()
             .build()
             .unwrap()
@@ -206,7 +206,7 @@ async fn test_experimental_http_max_request_bytes() {
             });
         let config = serde_json::json!({
             "limits": {
-                "experimental_http_max_request_bytes": experimental_http_max_request_bytes
+                "http_max_request_bytes": http_max_request_bytes
             }
         });
         crate::TestHarness::builder()

--- a/apollo-router/tests/fixtures/prometheus.router.yaml
+++ b/apollo-router/tests/fixtures/prometheus.router.yaml
@@ -1,5 +1,5 @@
 limits:
-  experimental_http_max_request_bytes: 60
+  http_max_request_bytes: 60
 telemetry:
   exporters:
     metrics:

--- a/apollo-router/tests/snapshots/lifecycle_tests__cli_config_experimental.snap
+++ b/apollo-router/tests/snapshots/lifecycle_tests__cli_config_experimental.snap
@@ -10,7 +10,6 @@ stdout:
 List of all experimental configurations with related GitHub discussions:
 
 	- experimental_batching: https://github.com/apollographql/router/discussions/3840
-	- experimental_http_max_request_bytes: https://github.com/apollographql/router/discussions/3220
 	- experimental_response_trace_id: https://github.com/apollographql/router/discussions/2147
 	- experimental_retry: https://github.com/apollographql/router/discussions/2241
 	- experimental_when_header: https://github.com/apollographql/router/discussions/1961

--- a/apollo-router/tests/telemetry/metrics.rs
+++ b/apollo-router/tests/telemetry/metrics.rs
@@ -153,7 +153,7 @@ async fn test_bad_queries() {
     router.execute_huge_query().await;
     router
         .assert_metrics_contains(
-            r#"apollo_router_http_requests_total{error="payload too large for the `experimental_http_max_request_bytes` configuration",status="413",otel_scope_name="apollo/router"} 1"#,
+            r#"apollo_router_http_requests_total{error="payload too large for the `http_max_request_bytes` configuration",status="413",otel_scope_name="apollo/router"} 1"#,
             None,
         )
         .await;

--- a/docs/shared/router-common-config.mdx
+++ b/docs/shared/router-common-config.mdx
@@ -21,7 +21,7 @@ router:
     args: [--hot-reload]
     configuration:
       limits:
-        experimental_http_max_request_bytes: 20000000 #20MB
+        http_max_request_bytes: 20000000 #20MB
       traffic_shaping:
         router:
           timeout: 6min

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -723,7 +723,7 @@ The router rejects any request that violates at least one of these limits.
 ```yaml title="router.yaml"
 limits:
   # Network-based limits
-  experimental_http_max_request_bytes: 2000000 # Default value: 2 MB
+  http_max_request_bytes: 2000000 # Default value: 2 MB
 
   # Parser-based limits
   parser_max_tokens: 15000 # Default value
@@ -743,8 +743,6 @@ See [this article](./operation-limits/).
 #### Network-based limits
 
 ##### `http_max_request_bytes`
-
-<ExperimentalFeature />
 
 Limits the amount of data read from the network for the body of HTTP requests,
 to protect against unbounded memory consumption.

--- a/docs/source/containerization/kubernetes.mdx
+++ b/docs/source/containerization/kubernetes.mdx
@@ -250,7 +250,7 @@ By default the router sets its maximum supported request size at 2MB, while the 
   router:
     configuration:
       limits:
-        experimental_http_max_request_bytes: 20000000 #20MB
+        http_max_request_bytes: 20000000 #20MB
   ```
 
 ### Increase request timeout


### PR DESCRIPTION
By default Apollo Router limits the size of the HTTP request body it will read from the network to 2 MB. In this version, the YAML configuration to change the limit is promoted from experimental to general availability.

For more information about launch stages, please see the documentation here: https://www.apollographql.com/docs/resources/product-launch-stages/

Before increasing this limit significantly consider testing performance in an environment similar to your production,
especially if some clients are untrusted. Many concurrent large requests could cause the Router to run out of memory.

Previous configuration will warn but still work:

```yaml
limits:
  experimental_http_max_request_bytes: 2000000 # Default value: 2 MB
```

The warning can be fixed by removing the `experimental_` prefix:

```yaml
limits:
  http_max_request_bytes: 2000000 # Default value: 2 MB
```

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
