### PR TITLE
reactivate the macos x86_64 builder

### DIFF
--- a/.changesets/fix_geal_osx_x86.md
+++ b/.changesets/fix_geal_osx_x86.md
@@ -1,0 +1,5 @@
+### reactivate the OSX Intel builder ([PR #4723](https://github.com/apollographql/router/pull/4723))
+
+Cross compiling the router from ARM to x86 encounters issues with deno snapshots, so for now we will reactivate x86 builds for OSX on CircleCI
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4723

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ executors:
       # We use the major.minor notation to bring in compatible patches.
       xcode: 14.2
     resource_class: macos.m1.medium.gen1
-  amd_macos_build: &amd_macos_build_executor
+  intel_macos_build: &intel_macos_build_executor
     macos:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
@@ -166,7 +166,6 @@ commands:
       - when:
           condition:
             or:
-              - equal: [ *amd_macos_build_executor, << parameters.platform >> ]
               - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
               - equal: [ *macos_test_executor, << parameters.platform >> ]
           steps:
@@ -178,7 +177,20 @@ commands:
             - run:
                 name: Write arch
                 command: |
-                  echo 'osx' >> ~/.arch
+                  echo 'osx-aarch64' >> ~/.arch
+      - when:
+          condition:
+            equal: [ *intel_macos_build_executor, << parameters.platform >> ]
+          steps:
+            - run:
+                name: Make link to md5
+                command: |
+                  mkdir -p ~/.local/aliases
+                  ln -s /sbin/md5 ~/.local/aliases/md5sum
+            - run:
+                name: Write arch
+                command: |
+                  echo 'osx-x86' >> ~/.arch
       - when:
           condition:
             or:
@@ -251,7 +263,7 @@ commands:
       - when:
           condition:
             or:
-              - equal: [ *amd_macos_build_executor, << parameters.platform >> ]
+              - equal: [ *intel_macos_build_executor, << parameters.platform >> ]
               - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
               - equal: [ *macos_test_executor, << parameters.platform >> ]
           steps:
@@ -293,7 +305,7 @@ commands:
       - when:
           condition:
             or:
-              - equal: [ *amd_macos_build_executor, << parameters.platform >> ]
+              - equal: [ *intel_macos_build_executor, << parameters.platform >> ]
               - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
               - equal: [ *macos_test_executor, << parameters.platform >> ]
           steps:
@@ -595,7 +607,7 @@ jobs:
       - when:
           condition:
             or:
-              - equal: [ *amd_macos_build_executor, << parameters.platform >> ]
+              - equal: [ *intel_macos_build_executor, << parameters.platform >> ]
               - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
 
           steps:
@@ -945,7 +957,7 @@ workflows:
           matrix:
             parameters:
               platform:
-                [ amd_macos_build, arm_macos_build, windows_build, amd_linux_build, arm_linux_build ]
+                [ intel_macos_build, arm_macos_build, windows_build, amd_linux_build, arm_linux_build ]
       - secops/wiz-docker:
           context:
             - platform-docker-ro
@@ -1042,7 +1054,7 @@ workflows:
           matrix:
             parameters:
               platform:
-                [ amd_macos_build, arm_macos_build, windows_build, amd_linux_build, arm_linux_build ]
+                [ intel_macos_build, arm_macos_build, windows_build, amd_linux_build, arm_linux_build ]
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -945,7 +945,7 @@ workflows:
           matrix:
             parameters:
               platform:
-                [ macos_build, windows_build, amd_linux_build, arm_linux_build ]
+                [ amd_macos_build, arm_macos_build, windows_build, amd_linux_build, arm_linux_build ]
       - secops/wiz-docker:
           context:
             - platform-docker-ro
@@ -1042,7 +1042,7 @@ workflows:
           matrix:
             parameters:
               platform:
-                [ macos_build, windows_build, amd_linux_build, arm_linux_build ]
+                [ amd_macos_build, arm_macos_build, windows_build, amd_linux_build, arm_linux_build ]
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,13 +42,20 @@ executors:
     environment:
       CARGO_BUILD_JOBS: 8
       RUST_TEST_THREADS: 8
-  macos_build: &macos_build_executor
+ arm_macos_build: &arm_macos_build_executor
     macos:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
       # We use the major.minor notation to bring in compatible patches.
       xcode: 14.2
     resource_class: macos.m1.medium.gen1
