### PR TITLE
Set a limit of simultaneous client subscription connections to the router by default

### DIFF
--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -2215,12 +2215,21 @@ expression: "&schema"
           "type": "boolean"
         },
         "max_opened_subscriptions": {
-          "description": "This is a limit to only have maximum X opened subscriptions at the same time. By default if it's not set there is no limit.",
-          "default": null,
-          "type": "integer",
-          "format": "uint",
-          "minimum": 0.0,
-          "nullable": true
+          "description": "This is a limit to only have maximum X opened subscriptions at the same time. By default it's set to 8000. If you want to disable the limit, just override it to `null`",
+          "default": 8000,
+          "anyOf": [
+            {
+              "type": "string",
+              "enum": [
+                "disabled"
+              ]
+            },
+            {
+              "type": "integer",
+              "format": "uint",
+              "minimum": 0.0
+            }
+          ]
         },
         "mode": {
           "description": "Select a subscription mode (callback or passthrough)",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -2215,7 +2215,7 @@ expression: "&schema"
           "type": "boolean"
         },
         "max_opened_subscriptions": {
-          "description": "This is a limit to only have maximum X opened subscriptions at the same time. By default it's set to 8000. If you want to disable the limit, just override it to `null`",
+          "description": "This is a limit to only have maximum X opened subscriptions at the same time. By default it's set to 8000. Set it to `disabled` to disable the limit.",
           "default": 8000,
           "anyOf": [
             {

--- a/apollo-router/src/plugins/subscription.rs
+++ b/apollo-router/src/plugins/subscription.rs
@@ -70,7 +70,7 @@ pub(crate) struct SubscriptionConfig {
     /// Enable the deduplication of subscription (for example if we detect the exact same request to subgraph we won't open a new websocket to the subgraph in passthrough mode)
     /// (default: true)
     pub(crate) enable_deduplication: bool,
-    /// This is a limit to only have maximum X opened subscriptions at the same time. By default it's set to 8000. If you want to disable the limit, just override it to `null`
+    /// This is a limit to only have maximum X opened subscriptions at the same time. By default it's set to 8000. Set it to `disabled` to disable the limit.
     pub(crate) max_opened_subscriptions: SubscriptionLimit,
     /// It represent the capacity of the in memory queue to know how many events we can keep in a buffer
     pub(crate) queue_capacity: Option<usize>,

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -1053,6 +1053,7 @@ mod tests {
     use crate::graphql::Response;
     use crate::plugins::subscription::Disabled;
     use crate::plugins::subscription::SubgraphPassthroughMode;
+    use crate::plugins::subscription::SubscriptionLimit;
     use crate::plugins::subscription::SubscriptionModeConfig;
     use crate::plugins::subscription::SUBSCRIPTION_CALLBACK_HMAC_KEY;
     use crate::plugins::traffic_shaping::Http2Config;
@@ -1651,7 +1652,7 @@ mod tests {
                 }),
             },
             enable_deduplication: true,
-            max_opened_subscriptions: None,
+            max_opened_subscriptions: SubscriptionLimit::Disabled(Disabled::Disabled),
             queue_capacity: None,
         }
     }

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -32,6 +32,7 @@ use crate::graphql::IntoGraphQLErrors;
 use crate::graphql::Response;
 use crate::plugin::DynPlugin;
 use crate::plugins::subscription::SubscriptionConfig;
+use crate::plugins::subscription::SubscriptionLimit;
 use crate::plugins::telemetry::tracing::apollo_telemetry::APOLLO_PRIVATE_DURATION_NS;
 use crate::plugins::telemetry::Telemetry;
 use crate::plugins::telemetry::LOGGING_DISPLAY_BODY;
@@ -390,7 +391,10 @@ async fn subscription_task(
         }
     };
 
-    let limit_is_set = subscription_config.max_opened_subscriptions.is_some();
+    let limit_is_set = matches!(
+        subscription_config.max_opened_subscriptions,
+        SubscriptionLimit::Limit(_)
+    );
     let mut subscription_handle = subscription_handle.clone();
     let operation_signature = context
         .extensions()

--- a/docs/source/executing-operations/subscription-support.mdx
+++ b/docs/source/executing-operations/subscription-support.mdx
@@ -130,6 +130,12 @@ After completing all [prerequisites](#prerequisites), in your router's [YAML con
 
 The Apollo Router supports two popular [WebSocket protocols](#websocket-setup) for subscriptions, and it also provides support for an [HTTP-callback-based protocol](#http-callback-setup). Your router must use whichever protocol is expected by each subgraph.
 
+<Caution>
+
+By default we set a limit (8000) on number of simultaneous client subscription connections to the router. If you want to disable this limit you can just override the default limit with `subscription.max_opened_subscriptions` set to `disabled`.
+
+</Caution>
+
 ### WebSocket setup
 
 Here's an example router configuration snippet that sets up subgraph subscriptions over WebSocket:
@@ -496,7 +502,7 @@ Client subscriptions are [long-lived HTTP connections](#how-it-works), which mea
 subscription:
   enabled: true
   #highlight-start
-  max_opened_subscriptions: 150 # Only 150 simultaneous connections allowed
+  max_opened_subscriptions: 150 # (default: 8000) Only 150 simultaneous connections allowed
   #highlight-end
 ```
 


### PR DESCRIPTION
In order to harden our default configuration I set a limit on opened subscriptions to 8000 for now. This number can be modify we can find a better default number.

Fixes #4405 

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
