### PR TITLE
change error when query plan is empty

### DIFF
--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -261,7 +261,7 @@ pub(crate) enum QueryPlannerError {
     /// Cache resolution failed: {0}
     CacheResolverError(Arc<CacheResolverError>),
 
-    /// empty query plan. This often means an unhandled Introspection query was sent. Please file an issue to apollographql/router.
+    /// empty query plan. This behavior is unexpected and we suggest opening an issue to apollographql/router with a reproduction.
     EmptyPlan(UsageReporting), // usage_reporting_signature
 
     /// unhandled planner result


### PR DESCRIPTION
This could be confusing for our users to talk about introspection.