### PR TITLE
release: v1.40.2: security: Apply `limits.http_max_request_bytes` on streaming request body decompression

### DIFF
--- a/.changesets/fix_geal_osx_x86.md
+++ b/.changesets/fix_geal_osx_x86.md
@@ -1,0 +1,5 @@
+### reactivate the OSX Intel builder ([PR #4723](https://github.com/apollographql/router/pull/4723))
+
+Cross compiling the router from ARM to x86 encounters issues with deno snapshots, so for now we will reactivate x86 builds for OSX on CircleCI
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4723

--- a/.changesets/fix_geal_osx_x86.md
+++ b/.changesets/fix_geal_osx_x86.md
@@ -1,5 +1,0 @@
-### reactivate the OSX Intel builder ([PR #4723](https://github.com/apollographql/router/pull/4723))
-
-Cross compiling the router from ARM to x86 encounters issues with deno snapshots, so for now we will reactivate x86 builds for OSX on CircleCI
-
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4723

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,13 +42,20 @@ executors:
     environment:
       CARGO_BUILD_JOBS: 8
       RUST_TEST_THREADS: 8
-  macos_build: &macos_build_executor
+  arm_macos_build: &arm_macos_build_executor
     macos:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
       # We use the major.minor notation to bring in compatible patches.
       xcode: 14.2
     resource_class: macos.m1.medium.gen1
+  intel_macos_build: &intel_macos_build_executor
+    macos:
+      # See https://circleci.com/docs/xcode-policy along with the support matrix
+      # at https://circleci.com/docs/using-macos#supported-xcode-versions.
+      # We use the major.minor notation to bring in compatible patches.
+      xcode: 14.2
+    resource_class: macos.x86.medium.gen2
   macos_test: &macos_test_executor
     macos:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
@@ -159,7 +166,7 @@ commands:
       - when:
           condition:
             or:
-              - equal: [ *macos_build_executor, << parameters.platform >> ]
+              - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
               - equal: [ *macos_test_executor, << parameters.platform >> ]
           steps:
             - run:
@@ -170,7 +177,20 @@ commands:
             - run:
                 name: Write arch
                 command: |
-                  echo 'osx' >> ~/.arch
+                  echo 'osx-aarch64' >> ~/.arch
+      - when:
+          condition:
+            equal: [ *intel_macos_build_executor, << parameters.platform >> ]
+          steps:
+            - run:
+                name: Make link to md5
+                command: |
+                  mkdir -p ~/.local/aliases
+                  ln -s /sbin/md5 ~/.local/aliases/md5sum
+            - run:
+                name: Write arch
+                command: |
+                  echo 'osx-x86' >> ~/.arch
       - when:
           condition:
             or:
@@ -243,7 +263,8 @@ commands:
       - when:
           condition:
             or:
-              - equal: [ *macos_build_executor, << parameters.platform >> ]
+              - equal: [ *intel_macos_build_executor, << parameters.platform >> ]
+              - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
               - equal: [ *macos_test_executor, << parameters.platform >> ]
           steps:
             - run:
@@ -284,7 +305,8 @@ commands:
       - when:
           condition:
             or:
-              - equal: [ *macos_build_executor, << parameters.platform >> ]
+              - equal: [ *intel_macos_build_executor, << parameters.platform >> ]
+              - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
               - equal: [ *macos_test_executor, << parameters.platform >> ]
           steps:
             - run:
@@ -333,15 +355,6 @@ commands:
                 name: Special case for Windows because of ssh-agent
                 command: |
                   printf "[net]\ngit-fetch-with-cli = true" >> ~/.cargo/Cargo.toml
-      - when:
-          condition:
-            or:
-              - equal: [ *macos_build_executor, << parameters.platform >> ]
-          steps:
-            - run:
-                name: Special case for OSX x86_64 builds
-                command: |
-                  rustup target add x86_64-apple-darwin
 
   install_extra_tools:
     steps:
