### PR TITLE
use Object::with_capacity with selection set len in format_response

### DIFF
--- a/.changesets/fix_format_response_index_map_with_capacity.md
+++ b/.changesets/fix_format_response_index_map_with_capacity.md
@@ -1,0 +1,5 @@
+### use Object::with_capacity with selection set len in format_response ([PR #4775](https://github.com/apollographql/router/pull/4775))
+
+This is far from a great improvement, I think this procedure probably needs to be changed to make a bigger dent. Maybe re-ordering and modifying in place, which would require much more effort. This change does seem to make a difference comparing flamegraphs, but it's small.
+
+By [@xuorig](https://github.com/xuorig) in https://github.com/apollographql/router/pull/4775

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -149,7 +149,7 @@ impl Query {
                         defer_conditions,
                     }) {
                         Some(subselection) => {
-                            let mut output = Object::default();
+                            let mut output = Object::with_capacity(subselection.selection_set.len());
                             let mut parameters = FormatParameters {
                                 variables: &variables,
                                 schema,
@@ -197,7 +197,7 @@ impl Query {
                         }
                     }
                 } else if let Some(operation) = original_operation {
-                    let mut output = Object::default();
+                    let mut output = Object::with_capacity(operation.selection_set.len());
 
                     let all_variables = if operation.variables.is_empty() {
                         variables
@@ -579,7 +579,7 @@ impl Query {
                         }
 
                         if output.is_null() {
-                            *output = Value::Object(Object::default());
+                            *output = Value::Object(Object::with_capacity(selection_set.len()));
                         }
                         let output_object = output.as_object_mut().ok_or(InvalidValue)?;
 


### PR DESCRIPTION
This is far from a great improvement, I think this procedure probably needs to be changed to make a bigger dent. Maybe re-ordering and modifying in place, which would require much more effort. This change does seem to make a difference comparing flamegraphs, but it's small.