### PR TITLE
add headers to the JWKS download request

### DIFF
--- a/.changesets/feat_geal_jwks_headers.md
+++ b/.changesets/feat_geal_jwks_headers.md
@@ -1,0 +1,5 @@
+### add headers to the JWKS download request ([Issue #4651](https://github.com/apollographql/router/issues/4651))
+
+This adds the ability to set static heaers on HTTP requests to download a JWKS from an identity provider
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4688

--- a/.changesets/feat_geal_jwks_headers.md
+++ b/.changesets/feat_geal_jwks_headers.md
@@ -1,5 +1,5 @@
-### add headers to the JWKS download request ([Issue #4651](https://github.com/apollographql/router/issues/4651))
+### Add headers to the JWKS download request ([Issue #4651](https://github.com/apollographql/router/issues/4651))
 
-This adds the ability to set static heaers on HTTP requests to download a JWKS from an identity provider
+This adds the ability to set static headers on HTTP requests to download a JWKS from an identity provider
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4688

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -259,6 +259,29 @@ expression: "&schema"
                         },
                         "nullable": true
                       },
+                      "headers": {
+                        "description": "List of headers to add to the JWKS request",
+                        "type": "array",
+                        "items": {
+                          "description": "Insert a header",
+                          "type": "object",
+                          "required": [
+                            "name",
+                            "value"
+                          ],
+                          "properties": {
+                            "name": {
+                              "description": "The name of the header",
+                              "type": "string"
+                            },
+                            "value": {
+                              "description": "The value for the header",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
                       "issuer": {
                         "description": "Expected issuer for tokens verified by that JWKS",
                         "type": "string",

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -607,6 +607,7 @@ async fn build_jwks_search_components() -> JwksManager {
             issuer: None,
             algorithms: None,
             poll_interval: Duration::from_secs(60),
+            headers: Vec::new(),
         });
     }
 
@@ -717,6 +718,7 @@ fn make_manager(jwk: &Jwk, issuer: Option<String>) -> JwksManager {
         issuer,
         algorithms: None,
         poll_interval: Duration::from_secs(60),
+        headers: Vec::new(),
     }];
     let map = HashMap::from([(url, jwks); 1]);
 
@@ -914,6 +916,7 @@ async fn it_rejects_key_with_restricted_algorithm() {
             issuer: None,
             algorithms: Some(HashSet::from([Algorithm::RS256])),
             poll_interval: Duration::from_secs(60),
+            headers: Vec::new(),
         });
     }
 
@@ -945,6 +948,7 @@ async fn it_rejects_and_accepts_keys_with_restricted_algorithms_and_unknown_jwks
             issuer: None,
             algorithms: Some(HashSet::from([Algorithm::RS256])),
             poll_interval: Duration::from_secs(60),
+            headers: Vec::new(),
         });
     }
 
@@ -983,6 +987,7 @@ async fn it_accepts_key_without_use_or_keyops() {
             issuer: None,
             algorithms: None,
             poll_interval: Duration::from_secs(60),
+            headers: Vec::new(),
         });
     }
 
@@ -1013,6 +1018,7 @@ async fn it_accepts_elliptic_curve_key_without_alg() {
             issuer: None,
             algorithms: None,
             poll_interval: Duration::from_secs(60),
+            headers: Vec::new(),
         });
     }
 
@@ -1043,6 +1049,7 @@ async fn it_accepts_rsa_key_without_alg() {
             issuer: None,
             algorithms: None,
             poll_interval: Duration::from_secs(60),
+            headers: Vec::new(),
         });
     }
 

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -1,9 +1,18 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::io;
 use std::path::Path;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use base64::Engine as _;
+use http::header::CONTENT_TYPE;
+use hyper::server::conn::AddrIncoming;
+use hyper::service::make_service_fn;
+use hyper::service::service_fn;
+use hyper::Server;
 use insta::assert_yaml_snapshot;
 use jsonwebtoken::encode;
 use jsonwebtoken::get_current_timestamp;
