### PR TITLE
Attach `dd.trace_id` to json formatted log messages

### DIFF
--- a/.changesets/fix_bryn_datadog_trace_id.md
+++ b/.changesets/fix_bryn_datadog_trace_id.md
@@ -1,7 +1,7 @@
-### Attach `dd.trace_id` to json formatted log messages ([PR #4764](https://github.com/apollographql/router/pull/4764))
+### Attach `dd.trace_id` to JSON formatted log messages ([PR #4764](https://github.com/apollographql/router/pull/4764))
 
-To enable correlation between DataDog tracing and logs, `dd.trace_id` must appear as a span attribute and also on the root of each `json` formatted log message.
-If users configure their router.yaml to include `dd.trace_id`:
+To enable correlation between DataDog tracing and logs, `dd.trace_id` must appear as a span attribute on the root of each JSON formatted log message.
+Once you configure the `dd.trace_id` attribute in router.yaml, it will automatically be extracted from the root span and attached to the logs:
 
 ```yaml title="router.yaml"
 telemetry:
@@ -12,7 +12,6 @@ telemetry:
         attributes:
           dd.trace_id: true
 ```
-Then the `dd.trace_id` attribute will automatically be extracted from the root span and attached to the logs.
 
 
 By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/4764

--- a/.changesets/fix_bryn_datadog_trace_id.md
+++ b/.changesets/fix_bryn_datadog_trace_id.md
@@ -1,0 +1,18 @@
+### Attach `dd.trace_id` to json formatted log messages ([PR #4764](https://github.com/apollographql/router/pull/4764))
+
+To enable correlation between DataDog tracing and logs, `dd.trace_id` must appear as a span attribute and also on the root of each `json` formatted log message.
+If users configure their router.yaml to include `dd.trace_id`:
+
+```yaml title="router.yaml"
+telemetry:
+  instrumentation:
+    spans:
+      mode: spec_compliant
+      router:
+        attributes:
+          dd.trace_id: true
+```
+Then the `dd.trace_id` attribute will automatically be extracted from the root span and attached to the logs.
+
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/4764

--- a/docs/source/configuration/authn-jwt.mdx
+++ b/docs/source/configuration/authn-jwt.mdx
@@ -146,7 +146,7 @@ The default value is `Bearer`.
 
 ##### `sources`
 
-</td>
+<tr>
 <td>
 
 This is an array of possible token sources, as it could be provided in different headers depending on the client, or it could be stored in a cookie. If the default token source defined by the above `header_name` and `header_value_prefix` does not find the token, then each of the alternative sources is tried until one matches.

--- a/docs/source/configuration/telemetry/exporters/tracing/datadog.mdx
+++ b/docs/source/configuration/telemetry/exporters/tracing/datadog.mdx
@@ -41,6 +41,21 @@ telemetry:
 
 For more details about Datadog configuration, see [Datadog Agent configuration](https://docs.datadoghq.com/opentelemetry/otlp_ingest_in_the_agent/?tab=host).
 
+### Enabling log correlation
+To enable Datadog log correlation `dd.trace_id` must be configured to appear on the `router` span:
+  
+```yaml title="router.yaml"
+telemetry:
+  instrumentation:
+    spans:
+      mode: spec_compliant
+      router:
+        attributes:
+          dd.trace_id: true
+```
+
+Your `json` formatted log messages will automatically output `dd.trace_id` on each log message if `dd.trace_id` was detected on the `router` span.
+
 ## Datadog native configuration
 
 <Caution>

--- a/docs/source/configuration/telemetry/exporters/tracing/datadog.mdx
+++ b/docs/source/configuration/telemetry/exporters/tracing/datadog.mdx
@@ -42,6 +42,7 @@ telemetry:
 For more details about Datadog configuration, see [Datadog Agent configuration](https://docs.datadoghq.com/opentelemetry/otlp_ingest_in_the_agent/?tab=host).
 
 ### Enabling log correlation
+
 To enable Datadog log correlation `dd.trace_id` must be configured to appear on the `router` span:
   
 ```yaml title="router.yaml"

--- a/docs/source/configuration/telemetry/exporters/tracing/datadog.mdx
+++ b/docs/source/configuration/telemetry/exporters/tracing/datadog.mdx
@@ -43,7 +43,7 @@ For more details about Datadog configuration, see [Datadog Agent configuration](
 
 ### Enabling log correlation
 
-To enable Datadog log correlation `dd.trace_id` must be configured to appear on the `router` span:
+To enable Datadog log correlation, you must configure `dd.trace_id` to appear on the `router` span:
   
 ```yaml title="router.yaml"
 telemetry:
@@ -52,10 +52,10 @@ telemetry:
       mode: spec_compliant
       router:
         attributes:
-          dd.trace_id: true
+          dd.trace_id: true #highlight-line
 ```
 
-Your `json` formatted log messages will automatically output `dd.trace_id` on each log message if `dd.trace_id` was detected on the `router` span.
+Your JSON formatted log messages will automatically output `dd.trace_id` on each log message if `dd.trace_id` was detected on the `router` span.
 
 ## Datadog native configuration
 


### PR DESCRIPTION
To enable correlation between DataDog tracing and logs dd.trace_id must appear as a span attribute and also on the root of each json formatted log message.

Currently, users can output dd.trace_id on logs but it is located within the span attributes, and therefore will not show as correlated in the datadog UI.

Old:
```
{"timestamp":"2024-03-07T14:42:44.408899252Z","level":"ERROR","message":"test","target":"apollo_router::plugins::telemetry","spans":[{"http.route":"/","http.request.method":"POST","url.path":"/","dd.trace_id":"3377607226581119358","client.name":"","client.version":"","name":"router"},{"name":"supergraph"},{"graphql.operation.type":"query","name":"execution"},{"apollo.subgraph.name":"products","name":"fetch"}],"resource":{"service.version":"1.40.1","process.executable.name":"router","service.name":"bryn-router"}}
```

New
```
{"timestamp":"2024-03-07T14:42:44.408899252Z","level":"ERROR","message":"test","target":"apollo_router::plugins::telemetry","dd.trace_id":"3377607226581119358","spans":[{"http.route":"/","http.request.method":"POST","url.path":"/","dd.trace_id":"3377607226581119358","client.name":"","client.version":"","name":"router"},{"name":"supergraph"},{"graphql.operation.type":"query","name":"execution"},{"apollo.subgraph.name":"products","name":"fetch"}],"resource":{"service.version":"1.40.1","process.executable.name":"router","service.name":"bryn-router"}}
```
This is how things look now:

![image](https://github.com/apollographql/router/assets/747836/0f249685-64fb-40c0-8090-4422fb0ae55a)


Fixes #4763


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
