### PR TITLE
build x86_64 and aarch64 packages for OSX

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,6 +333,15 @@ commands:
                 name: Special case for Windows because of ssh-agent
                 command: |
                   printf "[net]\ngit-fetch-with-cli = true" >> ~/.cargo/Cargo.toml
+      - when:
+          condition:
+            or:
+              - equal: [ *macos_build_executor, << parameters.platform >> ]
+          steps:
+            - run:
+                name: Special case for OSX x86_64 builds
+                command: |
+                  rustup target add x86_64-apple-darwin
 
   install_extra_tools:
     steps:
@@ -593,13 +602,28 @@ jobs:
                   - run: cargo xtask release prepare nightly
             - run:
                 command: >
-                  cargo xtask dist
+                  cargo xtask dist --target aarch64-apple-darwin
+            - run:
+                command: >
+                  cargo xtask dist --target x86_64-apple-darwin
             - run:
                 command: >
                   mkdir -p artifacts
             - run:
                 command: >
                   cargo xtask package
+                  --target aarch64-apple-darwin
+                  --apple-team-id ${APPLE_TEAM_ID}
+                  --apple-username ${APPLE_USERNAME}
+                  --cert-bundle-base64 ${MACOS_CERT_BUNDLE_BASE64}
+                  --cert-bundle-password ${MACOS_CERT_BUNDLE_PASSWORD}
+                  --keychain-password ${MACOS_KEYCHAIN_PASSWORD}
+                  --notarization-password ${MACOS_NOTARIZATION_PASSWORD}
+                  --output artifacts/
+            - run:
+                command: >
+                  cargo xtask package
+                  --target x86_64-apple-darwin
                   --apple-team-id ${APPLE_TEAM_ID}
                   --apple-username ${APPLE_USERNAME}
                   --cert-bundle-base64 ${MACOS_CERT_BUNDLE_BASE64}

--- a/xtask/src/commands/dist.rs
+++ b/xtask/src/commands/dist.rs
@@ -2,15 +2,32 @@ use anyhow::Result;
 use xtask::*;
 
 #[derive(Debug, clap::Parser)]
-pub struct Dist {}
+pub struct Dist {
+    #[clap(long)]
+    target: Option<String>,
+}
 
 impl Dist {
     pub fn run(&self) -> Result<()> {
-        cargo!(["build", "--release"]);
+        match &self.target {
+            Some(target) => {
+                cargo!(["build", "--release", "--target", target]);
 
-        let bin_path = TARGET_DIR.join("release").join(RELEASE_BIN);
+                let bin_path = TARGET_DIR
+                    .join(target.to_string())
+                    .join("release")
+                    .join(RELEASE_BIN);
 
-        eprintln!("successfully compiled to: {}", &bin_path);
+                eprintln!("successfully compiled to: {}", &bin_path);
+            }
+            None => {
+                cargo!(["build", "--release"]);
+
+                let bin_path = TARGET_DIR.join("release").join(RELEASE_BIN);
+
+                eprintln!("successfully compiled to: {}", &bin_path);
+            }
+        }
 
         Ok(())
     }

--- a/xtask/src/commands/package/mod.rs
+++ b/xtask/src/commands/package/mod.rs
@@ -36,7 +36,13 @@ pub struct Package {
 
 impl Package {
     pub fn run(&self) -> Result<()> {
-        let release_path = TARGET_DIR.join("release").join(RELEASE_BIN);
+        let release_path = match &self.target {
+            None => TARGET_DIR.join("release").join(RELEASE_BIN),
+            Some(target) => TARGET_DIR
+                .join(target.to_string())
+                .join("release")
+                .join(RELEASE_BIN),
+        };
 
         ensure!(
             release_path.exists(),


### PR DESCRIPTION
This reintroduces x86_64 OSX packages that were removed due to CircleCI's deprecation of their x84_64 OSX workers. This generates two different build artifacts of the router

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
