### PR TITLE
fix: Progressive override - use `.operations` instead of `.schema` for operations-related metrics

### DIFF
--- a/apollo-router/src/plugins/progressive_override/mod.rs
+++ b/apollo-router/src/plugins/progressive_override/mod.rs
@@ -214,7 +214,7 @@ impl Plugin for ProgressiveOverridePlugin {
 
                     if !relevant_labels.is_empty() {
                         u64_counter!(
-                            "apollo.router.schema.override.query",
+                            "apollo.router.operations.override.query",
                             "query with overridden fields",
                             1,
                             query.label_count = relevant_labels.len() as i64
@@ -223,7 +223,7 @@ impl Plugin for ProgressiveOverridePlugin {
 
                     if !externally_overridden_labels.is_empty() {
                         u64_counter!(
-                            "apollo.router.schema.override.external",
+                            "apollo.router.operations.override.external",
                             "override label(s) resolved by coprocessor/rhai",
                             1
                         );

--- a/apollo-router/src/plugins/progressive_override/tests.rs
+++ b/apollo-router/src/plugins/progressive_override/tests.rs
@@ -314,7 +314,7 @@ async fn query_with_overridden_labels_metrics() {
     async {
         query_with_labels("{ percent100 { foo } }", vec![]).await;
         assert_counter!(
-            "apollo.router.schema.override.query",
+            "apollo.router.operations.override.query",
             1,
             query.label_count = 2
         );
@@ -328,11 +328,11 @@ async fn query_with_externally_resolved_labels_metrics() {
     async {
         query_with_labels("{ percent100 { foo } }", vec!["foo"]).await;
         assert_counter!(
-            "apollo.router.schema.override.query",
+            "apollo.router.operations.override.query",
             1,
             query.label_count = 2
         );
-        assert_counter!("apollo.router.schema.override.external", 1);
+        assert_counter!("apollo.router.operations.override.external", 1);
     }
     .with_metrics()
     .await;


### PR DESCRIPTION
These were accidentally named under the impression that they were tracking schema-related config rather than operation-based behavior.