### PR TITLE
fix(telemetry): keep consistency between tracing otlp endpoint

### DIFF
--- a/.changesets/fix_bnjjj_4798.md
+++ b/.changesets/fix_bnjjj_4798.md
@@ -10,7 +10,7 @@ telemetry:
     tracing:
       otlp:
         enabled: true
-        endpoint: "http://localhost:4318/v1/traces"
+        endpoint: "http://localhost:4318"
         protocol: http
 ```
 

--- a/.changesets/fix_bnjjj_4798.md
+++ b/.changesets/fix_bnjjj_4798.md
@@ -1,0 +1,17 @@
+### Fix(telemetry): keep consistency between tracing otlp endpoint ([Issue #4798](https://github.com/apollographql/router/issues/4798))
+
+In our [documentation](https://www.apollographql.com/docs/router/configuration/telemetry/exporters/tracing/otlp/#endpoint) when configuration http endpoint for tracing otlp exporter we say that users should only include the base address of the otlp endpoint. It was only working for grpc protocol and not http due to [this bug](https://github.com/open-telemetry/opentelemetry-rust/issues/1618). This inconsistency is now fixed with a workaround in the router waiting for the fix in openetelemetry crate.
+
+So for example you'll have to specify the right path for http:
+
+```yaml
+telemetry:
+  exporters:
+    tracing:
+      otlp:
+        enabled: true
+        endpoint: "http://localhost:4318/v1/traces"
+        protocol: http
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/4801

--- a/apollo-router/src/plugins/telemetry/metrics/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/metrics/otlp.rs
@@ -10,6 +10,7 @@ use crate::plugins::telemetry::config::MetricsCommon;
 use crate::plugins::telemetry::metrics::CustomAggregationSelector;
 use crate::plugins::telemetry::metrics::MetricsBuilder;
 use crate::plugins::telemetry::metrics::MetricsConfigurator;
+use crate::plugins::telemetry::otlp::TelemetryDataKind;
 
 // TODO Remove MetricExporterBuilder once upstream issue is fixed
 // This has to exist because Http is not currently supported for metrics export
