### PR TITLE
Revert "use a non blocking stdout (#4625)"

### DIFF
--- a/.changesets/fix_geal_non_blocking_stdout.md
+++ b/.changesets/fix_geal_non_blocking_stdout.md
@@ -1,9 +1,0 @@
-### use a non blocking stdout and stderr ([Issue #4612](https://github.com/apollographql/router/issues/4612))
-
-If the router's output was piped into another process, and that process did not consume that output, it could entirely lock up the router. New connections were accepted, but requests never got an answer.
-This is due to Rust protecting stdout and stderr access by a lock, to prevent multiple threads from interleaving their writes. When the process receiving the output from the router does not consume, then the logger's writes to the stream start to block, which means the current thread is blocked while holding the lock. And then any other thread that might want to log something will end up blocked too, waiting for that lock to be released.
-
-This is fixed by  marking stdout and stderr as non blocking, which means that logs will be dropped silently when the buffer is full. This has another side effect that should be pointed out:
-**if we write to stdout or sdtderr directly without handling errors (example: using `println!` or `eprintln!`) while the output is not consumed, then the router will panic. While that may look concerning, we consider that panicking, which will immediately reject the in flight requests and may trigger a restart of the router, is a better outcome than the router amking requests hang indefinitely.**
-
-By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4625

--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -437,15 +437,6 @@ impl Executable {
             return Ok(());
         }
 
-        // mark stdout and stderr as non blocking. If they are blocking and piped
-        // to a program that does not consume them, the router starts hanging on
-        // all requests: https://github.com/apollographql/router/issues/4612
-        #[cfg(not(target_os = "windows"))]
-        {
-            let _ = set_blocking(libc::STDOUT_FILENO, false);
-            let _ = set_blocking(libc::STDERR_FILENO, false);
-        }
-
         copy_args_to_env();
 
         let apollo_telemetry_initialized = if graph_os() {
@@ -751,26 +742,6 @@ fn copy_args_to_env() {
             }
         }
     });
-}
-
-#[cfg(not(target_os = "windows"))]
-fn set_blocking(fd: std::os::fd::RawFd, blocking: bool) -> std::io::Result<()> {
-    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL, 0) };
-    if flags < 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-
-    let flags = if blocking {
-        flags & !libc::O_NONBLOCK
-    } else {
-        flags | libc::O_NONBLOCK
-    };
-    let res = unsafe { libc::fcntl(fd, libc::F_SETFL, flags) };
-    if res != 0 {
-        return Err(std::io::Error::last_os_error());
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/apollo-router/src/plugins/telemetry/fmt_layer.rs
+++ b/apollo-router/src/plugins/telemetry/fmt_layer.rs
@@ -2,7 +2,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::io::IsTerminal;
-use std::io::Write;
 use std::marker::PhantomData;
 
 use opentelemetry::Key;
@@ -183,12 +182,7 @@ where
             if self.fmt_event.format_event(&ctx, &mut buf, event).is_ok() {
                 let mut writer = self.make_writer.make_writer();
                 if let Err(err) = std::io::Write::write_all(&mut writer, buf.as_bytes()) {
-                    if err.kind() != std::io::ErrorKind::WouldBlock {
-                        let _ = std::io::stderr().write_all(
-                            format!("cannot flush the logging buffer, this is a bug: {err:?}")
-                                .as_bytes(),
-                        );
-                    }
+                    eprintln!("cannot flush the logging buffer, this is a bug: {err:?}");
                 }
             }
             buf.clear();

--- a/docs/source/customizations/native.mdx
+++ b/docs/source/customizations/native.mdx
@@ -281,24 +281,6 @@ tracing::info!(
 );
 ```
 
-## Logging
-
-The Router has a logging infrastructure based on the [tracing macros](https://docs.rs/tracing/latest/tracing/index.html#macros), like metrics, and those should be the preferred way to write logs, as they will be configurable through the Router's telemetry infrastructure.
-
-Example usage:
-
-```rust
-tracing::info!(service_name = name, "received request");
-```
-
-If writing to stdout or stderr directly is still needed, additional steps should be taken to prevent errors: due to the Router using non blocking IO for stdout and stderr, `println!` and `eprintln!` cannot be used, as they would panic if those streams were blocking.
-As an example, writing to stdout would be done like this:
-
-```rust
-use std::io::Write;
-let _ = writeln!(std::io::stdout(), "value={}", 1);
-```
-
 ## Plugin Lifecycle
 
 Like individual requests, plugins follow their own strict lifecycle that helps provide structure to the Apollo Router's execution.


### PR DESCRIPTION
This reverts commit 11fad3c8563b012b4a09d81644eb218df07ee4ba from #4625 on account of discomfort with the solution and not being able to concretely tie it back an actual fix for the root cause.  We have re-opened #4612 to track the need to get back to this.
