### PR TITLE
do not propagate Accept, Accept-Encoding and Content-Encoding headers

### DIFF
--- a/.changesets/fix_geal_headers_propagation_filter.md
+++ b/.changesets/fix_geal_headers_propagation_filter.md
@@ -1,0 +1,18 @@
+### Fix header propagation issues ([Issue #4312](https://github.com/apollographql/router/issues/4312)), ([Issue #4398](https://github.com/apollographql/router/issues/4398))
+
+This fixes two header propagation issues:
+* if a client request header has already been added to a subgraph request due to another header propagation rule, then it is only added once
+* `Accept`, `Accept-Encoding` and `Content-Encoding` were not in the list of reserved headers that cannot be propagated. They are now in that list because those headers are set explicitely by the Router in its subgraph requests
+
+There is a potential regression: if a router deployment was accidentally relying on header propagation to compress subgraph requests, then it will not work anymore because `Content-Encoding` is not propagated anymore. Instead it should be set up from the `traffic_shaping` section of the Router configuration:
+
+```yaml
+traffic_shaping:
+  all:
+    compression: gzip
+  subgraphs: # Rules applied to requests from the router to individual subgraphs
+    products:
+      compression: identity
+```
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4535

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -8017,6 +8017,13 @@ expression: "&schema"
                   "enum": [
                     "br"
                   ]
+                },
+                {
+                  "description": "identity",
+                  "type": "string",
+                  "enum": [
+                    "identity"
+                  ]
                 }
               ],
               "nullable": true
@@ -8185,6 +8192,13 @@ expression: "&schema"
                     "type": "string",
                     "enum": [
                       "br"
+                    ]
+                  },
+                  {
+                    "description": "identity",
+                    "type": "string",
+                    "enum": [
+                      "identity"
                     ]
                   }
                 ],

