### PR TITLE
docs: SupergraphRequest example

### DIFF
--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -272,7 +272,8 @@ Properties of the JSON body are divided into two high-level categories:
   },
   "body": {
     "query": "query Long {\n  me {\n  name\n}\n}",
-    "operationName": "MyQuery"
+    "operationName": "MyQuery",
+    "variables": {}
   },
   "context": {
     "entries": {


### PR DESCRIPTION
From [user request](https://apollograph.slack.com/archives/C0721M2F6/p1705952702706759), add (empty) `body.variables` to SupergraphRequest example 