### PR TITLE
docs: router HTTP response status codes

### DIFF
--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -33,6 +33,7 @@
         ]
       },
       "Debugging": {
+        "Errors": "/errors",
         "Telemetry": "/configuration/telemetry/overview",
         "Subgraph error inclusion": "/configuration/subgraph-error-inclusion"
       },

--- a/docs/source/errors.mdx
+++ b/docs/source/errors.mdx
@@ -1,7 +1,7 @@
 ---
 title: Errors
 subtitle: Error and status codes returned by the Apollo Router
-description: Error codes and response status codes returned by the Apollo Router
+description: Error codes and HTTP response status codes returned by the Apollo Router
 ---
 
 Learn about error codes and HTTP response status codes returned by the Apollo Router.
@@ -11,14 +11,14 @@ Learn about error codes and HTTP response status codes returned by the Apollo Ro
 <PropertyList kind="errCodes">
 <Property name="400" short="Bad request">
 
-The request failed GraphQL validation or failed to be parsed.
+A request failed GraphQL validation or failed to be parsed.
 
 </Property>
 <Property name="401" short="Unauthorized">
 
 Requests may receive this response in two cases:
 
-- For requests that requires authentication, the client's JWT failed verification.
+- For a client request that requires authentication, the client's JWT failed verification.
 - For a non-client subscription endpoint calling a subscription callback URL, the router couldn't find a matching subscription identifier between its registered subscriptions and a subscription event.
 
 </Property>
@@ -35,7 +35,7 @@ Both mutations and subscriptions must use POST.
 </Property>
 <Property name="406" short="Not acceptable">
 
-A query's HTTP `Accept` header didn't contain any of the router's supported mime-types: 
+A request's HTTP `Accept` header didn't contain any of the router's supported mime-types: 
 - `application/json`
 - `application/graphql-response+json`
 - `multipart/mixed;deferSpec=20220824`

--- a/docs/source/errors.mdx
+++ b/docs/source/errors.mdx
@@ -26,7 +26,7 @@ Used an unallowed HTTP method. Both mutations and subscriptions must use POST.
 </Property>
 <Property name="406" short="Not acceptable">
 
-A query's Accept header doesn't match one of the supported content types: 
+A query's HTTP `Accept` header doesn't contain any of the Router's supported mime-types: 
 - `application/json`
 - `application/graphql-response+json`
 - `multipart/mixed;deferSpec=20220824`

--- a/docs/source/errors.mdx
+++ b/docs/source/errors.mdx
@@ -11,14 +11,15 @@ Learn about error codes and HTTP response status codes returned by the Apollo Ro
 <PropertyList kind="errCodes">
 <Property name="400" short="Bad request">
 
-A request failed GraphQL validation, or a request failed to be parsed.
+The request failed GraphQL validation or failed to be parsed.
 
 </Property>
 <Property name="401" short="Unauthorized">
 
-For a client making a request that requires authentication, a JWT failed to be verified.
+Requests may receive this response in two cases:
 
-For a non-client subscription endpoint calling a subscription callback URL, the router couldn't find a matching subscription identifier between its registered subscriptions and a subscription event.
+- For requests that requires authentication, the client's JWT failed verification.
+- For a non-client subscription endpoint calling a subscription callback URL, the router couldn't find a matching subscription identifier between its registered subscriptions and a subscription event.
 
 </Property>
 <Property name="405" short="Method not allowed">
