### PR TITLE
feat(telemetry): static attribute on specific span

### DIFF
--- a/.changesets/feat_bnjjj_fix_4561.md
+++ b/.changesets/feat_bnjjj_fix_4561.md
@@ -1,0 +1,20 @@
+### Add static attribute on specific span in telemetry settings ([Issue #4561](https://github.com/apollographql/router/issues/4561))
+
+Example of configuration:
+
+```yaml
+telemetry:
+  instrumentation:
+    spans:
+      router:
+        attributes:
+          "my_attribute": "constant_value"
+      supergraph:
+        attributes:
+          "my_attribute": "constant_value"
+      subgraph:
+        attributes:
+          "my_attribute": "constant_value"
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/4566

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -6683,6 +6683,9 @@ expression: "&schema"
                               }
                             },
                             "additionalProperties": false
+                          },
+                          {
+                            "type": "string"
                           }
                         ]
                       }
@@ -7416,6 +7419,9 @@ expression: "&schema"
                               }
                             },
                             "additionalProperties": false
+                          },
+                          {
+                            "type": "string"
                           }
                         ]
                       }
@@ -7881,6 +7887,9 @@ expression: "&schema"
                               }
                             },
                             "additionalProperties": false
+                          },
+                          {
+                            "type": "string"
                           }
                         ]
                       }

--- a/docs/source/configuration/telemetry/instrumentation/spans.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/spans.mdx
@@ -161,6 +161,7 @@ telemetry:
             default: "unknown"
           "acme.custom_3":
             env: "ENV_VAR"
+          "static_attribute": "my_static_value"
             # ...
           
       supergraph:


### PR DESCRIPTION
Example of configuration:

```yaml
telemetry:
  instrumentation:
    spans:
      router:
        attributes:
          "my_attribute": "constant_value"
      supergraph:
        attributes:
          "my_attribute": "constant_value"
      subgraph:
        attributes:
          "my_attribute": "constant_value"
```

Fixes #4561 

----

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
