### PR TITLE
Let's standardise on aarch64 rather than arm64

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -127,6 +127,10 @@ get_architecture() {
     case "$_cputype" in
         x86_64 | x86-64 | x64 | amd64 | aarch64)
             ;;
+        arm64)
+            # Our binaries use aarch64 as part of their name, not arm64
+            _cputype=aarch64
+            ;;
         *)
             err "no precompiled binaries available for CPU architecture: $_cputype"
 


### PR DESCRIPTION
Modifying the install script is going to give us the correct behaviour.
