### PR TITLE
Fix valid APOLLO_TELEMETRY_DISABLED flag options

### DIFF
--- a/.changesets/fix_telemetry_env_var_inconsistency.md
+++ b/.changesets/fix_telemetry_env_var_inconsistency.md
@@ -1,0 +1,6 @@
+### Fix inconsistency in environment variable parsing for telemetry ([Issue #3203](https://github.com/apollographql/router/issues/ISSUE_NUMBER))
+
+Previously, the router would complain when using the rover recommendation of `APOLLO_TELEMETRY_DISABLED=1` environment
+variable. Now any non-falsey value can be used, such as 1, yes, on, etc..
+
+By [@nicholascioli](https://github.com/nicholascioli) in https://github.com/apollographql/router/pull/4549

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 
 use anyhow::anyhow;
 use anyhow::Result;
+use clap::builder::FalseyValueParser;
 use clap::ArgAction;
 use clap::Args;
 use clap::CommandFactory;
@@ -234,7 +235,7 @@ pub struct Opt {
     apollo_uplink_poll_interval: Duration,
 
     /// Disable sending anonymous usage information to Apollo.
-    #[clap(long, env = "APOLLO_TELEMETRY_DISABLED")]
+    #[clap(long, env = "APOLLO_TELEMETRY_DISABLED", value_parser = FalseyValueParser::new())]
     anonymous_telemetry_disabled: bool,
 
     /// The timeout for an http call to Apollo uplink. Defaults to 30s.
@@ -291,6 +292,10 @@ impl Opt {
             poll_interval: self.apollo_uplink_poll_interval,
             timeout: self.apollo_uplink_timeout,
         })
+    }
+
+    pub(crate) fn is_telemetry_disabled(&self) -> bool {
+        self.anonymous_telemetry_disabled
     }
 
     fn parse_endpoints(endpoints: &str) -> std::result::Result<Endpoints, anyhow::Error> {


### PR DESCRIPTION
Fixes #3023 

This commit allows for a more valid range of values for the env var APOLLO_TELEMETRY_DISABLED, which should fix inconsistencies with rover's behaviour when disabling telemetry.

There should probably be a way to pass the top-level command args to other portions of the codebase so that telemetry can be respected across the codebase using the same deserialization logic.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
