### PR TITLE
fix(telemetry): use the right default header name when experimental_response_trace_id is enabled

### DIFF
--- a/.changesets/fix_bnjjj_fix_4699.md
+++ b/.changesets/fix_bnjjj_fix_4699.md
@@ -1,0 +1,15 @@
+### Default header correctly set in `experimental_response_trace_id` when enabled ([Issue #4699](https://github.com/apollographql/router/issues/4699))
+
+When configuring the `experimental_response_trace_id` without an explicit header it now correctly takes the default one `apollo-trace-id`.
+
+Example of configuration:
+
+```yaml
+telemetry:
+  exporters:
+    tracing:
+      experimental_response_trace_id:
+        enabled: true
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/PULL_NUMBER

--- a/.changesets/fix_bnjjj_fix_4699.md
+++ b/.changesets/fix_bnjjj_fix_4699.md
@@ -12,4 +12,4 @@ telemetry:
         enabled: true
 ```
 
-By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/PULL_NUMBER
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/4702

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -376,23 +376,23 @@ impl Plugin for Telemetry {
                                     .on_response(response),
                             );
                             if expose_trace_id.enabled {
-                                if let Some(header_name) = &expose_trace_id.header_name {
-                                    let mut headers: HashMap<String, Vec<String>> =
-                                        HashMap::with_capacity(1);
-                                    if let Some(value) =
-                                        response.response.headers().get(header_name)
-                                    {
-                                        headers.insert(
-                                            header_name.to_string(),
-                                            vec![value.to_str().unwrap_or_default().to_string()],
-                                        );
-                                        let response_headers =
-                                            serde_json::to_string(&headers).unwrap_or_default();
-                                        span.record(
-                                            "apollo_private.http.response_headers",
-                                            &response_headers,
-                                        );
-                                    }
+                                let header_name = expose_trace_id
+                                    .header_name
+                                    .as_ref()
+                                    .unwrap_or_else(|| &DEFAULT_EXPOSE_TRACE_ID_HEADER_NAME);
+                                let mut headers: HashMap<String, Vec<String>> =
+                                    HashMap::with_capacity(1);
+                                if let Some(value) = response.response.headers().get(header_name) {
+                                    headers.insert(
+                                        header_name.to_string(),
+                                        vec![value.to_str().unwrap_or_default().to_string()],
+                                    );
+                                    let response_headers =
+                                        serde_json::to_string(&headers).unwrap_or_default();
+                                    span.record(
+                                        "apollo_private.http.response_headers",
+                                        &response_headers,
+                                    );
                                 }
                             }
 

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -379,7 +379,7 @@ impl Plugin for Telemetry {
                                 let header_name = expose_trace_id
                                     .header_name
                                     .as_ref()
-                                    .unwrap_or_else(|| &DEFAULT_EXPOSE_TRACE_ID_HEADER_NAME);
+                                    .unwrap_or(&DEFAULT_EXPOSE_TRACE_ID_HEADER_NAME);
                                 let mut headers: HashMap<String, Vec<String>> =
                                     HashMap::with_capacity(1);
                                 if let Some(value) = response.response.headers().get(header_name) {


### PR DESCRIPTION
When configuring the `experimental_response_trace_id` without an explicit header it now correctly takes the default one `apollo-trace-id`.

Example of configuration:

```yaml
telemetry:
  exporters:
    tracing:
      experimental_response_trace_id:
        enabled: true
```

Fixes #4699 


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
