### PR TITLE
Support loading JWT from other sources

### DIFF
--- a/.changesets/feat_geal_jwt_source.md
+++ b/.changesets/feat_geal_jwt_source.md
@@ -1,0 +1,5 @@
+### Support loading JWT from other sources ([PR #4711](https://github.com/apollographql/router/pull/4711))
+
+The token can be stored in different headers, but it can also be carried by a cookie. This adds cookies as an alternative source of tokens, and allows multiple alternative sources
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4711

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -69,6 +69,7 @@
 
         paths = [
             '''^apollo-router\/src\/.+\/testdata\/.+''',
+            '''^apollo-router/src/plugins/authentication/tests.rs$'''
         ]
 
 [[ rules ]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ dependencies = [
  "clap",
  "console",
  "console-subscriber",
+ "cookie",
  "dashmap",
  "derivative",
  "derive_more",
@@ -1657,6 +1658,16 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "cookie"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cd91cf61412820176e137621345ee43b3f4423e589e7ae4e50d601d93e35ef8"
+dependencies = [
+ "time",
+ "version_check",
+]
 
 [[package]]
 name = "cookie-factory"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -86,6 +86,7 @@ clap = { version = "4.5.1", default-features = false, features = [
     "help",
 ] }
 console-subscriber = { version = "0.2.0", optional = true }
+cookie = { version = "0.18.0", default-features = false }
 ci_info = { version = "0.14.14", features = ["serde-1"] }
 dashmap = { version = "5.5.3", features = ["serde"] }
 derivative = "2.2.0"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -279,6 +279,59 @@ expression: "&schema"
                     },
                     "additionalProperties": false
                   }
