### PR TITLE
replace the vec of reserved headers with a HashSet

### DIFF
--- a/apollo-router/src/plugins/headers.rs
+++ b/apollo-router/src/plugins/headers.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::task::Context;
 use std::task::Poll;
@@ -264,7 +265,7 @@ lazy_static! {
     // second hop.
     // In addition because our requests are not regular proxy requests content-type, content-length
     // and host are also in the exclude list.
-    static ref RESERVED_HEADERS: Vec<HeaderName> = [
+    static ref RESERVED_HEADERS: HashSet<HeaderName> = [
         CONNECTION,
         PROXY_AUTHENTICATE,
         PROXY_AUTHORIZATION,
@@ -390,7 +391,7 @@ where
                         .headers()
                         .iter()
                         .filter(|(name, _)| {
-                            !RESERVED_HEADERS.contains(name) && matching.is_match(name.as_str())
+                            !RESERVED_HEADERS.contains(*name) && matching.is_match(name.as_str())
                         })
                         .for_each(|(name, value)| {
                             headers.append(name, value.clone());

--- a/apollo-router/src/plugins/headers.rs
+++ b/apollo-router/src/plugins/headers.rs
@@ -17,7 +17,6 @@ use http::header::TRAILER;
 use http::header::TRANSFER_ENCODING;
 use http::header::UPGRADE;
 use http::HeaderValue;
-use lazy_static::lazy_static;
 use regex::Regex;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -236,11 +235,15 @@ impl Plugin for Headers {
 
 struct HeadersLayer {
     operations: Arc<Vec<Operation>>,
+    reserved_headers: Arc<HashSet<&'static HeaderName>>,
 }
 
 impl HeadersLayer {
     fn new(operations: Arc<Vec<Operation>>) -> Self {
-        Self { operations }
+        Self {
+            operations,
+            reserved_headers: Arc::new(RESERVED_HEADERS.iter().collect()),
+        }
     }
 }
 
@@ -251,35 +254,34 @@ impl<S> Layer<S> for HeadersLayer {
         HeadersService {
             inner,
             operations: self.operations.clone(),
+            reserved_headers: self.reserved_headers.clone(),
         }
     }
 }
 struct HeadersService<S> {
     inner: S,
     operations: Arc<Vec<Operation>>,
+    reserved_headers: Arc<HashSet<&'static HeaderName>>,
 }
 
-lazy_static! {
-    // Headers from https://datatracker.ietf.org/doc/html/rfc2616#section-13.5.1
-    // These are not propagated by default using a regex match as they will not make sense for the
-    // second hop.
-    // In addition because our requests are not regular proxy requests content-type, content-length
-    // and host are also in the exclude list.
-    static ref RESERVED_HEADERS: HashSet<HeaderName> = [
-        CONNECTION,
-        PROXY_AUTHENTICATE,
-        PROXY_AUTHORIZATION,
-        TE,
-        TRAILER,
-        TRANSFER_ENCODING,
-        UPGRADE,
-        CONTENT_LENGTH,
-        CONTENT_TYPE,
-        HOST,
-        HeaderName::from_static("keep-alive")
-    ]
-    .into();
-}
+// Headers from https://datatracker.ietf.org/doc/html/rfc2616#section-13.5.1
+// These are not propagated by default using a regex match as they will not make sense for the
+// second hop.
+// In addition because our requests are not regular proxy requests content-type, content-length
+// and host are also in the exclude list.
+static RESERVED_HEADERS: [HeaderName; 11] = [
+    CONNECTION,
+    PROXY_AUTHENTICATE,
+    PROXY_AUTHORIZATION,
+    TE,
+    TRAILER,
+    TRANSFER_ENCODING,
+    UPGRADE,
+    CONTENT_LENGTH,
+    CONTENT_TYPE,
+    HOST,
+    HeaderName::from_static("keep-alive"),
+];
 
 impl<S> Service<SubgraphRequest> for HeadersService<S>
 where
@@ -359,7 +361,7 @@ where
                         .drain()
                         .filter_map(|(name, value)| {
                             name.and_then(|name| {
-                                (RESERVED_HEADERS.contains(&name)
+                                (self.reserved_headers.contains(&name)
                                     || !matching.is_match(name.as_str()))
                                 .then_some((name, value))
                             })
@@ -391,7 +393,8 @@ where
                         .headers()
                         .iter()
                         .filter(|(name, _)| {
-                            !RESERVED_HEADERS.contains(*name) && matching.is_match(name.as_str())
+                            !self.reserved_headers.contains(*name)
+                                && matching.is_match(name.as_str())
                         })
                         .for_each(|(name, value)| {
                             headers.append(name, value.clone());


### PR DESCRIPTION
We keep finding cases i the router where we have a list of strings, like headers or span names, and call .contains() on that list, which results in going through the list one by one for a comparison, resulting in a significant perf hit

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
