### PR TITLE
refactor(multipart): do not enforce boundary in accept header

### DIFF
--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -81,6 +81,7 @@ use crate::services::PluggableSupergraphServiceBuilder;
 use crate::services::RouterRequest;
 use crate::services::RouterResponse;
 use crate::services::SupergraphResponse;
+use crate::services::MULTIPART_DEFER_ACCEPT;
 use crate::services::MULTIPART_DEFER_CONTENT_TYPE;
 use crate::test_harness::http_client;
 use crate::test_harness::http_client::MaybeMultipart;
@@ -1666,10 +1667,7 @@ async fn deferred_response_shape() -> Result<(), ApolloRouterError> {
     let mut response = client
         .post(&url)
         .body(query.to_string())
-        .header(
-            ACCEPT,
-            HeaderValue::from_static(MULTIPART_DEFER_CONTENT_TYPE),
-        )
+        .header(ACCEPT, HeaderValue::from_static(MULTIPART_DEFER_ACCEPT))
         .send()
         .await
         .unwrap();
@@ -1727,10 +1725,7 @@ async fn multipart_response_shape_with_one_chunk() -> Result<(), ApolloRouterErr
     let mut response = client
         .post(&url)
         .body(query.to_string())
-        .header(
-            ACCEPT,
-            HeaderValue::from_static(MULTIPART_DEFER_CONTENT_TYPE),
-        )
+        .header(ACCEPT, HeaderValue::from_static(MULTIPART_DEFER_ACCEPT))
         .send()
         .await
         .unwrap();

--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -1162,7 +1162,7 @@ async fn it_errors_on_bad_accept_header() -> Result<(), ApolloRouterError> {
     );
     assert_eq!(
         response.text().await.unwrap(),
-        r#"{"errors":[{"message":"'accept' header must be one of: \\\"*/*\\\", \"application/json\", \"application/graphql-response+json\", \"multipart/mixed;boundary=\\\"graphql\\\";subscriptionSpec=1.0\" or \"multipart/mixed;boundary=\\\"graphql\\\";deferSpec=20220824\"","extensions":{"code":"INVALID_ACCEPT_HEADER"}}]}"#
+        r#"{"errors":[{"message":"'accept' header must be one of: \\\"*/*\\\", \"application/json\", \"application/graphql-response+json\", \"multipart/mixed;subscriptionSpec=1.0\" or \"multipart/mixed;deferSpec=20220824\"","extensions":{"code":"INVALID_ACCEPT_HEADER"}}]}"#
     );
 
     server.shutdown().await

--- a/apollo-router/src/plugins/telemetry/metrics/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo.rs
@@ -357,10 +357,8 @@ mod test {
             .and_operation_name(operation_name)
             .and_context(context);
         if is_subscription {
-            request_builder = request_builder.header(
-                "accept",
-                "multipart/mixed; boundary=graphql; subscriptionSpec=1.0",
-            );
+            request_builder =
+                request_builder.header("accept", "multipart/mixed; subscriptionSpec=1.0");
         }
         TestHarness::builder()
             .extra_plugin(plugin)

--- a/apollo-router/src/services/layers/content_negotiation.rs
+++ b/apollo-router/src/services/layers/content_negotiation.rs
@@ -22,15 +22,15 @@ use crate::graphql;
 use crate::layers::sync_checkpoint::CheckpointService;
 use crate::layers::ServiceExt as _;
 use crate::services::router;
-use crate::services::router::service::MULTIPART_DEFER_HEADER_VALUE;
-use crate::services::router::service::MULTIPART_SUBSCRIPTION_HEADER_VALUE;
+use crate::services::router::service::MULTIPART_DEFER_CONTENT_TYPE_HEADER_VALUE;
+use crate::services::router::service::MULTIPART_SUBSCRIPTION_CONTENT_TYPE_HEADER_VALUE;
 use crate::services::router::ClientRequestAccepts;
 use crate::services::supergraph;
 use crate::services::APPLICATION_JSON_HEADER_VALUE;
-use crate::services::MULTIPART_DEFER_CONTENT_TYPE;
+use crate::services::MULTIPART_DEFER_ACCEPT;
 use crate::services::MULTIPART_DEFER_SPEC_PARAMETER;
 use crate::services::MULTIPART_DEFER_SPEC_VALUE;
-use crate::services::MULTIPART_SUBSCRIPTION_CONTENT_TYPE;
+use crate::services::MULTIPART_SUBSCRIPTION_ACCEPT;
 use crate::services::MULTIPART_SUBSCRIPTION_SPEC_PARAMETER;
 use crate::services::MULTIPART_SUBSCRIPTION_SPEC_VALUE;
 
@@ -95,8 +95,8 @@ where
                                             r#"'accept' header must be one of: \"*/*\", {:?}, {:?}, {:?} or {:?}"#,
                                             APPLICATION_JSON.essence_str(),
                                             GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
-                                            MULTIPART_SUBSCRIPTION_CONTENT_TYPE,
-                                            MULTIPART_DEFER_CONTENT_TYPE
+                                            MULTIPART_SUBSCRIPTION_ACCEPT,
+                                            MULTIPART_DEFER_ACCEPT
                                         ))
                                         .extension_code("INVALID_ACCEPT_HEADER")
                                         .build()
