### PR TITLE
Prevent subgraph request body being loaded into memory if compression is not enabled

### DIFF
--- a/.changesets/fix_bryn_compression_stream_fix.md
+++ b/.changesets/fix_bryn_compression_stream_fix.md
@@ -1,0 +1,6 @@
+### Prevent subgraph request body being loaded into memory if compression is not enabled ([Issue #4647](https://github.com/apollographql/router/issues/4648))
+
+Previously, even if compression was not enabled, the entire body of the request was loaded into memory.
+This PR adds logic to detect either `identity` or a missing content-type, and allows the request through untouched.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/4662

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -103,6 +103,12 @@ pub(crate) enum FetchError {
         /// The reason the compression failed.
         reason: String,
     },
+
+    /// header value was malformed
+    MalformedHeaderValue {
+        /// The name of the header that was malformed
+        header_name: String,
+    },
 }
 
 impl FetchError {
@@ -178,6 +184,7 @@ impl ErrorExtension for FetchError {
             FetchError::CompressionError { .. } => "COMPRESSION_ERROR",
             FetchError::MalformedRequest { .. } => "MALFORMED_REQUEST",
             FetchError::MalformedResponse { .. } => "MALFORMED_RESPONSE",
+            FetchError::MalformedHeaderValue { .. } => "MALFORMED_HEADER_VALUE",
         }
         .to_string()
     }

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -98,16 +98,14 @@ impl TryFrom<&str> for Compression {
             Ok(Compression::Br)
         } else if value == "identity" {
             Ok(Compression::Identity)
+        } else if value.contains(',') {
+            Err(CompressionError::UnsupportedMultipleCompressionAlgorithms {
+                content_type: value.to_string(),
+            })
         } else {
-            if value.contains(',') {
-                Err(CompressionError::UnsupportedMultipleCompressionAlgorithms {
-                    content_type: value.to_string(),
-                })
-            } else {
-                Err(CompressionError::UnsupportedCompressionAlgorithm {
-                    algorithm: value.to_string(),
-                })
-            }
+            Err(CompressionError::UnsupportedCompressionAlgorithm {
+                algorithm: value.to_string(),
+            })
         }
     }
 }

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -91,22 +91,23 @@ impl TryFrom<&str> for Compression {
 
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         if value == "gzip" {
-            return Ok(Compression::Gzip);
+            Ok(Compression::Gzip)
         } else if value == "deflate" {
-            return Ok(Compression::Deflate);
+            Ok(Compression::Deflate)
         } else if value == "br" {
-            return Ok(Compression::Br);
+            Ok(Compression::Br)
         } else if value == "identity" {
-            return Ok(Compression::Identity);
+            Ok(Compression::Identity)
         } else {
             if value.contains(',') {
-                return Err(CompressionError::UnsupportedMultipleCompressionAlgorithms {
+                Err(CompressionError::UnsupportedMultipleCompressionAlgorithms {
                     content_type: value.to_string(),
-                });
+                })
+            } else {
+                Err(CompressionError::UnsupportedCompressionAlgorithm {
+                    algorithm: value.to_string(),
+                })
             }
-            return Err(CompressionError::UnsupportedCompressionAlgorithm {
-                algorithm: value.to_string(),
-            });
         }
     }
 }


### PR DESCRIPTION
Previously even if compression was not enabled the entire body of the request is loaded into memory.

This PR adds logic to detect either `identity` or a missing content-type, and allows the request through untouched.

Tests have been added for content type detection and the act of draining the request.

In future we should move to a streaming compression implementation, however this can be a follow up.

Fixes #4648

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
