### PR TITLE
Use `ENDPOINT_CALLBACK` for extra_endpoints.

### DIFF
--- a/apollo-router/src/axum_factory/mod.rs
+++ b/apollo-router/src/axum_factory/mod.rs
@@ -6,7 +6,23 @@ mod listeners;
 pub(crate) mod tests;
 pub(crate) mod utils;
 
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+use axum::Router;
 pub(crate) use axum_http_server_factory::span_mode;
-pub use axum_http_server_factory::unsupported_set_axum_router_callback;
 pub(crate) use axum_http_server_factory::AxumHttpServerFactory;
 pub(crate) use listeners::ListenAddrAndRouter;
+
+static ENDPOINT_CALLBACK: OnceLock<Arc<dyn Fn(Router) -> Router + Send + Sync>> = OnceLock::new();
+
+/// Set a callback that may wrap or mutate `axum::Router` as they are added to the main router.
+/// Although part of the public API, this is not intended for use by end users, and may change at any time.
+#[doc(hidden)]
+pub fn unsupported_set_axum_router_callback(
+    callback: impl Fn(Router) -> Router + Send + Sync + 'static,
+) -> axum::response::Result<(), &'static str> {
+    ENDPOINT_CALLBACK
+        .set(Arc::new(callback))
+        .map_err(|_| "endpoint decorator was already set")
+}


### PR DESCRIPTION
`unsupported_set_axum_router_callback` was added in a previous PR. However it was not applied to custom endpoints.
It is now applied.
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
