### PR TITLE
make OperationKind public

### DIFF
--- a/.changesets/fix_geal_expose_operationkind.md
+++ b/.changesets/fix_geal_expose_operationkind.md
@@ -1,0 +1,5 @@
+### make OperationKind public ([Issue #4410](https://github.com/apollographql/router/issues/4410))
+
+`OperationKind` was already used in a public field but the type itself was still private.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4489

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -5,7 +5,7 @@
 pub(crate) use bridge_query_planner::*;
 pub(crate) use caching_query_planner::*;
 
-pub(crate) use self::fetch::OperationKind;
+pub use self::fetch::OperationKind;
 
 mod bridge_query_planner;
 mod caching_query_planner;

--- a/apollo-router/src/services/mod.rs
+++ b/apollo-router/src/services/mod.rs
@@ -10,6 +10,7 @@ use crate::graphql::Request;
 use crate::http_ext;
 pub use crate::http_ext::TryIntoHeaderName;
 pub use crate::http_ext::TryIntoHeaderValue;
+pub use crate::query_planner::OperationKind;
 pub(crate) use crate::services::execution::Request as ExecutionRequest;
 pub(crate) use crate::services::execution::Response as ExecutionResponse;
 pub(crate) use crate::services::query_planner::Request as QueryPlannerRequest;


### PR DESCRIPTION
Fix #4410

`OperationKind` was already used in a public field but the type itself was still private.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