+  amd_macos_build: &amd_macos_build_executor
+    macos:
+      # See https://circleci.com/docs/xcode-policy along with the support matrix
+      # at https://circleci.com/docs/using-macos#supported-xcode-versions.
+      # We use the major.minor notation to bring in compatible patches.
+      xcode: 14.2
+    resource_class: macos.x86.medium.gen2
   macos_test: &macos_test_executor
     macos:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
@@ -159,7 +166,8 @@ commands:
       - when:
           condition:
             or:
-              - equal: [ *macos_build_executor, << parameters.platform >> ]
+              - equal: [ *amd_acos_build_executor, << parameters.platform >> ]
+              - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
               - equal: [ *macos_test_executor, << parameters.platform >> ]
           steps:
             - run:
@@ -243,7 +251,8 @@ commands:
       - when:
           condition:
             or:
-              - equal: [ *macos_build_executor, << parameters.platform >> ]
+              - equal: [ *amd_macos_build_executor, << parameters.platform >> ]
+              - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
               - equal: [ *macos_test_executor, << parameters.platform >> ]
           steps:
             - run:
@@ -284,7 +293,8 @@ commands:
       - when:
           condition:
             or:
-              - equal: [ *macos_build_executor, << parameters.platform >> ]
+              - equal: [ *amd_macos_build_executor, << parameters.platform >> ]
+              - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
               - equal: [ *macos_test_executor, << parameters.platform >> ]
           steps:
             - run:
@@ -333,15 +343,6 @@ commands:
                 name: Special case for Windows because of ssh-agent
                 command: |
                   printf "[net]\ngit-fetch-with-cli = true" >> ~/.cargo/Cargo.toml
-      - when:
-          condition:
-            or:
-              - equal: [ *macos_build_executor, << parameters.platform >> ]
-          steps:
-            - run:
-                name: Special case for OSX x86_64 builds
-                command: |
-                  rustup target add x86_64-apple-darwin
 
   install_extra_tools:
     steps:
@@ -602,28 +603,13 @@ jobs:
                   - run: cargo xtask release prepare nightly
             - run:
                 command: >
-                  cargo xtask dist --target aarch64-apple-darwin
-            - run:
-                command: >
-                  cargo xtask dist --target x86_64-apple-darwin
+                  cargo xtask dist
             - run:
                 command: >
                   mkdir -p artifacts
             - run:
                 command: >
                   cargo xtask package
-                  --target aarch64-apple-darwin
-                  --apple-team-id ${APPLE_TEAM_ID}
-                  --apple-username ${APPLE_USERNAME}
-                  --cert-bundle-base64 ${MACOS_CERT_BUNDLE_BASE64}
-                  --cert-bundle-password ${MACOS_CERT_BUNDLE_PASSWORD}
-                  --keychain-password ${MACOS_KEYCHAIN_PASSWORD}
-                  --notarization-password ${MACOS_NOTARIZATION_PASSWORD}
-                  --output artifacts/
-            - run:
-                command: >
-                  cargo xtask package
-                  --target x86_64-apple-darwin
                   --apple-team-id ${APPLE_TEAM_ID}
                   --apple-username ${APPLE_USERNAME}
                   --cert-bundle-base64 ${MACOS_CERT_BUNDLE_BASE64}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -594,7 +594,10 @@ jobs:
           platform: << parameters.platform >>
       - when:
           condition:
-            equal: [ *macos_build_executor, << parameters.platform >> ]
+            or:
+              - equal: [ *amd_macos_build_executor, << parameters.platform >> ]
+              - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
+
           steps:
             - when:
                 condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ executors:
     environment:
       CARGO_BUILD_JOBS: 8
       RUST_TEST_THREADS: 8
- arm_macos_build: &arm_macos_build_executor
+  arm_macos_build: &arm_macos_build_executor
     macos:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,7 +166,7 @@ commands:
       - when:
           condition:
             or:
-              - equal: [ *amd_acos_build_executor, << parameters.platform >> ]
+              - equal: [ *amd_macos_build_executor, << parameters.platform >> ]
               - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
               - equal: [ *macos_test_executor, << parameters.platform >> ]
           steps:


### PR DESCRIPTION
Cross compiling the router from ARM to x86 encounters issues with deno snapshots, so for now we will reactivate x86 builds for macos on CircleCI

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