@@ -42,7 +43,7 @@ impl MetricsConfigurator for super::super::otlp::Config {
         mut builder: MetricsBuilder,
         metrics_config: &MetricsCommon,
     ) -> Result<MetricsBuilder, BoxError> {
-        let exporter: MetricExporterBuilder = self.exporter()?;
+        let exporter: MetricExporterBuilder = self.exporter(TelemetryDataKind::Metrics)?;
         if !self.enabled {
             return Ok(builder);
         }

--- a/apollo-router/src/plugins/telemetry/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/otlp.rs
@@ -1,6 +1,9 @@
 //! Shared configuration for Otlp tracing and metrics.
 use std::collections::HashMap;
+use std::str::FromStr;
 
+use http::uri::Parts;
+use http::uri::PathAndQuery;
 use http::Uri;
 use lazy_static::lazy_static;
 use opentelemetry::sdk::metrics::reader::TemporalitySelector;
@@ -27,6 +30,8 @@ lazy_static! {
     static ref DEFAULT_GRPC_ENDPOINT: Uri = Uri::from_static("http://127.0.0.1:4317");
     static ref DEFAULT_HTTP_ENDPOINT: Uri = Uri::from_static("http://127.0.0.1:4318");
 }
+
+const DEFAULT_HTTP_ENDPOINT_PATH: &str = "/v1/traces";
 
 #[derive(Debug, Clone, Deserialize, JsonSchema, Default)]
 #[serde(deny_unknown_fields)]
@@ -60,9 +65,15 @@ pub(crate) struct Config {
     pub(crate) temporality: Temporality,
 }
 
+pub(crate) enum TelemetryDataKind {
+    Traces,
+    Metrics,
+}
+
 impl Config {
     pub(crate) fn exporter<T: From<HttpExporterBuilder> + From<TonicExporterBuilder>>(
         &self,
+        kind: TelemetryDataKind,
     ) -> Result<T, BoxError> {
         match self.protocol {
             Protocol::Grpc => {
@@ -82,7 +93,12 @@ impl Config {
                 Ok(exporter)
             }
             Protocol::Http => {
-                let endpoint = self.endpoint.to_uri(&DEFAULT_HTTP_ENDPOINT);
+                let endpoint = add_missing_path(
+                    kind,
+                    self.endpoint
+                        .to_uri(&DEFAULT_HTTP_ENDPOINT)
+                        .map(|e| e.into_parts()),
+                )?;
                 let http = self.http.clone();
                 let exporter = opentelemetry_otlp::new_exporter()
                     .http()
@@ -97,6 +113,48 @@ impl Config {
             }
         }
     }
+}
+
+// Waiting for https://github.com/open-telemetry/opentelemetry-rust/issues/1618 to be fixed
+fn add_missing_path(
+    kind: TelemetryDataKind,
+    mut endpoint_parts: Option<Parts>,
+) -> Result<Option<Uri>, BoxError> {
+    if let Some(endpoint_parts) = &mut endpoint_parts {
+        if let TelemetryDataKind::Traces = kind {
+            match &mut endpoint_parts.path_and_query {
+                Some(path_and_query) => {
+                    if !path_and_query.path().ends_with(DEFAULT_HTTP_ENDPOINT_PATH) {
+                        match path_and_query.query() {
+                            Some(query) => {
+                                endpoint_parts.path_and_query =
+                                    Some(PathAndQuery::from_str(&format!(
+                                        "{}{DEFAULT_HTTP_ENDPOINT_PATH}?{query}",
+                                        path_and_query.path().trim_end_matches('/')
+                                    ))?);
+                            }
+                            None => {
+                                *path_and_query = PathAndQuery::from_str(&format!(
+                                    "{}{DEFAULT_HTTP_ENDPOINT_PATH}",
+                                    path_and_query.path().trim_end_matches('/')
+                                ))?;
+                            }
+                        }
+                    }
+                }
+                None => {
+                    endpoint_parts.path_and_query =
+                        Some(PathAndQuery::from_static(DEFAULT_HTTP_ENDPOINT_PATH));
+                }
+            }
+        }
+    }
+    let endpoint = match endpoint_parts {
+        Some(endpoint_parts) => Some(Uri::from_parts(endpoint_parts)?),
+        None => None,
+    };
+
+    Ok(endpoint)
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default, JsonSchema)]
@@ -249,5 +307,44 @@ mod tests {
         };
         let domain = exporter.default_tls_domain(&url);
         assert_eq!(domain, Some("foo.bar"));
+    }
+
+    #[test]
+    fn test_add_missing_path() {
+        let url = Uri::from_str("https://api.apm.com:433/v1/traces").unwrap();
+        let url = add_missing_path(TelemetryDataKind::Traces, url.into_parts().into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            url.to_string(),
+            String::from("https://api.apm.com:433/v1/traces")
+        );
+
+        let url = Uri::from_str("https://api.apm.com:433/").unwrap();
+        let url = add_missing_path(TelemetryDataKind::Traces, url.into_parts().into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            url.to_string(),
+            String::from("https://api.apm.com:433/v1/traces")
+        );
+
+        let url = Uri::from_str("https://api.apm.com:433/?hi=hello").unwrap();
+        let url = add_missing_path(TelemetryDataKind::Traces, url.into_parts().into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            url.to_string(),
+            String::from("https://api.apm.com:433/v1/traces?hi=hello")
+        );
+
+        let url = Uri::from_str("https://api.apm.com:433/v1?hi=hello").unwrap();
+        let url = add_missing_path(TelemetryDataKind::Traces, url.into_parts().into())
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            url.to_string(),
+            String::from("https://api.apm.com:433/v1/v1/traces?hi=hello")
+        );
     }
 }

--- a/apollo-router/src/plugins/telemetry/tracing/otlp.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/otlp.rs
@@ -8,6 +8,7 @@ use tower::BoxError;
 
 use crate::plugins::telemetry::config::TracingCommon;
 use crate::plugins::telemetry::config_new::spans::Spans;
+use crate::plugins::telemetry::otlp::TelemetryDataKind;
 use crate::plugins::telemetry::tracing::SpanProcessorExt;
 use crate::plugins::telemetry::tracing::TracingConfigurator;
 
@@ -23,7 +24,8 @@ impl TracingConfigurator for super::super::otlp::Config {
         _spans_config: &Spans,
     ) -> Result<Builder, BoxError> {
         tracing::info!("Configuring Otlp tracing: {}", self.batch_processor);
-        let exporter: SpanExporterBuilder = self.exporter()?;
+        let exporter: SpanExporterBuilder = self.exporter(TelemetryDataKind::Traces)?;
+
         Ok(builder.with_span_processor(
             BatchSpanProcessor::builder(
                 exporter.build_span_exporter()?,


### PR DESCRIPTION
In our [documentation](https://www.apollographql.com/docs/router/configuration/telemetry/exporters/tracing/otlp/#endpoint) when configuration http endpoint for tracing otlp exporter we say that users should only include the base address of the otlp endpoint. It was only working for grpc protocol and not http due to [this bug](https://github.com/open-telemetry/opentelemetry-rust/issues/1618). This inconsistency is now fixed with a workaround in the router waiting for the fix in openetelemetry crate.

So for example you'll have to specify the right path for http:

```yaml
telemetry:
  exporters:
    tracing:
      otlp:
        enabled: true
        endpoint: "http://localhost:4318"
        protocol: http
```


Fixes #4798

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
