### PR TITLE
Allow OSX x86_64 binaries in the install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -97,15 +97,6 @@ get_architecture() {
         fi
     fi
 
-    # If our OS is Darwin, we only have binaries for arm64 machines.
-    # Check and exit early
-    if [ "$_ostype" = Darwin ] && [ "$_cputype" != arm64 ]; then
-        say "No precompiled binaries available on macOS for CPU architecture: $_cputype"
-        say "The most recent macOS release which supports Intel is 1.37.0"
-        say "Please refer to this issue for more details:  https://github.com/apollographql/router/issues/4483"
-        err "No precompiled binaries available on macOS for CPU architecture: $_cputype"
-    fi
-
     case "$_ostype" in
         Linux)
             _ostype=unknown-linux-gnu


### PR DESCRIPTION
Related:
* https://github.com/apollographql/router/pull/4484
* https://github.com/apollographql/router/pull/4515 
* https://github.com/apollographql/router/pull/4518
* https://github.com/apollographql/router/pull/4605
<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
