### PR TITLE
Ability to automatically switch the logging format depending on the terminal

### DIFF
--- a/.changesets/feat_bnjjj_feat_4369.md
+++ b/.changesets/feat_bnjjj_feat_4369.md
@@ -1,0 +1,20 @@
+### Ability to automatically switch the logging format depending on the terminal ([Issue #4369](https://github.com/apollographql/router/issues/4369))
+
+You can configure the logging output format when you're running on an interactive shell. If bother `format` and `tty_format` are configured then the format depends on how the router is run:
+
+* In an interactive shell, `tty_format` will take precedence.
+* In a non-interactive shell, `format` will take precedence.
+
+You can explicitly set the format in `router.yaml` with `telemetry.exporters.logging.stdout.tty_format`:
+
+```yaml title="router.yaml"
+telemetry:
+  exporters:
+     logging:
+       stdout:
+         enabled: true
+         format: json
+         tty_format: text
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/4567

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -3202,6 +3202,173 @@ expression: "&schema"
                         }
                       },
                       "additionalProperties": false
+                    },
+                    "tty_format": {
+                      "description": "The format to log to stdout when you're running on an interactive terminal. When configured it will automatically use this `tty_format`` instead of the original `format` when an interactive terminal is detected",
+                      "oneOf": [
+                        {
+                          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Json.html",
+                          "type": "object",
+                          "required": [
+                            "json"
+                          ],
+                          "properties": {
+                            "json": {
+                              "type": "object",
+                              "properties": {
+                                "display_current_span": {
+                                  "description": "Include the current span in this log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_filename": {
+                                  "description": "Include the filename with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_level": {
+                                  "description": "Include the level with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_line_number": {
+                                  "description": "Include the line number with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_resource": {
+                                  "description": "Include the resource with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_span_list": {
+                                  "description": "Include all of the containing span information with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_target": {
+                                  "description": "Include the target with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_thread_id": {
+                                  "description": "Include the thread_id with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_thread_name": {
+                                  "description": "Include the thread_name with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_timestamp": {
+                                  "description": "Include the timestamp with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Json.html",
+                          "type": "string",
+                          "enum": [
+                            "json"
+                          ]
+                        },
+                        {
+                          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Full.html",
+                          "type": "object",
+                          "required": [
+                            "text"
+                          ],
+                          "properties": {
+                            "text": {
+                              "type": "object",
+                              "properties": {
+                                "ansi_escape_codes": {
+                                  "description": "Process ansi escapes (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_current_span": {
+                                  "description": "Include the current span in this log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_filename": {
+                                  "description": "Include the filename with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_level": {
+                                  "description": "Include the level with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_line_number": {
+                                  "description": "Include the line number with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_resource": {
+                                  "description": "Include the resource with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_service_name": {
+                                  "description": "Include the service name with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_service_namespace": {
+                                  "description": "Include the service namespace with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_span_list": {
+                                  "description": "Include all of the containing span information with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                },
+                                "display_target": {
+                                  "description": "Include the target with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_thread_id": {
+                                  "description": "Include the thread_id with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_thread_name": {
+                                  "description": "Include the thread_name with the log event.",
+                                  "default": false,
+                                  "type": "boolean"
+                                },
+                                "display_timestamp": {
+                                  "description": "Include the timestamp with the log event. (default: true)",
+                                  "default": true,
+                                  "type": "boolean"
+                                }
+                              },
+                              "additionalProperties": false
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        {
+                          "description": "Tracing subscriber https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/format/struct.Full.html",
+                          "type": "string",
+                          "enum": [
+                            "text"
+                          ]
+                        }
+                      ],
+                      "nullable": true
                     }
                   },
                   "additionalProperties": false

--- a/apollo-router/src/plugins/telemetry/config_new/logging.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/logging.rs
@@ -105,6 +105,8 @@ pub(crate) struct StdOut {
     pub(crate) enabled: bool,
     /// The format to log to stdout.
     pub(crate) format: Format,
+    /// The format to log to stdout when you're running on an interactive terminal. When configured it will automatically use this `tty_format`` instead of the original `format` when an interactive terminal is detected
+    pub(crate) tty_format: Option<Format>,
     /// Log rate limiting. The limit is set per type of log message
     pub(crate) rate_limit: RateLimit,
 }
@@ -114,6 +116,7 @@ impl Default for StdOut {
         StdOut {
             enabled: true,
             format: Format::default(),
+            tty_format: None,
             rate_limit: RateLimit::default(),
         }
     }

--- a/docs/source/configuration/telemetry/exporters/logging/stdout.mdx
+++ b/docs/source/configuration/telemetry/exporters/logging/stdout.mdx
@@ -42,6 +42,25 @@ telemetry:
          format: text #highlight-line
 ```
 
+### `tty_format`
+
+You can configure the logging output format when you're running on an interactive shell. If bother `format` and `tty_format` are configured then the format depends on how the router is run:
+
+* In an interactive shell, `tty_format` will take precedence.
+* In a non-interactive shell, `format` will take precedence.
+
+You can explicitly set the format in [`router.yaml`](../../../overview#yaml-config-file) with `telemetry.exporters.logging.stdout.tty_format`:
+
+```yaml title="router.yaml"
+telemetry:
+  exporters:
+     logging:
+       stdout:
+         enabled: true
+         format: json
+         tty_format: text #highlight-line
+```
+
 ### `rate_limit`
 
 The rate at which log messages are produced can become too high, especially for request processing errors. To prevent the router from filling its logs with redundant messages, you can use the `rate_limit` option to set the logging rate limit.
@@ -69,6 +88,7 @@ For configuration options specific to each output format, see the [`text`](#text
 |-----------------------|----------------------------|-----------------|------------------------------------------------------|
 | `enabled`             | `true`\|`false`            | `false`         | Enable or disable stdout logging.                    |
 | `format`              |                            | `text`\|`json`  | See the [format documentation](#format) for details. |
+| `tty_format`          |                            | `text`\|`json`  | See the [format documentation](#format) for details. |
 
 
 ## Logging output format

--- a/docs/source/configuration/telemetry/exporters/logging/stdout.mdx
+++ b/docs/source/configuration/telemetry/exporters/logging/stdout.mdx
@@ -44,7 +44,9 @@ telemetry:
 
 ### `tty_format`
 
-You can configure the logging output format when you're running on an interactive shell. If bother `format` and `tty_format` are configured then the format depends on how the router is run:
+You can configure the log format when you're running on an interactive shell. This is useful during development.
+
+If both `format` and `tty_format` are configured then the output depends on the environment where the Router is run:
 
 * In an interactive shell, `tty_format` will take precedence.
 * In a non-interactive shell, `format` will take precedence.


### PR DESCRIPTION
You can configure the logging output format when you're running on an interactive shell. If bother `format` and `tty_format` are configured then the format depends on how the router is run:

* In an interactive shell, `tty_format` will take precedence.
* In a non-interactive shell, `format` will take precedence.

You can explicitly set the format in `router.yaml` with `telemetry.exporters.logging.stdout.tty_format`:

```yaml title="router.yaml"
telemetry:
  exporters:
     logging:
       stdout:
         enabled: true
         format: json
         tty_format: text
```

Fixes #4369

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