@@ -12,6 +21,7 @@ use jsonwebtoken::jwk::EllipticCurveKeyParameters;
 use jsonwebtoken::jwk::EllipticCurveKeyType;
 use jsonwebtoken::jwk::JwkSet;
 use jsonwebtoken::EncodingKey;
+use mime::APPLICATION_JSON;
 use p256::ecdsa::SigningKey;
 use p256::pkcs8::EncodePrivateKey;
 use rand_core::OsRng;
@@ -19,6 +29,7 @@ use serde::Serialize;
 use serde_json::Value;
 use tracing::subscriber;
 
+use super::Header;
 use super::*;
 use crate::assert_snapshot_subscriber;
 use crate::plugin::test;
@@ -1070,4 +1081,60 @@ fn test_parse_failure_logs() {
         let jwks = parse_jwks(include_str!("testdata/jwks.json")).expect("expected to parse jwks");
         assert_yaml_snapshot!(jwks);
     });
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn jwks_send_headers() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let socket_addr = listener.local_addr().unwrap();
+
+    let got_header = Arc::new(AtomicBool::new(false));
+    let gh = got_header.clone();
+    let service = make_service_fn(move |_| {
+        let gh = gh.clone();
+        async move {
+            //let gh1 = gh.clone();
+            Ok::<_, io::Error>(service_fn(move |req| {
+                println!("got re: {:?}", req.headers());
+                let gh: Arc<AtomicBool> = gh.clone();
+                async move {
+                    if req
+                        .headers()
+                        .get("jwks-authz")
+                        .and_then(|v| v.to_str().ok())
+                        == Some("user1")
+                    {
+                        gh.store(true, Ordering::Release);
+                    }
+                    Ok::<_, io::Error>(
+                        http::Response::builder()
+                            .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
+                            .status(StatusCode::OK)
+                            .version(http::Version::HTTP_11)
+                            .body::<hyper::Body>(include_str!("testdata/jwks.json").into())
+                            .unwrap(),
+                    )
+                }
+            }))
+        }
+    });
+    let server = Server::builder(AddrIncoming::from_listener(listener).unwrap()).serve(service);
+    tokio::task::spawn(server);
+
+    let url = Url::parse(&format!("http://{socket_addr}/")).unwrap();
+
+    let _jwks_manager = JwksManager::new(vec![JwksConfig {
+        url,
+        issuer: None,
+        algorithms: Some(HashSet::from([Algorithm::RS256])),
+        poll_interval: Duration::from_secs(60),
+        headers: vec![Header {
+            name: HeaderName::from_static("jwks-authz"),
+            value: HeaderValue::from_static("user1"),
+        }],
+    }])
+    .await
+    .unwrap();
+
+    assert!(got_header.load(Ordering::Acquire));
 }

--- a/docs/source/configuration/authn-jwt.mdx
+++ b/docs/source/configuration/authn-jwt.mdx
@@ -47,6 +47,9 @@ Otherwise, if you issue JWTs via a popular third-party IdP (Auth0, Okta, PingOne
             - url: https://dev-zzp5enui.us.auth0.com/.well-known/jwks.json
               issuer: <optional name of issuer>
               poll_interval: <optional poll interval>
+              headers: # optional list of static headers added to the HTTP request to the JWKS URL
+                - name: User-Agent
+                  value: router
           # These keys are optional. Default values are shown.
           header_name: Authorization
           header_value_prefix: Bearer
@@ -99,6 +102,7 @@ The following configuration options are supported:
 - `issuer`: **optional** name of the issuer, that will be compared to the `iss` claim in the JWT if present. If it does not match, the request will be rejected.
 - `algorithms`: **optional** list of accepted algorithms. Possible values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `EdDSA`
 - `poll_interval`: **optional** interval in human-readable format (e.g. `60s` or `1hour 30s`) at which the JWKS will be polled for changes. If not specified, the JWKS endpoint will be polled every 60 seconds.
+- `headers`: **optional** a list of headers sent when downloading from the JWKS URL
 
 </td>
 </tr>


### PR DESCRIPTION
Fix #4651

This adds the ability to set static headers on HTTP requests to download a JWKS from an identity provider

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
