### PR TITLE
Add missing unit tests for subgraph batching

### DIFF
--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -245,7 +245,7 @@ mod tests {
             .map(|index| {
                 let (tx, rx) = oneshot::channel();
                 let graphql_request = graphql::Request::fake_builder()
-                    .operation_name("batch_test")
+                    .operation_name(format!("batch_test_{index}"))
                     .query(format!("query batch_test {{ slot{index} }}"))
                     .build();
 
@@ -271,8 +271,8 @@ mod tests {
         // Try to assemble them
         let (op_name, _context, request, txs) = Waiter::assemble_batch(waiters).await.unwrap();
 
-        // Make sure we've assembled the request correctly
-        assert_eq!(op_name, "batch_test");
+        // Make sure that the name of the entire batch is that of the first
+        assert_eq!(op_name, "batch_test_0");
 
         // We should see the aggregation of all of the requests
         let actual: Vec<graphql::Request> = serde_json::from_str(
@@ -283,7 +283,7 @@ mod tests {
         let expected: Vec<_> = (0..2)
             .map(|index| {
                 graphql::Request::fake_builder()
-                    .operation_name("batch_test")
+                    .operation_name(format!("batch_test_{index}"))
                     .query(format!("query batch_test {{ slot{index} }}"))
                     .build()
             })

--- a/apollo-router/src/batching.rs
+++ b/apollo-router/src/batching.rs
@@ -227,14 +227,14 @@ impl Drop for Batch {
 mod tests {
     use std::time::Duration;
 
-    use crate::graphql;
-    use crate::services::{SubgraphRequest, SubgraphResponse};
-    use crate::Context;
-
     use hyper::body::to_bytes;
     use tokio::sync::oneshot;
 
     use super::Waiter;
+    use crate::graphql;
+    use crate::services::SubgraphRequest;
+    use crate::services::SubgraphResponse;
+    use crate::Context;
 
     #[tokio::test(flavor = "multi_thread")]
     async fn it_assembles_batch() {


### PR DESCRIPTION
This commit adds a few more unit tests for verifying the functionality of all helper methods and, where applicable, beefy methods pertinent to the subgraph batching initiative.

Note: This commit builds off of #4780 so @garypen please refer to [this commit](https://github.com/apollographql/router/pull/4787/commits/e7038b3832a95246bc23da33959f74d1a46ddf5e).

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