@@ -593,7 +606,10 @@ jobs:
           platform: << parameters.platform >>
       - when:
           condition:
-            equal: [ *macos_build_executor, << parameters.platform >> ]
+            or:
+              - equal: [ *intel_macos_build_executor, << parameters.platform >> ]
+              - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
+
           steps:
             - when:
                 condition:
@@ -602,28 +618,13 @@ jobs:
                   - run: cargo xtask release prepare nightly
             - run:
                 command: >
-                  cargo xtask dist --target aarch64-apple-darwin
-            - run:
-                command: >
-                  cargo xtask dist --target x86_64-apple-darwin
+                  cargo xtask dist
             - run:
                 command: >
                   mkdir -p artifacts
             - run:
                 command: >
                   cargo xtask package
-                  --target aarch64-apple-darwin
-                  --apple-team-id ${APPLE_TEAM_ID}
-                  --apple-username ${APPLE_USERNAME}
-                  --cert-bundle-base64 ${MACOS_CERT_BUNDLE_BASE64}
-                  --cert-bundle-password ${MACOS_CERT_BUNDLE_PASSWORD}
-                  --keychain-password ${MACOS_KEYCHAIN_PASSWORD}
-                  --notarization-password ${MACOS_NOTARIZATION_PASSWORD}
-                  --output artifacts/
-            - run:
-                command: >
-                  cargo xtask package
-                  --target x86_64-apple-darwin
                   --apple-team-id ${APPLE_TEAM_ID}
                   --apple-username ${APPLE_USERNAME}
                   --cert-bundle-base64 ${MACOS_CERT_BUNDLE_BASE64}
@@ -956,7 +957,7 @@ workflows:
           matrix:
             parameters:
               platform:
-                [ macos_build, windows_build, amd_linux_build, arm_linux_build ]
+                [ intel_macos_build, arm_macos_build, windows_build, amd_linux_build, arm_linux_build ]
       - secops/wiz-docker:
           context:
             - platform-docker-ro
@@ -1053,7 +1054,7 @@ workflows:
           matrix:
             parameters:
               platform:
-                [ macos_build, windows_build, amd_linux_build, arm_linux_build ]
+                [ intel_macos_build, arm_macos_build, windows_build, amd_linux_build, arm_linux_build ]
           filters:
             branches:
               ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.
 
 # [1.40.2] - 2024-03-06
 
