### PR TITLE
Support configuring container resource HPA targets

### DIFF
--- a/.changesets/feat_add_container_scaling_config.md
+++ b/.changesets/feat_add_container_scaling_config.md
@@ -1,0 +1,5 @@
+### Support configuring container resource HPA targets ([PR #4776](https://github.com/apollographql/router/pull/4776))
+
+Allow configuring container resource HPA targets in the helm chart (https://kubernetes.io/blog/2023/05/02/hpa-container-resource-metric/).
+
+By [@caugustus](https://github.com/caugustus) in https://github.com/apollographql/router/pull/4776

--- a/helm/chart/router/templates/hpa.yaml
+++ b/helm/chart/router/templates/hpa.yaml
@@ -36,4 +36,13 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
+    {{- range .Values.autoscaling.containerBased }}
+    - type: ContainerResource
+      containerResource:
+        container: {{ .name }}
+        name: {{ .type }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .targetUtilizationPercentage }}
+    {{- end }}
 {{- end }}

--- a/helm/chart/router/values.yaml
+++ b/helm/chart/router/values.yaml
@@ -210,6 +210,13 @@ autoscaling:
   maxReplicas: 100
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
+  #
+  # Specify container-specific HPA scaling targets
+  # Only available in 1.27+ (https://kubernetes.io/blog/2023/05/02/hpa-container-resource-metric/)
+  # containerBased:
+  #   - name: <container name>
+  #     type: cpu
+  #     targetUtilizationPercentage: 75
 
 nodeSelector: {}
 


### PR DESCRIPTION
Update the helm chart to allow specifying container resource HPA targets (https://kubernetes.io/blog/2023/05/02/hpa-container-resource-metric/). This functionality is only available in Kubernetes 1.27+ by default. Multiple containers and criteria types can be configured.

This supports the use case when the router is running with extra containers that have independent scaling constraints from the overall pod usage.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
