### PR TITLE
Modify fmt_layer on_event() processing to help macOS

### DIFF
--- a/apollo-router/src/plugins/telemetry/fmt_layer.rs
+++ b/apollo-router/src/plugins/telemetry/fmt_layer.rs
@@ -1,10 +1,10 @@
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io::IsTerminal;
 use std::io::Write;
 use std::marker::PhantomData;
 
-use bytes::BytesMut;
 use opentelemetry::Key;
 use opentelemetry::KeyValue;
 use tracing::field;
@@ -30,8 +30,6 @@ use crate::plugins::telemetry::formatters::text::Text;
 use crate::plugins::telemetry::formatters::FilteringFormatter;
 use crate::plugins::telemetry::reload::LayeredTracer;
 use crate::plugins::telemetry::resource::ConfigResource;
-
-const WRITER_BUF_SIZE: usize = 8_192;
 
 pub(crate) fn create_fmt_layer(
     config: &config::Conf,
@@ -164,58 +162,65 @@ where
     }
 
     fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
-        let mut buf = BytesMut::with_capacity(WRITER_BUF_SIZE);
-
-        match self.fmt_event.format_event(&ctx, &mut buf, event) {
-            Ok(()) => {
-                let mut writer = self.make_writer.make_writer();
-                let limit = buf.len();
-                let mut index = 0;
-                let mut carry_on = true;
-                while index < limit {
-                    // NOTE: Do not raise this limit about 1_024 for macOS without testing it works
-                    // correctly. This figure was determined experimentally by observing pauses in
-                    // logging during startup. If the figure goes above 1_024, you will get a 5s
-                    // pause during logging at startup on macOS. This may change in the future or
-                    // depending on your version of macOS, so we'll need to verify it a couple of
-                    // times a year to see if anything has changed.
-                    #[cfg(target_os = "macos")]
-                    let upper = index + std::cmp::min(limit - index, 1_024);
-                    #[cfg(not(target_os = "macos"))]
-                    let upper = index + std::cmp::min(limit - index, WRITER_BUF_SIZE);
-
-                    match writer.write(&buf[index..upper]) {
-                        Ok(written) => {
-                            carry_on = true;
-                            index += written;
-                        }
-                        Err(err) => {
-                            if !carry_on || err.kind() == std::io::ErrorKind::BrokenPipe {
-                                break;
-                            }
-                            if err.kind() != std::io::ErrorKind::WouldBlock {
-                                carry_on = false;
-                                let _ = std::io::stderr()
-                                    .write_all(format!("error during write: {err:?}\n").as_bytes());
-                                let _ = std::io::stderr().flush();
-                            }
-                        }
-                    }
-                }
-                if let Err(err) = writer.flush() {
-                    if err.kind() != std::io::ErrorKind::WouldBlock {
-                        let _ = std::io::stderr()
-                            .write_all(format!("error during flush: {err:?}\n").as_bytes());
-                        let _ = std::io::stderr().flush();
-                    }
-                }
-            }
-            Err(err) => {
-                let _ = std::io::stderr()
-                    .write_all(format!("error during format_event: {err:?}\n").as_bytes());
-                let _ = std::io::stderr().flush();
-            }
+        thread_local! {
+            static BUF: RefCell<String> = RefCell::new(String::new());
         }
+
+        BUF.with(|buf| {
+            let mut buf = &mut *(buf.borrow_mut());
+            match self.fmt_event.format_event(&ctx, &mut buf, event) {
+                Ok(()) => {
+                    let mut writer = self.make_writer.make_writer();
+                    let limit = buf.len();
+                    let mut index = 0;
+                    let mut carry_on = true;
+                    while index < limit {
+                        // NOTE: Do not raise this limit about 1_024 for macOS without testing it works
+                        // correctly. This figure was determined experimentally by observing pauses in
+                        // logging during startup. If the figure goes above 1_024, you will get a 5s
+                        // pause during logging at startup on macOS. This may change in the future or
+                        // depending on your version of macOS, so we'll need to verify it a couple of
+                        // times a year to see if anything has changed.
+                        #[cfg(target_os = "macos")]
+                        let upper = index + std::cmp::min(limit - index, 1_024);
+                        #[cfg(not(target_os = "macos"))]
+                        let upper = limit;
+
+                        match writer.write(&buf.as_bytes()[index..upper]) {
+                            Ok(written) => {
+                                carry_on = true;
+                                index += written;
+                            }
+                            Err(err) => {
+                                if !carry_on || err.kind() == std::io::ErrorKind::BrokenPipe {
+                                    break;
+                                }
+                                if err.kind() != std::io::ErrorKind::WouldBlock {
+                                    carry_on = false;
+                                    let _ = std::io::stderr().write_all(
+                                        format!("error during write: {err:?}\n").as_bytes(),
+                                    );
+                                    let _ = std::io::stderr().flush();
+                                }
+                            }
+                        }
+                    }
+                    if let Err(err) = writer.flush() {
+                        if err.kind() != std::io::ErrorKind::WouldBlock {
+                            let _ = std::io::stderr()
+                                .write_all(format!("error during flush: {err:?}\n").as_bytes());
+                            let _ = std::io::stderr().flush();
+                        }
+                    }
+                }
+                Err(err) => {
+                    let _ = std::io::stderr()
+                        .write_all(format!("error during format_event: {err:?}\n").as_bytes());
+                    let _ = std::io::stderr().flush();
+                }
+            }
+            buf.clear();
+        });
     }
 }
 

--- a/apollo-router/src/plugins/telemetry/fmt_layer.rs
+++ b/apollo-router/src/plugins/telemetry/fmt_layer.rs
@@ -175,12 +175,14 @@ where
                     let mut index = 0;
                     let mut carry_on = true;
                     while index < limit {
-                        // NOTE: Do not raise this limit about 1_024 for macOS without testing it works
-                        // correctly. This figure was determined experimentally by observing pauses in
-                        // logging during startup. If the figure goes above 1_024, you will get a 5s
-                        // pause during logging at startup on macOS. This may change in the future or
-                        // depending on your version of macOS, so we'll need to verify it a couple of
-                        // times a year to see if anything has changed.
+                        // NOTE: Now that the router is using non-blocking IO for logging, you must
+                        // not raise upper above 1_024 for macOS without testing it works correctly.
+                        // This figure was determined experimentally by observing pauses in logging
+                        // during startup. If the figure goes above 1_024, you will get a 5s pause
+                        // during logging at startup on macOS.
+                        // This may change in the future or depending on your version of macOS, so
+                        // we'll need to verify it a couple of times a year to see if anything has
+                        // changed.
                         #[cfg(target_os = "macos")]
                         let upper = index + std::cmp::min(limit - index, 1_024);
                         #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
Empirically determine that it's not a good idea to try to write more than 1_024 bytes to a non-blocking fd on macOS.

Modify the on_event() processing to take account of this.

