### PR TITLE
HTTP headers: remove space after ';'

### DIFF
--- a/apollo-router/src/plugins/authorization/authenticated.rs
+++ b/apollo-router/src/plugins/authorization/authenticated.rs
@@ -1657,7 +1657,7 @@ mod tests {
         let mut headers: MultiMap<TryIntoHeaderName, TryIntoHeaderValue> = MultiMap::new();
         headers.insert(
             "Accept".into(),
-            "multipart/mixed; deferSpec=20220824".into(),
+            "multipart/mixed;deferSpec=20220824".into(),
         );
         context.private_entries.lock().insert(ClientRequestAccepts {
             multipart_defer: true,

--- a/apollo-router/src/plugins/authorization/authenticated.rs
+++ b/apollo-router/src/plugins/authorization/authenticated.rs
@@ -1655,10 +1655,7 @@ mod tests {
         )
         .unwrap();*/
         let mut headers: MultiMap<TryIntoHeaderName, TryIntoHeaderValue> = MultiMap::new();
-        headers.insert(
-            "Accept".into(),
-            "multipart/mixed;deferSpec=20220824".into(),
-        );
+        headers.insert("Accept".into(), "multipart/mixed;deferSpec=20220824".into());
         context.private_entries.lock().insert(ClientRequestAccepts {
             multipart_defer: true,
             multipart_subscription: true,

--- a/apollo-router/src/plugins/telemetry/metrics/apollo.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/apollo.rs
@@ -358,7 +358,7 @@ mod test {
             .and_context(context);
         if is_subscription {
             request_builder =
-                request_builder.header("accept", "multipart/mixed; subscriptionSpec=1.0");
+                request_builder.header("accept", "multipart/mixed;subscriptionSpec=1.0");
         }
         TestHarness::builder()
             .extra_plugin(plugin)

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -267,9 +267,9 @@ async fn service_call(
                 || (is_subscription && !accepts_multipart_subscription)
             {
                 let (error_message, error_code) = if is_deferred {
-                    (String::from("the router received a query with the @defer directive but the client does not accept multipart/mixed HTTP responses. To enable @defer support, add the HTTP header 'Accept: multipart/mixed; deferSpec=20220824'"), "DEFER_BAD_HEADER")
+                    (String::from("the router received a query with the @defer directive but the client does not accept multipart/mixed HTTP responses. To enable @defer support, add the HTTP header 'Accept: multipart/mixed;deferSpec=20220824'"), "DEFER_BAD_HEADER")
                 } else {
-                    (String::from("the router received a query with a subscription but the client does not accept multipart/mixed HTTP responses. To enable subscription support, add the HTTP header 'Accept: multipart/mixed; subscriptionSpec=1.0'"), "SUBSCRIPTION_BAD_HEADER")
+                    (String::from("the router received a query with a subscription but the client does not accept multipart/mixed HTTP responses. To enable subscription support, add the HTTP header 'Accept: multipart/mixed;subscriptionSpec=1.0'"), "SUBSCRIPTION_BAD_HEADER")
                 };
                 let mut response = SupergraphResponse::new_from_graphql_response(
                     graphql::Response::builder()

--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_without_header.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_without_header.snap
@@ -5,7 +5,7 @@ expression: res
 {
   "errors": [
     {
-      "message": "the router received a query with a subscription but the client does not accept multipart/mixed HTTP responses. To enable subscription support, add the HTTP header 'Accept: multipart/mixed; subscriptionSpec=1.0'",
+      "message": "the router received a query with a subscription but the client does not accept multipart/mixed HTTP responses. To enable subscription support, add the HTTP header 'Accept: multipart/mixed;subscriptionSpec=1.0'",
       "extensions": {
         "code": "SUBSCRIPTION_BAD_HEADER"
       }

--- a/apollo-router/src/test_harness/http_client.rs
+++ b/apollo-router/src/test_harness/http_client.rs
@@ -110,7 +110,7 @@ where
         .map_request(|mut request: http::Request<RequestBody>| {
             request.headers_mut().insert(
                 "accept",
-                "multipart/mixed; deferSpec=20220824".try_into().unwrap(),
+                "multipart/mixed;deferSpec=20220824".try_into().unwrap(),
             );
             request
         })

--- a/apollo-router/tests/apollo_reports.rs
+++ b/apollo-router/tests/apollo_reports.rs
@@ -433,7 +433,7 @@ async fn test_condition_if() {
         let request = supergraph::Request::fake_builder()
             .query("query($if: Boolean!) {topProducts {  name    ... @defer(if: $if) {  reviews {    author {      name    }  }  reviews {    author {      name    }  }    }}}")
             .variable("if", true)
-            .header(ACCEPT, "multipart/mixed; deferSpec=20220824")
+            .header(ACCEPT, "multipart/mixed;deferSpec=20220824")
             .build()
             .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");
@@ -449,7 +449,7 @@ async fn test_condition_else() {
         let request = supergraph::Request::fake_builder()
         .query("query($if: Boolean!) {topProducts {  name    ... @defer(if: $if) {  reviews {    author {      name    }  }  reviews {    author {      name    }  }    }}}")
         .variable("if", false)
-        .header(ACCEPT, "multipart/mixed; deferSpec=20220824")
+        .header(ACCEPT, "multipart/mixed;deferSpec=20220824")
         .build()
         .unwrap();
         let req: router::Request = request.try_into().expect("could not convert request");

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -798,7 +798,7 @@ async fn query_just_at_token_limit() {
 async fn normal_query_with_defer_accept_header() {
     let request = supergraph::Request::fake_builder()
         .query(r#"{ me { reviews { author { reviews { author { name } } } } } }"#)
-        .header(ACCEPT, "multipart/mixed; deferSpec=20220824")
+        .header(ACCEPT, "multipart/mixed;deferSpec=20220824")
         .build()
         .expect("expecting valid request");
     let (mut response, _registry) = {
@@ -841,7 +841,7 @@ async fn defer_path_with_disabled_config() {
             }
         }"#,
         )
-        .header(ACCEPT, "multipart/mixed; deferSpec=20220824")
+        .header(ACCEPT, "multipart/mixed;deferSpec=20220824")
         .build()
         .expect("expecting failure due to disabled config defer support");
 
@@ -878,7 +878,7 @@ async fn defer_path() {
             }
         }"#,
         )
-        .header(ACCEPT, "multipart/mixed; deferSpec=20220824")
+        .header(ACCEPT, "multipart/mixed;deferSpec=20220824")
         .build()
         .expect("expecting valid request");
 
@@ -921,7 +921,7 @@ async fn defer_path_in_array() {
                 }
             }"#,
         )
-        .header(ACCEPT, "multipart/mixed; deferSpec=20220824")
+        .header(ACCEPT, "multipart/mixed;deferSpec=20220824")
         .build()
         .expect("expecting valid request");
 
@@ -994,7 +994,7 @@ async fn defer_empty_primary_response() {
             }
         }"#,
         )
-        .header(ACCEPT, "multipart/mixed; deferSpec=20220824")
+        .header(ACCEPT, "multipart/mixed;deferSpec=20220824")
         .build()
         .expect("expecting valid request");
 
@@ -1031,7 +1031,7 @@ async fn defer_default_variable() {
 
     let request = supergraph::Request::fake_builder()
         .query(query)
-        .header(ACCEPT, "multipart/mixed; deferSpec=20220824")
+        .header(ACCEPT, "multipart/mixed;deferSpec=20220824")
         .build()
         .expect("expecting valid request");
 
@@ -1051,7 +1051,7 @@ async fn defer_default_variable() {
     let request = supergraph::Request::fake_builder()
         .query(query)
         .variable("if", false)
-        .header(ACCEPT, "multipart/mixed; deferSpec=20220824")
+        .header(ACCEPT, "multipart/mixed;deferSpec=20220824")
         .build()
         .expect("expecting valid request");
 

--- a/apollo-router/tests/snapshots/integration_tests__defer_query_without_accept.snap
+++ b/apollo-router/tests/snapshots/integration_tests__defer_query_without_accept.snap
@@ -2,4 +2,4 @@
 source: apollo-router/tests/integration_tests.rs
 expression: "std::str::from_utf8(first.to_vec().as_slice()).unwrap()"
 ---
-{"errors":[{"message":"the router received a query with the @defer directive but the client does not accept multipart/mixed HTTP responses. To enable @defer support, add the HTTP header 'Accept: multipart/mixed; deferSpec=20220824'","extensions":{"code":"DEFER_BAD_HEADER"}}]}
+{"errors":[{"message":"the router received a query with the @defer directive but the client does not accept multipart/mixed HTTP responses. To enable @defer support, add the HTTP header 'Accept: multipart/mixed;deferSpec=20220824'","extensions":{"code":"DEFER_BAD_HEADER"}}]}

--- a/dev-docs/multipart-subscriptions-protocol.md
+++ b/dev-docs/multipart-subscriptions-protocol.md
@@ -4,10 +4,10 @@ Instead of relying on WebSockets, the subscriptions protocol supported by the ro
 
 ## Communication
 
-When sending a request containing a subscription to the router, clients MUST support the `multipart/mixed; subscriptionSpec="1.0"` content-type in addition to the `application/json` content-type:
+When sending a request containing a subscription to the router, clients MUST support the `multipart/mixed;subscriptionSpec="1.0"` content-type in addition to the `application/json` content-type:
 
 ```
-Accept: multipart/mixed; subscriptionSpec="1.0", application/json
+Accept: multipart/mixed;subscriptionSpec="1.0", application/json
 ```
 
 The router will then respond with a stream of body parts, following the [definition of multipart content specified in RFC1341](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html).

--- a/docs/source/executing-operations/subscription-multipart-protocol.mdx
+++ b/docs/source/executing-operations/subscription-multipart-protocol.mdx
@@ -14,7 +14,7 @@ To execute a subscription on the Apollo Router, a GraphQL client sends an HTTP r
 The only difference is that the request should include the following `Accept` header:
 
 ```text title="Example header"
-Accept: multipart/mixed; boundary="graphql"; subscriptionSpec="1.0", application/json
+Accept: multipart/mixed;subscriptionSpec="1.0", application/json
 ```
 
 <Tip>

--- a/docs/source/executing-operations/subscription-support.mdx
+++ b/docs/source/executing-operations/subscription-support.mdx
@@ -339,7 +339,7 @@ To quickly try out the Apollo Router's HTTP-based subscriptions _without_ settin
 
 ```bash
  curl 'http://localhost:4000/' -v \
-  -H 'accept: multipart/mixed; boundary="graphql"; subscriptionSpec=1.0, application/json' \
+  -H 'accept: multipart/mixed;subscriptionSpec=1.0, application/json' \
   -H 'content-type: application/json' \
   --data-raw '{"query":"subscription OnProductPriceChanged { productPriceChanged { name price reviews { score } } }","operationName":"OnProductPriceChanged"}'
 ```


### PR DESCRIPTION
Nitpick follow up from https://github.com/apollographql/router/pull/4447 to use the MDN convention of adding a space after `,` and none after `;`. I didn't really find a reference for that but I think it makes sense? 


Closest I could get is [RFC7231](https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.1) that says:

```
For example, the following examples are all equivalent, but the first is preferred for consistency:

     text/html;charset=utf-8
     text/html;charset=UTF-8
     Text/HTML;Charset="utf-8"
     text/html; charset="utf-8"
```


Also remove a leftover `boundary=graphql` from the executing_operations docs