@@ -144,13 +144,15 @@ where
                         .headers
                         .insert(CONTENT_TYPE, APPLICATION_JSON_HEADER_VALUE.clone());
                 } else if accepts_multipart_defer {
-                    parts
-                        .headers
-                        .insert(CONTENT_TYPE, MULTIPART_DEFER_HEADER_VALUE.clone());
+                    parts.headers.insert(
+                        CONTENT_TYPE,
+                        MULTIPART_DEFER_CONTENT_TYPE_HEADER_VALUE.clone(),
+                    );
                 } else if accepts_multipart_subscription {
-                    parts
-                        .headers
-                        .insert(CONTENT_TYPE, MULTIPART_SUBSCRIPTION_HEADER_VALUE.clone());
+                    parts.headers.insert(
+                        CONTENT_TYPE,
+                        MULTIPART_SUBSCRIPTION_CONTENT_TYPE_HEADER_VALUE.clone(),
+                    );
                 }
                 (parts, res)
             })
@@ -276,10 +278,7 @@ mod tests {
             ACCEPT,
             HeaderValue::from_static(GRAPHQL_JSON_RESPONSE_HEADER_VALUE),
         );
-        default_headers.append(
-            ACCEPT,
-            HeaderValue::from_static(MULTIPART_DEFER_CONTENT_TYPE),
-        );
+        default_headers.append(ACCEPT, HeaderValue::from_static(MULTIPART_DEFER_ACCEPT));
         let accepts = parse_accept(&default_headers);
         assert!(accepts.multipart_defer);
     }

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -71,10 +71,8 @@ pub(crate) fn apollo_graph_reference() -> Option<String> {
 // set the supported `@defer` specification version to https://github.com/graphql/graphql-spec/pull/742/commits/01d7b98f04810c9a9db4c0e53d3c4d54dbf10b82
 pub(crate) const MULTIPART_DEFER_SPEC_PARAMETER: &str = "deferSpec";
 pub(crate) const MULTIPART_DEFER_SPEC_VALUE: &str = "20220824";
-pub(crate) const MULTIPART_DEFER_CONTENT_TYPE: &str =
-    "multipart/mixed;boundary=\"graphql\";deferSpec=20220824";
+pub(crate) const MULTIPART_DEFER_CONTENT_TYPE: &str = "multipart/mixed;deferSpec=20220824";
 
-pub(crate) const MULTIPART_SUBSCRIPTION_CONTENT_TYPE: &str =
-    "multipart/mixed;boundary=\"graphql\";subscriptionSpec=1.0";
+pub(crate) const MULTIPART_SUBSCRIPTION_CONTENT_TYPE: &str = "multipart/mixed;subscriptionSpec=1.0";
 pub(crate) const MULTIPART_SUBSCRIPTION_SPEC_PARAMETER: &str = "subscriptionSpec";
 pub(crate) const MULTIPART_SUBSCRIPTION_SPEC_VALUE: &str = "1.0";

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -71,8 +71,12 @@ pub(crate) fn apollo_graph_reference() -> Option<String> {
 // set the supported `@defer` specification version to https://github.com/graphql/graphql-spec/pull/742/commits/01d7b98f04810c9a9db4c0e53d3c4d54dbf10b82
 pub(crate) const MULTIPART_DEFER_SPEC_PARAMETER: &str = "deferSpec";
 pub(crate) const MULTIPART_DEFER_SPEC_VALUE: &str = "20220824";
-pub(crate) const MULTIPART_DEFER_CONTENT_TYPE: &str = "multipart/mixed;deferSpec=20220824";
+pub(crate) const MULTIPART_DEFER_ACCEPT: &str = "multipart/mixed;deferSpec=20220824";
+pub(crate) const MULTIPART_DEFER_CONTENT_TYPE: &str =
+    "multipart/mixed;boundary=\"graphql\";deferSpec=20220824";
 
-pub(crate) const MULTIPART_SUBSCRIPTION_CONTENT_TYPE: &str = "multipart/mixed;subscriptionSpec=1.0";
+pub(crate) const MULTIPART_SUBSCRIPTION_ACCEPT: &str = "multipart/mixed;subscriptionSpec=1.0";
+pub(crate) const MULTIPART_SUBSCRIPTION_CONTENT_TYPE: &str =
+    "multipart/mixed;boundary=\"graphql\";subscriptionSpec=1.0";
 pub(crate) const MULTIPART_SUBSCRIPTION_SPEC_PARAMETER: &str = "subscriptionSpec";
 pub(crate) const MULTIPART_SUBSCRIPTION_SPEC_VALUE: &str = "1.0";

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -17,8 +17,8 @@ use serde_json_bytes::Value;
 use static_assertions::assert_impl_all;
 use tower::BoxError;
 
-use self::service::MULTIPART_DEFER_HEADER_VALUE;
-use self::service::MULTIPART_SUBSCRIPTION_HEADER_VALUE;
+use self::service::MULTIPART_DEFER_CONTENT_TYPE_HEADER_VALUE;
+use self::service::MULTIPART_SUBSCRIPTION_CONTENT_TYPE_HEADER_VALUE;
 use super::supergraph;
 use crate::graphql;
 use crate::http_ext::header_map;
@@ -283,8 +283,8 @@ impl Response {
                 .get(CONTENT_TYPE)
                 .iter()
                 .any(|value| {
-                    *value == MULTIPART_DEFER_HEADER_VALUE
-                        || *value == MULTIPART_SUBSCRIPTION_HEADER_VALUE
+                    *value == MULTIPART_DEFER_CONTENT_TYPE_HEADER_VALUE
+                        || *value == MULTIPART_SUBSCRIPTION_CONTENT_TYPE_HEADER_VALUE
                 })
             {
                 let multipart = Multipart::new(self.response.into_body(), "graphql");

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -66,16 +66,18 @@ use crate::services::SupergraphCreator;
 use crate::services::SupergraphRequest;
 use crate::services::SupergraphResponse;
 use crate::services::APPLICATION_JSON_HEADER_VALUE;
+use crate::services::MULTIPART_DEFER_ACCEPT;
 use crate::services::MULTIPART_DEFER_CONTENT_TYPE;
+use crate::services::MULTIPART_SUBSCRIPTION_ACCEPT;
 use crate::services::MULTIPART_SUBSCRIPTION_CONTENT_TYPE;
 use crate::Configuration;
 use crate::Context;
 use crate::Endpoint;
 use crate::ListenAddr;
 
-pub(crate) static MULTIPART_DEFER_HEADER_VALUE: HeaderValue =
+pub(crate) static MULTIPART_DEFER_CONTENT_TYPE_HEADER_VALUE: HeaderValue =
     HeaderValue::from_static(MULTIPART_DEFER_CONTENT_TYPE);
-pub(crate) static MULTIPART_SUBSCRIPTION_HEADER_VALUE: HeaderValue =
+pub(crate) static MULTIPART_SUBSCRIPTION_CONTENT_TYPE_HEADER_VALUE: HeaderValue =
     HeaderValue::from_static(MULTIPART_SUBSCRIPTION_CONTENT_TYPE);
 static ACCEL_BUFFERING_HEADER_NAME: HeaderName = HeaderName::from_static("x-accel-buffering");
 static ACCEL_BUFFERING_HEADER_VALUE: HeaderValue = HeaderValue::from_static("no");
@@ -295,13 +297,15 @@ impl RouterService {
                     })
                 } else if accepts_multipart_defer || accepts_multipart_subscription {
                     if accepts_multipart_defer {
-                        parts
-                            .headers
-                            .insert(CONTENT_TYPE, MULTIPART_DEFER_HEADER_VALUE.clone());
+                        parts.headers.insert(
+                            CONTENT_TYPE,
+                            MULTIPART_DEFER_CONTENT_TYPE_HEADER_VALUE.clone(),
+                        );
                     } else if accepts_multipart_subscription {
-                        parts
-                            .headers
-                            .insert(CONTENT_TYPE, MULTIPART_SUBSCRIPTION_HEADER_VALUE.clone());
+                        parts.headers.insert(
+                            CONTENT_TYPE,
+                            MULTIPART_SUBSCRIPTION_CONTENT_TYPE_HEADER_VALUE.clone(),
+                        );
                     }
                     // Useful when you're using a proxy like nginx which enable proxy_buffering by default (http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering)
                     parts.headers.insert(
@@ -340,10 +344,11 @@ impl RouterService {
                             .error(
                                 graphql::Error::builder()
                                     .message(format!(
-                                        r#"'accept' header must be one of: \"*/*\", {:?}, {:?} or {:?}"#,
+                                        r#"'accept' header must be one of: \"*/*\", {:?}, {:?}, {:?} or {:?}"#,
                                         APPLICATION_JSON.essence_str(),
                                         GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
-                                        MULTIPART_DEFER_CONTENT_TYPE
+                                        MULTIPART_DEFER_ACCEPT,
+                                        MULTIPART_SUBSCRIPTION_ACCEPT,
                                     ))
                                     .extension_code("INVALID_ACCEPT_HEADER")
                                     .build(),

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -269,7 +269,7 @@ async fn service_call(
                 let (error_message, error_code) = if is_deferred {
                     (String::from("the router received a query with the @defer directive but the client does not accept multipart/mixed HTTP responses. To enable @defer support, add the HTTP header 'Accept: multipart/mixed; deferSpec=20220824'"), "DEFER_BAD_HEADER")
                 } else {
-                    (String::from("the router received a query with a subscription but the client does not accept multipart/mixed HTTP responses. To enable subscription support, add the HTTP header 'Accept: multipart/mixed; boundary=graphql; subscriptionSpec=1.0'"), "SUBSCRIPTION_BAD_HEADER")
+                    (String::from("the router received a query with a subscription but the client does not accept multipart/mixed HTTP responses. To enable subscription support, add the HTTP header 'Accept: multipart/mixed; subscriptionSpec=1.0'"), "SUBSCRIPTION_BAD_HEADER")
                 };
                 let mut response = SupergraphResponse::new_from_graphql_response(
                     graphql::Response::builder()

--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_without_header.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_without_header.snap
@@ -1,11 +1,11 @@
 ---
-source: apollo-router/src/services/supergraph_service.rs
+source: apollo-router/src/services/supergraph/tests.rs
 expression: res
 ---
 {
   "errors": [
     {
-      "message": "the router received a query with a subscription but the client does not accept multipart/mixed HTTP responses. To enable subscription support, add the HTTP header 'Accept: multipart/mixed; boundary=graphql; subscriptionSpec=1.0'",
+      "message": "the router received a query with a subscription but the client does not accept multipart/mixed HTTP responses. To enable subscription support, add the HTTP header 'Accept: multipart/mixed; subscriptionSpec=1.0'",
       "extensions": {
         "code": "SUBSCRIPTION_BAD_HEADER"
       }

--- a/apollo-router/src/test_harness/http_client.rs
+++ b/apollo-router/src/test_harness/http_client.rs
@@ -123,7 +123,8 @@ where
                 let defer_spec = mediatype::Name::new("deferSpec").unwrap();
                 assert_eq!(media_type.subty, "mixed");
                 assert_eq!(media_type.get_param(defer_spec).unwrap(), "20220824");
-                let boundary = "\r\n--graphql".to_string();
+                let boundary = media_type.get_param(mediatype::names::BOUNDARY).unwrap();
+                let boundary = format!("\r\n--{}", boundary.unquoted_str());
                 MaybeMultipart::Multipart(parse_multipart(boundary, body).await)
             } else {
                 let mut vec = Vec::new();

--- a/apollo-router/src/test_harness/http_client.rs
+++ b/apollo-router/src/test_harness/http_client.rs
@@ -123,8 +123,7 @@ where
                 let defer_spec = mediatype::Name::new("deferSpec").unwrap();
                 assert_eq!(media_type.subty, "mixed");
                 assert_eq!(media_type.get_param(defer_spec).unwrap(), "20220824");
-                let boundary = media_type.get_param(mediatype::names::BOUNDARY).unwrap();
-                let boundary = format!("\r\n--{}", boundary.unquoted_str());
+                let boundary = "\r\n--graphql".to_string();
                 MaybeMultipart::Multipart(parse_multipart(boundary, body).await)
             } else {
                 let mut vec = Vec::new();

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -491,10 +491,7 @@ impl IntegrationTest {
         let mut request = client
             .post("http://localhost:4000")
             .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
-            .header(
-                ACCEPT,
-                "multipart/mixed;boundary=\"graphql\";subscriptionSpec=1.0",
-            )
+            .header(ACCEPT, "multipart/mixed;subscriptionSpec=1.0")
             .header("apollographql-client-name", "custom_name")
             .header("apollographql-client-version", "1.0")
             .json(&json!({"query":subscription,"variables":{}}))

--- a/apollo-router/tests/integration/subscription.rs
+++ b/apollo-router/tests/integration/subscription.rs
@@ -186,10 +186,7 @@ async fn run_subscription(sub_query: &str, id: Option<i64>) -> reqwest::Response
 
     let mut request = client
         .post("http://localhost:4000")
-        .header(
-            "accept",
-            "multipart/mixed;boundary=\"graphql\";subscriptionSpec=1.0",
-        )
+        .header("accept", "multipart/mixed;subscriptionSpec=1.0")
         .header("apollographql-client-name", "custom_name")
         .header("apollographql-client-version", "1.0")
         .json(&json!({"query":sub_query,"variables":{}}));

--- a/docs/source/executing-operations/defer-support.mdx
+++ b/docs/source/executing-operations/defer-support.mdx
@@ -40,6 +40,19 @@ To learn the basics of the `@defer` directive and how you can use it with your s
 
 The remainder of this article covers the Apollo Router's defer implementation in greater depth.
 
+## Executing a `@defer` query
+
+To execute a deferred query on the Apollo Router, a GraphQL client sends an HTTP request with _almost_ the exact same format that it uses for usual query and mutation requests.
+
+The only difference is that the request should include the following `Accept` header:
+
+```text title="Example header"
+Accept: multipart/mixed; deferSpec=20220824, application/json
+```
+
+> Note: because the parts are always JSON, it is never possible for `\r\n--graphql` to appear in the contents of a part. For convenience, servers MAY use `graphql` as a boundary.
+> Clients MUST accomodate any boundary returned by the server in `Content-Type`.
+
 ## How does the Apollo Router defer fields?
 
 As discussed in [this article](/graphos/operations/defer/#which-fields-can-my-router-defer), the Apollo Router can defer the following fields in your schema:


### PR DESCRIPTION
Related to #4395

Remove the multipart boundary from the client `Accept` header. Typically, the boundary is decided by the server in order to avoid nameclashes with the parts contents. It just happens that `--graphql` works all the time for us because the part contents are JSON.

Keep `--graphql` as a "may" for convenience but mandate that clients support any boundary sent by the server. I _think_ this is already the case for web/ios/kotlin? Ping @alessbell @calvincestari 

ping @martinbonnin  @abernix 

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