+                },
+                "sources": {
+                  "description": "Alternative sources to extract the JWT",
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "required": [
+                          "type"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "HTTP header expected to contain JWT",
+                            "default": "authorization",
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "header"
+                            ]
+                          },
+                          "value_prefix": {
+                            "description": "Header value prefix",
+                            "default": "Bearer",
+                            "type": "string"
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "required": [
+                          "name",
+                          "type"
+                        ],
+                        "properties": {
+                          "name": {
+                            "description": "Name of the cookie containing the JWT",
+                            "type": "string"
+                          },
+                          "type": {
+                            "type": "string",
+                            "enum": [
+                              "cookie"
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
                 }
               },
               "additionalProperties": false

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -592,6 +592,188 @@ async fn it_panics_when_auth_prefix_has_correct_format_but_contains_trailing_whi
     let _test_harness = build_a_test_harness(None, Some("SOMETHING ".to_string()), false).await;
 }
 
+#[tokio::test]
+async fn it_extracts_the_token_from_cookies() {
+    let mut mock_service = test::MockSupergraphService::new();
+    mock_service.expect_clone().return_once(move || {
+        println!("cloned to supergraph mock");
+        let mut mock_service = test::MockSupergraphService::new();
+        mock_service
+            .expect_call()
+            .once()
+            .returning(move |req: supergraph::Request| {
+                Ok(supergraph::Response::fake_builder()
+                    .data("response created within the mock")
+                    .context(req.context)
+                    .build()
+                    .unwrap())
+            });
+        mock_service
+    });
+    let jwks_url = create_an_url("jwks.json");
+
+    let config = serde_json::json!({
+        "authentication": {
+            "router": {
+                "jwt" : {
+                    "jwks": [
+                        {
+                            "url": &jwks_url
+                        }
+                    ],
+                    "sources": [
+                        {
+                            "type": "cookie",
+                            "name": "authz"
+                        }
+                    ],
+                }
+            }
+        },
+        "rhai": {
+            "scripts":"tests/fixtures",
+            "main":"require_authentication.rhai"
+        }
+    });
+    let test_harness = crate::TestHarness::builder()
+        .configuration_json(config)
+        .unwrap()
+        .supergraph_hook(move |_| mock_service.clone().boxed())
+        .build_router()
+        .await
+        .unwrap();
+
+    let token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6ImtleTEifQ.eyJleHAiOjEwMDAwMDAwMDAwLCJhbm90aGVyIGNsYWltIjoidGhpcyBpcyBhbm90aGVyIGNsYWltIn0.4GrmfxuUST96cs0YUC0DfLAG218m7vn8fO_ENfXnu5A";
+
+    // Let's create a request with our operation name
+    let request_with_appropriate_name = supergraph::Request::canned_builder()
+        .operation_name("me".to_string())
+        .header(
+            http::header::COOKIE,
+            format!("a= b; c = d HttpOnly; authz = {token}; e = f"),
+        )
+        .build()
+        .unwrap();
+
+    // ...And call our service stack with it
+    let mut service_response = test_harness
+        .oneshot(request_with_appropriate_name.try_into().unwrap())
+        .await
+        .unwrap();
+    let response: graphql::Response = serde_json::from_slice(
+        service_response
+            .next_response()
+            .await
+            .unwrap()
+            .unwrap()
+            .to_vec()
+            .as_slice(),
+    )
+    .unwrap();
+
+    assert_eq!(response.errors, vec![]);
+
+    assert_eq!(StatusCode::OK, service_response.response.status());
+
+    let expected_mock_response_data = "response created within the mock";
+    // with the expected message
+    assert_eq!(expected_mock_response_data, response.data.as_ref().unwrap());
+}
+
+#[tokio::test]
+async fn it_supports_multiple_sources() {
+    let mut mock_service = test::MockSupergraphService::new();
+    mock_service.expect_clone().return_once(move || {
+        println!("cloned to supergraph mock");
+        let mut mock_service = test::MockSupergraphService::new();
+        mock_service
+            .expect_call()
+            .once()
+            .returning(move |req: supergraph::Request| {
+                Ok(supergraph::Response::fake_builder()
+                    .data("response created within the mock")
+                    .context(req.context)
+                    .build()
+                    .unwrap())
+            });
+        mock_service
+    });
+    let jwks_url = create_an_url("jwks.json");
+
+    let config = serde_json::json!({
+        "authentication": {
+            "router": {
+                "jwt" : {
+                    "jwks": [
+                        {
+                            "url": &jwks_url
+                        }
+                    ],
+                    "sources": [
+                        {
+                            "type": "cookie",
+                            "name": "authz"
+                        },
+                        {
+                            "type": "header",
+                            "name": "authz1"
+                        },
+                        {
+                            "type": "header",
+                            "name": "authz2",
+                            "value_prefix": "bear"
+                        }
+                    ],
+                }
+            }
+        },
+        "rhai": {
+            "scripts":"tests/fixtures",
+            "main":"require_authentication.rhai"
+        }
+    });
+    let test_harness = crate::TestHarness::builder()
+        .configuration_json(config)
+        .unwrap()
+        .supergraph_hook(move |_| mock_service.clone().boxed())
+        .build_router()
+        .await
+        .unwrap();
+
+    let token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiIsImtpZCI6ImtleTEifQ.eyJleHAiOjEwMDAwMDAwMDAwLCJhbm90aGVyIGNsYWltIjoidGhpcyBpcyBhbm90aGVyIGNsYWltIn0.4GrmfxuUST96cs0YUC0DfLAG218m7vn8fO_ENfXnu5A";
+
+    // Let's create a request with our operation name
+    let request_with_appropriate_name = supergraph::Request::canned_builder()
+        .operation_name("me".to_string())
+        .header("Authz2", format!("Bear {token}"))
+        .build()
+        .unwrap();
+
+    // ...And call our service stack with it
+    let mut service_response = test_harness
+        .oneshot(request_with_appropriate_name.try_into().unwrap())
+        .await
+        .unwrap();
+    let response: graphql::Response = serde_json::from_slice(
+        service_response
+            .next_response()
+            .await
+            .unwrap()
+            .unwrap()
+            .to_vec()
+            .as_slice(),
+    )
+    .unwrap();
+
+    assert_eq!(response.errors, vec![]);
+
+    assert_eq!(StatusCode::OK, service_response.response.status());
+
+    let expected_mock_response_data = "response created within the mock";
+    // with the expected message
+    assert_eq!(expected_mock_response_data, response.data.as_ref().unwrap());
+}
+
 async fn build_jwks_search_components() -> JwksManager {
     let mut sets = vec![];
     let mut urls = vec![];
@@ -768,7 +950,10 @@ async fn issuer_check() {
         .unwrap();
 
     let mut config = JWTConf::default();
-    config.sources.push(Source::Header(HeaderSource::default()));
+    config.sources.push(Source::Header {
+        name: super::default_header_name(),
+        value_prefix: super::default_header_value_prefix(),
+    });
     match authenticate(&config, &manager, request.try_into().unwrap()) {
         ControlFlow::Break(res) => {
             panic!("unexpected response: {res:?}");

--- a/apollo-router/src/plugins/authentication/tests.rs
+++ b/apollo-router/src/plugins/authentication/tests.rs
@@ -767,7 +767,9 @@ async fn issuer_check() {
         .build()
         .unwrap();
 
-    match authenticate(&JWTConf::default(), &manager, request.try_into().unwrap()) {
+    let mut config = JWTConf::default();
+    config.sources.push(Source::Header(HeaderSource::default()));
+    match authenticate(&config, &manager, request.try_into().unwrap()) {
         ControlFlow::Break(res) => {
             panic!("unexpected response: {res:?}");
         }
@@ -800,7 +802,7 @@ async fn issuer_check() {
         .build()
         .unwrap();
 
-    match authenticate(&JWTConf::default(), &manager, request.try_into().unwrap()) {
+    match authenticate(&config, &manager, request.try_into().unwrap()) {
         ControlFlow::Break(res) => {
             let response: graphql::Response = serde_json::from_slice(
                 &hyper::body::to_bytes(res.response.into_body())
@@ -840,7 +842,7 @@ async fn issuer_check() {
         .build()
         .unwrap();
 
-    match authenticate(&JWTConf::default(), &manager, request.try_into().unwrap()) {
+    match authenticate(&config, &manager, request.try_into().unwrap()) {
         ControlFlow::Break(res) => {
             let response: graphql::Response = serde_json::from_slice(
                 &hyper::body::to_bytes(res.response.into_body())
@@ -875,7 +877,7 @@ async fn issuer_check() {
         .build()
         .unwrap();
 
-    match authenticate(&JWTConf::default(), &manager, request.try_into().unwrap()) {
+    match authenticate(&config, &manager, request.try_into().unwrap()) {
         ControlFlow::Break(res) => {
             let response: graphql::Response = serde_json::from_slice(
                 &hyper::body::to_bytes(res.response.into_body())

--- a/docs/source/configuration/authn-jwt.mdx
+++ b/docs/source/configuration/authn-jwt.mdx
@@ -55,7 +55,7 @@ Otherwise, if you issue JWTs via a popular third-party IdP (Auth0, Okta, PingOne
             - type: header
               name: X-Authorization
               value_prefix: Bearer
-            - cookie:
+            - type: cookie
               name: authz
     ```
 
@@ -155,7 +155,7 @@ This is an array of possible token sources, as it could be provided in different
             - type: header
               name: X-Authorization
               value_prefix: Bearer
-            - cookie:
+            - type: cookie
               name: authz
 ```
 

--- a/docs/source/configuration/authn-jwt.mdx
+++ b/docs/source/configuration/authn-jwt.mdx
@@ -150,6 +150,8 @@ This is an array of possible token sources, as it could be provided in different
 ```yaml title="router.yaml"
     authentication:
       router:
+        jwks:
+          - url: https://dev-zzp5enui.us.auth0.com/.well-known/jwks.json
         jwt:
           sources:
             - type: header

--- a/docs/source/configuration/authn-jwt.mdx
+++ b/docs/source/configuration/authn-jwt.mdx
@@ -150,9 +150,9 @@ This is an array of possible token sources, as it could be provided in different
 ```yaml title="router.yaml"
     authentication:
       router:
-        jwks:
-          - url: https://dev-zzp5enui.us.auth0.com/.well-known/jwks.json
         jwt:
+          jwks:
+            - url: https://dev-zzp5enui.us.auth0.com/.well-known/jwks.json
           sources:
             - type: header
               name: X-Authorization

--- a/docs/source/configuration/authn-jwt.mdx
+++ b/docs/source/configuration/authn-jwt.mdx
@@ -50,6 +50,13 @@ Otherwise, if you issue JWTs via a popular third-party IdP (Auth0, Okta, PingOne
           # These keys are optional. Default values are shown.
           header_name: Authorization
           header_value_prefix: Bearer
+          # array of alternative token sources
+          sources:
+            - type: header
+              name: X-Authorization
+              value_prefix: Bearer
+            - cookie:
+              name: authz
     ```
 
     These options are documented [below](#configuration-options).
@@ -129,6 +136,28 @@ The default value is `Authorization`.
 The string that will always precede the JWT in the header value corresponding to [`header_name`](#header_name). This value must not include whitespace.
 
 The default value is `Bearer`.
+
+</td>
+</tr>
+
+##### `sources`
+
+</td>
+<td>
+
+This is an array of possible token sources, as it could be provided in different headers depending on the client, or it could be stored in a cookie. If the default token source defined by the above `header_name` and `header_value_prefix` does not find the token, then each of the alternative sources is tried until one matches.
+
+```yaml title="router.yaml"
+    authentication:
+      router:
+        jwt:
+          sources:
+            - type: header
+              name: X-Authorization
+              value_prefix: Bearer
+            - cookie:
+              name: authz
+```
 
 </td>
 </tr>
@@ -629,7 +658,7 @@ The y-coordinate of the elliptic curve point for this public key, as the base64-
 
   // highlight-start
   // Symmetric-algorithm-specific property
-  "k": "c2VjcmV0Cg==" // ⚠️ This is a base64-encoded shared secret! ⚠️
+  "k": "c2VjcmV0Cg" // ⚠️ This is a base64-encoded shared secret! ⚠️
   // highlight-end
 }
 ```
@@ -651,7 +680,7 @@ The y-coordinate of the elliptic curve point for this public key, as the base64-
 </td>
 <td>
 
-The value of the shared symmetric key, as the base64-encoded value of the key's octet sequence representation.
+The value of the shared symmetric key, as the [(URL safe, without padding) base64-encoded value](https://datatracker.ietf.org/doc/html/rfc7515#section-2) of the key's octet sequence representation.
 
 **⚠️ If your JWK uses a symmetric signature algorithm, always [provide your JWKS to the router](#jwks) via a `file://` URL!** Shared keys should never be made available over the network.
 


### PR DESCRIPTION
Fix https://github.com/apollographql/router/issues/4665 (docs)

The token can be stored in different headers, but it can also be carried by a cookie. This adds cookies as an alternative source of tokens, and allows multiple alternative sources

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
