### PR TITLE
Prioritize errors in response

### DIFF
--- a/.changesets/fix_nc_prioritize_errors_in_response.md
+++ b/.changesets/fix_nc_prioritize_errors_in_response.md
@@ -1,0 +1,7 @@
+### Prioritize errors in GraphQL response ([Issue #4375](https://github.com/apollographql/router/issues/4375))
+
+Previously, the router would return data from an operation before any potential errors in the request.
+[As recommended in the GraphQL spec](https://spec.graphql.org/draft/#note-6f005), the suggested route
+is to try to return errors first before data in the response. The router now does so.
+
+By [@nicholascioli](https://github.com/nicholascioli) in https://github.com/apollographql/router/pull/4728

--- a/apollo-router/src/axum_factory/snapshots/apollo_router__axum_factory__tests__defer_is_not_buffered.snap
+++ b/apollo-router/src/axum_factory/snapshots/apollo_router__axum_factory__tests__defer_is_not_buffered.snap
@@ -4,6 +4,14 @@ expression: parts
 ---
 [
   {
+    "errors": [
+      {
+        "message": "couldn't find mock for query {\"query\":\"query TopProducts__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on Product{reviews{__typename id product{__typename upc}}}}}\",\"operationName\":\"TopProducts__reviews__1\",\"variables\":{\"representations\":[{\"__typename\":\"Product\",\"upc\":\"1\"},{\"__typename\":\"Product\",\"upc\":\"2\"}]}}",
+        "extensions": {
+          "code": "FETCH_ERROR"
+        }
+      }
+    ],
     "data": {
       "topProducts": [
         {
@@ -18,14 +26,6 @@ expression: parts
         }
       ]
     },
-    "errors": [
-      {
-        "message": "couldn't find mock for query {\"query\":\"query TopProducts__reviews__1($representations:[_Any!]!){_entities(representations:$representations){...on Product{reviews{__typename id product{__typename upc}}}}}\",\"operationName\":\"TopProducts__reviews__1\",\"variables\":{\"representations\":[{\"__typename\":\"Product\",\"upc\":\"1\"},{\"__typename\":\"Product\",\"upc\":\"2\"}]}}",
-        "extensions": {
-          "code": "FETCH_ERROR"
-        }
-      }
-    ],
     "hasNext": true
   },
   {

--- a/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__authenticated__tests__unauthenticated_request.snap
+++ b/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__authenticated__tests__unauthenticated_request.snap
@@ -3,16 +3,6 @@ source: apollo-router/src/plugins/authorization/authenticated.rs
 expression: response
 ---
 {
-  "data": {
-    "orga": {
-      "id": 1,
-      "creatorUser": {
-        "id": 0,
-        "name": "Ada",
-        "phone": null
-      }
-    }
-  },
   "errors": [
     {
       "message": "Unauthorized field or type",
@@ -25,5 +15,15 @@ expression: response
         "code": "UNAUTHORIZED_FIELD_OR_TYPE"
       }
     }
-  ]
+  ],
+  "data": {
+    "orga": {
+      "id": 1,
+      "creatorUser": {
+        "id": 0,
+        "name": "Ada",
+        "phone": null
+      }
+    }
+  }
 }

--- a/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__authenticated_directive.snap
+++ b/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__authenticated_directive.snap
@@ -3,16 +3,6 @@ source: apollo-router/src/plugins/authorization/tests.rs
 expression: response
 ---
 {
-  "data": {
-    "orga": {
-      "id": null,
-      "creatorUser": {
-        "id": 0,
-        "name": "Ada",
-        "phone": null
-      }
-    }
-  },
   "errors": [
     {
       "message": "Unauthorized field or type",
@@ -35,5 +25,15 @@ expression: response
         "code": "UNAUTHORIZED_FIELD_OR_TYPE"
       }
     }
-  ]
+  ],
+  "data": {
+    "orga": {
+      "id": null,
+      "creatorUser": {
+        "id": 0,
+        "name": "Ada",
+        "phone": null
+      }
+    }
+  }
 }

