### PR TITLE
Allow access to the parsed document via context

### DIFF
--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -95,6 +95,7 @@ pub use crate::router::RouterHttpServer;
 pub use crate::router::SchemaSource;
 pub use crate::router::ShutdownSource;
 pub use crate::router_factory::Endpoint;
+pub use crate::services::layers::query_analysis::ParsedDocument;
 pub use crate::test_harness::MockedSubgraphs;
 pub use crate::test_harness::TestHarness;
 pub use crate::uplink::UplinkConfig;

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -158,14 +158,26 @@ impl QueryAnalysisLayer {
     }
 }
 
-pub(crate) type ParsedDocument = Arc<ParsedDocumentInner>;
+/// The parsed request document that can be used by plugins to inspect what is being executed.
+/// This is populated in context once query analysis has taken place.
+/// It can be retrieved by calling `context.extensions().get::<ParsedDocument>()`.
+/// Note that although this is a public API apollo-rs is not 1.0, and therefore we cannot guarantee API stability for `ExecutableDocument`.
+pub type ParsedDocument = Arc<ParsedDocumentInner>;
 
 #[derive(Debug, Default)]
-pub(crate) struct ParsedDocumentInner {
+pub struct ParsedDocumentInner {
     pub(crate) ast: ast::Document,
     pub(crate) executable: ExecutableDocument,
     pub(crate) parse_errors: Option<DiagnosticList>,
     pub(crate) validation_errors: Option<DiagnosticList>,
+}
+
+impl ParsedDocumentInner {
+    /// Get a reference to the executable document.
+    /// Note that although this is a public API apollo-rs is not 1.0, and therefore we cannot guarantee API stability for `ExecutableDocument`.
+    pub fn executable_document(&self) -> &ExecutableDocument {
+        &self.executable
+    }
 }
 
 impl Display for ParsedDocumentInner {


### PR DESCRIPTION
We are nearing 1.0 of apollo-rs, and we need to allow users to access apollo-rs datastructures without having to jump through hoops.

Allow access of the parsed document via context extension, but clearly documenting that was may still make breaking changes.

We will create a way to access schema via a ParsedSchema extension.

Part of #4602


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
