### PR TITLE
feat(redis): add options to set username and password separately

### DIFF
--- a/.changesets/feat_bnjjj_feat_4346.md
+++ b/.changesets/feat_bnjjj_feat_4346.md
@@ -7,9 +7,9 @@ supergraph:
   query_planning:
     experimental_cache:
       redis: #highlight-line
-        urls: ["redis://..."]
-        username: admin/123 # Optional, can be part of the urls directly, mainly useful if you have special character like '/' in your password that doesn't work in url
-        password: admin # Optional, can be part of the urls directly, mainly useful if you have special character like '/' in your password that doesn't work in url
+        urls: ["redis://..."] #highlight-line
+        username: admin/123 # Optional, can be part of the urls directly, mainly useful if you have special character like '/' in your password that doesn't work in url. This field takes precedence over the username in the URL
+        password: admin # Optional, can be part of the urls directly, mainly useful if you have special character like '/' in your password that doesn't work in url. This field takes precedence over the password in the URL
         timeout: 5ms # Optional, by default: 2ms
         ttl: 24h # Optional, by default no expiration
 ```

--- a/.changesets/feat_bnjjj_feat_4346.md
+++ b/.changesets/feat_bnjjj_feat_4346.md
@@ -1,0 +1,17 @@
+### Add options to set username and password separately for Redis ([Issue #4346](https://github.com/apollographql/router/issues/4346))
+
+Example of configuration:
+
+```yaml title="router.yaml"
+supergraph:
+  query_planning:
+    experimental_cache:
+      redis: #highlight-line
+        urls: ["redis://..."]
+        username: admin/123 # Optional, can be part of the urls directly, mainly useful if you have special character like '/' in your password that doesn't work in url
+        password: admin # Optional, can be part of the urls directly, mainly useful if you have special character like '/' in your password that doesn't work in url
+        timeout: 5ms # Optional, by default: 2ms
+        ttl: 24h # Optional, by default no expiration
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/4453

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -136,6 +136,14 @@ impl RedisCacheStorage {
         let url = Self::preprocess_urls(config.urls)?;
         let mut client_config = RedisConfig::from_url(url.as_str())?;
 
+        if let Some(username) = config.username {
+            client_config.username = Some(username);
+        }
+
+        if let Some(password) = config.password {
+            client_config.password = Some(password);
+        }
+
         if let Some(tls) = config.tls.as_ref() {
             let tls_cert_store = tls.create_certificate_store().transpose()?;
             let client_cert_config = tls.client_authentication.as_ref();

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -913,9 +913,9 @@ pub(crate) struct RedisCache {
     /// List of URLs to the Redis cluster
     pub(crate) urls: Vec<url::Url>,
 
-    /// Redis username if not provided in the URLs, this field takes precedence over the username in the URL
+    /// Redis username if not provided in the URLs. This field takes precedence over the username in the URL
     pub(crate) username: Option<String>,
-    /// Redis password if not provided in the URLs, this field takes precedence over the password in the URL
+    /// Redis password if not provided in the URLs. This field takes precedence over the password in the URL
     pub(crate) password: Option<String>,
 
     #[serde(deserialize_with = "humantime_serde::deserialize", default)]

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -913,6 +913,11 @@ pub(crate) struct RedisCache {
     /// List of URLs to the Redis cluster
     pub(crate) urls: Vec<url::Url>,
 
+    /// Redis username if not provided in the URLs, this field takes precedence over the username in the URL
+    pub(crate) username: Option<String>,
+    /// Redis password if not provided in the URLs, this field takes precedence over the password in the URL
+    pub(crate) password: Option<String>,
+
     #[serde(deserialize_with = "humantime_serde::deserialize", default)]
     #[schemars(with = "Option<String>", default)]
     /// Redis request timeout (default: 2ms)

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -83,6 +83,11 @@ expression: "&schema"
                     "urls"
                   ],
                   "properties": {
+                    "password": {
+                      "description": "Redis password if not provided in the URLs, this field takes precedence over the password in the URL",
+                      "type": "string",
+                      "nullable": true
+                    },
                     "timeout": {
                       "description": "Redis request timeout (default: 2ms)",
                       "default": null,
@@ -140,6 +145,11 @@ expression: "&schema"
                         "type": "string",
                         "format": "uri"
                       }
+                    },
+                    "username": {
+                      "description": "Redis username if not provided in the URLs, this field takes precedence over the username in the URL",
+                      "type": "string",
+                      "nullable": true
                     }
                   },
                   "additionalProperties": false,
@@ -1207,6 +1217,11 @@ expression: "&schema"
             "urls"
           ],
           "properties": {
+            "password": {
+              "description": "Redis password if not provided in the URLs, this field takes precedence over the password in the URL",
+              "type": "string",
+              "nullable": true
+            },
             "timeout": {
               "description": "Redis request timeout (default: 2ms)",
               "default": null,
@@ -1264,6 +1279,11 @@ expression: "&schema"
                 "type": "string",
                 "format": "uri"
               }
+            },
+            "username": {
+              "description": "Redis username if not provided in the URLs, this field takes precedence over the username in the URL",
+              "type": "string",
+              "nullable": true
             }
           },
           "additionalProperties": false
