### PR TITLE
docs: document premium vs enterprise router features

### DIFF
--- a/docs/source/configuration/authn-jwt.mdx
+++ b/docs/source/configuration/authn-jwt.mdx
@@ -3,7 +3,7 @@ title: JWT Authentication in the Apollo Router
 description: Restrict access to credentialed users and systems
 ---
 
-<GraphOSEnterpriseRequired />
+<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#graphos-router" />
 
 Authentication is crucial to prevent illegitimate access and protect sensitive data in your graph. The Apollo Router supports request authentication and key rotation via the [JSON Web Token](https://www.rfc-editor.org/rfc/rfc7519) (**JWT**) and [JSON Web Key](https://www.rfc-editor.org/rfc/rfc7517) (**JWK**) standards. This support is compatible with popular identity providers (**IdPs**) like Okta and Auth0.
 

--- a/docs/source/configuration/authorization.mdx
+++ b/docs/source/configuration/authorization.mdx
@@ -3,7 +3,7 @@ title: Authorization in the Apollo Router
 description: Strengthen service security with a centralized governance layer
 ---
 
-<GraphOSEnterpriseRequired />
+<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#graphos-router" />
 
 APIs provide access to business-critical data. Unrestricted access can result in data breaches, monetary losses, or potential denial of service. Even for internal services, checks can be essential to limit data to authorized parties.
 

--- a/docs/source/configuration/distributed-caching.mdx
+++ b/docs/source/configuration/distributed-caching.mdx
@@ -4,7 +4,7 @@ subtitle: Redis-backed caching for query plans and APQ
 description: Distributed caching for Apollo Router with GraphOS Enterprise. Configure a Redis-backed cache for query plans and automatic persisted queries (APQ).
 ---
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#graphos-router" />
 
 If you have multiple Apollo Router instances, those instances can share a Redis-backed cache for their query plans and automatic persisted queries (APQ). This means that if _any_ of your router instances caches a particular value, _all_ of your instances can look up that value to significantly improve responsiveness. For more details on query plans and APQ, see the article on [in-memory caching](./in-memory-caching).
 

--- a/docs/source/configuration/operation-limits.mdx
+++ b/docs/source/configuration/operation-limits.mdx
@@ -3,7 +3,7 @@ title: Enforcing operation limits in the Apollo Router
 description: With GraphOS Enterprise
 ---
 
-<EnterpriseFeature />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#graphos-router" />
 
 You can define **operation limits** in your router's configuration to reject potentially malicious requests. An operation that exceeds _any_ specified limit is rejected (unless you run your router in [`warn_only` mode](#warn_only-mode)).
 

--- a/docs/source/configuration/persisted-queries.mdx
+++ b/docs/source/configuration/persisted-queries.mdx
@@ -4,7 +4,7 @@ description: Secure your graph while minimizing request latency
 minVersion: 1.25.0
 ---
 
-<GraphOSEnterpriseRequired />
+<EnterpriseFeature linkWithAnchor="https://www.apollographql.com/pricing#graphos-router" />
 
 <PQIntro />
 

--- a/docs/source/configuration/telemetry/exporters/metrics/overview.mdx
+++ b/docs/source/configuration/telemetry/exporters/metrics/overview.mdx
@@ -180,7 +180,7 @@ telemetry:
 
 <Note>
 
-OpenTelemetry includes many [standard attributes](https://opentelemetry.io/docs/specs/semconv/attributes-registry/) that you can use these via custom [instruments](../instrumentation/instruments). 
+OpenTelemetry includes many [standard attributes](https://opentelemetry.io/docs/specs/semconv/attributes-registry/) that you can use via custom [instruments](../instrumentation/instruments). 
 
 </Note>
 

--- a/docs/source/configuration/telemetry/instrumentation/conditions.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/conditions.mdx
@@ -4,7 +4,7 @@ subtitle: Set conditions for when events or instruments are triggered
 description: Set conditions for when events or instruments are triggered in the Apollo Router
 ---
 
-<EnterpriseFeature />
+<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#observability"/>
 
 You can set conditions for when an [instrument](./instruments) should be mutated or an [event](./events) should be triggered.
 

--- a/docs/source/configuration/telemetry/instrumentation/events.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/events.mdx
@@ -61,7 +61,7 @@ telemetry:
 
 ### Custom events
 
-<EnterpriseFeature />
+<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#observability"/>
 
 For each service you can also configure custom events.
 

--- a/docs/source/configuration/telemetry/instrumentation/instruments.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/instruments.mdx
@@ -59,7 +59,7 @@ See the [attributes](#attributes) configuration for more information.
 
 ### Custom instruments 
 
-<EnterpriseFeature />
+<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#observability"/>
 
 You can define custom instruments on the router, supergraph and subgraph services in the router pipeline.
 

--- a/docs/source/configuration/telemetry/instrumentation/spans.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/spans.mdx
@@ -37,11 +37,11 @@ Spans may have attributes attached to them from the Apollo Router pipeline. Thes
 
 Attributes may be drawn from [standard attributes](./standard-attributes) or [selectors](./selectors). 
 
-<EnterpriseFeature>
+<PremiumFeatureFeature>
 
-Granular customization of attributes on spans is an Enterprise Feature that requires a [GraphOS Enterprise plan](/graphos/enterprise/).
+Granular customization of attributes on spans requires a GraphOS [Dedicated or Enterprise plan](https://www.apollographql.com/pricing#observability).
 
-</EnterpriseFeature>
+</PremiumFeatureFeature>
 
 The attributes that are available depend on the service of the pipeline.
 

--- a/docs/source/configuration/telemetry/overview.mdx
+++ b/docs/source/configuration/telemetry/overview.mdx
@@ -143,6 +143,6 @@ You can use [standard attributes](./instrumentation/standard-attributes) or [sel
 
 <PremiumFeature>
 
-[Custom attributes for spans](./instrumentation/spans/#attributes) equire a GraphOS [Dedicated or Enterprise plan](https://www.apollographql.com/pricing#observability).
+[Custom attributes for spans](./instrumentation/spans/#attributes) require a GraphOS [Dedicated or Enterprise plan](https://www.apollographql.com/pricing#observability).
 
 </PremiumFeature>

--- a/docs/source/configuration/telemetry/overview.mdx
+++ b/docs/source/configuration/telemetry/overview.mdx
@@ -141,8 +141,8 @@ Example attributes include:
 
 You can use [standard attributes](./instrumentation/standard-attributes) or [selectors](./instrumentation/selectors) as span attributes.
 
-<EnterpriseFeature>
+<PremiumFeature>
 
-[Custom attributes for spans](./instrumentation/spans/#attributes) is an Enterprise Feature that requires a [GraphOS Enterprise plan](/graphos/enterprise/).
+[Custom attributes for spans](./instrumentation/spans/#attributes) equire a GraphOS [Dedicated or Enterprise plan](https://www.apollographql.com/pricing#observability).
 
-</EnterpriseFeature>
+</PremiumFeature>

--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -5,7 +5,7 @@ description: Customize your router's behavior in any language
 
 import CoprocTypicalConfig from '../../shared/coproc-typical-config.mdx';
 
-<EnterpriseFeature />
+<PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#graphos-router" />
 
 With **external coprocessing**, you can hook into the Apollo Router's request-handling lifecycle by writing standalone code in any language and framework. This code (i.e., your **coprocessor**) can run anywhere on your network that's accessible to the router over HTTP.
 

--- a/docs/source/enterprise-features.mdx
+++ b/docs/source/enterprise-features.mdx
@@ -19,7 +19,7 @@ Try out Enterprise GraphOS Router features for free with an [Enterprise trial](/
 
 <Tip>
 
-Articles about enterprise features are marked with a **❖** icon in the left navigation.
+Articles about Enterprise features are marked with a **❖** icon in the left navigation.
 
 </Tip>
 

--- a/docs/source/enterprise-features.mdx
+++ b/docs/source/enterprise-features.mdx
@@ -5,7 +5,7 @@ description: Available with GraphOS Enterprise
 
 Since the Apollo Router is [source-available](https://www.apollographql.com/blog/evaluating-apollo-router-understanding-free-and-open-vs-commercial-features), you can use its codebase without connecting it to GraphOS. GraphOS organizations with the Enterprise plan can [connect a self-hosted router to GraphOS](/graphos/quickstart/self-hosted#6-connect-the-router-to-graphos) for an expanded feature set.
 
-A router connected to GraphOS, whether cloud- or self-hosted, is called a **GraphOS Router**, and has access to specific GraphOS features depending on the connected GraphOS organization's plan. Refer to the [pricing page](https://www.apollographql.com/pricing#graphos-router) to compare GraphOS Router features across plan types.
+A router connected to GraphOS, whether cloud- or self-hosted, is called a **GraphOS Router**. It has access to specific GraphOS features depending on the connected GraphOS organization's plan. Refer to the [pricing page](https://www.apollographql.com/pricing#graphos-router) to compare GraphOS Router features across plan types.
 
 <Tip>
 

--- a/docs/source/enterprise-features.mdx
+++ b/docs/source/enterprise-features.mdx
@@ -5,11 +5,11 @@ description: Available with GraphOS Enterprise
 
 Since the Apollo Router is [source-available](https://www.apollographql.com/blog/evaluating-apollo-router-understanding-free-and-open-vs-commercial-features), you can use its codebase without connecting it to GraphOS. GraphOS organizations with the Enterprise plan can [connect a self-hosted router to GraphOS](/graphos/quickstart/self-hosted#6-connect-the-router-to-graphos) for an expanded feature set.
 
-A router connected to GraphOS, whether cloud- or self-hosted, is called a **GraphOS Router**. It has access to specific GraphOS features depending on the connected GraphOS organization's plan. Refer to the [pricing page](https://www.apollographql.com/pricing#graphos-router) to compare GraphOS Router features across plan types.
+A router connected to GraphOS, whether cloud- or self-hosted, is called a **GraphOS router**. It has access to specific GraphOS features depending on the connected GraphOS organization's plan. Refer to the [pricing page](https://www.apollographql.com/pricing#graphos-router) to compare GraphOS router features across plan types.
 
 <Tip>
 
-Try out Enterprise GraphOS Router features for free with an [Enterprise trial](/graphos/org/plans/#enterprise-trials).
+Try out Enterprise GraphOS router features for free with an [Enterprise trial](/graphos/org/plans/#enterprise-trials).
 
 </Tip>
 

--- a/docs/source/enterprise-features.mdx
+++ b/docs/source/enterprise-features.mdx
@@ -3,28 +3,23 @@ title: Enterprise features for the Apollo Router
 description: Available with GraphOS Enterprise
 ---
 
-The Apollo Router provides expanded performance, security, and customization features for organizations with a [GraphOS Enterprise plan](https://www.apollographql.com/pricing/).
+Since the Apollo Router is [source-available](https://www.apollographql.com/blog/evaluating-apollo-router-understanding-free-and-open-vs-commercial-features), you can use its codebase without connecting it to GraphOS. GraphOS organizations with the Enterprise plan can [connect a self-hosted router to GraphOS](/graphos/quickstart/self-hosted#6-connect-the-router-to-graphos) for an expanded feature set.
+
+A router connected to GraphOS, whether cloud- or self-hosted, is called a **GraphOS Router**, and has access to specific GraphOS features depending on the connected GraphOS organization's plan. Refer to the [pricing page](https://www.apollographql.com/pricing#graphos-router) to compare GraphOS Router features across plan types.
 
 <Tip>
 
-Try out these Enterprise features for free with an [Enterprise trial](/graphos/org/plans/#enterprise-trials).
+Try out Enterprise GraphOS Router features for free with an [Enterprise trial](/graphos/org/plans/#enterprise-trials).
 
 </Tip>
 
 ## List of features
 
-- **Real-time updates** via [GraphQL subscriptions](./executing-operations/subscription-support/)
-- **Authentication of inbound requests** via [JSON Web Token (JWT)](./configuration/authn-jwt/)
-- [**Authorization** of specific fields and types](./configuration/authorization) through the [`@requiresScopes`](./configuration/authorization#requiresscopes), [`@authenticated`](./configuration/authorization#authenticated), and [`@policy`](./configuration/authorization#policy) directives
-- Redis-backed [**distributed caching** of query plans and persisted queries](./configuration/distributed-caching/) and [**subgraph entity caching**](./configuration/entity-caching/)
-- **Custom request handling** in any language via [external coprocessing](./customizations/coprocessor/)
-- **Mitigation of potentially malicious requests** via [operation limits](./configuration/operation-limits) and [safelisting with persisted queries](./configuration/persisted-queries)
-- **Custom instrumentation and telemetry**, including [custom attributes for spans](./configuration/telemetry/instrumentation/spans/#attributes).
-- An [**offline Enterprise license**](#offline-enterprise-license) enables running the router with Enterprise features when disconnected from the internet.
+<GraphOSRouterFeatures />
 
 <Tip>
 
-Articles specifically about Enterprise features are marked with a **❖** icon in the left navigation.
+Articles about enterprise features are marked with a **❖** icon in the left navigation.
 
 </Tip>
 

--- a/docs/source/executing-operations/subscription-support.mdx
+++ b/docs/source/executing-operations/subscription-support.mdx
@@ -3,13 +3,13 @@ title: GraphQL subscriptions with a self-hosted router
 description: Real-time data with GraphOS Enterprise
 ---
 
-<blockquote>
+<PremiumFeature>
 
-⚠️ **For self-hosted routers, subscription support is an [Enterprise feature](../enterprise-features/).**
+**For self-hosted routers, subscription support is an [Enterprise feature](../enterprise-features/).**
 
-Subscription support is also available for cloud routers with a GraphOS Serverless plan. [See the docs.](/graphos/operations/subscriptions)
+Subscription support is also available for cloud routers with a GraphOS Serverless or Dedicated plan. [See the docs.](/graphos/operations/subscriptions)
 
-</blockquote>
+</PremiumFeature>
 
 With [GraphOS Enterprise](/graphos/enterprise/), self-hosted instances of the Apollo Router provide support for GraphQL subscription operations:
 


### PR DESCRIPTION
Many features that were previously denoted "Enterprise only" are also now included in the Dedicated plan.
This PR calls those out and adds an explanation of "GraphOS Router" found on the often linked pricing page.

This PR is dependent on component changes in https://github.com/apollographql/docs/pull/777 and should be merged shortly after it.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
