### PR TITLE
define a trace id for propagated headers when not sampling

### DIFF
--- a/.changesets/fix_geal_propagate_headers_when_not_sampling.md
+++ b/.changesets/fix_geal_propagate_headers_when_not_sampling.md
@@ -1,0 +1,5 @@
+### Propagate tracing headers even when not sampling a trace ([Issue #4544](https://github.com/apollographql/router/issues/4544))
+
+When the router was configured to sample only a portion of the trace, either through a ratio or using parent based sampling, and when trace propagation was configured, if a trace was not sampled, the router did not send the propagation headers to the subgraph. The subgraph was then unable to decide whether to record the trace or not. Now we make sure that trace headers will be sent even when a trace is not sampled.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4609

--- a/apollo-router/src/services/external.rs
+++ b/apollo-router/src/services/external.rs
@@ -22,6 +22,7 @@ use tower::BoxError;
 use tower::Service;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
+use crate::plugins::telemetry::reload::prepare_context;
 use crate::query_planner::QueryPlan;
 use crate::Context;
 
@@ -283,7 +284,7 @@ where
 
         get_text_map_propagator(|propagator| {
             propagator.inject_context(
-                &tracing::span::Span::current().context(),
+                &prepare_context(tracing::span::Span::current().context()),
                 &mut opentelemetry_http::HeaderInjector(request.headers_mut()),
             );
         });

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -42,7 +42,6 @@ use crate::configuration::TlsClientAuth;
 use crate::error::FetchError;
 use crate::plugins::authentication::subgraph::SigningParamsConfig;
 use crate::plugins::telemetry::reload::prepare_context;
-use crate::plugins::telemetry::reload::OPENTELEMETRY_TRACER_HANDLE;
 use crate::plugins::telemetry::LOGGING_DISPLAY_BODY;
 use crate::plugins::telemetry::LOGGING_DISPLAY_HEADERS;
 use crate::plugins::traffic_shaping::Http2Config;
@@ -228,30 +227,6 @@ impl tower::Service<HttpRequest> for HttpClientService {
             //"graphql.operation.name" = %operation_name,
         );
         get_text_map_propagator(|propagator| {
-            /*println!("got propagator");
-            let mut context = prepare_context(http_req_span.context());
-            println!("got context: {:?}", context);
-            println!("got context span: {:?}", context.span());
-
-            println!("got span context: {:?}", context.span().span_context());
-            println!(
-                "is sampled: {:?}",
-                context.span().span_context().is_sampled()
-            );
-
-            if !context.span().span_context().is_valid() {
-                if let Some(tracer) = OPENTELEMETRY_TRACER_HANDLE.get() {
-                    let span_context = SpanContext::new(
-                        tracer.new_trace_id(),
-                        tracer.new_span_id(),
-                        TraceFlags::default(),
-                        false,
-                        TraceState::default(),
-                    );
-                    context = context.with_remote_span_context(span_context);
-                }
-            }*/
-
             propagator.inject_context(
                 &prepare_context(http_req_span.context()),
                 &mut opentelemetry_http::HeaderInjector(http_request.headers_mut()),


### PR DESCRIPTION
Fix https://github.com/apollographql/router/issues/4544

When a trace is not sampled (due to the filtering layer we use in the telemetry plugin), the `OpenTelemetryLayer` is not called, and so a `TraceId`(the opentelemetry-api one, not the router side one) is never generated, which means that when reaching the header propagation code, the current span context is invalid (trace id = 0 and span id = 0) and so the propagation headers are not sent.
We want the propagation headers to still be sent when the trace is not sampled, to let the subgraphs know that they should not sample the trace either.

One option was to explicitely set the propagation headers, but that depends a lot on which propagation protocol is used. The trick I use here is generating on the fly a span context with non zero trace id and span id, so that the headers can be generated.
I will try another approach where I generate them when creating the span.
<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
