### PR TITLE
Introduce constants for span status

### DIFF
--- a/apollo-router/src/axum_factory/utils.rs
+++ b/apollo-router/src/axum_factory/utils.rs
@@ -10,6 +10,7 @@ use tracing::Span;
 
 use crate::plugins::telemetry::SpanMode;
 use crate::plugins::telemetry::OTEL_STATUS_CODE;
+use crate::plugins::telemetry::OTEL_STATUS_CODE_ERROR;
 use crate::uplink::license_enforcement::LicenseState;
 use crate::uplink::license_enforcement::LICENSE_EXPIRED_SHORT_MESSAGE;
 
@@ -55,7 +56,7 @@ impl<B> MakeSpan<B> for PropagatingMakeSpan {
             self.license,
             LicenseState::LicensedWarn | LicenseState::LicensedHalt
         ) {
-            span.record(OTEL_STATUS_CODE, "Error");
+            span.record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
             span.record("apollo_router.license", LICENSE_EXPIRED_SHORT_MESSAGE);
         }
 

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -148,7 +148,12 @@ const SUBGRAPH_FTV1: &str = "apollo_telemetry::subgraph_ftv1";
 pub(crate) const STUDIO_EXCLUDE: &str = "apollo_telemetry::studio::exclude";
 pub(crate) const LOGGING_DISPLAY_HEADERS: &str = "apollo_telemetry::logging::display_headers";
 pub(crate) const LOGGING_DISPLAY_BODY: &str = "apollo_telemetry::logging::display_body";
+
 pub(crate) const OTEL_STATUS_CODE: &str = "otel.status_code";
+#[allow(dead_code)]
+pub(crate) const OTEL_STATUS_DESCRIPTION: &str = "otel.status_description";
+pub(crate) const OTEL_STATUS_CODE_OK: &str = "OK";
+pub(crate) const OTEL_STATUS_CODE_ERROR: &str = "ERROR";
 const GLOBAL_TRACER_NAME: &str = "apollo-router";
 const DEFAULT_EXPOSE_TRACE_ID_HEADER: &str = "apollo-trace-id";
 static DEFAULT_EXPOSE_TRACE_ID_HEADER_NAME: HeaderName =
@@ -407,12 +412,12 @@ impl Plugin for Telemetry {
                             }
 
                             if response.response.status() >= StatusCode::BAD_REQUEST {
-                                span.record(OTEL_STATUS_CODE, "Error");
+                                span.record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
                             } else {
-                                span.record(OTEL_STATUS_CODE, "Ok");
+                                span.record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_OK);
                             }
                         } else if let Err(err) = &response {
-                            span.record(OTEL_STATUS_CODE, "Error");
+                            span.record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
                             span.set_dyn_attributes(
                                 config.instrumentation.spans.router.attributes.on_error(err),
                             );
@@ -598,9 +603,9 @@ impl Plugin for Telemetry {
                         match &result {
                             Ok(resp) => {
                                 if resp.response.status() >= StatusCode::BAD_REQUEST {
-                                    span.record(OTEL_STATUS_CODE, "Error");
+                                    span.record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
                                 } else {
-                                    span.record(OTEL_STATUS_CODE, "Ok");
+                                    span.record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_OK);
                                 }
                                 span.set_dyn_attributes(
                                     conf.instrumentation
@@ -611,7 +616,7 @@ impl Plugin for Telemetry {
                                 );
                             }
                             Err(err) => {
-                                span.record(OTEL_STATUS_CODE, "Error");
+                                span.record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
 
                                 span.set_dyn_attributes(
                                     conf.instrumentation.spans.subgraph.attributes.on_error(err),


### PR DESCRIPTION
Otel internally does a case-insensitive compare, so it's just a minor code improvement that doesn't affect existing tests for spans in any way.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