--- a/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__authenticated_directive_dry_run.snap
+++ b/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__authenticated_directive_dry_run.snap
@@ -3,16 +3,6 @@ source: apollo-router/src/plugins/authorization/tests.rs
 expression: response
 ---
 {
-  "data": {
-    "orga": {
-      "id": 1,
-      "creatorUser": {
-        "id": 0,
-        "name": "Ada",
-        "phone": "1234"
-      }
-    }
-  },
   "errors": [
     {
       "message": "Unauthorized field or type",
@@ -35,5 +25,15 @@ expression: response
         "code": "UNAUTHORIZED_FIELD_OR_TYPE"
       }
     }
-  ]
+  ],
+  "data": {
+    "orga": {
+      "id": 1,
+      "creatorUser": {
+        "id": 0,
+        "name": "Ada",
+        "phone": "1234"
+      }
+    }
+  }
 }

--- a/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__authenticated_directive_reject_unauthorized.snap
+++ b/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__authenticated_directive_reject_unauthorized.snap
@@ -3,7 +3,6 @@ source: apollo-router/src/plugins/authorization/tests.rs
 expression: response
 ---
 {
-  "data": {},
   "errors": [
     {
       "message": "Unauthorized field or type",
@@ -26,5 +25,6 @@ expression: response
         "code": "UNAUTHORIZED_FIELD_OR_TYPE"
       }
     }
-  ]
+  ],
+  "data": {}
 }

--- a/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__scopes_directive-2.snap
+++ b/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__scopes_directive-2.snap
@@ -3,16 +3,6 @@ source: apollo-router/src/plugins/authorization/tests.rs
 expression: response
 ---
 {
-  "data": {
-    "orga": {
-      "id": 1,
-      "creatorUser": {
-        "id": 0,
-        "name": "Ada",
-        "phone": null
-      }
-    }
-  },
   "errors": [
     {
       "message": "Unauthorized field or type",
@@ -25,5 +15,15 @@ expression: response
         "code": "UNAUTHORIZED_FIELD_OR_TYPE"
       }
     }
-  ]
+  ],
+  "data": {
+    "orga": {
+      "id": 1,
+      "creatorUser": {
+        "id": 0,
+        "name": "Ada",
+        "phone": null
+      }
+    }
+  }
 }

--- a/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__scopes_directive-4.snap
+++ b/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__scopes_directive-4.snap
@@ -3,16 +3,6 @@ source: apollo-router/src/plugins/authorization/tests.rs
 expression: response
 ---
 {
-  "data": {
-    "orga": {
-      "id": 1,
-      "creatorUser": {
-        "id": 0,
-        "name": "Ada",
-        "phone": null
-      }
-    }
-  },
   "errors": [
     {
       "message": "Unauthorized field or type",
@@ -25,5 +15,15 @@ expression: response
         "code": "UNAUTHORIZED_FIELD_OR_TYPE"
       }
     }
-  ]
+  ],
+  "data": {
+    "orga": {
+      "id": 1,
+      "creatorUser": {
+        "id": 0,
+        "name": "Ada",
+        "phone": null
+      }
+    }
+  }
 }

--- a/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__scopes_directive.snap
+++ b/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__scopes_directive.snap
@@ -3,12 +3,6 @@ source: apollo-router/src/plugins/authorization/tests.rs
 expression: response
 ---
 {
-  "data": {
-    "orga": {
-      "id": 1,
-      "creatorUser": null
-    }
-  },
   "errors": [
     {
       "message": "Unauthorized field or type",
@@ -20,5 +14,11 @@ expression: response
         "code": "UNAUTHORIZED_FIELD_OR_TYPE"
       }
     }
-  ]
+  ],
+  "data": {
+    "orga": {
+      "id": 1,
+      "creatorUser": null
+    }
+  }
 }

--- a/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__scopes_directive_dry_run.snap
+++ b/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__scopes_directive_dry_run.snap
@@ -3,16 +3,6 @@ source: apollo-router/src/plugins/authorization/tests.rs
 expression: response
 ---
 {
-  "data": {
-    "orga": {
-      "id": 1,
-      "creatorUser": {
-        "id": 0,
-        "name": "Ada",
-        "phone": "1234"
-      }
-    }
-  },
   "errors": [
     {
       "message": "Unauthorized field or type",
@@ -35,5 +25,15 @@ expression: response
         "code": "UNAUTHORIZED_FIELD_OR_TYPE"
       }
     }
-  ]
+  ],
+  "data": {
+    "orga": {
+      "id": 1,
+      "creatorUser": {
+        "id": 0,
+        "name": "Ada",
+        "phone": "1234"
+      }
+    }
+  }
 }

