### PR TITLE
send log events with traces

### DIFF
--- a/.changesets/fix_geal_event_sampling.md
+++ b/.changesets/fix_geal_event_sampling.md
@@ -1,0 +1,5 @@
+### Reactivate log events in traces ([PR #4486](https://github.com/apollographql/router/pull/4486))
+
+This fixes a regression introduced in #2999, where events were not sent with traces anymore due to too aggressive sampling
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4486

--- a/apollo-router/src/plugins/telemetry/reload.rs
+++ b/apollo-router/src/plugins/telemetry/reload.rs
@@ -175,9 +175,9 @@ where
         meta: &tracing::Metadata<'_>,
         cx: &tracing_subscriber::layer::Context<'_, S>,
     ) -> bool {
-        // we ignore events
+        // we ignore metric events
         if !meta.is_span() {
-            return false;
+            return meta.fields().iter().any(|f| f.name() == "message");
         }
 
         // if there's an exsting otel context set by the client request, and it is sampled,


### PR DESCRIPTION
Fix #4321 
Fix #3872 (the regression appears in 1.30, when #2999 was merged)

related: #2402

This fixes a regression introduced in #2999, where events were not sent anymore with traces

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