--- a/apollo-router/src/plugins/headers.rs
+++ b/apollo-router/src/plugins/headers.rs
@@ -309,7 +309,7 @@ where
 
 impl<S> HeadersService<S> {
     fn modify_request(&self, req: &mut SubgraphRequest) {
-        let mut already_propagated: HashSet<&HeaderName> = HashSet::new();
+        let mut already_propagated: HashSet<&str> = HashSet::new();
 
         for operation in &*self.operations {
             match operation {
@@ -390,7 +390,7 @@ impl<S> HeadersService<S> {
                     rename,
                     default,
                 }) => {
-                    if !already_propagated.contains(named) {
+                    if !already_propagated.contains(named.as_str()) {
                         let headers = req.subgraph_request.headers_mut();
                         let values = req.supergraph_request.headers().get_all(named);
                         if values.iter().count() == 0 {
@@ -402,7 +402,7 @@ impl<S> HeadersService<S> {
                                 headers.append(rename.as_ref().unwrap_or(named), value.clone());
                             }
                         }
-                        already_propagated.insert(named);
+                        already_propagated.insert(named.as_str());
                     }
                 }
                 Operation::Propagate(Propagate::Matching { matching }) => {
@@ -416,7 +416,7 @@ impl<S> HeadersService<S> {
                                 && matching.is_match(name.as_str())
                         })
                         .for_each(|(name, value)| {
-                            if !already_propagated.contains(name) {
+                            if !already_propagated.contains(name.as_str()) {
                                 headers.append(name, value.clone());
 
                                 // we have to this because don't want to propagate headers that are accounted for in the
@@ -426,7 +426,7 @@ impl<S> HeadersService<S> {
                                     None => previous_name = Some(name),
                                     Some(previous) => {
                                         if previous != name {
-                                            already_propagated.insert(previous);
+                                            already_propagated.insert(previous.as_str());
                                             previous_name = Some(name);
                                         }
                                     }
@@ -434,7 +434,7 @@ impl<S> HeadersService<S> {
                             }
                         });
                     if let Some(name) = previous_name {
-                        already_propagated.insert(name);
+                        already_propagated.insert(name.as_str());
                     }
                 }
             }

--- a/apollo-router/src/plugins/headers.rs
+++ b/apollo-router/src/plugins/headers.rs
@@ -309,6 +309,8 @@ where
 
 impl<S> HeadersService<S> {
     fn modify_request(&self, req: &mut SubgraphRequest) {
+        let mut already_propagated: HashSet<&HeaderName> = HashSet::new();
+
         for operation in &*self.operations {
             match operation {
                 Operation::Insert(insert_config) => match insert_config {
@@ -388,19 +390,23 @@ impl<S> HeadersService<S> {
                     rename,
                     default,
                 }) => {
-                    let headers = req.subgraph_request.headers_mut();
-                    let values = req.supergraph_request.headers().get_all(named);
-                    if values.iter().count() == 0 {
-                        if let Some(default) = default {
-                            headers.append(rename.as_ref().unwrap_or(named), default.clone());
+                    if !already_propagated.contains(named) {
+                        let headers = req.subgraph_request.headers_mut();
+                        let values = req.supergraph_request.headers().get_all(named);
+                        if values.iter().count() == 0 {
+                            if let Some(default) = default {
+                                headers.append(rename.as_ref().unwrap_or(named), default.clone());
+                            }
+                        } else {
+                            for value in values {
+                                headers.append(rename.as_ref().unwrap_or(named), value.clone());
+                            }
                         }
-                    } else {
-                        for value in values {
-                            headers.append(rename.as_ref().unwrap_or(named), value.clone());
-                        }
+                        already_propagated.insert(named);
                     }
                 }
                 Operation::Propagate(Propagate::Matching { matching }) => {
+                    let mut previous_name = None;
                     let headers = req.subgraph_request.headers_mut();
                     req.supergraph_request
                         .headers()
@@ -410,8 +416,26 @@ impl<S> HeadersService<S> {
                                 && matching.is_match(name.as_str())
                         })
                         .for_each(|(name, value)| {
-                            headers.append(name, value.clone());
+                            if !already_propagated.contains(name) {
+                                headers.append(name, value.clone());
+
+                                // we have to this because don't want to propagate headers that are accounted for in the
+                                // `already_propagated` set, but in the iteration here we might go through the same header
+                                // multiple times
+                                match previous_name {
+                                    None => previous_name = Some(name),
+                                    Some(previous) => {
+                                        if previous != name {
+                                            already_propagated.insert(previous);
+                                            previous_name = Some(name);
+                                        }
+                                    }
+                                }
+                            }
                         });
+                    if let Some(name) = previous_name {
+                        already_propagated.insert(name);
+                    }
                 }
             }
         }
@@ -837,6 +861,66 @@ mod test {
                 ("db", "vdb"),
                 ("db", "vdb2"),
             ]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_propagate_multiple_matching_rules() -> Result<(), BoxError> {
+        let service = HeadersService {
+            inner: MockSubgraphService::new(),
+            operations: Arc::new(vec![
+                Operation::Propagate(Propagate::Named {
+                    named: HeaderName::from_static("dc"),
+                    rename: None,
+                    default: None,
+                }),
+                Operation::Propagate(Propagate::Matching {
+                    matching: Regex::from_str("dc")?,
+                }),
+            ]),
+            reserved_headers: Arc::new(RESERVED_HEADERS.iter().collect()),
+        };
+
+        let mut request = SubgraphRequest {
+            supergraph_request: Arc::new(
+                http::Request::builder()
+                    .header("da", "vda")
+                    .header("db", "vdb")
+                    .header("dc", "vdb2")
+                    .body(
+                        Request::builder()
+                            .query("query")
+                            .operation_name("my_operation_name")
+                            .build(),
+                    )
+                    .expect("expecting valid request"),
+            ),
+            subgraph_request: http::Request::builder()
+                .header("aa", "vaa")
+                .header("ab", "vab")
+                .header("ac", "vac")
+                .body(Request::builder().query("query").build())
+                .expect("expecting valid request"),
+            operation_kind: OperationKind::Query,
+            context: Context::new(),
+            subgraph_name: String::from("test").into(),
+            subscription_stream: None,
+            connection_closed_signal: None,
+            query_hash: Default::default(),
+            authorization: Default::default(),
+        };
+        service.modify_request(&mut request);
+        let headers = request
+            .subgraph_request
+            .headers()
+            .iter()
+            .map(|(name, value)| (name.as_str(), value.to_str().unwrap()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            headers,
+            vec![("aa", "vaa"), ("ab", "vab"), ("ac", "vac"), ("dc", "vdb2"),]
         );
 
         Ok(())

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -124,6 +124,8 @@ pub(crate) enum Compression {
     Deflate,
     /// brotli
     Br,
+    /// identity
+    Identity,
 }
 
 impl Display for Compression {

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -134,6 +134,7 @@ impl Display for Compression {
             Compression::Gzip => write!(f, "gzip"),
             Compression::Deflate => write!(f, "deflate"),
             Compression::Br => write!(f, "br"),
+            Compression::Identity => write!(f, "identity"),
         }
     }
 }


### PR DESCRIPTION
Fix #4312
Fix #4398

Potential regression caused by this PR: the only way to activate subgraph request compression right now is to have the `Content-Encoding` header set. This header was not part of the reserved headers before, and it is now, so if a router was configured to propagate that header (either explicitely or by overly large matching), then now the subgraph request will not be compressed.
I do not think it is a good idea to have subgraph compression driven by the headers. That header should instead be set by the subgraph service directly, from an option set in configuration
<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