--- a/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__scopes_directive_reject_unauthorized.snap
+++ b/apollo-router/src/plugins/authorization/snapshots/apollo_router__plugins__authorization__tests__scopes_directive_reject_unauthorized.snap
@@ -3,7 +3,6 @@ source: apollo-router/src/plugins/authorization/tests.rs
 expression: response
 ---
 {
-  "data": {},
   "errors": [
     {
       "message": "Unauthorized field or type",
@@ -15,5 +14,6 @@ expression: response
         "code": "UNAUTHORIZED_FIELD_OR_TYPE"
       }
     }
-  ]
+  ],
+  "data": {}
 }

--- a/apollo-router/src/plugins/include_subgraph_errors.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors.rs
@@ -102,19 +102,19 @@ mod test {
     use crate::Configuration;
 
     static UNREDACTED_PRODUCT_RESPONSE: Lazy<Bytes> = Lazy::new(|| {
-        Bytes::from_static(r#"{"data":{"topProducts":null},"errors":[{"message":"couldn't find mock for query {\"query\":\"query ErrorTopProducts__products__0($first:Int){topProducts(first:$first){__typename upc name}}\",\"operationName\":\"ErrorTopProducts__products__0\",\"variables\":{\"first\":2}}","extensions":{"test":"value","code":"FETCH_ERROR"}}]}"#.as_bytes())
+        Bytes::from_static(r#"{"errors":[{"message":"couldn't find mock for query {\"query\":\"query ErrorTopProducts__products__0($first:Int){topProducts(first:$first){__typename upc name}}\",\"operationName\":\"ErrorTopProducts__products__0\",\"variables\":{\"first\":2}}","extensions":{"test":"value","code":"FETCH_ERROR"}}],"data":{"topProducts":null}}"#.as_bytes())
     });
 
     static REDACTED_PRODUCT_RESPONSE: Lazy<Bytes> = Lazy::new(|| {
         Bytes::from_static(
-            r#"{"data":{"topProducts":null},"errors":[{"message":"Subgraph errors redacted"}]}"#
+            r#"{"errors":[{"message":"Subgraph errors redacted"}],"data":{"topProducts":null}}"#
                 .as_bytes(),
         )
     });
 
     static REDACTED_ACCOUNT_RESPONSE: Lazy<Bytes> = Lazy::new(|| {
         Bytes::from_static(
-            r#"{"data":null,"errors":[{"message":"Subgraph errors redacted"}]}"#.as_bytes(),
+            r#"{"errors":[{"message":"Subgraph errors redacted"}],"data":null}"#.as_bytes(),
         )
     });
 

--- a/apollo-router/src/plugins/telemetry/logging/snapshots/apollo_router__plugins__telemetry__logging__test__when_header@logs.snap
+++ b/apollo-router/src/plugins/telemetry/logging/snapshots/apollo_router__plugins__telemetry__logging__test__when_header@logs.snap
@@ -42,7 +42,6 @@ expression: yaml
       name: supergraph
       otel.kind: INTERNAL
 - fields:
-    http.response.body: "Response { label: None, data: Some(Object({\"data\": String(\"res\")})), path: None, errors: [], extensions: {}, has_next: None, subscribed: None, created_at: None, incremental: [] }"
+    http.response.body: "Response { label: None, errors: [], data: Some(Object({\"data\": String(\"res\")})), path: None, extensions: {}, has_next: None, subscribed: None, created_at: None, incremental: [] }"
   level: INFO
   message: Supergraph GraphQL response
-

--- a/apollo-router/src/services/router/snapshots/apollo_router__services__router__tests__escaped_quotes_in_string_literal.snap
+++ b/apollo-router/src/services/router/snapshots/apollo_router__services__router__tests__escaped_quotes_in_string_literal.snap
@@ -5,6 +5,7 @@ expression: "(graphql_response, &subgraph_query_log)"
 (
     Response {
         label: None,
+        errors: [],
         data: Some(
             Object({
                 "topProducts": Array([
@@ -24,7 +25,6 @@ expression: "(graphql_response, &subgraph_query_log)"
             }),
         ),
         path: None,
-        errors: [],
         extensions: {},
         has_next: None,
         subscribed: None,

--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__errors_on_nullified_paths.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__errors_on_nullified_paths.snap
@@ -1,17 +1,8 @@
 ---
-source: apollo-router/src/services/supergraph_service.rs
+source: apollo-router/src/services/supergraph/tests.rs
 expression: stream.next_response().await.unwrap()
 ---
 {
-  "data": {
-    "foo": {
-      "id": 1,
-      "bar": {
-        "id": 2,
-        "something": null
-      }
-    }
-  },
   "errors": [
     {
       "message": "Could not fetch bar",
@@ -23,5 +14,14 @@ expression: stream.next_response().await.unwrap()
         "code": "NOT_FOUND"
       }
     }
-  ]
+  ],
+  "data": {
+    "foo": {
+      "id": 1,
+      "bar": {
+        "id": 2,
+        "something": null
+      }
+    }
+  }
 }

--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__missing_entities.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__missing_entities.snap
@@ -1,8 +1,13 @@
 ---
-source: apollo-router/src/services/supergraph_service.rs
+source: apollo-router/src/services/supergraph/tests.rs
 expression: stream.next_response().await.unwrap()
 ---
 {
+  "errors": [
+    {
+      "message": "error"
+    }
+  ],
   "data": {
     "currentUser": {
       "id": "0",
@@ -11,10 +16,5 @@ expression: stream.next_response().await.unwrap()
         "name": null
       }
     }
-  },
-  "errors": [
-    {
-      "message": "error"
-    }
-  ]
+  }
 }

--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_callback_schema_reload-3.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_callback_schema_reload-3.snap
@@ -1,9 +1,8 @@
 ---
-source: apollo-router/src/services/supergraph_service.rs
-expression: stream.next_response().await.unwrap()
+source: apollo-router/src/services/supergraph/tests.rs
+expression: "tokio::time::timeout(Duration::from_secs(1),\n                stream.next_response()).await.unwrap().unwrap()"
 ---
 {
-  "data": null,
   "errors": [
     {
       "message": "subscription has been closed due to a schema reload",
@@ -11,5 +10,6 @@ expression: stream.next_response().await.unwrap()
         "code": "SUBSCRIPTION_SCHEMA_RELOAD"
       }
     }
-  ]
+  ],
+  "data": null
 }

--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_with_callback-3.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_with_callback-3.snap
@@ -1,11 +1,8 @@
 ---
-source: apollo-router/src/services/supergraph_service.rs
+source: apollo-router/src/services/supergraph/tests.rs
 expression: stream.next_response().await.unwrap()
 ---
 {
-  "data": {
-    "userWasCreated": null
-  },
   "errors": [
     {
       "message": "cannot fetch the name",
@@ -13,5 +10,8 @@ expression: stream.next_response().await.unwrap()
         "code": "INVALID"
       }
     }
-  ]
+  ],
+  "data": {
+    "userWasCreated": null
+  }
 }

