### PR TITLE
fix PR body extraction in changesets

### DIFF
--- a/xtask/src/commands/changeset/mod.rs
+++ b/xtask/src/commands/changeset/mod.rs
@@ -392,11 +392,9 @@ impl Create {
                                     let pr_body = pr_info.body.clone().replace("\r\n", "\n");
 
                                     // Remove the trailing part of the checklist from the PR body.
-                                    // In the future, we will use the "start metadata" HTML tag, but for now,
-                                    // we support both.
-                                    let pr_body_trailer_regex = regex::Regex::new(
-                                    r"(?ms)(^<!-- start metadata -->\n---$\n)?^\*\*Checklist\*\*$[\s\S]*",
-                                    )?;
+                                    let pr_body_meta_regex = regex::Regex::new(
+                                        r"(?m)<!-- start metadata -->\n---",
+                                        )?;
 
                                     // Remove all the "Fixes" references, since we're already going to reference
                                     // those in the course of generating the template.
@@ -404,13 +402,13 @@ impl Create {
                                         r"(?m)^(- )?Fix(es)? #.*$",
                                     )?;
 
-                                    // Run the above Regexes and trim the blurb.
+                                    let index = pr_body_meta_regex.find(&pr_body).map(|mat| mat.start()).unwrap_or(pr_body.len());
+                                    // Run the above Regex and trim the blurb.
                                     let clean_pr_body = pr_body_fixes_regex
-                                        .replace_all(pr_body_trailer_regex
-                                        .replace(&pr_body, "")
-                                        .trim(), "")
+                                        .replace_all(&pr_body[..index].trim(), "")
                                         .trim()
                                         .to_string();
+
 
                                     TemplateContext {
                                         title: pr_info.title.clone(),

--- a/xtask/src/commands/changeset/mod.rs
+++ b/xtask/src/commands/changeset/mod.rs
@@ -19,7 +19,7 @@
 ///               --response-derives='Debug' \
 ///               --custom-scalars-module='crate::commands::changeset::scalars' \
 ///               ./matching_pull_request.graphql
-/// a
+///
 mod matching_pull_request;
 mod scalars;
 

--- a/xtask/src/commands/changeset/mod.rs
+++ b/xtask/src/commands/changeset/mod.rs
@@ -19,7 +19,7 @@
 ///               --response-derives='Debug' \
 ///               --custom-scalars-module='crate::commands::changeset::scalars' \
 ///               ./matching_pull_request.graphql
-///
+/// a
 mod matching_pull_request;
 mod scalars;
 


### PR DESCRIPTION
the generated changesets still contained this:

```
<!-- start metadata -->
---
```
<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
