### PR TITLE
only load the TLS native store once

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ dependencies = [
  "rstack",
  "rust-embed",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "schemars",
  "semver 1.0.21",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -187,6 +187,7 @@ reqwest = { version = "0.11.24", default-features = false, features = [
 router-bridge = "=0.5.16+v2.7.1"
 rust-embed = "8.2.0"
 rustls = "0.21.10"
+rustls-native-certs = "0.6.3"
 rustls-pemfile = "1.0.4"
 schemars = { version = "0.8.16", features = ["url"] }
 shellexpand = "3.1.0"

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -336,12 +336,13 @@ pub(crate) async fn create_subgraph_services(
     >,
     BoxError,
 > {
-    let tls_root_store: Option<RootCertStore> = configuration
+    let tls_root_store: RootCertStore = configuration
         .tls
         .subgraph
         .all
         .create_certificate_store()
-        .transpose()?;
+        .transpose()?
+        .unwrap_or_else(crate::services::http::HttpClientService::native_roots_store);
 
     let subscription_plugin_conf = plugins
         .iter()

--- a/apollo-router/src/services/http.rs
+++ b/apollo-router/src/services/http.rs
@@ -50,7 +50,13 @@ impl HttpClientServiceFactory {
     ) -> Self {
         use indexmap::IndexMap;
 
-        let service = HttpClientService::from_config(service, configuration, &None, http2).unwrap();
+        let service = HttpClientService::from_config(
+            service,
+            configuration,
+            &rustls::RootCertStore::empty(),
+            http2,
+        )
+        .unwrap();
 
         HttpClientServiceFactory {
             service: Arc::new(service),

--- a/apollo-router/src/services/http/tests.rs
+++ b/apollo-router/src/services/http/tests.rs
@@ -100,8 +100,13 @@ async fn tls_self_signed() {
             client_authentication: None,
         },
     );
-    let subgraph_service =
-        HttpClientService::from_config("test", &config, &None, Http2Config::Enable).unwrap();
+    let subgraph_service = HttpClientService::from_config(
+        "test",
+        &config,
+        &rustls::RootCertStore::empty(),
+        Http2Config::Enable,
+    )
+    .unwrap();
 
     let url = Uri::from_str(&format!("https://localhost:{}", socket_addr.port())).unwrap();
     let response = subgraph_service
@@ -152,8 +157,13 @@ async fn tls_custom_root() {
             client_authentication: None,
         },
     );
-    let subgraph_service =
-        HttpClientService::from_config("test", &config, &None, Http2Config::Enable).unwrap();
+    let subgraph_service = HttpClientService::from_config(
+        "test",
+        &config,
+        &rustls::RootCertStore::empty(),
+        Http2Config::Enable,
+    )
+    .unwrap();
 
     let url = Uri::from_str(&format!("https://localhost:{}", socket_addr.port())).unwrap();
     let response = subgraph_service
@@ -257,8 +267,13 @@ async fn tls_client_auth() {
             }),
         },
     );
-    let subgraph_service =
-        HttpClientService::from_config("test", &config, &None, Http2Config::Enable).unwrap();
+    let subgraph_service = HttpClientService::from_config(
+        "test",
+        &config,
+        &rustls::RootCertStore::empty(),
+        Http2Config::Enable,
+    )
+    .unwrap();
 
     let url = Uri::from_str(&format!("https://localhost:{}", socket_addr.port())).unwrap();
     let response = subgraph_service


### PR DESCRIPTION
Fix #4491 

when TLS was not configured for subgraphs, the OS provided list of certificates was parsed once per subgraph, which resulted in long loading times on OSX.
This generates the native root store once, and reuses it across subgraphs

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