--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_with_callback_with_limit-3.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_with_callback_with_limit-3.snap
@@ -1,11 +1,8 @@
 ---
-source: apollo-router/src/services/supergraph_service.rs
+source: apollo-router/src/services/supergraph/tests.rs
 expression: stream.next_response().await.unwrap()
 ---
 {
-  "data": {
-    "userWasCreated": null
-  },
   "errors": [
     {
       "message": "cannot fetch the name",
@@ -13,5 +10,8 @@ expression: stream.next_response().await.unwrap()
         "code": "INVALID"
       }
     }
-  ]
+  ],
+  "data": {
+    "userWasCreated": null
+  }
 }

--- a/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_with_callback_with_limit-4.snap
+++ b/apollo-router/src/services/supergraph/snapshots/apollo_router__services__supergraph__tests__subscription_with_callback_with_limit-4.snap
@@ -1,9 +1,8 @@
 ---
-source: apollo-router/src/services/supergraph_service.rs
+source: apollo-router/src/services/supergraph/tests.rs
 expression: res
 ---
 {
-  "data": null,
   "errors": [
     {
       "message": "can't open new subscription, limit reached",
@@ -11,5 +10,6 @@ expression: res
         "code": "SUBSCRIPTION_MAX_LIMIT"
       }
     }
-  ]
+  ],
+  "data": null
 }

