### PR TITLE
Change the new federation version metric to a gauge

### DIFF
--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -8,6 +8,9 @@ use std::time::Instant;
 
 use apollo_compiler::ast;
 use futures::future::BoxFuture;
+use opentelemetry_api::metrics::MeterProvider as _;
+use opentelemetry_api::metrics::ObservableGauge;
+use opentelemetry_api::KeyValue;
 use router_bridge::planner::IncrementalDeliverySupport;
 use router_bridge::planner::PlanOptions;
 use router_bridge::planner::PlanSuccess;
@@ -30,6 +33,7 @@ use crate::graphql;
 use crate::introspection::Introspection;
 use crate::json_ext::Object;
 use crate::json_ext::Path;
+use crate::metrics::meter_provider;
 use crate::plugins::authorization::AuthorizationPlugin;
 use crate::plugins::authorization::CacheKeyMetadata;
 use crate::plugins::authorization::UnauthorizedPaths;
@@ -62,6 +66,23 @@ pub(crate) struct BridgeQueryPlanner {
     introspection: Option<Arc<Introspection>>,
     configuration: Arc<Configuration>,
     enable_authorization_directives: bool,
+    _federation_instrument: ObservableGauge<u64>,
+}
+
+fn federation_version_instrument(federation_version: Option<i64>) -> ObservableGauge<u64> {
+    meter_provider()
+        .meter("apollo/router")
+        .u64_observable_gauge("apollo.router.supergraph.federation")
+        .with_callback(move |observer| {
+            observer.observe(
+                1,
+                &[KeyValue::new(
+                    "federation.version",
+                    federation_version.unwrap_or(0),
+                )],
+            );
+        })
+        .init()
 }
 
 impl BridgeQueryPlanner {
@@ -70,14 +91,6 @@ impl BridgeQueryPlanner {
         configuration: Arc<Configuration>,
     ) -> Result<Self, ServiceBuildError> {
         let schema = Schema::parse(&sdl, &configuration)?;
-
-        let federation_version = schema.federation_version().unwrap_or(0);
-        u64_counter!(
-            "apollo.router.lifecycle.federation_version",
-            "The federation major version inferred from the supergraph schema",
-            1,
-            "version" = federation_version
-        );
 
         let planner = Planner::new(
             sdl,
@@ -238,12 +251,14 @@ impl BridgeQueryPlanner {
 
         let enable_authorization_directives =
             AuthorizationPlugin::enable_directives(&configuration, &schema)?;
+        let federation_instrument = federation_version_instrument(schema.federation_version());
         Ok(Self {
             planner,
             schema,
             introspection,
             enable_authorization_directives,
             configuration,
+            _federation_instrument: federation_instrument,
         })
     }
 
@@ -294,12 +309,14 @@ impl BridgeQueryPlanner {
 
         let enable_authorization_directives =
             AuthorizationPlugin::enable_directives(&configuration, &schema)?;
+        let federation_instrument = federation_version_instrument(schema.federation_version());
         Ok(Self {
             planner,
             schema,
             introspection,
             enable_authorization_directives,
             configuration,
+            _federation_instrument: federation_instrument,
         })
     }
 

--- a/apollo-router/src/testdata/minimal_fed2_supergraph.graphql
+++ b/apollo-router/src/testdata/minimal_fed2_supergraph.graphql
@@ -23,7 +23,6 @@ scalar join__FieldSet
 
 enum join__Graph {
   SUBGRAPH_A @join__graph(name: "subgraph-a", url: "http://graphql.subgraph-a.svc.cluster.local:4000")
-  SUBGRAPH_B @join__graph(name: "subgraph-b", url: "http://localhost:4002")
 }
 
 scalar link__Import
@@ -40,6 +39,6 @@ enum link__Purpose {
   EXECUTION
 }
 
-type Query {
-  me: String
+type Query @join__type(graph: SUBGRAPH_A) {
+  me: String @join__field(graph: SUBGRAPH_A)
 }

--- a/apollo-router/tests/telemetry/metrics.rs
+++ b/apollo-router/tests/telemetry/metrics.rs
@@ -68,23 +68,6 @@ async fn test_metrics_reloading() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_metrics_fed_version() {
-    let mut router = IntegrationTest::builder()
-        .config(PROMETHEUS_CONFIG)
-        .build()
-        .await;
-
-    router.start().await;
-    router.assert_started().await;
-    // Make sure the planner is initialized
-    router.execute_default_query().await;
-
-    router
-        .assert_metrics_contains(r#"apollo_router_supergraph_federation{federation_version="1",otel_scope_name="apollo/router"} 1"#, None)
-        .await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_subgraph_auth_metrics() {
     let mut router = IntegrationTest::builder()
         .config(SUBGRAPH_AUTH_CONFIG)

--- a/apollo-router/tests/telemetry/metrics.rs
+++ b/apollo-router/tests/telemetry/metrics.rs
@@ -40,6 +40,10 @@ async fn test_metrics_reloading() {
         router.assert_reloaded().await;
     }
 
+    router
+        .assert_metrics_contains(r#"apollo_router_supergraph_federation{federation_version="1",otel_scope_name="apollo/router"} 1"#, None)
+        .await;
+
     router.assert_metrics_contains(r#"apollo_router_cache_hit_count_total{kind="query planner",storage="memory",otel_scope_name="apollo/router"} 4"#, None).await;
     router.assert_metrics_contains(r#"apollo_router_cache_miss_count_total{kind="query planner",storage="memory",otel_scope_name="apollo/router"} 2"#, None).await;
     router.assert_metrics_contains(r#"apollo_router_http_request_duration_seconds_bucket{status="200",otel_scope_name="apollo/router",le="100"}"#, None).await;


### PR DESCRIPTION
Follow-up to #4713.

Per discussion with @BrynCooke this changes the new metric to a gauge, named `apollo.router.supergraph.federation`.

Also adds a basic test for it.
