### PR TITLE
Provide unsupported access to the parsed executable document.

### DIFF
--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -562,12 +562,12 @@ impl Service<QueryPlannerRequest> for BridgeQueryPlanner {
                     )))
                 }
                 Ok(modified_query) => {
-                    let executable = modified_query
+                    let executable_document = modified_query
                         .to_executable(schema)
                         // Assume transformation creates a valid document: ignore conversion errors
                         .unwrap_or_else(|invalid| invalid.partial);
                     doc = Arc::new(ParsedDocumentInner {
-                        executable,
+                        executable: Arc::new(executable_document),
                         ast: modified_query,
                         // Carry errors from previous ParsedDocument
                         // and assume transformation doesn’t introduce new errors.
@@ -682,12 +682,12 @@ impl BridgeQueryPlanner {
 
         if let Some((unauthorized_paths, new_doc)) = filter_res {
             key.filtered_query = new_doc.to_string();
-            let executable = new_doc
+            let executable_document = new_doc
                 .to_executable(&self.schema.api_schema().definitions)
                 // Assume transformation creates a valid document: ignore conversion errors
                 .unwrap_or_else(|invalid| invalid.partial);
             doc = Arc::new(ParsedDocumentInner {
-                executable,
+                executable: Arc::new(executable_document),
                 ast: new_doc,
                 // Carry errors from previous ParsedDocument
                 // and assume transformation doesn’t introduce new errors.

--- a/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
+++ b/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
@@ -286,7 +286,7 @@ mod forbid_http_get_mutations_tests {
             .lock()
             .insert::<ParsedDocument>(Arc::new(ParsedDocumentInner {
                 ast,
-                executable,
+                executable: Arc::new(executable),
                 parse_errors: None,
                 validation_errors: None,
             }));

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -163,7 +163,7 @@ pub(crate) type ParsedDocument = Arc<ParsedDocumentInner>;
 #[derive(Debug, Default)]
 pub(crate) struct ParsedDocumentInner {
     pub(crate) ast: ast::Document,
-    pub(crate) executable: ExecutableDocument,
+    pub(crate) executable: Arc<ExecutableDocument>,
     pub(crate) parse_errors: Option<DiagnosticList>,
     pub(crate) validation_errors: Option<DiagnosticList>,
 }

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -291,7 +291,7 @@ impl Query {
         let validate =
             configuration.experimental_graphql_validation_mode != GraphQLValidationMode::Legacy;
         // Stretch the meaning of "assume valid" to "we’ll check later"
-        let (executable, validation_errors) = if validate {
+        let (executable_document, validation_errors) = if validate {
             match ast.to_executable_validate(schema) {
                 Ok(doc) => (doc.into_inner(), None),
                 Err(WithErrors { partial, errors }) => (partial, Some(errors)),
@@ -309,7 +309,7 @@ impl Query {
 
         Arc::new(ParsedDocumentInner {
             ast,
-            executable,
+            executable: Arc::new(executable_document),
             parse_errors,
             validation_errors,
         })


### PR DESCRIPTION
This is unsupported because apollo_rs is not at 1.0 and we may change things later.

If you decide to use `unsupported_executable_document` it is at your own risk.

We WILL be changing this later once apollo-rs reaches 1.0.

ExecutableDocument has to be moved into an `Arc` so that we can expose it.