### PR TITLE
update our base linux image to avoid CI brown outs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,14 +30,14 @@ executors:
       RUST_TEST_THREADS: 6
   arm_linux_build: &arm_linux_build_executor
     machine:
-      image: ubuntu-2004:2022.04.1
+      image: ubuntu-2004:2024.01.1
     resource_class: arm.large
     environment:
       CARGO_BUILD_JOBS: 8
       RUST_TEST_THREADS: 8
   arm_linux_test: &arm_linux_test_executor
     machine:
-      image: ubuntu-2004:2022.04.1
+      image: ubuntu-2004:2024.01.1
     resource_class: arm.xlarge
     environment:
       CARGO_BUILD_JOBS: 8


### PR DESCRIPTION
Update our linux images
from: `2004:2022.04.1`
to: `2004:2024.01.1`

Still `ubuntu 20.04` based, but with more recent patches and not subject to brown outs.

