### PR TITLE
Add config for router-subgraph batching

### DIFF
--- a/apollo-router/feature_discussions.json
+++ b/apollo-router/feature_discussions.json
@@ -2,8 +2,7 @@
   "experimental": {
     "experimental_retry": "https://github.com/apollographql/router/discussions/2241",
     "experimental_response_trace_id": "https://github.com/apollographql/router/discussions/2147",
-    "experimental_when_header": "https://github.com/apollographql/router/discussions/1961",
-    "experimental_batching": "https://github.com/apollographql/router/discussions/3840"
+    "experimental_when_header": "https://github.com/apollographql/router/discussions/1961"
   },
   "preview": {
     "preview_entity_cache": "https://github.com/apollographql/router/discussions/4592"

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -325,7 +325,7 @@ impl InstrumentData {
 
         populate_config_instrument!(
             apollo.router.config.batching,
-            "$.experimental_batching[?(@.enabled == true)]",
+            "$.batching[?(@.enabled == true)]",
             opt.mode,
             "$.mode"
         );

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -701,6 +701,7 @@ expression: "&schema"
               ],
               "properties": {
                 "all": {
+                  "description": "Common options for configuring subgraph batching",
                   "type": "object",
                   "required": [
                     "enabled"
@@ -725,6 +726,7 @@ expression: "&schema"
                 "subgraphs": {
                   "type": "object",
                   "additionalProperties": {
+                    "description": "Common options for configuring subgraph batching",
                     "type": "object",
                     "required": [
                       "enabled"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -661,6 +661,91 @@ expression: "&schema"
         }
       }
     },
+    "batching": {
+      "description": "Batching configuration.",
+      "default": {
+        "enabled": false,
+        "mode": "batch_http_link",
+        "subgraph": null
+      },
+      "type": "object",
+      "required": [
+        "mode"
+      ],
+      "properties": {
+        "enabled": {
+          "description": "Activates Batching (disabled by default)",
+          "default": false,
+          "type": "boolean"
+        },
+        "mode": {
+          "description": "Batching mode",
+          "oneOf": [
+            {
+              "description": "batch_http_link",
+              "type": "string",
+              "enum": [
+                "batch_http_link"
+              ]
+            }
+          ]
+        },
+        "subgraph": {
+          "description": "Subgraph options for batching\n\nNote: Batching from the router to subgraphs can either be enabled for all subgraphs or configured per subgraph, but not both.",
+          "oneOf": [
+            {
+              "description": "Batching options for all known subgraphs",
+              "type": "object",
+              "required": [
+                "all"
+              ],
+              "properties": {
+                "all": {
+                  "type": "object",
+                  "required": [
+                    "enabled"
+                  ],
+                  "properties": {
+                    "enabled": {
+                      "description": "Whether this batching config should be enabled",
+                      "type": "boolean"
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "description": "Per-subgraph batching options",
+              "type": "object",
+              "required": [
+                "subgraphs"
+              ],
+              "properties": {
+                "subgraphs": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "object",
+                    "required": [
+                      "enabled"
+                    ],
+                    "properties": {
+                      "enabled": {
+                        "description": "Whether this batching config should be enabled",
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ],
+          "nullable": true
+        }
+      },
+      "additionalProperties": false
+    },
     "coprocessor": {
       "description": "Configures the externalization plugin",
       "type": "object",
@@ -1266,37 +1351,6 @@ expression: "&schema"
           ]
         }
       ]
-    },
-    "experimental_batching": {
-      "description": "Batching configuration.",
-      "default": {
-        "enabled": false,
-        "mode": "batch_http_link"
-      },
-      "type": "object",
-      "required": [
-        "mode"
-      ],
-      "properties": {
-        "enabled": {
-          "description": "Activates Batching (disabled by default)",
-          "default": false,
-          "type": "boolean"
-        },
-        "mode": {
-          "description": "Batching mode",
-          "oneOf": [
-            {
-              "description": "batch_http_link",
-              "type": "string",
-              "enum": [
-                "batch_http_link"
-              ]
-            }
-          ]
-        }
-      },
-      "additionalProperties": false
     },
     "experimental_chaos": {
       "description": "Configuration for chaos testing, trying to reproduce bugs that require uncommon conditions. You probably don’t want this in production!",

--- a/apollo-router/src/configuration/testdata/metrics/batching.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/batching.router.yaml
@@ -1,3 +1,3 @@
-experimental_batching:
+batching:
   enabled: true
   mode: batch_http_link

--- a/apollo-router/src/services/router/tests.rs
+++ b/apollo-router/src/services/router/tests.rs
@@ -305,7 +305,7 @@ async fn it_processes_a_valid_query_batch() {
                 hyper::Body::from(result)
             });
         let config = serde_json::json!({
-            "experimental_batching": {
+            "batching": {
                 "enabled": true,
                 "mode" : "batch_http_link"
             }
@@ -394,7 +394,7 @@ async fn it_will_not_process_a_poorly_formatted_query_batch() {
                 hyper::Body::from(result)
             });
         let config = serde_json::json!({
-            "experimental_batching": {
+            "batching": {
                 "enabled": true,
                 "mode" : "batch_http_link"
             }
@@ -448,7 +448,7 @@ async fn it_will_process_a_non_batched_defered_query() {
                 hyper::Body::from(bytes)
             });
         let config = serde_json::json!({
-            "experimental_batching": {
+            "batching": {
                 "enabled": true,
                 "mode" : "batch_http_link"
             }
@@ -508,7 +508,7 @@ async fn it_will_not_process_a_batched_deferred_query() {
                 hyper::Body::from(result)
             });
         let config = serde_json::json!({
-            "experimental_batching": {
+            "batching": {
                 "enabled": true,
                 "mode" : "batch_http_link"
             }

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -362,7 +362,7 @@ impl LicenseEnforcementReport {
                 .name("File uploads plugin")
                 .build(),
             ConfigurationRestriction::builder()
-                .path("$.experimental_batching")
+                .path("$.batching")
                 .name("Batching support")
                 .build(),
         ]

--- a/apollo-router/tests/fixtures/apollo_reports_batch.router.yaml
+++ b/apollo-router/tests/fixtures/apollo_reports_batch.router.yaml
@@ -1,4 +1,4 @@
-experimental_batching:
+batching:
   enabled: true
   mode: batch_http_link
 rhai:
@@ -28,5 +28,3 @@ telemetry:
     send_variable_values:
       only:
         - "sendValue"
-
-

--- a/apollo-router/tests/snapshots/lifecycle_tests__cli_config_experimental.snap
+++ b/apollo-router/tests/snapshots/lifecycle_tests__cli_config_experimental.snap
@@ -9,8 +9,6 @@ stderr:
 stdout:
 List of all experimental configurations with related GitHub discussions:
 
-	- experimental_batching: https://github.com/apollographql/router/discussions/3840
 	- experimental_response_trace_id: https://github.com/apollographql/router/discussions/2147
 	- experimental_retry: https://github.com/apollographql/router/discussions/2241
 	- experimental_when_header: https://github.com/apollographql/router/discussions/1961
-

--- a/docs/source/configuration/traffic-shaping.mdx
+++ b/docs/source/configuration/traffic-shaping.mdx
@@ -64,7 +64,7 @@ You can change the default timeout for client requests to the router like so:
 
 ```yaml title="router.yaml"
 traffic_shaping:
-  router: 
+  router:
     timeout: 50s # If client requests to the router take more than 50 seconds, cancel the request (30 seconds by default)
 ```
 
@@ -72,7 +72,7 @@ You can change the default timeout for all requests between the router and subgr
 
 ```yaml title="router.yaml"
 traffic_shaping:
-  all: 
+  all:
     timeout: 50s # If subgraph requests take more than 50 seconds, cancel the request (30 seconds by default)
 ```
 
@@ -91,7 +91,7 @@ Compression is automatically supported on the client side, depending on the `Acc
 The Apollo Router has _experimental_ support for receiving client query batches:
 
 ```yaml title="router.yaml"
-experimental_batching:
+batching:
   enabled: true
   mode: batch_http_link
 ```

--- a/docs/source/executing-operations/query-batching.mdx
+++ b/docs/source/executing-operations/query-batching.mdx
@@ -1,6 +1,6 @@
 ---
 title: Query batching
-description: Receive query batches with the Apollo Router  
+description: Receive query batches with the Apollo Router
 ---
 
 <ExperimentalFeature />
@@ -15,7 +15,7 @@ The Apollo Router supports client and subgraph query batching.
 
 If you’re using Apollo Client, you can leverage the built-in support for batching to reduce the number of individual operations sent to the router.
 
-Once configured, Apollo Client automatically combines multiple operations into a single HTTP request. The number of operations within a batch is client-configurable, including the maximum number in a batch and the maximum duration to wait for operations to accumulate before sending the batch. 
+Once configured, Apollo Client automatically combines multiple operations into a single HTTP request. The number of operations within a batch is client-configurable, including the maximum number in a batch and the maximum duration to wait for operations to accumulate before sending the batch.
 
 The Apollo Router must be configured to receive query batches, otherwise it rejects them. When processing a  batch, the router deserializes and processes each operation of a batch independently, and it responds to the client only after all operations of the batch have been completed. Each operation executes concurrently with respect to other operations in the batch.
 
@@ -27,12 +27,12 @@ Both the Apollo Router and client need to be configured to support query batchin
 
 #### Client Query Batching
 
-By default, receiving client query batches is _not_ enabled in the Apollo Router. 
+By default, receiving client query batches is _not_ enabled in the Apollo Router.
 
 To enable query batching, set the following fields in your `router.yaml` configuration file:
 
 ```yaml title="router.yaml"
-experimental_batching:
+batching:
   enabled: true
   mode: batch_http_link
 ```
@@ -46,19 +46,31 @@ experimental_batching:
 
 If Client query batching is enabled, and the router subgraphs [support query batching](https://www.apollographql.com/docs/apollo-server/api/apollo-server#allowbatchedhttprequests), then subgraph query batching may be enabled by setting the following fields in your `router.yaml` configuration file:
 
-```yaml title="router.yaml"
-experimental_batching:
+```yaml title="router.all_enabled.yaml"
+batching:
   enabled: true
   mode: batch_http_link
   subgraph:
+    # Enable batching on all subgraphs
     all:
       enabled: true
+```
+
+```yaml title="router.yaml"
+batching:
+  enabled: true
+  mode: batch_http_link
+  subgraph:
+    # Configure batching support per subgraph
     subgraphs:
       subgraph_1:
         enabled: true
       subgraph_2:
         enabled: true
 ```
+
+<Note>
+The router can be configured to either support batching for all subgraphs or configured per each subgraph, but not both.
 
 <Note>
 There are limitations on the ability of the router to preserve batches from the client request into the subgraph requests. In particular, certain forms of queries will require data to be present before they are processed. Bearing this constraint in mind, the router will only be able to generate batches from queries which are processed which don't contain such constraints.
@@ -276,7 +288,7 @@ As a result, the router returns an invalid batch error:
 
 ### Individual query error
 
-If a single query in a batch cannot be processed, this results in an individual error. 
+If a single query in a batch cannot be processed, this results in an individual error.
 
 For example, the query `MyFirstQuery` is accessing a field that doesn't exist, while the rest of the batch query is valid.
 
@@ -313,7 +325,7 @@ As a result, an error is returned for the individual invalid query and the other
 ## Known limitations
 
 ### Unsupported query modes
- 
+
 When batching is enabled, any batch operation that results in a stream of responses is unsupported, including:
 - [`@defer`](/graphos/operations/defer/)
 - [subscriptions](/graphos/operations/subscriptions/)


### PR DESCRIPTION
This commit adds configuration options for later use in the router to subgraph epic. More changes will be necessary to actually use these new configuration changes.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
