### PR TITLE
Improve schema enforcement

### DIFF
--- a/apollo-router/src/spec/mod.rs
+++ b/apollo-router/src/spec/mod.rs
@@ -25,6 +25,7 @@ use crate::json_ext::Object;
 
 pub(crate) const LINK_DIRECTIVE_NAME: &str = "link";
 pub(crate) const LINK_URL_ARGUMENT: &str = "url";
+pub(crate) const LINK_AS_ARGUMENT: &str = "as";
 
 /// GraphQL parsing errors.
 #[derive(Error, Debug, Display, Clone, Serialize, Deserialize)]

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -116,7 +116,9 @@ impl ParsedLinkSpec {
                 let spec_name = captures.get(2).unwrap().as_str().to_string();
                 let version_string = captures.get(3).unwrap().as_str().to_string();
 
-                let Ok(parsed_version) = semver::Version::parse(&version_string) else {
+                let Ok(parsed_version) =
+                    semver::Version::parse(format!("{}.0", &version_string).as_str())
+                else {
                     return None;
                 };
                 let imported_as = link_directive

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -4,7 +4,6 @@
 #![allow(clippy::derive_partial_eq_without_eq)]
 
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::fmt::Display;
 use std::fmt::Formatter;
 use std::str::FromStr;
@@ -12,6 +11,9 @@ use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
+use apollo_compiler::ast::Definition;
+use apollo_compiler::schema::Directive;
+use apollo_compiler::Node;
 use buildstructor::Builder;
 use displaydoc::Display;
 use itertools::Itertools;
@@ -27,6 +29,7 @@ use serde::Serialize;
 use serde_json::Value;
 use thiserror::Error;
 
+use crate::spec::LINK_AS_ARGUMENT;
 use crate::spec::LINK_DIRECTIVE_NAME;
 use crate::spec::LINK_URL_ARGUMENT;
 use crate::Configuration;
@@ -82,7 +85,67 @@ where
 #[derive(Debug)]
 pub(crate) struct LicenseEnforcementReport {
     restricted_config_in_use: Vec<ConfigurationRestriction>,
-    restricted_schema_in_use: Vec<SchemaRestriction>,
+    restricted_schema_in_use: Vec<SchemaViolation>,
+}
+
+#[derive(Debug)]
+struct ParsedLinkSpec {
+    spec_name: String,
+    version: semver::Version,
+    base_url: String,
+    imported_as: Option<String>,
+    url: String,
+}
+
+impl ParsedLinkSpec {
+    fn from_link_directive(link_directive: &Node<Directive>) -> Option<ParsedLinkSpec> {
+        link_directive
+            .argument_by_name(LINK_URL_ARGUMENT)
+            .and_then(|value| {
+                let Some(url) = value.as_str() else {
+                    return None;
+                };
+                // capture url + spec name, spec name, and version from a link spec url
+                let re = Regex::new(r"^(.*/([^/]+))/v(\d+\.\d+)$").unwrap();
+                let Some(captures) = re.captures(url) else {
+                    return None;
+                };
+
+                let full_url = captures.get(0).unwrap().as_str().to_string();
+                let base_url = captures.get(1).unwrap().as_str().to_string();
+                let spec_name = captures.get(2).unwrap().as_str().to_string();
+                let version_string = captures.get(3).unwrap().as_str().to_string();
+
+                let Ok(parsed_version) = semver::Version::parse(&version_string) else {
+                    return None;
+                };
+                let imported_as = link_directive
+                    .argument_by_name(LINK_AS_ARGUMENT)
+                    .map(|as_arg| as_arg.as_str().unwrap_or_default().to_string());
+
+                Some(ParsedLinkSpec {
+                    spec_name,
+                    base_url,
+                    version: parsed_version,
+                    imported_as,
+                    url: full_url,
+                })
+            })
+    }
+
+    // Implements directive name construction logic for link directives.
+    // 1. If the link directive has an `as` argument, use that as the prefix.
+    // 2. If the link directive's spec name is the same as the default name, use the default name with no prefix.
+    // 3. Otherwise, use the spec name as the prefix.
+    fn directive_name(&self, default_name: &str) -> String {
+        if let Some(imported_as) = &self.imported_as {
+            format!("{}__{}", imported_as, default_name)
+        } else if self.spec_name == default_name {
+            default_name.to_string()
+        } else {
+            format!("{}__{}", self.spec_name, default_name)
+        }
+    }
 }
 
 impl LicenseEnforcementReport {
@@ -134,60 +197,82 @@ impl LicenseEnforcementReport {
     fn validate_schema(
         schema: &apollo_compiler::ast::Document,
         schema_restrictions: &Vec<SchemaRestriction>,
-    ) -> Vec<SchemaRestriction> {
-        let feature_urls = schema
+    ) -> Vec<SchemaViolation> {
+        let link_specs = schema
             .definitions
             .iter()
             .filter_map(|def| def.as_schema_definition())
             .flat_map(|def| def.directives.get_all(LINK_DIRECTIVE_NAME))
             .filter_map(|link| {
-                link.argument_by_name(LINK_URL_ARGUMENT)
-                    .and_then(|value| value.as_str().map(|s| s.to_string()))
+                ParsedLinkSpec::from_link_directive(link)
+                    .map(|spec| (spec.base_url.to_owned(), spec))
             })
-            .collect::<HashSet<_>>();
-
-        // collect directive definitions and their argument names
-        let directive_to_arg_names_map = schema
-            .definitions
-            .iter()
-            .filter_map(|def| def.as_directive_definition())
-            .map(|directive_def| {
-                let arg_names = directive_def
-                    .arguments
-                    .iter()
-                    .map(|arg| arg.name.to_string())
-                    .collect::<Vec<String>>();
-                (directive_def.name.to_string(), arg_names)
-            })
-            .collect::<HashMap<String, Vec<String>>>();
+            .collect::<HashMap<_, _>>();
 
         let mut schema_violations = Vec::new();
 
         for restriction in schema_restrictions {
             match restriction {
-                SchemaRestriction::Directive { url, name } => {
-                    if feature_urls.contains(url) {
-                        schema_violations.push(SchemaRestriction::Directive {
-                            url: url.to_string(),
-                            name: name.to_string(),
-                        });
+                SchemaRestriction::Spec {
+                    base_url,
+                    name,
+                    version_req,
+                } => {
+                    if let Some(link_spec) = link_specs.get(base_url) {
+                        if semver::VersionReq::parse(version_req)
+                            .unwrap()
+                            .matches(&link_spec.version)
+                        {
+                            schema_violations.push(SchemaViolation::Spec {
+                                url: link_spec.url.to_string(),
+                                name: name.to_string(),
+                            });
+                        }
                     }
                 }
                 SchemaRestriction::DirectiveArgument {
-                    url,
+                    base_url,
                     name,
+                    version_req,
                     argument,
+                    explanation,
                 } => {
-                    if directive_to_arg_names_map
-                        .get(name.strip_prefix('@').unwrap_or_default())
-                        .map(|args| args.contains(argument))
-                        .unwrap_or_default()
-                    {
-                        schema_violations.push(SchemaRestriction::DirectiveArgument {
-                            url: url.to_string(),
-                            name: name.to_string(),
-                            argument: argument.to_string(),
-                        });
+                    if let Some(link_spec) = link_specs.get(base_url) {
+                        if semver::VersionReq::parse(version_req)
+                            .unwrap()
+                            .matches(&link_spec.version)
+                        {
+                            let directive_name = link_spec.directive_name(name);
+                            if schema
+                                .definitions
+                                .iter()
+                                .flat_map(|def| match def {
+                                    // To traverse additional directive locations, add match arms for the respective definition types required.
+                                    // As of writing this, this is only implemented for finding usages of progressive override on object type fields, but it can be extended to other directive locations trivially.
+                                    Definition::ObjectTypeDefinition(object_type_def) => {
+                                        let directives_on_object =
+                                            object_type_def.directives.get_all(&directive_name);
+                                        let directives_on_fields =
+                                            object_type_def.fields.iter().flat_map(|field| {
+                                                field.directives.get_all(&directive_name)
+                                            });
+
+                                        directives_on_object
+                                            .chain(directives_on_fields)
+                                            .collect::<Vec<_>>()
+                                    }
+                                    _ => vec![],
+                                })
+                                .any(|directive| directive.argument_by_name(argument).is_some())
+                            {
+                                schema_violations.push(SchemaViolation::DirectiveArgument {
+                                    url: link_spec.url.to_string(),
+                                    name: directive_name.to_string(),
+                                    argument: argument.to_string(),
+                                    explanation: explanation.to_string(),
+                                });
+                            }
+                        }
                     }
                 }
             }
@@ -280,18 +365,22 @@ impl LicenseEnforcementReport {
 
     fn schema_restrictions() -> Vec<SchemaRestriction> {
         vec![
-            SchemaRestriction::Directive {
-                name: "@authenticated".to_string(),
-                url: "https://specs.apollo.dev/authenticated/v0.1".to_string(),
+            SchemaRestriction::Spec {
+                name: "authenticated".to_string(),
+                base_url: "https://specs.apollo.dev/authenticated".to_string(),
+                version_req: "=0.1.0".to_string(),
             },
-            SchemaRestriction::Directive {
-                name: "@requiresScopes".to_string(),
-                url: "https://specs.apollo.dev/requiresScopes/v0.1".to_string(),
+            SchemaRestriction::Spec {
+                name: "requiresScopes".to_string(),
+                base_url: "https://specs.apollo.dev/requiresScopes".to_string(),
+                version_req: "=0.1.0".to_string(),
             },
             SchemaRestriction::DirectiveArgument {
-                name: "@join__field".to_string(),
+                name: "field".to_string(),
                 argument: "overrideLabel".to_string(),
-                url: "".to_string(),
+                base_url: "https://specs.apollo.dev/join".to_string(),
+                version_req: ">=0.4.0".to_string(),
+                explanation: "The `overrideLabel` argument on the join spec's @field directive is restricted to Enterprise users. This argument exists in your supergraph as a result of using the `@override` directive with the `label` argument in one or more of your subgraphs.".to_string()
             },
         ]
     }
@@ -411,39 +500,54 @@ pub(crate) struct ConfigurationRestriction {
     value: Option<Value>,
 }
 
-// An individual check for the supergraph schema
-// #[derive(Builder, Clone, Debug, Serialize, Deserialize)]
-// pub(crate) struct SchemaRestriction {
-//     name: String,
-//     url: String,
-// }
-
 /// An individual check for the supergraph schema
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) enum SchemaRestriction {
-    Directive {
+    Spec {
+        base_url: String,
         name: String,
-        url: String,
+        version_req: String,
     },
+    // Note: this restriction is currently only traverses directives belonging
+    // to object types and their fields. See note in `schema_restrictions` loop
+    // for where to update if this restriction is to be enforced on other
+    // directives.
     DirectiveArgument {
+        base_url: String,
         name: String,
-        url: String,
+        version_req: String,
         argument: String,
+        explanation: String,
     },
 }
 
-impl Display for SchemaRestriction {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) enum SchemaViolation {
+    Spec {
+        url: String,
+        name: String,
+    },
+    DirectiveArgument {
+        url: String,
+        name: String,
+        argument: String,
+        explanation: String,
+    },
+}
+
+impl Display for SchemaViolation {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
-            SchemaRestriction::Directive { name, url } => {
-                write!(f, "* {}\n  {}", name, url)
+            SchemaViolation::Spec { name, url } => {
+                write!(f, "* @{}\n  {}", name, url)
             }
-            SchemaRestriction::DirectiveArgument {
+            SchemaViolation::DirectiveArgument {
                 name,
                 url,
                 argument,
+                explanation,
             } => {
-                write!(f, "* {}.{}\n  {}", name, argument, url)
+                write!(f, "* @{}.{}\n  {}\n\n{}", name, argument, url, explanation)
             }
         }
     }
@@ -601,5 +705,73 @@ mod test {
             "should have found restricted features"
         );
         assert_snapshot!(report.to_string());
+    }
+
+    #[test]
+    fn progressive_override_with_renamed_join_spec() {
+        let report = check(
+            include_str!("testdata/oss.router.yaml"),
+            include_str!("testdata/progressive_override_renamed_join.graphql"),
+        );
+
+        assert!(
+            !report.restricted_schema_in_use.is_empty(),
+            "should have found restricted features"
+        );
+        assert_snapshot!(report.to_string());
+    }
+
+    #[test]
+    fn schema_enforcement_spec_version_in_range() {
+        let report = check(
+            include_str!("testdata/oss.router.yaml"),
+            include_str!("testdata/schema_enforcement_spec_version_in_range.graphql"),
+        );
+
+        assert!(
+            !report.restricted_schema_in_use.is_empty(),
+            "should have found restricted features"
+        );
+        assert_snapshot!(report.to_string());
+    }
+
+    #[test]
+    fn schema_enforcement_spec_version_out_of_range() {
+        let report = check(
+            include_str!("testdata/oss.router.yaml"),
+            include_str!("testdata/schema_enforcement_spec_version_out_of_range.graphql"),
+        );
+
+        assert!(
+            report.restricted_schema_in_use.is_empty(),
+            "shouldn't have found restricted features"
+        );
+    }
+
+    #[test]
+    fn schema_enforcement_directive_arg_version_in_range() {
+        let report = check(
+            include_str!("testdata/oss.router.yaml"),
+            include_str!("testdata/schema_enforcement_directive_arg_version_in_range.graphql"),
+        );
+
+        assert!(
+            !report.restricted_schema_in_use.is_empty(),
+            "should have found restricted features"
+        );
+        assert_snapshot!(report.to_string());
+    }
+
+    #[test]
+    fn schema_enforcement_directive_arg_version_out_of_range() {
+        let report = check(
+            include_str!("testdata/oss.router.yaml"),
+            include_str!("testdata/schema_enforcement_directive_arg_version_out_of_range.graphql"),
+        );
+
+        assert!(
+            report.restricted_schema_in_use.is_empty(),
+            "shouldn't have found restricted features"
+        );
     }
 }

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -221,10 +221,7 @@ impl LicenseEnforcementReport {
                     version_req,
                 } => {
                     if let Some(link_spec) = link_specs.get(spec_url) {
-                        if semver::VersionReq::parse(version_req)
-                            .unwrap()
-                            .matches(&link_spec.version)
-                        {
+                        if version_req.matches(&link_spec.version) {
                             schema_violations.push(SchemaViolation::Spec {
                                 url: link_spec.url.to_string(),
                                 name: name.to_string(),
@@ -240,10 +237,7 @@ impl LicenseEnforcementReport {
                     explanation,
                 } => {
                     if let Some(link_spec) = link_specs.get(spec_url) {
-                        if semver::VersionReq::parse(version_req)
-                            .unwrap()
-                            .matches(&link_spec.version)
-                        {
+                        if version_req.matches(&link_spec.version) {
                             let directive_name = link_spec.directive_name(name);
                             if schema
                                 .definitions
@@ -370,18 +364,42 @@ impl LicenseEnforcementReport {
             SchemaRestriction::Spec {
                 name: "authenticated".to_string(),
                 spec_url: "https://specs.apollo.dev/authenticated".to_string(),
-                version_req: "=0.1.0".to_string(),
+                version_req: semver::VersionReq {
+                    comparators: vec![semver::Comparator {
+                        op: semver::Op::Exact,
+                        major: 0,
+                        minor: 1.into(),
+                        patch: 0.into(),
+                        pre: semver::Prerelease::EMPTY,
+                    }],
+                },
             },
             SchemaRestriction::Spec {
                 name: "requiresScopes".to_string(),
                 spec_url: "https://specs.apollo.dev/requiresScopes".to_string(),
-                version_req: "=0.1.0".to_string(),
+                version_req: semver::VersionReq {
+                    comparators: vec![semver::Comparator {
+                        op: semver::Op::Exact,
+                        major: 0,
+                        minor: 1.into(),
+                        patch: 0.into(),
+                        pre: semver::Prerelease::EMPTY,
+                    }],
+                },
             },
             SchemaRestriction::DirectiveArgument {
                 name: "field".to_string(),
                 argument: "overrideLabel".to_string(),
                 spec_url: "https://specs.apollo.dev/join".to_string(),
-                version_req: ">=0.4.0".to_string(),
+                version_req: semver::VersionReq {
+                    comparators: vec![semver::Comparator {
+                        op: semver::Op::GreaterEq,
+                        major: 0,
+                        minor: 4.into(),
+                        patch: 0.into(),
+                        pre: semver::Prerelease::EMPTY,
+                    }],
+                },
                 explanation: "The `overrideLabel` argument on the join spec's @field directive is restricted to Enterprise users. This argument exists in your supergraph as a result of using the `@override` directive with the `label` argument in one or more of your subgraphs.".to_string()
             },
         ]
@@ -503,12 +521,12 @@ pub(crate) struct ConfigurationRestriction {
 }
 
 /// An individual check for the supergraph schema
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug)]
 pub(crate) enum SchemaRestriction {
     Spec {
         spec_url: String,
         name: String,
-        version_req: String,
+        version_req: semver::VersionReq,
     },
     // Note: this restriction is currently only traverses directives belonging
     // to object types and their fields. See note in `schema_restrictions` loop
@@ -517,7 +535,7 @@ pub(crate) enum SchemaRestriction {
     DirectiveArgument {
         spec_url: String,
         name: String,
-        version_req: String,
+        version_req: semver::VersionReq,
         argument: String,
         explanation: String,
     },

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -110,7 +110,12 @@ impl ParsedLinkSpec {
 
                 let mut segments = parsed_url.path_segments()?;
                 let spec_name = segments.next()?.to_string();
-                let spec_url = format!("{}://{}/{}", parsed_url.scheme(), parsed_url.host()?, spec_name);
+                let spec_url = format!(
+                    "{}://{}/{}",
+                    parsed_url.scheme(),
+                    parsed_url.host()?,
+                    spec_name
+                );
                 let version_string = segments.next()?.strip_prefix('v')?;
                 let parsed_version =
                     semver::Version::parse(format!("{}.0", &version_string).as_str()).ok()?;

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__progressive_override_with_renamed_join_spec.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__progressive_override_with_renamed_join_spec.snap
@@ -1,10 +1,10 @@
 ---
 source: apollo-router/src/uplink/license_enforcement.rs
-assertion_line: 660
+assertion_line: 674
 expression: report.to_string()
 ---
 Schema features:
-* @join__field.overrideLabel
+* @j__field.overrideLabel
   https://specs.apollo.dev/join/v0.4
 
 The `overrideLabel` argument on the join spec's @field directive is restricted to Enterprise users. This argument exists in your supergraph as a result of using the `@override` directive with the `label` argument in one or more of your subgraphs.

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__schema_enforcement_directive_arg_version_in_range.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__schema_enforcement_directive_arg_version_in_range.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/uplink/license_enforcement.rs
-assertion_line: 660
+assertion_line: 741
 expression: report.to_string()
 ---
 Schema features:

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__schema_enforcement_spec_version_in_range.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__schema_enforcement_spec_version_in_range.snap
@@ -1,0 +1,8 @@
+---
+source: apollo-router/src/uplink/license_enforcement.rs
+assertion_line: 714
+expression: report.to_string()
+---
+Schema features:
+* @authenticated
+  https://specs.apollo.dev/authenticated/v0.1

--- a/apollo-router/src/uplink/testdata/progressive_override_renamed_join.graphql
+++ b/apollo-router/src/uplink/testdata/progressive_override_renamed_join.graphql
@@ -1,0 +1,77 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION, as: "j") {
+  query: Query
+}
+
+directive @j__enumValue(graph: j__Graph!) repeatable on ENUM_VALUE
+
+directive @j__field(
+  graph: j__Graph
+  requires: j__FieldSet
+  provides: j__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+  overrideLabel: String
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @j__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @j__implements(
+  graph: j__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @j__type(
+  graph: j__Graph!
+  key: j__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @j__unionMember(graph: j__Graph!, member: String!) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar j__FieldSet
+
+enum j__Graph {
+  SUBGRAPH1 @j__graph(name: "Subgraph1", url: "https://Subgraph1")
+  SUBGRAPH2 @j__graph(name: "Subgraph2", url: "https://Subgraph2")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  \`SECURITY\` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  \`EXECUTION\` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query @j__type(graph: SUBGRAPH1) @j__type(graph: SUBGRAPH2) {
+  t: T @j__field(graph: SUBGRAPH1)
+}
+
+type T
+  @j__type(graph: SUBGRAPH1, key: "k")
+  @j__type(graph: SUBGRAPH2, key: "k") {
+  k: ID
+  a: Int
+    @j__field(graph: SUBGRAPH1, override: "Subgraph2", overrideLabel: "foo")
+    @j__field(graph: SUBGRAPH2, overrideLabel: "foo")
+  b: Int @j__field(graph: SUBGRAPH2)
+}

--- a/apollo-router/src/uplink/testdata/schema_enforcement_directive_arg_version_in_range.graphql
+++ b/apollo-router/src/uplink/testdata/schema_enforcement_directive_arg_version_in_range.graphql
@@ -1,0 +1,19 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION) {
+  query: Query
+}
+
+type Query @join__type(graph: SUBGRAPH1) @join__type(graph: SUBGRAPH2) {
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "k")
+  @join__type(graph: SUBGRAPH2, key: "k") {
+  k: ID
+  a: Int
+    @join__field(graph: SUBGRAPH1, override: "Subgraph2", overrideLabel: "foo")
+    @join__field(graph: SUBGRAPH2, overrideLabel: "foo")
+  b: Int @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-router/src/uplink/testdata/schema_enforcement_directive_arg_version_out_of_range.graphql
+++ b/apollo-router/src/uplink/testdata/schema_enforcement_directive_arg_version_out_of_range.graphql
@@ -1,0 +1,17 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+type Query @join__type(graph: SUBGRAPH1) @join__type(graph: SUBGRAPH2) {
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "k")
+  @join__type(graph: SUBGRAPH2, key: "k") {
+  k: ID
+  a: Int @join__field(graph: SUBGRAPH1, override: "Subgraph2")
+  b: Int @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-router/src/uplink/testdata/schema_enforcement_spec_version_in_range.graphql
+++ b/apollo-router/src/uplink/testdata/schema_enforcement_spec_version_in_range.graphql
@@ -1,0 +1,5 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/authenticated/v0.1", for: SECURITY) {
+  query: Query
+}

--- a/apollo-router/src/uplink/testdata/schema_enforcement_spec_version_out_of_range.graphql
+++ b/apollo-router/src/uplink/testdata/schema_enforcement_spec_version_out_of_range.graphql
@@ -1,0 +1,5 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/authenticated/v0.2", for: SECURITY) {
+  query: Query
+}


### PR DESCRIPTION
The initial implementation of directive argument schema enforcement is lacking:
* It doesn't handle renames of the `join` spec via `as`, meaning the restriction could be circumvented via a `join` rename.
* It only looked for the directive argument on the definition rather than actual usages. If the arg is defined but unused, we shouldn't enforce anything. It might exist in the definition simply as a result of using the latest versions of subgraph libs/composition.

Additionally, this PR introduces the requirement of specifying a `semver::VersionReq` for enforcement.