--- a/apollo-router/tests/integration/file_upload.rs
+++ b/apollo-router/tests/integration/file_upload.rs
@@ -641,13 +641,6 @@ async fn it_fails_invalid_file_order() -> Result<(), BoxError> {
         .run_test(|response| {
             insta::assert_json_snapshot!(response, @r###"
             {
-              "data": {
-                "file0": {
-                  "filename": "file0",
-                  "body": "file0 contents"
-                },
-                "file1": null
-              },
               "errors": [
                 {
                   "message": "HTTP fetch failed from 'uploads2': HTTP fetch failed from 'uploads2': error from user's HttpBody stream: error reading a body from connection: Missing files in the request: '1'.",
@@ -658,7 +651,14 @@ async fn it_fails_invalid_file_order() -> Result<(), BoxError> {
                     "reason": "HTTP fetch failed from 'uploads2': error from user's HttpBody stream: error reading a body from connection: Missing files in the request: '1'."
                   }
                 }
-              ]
+              ],
+              "data": {
+                "file0": {
+                  "filename": "file0",
+                  "body": "file0 contents"
+                },
+                "file1": null
+              }
             }
             "###);
         })

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__redis__test__entity_cache_authorization-2.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__redis__test__entity_cache_authorization-2.snap
@@ -3,6 +3,17 @@ source: apollo-router/tests/integration/redis.rs
 expression: response
 ---
 {
+  "errors": [
+    {
+      "message": "Unauthorized field or type",
+      "path": [
+        "me"
+      ],
+      "extensions": {
+        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
+      }
+    }
+  ],
   "data": {
     "me": null,
     "topProducts": [
@@ -35,16 +46,5 @@ expression: response
         ]
       }
     ]
-  },
-  "errors": [
-    {
-      "message": "Unauthorized field or type",
-      "path": [
-        "me"
-      ],
-      "extensions": {
-        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
-      }
-    }
-  ]
+  }
 }

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__redis__test__entity_cache_authorization-3.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__redis__test__entity_cache_authorization-3.snap
@@ -3,6 +3,18 @@ source: apollo-router/tests/integration/redis.rs
 expression: response
 ---
 {
+  "errors": [
+    {
+      "message": "Unauthorized field or type",
+      "path": [
+        "me",
+        "name"
+      ],
+      "extensions": {
+        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
+      }
+    }
+  ],
   "data": {
     "me": {
       "id": "1",
@@ -38,17 +50,5 @@ expression: response
         ]
       }
     ]
-  },
-  "errors": [
-    {
-      "message": "Unauthorized field or type",
-      "path": [
-        "me",
-        "name"
-      ],
-      "extensions": {
-        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
-      }
-    }
-  ]
+  }
 }

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__redis__test__entity_cache_authorization.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__redis__test__entity_cache_authorization.snap
@@ -3,6 +3,30 @@ source: apollo-router/tests/integration/redis.rs
 expression: response
 ---
 {
+  "errors": [
+    {
+      "message": "Unauthorized field or type",
+      "path": [
+        "me"
+      ],
+      "extensions": {
+        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
+      }
+    },
+    {
+      "message": "Unauthorized field or type",
+      "path": [
+        "topProducts",
+        "@",
+        "reviews",
+        "@",
+        "author"
+      ],
+      "extensions": {
+        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
+      }
+    }
+  ],
   "data": {
     "me": null,
     "topProducts": [
@@ -29,29 +53,5 @@ expression: response
         ]
       }
     ]
-  },
-  "errors": [
-    {
-      "message": "Unauthorized field or type",
-      "path": [
-        "me"
-      ],
-      "extensions": {
-        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
-      }
-    },
-    {
-      "message": "Unauthorized field or type",
-      "path": [
-        "topProducts",
-        "@",
-        "reviews",
-        "@",
-        "author"
-      ],
-      "extensions": {
-        "code": "UNAUTHORIZED_FIELD_OR_TYPE"
-      }
-    }
-  ]
+  }
 }


### PR DESCRIPTION
*Description here*

Previously, the router would always respond with data first, and then show any errors in the request. The GraphQL spec suggests having the errors show up before data, so this commit makes errors output first before data.

As expected, this change updates a LOT of snapshot tests to move the errors up. Care was taken to make sure that the only change was the order of the output, but please double check during review.

Fixes #4375

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [X] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
