### PR TITLE
release: v1.41.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to Router will be documented in this file.
 
 This project adheres to [Semantic Versioning v2.0.0](https://semver.org/spec/v2.0.0.html).
 
-# [1.41.0] - 2024-03-08
+
+# [1.41.1] - 2024-03-08
+
+> [!NOTE]
+>
+> v1.41.1 replaces a failed publish of v1.41.0.  The version number had to be moved from v1.41.0 to v1.41.1, but the release is otherwise the same.  Apologies for the confusion!
 
 ## 🚀 Features
 
@@ -45,6 +50,12 @@ telemetry:
 ```
 
 By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/4702
+
+# [1.41.0] - 2024-03-08
+
+> [!NOTE]
+>
+> The release of v1.41.0 failed unexpectedly late in the deployment process due to a preventable publishing failure.  The release has been yanked from Crates.io on account of not being published successfully across all deployment targets.  This release is fully replaced by v1.41.1.  Apologies for the confusion!
 
 # [1.40.2] - 2024-03-06
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router"
-version = "1.41.0"
+version = "1.41.1"
 dependencies = [
  "access-json",
  "anyhow",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-benchmarks"
-version = "1.41.0"
+version = "1.41.1"
 dependencies = [
  "apollo-parser",
  "apollo-router",
@@ -424,7 +424,7 @@ dependencies = [
 
 [[package]]
 name = "apollo-router-scaffold"
-version = "1.41.0"
+version = "1.41.1"
 dependencies = [
  "anyhow",
  "cargo-scaffold",

--- a/apollo-router-benchmarks/Cargo.toml
+++ b/apollo-router-benchmarks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-benchmarks"
-version = "1.41.0"
+version = "1.41.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/Cargo.toml
+++ b/apollo-router-scaffold/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router-scaffold"
-version = "1.41.0"
+version = "1.41.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/apollo-router-scaffold/templates/base/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/Cargo.toml
@@ -22,7 +22,7 @@ apollo-router = { path ="{{integration_test}}apollo-router" }
 apollo-router = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
 # Note if you update these dependencies then also update xtask/Cargo.toml
-apollo-router = "1.41.0"
+apollo-router = "1.41.1"
 {{/if}}
 {{/if}}
 async-trait = "0.1.52"

--- a/apollo-router-scaffold/templates/base/xtask/Cargo.toml
+++ b/apollo-router-scaffold/templates/base/xtask/Cargo.toml
@@ -13,7 +13,7 @@ apollo-router-scaffold = { path ="{{integration_test}}apollo-router-scaffold" }
 {{#if branch}}
 apollo-router-scaffold = { git="https://github.com/apollographql/router.git", branch="{{branch}}" }
 {{else}}
-apollo-router-scaffold = { git = "https://github.com/apollographql/router.git", tag = "v1.41.0" }
+apollo-router-scaffold = { git = "https://github.com/apollographql/router.git", tag = "v1.41.1" }
 {{/if}}
 {{/if}}
 anyhow = "1.0.58"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apollo-router"
-version = "1.41.0"
+version = "1.41.1"
 authors = ["Apollo Graph, Inc. <packages@apollographql.com>"]
 repository = "https://github.com/apollographql/router/"
 documentation = "https://docs.rs/apollo-router"

--- a/dockerfiles/tracing/docker-compose.datadog.yml
+++ b/dockerfiles/tracing/docker-compose.datadog.yml
@@ -3,7 +3,7 @@ services:
 
   apollo-router:
     container_name: apollo-router
-    image: ghcr.io/apollographql/router:v1.41.0
+    image: ghcr.io/apollographql/router:v1.41.1
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/datadog.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.jaeger.yml
+++ b/dockerfiles/tracing/docker-compose.jaeger.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     #build: ./router
-    image: ghcr.io/apollographql/router:v1.41.0
+    image: ghcr.io/apollographql/router:v1.41.1
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/jaeger.router.yaml:/etc/config/configuration.yaml

--- a/dockerfiles/tracing/docker-compose.zipkin.yml
+++ b/dockerfiles/tracing/docker-compose.zipkin.yml
@@ -4,7 +4,7 @@ services:
   apollo-router:
     container_name: apollo-router
     build: ./router
-    image: ghcr.io/apollographql/router:v1.41.0
+    image: ghcr.io/apollographql/router:v1.41.1
     volumes:
       - ./supergraph.graphql:/etc/config/supergraph.graphql
       - ./router/zipkin.router.yaml:/etc/config/configuration.yaml

--- a/helm/chart/router/Chart.yaml
+++ b/helm/chart/router/Chart.yaml
@@ -20,10 +20,10 @@ type: application
 # so it matches the shape of our release process and release automation.
 # By proxy of that decision, this version uses SemVer 2.0.0, though the prefix
 # of "v" is not included.
-version: 1.41.0
+version: 1.41.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v1.41.0"
+appVersion: "v1.41.1"

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -2,7 +2,7 @@
 
 [router](https://github.com/apollographql/router) Rust Graph Routing runtime for Apollo Federation
 
-![Version: 1.41.0](https://img.shields.io/badge/Version-1.41.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.41.0](https://img.shields.io/badge/AppVersion-v1.41.0-informational?style=flat-square)
+![Version: 1.41.1](https://img.shields.io/badge/Version-1.41.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.41.1](https://img.shields.io/badge/AppVersion-v1.41.1-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -11,7 +11,7 @@
 ## Get Repo Info
 
 ```console
-helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.41.0
+helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.41.1
 ```
 
 ## Install Chart
@@ -19,7 +19,7 @@ helm pull oci://ghcr.io/apollographql/helm-charts/router --version 1.41.0
 **Important:** only helm3 is supported
 
 ```console
-helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 1.41.0 --values my-values.yaml
+helm upgrade --install [RELEASE_NAME] oci://ghcr.io/apollographql/helm-charts/router --version 1.41.1 --values my-values.yaml
 ```
 
 _See [configuration](#configuration) below._

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -11,7 +11,7 @@ BINARY_DOWNLOAD_PREFIX="https://github.com/apollographql/router/releases/downloa
 
 # Router version defined in apollo-router's Cargo.toml
 # Note: Change this line manually during the release steps.
-PACKAGE_VERSION="v1.41.0"
+PACKAGE_VERSION="v1.41.1"
 
 download_binary() {
     downloader --check


### PR DESCRIPTION
> [!NOTE]
>
> v1.41.1 replaces a failed publish of v1.41.0.  The version number had to be moved from v1.41.0 to v1.41.1, but the release is otherwise the same.  Apologies for the confusion!

Only the version numbers have changed.