### PR TITLE
Aggregate meter provider also delegates to global meter provider

### DIFF
--- a/apollo-router/src/metrics/filter.rs
+++ b/apollo-router/src/metrics/filter.rs
@@ -9,7 +9,6 @@ use opentelemetry::metrics::Counter;
 use opentelemetry::metrics::Histogram;
 use opentelemetry::metrics::InstrumentProvider;
 use opentelemetry::metrics::Meter;
-use opentelemetry::metrics::MeterProvider;
 use opentelemetry::metrics::ObservableCounter;
 use opentelemetry::metrics::ObservableGauge;
 use opentelemetry::metrics::ObservableUpDownCounter;
@@ -22,8 +21,42 @@ use opentelemetry_api::KeyValue;
 use regex::Regex;
 
 #[derive(Clone)]
+pub(crate) enum MeterProvider {
+    Regular(opentelemetry::sdk::metrics::MeterProvider),
+    Global(opentelemetry::global::GlobalMeterProvider),
+}
+
+impl MeterProvider {
+    fn shutdown(&self) -> opentelemetry::metrics::Result<()> {
+        match self {
+            MeterProvider::Regular(provider) => provider.shutdown(),
+            MeterProvider::Global(_provider) => Ok(()),
+        }
+    }
+
+    fn force_flush(&self, cx: &Context) -> opentelemetry::metrics::Result<()> {
+        match self {
+            MeterProvider::Regular(provider) => provider.force_flush(cx),
+            MeterProvider::Global(_provider) => Ok(()),
+        }
+    }
+}
+
+impl From<opentelemetry::sdk::metrics::MeterProvider> for MeterProvider {
+    fn from(provider: opentelemetry::sdk::metrics::MeterProvider) -> Self {
+        MeterProvider::Regular(provider)
+    }
+}
+
+impl From<opentelemetry::global::GlobalMeterProvider> for MeterProvider {
+    fn from(provider: opentelemetry::global::GlobalMeterProvider) -> Self {
+        MeterProvider::Global(provider)
+    }
+}
+
+#[derive(Clone)]
 pub(crate) struct FilterMeterProvider {
-    delegate: opentelemetry::sdk::metrics::MeterProvider,
+    delegate: MeterProvider,
     deny: Option<Regex>,
     allow: Option<Regex>,
 }
