### PR TITLE
Add integration test for non-nullable files

### DIFF
--- a/apollo-router/tests/fixtures/file_upload/schema.graphql
+++ b/apollo-router/tests/fixtures/file_upload/schema.graphql
@@ -82,6 +82,7 @@ type Mutation
   @join__type(graph: UPLOADS_CLONE)
 {
   singleUpload(file: Upload): File @join__field(graph: UPLOADS)
+  singleUploadNonNull(file: Upload!): File! @join__field(graph: UPLOADS)
   singleUploadClone(file: UploadClone): FileClone @join__field(graph: UPLOADS_CLONE)
   multiUpload(files: [Upload!]!): [File!]! @join__field(graph: UPLOADS)
   nestedUpload(nested: NestedUpload): File @join__field(graph: UPLOADS)


### PR DESCRIPTION
Existing integration tests for the file uploads plugin did not test for non-nullable uploads. As this is realistically the more common case, this commit adds a test to ensure that non-nullable files work as expected.

This is necessary since the router does some substitution of the variables for the file upload case which might cause validation issues if not carefully tested.

As is the case in #4754, this commit is rebased off of #4726 as certain tests fail when the output blocks.

Fixes #4708 

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [X] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
