### PR TITLE
add formatting options for trace_id

### DIFF
--- a/.changesets/feat_telemetry_header_format.md
+++ b/.changesets/feat_telemetry_header_format.md
@@ -1,0 +1,21 @@
+### Specify Trace ID Formatting ([PR #4530](https://github.com/apollographql/router/pull/4530))
+
+This adds the ability to specify the format of the trace ID in the response headers of the supergraph service.
+
+An example configuration making use of this feature is shown below:
+```yaml
+telemetry:
+  apollo:
+    client_name_header: name_header
+    client_version_header: version_header
+  exporters:
+    tracing:
+      experimental_response_trace_id:
+        enabled: true
+        header_name: trace_id
+        format: decimal # Optional, defaults to hexadecimal
+```
+
+If the format is not specified, then the trace ID will continue to be in hexadecimal format.
+
+By [@nicholascioli](https://github.com/nicholascioli) in https://github.com/apollographql/router/pull/4530

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -5639,6 +5639,25 @@ expression: "&schema"
                       "default": false,
                       "type": "boolean"
                     },
+                    "format": {
+                      "description": "Format of the trace ID in response headers",
+                      "oneOf": [
+                        {
+                          "description": "Format the Trace ID as a hexadecimal number\n\n(e.g. Trace ID 16 -> 00000000000000000000000000000010)",
+                          "type": "string",
+                          "enum": [
+                            "hexadecimal"
+                          ]
+                        },
+                        {
+                          "description": "Format the Trace ID as a decimal number\n\n(e.g. Trace ID 16 -> 16)",
+                          "type": "string",
+                          "enum": [
+                            "decimal"
+                          ]
+                        }
+                      ]
+                    },
                     "header_name": {
                       "description": "Choose the header name to expose trace_id (default: apollo-trace-id)",
                       "type": "string",

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -181,6 +181,22 @@ pub(crate) struct ExposeTraceId {
     #[schemars(with = "Option<String>")]
     #[serde(deserialize_with = "deserialize_option_header_name")]
     pub(crate) header_name: Option<HeaderName>,
+    /// Format of the trace ID in response headers
+    pub(crate) format: TraceIdFormat,
+}
+
+#[derive(Clone, Default, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "lowercase")]
+pub(crate) enum TraceIdFormat {
+    /// Format the Trace ID as a hexadecimal number
+    ///
+    /// (e.g. Trace ID 16 -> 00000000000000000000000000000010)
+    #[default]
+    Hexadecimal,
+    /// Format the Trace ID as a decimal number
+    ///
+    /// (e.g. Trace ID 16 -> 16)
+    Decimal,
 }
 
 /// Configure propagation of traces. In general you won't have to do this as these are automatically configured

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -61,6 +61,7 @@ use self::apollo_exporter::Sender;
 use self::config::Conf;
 use self::config::Sampler;
 use self::config::SamplerOption;
+use self::config::TraceIdFormat;
 use self::config_new::spans::Spans;
 use self::metrics::apollo::studio::SingleTypeStat;
 use self::metrics::AttributesForwardConf;
@@ -473,9 +474,18 @@ impl Plugin for Telemetry {
                         .unwrap_or_else(|| DEFAULT_EXPOSE_TRACE_ID_HEADER_NAME.clone())
                 });
 
+                // Append the trace ID with the right format, based on the config
+                let format_id = |trace: TraceId| {
+                    let id = match config.exporters.tracing.response_trace_id.format {
+                        TraceIdFormat::Hexadecimal => format!("{:032x}", trace.to_u128()),
+                        TraceIdFormat::Decimal => format!("{}", trace.to_u128()),
+                    };
+
+                    HeaderValue::from_str(&id).ok()
+                };
                 if let (Some(header_name), Some(trace_id)) = (
                     expose_trace_id_header,
-                    TraceId::maybe_new().and_then(|t| HeaderValue::from_str(&t.to_string()).ok()),
+                    TraceId::maybe_new().and_then(format_id),
                 ) {
                     resp.response.headers_mut().append(header_name, trace_id);
                 }


### PR DESCRIPTION
resolves #4422

Previously, when the `experimental_response_trace_id` was enabled, the router would append the trace id, if present, to the headers of the response in hexadecimal format, left-padded with 0s. This commit allows specifying through the new config option `format` whether to have that value be hexadecimal (the previous behaviour and the new default) or decimal.

Below is an example of the new configuration option in action:

```yaml
telemetry:
  apollo:
    client_name_header: name_header
    client_version_header: version_header
  exporters:
    tracing:
      experimental_response_trace_id:
        enabled: true
        header_name: trace_id
        format: decimal # Optional, defaults to hexadecimal
```

Note: Writing tests for this would be useful, but it seems very difficult to prime a trace ID that isn't randomly generated for unit testing.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