@@ -31,19 +64,15 @@ pub(crate) struct FilterMeterProvider {
 #[buildstructor]
 impl FilterMeterProvider {
     #[builder]
-    fn new(
-        delegate: opentelemetry::sdk::metrics::MeterProvider,
-        deny: Option<Regex>,
-        allow: Option<Regex>,
-    ) -> Self {
+    fn new<T: Into<MeterProvider>>(delegate: T, deny: Option<Regex>, allow: Option<Regex>) -> Self {
         FilterMeterProvider {
-            delegate,
+            delegate: delegate.into(),
             deny,
             allow,
         }
     }
 
-    pub(crate) fn private(delegate: opentelemetry::sdk::metrics::MeterProvider) -> Self {
+    pub(crate) fn private<T: Into<MeterProvider>>(delegate: T) -> Self {
         FilterMeterProvider::builder()
             .delegate(delegate)
             .allow(
@@ -55,7 +84,7 @@ impl FilterMeterProvider {
             .build()
     }
 
-    pub(crate) fn public(delegate: opentelemetry::sdk::metrics::MeterProvider) -> Self {
+    pub(crate) fn public<T: Into<MeterProvider>>(delegate: T) -> Self {
         FilterMeterProvider::builder()
             .delegate(delegate)
             .deny(
@@ -66,7 +95,7 @@ impl FilterMeterProvider {
     }
 
     #[cfg(test)]
-    pub(crate) fn all(delegate: opentelemetry::sdk::metrics::MeterProvider) -> Self {
+    pub(crate) fn all<T: Into<MeterProvider>>(delegate: T) -> Self {
         FilterMeterProvider::builder().delegate(delegate).build()
     }
 
@@ -177,7 +206,7 @@ impl InstrumentProvider for FilteredInstrumentProvider {
     }
 }
 
-impl MeterProvider for FilterMeterProvider {
+impl opentelemetry::metrics::MeterProvider for FilterMeterProvider {
     fn versioned_meter(
         &self,
         name: impl Into<Cow<'static, str>>,
@@ -185,9 +214,14 @@ impl MeterProvider for FilterMeterProvider {
         schema_url: Option<impl Into<Cow<'static, str>>>,
         attributes: Option<Vec<KeyValue>>,
     ) -> Meter {
-        let delegate = self
-            .delegate
-            .versioned_meter(name, version, schema_url, attributes);
+        let delegate = match &self.delegate {
+            MeterProvider::Regular(provider) => {
+                provider.versioned_meter(name, version, schema_url, attributes)
+            }
+            MeterProvider::Global(provider) => {
+                provider.versioned_meter(name, version, schema_url, attributes)
+            }
+        };
         Meter::new(Arc::new(FilteredInstrumentProvider {
             noop: NoopMeterProvider::default().meter(""),
             delegate,
@@ -206,6 +240,7 @@ mod test {
     use opentelemetry::sdk::metrics::MeterProviderBuilder;
     use opentelemetry::sdk::metrics::PeriodicReader;
     use opentelemetry::testing::metrics::InMemoryMetricsExporter;
+    use opentelemetry_api::global::GlobalMeterProvider;
     use opentelemetry_api::Context;
 
     use crate::metrics::filter::FilterMeterProvider;
@@ -261,13 +296,66 @@ mod test {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_public_metrics() {
+    async fn test_description_and_unit() {
         let exporter = InMemoryMetricsExporter::default();
-        let meter_provider = FilterMeterProvider::public(
+        let meter_provider = FilterMeterProvider::private(
             MeterProviderBuilder::default()
                 .with_reader(PeriodicReader::builder(exporter.clone(), runtime::Tokio).build())
                 .build(),
         );
+        let cx = Context::default();
+        let filtered = meter_provider.versioned_meter("filtered", "".into(), "".into(), None);
+        filtered
+            .u64_counter("apollo.router.operations")
+            .with_description("desc")
+            .with_unit(Unit::new("ms"))
+            .init()
+            .add(1, &[]);
+        meter_provider.force_flush(&cx).unwrap();
+
+        let metrics: Vec<_> = exporter
+            .get_finished_metrics()
+            .unwrap()
+            .into_iter()
+            .flat_map(|m| m.scope_metrics.into_iter())
+            .flat_map(|m| m.metrics)
+            .collect();
+        assert!(metrics.iter().any(|m| m.name == "apollo.router.operations"
+            && m.description == "desc"
+            && m.unit == Unit::new("ms")));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_public_metrics_using_meter_provider() {
+        let exporter = InMemoryMetricsExporter::default();
+        test_public_metrics(
+            exporter.clone(),
+            MeterProviderBuilder::default()
+                .with_reader(PeriodicReader::builder(exporter.clone(), runtime::Tokio).build())
+                .build(),
+        )
+        .await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_public_metrics_using_global_meter_provider() {
+        let exporter = InMemoryMetricsExporter::default();
+
+        test_public_metrics(
+            exporter.clone(),
+            GlobalMeterProvider::new(
+                MeterProviderBuilder::default()
+                    .with_reader(PeriodicReader::builder(exporter.clone(), runtime::Tokio).build())
+                    .build(),
+            ),
+        )
+        .await;
+    }
+    async fn test_public_metrics<T: Into<super::MeterProvider>>(
+        exporter: InMemoryMetricsExporter,
+        meter_provider: T,
+    ) {
+        let meter_provider = FilterMeterProvider::public(meter_provider);
         let cx = Context::default();
         let filtered = meter_provider.versioned_meter("filtered", "".into(), "".into(), None);
         filtered
@@ -304,35 +392,5 @@ mod test {
         assert!(!metrics
             .iter()
             .any(|m| m.name == "apollo.router.entities.test"));
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn test_description_and_unit() {
-        let exporter = InMemoryMetricsExporter::default();
-        let meter_provider = FilterMeterProvider::private(
-            MeterProviderBuilder::default()
-                .with_reader(PeriodicReader::builder(exporter.clone(), runtime::Tokio).build())
-                .build(),
-        );
-        let cx = Context::default();
-        let filtered = meter_provider.versioned_meter("filtered", "".into(), "".into(), None);
-        filtered
-            .u64_counter("apollo.router.operations")
-            .with_description("desc")
-            .with_unit(Unit::new("ms"))
-            .init()
-            .add(1, &[]);
-        meter_provider.force_flush(&cx).unwrap();
-
-        let metrics: Vec<_> = exporter
-            .get_finished_metrics()
-            .unwrap()
-            .into_iter()
-            .flat_map(|m| m.scope_metrics.into_iter())
-            .flat_map(|m| m.metrics)
-            .collect();
-        assert!(metrics.iter().any(|m| m.name == "apollo.router.operations"
-            && m.description == "desc"
-            && m.unit == Unit::new("ms")));
     }
 }


### PR DESCRIPTION
The `AggregateMeterProvider` is used by the Router to allow us to have several metrics subsystems that forward metrics to different places. In addition it has enhanced testability.

However, some users may be trying to set up otel by themselves outside of the regular router lifecycle, and they will receive no metrics.

This PR also makes the `AggregateMeterProvider` forward to the `GlobalMeterProvider`. The setup for this happens at creation time of `AggregateMeterProvider` and setting the regular otel meter provider after this happens will have no effect.

This functionality is not reccommeneded for general users, and may change in breaking ways in the future.

Fixes #4313


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
