### PR TITLE
Add selectors to extract body elements using JSONPath

### DIFF
--- a/.changesets/feat_bnjjj_fix_4443.md
+++ b/.changesets/feat_bnjjj_fix_4443.md
@@ -1,0 +1,18 @@
+### Add selectors to extract body elements from subgraph response using JSONPath ([Issue #4443](https://github.com/apollographql/router/issues/4443))
+
+Deprecated `subgraph_response_body` in favor of `subgraph_response_data` and `subgraph_response_errors` which is a [selector](https://www.apollographql.com/docs/router/configuration/telemetry/instrumentation/selectors/) and use a JSON Path to fetch data/errors from the subgraph response. 
+
+Example:
+
+```yaml
+telemetry:
+  instrumentation:
+    spans:
+      subgraph:
+        attributes:
+          "my_attribute":
+            subgraph_response_data: "$.productName"
+            subgraph_response_errors: "$.[0].message"
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/4579

--- a/apollo-router/src/configuration/migrations/0022-spans_subgraph_response_body.yaml
+++ b/apollo-router/src/configuration/migrations/0022-spans_subgraph_response_body.yaml
@@ -1,0 +1,6 @@
+description: log warning because span selector `subgraph_response_body` is deprecated
+actions:
+  - type: log
+    level: warn
+    path: telemetry.instrumentation.spans.subgraph.attributes.*.subgraph_response_body
+    log: "'subgraph_response_body' span selector is deprecated, please use 'subgraph_response_data' or subgraph_response_error' instead.\n\n List of available selectors https://www.apollographql.com/docs/router/configuration/telemetry/instrumentation/selectors"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1,6 +1,5 @@
 ---
 source: apollo-router/src/configuration/tests.rs
-assertion_line: 31
 expression: "&schema"
 ---
 {
@@ -7059,6 +7058,7 @@ expression: "&schema"
                             "additionalProperties": false
                           },
                           {
+                            "description": "Deprecated, use SubgraphResponseData and SubgraphResponseError instead",
                             "type": "object",
                             "required": [
                               "subgraph_response_body"
@@ -7124,6 +7124,150 @@ expression: "&schema"
                                 "nullable": true
                               },
                               "subgraph_response_body": {
+                                "description": "The subgraph response body json path.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "subgraph_response_data"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              },
+                              "subgraph_response_data": {
+                                "description": "The subgraph response body json path.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "required": [
+                              "subgraph_response_errors"
+                            ],
+                            "properties": {
+                              "default": {
+                                "description": "Optional default value.",
+                                "anyOf": [
+                                  {
+                                    "description": "bool values",
+                                    "type": "boolean"
+                                  },
+                                  {
+                                    "description": "i64 values",
+                                    "type": "integer",
+                                    "format": "int64"
+                                  },
+                                  {
+                                    "description": "f64 values",
+                                    "type": "number",
+                                    "format": "double"
+                                  },
+                                  {
+                                    "description": "String values",
+                                    "type": "string"
+                                  },
+                                  {
+                                    "description": "Array of homogeneous values",
+                                    "anyOf": [
+                                      {
+                                        "description": "Array of bools",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of integers",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "integer",
+                                          "format": "int64"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of floats",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "number",
+                                          "format": "double"
+                                        }
+                                      },
+                                      {
+                                        "description": "Array of strings",
+                                        "type": "array",
+                                        "items": {
+                                          "type": "string"
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ],
+                                "nullable": true
+                              },
+                              "subgraph_response_errors": {
                                 "description": "The subgraph response body json path.",
                                 "type": "string"
                               }

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -4,9 +4,7 @@
 
 use std::cmp::min;
 use std::fmt;
-use std::str::FromStr;
 
-use jsonpath_rust::JsonPathInst;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json_bytes::ByteString;

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -4,7 +4,9 @@
 
 use std::cmp::min;
 use std::fmt;
+use std::str::FromStr;
 
+use jsonpath_rust::JsonPathInst;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json_bytes::ByteString;

--- a/apollo-router/src/plugin/serde.rs
+++ b/apollo-router/src/plugin/serde.rs
@@ -6,6 +6,7 @@ use std::str::FromStr;
 use access_json::JSONQuery;
 use http::header::HeaderName;
 use http::HeaderValue;
+use jsonpath_rust::JsonPathInst;
 use regex::Regex;
 use serde::de;
 use serde::de::Error;
@@ -208,4 +209,28 @@ where
         }
     }
     deserializer.deserialize_str(RegexVisitor)
+}
+
+pub(crate) fn deserialize_jsonpath<'de, D>(deserializer: D) -> Result<JsonPathInst, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserializer.deserialize_str(JSONPathVisitor)
+}
+
+struct JSONPathVisitor;
+
+impl<'de> serde::de::Visitor<'de> for JSONPathVisitor {
+    type Value = JsonPathInst;
+
+    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+        write!(formatter, "a string that begins with '$'")
+    }
+
+    fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        JsonPathInst::from_str(s).map_err(serde::de::Error::custom)
+    }
 }

--- a/apollo-router/src/plugin/serde.rs
+++ b/apollo-router/src/plugin/serde.rs
@@ -224,7 +224,7 @@ impl<'de> serde::de::Visitor<'de> for JSONPathVisitor {
     type Value = JsonPathInst;
 
     fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-        write!(formatter, "a string that begins with '$'")
+        write!(formatter, "a JSON path")
     }
 
     fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>

--- a/apollo-router/src/plugins/telemetry/config_new/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/selectors.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use access_json::JSONQuery;
 use derivative::Derivative;
 use jsonpath_rust::JsonPathFinder;
@@ -8,7 +6,6 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 #[cfg(test)]
 use serde::Serialize;
-use serde_json::Value;
 use serde_json_bytes::ByteString;
 use sha2::Digest;
 

--- a/apollo-router/src/plugins/telemetry/config_new/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/selectors.rs
@@ -1,14 +1,21 @@
+use std::ops::Deref;
+
 use access_json::JSONQuery;
+use derivative::Derivative;
+use jsonpath_rust::JsonPathFinder;
+use jsonpath_rust::JsonPathInst;
 use schemars::JsonSchema;
 use serde::Deserialize;
 #[cfg(test)]
 use serde::Serialize;
+use serde_json::Value;
 use serde_json_bytes::ByteString;
 use sha2::Digest;
 
 use crate::context::OPERATION_KIND;
 use crate::context::OPERATION_NAME;
 use crate::plugin::serde::deserialize_json_query;
+use crate::plugin::serde::deserialize_jsonpath;
 use crate::plugins::telemetry::config::AttributeValue;
 use crate::plugins::telemetry::config_new::get_baggage;
 use crate::plugins::telemetry::config_new::trace_id;
@@ -240,8 +247,9 @@ pub(crate) enum SupergraphSelector {
     Static(String),
 }
 
-#[derive(Deserialize, JsonSchema, Clone, Debug)]
+#[derive(Deserialize, JsonSchema, Clone, Derivative)]
 #[serde(deny_unknown_fields, rename_all = "snake_case", untagged)]
+#[derivative(Debug)]
 pub(crate) enum SubgraphSelector {
     SubgraphOperationName {
         /// The operation name from the subgraph query.
@@ -281,11 +289,38 @@ pub(crate) enum SubgraphSelector {
         /// Optional default value.
         default: Option<AttributeValue>,
     },
+    /// Deprecated, use SubgraphResponseData and SubgraphResponseError instead
     SubgraphResponseBody {
         /// The subgraph response body json path.
         #[schemars(with = "String")]
         #[serde(deserialize_with = "deserialize_json_query")]
         subgraph_response_body: JSONQuery,
+        #[serde(skip)]
+        #[allow(dead_code)]
+        /// Optional redaction pattern.
+        redact: Option<String>,
+        /// Optional default value.
+        default: Option<AttributeValue>,
+    },
+    SubgraphResponseData {
+        /// The subgraph response body json path.
+        #[schemars(with = "String")]
+        #[derivative(Debug = "ignore")]
+        #[serde(deserialize_with = "deserialize_jsonpath")]
+        subgraph_response_data: JsonPathInst,
+        #[serde(skip)]
+        #[allow(dead_code)]
+        /// Optional redaction pattern.
+        redact: Option<String>,
+        /// Optional default value.
+        default: Option<AttributeValue>,
+    },
+    SubgraphResponseErrors {
+        /// The subgraph response body json path.
+        #[schemars(with = "String")]
+        #[derivative(Debug = "ignore")]
+        #[serde(deserialize_with = "deserialize_jsonpath")]
+        subgraph_response_errors: JsonPathInst,
         #[serde(skip)]
         #[allow(dead_code)]
         /// Optional redaction pattern.
@@ -781,6 +816,49 @@ impl Selector for SubgraphSelector {
                 .as_ref()
                 .and_then(|v| v.maybe_to_otel_value())
                 .or_else(|| default.maybe_to_otel_value()),
+            SubgraphSelector::SubgraphResponseData {
+                subgraph_response_data,
+                default,
+                ..
+            } => if let Some(data) = &response.response.body().data {
+                let data: serde_json::Value = serde_json::to_value(data.clone()).ok()?;
+                let mut val =
+                    JsonPathFinder::new(Box::new(data), Box::new(subgraph_response_data.clone()))
+                        .find();
+                if let serde_json::Value::Array(array) = &mut val {
+                    if array.len() == 1 {
+                        val = array
+                            .pop()
+                            .expect("already checked the array had a length of 1; qed");
+                    }
+                }
+
+                val.maybe_to_otel_value()
+            } else {
+                None
+            }
+            .or_else(|| default.maybe_to_otel_value()),
+            SubgraphSelector::SubgraphResponseErrors {
+                subgraph_response_errors: subgraph_response_error,
+                default,
+                ..
+            } => {
+                let errors = response.response.body().errors.clone();
+                let data: serde_json::Value = serde_json::to_value(errors).ok()?;
+                let mut val =
+                    JsonPathFinder::new(Box::new(data), Box::new(subgraph_response_error.clone()))
+                        .find();
+                if let serde_json::Value::Array(array) = &mut val {
+                    if array.len() == 1 {
+                        val = array
+                            .pop()
+                            .expect("already checked the array had a length of 1; qed");
+                    }
+                }
+
+                val.maybe_to_otel_value()
+            }
+            .or_else(|| default.maybe_to_otel_value()),
             SubgraphSelector::ResponseContext {
                 response_context,
                 default,
@@ -801,9 +879,11 @@ impl Selector for SubgraphSelector {
 
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
     use std::sync::Arc;
 
     use http::StatusCode;
+    use jsonpath_rust::JsonPathInst;
     use opentelemetry::baggage::BaggageExt;
     use opentelemetry::trace::SpanContext;
     use opentelemetry::trace::SpanId;
@@ -813,6 +893,7 @@ mod test {
     use opentelemetry::trace::TraceState;
     use opentelemetry::Context;
     use opentelemetry::KeyValue;
+    use opentelemetry_api::StringValue;
     use serde_json::json;
     use tracing::span;
     use tracing::subscriber;
@@ -1953,6 +2034,92 @@ mod test {
                 )
                 .unwrap(),
             opentelemetry::Value::I64(204)
+        );
+    }
+
+    #[test]
+    fn subgraph_subgraph_response_data() {
+        let selector = SubgraphSelector::SubgraphResponseData {
+            subgraph_response_data: JsonPathInst::from_str("$.hello").unwrap(),
+            redact: None,
+            default: None,
+        };
+        assert_eq!(
+            selector
+                .on_response(
+                    &crate::services::SubgraphResponse::fake_builder()
+                        .data(serde_json_bytes::json!({
+                            "hello": "bonjour"
+                        }))
+                        .build()
+                )
+                .unwrap(),
+            opentelemetry::Value::String("bonjour".into())
+        );
+
+        assert_eq!(
+            selector
+                .on_response(
+                    &crate::services::SubgraphResponse::fake_builder()
+                        .data(serde_json_bytes::json!({
+                            "hello": ["bonjour", "hello", "ciao"]
+                        }))
+                        .build()
+                )
+                .unwrap(),
+            opentelemetry::Value::Array(
+                vec![
+                    StringValue::from("bonjour"),
+                    StringValue::from("hello"),
+                    StringValue::from("ciao")
+                ]
+                .into()
+            )
+        );
+
+        assert!(selector
+            .on_response(
+                &crate::services::SubgraphResponse::fake_builder()
+                    .data(serde_json_bytes::json!({
+                        "hi": ["bonjour", "hello", "ciao"]
+                    }))
+                    .build()
+            )
+            .is_none());
+
+        let selector = SubgraphSelector::SubgraphResponseData {
+            subgraph_response_data: JsonPathInst::from_str("$.hello.*.greeting").unwrap(),
+            redact: None,
+            default: None,
+        };
+        assert_eq!(
+            selector
+                .on_response(
+                    &crate::services::SubgraphResponse::fake_builder()
+                        .data(serde_json_bytes::json!({
+                            "hello": {
+                                "french": {
+                                    "greeting": "bonjour"
+                                },
+                                "english": {
+                                    "greeting": "hello"
+                                },
+                                "italian": {
+                                    "greeting": "ciao"
+                                }
+                            }
+                        }))
+                        .build()
+                )
+                .unwrap(),
+            opentelemetry::Value::Array(
+                vec![
+                    StringValue::from("bonjour"),
+                    StringValue::from("hello"),
+                    StringValue::from("ciao")
+                ]
+                .into()
+            )
         );
     }
 

--- a/docs/source/configuration/telemetry/instrumentation/selectors.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/selectors.mdx
@@ -63,21 +63,22 @@ The supergraph service is executed after query parsing but before query executio
 
 The subgraph service executes multiple times during query execution, with each execution representing a call to a single subgraph. It is GraphQL centric and deals with GraphQL queries and responses.
 
-| Selector                    | Defaultable | Values                              | Description                                  |
-|-----------------------------|-------------|-------------------------------------|----------------------------------------------|
-| `subgraph_operation_name`   | Yes         |                                     | The operation name from the subgraph query   |
-| `subgraph_operation_kind`   | No          | `query`\|`mutation`\|`subscription` | The operation kind from the subgraph query   |
-| `subgraph_query`            | Yes         |                                     | The graphql query to the subgraph            |
-| `subgraph_query_variable`   | Yes         |                                     | The name of a subgraph query variable        |
-| `subgraph_response_body`    | Yes         |                                     | Json Path into the subgraph response body    |
-| `subgraph_request_header`   | Yes         |                                     | The name of a subgraph request header        |
-| `subgraph_response_header`  | Yes         |                                     | The name of a subgraph response header       |
-| `subgraph_response_status`  | Yes         |                                     | The name of a subgraph response header       |
-| `supergraph_operation_name` | Yes         |                                     | The operation name from the supergraph query |
-| `supergraph_operation_kind` | Yes         | `query`\|`mutation`\|`subscription` | The operation kind from the supergraph query |
-| `supergraph_query`          | Yes         |                                     | The graphql query to the supergraph          |
-| `supergraph_query_variable` | Yes         |                                     | The name of a supergraph query variable      |
-| `request_context`           | Yes         |                                     | The name of a request context key            |
-| `response_context`          | Yes         |                                     | The name of a response context key           |
-| `baggage`                   | Yes         |                                     | The name of a baggage item                   |
-| `env`                       | Yes         |                                     | The name of an environment variable          |
+| Selector                    | Defaultable | Values                              | Description                                        |
+|-----------------------------|-------------|-------------------------------------|----------------------------------------------------|
+| `subgraph_operation_name`   | Yes         |                                     | The operation name from the subgraph query         |
+| `subgraph_operation_kind`   | No          | `query`\|`mutation`\|`subscription` | The operation kind from the subgraph query         |
+| `subgraph_query`            | Yes         |                                     | The graphql query to the subgraph                  |
+| `subgraph_query_variable`   | Yes         |                                     | The name of a subgraph query variable              |
+| `subgraph_response_data`    | Yes         |                                     | Json Path into the subgraph response body data     |
+| `subgraph_response_errors`  | Yes         |                                     | Json Path into the subgraph response body errors   |
+| `subgraph_request_header`   | Yes         |                                     | The name of a subgraph request header              |
+| `subgraph_response_header`  | Yes         |                                     | The name of a subgraph response header             |
+| `subgraph_response_status`  | Yes         |                                     | The name of a subgraph response header             |
+| `supergraph_operation_name` | Yes         |                                     | The operation name from the supergraph query       |
+| `supergraph_operation_kind` | Yes         | `query`\|`mutation`\|`subscription` | The operation kind from the supergraph query       |
+| `supergraph_query`          | Yes         |                                     | The graphql query to the supergraph                |
+| `supergraph_query_variable` | Yes         |                                     | The name of a supergraph query variable            |
+| `request_context`           | Yes         |                                     | The name of a request context key                  |
+| `response_context`          | Yes         |                                     | The name of a response context key                 |
+| `baggage`                   | Yes         |                                     | The name of a baggage item                         |
+| `env`                       | Yes         |                                     | The name of an environment variable                |

--- a/docs/source/configuration/telemetry/instrumentation/selectors.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/selectors.mdx
@@ -63,22 +63,22 @@ The supergraph service is executed after query parsing but before query executio
 
 The subgraph service executes multiple times during query execution, with each execution representing a call to a single subgraph. It is GraphQL centric and deals with GraphQL queries and responses.
 
-| Selector                    | Defaultable | Values                              | Description                                        |
-|-----------------------------|-------------|-------------------------------------|----------------------------------------------------|
-| `subgraph_operation_name`   | Yes         |                                     | The operation name from the subgraph query         |
-| `subgraph_operation_kind`   | No          | `query`\|`mutation`\|`subscription` | The operation kind from the subgraph query         |
-| `subgraph_query`            | Yes         |                                     | The graphql query to the subgraph                  |
-| `subgraph_query_variable`   | Yes         |                                     | The name of a subgraph query variable              |
-| `subgraph_response_data`    | Yes         |                                     | Json Path into the subgraph response body data     |
-| `subgraph_response_errors`  | Yes         |                                     | Json Path into the subgraph response body errors   |
-| `subgraph_request_header`   | Yes         |                                     | The name of a subgraph request header              |
-| `subgraph_response_header`  | Yes         |                                     | The name of a subgraph response header             |
-| `subgraph_response_status`  | Yes         |                                     | The name of a subgraph response header             |
-| `supergraph_operation_name` | Yes         |                                     | The operation name from the supergraph query       |
-| `supergraph_operation_kind` | Yes         | `query`\|`mutation`\|`subscription` | The operation kind from the supergraph query       |
-| `supergraph_query`          | Yes         |                                     | The graphql query to the supergraph                |
-| `supergraph_query_variable` | Yes         |                                     | The name of a supergraph query variable            |
-| `request_context`           | Yes         |                                     | The name of a request context key                  |
-| `response_context`          | Yes         |                                     | The name of a response context key                 |
-| `baggage`                   | Yes         |                                     | The name of a baggage item                         |
-| `env`                       | Yes         |                                     | The name of an environment variable                |
+| Selector                    | Defaultable | Values                              | Description                                                                     |
+|-----------------------------|-------------|-------------------------------------|---------------------------------------------------------------------------------|
+| `subgraph_operation_name`   | Yes         |                                     | The operation name from the subgraph query                                      |
+| `subgraph_operation_kind`   | No          | `query`\|`mutation`\|`subscription` | The operation kind from the subgraph query                                      |
+| `subgraph_query`            | Yes         |                                     | The graphql query to the subgraph                                               |
+| `subgraph_query_variable`   | Yes         |                                     | The name of a subgraph query variable                                           |
+| `subgraph_response_data`    | Yes         |                                     | Json Path into the subgraph response body data (it might impact performances)   |
+| `subgraph_response_errors`  | Yes         |                                     | Json Path into the subgraph response body errors (it might impact performances) |
+| `subgraph_request_header`   | Yes         |                                     | The name of a subgraph request header                                           |
+| `subgraph_response_header`  | Yes         |                                     | The name of a subgraph response header                                          |
+| `subgraph_response_status`  | Yes         |                                     | The name of a subgraph response header                                          |
+| `supergraph_operation_name` | Yes         |                                     | The operation name from the supergraph query                                    |
+| `supergraph_operation_kind` | Yes         | `query`\|`mutation`\|`subscription` | The operation kind from the supergraph query                                    |
+| `supergraph_query`          | Yes         |                                     | The graphql query to the supergraph                                             |
+| `supergraph_query_variable` | Yes         |                                     | The name of a supergraph query variable                                         |
+| `request_context`           | Yes         |                                     | The name of a request context key                                               |
+| `response_context`          | Yes         |                                     | The name of a response context key                                              |
+| `baggage`                   | Yes         |                                     | The name of a baggage item                                                      |
+| `env`                       | Yes         |                                     | The name of an environment variable                                             |


### PR DESCRIPTION
Deprecated `subgraph_response_body` in favor of `subgraph_response_data` and `subgraph_response_errors` which is a [selector](https://www.apollographql.com/docs/router/configuration/telemetry/instrumentation/selectors/) and use a JSON Path to fetch data/errors from the subgraph response. 

Example:

```yaml
telemetry:
  instrumentation:
    spans:
      subgraph:
        attributes:
          "my_attribute":
            subgraph_response_data: "$.productName"
            subgraph_response_errors: "$.[0].message"
```

Fixes #4443

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
