### PR TITLE
fix federation version extraction

### DIFF
--- a/apollo-router/build/main.rs
+++ b/apollo-router/build/main.rs
@@ -9,15 +9,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .expect("could not read Cargo.toml"),
     )
     .expect("could not parse Cargo.toml");
-    let router_bridge_version = cargo_manifest
+
+    let router_bridge = cargo_manifest
         .get("dependencies")
         .expect("Cargo.toml does not contain dependencies")
         .as_object()
         .expect("Cargo.toml dependencies key is not an object")
         .get("router-bridge")
-        .expect("Cargo.toml dependencies does not have an entry for router-bridge")
+        .expect("Cargo.toml dependencies does not have an entry for router-bridge");
+    let router_bridge_version = router_bridge
         .as_str()
-        .unwrap_or_default();
+        .or_else(|| {
+            router_bridge
+                .as_object()
+                .and_then(|o| o.get("version"))
+                .and_then(|version| version.as_str())
+        })
+        .expect("router-bridge does not have a version");
 
     let mut it = router_bridge_version.split('+');
     let _ = it.next();


### PR DESCRIPTION
when running `cargo publish`, the `Cargo.toml` file is rewritten, and the shorthand `crate_name = "version"` is converted to an object

Follows up 127fa59b3560a0b6fe97f07c20f30d6d0f59d480 in  https://github.com/apollographql/router/pull/4583