-> :warn: Note: This release has additional release notes which are still work in progress.
+## 🔒 Security
+
+### Apply `limits.http_max_request_bytes` on streaming request body decompression ([PR #TODO](https://github.com/apollographql/router/pull/TODO))
+
+This release fixes a Denial-of-Service (DoS) type vulnerability which exists in affected versions of the Router according to our [published security advistory](https://github.com/apollographql/router/security/advisories/GHSA-cgqf-3cq5-wvcj).  The fix changes the evaluation of the `limits.http_max_request_bytes` configuration to take place on a stream of bytes, allowing it to be applied to compressed HTTP payloads, prior to decompression.  Previously, the limit was only being applied after the entirety of the compressed payload was decompressed, which could result in significant memory consumption which exceeded configured expectations while compressed payloads were expanded.
 
 ## 🐛 Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.
 
 ## 🔒 Security
 
-### Apply `limits.http_max_request_bytes` on streaming request body decompression ([PR #TODO](https://github.com/apollographql/router/pull/TODO))
+### Apply `limits.http_max_request_bytes` on streaming request body decompression ([PR #4759](https://github.com/apollographql/router/pull/4759))
 
 This release fixes a Denial-of-Service (DoS) type vulnerability which exists in affected versions of the Router according to our [published security advistory](https://github.com/apollographql/router/security/advisories/GHSA-cgqf-3cq5-wvcj).  The fix changes the evaluation of the `limits.http_max_request_bytes` configuration to take place on a stream of bytes, allowing it to be applied to compressed HTTP payloads, prior to decompression.  Previously, the limit was only being applied after the entirety of the compressed payload was decompressed, which could result in significant memory consumption which exceeded configured expectations while compressed payloads were expanded.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 
+# [1.40.2] - 2024-03-06
+
+> :warn: Note: This release has additional release notes which are still work in progress.
+
+## 🐛 Fixes
+
+### Re-activate the macOS Intel builder ([PR #4723](https://github.com/apollographql/router/pull/4723))
+
+We have re-activated macOS Intel (x86) builds in CircleCI, despite their upcoming deprecation, while we take a different approach to solving this and maintaining Intel support for the time-being.   This became necessary since cross-compiling the router from ARM to x86 resulted in issues with V8 snapshots and runtime issues on the macOS Intel binaries produced by those Apple Silicon build machines.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4723
+
 # [1.40.1] - 2024-02-16
 
 ## 🐛 Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4073,9 +4073,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "1.40.2-rc.0"
+version = "1.40.2"
 dependencies = [
  "access-json",
  "anyhow",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "1.40.2-rc.0"
+version = "1.40.2"
 dependencies = [
  "apollo-parser",
  "apollo-router",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-scaffold"
-version = "1.40.2-rc.0"
+version = "1.40.2"
 dependencies = [
  "anyhow",
  "cargo-scaffold",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "1.40.1"
+version = "1.40.2-rc.0"
 dependencies = [
  "access-json",
  "anyhow",
@@ -407,7 +407,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "1.40.1"
+version = "1.40.2-rc.0"
 dependencies = [
  "apollo-parser",
  "apollo-router",
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-scaffold"
-version = "1.40.1"
+version = "1.40.2-rc.0"
 dependencies = [
  "anyhow",
  "cargo-scaffold",

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "1.40.1"
+version = "1.40.2-rc.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "1.40.2-rc.0"
+version = "1.40.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-scaffold"
-version = "1.40.2-rc.0"
+version = "1.40.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-scaffold"
-version = "1.40.1"
+version = "1.40.2-rc.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -22,7 +22,7 @@ apollo-router = { path ="{{integration_test}}apollo-router" }
 apollo-router = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
 # Note if you update these dependencies then also update xtask/Cargo.toml
-apollo-router = "1.40.2-rc.0"
+apollo-router = "1.40.2"
 {{/if}}
 {{/if}}
 async-trait = "0.1.52"

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -22,7 +22,7 @@ apollo-router = { path ="{{integration_test}}apollo-router" }
 apollo-router = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
 # Note if you update these dependencies then also update xtask/Cargo.toml
-apollo-router = "1.40.1"
+apollo-router = "1.40.2-rc.0"
 {{/if}}
 {{/if}}
 async-trait = "0.1.52"

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -13,7 +13,7 @@ apollo-router-scaffold = { path ="{{integration_test}}apollo-router-scaffold" }
 {{#if branch}}
 apollo-router-scaffold = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
-apollo-router-scaffold = { git = "https://github.com/apollographql/router.git", tag = "v1.40.1" }
+apollo-router-scaffold = { git = "https://github.com/apollographql/router.git", tag = "v1.40.2-rc.0" }
 {{/if}}
 {{/if}}
 anyhow = "1.0.58"

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -13,7 +13,7 @@ apollo-router-scaffold = { path ="{{integration_test}}apollo-router-scaffold" }
 {{#if branch}}
 apollo-router-scaffold = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
-apollo-router-scaffold = { git = "https://github.com/apollographql/router.git", tag = "v1.40.2-rc.0" }
+apollo-router-scaffold = { git = "https://github.com/apollographql/router.git", tag = "v1.40.2" }
 {{/if}}
 {{/if}}
 anyhow = "1.0.58"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "1.40.2-rc.0"
+version = "1.40.2"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 repository = "https://github.com/apollographql/router/"
 documentation = "https://docs.rs/apollo-router"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "1.40.1"
+version = "1.40.2-rc.0"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 repository = "https://github.com/apollographql/router/"
 documentation = "https://docs.rs/apollo-router"

--- a/apollo-router/src/plugins/telemetry/proto/reports.proto
+++ b/apollo-router/src/plugins/telemetry/proto/reports.proto
@@ -284,11 +284,11 @@ message Trace {
   double field_execution_weight = 31;
 
 
-
   // removed: Node parse = 12; Node validate = 13;
   //          Id128 server_id = 1; Id128 client_id = 2;
   //          String client_reference_id = 23; String client_address = 9;
-  reserved 1, 2, 9, 12, 13, 23;
+  //          29 and 30 were internal fields.
+  reserved 1, 2, 9, 12, 13, 23, 29, 30;
 }
 
 // The `service` value embedded within the header key is not guaranteed to contain an actual service,
@@ -437,8 +437,6 @@ message ReferencedFieldsForType {
   bool is_interface = 2;
 }
 
-
-
 // This is the top-level message used by Apollo Server, Apollo Router, and other libraries to report usage information
 // to Apollo. This message consists of traces and stats for operations. By default, each individual operation execution
 // should be either represented as a trace or within stats, but not both. However if the "traces_pre_aggregated" field
@@ -491,6 +489,7 @@ message ContextualizedStats {
   // field executions and thus only reflects operations for which field-level tracing occurred.
   map<string, TypeStat> per_type_stat = 3;
 
+  reserved 4, 5;
 }
 
 message QueryMetadata {

--- a/apollo-router/src/services/http/service.rs
+++ b/apollo-router/src/services/http/service.rs
@@ -391,6 +391,13 @@ pin_project! {
     }
 }
 
+impl<B: hyper::body::HttpBody> BodyStream<B> {
+    /// Create a new `BodyStream`.
+    pub(crate) fn new(body: DecompressionBody<B>) -> Self {
+        Self { inner: body }
+    }
+}
+
 impl<B> Stream for BodyStream<B>
 where
     B: hyper::body::HttpBody,

--- a/apollo-router/src/services/layers/content_negotiation.rs
+++ b/apollo-router/src/services/layers/content_negotiation.rs
@@ -71,6 +71,17 @@ where
                             .to_string(),
                         ))
                         .expect("cannot fail");
+                    u64_counter!(
+                        "apollo_router_http_requests_total",
+                        "Total number of HTTP requests made.",
+                        1,
+                        status = StatusCode::UNSUPPORTED_MEDIA_TYPE.as_u16() as i64,
+                        error = format!(
+                            r#"'content-type' header must be one of: {:?} or {:?}"#,
+                            APPLICATION_JSON.essence_str(),
+                            GRAPHQL_JSON_RESPONSE_HEADER_VALUE,
+                        )
+                    );
 
                     return Ok(ControlFlow::Break(response.into()));
                 }

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -10,7 +10,6 @@ use std::time::SystemTime;
 
 use buildstructor::buildstructor;
 use http::header::ACCEPT;
-use http::header::CONTENT_ENCODING;
 use http::header::CONTENT_TYPE;
 use http::HeaderValue;
 use jsonpath_lib::Selector;
@@ -378,7 +377,7 @@ impl IntegrationTest {
     }
 
     #[allow(dead_code)]
-    pub fn execute_bad_content_encoding(
+    pub fn execute_bad_content_type(
         &self,
     ) -> impl std::future::Future<Output = (String, reqwest::Response)> {
         self.execute_query_internal(&json!({"garbage":{}}), Some("garbage"))
@@ -387,7 +386,7 @@ impl IntegrationTest {
     fn execute_query_internal(
         &self,
         query: &Value,
-        content_encoding: Option<&'static str>,
+        content_type: Option<&'static str>,
     ) -> impl std::future::Future<Output = (String, reqwest::Response)> {
         assert!(
             self.router.is_some(),
@@ -404,8 +403,10 @@ impl IntegrationTest {
 
                 let mut request = client
                     .post("http://localhost:4000")
-                    .header(CONTENT_TYPE, APPLICATION_JSON.essence_str())
-                    .header(CONTENT_ENCODING, content_encoding.unwrap_or("identity"))
+                    .header(
+                        CONTENT_TYPE,
+                        content_type.unwrap_or(APPLICATION_JSON.essence_str()),
+                    )
                     .header("apollographql-client-name", "custom_name")
                     .header("apollographql-client-version", "1.0")
                     .header("x-my-header", "test")

--- a/apollo-router/tests/telemetry/metrics.rs
+++ b/apollo-router/tests/telemetry/metrics.rs
@@ -135,10 +135,11 @@ async fn test_bad_queries() {
             None,
         )
         .await;
-    router.execute_bad_content_encoding().await;
+    router.execute_bad_content_type().await;
+
     router
             .assert_metrics_contains(
-                r#"apollo_router_http_requests_total{error="unknown content-encoding header value \"garbage\"",status="400",otel_scope_name="apollo/router"}"#,
+                r#"apollo_router_http_requests_total{error="'content-type' header must be one of: \"application/json\" or \"application/graphql-response+json\"",status="415",otel_scope_name="apollo/router"}"#,
                 None,
             )
             .await;

--- a/dockerfiles/tracing/docker-compose.datadog.yml
+++ b/dockerfiles/tracing/docker-compose.datadog.yml
@@ -3,7 +3,7 @@ services:
 
   apollo-router:
     container_name: apollo-router
-    image: ghcr.io/apollographql/router:v1.40.2-rc.0
+    image: ghcr.io/apollographql/router:v1.40.2
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/datadog.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.datadog.yml
+++ b/dockerfiles/tracing/docker-compose.datadog.yml
@@ -3,7 +3,7 @@ services:
 
   apollo-router:
     container_name: apollo-router
-    image: ghcr.io/apollographql/router:v1.40.1
+    image: ghcr.io/apollographql/router:v1.40.2-rc.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/datadog.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.jaeger.yml
+++ b/dockerfiles/tracing/docker-compose.jaeger.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     #build: ./router
-    image: ghcr.io/apollographql/router:v1.40.1
+    image: ghcr.io/apollographql/router:v1.40.2-rc.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/jaeger.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.jaeger.yml
+++ b/dockerfiles/tracing/docker-compose.jaeger.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     #build: ./router
-    image: ghcr.io/apollographql/router:v1.40.2-rc.0
+    image: ghcr.io/apollographql/router:v1.40.2
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/jaeger.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.zipkin.yml
+++ b/dockerfiles/tracing/docker-compose.zipkin.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     build: ./router
-    image: ghcr.io/apollographql/router:v1.40.1
+    image: ghcr.io/apollographql/router:v1.40.2-rc.0
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/zipkin.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.zipkin.yml
+++ b/dockerfiles/tracing/docker-compose.zipkin.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     build: ./router
-    image: ghcr.io/apollographql/router:v1.40.2-rc.0
+    image: ghcr.io/apollographql/router:v1.40.2
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/zipkin.router.yaml:/etc/config/configuration.yaml

--- a/helm/chart/router/Chart.yaml
+++ b/helm/chart/router/Chart.yaml
@@ -20,10 +20,10 @@ type: application
 # so it matches the shape of our release process and release automation.
 # By proxy of that decision, this version uses SemVer 2.0.0, though the prefix
 # of "v" is not included.
-version: 1.40.1
+version: 1.40.2-rc.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.40.1"
+appVersion: "v1.40.2-rc.0"

--- a/helm/chart/router/Chart.yaml
+++ b/helm/chart/router/Chart.yaml
@@ -20,10 +20,10 @@ type: application
 # so it matches the shape of our release process and release automation.
 # By proxy of that decision, this version uses SemVer 2.0.0, though the prefix
 # of "v" is not included.
-version: 1.40.2-rc.0
+version: 1.40.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.40.2-rc.0"
+appVersion: "v1.40.2"

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -2,7 +2,7 @@
 
 [router](https://github.com/apollographql/router) Rust Graph Routing runtime for Apollo Federation
 
-![Version: 1.40.2-rc.0](https://img.shields.io/badge/Version-1.40.2--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.40.2-rc.0](https://img.shields.io/badge/AppVersion-v1.40.2--rc.0-informational?style=flat-square)
+![Version: 1.40.2](https://img.shields.io/badge/Version-1.40.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.40.2](https://img.shields.io/badge/AppVersion-v1.40.2-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@
 ## Get Repo Info
 
 ```console
-helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.40.2-rc.0
+helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.40.2
 ```
 
 ## Install Chart
@@ -19,7 +19,7 @@ helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.40.2-rc.0
 **Important:** only helm3 is supported
 
 ```console
-helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 1.40.2-rc.0 --values my-values.yaml
+helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 1.40.2 --values my-values.yaml
 ```
 
 _See [configuration](#configuration) below._

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -2,7 +2,7 @@
 
 [router](https://github.com/apollographql/router) Rust Graph Routing runtime for Apollo Federation
 
-![Version: 1.40.1](https://img.shields.io/badge/Version-1.40.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.40.1](https://img.shields.io/badge/AppVersion-v1.40.1-informational?style=flat-square)
+![Version: 1.40.2-rc.0](https://img.shields.io/badge/Version-1.40.2--rc.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.40.2-rc.0](https://img.shields.io/badge/AppVersion-v1.40.2--rc.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@
 ## Get Repo Info
 
 ```console
-helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.40.1
+helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.40.2-rc.0
 ```
 
 ## Install Chart
@@ -19,7 +19,7 @@ helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.40.1
 **Important:** only helm3 is supported
 
 ```console
-helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 1.40.1 --values my-values.yaml
+helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 1.40.2-rc.0 --values my-values.yaml
 ```
 
 _See [configuration](#configuration) below._

--- a/licenses.html
+++ b/licenses.html
@@ -12971,109 +12971,6 @@ these terms.
                 <h3 id="Elastic-2.0">Elastic License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/apollographql/federation/ ">router-bridge</a></li>
-                </ul>
-                <pre class="license-text">Copyright 2021 Apollo Graph, Inc.
-
-Elastic License 2.0
-
-## Acceptance
-
-By using the software, you agree to all of the terms and conditions below.
-
-## Copyright License
-
-The licensor grants you a non-exclusive, royalty-free, worldwide,
-non-sublicensable, non-transferable license to use, copy, distribute, make
-available, and prepare derivative works of the software, in each case subject to
-the limitations and conditions below.
-
-## Limitations
-
-You may not provide the software to third parties as a hosted or managed
-service, where the service provides users with access to any substantial set of
-the features or functionality of the software.
-
-You may not move, change, disable, or circumvent the license key functionality
-in the software, and you may not remove or obscure any functionality in the
-software that is protected by the license key.
-
-You may not alter, remove, or obscure any licensing, copyright, or other notices
-of the licensor in the software. Any use of the licensor’s trademarks is subject
-to applicable law.
-
-## Patents
-
-The licensor grants you a license, under any patent claims the licensor can
-license, or becomes able to license, to make, have made, use, sell, offer for
-sale, import and have imported the software, in each case subject to the
-limitations and conditions in this license. This license does not cover any
-patent claims that you cause to be infringed by modifications or additions to
-the software. If you or your company make any written claim that the software
-infringes or contributes to infringement of any patent, your patent license for
-the software granted under these terms ends immediately. If your company makes
-such a claim, your patent license ends immediately for work on behalf of your
-company.
-
-## Notices
-
-You must ensure that anyone who gets a copy of any part of the software from you
-also gets a copy of these terms.
-
-If you modify the software, you must include in any modified copies of the
-software prominent notices stating that you have modified the software.
-
-## No Other Rights
-
-These terms do not imply any licenses other than those expressly granted in
-these terms.
-
-## Termination
-
-If you use the software in violation of these terms, such use is not licensed,
-and your licenses will automatically terminate. If the licensor provides you
-with a notice of your violation, and you cease all violation of this license no
-later than 30 days after you receive that notice, your licenses will be
-reinstated retroactively. However, if you violate these terms after such
-reinstatement, any additional violation of these terms will cause your licenses
-to terminate automatically and permanently.
-
-## No Liability
-
-*As far as the law allows, the software comes as is, without any warranty or
-condition, and the licensor will not be liable to you for any damages arising
-out of these terms or the use or nature of the software, under any kind of
-legal claim.*
-
-## Definitions
-
-The **licensor** is the entity offering these terms, and the **software** is the
-software the licensor makes available under these terms, including any portion
-of it.
-
-**you** refers to the individual or entity agreeing to these terms.
-
-**your company** is any legal entity, sole proprietorship, or other kind of
-organization that you work for, plus all organizations that have control over,
-are under the control of, or are under common control with that
-organization. **control** means ownership of substantially all the assets of an
-entity, or the power to direct its management and policies by vote, contract, or
-otherwise. Control can be direct or indirect.
-
-**your licenses** are all the licenses granted to you for the software under
-these terms.
-
-**use** means anything you do with the software requiring one of your licenses.
-
-**trademark** means trademarks, service marks, and similar rights.
-
---------------------------------------------------------------------------------
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Elastic-2.0">Elastic License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/apollographql/federation-next ">apollo-federation</a></li>
                 </ul>
                 <pre class="license-text">Copyright 2021 Apollo Graph, Inc.
@@ -13175,6 +13072,107 @@ these terms.
 **trademark** means trademarks, service marks, and similar rights.
 
 --------------------------------------------------------------------------------</pre>
+            </li>
+            <li class="license">
+                <h3 id="Elastic-2.0">Elastic License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/apollographql/federation/ ">router-bridge</a></li>
+                </ul>
+                <pre class="license-text">Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor’s trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.
+</pre>
             </li>
             <li class="license">
                 <h3 id="ISC">ISC License</h3>

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/router/releases/downloa
 
 # Router version defined in apollo-router's Cargo.toml
 # Note: Change this line manually during the release steps.
-PACKAGE_VERSION="v1.40.2-rc.0"
+PACKAGE_VERSION="v1.40.2"
 
 download_binary() {
     downloader --check

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/router/releases/downloa
 
 # Router version defined in apollo-router's Cargo.toml
 # Note: Change this line manually during the release steps.
-PACKAGE_VERSION="v1.40.1"
+PACKAGE_VERSION="v1.40.2-rc.0"
 
 download_binary() {
     downloader --check


### PR DESCRIPTION
## 🔒 Security

### Apply `limits.http_max_request_bytes` on streaming request body decompression

This fixes a Denial-of-Service (DoS) type vulnerability which exists in affected versions of the Router (back to v0.9.5).  This fix changes the evaluation of the `limits.http_max_request_bytes` configuration to take place on a stream of bytes, allowing it to be applied to compressed HTTP payloads, prior to decompression.  Previously, the limit was only being applied after the entirety of the compressed payload was decompressed, which could result in significant memory consumption which exceeded configured expectations while compressed payloads were expanded.

By [@Geal](https://github.com/Geal) in 9e9527c73c8f34fc8438b09066163cd42520f413

## 🐛 Fixes

### Re-activate the macOS Intel builder ([PR #4723](https://github.com/apollographql/router/pull/4723))

We have re-activated macOS Intel (x86) builds in CircleCI, despite their upcoming deprecation, while we take a different approach to solving this and maintaining Intel support for the time-being.   This became necessary since cross-compiling the router from ARM to x86 resulted in issues with V8 snapshots and runtime issues on the macOS Intel binaries produced by those Apple Silicon build machines.

By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4723