### PR TITLE
hash all entities to the same slot to support MGET in clusters

### DIFF
--- a/.changesets/fix_geal_entity_cache_slots.md
+++ b/.changesets/fix_geal_entity_cache_slots.md
@@ -1,0 +1,5 @@
+### Entity cache: fix support for Redis cluster ([PR #4790](https://github.com/apollographql/router/pull/4790))
+
+in a Redis cluster, entities can be stored in different nodes, and a query to one node should only refer to the keys it manages. This is challenging for the MGET operation which requests multiple entities in the same request from the same node. This splits the MGET query in multiple MGETs calls grouped by key hash, to make sure each one will get to the corresponding node, then merges responses in the correct order.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4790

--- a/apollo-router/src/cache/redis.rs
+++ b/apollo-router/src/cache/redis.rs
@@ -463,11 +463,12 @@ impl RedisCacheStorage {
             }
 
             // then we query all the key groups at the same time
-            let results = //: Vec<(Vec<usize>, Result<Vec<Option<RedisValue<V>>>, RedisError>)> =
-                futures::future::join_all(h.into_iter().map(|(_, (indexes, keys))| {
-                    self.inner.mget(keys).map(|values:Result<Vec<Option<RedisValue<V>>>, RedisError>| (indexes, values))
-                }))
-                .await;
+            let results = futures::future::join_all(h.into_iter().map(|(_, (indexes, keys))| {
+                self.inner
+                    .mget(keys)
+                    .map(|values: Result<Vec<Option<RedisValue<V>>>, RedisError>| (indexes, values))
+            }))
+            .await;
 
             // then we have to assemble the results, by making sure that the values are in the same order as
             // the keys argument's order

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -627,7 +627,7 @@ fn extract_cache_keys(
         // - query hash: invalidate the entry for a specific query and operation name
         // - additional data: separate cache entries depending on info like authorization status
         let key = format!(
-            "subgraph:{}:{}:{}:{{{}:{}}}",
+            "subgraph:{}:{}:{}:{}:{}",
             subgraph_name, &typename, hashed_entity_key, query_hash, additional_data_hash
         );
 

--- a/apollo-router/src/plugins/cache/entity.rs
+++ b/apollo-router/src/plugins/cache/entity.rs
@@ -627,7 +627,7 @@ fn extract_cache_keys(
         // - query hash: invalidate the entry for a specific query and operation name
         // - additional data: separate cache entries depending on info like authorization status
         let key = format!(
-            "subgraph:{}:{}:{}:{}:{}",
+            "subgraph:{}:{}:{}:{{{}:{}}}",
             subgraph_name, &typename, hashed_entity_key, query_hash, additional_data_hash
         );
 


### PR DESCRIPTION
in a Redis cluster, entities can be stored in different nodes, which makes MGET fails. This splits the MGET query in multiple MGETs calls grouped by key hash, to make sure each one will get to the corresponding node, then merges responses in the correct order.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
