### PR TITLE
Fix the datadog default tracing exporter URL.

### DIFF
--- a/.changesets/fix_bryn_fix_datadog_default_url.md
+++ b/.changesets/fix_bryn_fix_datadog_default_url.md
@@ -1,0 +1,6 @@
+### Fix the Datadog default tracing exporter URL ([Issue #4415](https://github.com/apollographql/router/issues/4416))
+
+The default URL for the Datadog exporter was incorrectly set to `http://localhost:8126/v0.4/traces` which caused issues for users that were running different agent versions.
+This is now fixed and matches the exporter URL of `http://127.0.0.1:8126`.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/4444

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -33,7 +33,7 @@ lazy_static! {
         map.insert("subgraph_request", "graphql.operation.name");
         map
     };
-    static ref DEFAULT_ENDPOINT: Uri = Uri::from_static("http://localhost:8126/v0.4/traces");
+    static ref DEFAULT_ENDPOINT: Uri = Uri::from_static("http://127.0.0.1:8126");
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema, Default)]

--- a/docs/source/configuration/telemetry/exporters/tracing/datadog.mdx
+++ b/docs/source/configuration/telemetry/exporters/tracing/datadog.mdx
@@ -57,8 +57,8 @@ telemetry:
      tracing:
        datadog:
          enabled: true
-         # Optional endpoint, either 'default' or a URL (Defaults to http://localhost:8126/v0.4/traces)
-         endpoint: "http://${env.DATADOG_AGENT_HOST}:8126/v0.4/traces"
+         # Optional endpoint, either 'default' or a URL (Defaults to http://localhost:8126)
+         endpoint: "http://${env.DATADOG_AGENT_HOST}:8126"
 ```
 
 ### `enabled`

--- a/docs/source/configuration/telemetry/exporters/tracing/datadog.mdx
+++ b/docs/source/configuration/telemetry/exporters/tracing/datadog.mdx
@@ -57,7 +57,7 @@ telemetry:
      tracing:
        datadog:
          enabled: true
-         # Optional endpoint, either 'default' or a URL (Defaults to http://localhost:8126)
+         # Optional endpoint, either 'default' or a URL (Defaults to http://127.0.0.1:8126)
          endpoint: "http://${env.DATADOG_AGENT_HOST}:8126"
 ```
 


### PR DESCRIPTION
The default URL for the datadog exporter was incorrectly set to `http://localhost:8126/v0.4/traces`

This now matches the default exporter URL of http://127.0.0.1:8126.
https://github.com/open-telemetry/opentelemetry-rust-contrib/blob/main/opentelemetry-datadog/src/exporter/mod.rs#L31

Fixes #4416 

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
