### PR TITLE
Add a metric for federation version

### DIFF
--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -71,6 +71,14 @@ impl BridgeQueryPlanner {
     ) -> Result<Self, ServiceBuildError> {
         let schema = Schema::parse(&sdl, &configuration)?;
 
+        let federation_version = schema.federation_version().unwrap_or(0);
+        u64_counter!(
+            "apollo.router.lifecycle.federation_version",
+            "The federation major version inferred from the supergraph schema",
+            1,
+            "version" = federation_version
+        );
+
         let planner = Planner::new(
             sdl,
             QueryPlannerConfig {

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -248,6 +248,41 @@ impl Schema {
         self.diagnostics.is_some()
     }
 
+    /// Return the federation major version based on the @link or @core directives in the schema,
+    /// or None if there are no federation directives.
+    pub(crate) fn federation_version(&self) -> Option<i64> {
+        for directive in &self.definitions.schema_definition.directives {
+            let join_url = if directive.name == "core" {
+                let Some(feature) = directive
+                    .argument_by_name("feature")
+                    .and_then(|value| value.as_str())
+                else {
+                    continue;
+                };
+
+                feature
+            } else if directive.name == "link" {
+                let Some(url) = directive
+                    .argument_by_name("url")
+                    .and_then(|value| value.as_str())
+                else {
+                    continue;
+                };
+
+                url
+            } else {
+                continue;
+            };
+
+            match join_url.rsplit_once("/v") {
+                Some(("https://specs.apollo.dev/join", "0.1")) => return Some(1),
+                Some(("https://specs.apollo.dev/join", _)) => return Some(2),
+                _ => {}
+            }
+        }
+        None
+    }
+
     pub(crate) fn has_spec(&self, base_url: &str, expected_version_range: &str) -> bool {
         self.definitions
             .schema_definition
@@ -514,6 +549,25 @@ mod tests {
         };
         assert!(has_in_stock_field(&schema));
         assert!(!has_in_stock_field(schema.api_schema.as_ref().unwrap()));
+    }
+
+    #[test]
+    fn federation_version() {
+        // @core directive
+        let schema = Schema::parse_test(
+            include_str!("../testdata/minimal_supergraph.graphql"),
+            &Default::default(),
+        )
+        .unwrap();
+        assert_eq!(schema.federation_version(), Some(1));
+
+        // @link directive
+        let schema = Schema::parse_test(
+            include_str!("../testdata/minimal_fed2_supergraph.graphql"),
+            &Default::default(),
+        )
+        .unwrap();
+        assert_eq!(schema.federation_version(), Some(2));
     }
 
     #[test]

--- a/apollo-router/src/testdata/minimal_fed2_supergraph.graphql
+++ b/apollo-router/src/testdata/minimal_fed2_supergraph.graphql
@@ -1,0 +1,45 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH_A @join__graph(name: "subgraph-a", url: "http://graphql.subgraph-a.svc.cluster.local:4000")
+  SUBGRAPH_B @join__graph(name: "subgraph-b", url: "http://localhost:4002")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query {
+  me: String
+}


### PR DESCRIPTION
To get a better understanding of how many users are still on fed v1, this PR adds a metric.

I put it under the `lifecycle` key, is that appropriate?

The version is inferred based on the version of the join spec that is used, as this is closely tied to the federation version. The federation minor version is not available in a supergraph as far as I know (it could only be inferred based on features that are in use, but that's not reliable if someone doesn't use every feature).

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
