### PR TITLE
Add config metrics for file uploads

### DIFF
--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -329,6 +329,15 @@ impl InstrumentData {
             opt.mode,
             "$.mode"
         );
+
+        populate_config_instrument!(
+            apollo.router.config.file_uploads.multipart,
+            "$.preview_file_uploads[?(@.enabled == true)].protocols.multipart[?(@.enabled == true)]",
+            opt.limits.max_file_size,
+            "$.limits.max_file_size",
+            opt.limits.max_files,
+            "$.limits.max_files"
+        );
     }
 
     fn populate_env_instrument(&mut self) {

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@file_uploads.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@file_uploads.router.yaml.snap
@@ -1,0 +1,12 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.non_zero()"
+---
+- name: apollo.router.config.file_uploads.multipart
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.limits.max_file_size.: 1000
+          opt.limits.max_files.: 10
+

--- a/apollo-router/src/configuration/testdata/metrics/file_uploads.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/file_uploads.router.yaml
@@ -1,0 +1,10 @@
+preview_file_uploads:
+  enabled: true
+  protocols:
+      multipart:
+        enabled: true
+        mode: stream
+        limits:
+            max_file_size: 1000
+            max_files: 10
+


### PR DESCRIPTION
This PR adds config metrics to file uploads.

Config metrics are sent to Apollo to enable us to see which features are in use and how they are used.

Part of #4504 


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