@@ -2309,6 +2329,11 @@ expression: "&schema"
                     "urls"
                   ],
                   "properties": {
+                    "password": {
+                      "description": "Redis password if not provided in the URLs, this field takes precedence over the password in the URL",
+                      "type": "string",
+                      "nullable": true
+                    },
                     "timeout": {
                       "description": "Redis request timeout (default: 2ms)",
                       "default": null,
@@ -2366,6 +2391,11 @@ expression: "&schema"
                         "type": "string",
                         "format": "uri"
                       }
+                    },
+                    "username": {
+                      "description": "Redis username if not provided in the URLs, this field takes precedence over the username in the URL",
+                      "type": "string",
+                      "nullable": true
                     }
                   },
                   "additionalProperties": false,

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -84,7 +84,7 @@ expression: "&schema"
                   ],
                   "properties": {
                     "password": {
-                      "description": "Redis password if not provided in the URLs, this field takes precedence over the password in the URL",
+                      "description": "Redis password if not provided in the URLs. This field takes precedence over the password in the URL",
                       "type": "string",
                       "nullable": true
                     },
@@ -147,7 +147,7 @@ expression: "&schema"
                       }
                     },
                     "username": {
-                      "description": "Redis username if not provided in the URLs, this field takes precedence over the username in the URL",
+                      "description": "Redis username if not provided in the URLs. This field takes precedence over the username in the URL",
                       "type": "string",
                       "nullable": true
                     }
@@ -1218,7 +1218,7 @@ expression: "&schema"
           ],
           "properties": {
             "password": {
-              "description": "Redis password if not provided in the URLs, this field takes precedence over the password in the URL",
+              "description": "Redis password if not provided in the URLs. This field takes precedence over the password in the URL",
               "type": "string",
               "nullable": true
             },
@@ -1281,7 +1281,7 @@ expression: "&schema"
               }
             },
             "username": {
-              "description": "Redis username if not provided in the URLs, this field takes precedence over the username in the URL",
+              "description": "Redis username if not provided in the URLs. This field takes precedence over the username in the URL",
               "type": "string",
               "nullable": true
             }
@@ -2330,7 +2330,7 @@ expression: "&schema"
                   ],
                   "properties": {
                     "password": {
-                      "description": "Redis password if not provided in the URLs, this field takes precedence over the password in the URL",
+                      "description": "Redis password if not provided in the URLs. This field takes precedence over the password in the URL",
                       "type": "string",
                       "nullable": true
                     },
@@ -2393,7 +2393,7 @@ expression: "&schema"
                       }
                     },
                     "username": {
-                      "description": "Redis username if not provided in the URLs, this field takes precedence over the username in the URL",
+                      "description": "Redis username if not provided in the URLs. This field takes precedence over the username in the URL",
                       "type": "string",
                       "nullable": true
                     }

--- a/docs/source/configuration/distributed-caching.mdx
+++ b/docs/source/configuration/distributed-caching.mdx
@@ -95,8 +95,8 @@ supergraph:
     experimental_cache:
       redis: #highlight-line
         urls: ["redis://..."] #highlight-line
-        username: admin/123 # Optional, can be part of the urls directly, mainly useful if you have special character like '/' in your password that doesn't work in url
-        password: admin # Optional, can be part of the urls directly, mainly useful if you have special character like '/' in your password that doesn't work in url
+        username: admin/123 # Optional, can be part of the urls directly, mainly useful if you have special character like '/' in your password that doesn't work in url. This field takes precedence over the username in the URL
+        password: admin # Optional, can be part of the urls directly, mainly useful if you have special character like '/' in your password that doesn't work in url. This field takes precedence over the password in the URL
         timeout: 5ms # Optional, by default: 2ms
         ttl: 24h # Optional, by default no expiration
 ```

--- a/docs/source/configuration/distributed-caching.mdx
+++ b/docs/source/configuration/distributed-caching.mdx
@@ -95,6 +95,8 @@ supergraph:
     experimental_cache:
       redis: #highlight-line
         urls: ["redis://..."] #highlight-line
+        username: admin/123 # Optional, can be part of the urls directly, mainly useful if you have special character like '/' in your password that doesn't work in url
+        password: admin # Optional, can be part of the urls directly, mainly useful if you have special character like '/' in your password that doesn't work in url
         timeout: 5ms # Optional, by default: 2ms
         ttl: 24h # Optional, by default no expiration
 ```


### PR DESCRIPTION
Example of configuration:

```yaml title="router.yaml"
supergraph:
  query_planning:
    experimental_cache:
      redis: #highlight-line
        urls: ["redis://..."] #highlight-line
        username: admin/123 # Optional, can be part of the urls directly, mainly useful if you have special character like '/' in your password that doesn't work in url
        password: admin # Optional, can be part of the urls directly, mainly useful if you have special character like '/' in your password that doesn't work in url
        timeout: 5ms # Optional, by default: 2ms
        ttl: 24h # Optional, by default no expiration
```

Fixes #4346

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