@@ -48,7 +49,7 @@ Request traffic exceeded configured rate limits. See [client side traffic shapin
 </Property>
 <Property name="500" short="Internal server error">
 
-The router encountered an unexpected issue. Report this [possible bug](https://github.com/apollographql/router/issues/new?assignees=&labels=raised+by+user&projects=&template=bug_report.md&title=) to the router team.
+The router encountered an unexpected issue. [Report](https://github.com/apollographql/router/issues/new?assignees=&labels=raised+by+user&projects=&template=bug_report.md&title=) this possible bug to the router team.
 
 </Property>
 </PropertyList>

--- a/docs/source/errors.mdx
+++ b/docs/source/errors.mdx
@@ -1,0 +1,46 @@
+---
+title: Errors
+subtitle: Error and status codes returned by the Apollo Router
+description: Error codes and response status codes returned by the Apollo Router
+---
+
+Learn about error codes and HTTP response status codes returned by the Apollo Router.
+
+## Status codes
+
+<PropertyList kind="errCodes">
+<Property name="400" short="Bad request">
+
+A problem when validating GraphQL or parsing an HTTP request.
+
+</Property>
+<Property name="401" short="Unauthorized">
+
+Sent an event to a non-existent subscription or used an invalid hash. Returned by either the authorization plugin to clients or the subscription endpoint.
+
+</Property>
+<Property name="405" short="Method not allowed">
+
+Used an unallowed HTTP method. Both mutations and subscriptions must use POST.
+
+</Property>
+<Property name="406" short="Not acceptable">
+
+A query's Accept header doesn't match one of the supported content types: 
+- `application/json`
+- `application/graphql-response+json`
+- `multipart/mixed;deferSpec=20220824`
+- `multipart/mixed;subscriptionSpec=1.0`.
+
+</Property>
+<Property name="429" short="Too many requests">
+
+Exceeded configured rate limits. See [client side traffic shaping](/configuration/traffic-shaping/#client-side-traffic-shaping).
+
+</Property>
+<Property name="500" short="Internal server error">
+
+An unexpected issue. Report this [possible bug](https://github.com/apollographql/router/issues/new?assignees=&labels=raised+by+user&projects=&template=bug_report.md&title=) to the router team.
+
+</Property>
+</PropertyList>

--- a/docs/source/errors.mdx
+++ b/docs/source/errors.mdx
@@ -11,22 +11,30 @@ Learn about error codes and HTTP response status codes returned by the Apollo Ro
 <PropertyList kind="errCodes">
 <Property name="400" short="Bad request">
 
-A problem when validating GraphQL or parsing an HTTP request.
+A request failed GraphQL validation, or a request failed to be parsed.
 
 </Property>
 <Property name="401" short="Unauthorized">
 
-Sent an event to a non-existent subscription or used an invalid hash. Returned by either the authorization plugin to clients or the subscription endpoint.
+For a client making a request that requires authentication, a JWT failed to be verified.
+
+For a non-client subscription endpoint calling a subscription callback URL, the router couldn't find a matching subscription identifier between its registered subscriptions and a subscription event.
 
 </Property>
 <Property name="405" short="Method not allowed">
 
-Used an unallowed HTTP method. Both mutations and subscriptions must use POST.
+A request used an unallowed HTTP method.
+
+<Note> 
+
+Both mutations and subscriptions must use POST.
+
+</Note>
 
 </Property>
 <Property name="406" short="Not acceptable">
 
-A query's HTTP `Accept` header doesn't contain any of the Router's supported mime-types: 
+A query's HTTP `Accept` header didn't contain any of the router's supported mime-types: 
 - `application/json`
 - `application/graphql-response+json`
 - `multipart/mixed;deferSpec=20220824`
@@ -35,12 +43,18 @@ A query's HTTP `Accept` header doesn't contain any of the Router's supported mim
 </Property>
 <Property name="429" short="Too many requests">
 
-Exceeded configured rate limits. See [client side traffic shaping](/configuration/traffic-shaping/#client-side-traffic-shaping).
+Request traffic exceeded configured rate limits. See [client side traffic shaping](/configuration/traffic-shaping/#client-side-traffic-shaping).
 
 </Property>
 <Property name="500" short="Internal server error">
 
-An unexpected issue. Report this [possible bug](https://github.com/apollographql/router/issues/new?assignees=&labels=raised+by+user&projects=&template=bug_report.md&title=) to the router team.
+The router encountered an unexpected issue. Report this [possible bug](https://github.com/apollographql/router/issues/new?assignees=&labels=raised+by+user&projects=&template=bug_report.md&title=) to the router team.
 
 </Property>
 </PropertyList>
+
+<Note>
+
+You can create Rhai scripts that throw custom status codes. See [Terminating client requests](/customizations/rhai-api#terminating-client-requests) to learn more.
+
+</Note>


### PR DESCRIPTION
Document router response status codes in [new errors page](https://deploy-preview-4733--apollo-router-docs.netlify.app/errors)

Resolves https://github.com/apollographql/router/issues/4740 and https://apollographql.atlassian.net/browse/DOC-34