### PR TITLE
Fix trailing dot on internal router usage metric attributes

### DIFF
--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -408,7 +408,7 @@ impl From<InstrumentData> for Metrics {
                 .map(|(metric_name, (value, attributes))| {
                     let attributes: Vec<_> = attributes
                         .into_iter()
-                        .map(|(k, v)| KeyValue::new(k.replace("__", "."), v))
+                        .map(|(k, v)| KeyValue::new(k.trim_end_matches("__").replace("__", "."), v))
                         .collect();
                     data.meter
                         .u64_observable_gauge(metric_name)

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@apq.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@apq.router.yaml.snap
@@ -7,7 +7,6 @@ expression: "&metrics.non_zero()"
     datapoints:
       - value: 1
         attributes:
-          opt.router.cache.in_memory.: true
-          opt.router.cache.redis.: true
-          opt.subgraph.: true
-
+          opt.router.cache.in_memory: true
+          opt.router.cache.redis: true
+          opt.subgraph: true

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@authorization.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@authorization.router.yaml.snap
@@ -7,6 +7,5 @@ expression: "&metrics.non_zero()"
     datapoints:
       - value: 1
         attributes:
-          opt.directives.: false
-          opt.require_authentication.: true
-
+          opt.directives: false
+          opt.require_authentication: true

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@authorization_directives.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@authorization_directives.router.yaml.snap
@@ -7,6 +7,5 @@ expression: "&metrics.non_zero()"
     datapoints:
       - value: 1
         attributes:
-          opt.directives.: true
-          opt.require_authentication.: false
-
+          opt.directives: true
+          opt.require_authentication: false

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@batching.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@batching.router.yaml.snap
@@ -7,5 +7,4 @@ expression: "&metrics.non_zero()"
     datapoints:
       - value: 1
         attributes:
-          opt.mode.: batch_http_link
-
+          opt.mode: batch_http_link

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@coprocessor.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@coprocessor.router.yaml.snap
@@ -7,10 +7,9 @@ expression: "&metrics.non_zero()"
     datapoints:
       - value: 1
         attributes:
-          opt.router.request.: true
-          opt.router.response.: true
-          opt.subgraph.request.: true
-          opt.subgraph.response.: true
-          opt.supergraph.request.: true
-          opt.supergraph.response.: true
-
+          opt.router.request: true
+          opt.router.response: true
+          opt.subgraph.request: true
+          opt.subgraph.response: true
+          opt.supergraph.request: true
+          opt.supergraph.response: true

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@entities.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@entities.router.yaml.snap
@@ -7,7 +7,6 @@ expression: "&metrics.non_zero()"
     datapoints:
       - value: 1
         attributes:
-          opt.enabled.: true
-          opt.subgraph.enabled.: true
-          opt.subgraph.ttl.: true
-
+          opt.enabled: true
+          opt.subgraph.enabled: true
+          opt.subgraph.ttl: true

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@file_uploads.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@file_uploads.router.yaml.snap
@@ -7,6 +7,5 @@ expression: "&metrics.non_zero()"
     datapoints:
       - value: 1
         attributes:
-          opt.limits.max_file_size.: 1mb
-          opt.limits.max_files.: 10
-
+          opt.limits.max_file_size: 1mb
+          opt.limits.max_files: 10

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@limits.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@limits.router.yaml.snap
@@ -7,12 +7,11 @@ expression: "&metrics.non_zero()"
     datapoints:
       - value: 1
         attributes:
-          opt.operation.max_aliases.: true
-          opt.operation.max_depth.: true
-          opt.operation.max_height.: true
-          opt.operation.max_root_fields.: true
-          opt.operation.warn_only.: true
-          opt.parser.max_recursion.: true
-          opt.parser.max_tokens.: true
-          opt.request.max_size.: true
-
+          opt.operation.max_aliases: true
+          opt.operation.max_depth: true
+          opt.operation.max_height: true
+          opt.operation.max_root_fields: true
+          opt.operation.warn_only: true
+          opt.parser.max_recursion: true
+          opt.parser.max_tokens: true
+          opt.request.max_size: true

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@persisted_queries.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@persisted_queries.router.yaml.snap
@@ -7,7 +7,6 @@ expression: "&metrics.non_zero()"
     datapoints:
       - value: 1
         attributes:
-          opt.log_unknown.: true
-          opt.safelist.enabled.: true
-          opt.safelist.require_id.: true
-
+          opt.log_unknown: true
+          opt.safelist.enabled: true
+          opt.safelist.require_id: true

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@subscriptions.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@subscriptions.router.yaml.snap
@@ -7,9 +7,8 @@ expression: "&metrics.non_zero()"
     datapoints:
       - value: 1
         attributes:
-          opt.deduplication.: false
-          opt.max_opened.: true
-          opt.mode.callback.: true
-          opt.mode.passthrough.: true
-          opt.queue_capacity.: true
-
+          opt.deduplication: false
+          opt.max_opened: true
+          opt.mode.callback: true
+          opt.mode.passthrough: true
+          opt.queue_capacity: true

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@telemetry.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@telemetry.router.yaml.snap
@@ -7,19 +7,18 @@ expression: "&metrics.non_zero()"
     datapoints:
       - value: 1
         attributes:
-          opt.events.: false
-          opt.instruments.: false
-          opt.logging.experimental_when_header.: true
-          opt.metrics.otlp.: true
-          opt.metrics.prometheus.: true
-          opt.spans.: true
-          opt.spans.default_attribute_requirement_level.: recommended
-          opt.spans.mode.: spec_compliant
-          opt.spans.router.: true
-          opt.spans.subgraph.: true
-          opt.spans.supergraph.: true
-          opt.tracing.datadog.: true
-          opt.tracing.jaeger.: true
-          opt.tracing.otlp.: true
-          opt.tracing.zipkin.: true
-
+          opt.events: false
+          opt.instruments: false
+          opt.logging.experimental_when_header: true
+          opt.metrics.otlp: true
+          opt.metrics.prometheus: true
+          opt.spans: true
+          opt.spans.default_attribute_requirement_level: recommended
+          opt.spans.mode: spec_compliant
+          opt.spans.router: true
+          opt.spans.subgraph: true
+          opt.spans.supergraph: true
+          opt.tracing.datadog: true
+          opt.tracing.jaeger: true
+          opt.tracing.otlp: true
+          opt.tracing.zipkin: true

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@tls.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@tls.router.yaml.snap
@@ -7,7 +7,6 @@ expression: "&metrics.non_zero()"
     datapoints:
       - value: 1
         attributes:
-          opt.router.tls.server.: true
-          opt.router.tls.subgraph.ca_override.: true
-          opt.router.tls.subgraph.client_authentication.: true
-
+          opt.router.tls.server: true
+          opt.router.tls.subgraph.ca_override: true
+          opt.router.tls.subgraph.client_authentication: true

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@traffic_shaping.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@traffic_shaping.router.yaml.snap
@@ -7,12 +7,11 @@ expression: "&metrics.non_zero()"
     datapoints:
       - value: 1
         attributes:
-          opt.router.rate_limit.: true
-          opt.router.timeout.: true
-          opt.subgraph.compression.: true
-          opt.subgraph.deduplicate_query.: true
-          opt.subgraph.http2.: true
-          opt.subgraph.rate_limit.: true
-          opt.subgraph.retry.: true
-          opt.subgraph.timeout.: true
-
+          opt.router.rate_limit: true
+          opt.router.timeout: true
+          opt.subgraph.compression: true
+          opt.subgraph.deduplicate_query: true
+          opt.subgraph.http2: true
+          opt.subgraph.rate_limit: true
+          opt.subgraph.retry: true
+          opt.subgraph.timeout: true


### PR DESCRIPTION
Internal config metric attributes had an extra trailing dot that was introduced in #4364.

This PR strips off the extra dot that was introduced.

Fixes #4689

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
