### PR TITLE
Entity cache: Add spans around redis interaction

### DIFF
--- a/.changesets/feat_geal_entity_cache_span.md
+++ b/.changesets/feat_geal_entity_cache_span.md
@@ -1,0 +1,5 @@
+### Entity cache: Add spans around redis interaction ([PR #4667](https://github.com/apollographql/router/pull/4667))
+
+This adds the `cache_lookup` and `cache_store` spans to show the entity cache's Redis calls in traces. This also changes the behavior slightly so that storing in Redis does not stop the execution of the rest of the query
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4667


### PR DESCRIPTION
This adds the `cache_lookup` and `cache_store` spans to show the Redis calls in entity cache. This also changes the behavior slightly so that storing in Redis does not stop the execution of the rest of the query

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
