### PR TITLE
feat(subscription): add configurable heartbeat for websocket protocol

### DIFF
--- a/.changesets/feat_subscription_websocket_heartbeat.md
+++ b/.changesets/feat_subscription_websocket_heartbeat.md
@@ -1,0 +1,17 @@
+### feat(subscription): add configurable heartbeat for websocket protocol ([Issue #4621](https://github.com/apollographql/router/issues/4621))
+
+Add the ability to enable heartbeat for cases where the subgraph drops idle connections.
+For example, https://netflix.github.io/dgs/
+
+Example of configuration:
+
+```yaml
+subscription:
+  mode:
+    passthrough:
+      all:
+        path: /graphql
+        heartbeat_interval: enable #Optional
+ ```
+
+By [@IvanGoncharov](https://github.com/IvanGoncharov) in https://github.com/apollographql/router/pull/4802

--- a/.changesets/feat_subscription_websocket_heartbeat.md
+++ b/.changesets/feat_subscription_websocket_heartbeat.md
@@ -1,9 +1,8 @@
-### feat(subscription): add configurable heartbeat for websocket protocol ([Issue #4621](https://github.com/apollographql/router/issues/4621))
+### Subscriptions: Add configurable "heartbeat" to subgraph WebSocket protocol ([Issue #4621](https://github.com/apollographql/router/issues/4621))
 
-Add the ability to enable heartbeat for cases where the subgraph drops idle connections.
-For example, https://netflix.github.io/dgs/
+To account for GraphQL Subscription WebSocket implementations (e.g., [DGS](https://netflix.github.io/dgs/)) which drop idle connections by design, the router adds the ability to configure a heartbeat to keep active connections alive.
 
-Example of configuration:
+An example of configuration:
 
 ```yaml
 subscription:

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -2464,6 +2464,27 @@ expression: "&schema"
                   "default": null,
                   "type": "object",
                   "properties": {
+                    "heartbeat_interval": {
+                      "description": "Heartbeat interval for graphql-ws protocol (default: disabled)",
+                      "default": "disabled",
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "disabled"
+                          ]
+                        },
+                        {
+                          "type": "string",
+                          "enum": [
+                            "enabled"
+                          ]
+                        },
+                        {
+                          "type": "string"
+                        }
+                      ]
+                    },
                     "path": {
                       "description": "Path on which WebSockets are listening",
                       "default": null,
@@ -2491,6 +2512,27 @@ expression: "&schema"
                     "description": "WebSocket configuration for a specific subgraph",
                     "type": "object",
                     "properties": {
+                      "heartbeat_interval": {
+                        "description": "Heartbeat interval for graphql-ws protocol (default: disabled)",
+                        "default": "disabled",
+                        "anyOf": [
+                          {
+                            "type": "string",
+                            "enum": [
+                              "disabled"
+                            ]
+                          },
+                          {
+                            "type": "string",
+                            "enum": [
+                              "enabled"
+                            ]
+                          },
+                          {
+                            "type": "string"
+                          }
+                        ]
+                      },
                       "path": {
                         "description": "Path on which WebSockets are listening",
                         "default": null,

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -2404,12 +2404,19 @@ expression: "&schema"
               "properties": {
                 "heartbeat_interval": {
                   "description": "Heartbeat interval for callback mode (default: 5secs)",
-                  "default": "5s",
+                  "default": "enabled",
                   "anyOf": [
                     {
                       "type": "string",
                       "enum": [
                         "disabled"
+                      ]
+                    },
+                    {
+                      "description": "enable with default interval of 5s",
+                      "type": "string",
+                      "enum": [
+                        "enabled"
                       ]
                     },
                     {
@@ -2475,6 +2482,7 @@ expression: "&schema"
                           ]
                         },
                         {
+                          "description": "enable with default interval of 5s",
                           "type": "string",
                           "enum": [
                             "enabled"
@@ -2523,6 +2531,7 @@ expression: "&schema"
                             ]
                           },
                           {
+                            "description": "enable with default interval of 5s",
                             "type": "string",
                             "enum": [
                               "enabled"

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -2407,6 +2407,7 @@ expression: "&schema"
                   "default": "enabled",
                   "anyOf": [
                     {
+                      "description": "disable heartbeat",
                       "type": "string",
                       "enum": [
                         "disabled"
@@ -2420,6 +2421,7 @@ expression: "&schema"
                       ]
                     },
                     {
+                      "description": "enable with custom interval, e.g. '100ms', '10s' or '1m'",
                       "type": "string"
                     }
                   ]
@@ -2476,6 +2478,7 @@ expression: "&schema"
                       "default": "disabled",
                       "anyOf": [
                         {
+                          "description": "disable heartbeat",
                           "type": "string",
                           "enum": [
                             "disabled"
@@ -2489,6 +2492,7 @@ expression: "&schema"
                           ]
                         },
                         {
+                          "description": "enable with custom interval, e.g. '100ms', '10s' or '1m'",
                           "type": "string"
                         }
                       ]
@@ -2525,6 +2529,7 @@ expression: "&schema"
                         "default": "disabled",
                         "anyOf": [
                           {
+                            "description": "disable heartbeat",
                             "type": "string",
                             "enum": [
                               "disabled"
@@ -2538,6 +2543,7 @@ expression: "&schema"
                             ]
                           },
                           {
+                            "description": "enable with custom interval, e.g. '100ms', '10s' or '1m'",
                             "type": "string"
                           }
                         ]

--- a/apollo-router/src/plugins/subscription.rs
+++ b/apollo-router/src/plugins/subscription.rs
@@ -171,9 +171,11 @@ pub(crate) struct CallbackMode {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case", untagged)]
 pub(crate) enum HeartbeatInterval {
+    /// disable heartbeat
     Disabled(Disabled),
     /// enable with default interval of 5s
     Enabled(Enabled),
+    /// enable with custom interval, e.g. '100ms', '10s' or '1m'
     #[serde(with = "humantime_serde")]
     #[schemars(with = "String")]
     Duration(Duration),

--- a/apollo-router/src/plugins/subscription.rs
+++ b/apollo-router/src/plugins/subscription.rs
@@ -112,7 +112,7 @@ impl SubscriptionModeConfig {
             if callback_cfg.subgraphs.contains(service_name) || callback_cfg.subgraphs.is_empty() {
                 let callback_cfg = CallbackMode {
                     public_url: callback_cfg.public_url.clone(),
-                    heartbeat_interval: callback_cfg.heartbeat_interval.clone(),
+                    heartbeat_interval: callback_cfg.heartbeat_interval,
                     listen: callback_cfg.listen.clone(),
                     path: callback_cfg.path.clone(),
                     subgraphs: HashSet::new(), // We don't need it
@@ -168,7 +168,7 @@ pub(crate) struct CallbackMode {
     pub(crate) subgraphs: HashSet<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case", untagged)]
 pub(crate) enum HeartbeatInterval {
     Disabled(Disabled),
@@ -186,22 +186,22 @@ impl HeartbeatInterval {
     pub(crate) fn new_disabled() -> Self {
         Self::Disabled(Disabled::Disabled)
     }
-    pub(crate) fn into_option(&self) -> Option<Duration> {
+    pub(crate) fn into_option(self) -> Option<Duration> {
         match self {
             Self::Disabled(_) => None,
             Self::Enabled(_) => Some(Duration::from_secs(5)),
-            Self::Duration(duration) => Some(*duration),
+            Self::Duration(duration) => Some(duration),
         }
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum Disabled {
     Disabled,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize, Serialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum Enabled {
     Enabled,

--- a/apollo-router/src/protocols/websocket.rs
+++ b/apollo-router/src/protocols/websocket.rs
@@ -445,19 +445,15 @@ where
 }
 
 fn send_heartbeat(mut stream: Pin<&mut impl Sink<ClientMessage>>, cx: &mut std::task::Context<'_>) {
-    match stream.as_mut().poll_flush(cx) {
-        Poll::Ready(Ok(_)) => match stream.as_mut().poll_ready(cx) {
-            Poll::Ready(Ok(_)) => {
-                // Ignore error
-                let _ = stream.start_send(ClientMessage::Ping {
-                    payload: Some(serde_json_bytes::Value::String(
-                        "APOLLO_ROUTER_HEARTBEAT".into()
-                    ))
-                });
-            }
-            _ => (),
-        },
-        _ => (),
+    if stream.as_mut().poll_flush(cx).map(|result| result.is_ok()) == Poll::Ready(true)
+        && stream.as_mut().poll_ready(cx).map(|result| result.is_ok()) == Poll::Ready(true)
+    {
+        // Ignore error
+        let _ = stream.start_send(ClientMessage::Ping {
+            payload: Some(serde_json_bytes::Value::String(
+                "APOLLO_ROUTER_HEARTBEAT".into(),
+            )),
+        });
     }
 }
 

--- a/apollo-router/src/protocols/websocket.rs
+++ b/apollo-router/src/protocols/websocket.rs
@@ -521,9 +521,8 @@ where
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Option<Self::Item>> {
         let mut this = self.as_mut().project();
-        let mut stream = Pin::new(&mut this.stream);
 
-        match stream.as_mut().poll_next(cx) {
+        match Pin::new(&mut this.stream).poll_next(cx) {
             Poll::Ready(message) => match message {
                 Some(server_message) => match server_message {
                     Ok(server_message) => {
@@ -536,7 +535,8 @@ where
                         if let ServerMessage::Ping { .. } = server_message {
                             // Send pong asynchronously
                             let _ = Pin::new(
-                                &mut stream.as_mut().send(ClientMessage::Pong { payload: None }),
+                                &mut Pin::new(&mut this.stream)
+                                    .send(ClientMessage::Pong { payload: None }),
                             )
                             .poll(cx);
                         }

--- a/apollo-router/src/protocols/websocket.rs
+++ b/apollo-router/src/protocols/websocket.rs
@@ -3,6 +3,7 @@ use std::task::Poll;
 use std::time::Duration;
 
 use futures::future;
+use futures::stream::SplitStream;
 use futures::Future;
 use futures::Sink;
 use futures::SinkExt;
@@ -16,6 +17,7 @@ use serde::Serialize;
 use serde_json_bytes::Value;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
+use tokio_stream::wrappers::IntervalStream;
 use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 use tokio_tungstenite::tungstenite::Message;
@@ -213,29 +215,25 @@ impl ServerMessage {
     }
 }
 
-pin_project! {
 pub(crate) struct GraphqlWebSocket<S> {
-    #[pin]
     stream: S,
     id: String,
     protocol: WebSocketProtocol,
-    heartbeat_interval: Option<tokio::time::Interval>,
-    // Booleans for state machine when closing the stream
-    completed: bool,
-    terminated: bool,
-}
 }
 
 impl<S> GraphqlWebSocket<S>
 where
-    S: Stream<Item = serde_json::Result<ServerMessage>> + Sink<ClientMessage> + std::marker::Unpin,
+    S: Stream<Item = serde_json::Result<ServerMessage>>
+        + Sink<ClientMessage>
+        + std::marker::Unpin
+        + std::marker::Send
+        + 'static,
 {
     pub(crate) async fn new(
         mut stream: S,
         id: String,
         protocol: WebSocketProtocol,
         connection_params: Option<Value>,
-        heartbeat_interval: Option<tokio::time::Duration>,
     ) -> Result<Self, graphql::Error> {
         let connection_init_msg = match connection_params {
             Some(connection_params) => ClientMessage::ConnectionInit {
@@ -287,25 +285,40 @@ where
                 .build());
         }
 
-        let heartbeat_interval = if protocol == WebSocketProtocol::GraphqlWs {
-            heartbeat_interval.map(|duration| {
-                let mut interval =
-                    tokio::time::interval_at(tokio::time::Instant::now() + duration, duration);
-                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-                interval
-            })
-        } else {
-            None
-        };
-
         Ok(Self {
             stream,
             id,
             protocol,
-            heartbeat_interval,
-            completed: false,
-            terminated: false,
         })
+    }
+
+    pub(crate) async fn into_subscription(
+        mut self,
+        request: graphql::Request,
+        heartbeat_interval: Option<tokio::time::Duration>,
+    ) -> Result<SubscriptionStream<S>, graphql::Error> {
+        tracing::info!(
+            monotonic_counter
+                .apollo
+                .router
+                .operations
+                .subscriptions
+                .events = 1u64,
+            subscriptions.mode = "passthrough"
+        );
+
+        self.stream
+            .send(self.protocol.subscribe(self.id.to_string(), request))
+            .await
+            .map(|_| {
+                SubscriptionStream::new(self.stream, self.id, self.protocol, heartbeat_interval)
+            })
+            .map_err(|_err| {
+                graphql::Error::builder()
+                    .message("cannot send to websocket connection")
+                    .extension_code("WEBSOCKET_CONNECTION_ERROR")
+                    .build()
+            })
     }
 }
 
@@ -375,7 +388,129 @@ where
         })
 }
 
-impl<S> Stream for GraphqlWebSocket<S>
+pub(crate) struct SubscriptionStream<S> {
+    inner_stream: SplitStream<InnerStream<S>>,
+    close_signal: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl<S> SubscriptionStream<S>
+where
+    S: Stream<Item = serde_json::Result<ServerMessage>>
+        + Sink<ClientMessage>
+        + std::marker::Unpin
+        + std::marker::Send
+        + 'static,
+{
+    pub(crate) fn new(
+        stream: S,
+        id: String,
+        protocol: WebSocketProtocol,
+        heartbeat_interval: Option<tokio::time::Duration>,
+    ) -> Self {
+        let (mut sink, inner_stream) = InnerStream::new(stream, id, protocol).split();
+        let (close_signal, close_sentinel) = tokio::sync::oneshot::channel::<()>();
+
+        tokio::task::spawn(async move {
+            if let (WebSocketProtocol::GraphqlWs, Some(duration)) = (protocol, heartbeat_interval) {
+                let mut interval =
+                    tokio::time::interval_at(tokio::time::Instant::now() + duration, duration);
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                let mut heartbeat_stream = IntervalStream::new(interval)
+                    .map(|_| {
+                        Ok(ClientMessage::Ping {
+                            payload: Some(serde_json_bytes::Value::String(
+                                "APOLLO_ROUTER_HEARTBEAT".into(),
+                            )),
+                        })
+                    })
+                    .take_until(close_sentinel);
+                if let Err(err) = sink.send_all(&mut heartbeat_stream).await {
+                    tracing::trace!("cannot send heartbeat: {err:?}");
+                    if let Some(close_sentinel) = heartbeat_stream.take_future() {
+                        if let Err(err) = close_sentinel.await {
+                            tracing::trace!("cannot shutdown sink: {err:?}");
+                        }
+                    }
+                }
+            } else if let Err(err) = close_sentinel.await {
+                tracing::trace!("cannot shutdown sink: {err:?}");
+            };
+
+            tracing::info!(
+                monotonic_counter
+                    .apollo
+                    .router
+                    .operations
+                    .subscriptions
+                    .events = 1u64,
+                subscriptions.mode = "passthrough",
+                subscriptions.complete = true
+            );
+
+            if let Err(err) = sink.close().await {
+                tracing::trace!("cannot close the websocket stream: {err:?}");
+            }
+        });
+
+        Self {
+            inner_stream,
+            close_signal: Some(close_signal),
+        }
+    }
+}
+
+impl<S> Drop for SubscriptionStream<S> {
+    fn drop(&mut self) {
+        if let Some(close_signal) = self.close_signal.take() {
+            if let Err(err) = close_signal.send(()) {
+                tracing::trace!("cannot close the websocket stream: {err:?}");
+            }
+        }
+    }
+}
+
+impl<S> Stream for SubscriptionStream<S>
+where
+    S: Stream<Item = serde_json::Result<ServerMessage>> + Sink<ClientMessage> + std::marker::Unpin,
+{
+    type Item = graphql::Response;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Option<Self::Item>> {
+        self.inner_stream.poll_next_unpin(cx)
+    }
+}
+
+pin_project! {
+struct InnerStream<S> {
+    #[pin]
+    stream: S,
+    id: String,
+    protocol: WebSocketProtocol,
+    // Booleans for state machine when closing the stream
+    completed: bool,
+    terminated: bool,
+}
+}
+
+impl<S> InnerStream<S>
+where
+    S: Stream<Item = serde_json::Result<ServerMessage>> + Sink<ClientMessage> + std::marker::Unpin,
+{
+    fn new(stream: S, id: String, protocol: WebSocketProtocol) -> Self {
+        Self {
+            stream,
+            id,
+            protocol,
+            completed: false,
+            terminated: false,
+        }
+    }
+}
+
+impl<S> Stream for InnerStream<S>
 where
     S: Stream<Item = serde_json::Result<ServerMessage>> + Sink<ClientMessage>,
 {
@@ -392,9 +527,6 @@ where
             Poll::Ready(message) => match message {
                 Some(server_message) => match server_message {
                     Ok(server_message) => {
-                        if let Some(heartbeat_interval) = this.heartbeat_interval {
-                            heartbeat_interval.reset();
-                        }
                         if let Some(id) = &server_message.id() {
                             if this.id != id {
                                 tracing::error!("we should not receive data from other subscriptions, closing the stream");
@@ -431,33 +563,12 @@ where
                 },
                 None => Poll::Ready(None),
             },
-            Poll::Pending => {
-                if let Some(heartbeat_interval) = this.heartbeat_interval {
-                    match heartbeat_interval.poll_tick(cx) {
-                        Poll::Ready(_) => send_heartbeat(this.stream, cx),
-                        Poll::Pending => (),
-                    };
-                }
-                Poll::Pending
-            }
+            Poll::Pending => Poll::Pending,
         }
     }
 }
 
-fn send_heartbeat(mut stream: Pin<&mut impl Sink<ClientMessage>>, cx: &mut std::task::Context<'_>) {
-    if stream.as_mut().poll_flush(cx).map(|result| result.is_ok()) == Poll::Ready(true)
-        && stream.as_mut().poll_ready(cx).map(|result| result.is_ok()) == Poll::Ready(true)
-    {
-        // Ignore error
-        let _ = stream.start_send(ClientMessage::Ping {
-            payload: Some(serde_json_bytes::Value::String(
-                "APOLLO_ROUTER_HEARTBEAT".into(),
-            )),
-        });
-    }
-}
-
-impl<S> Sink<graphql::Request> for GraphqlWebSocket<S>
+impl<S> Sink<ClientMessage> for InnerStream<S>
 where
     S: Stream<Item = serde_json::Result<ServerMessage>> + Sink<ClientMessage>,
 {
@@ -482,26 +593,15 @@ where
         })
     }
 
-    fn start_send(self: Pin<&mut Self>, item: graphql::Request) -> Result<(), Self::Error> {
+    fn start_send(self: Pin<&mut Self>, item: ClientMessage) -> Result<(), Self::Error> {
         let mut this = self.project();
 
-        tracing::info!(
-            monotonic_counter
-                .apollo
-                .router
-                .operations
-                .subscriptions
-                .events = 1u64,
-            subscriptions.mode = "passthrough"
-        );
-        Pin::new(&mut this.stream)
-            .start_send(this.protocol.subscribe(this.id.to_string(), item))
-            .map_err(|_err| {
-                graphql::Error::builder()
-                    .message("cannot send to websocket connection")
-                    .extension_code("WEBSOCKET_CONNECTION_ERROR")
-                    .build()
-            })
+        Pin::new(&mut this.stream).start_send(item).map_err(|_err| {
+            graphql::Error::builder()
+                .message("cannot send to websocket connection")
+                .extension_code("WEBSOCKET_CONNECTION_ERROR")
+                .build()
+        })
     }
 
     fn poll_flush(
@@ -521,16 +621,6 @@ where
         self: Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> Poll<Result<(), Self::Error>> {
-        tracing::info!(
-            monotonic_counter
-                .apollo
-                .router
-                .operations
-                .subscriptions
-                .events = 1u64,
-            subscriptions.mode = "passthrough",
-            subscriptions.complete = true
-        );
         let mut this = self.project();
         if !*this.completed {
             match Pin::new(
@@ -586,7 +676,7 @@ mod tests {
     use axum::routing::get;
     use axum::Router;
     use axum::Server;
-    use futures::StreamExt;
+    use futures::FutureExt;
     use http::HeaderValue;
     use tokio_tungstenite::connect_async;
     use tokio_tungstenite::tungstenite::client::IntoClientRequest;
@@ -597,6 +687,7 @@ mod tests {
 
     async fn emulate_correct_websocket_server_new_protocol(
         send_ping: bool,
+        heartbeat_interval: Option<tokio::time::Duration>,
         port: Option<u16>,
     ) -> SocketAddr {
         let ws_handler = move |ws: WebSocketUpgrade| async move {
@@ -653,6 +744,26 @@ mod tests {
                     ))
                     .await
                     .unwrap();
+
+                if let Some(duration) = heartbeat_interval {
+                   tokio::time::pause();
+                   assert!(
+                       socket.next().now_or_never().is_none(),
+                       "It should be no pending messages"
+                   );
+
+                   tokio::time::sleep(duration).await;
+                   let ping_message = socket.next().await.unwrap().unwrap();
+                   assert_eq!(ping_message, AxumWsMessage::Text(
+                       serde_json::to_string(&ClientMessage::Ping { payload: Some(serde_json_bytes::Value::String("APOLLO_ROUTER_HEARTBEAT".into())) }).unwrap(),
+                   ));
+
+                   assert!(
+                       socket.next().now_or_never().is_none(),
+                       "It should be no pending messages"
+                   );
+                   tokio::time::resume();
+                }
 
                 socket
                     .send(AxumWsMessage::Text(
@@ -812,16 +923,27 @@ mod tests {
 
     #[tokio::test]
     async fn test_ws_connection_new_proto_with_ping() {
-        test_ws_connection_new_proto(true, None).await
+        test_ws_connection_new_proto(true, None, None).await
     }
 
     #[tokio::test]
     async fn test_ws_connection_new_proto_without_ping() {
-        test_ws_connection_new_proto(false, None).await
+        test_ws_connection_new_proto(false, None, None).await
     }
 
-    async fn test_ws_connection_new_proto(send_ping: bool, port: Option<u16>) {
-        let socket_addr = emulate_correct_websocket_server_new_protocol(send_ping, port).await;
+    #[tokio::test]
+    async fn test_ws_connection_new_proto_with_heartbeat() {
+        test_ws_connection_new_proto(false, Some(tokio::time::Duration::from_secs(60)), None).await
+    }
+
+    async fn test_ws_connection_new_proto(
+        send_ping: bool,
+        heartbeat_interval: Option<tokio::time::Duration>,
+        port: Option<u16>,
+    ) {
+        let socket_addr =
+            emulate_correct_websocket_server_new_protocol(send_ping, heartbeat_interval, port)
+                .await;
         let url = url::Url::parse(format!("ws://{}/ws", socket_addr).as_str()).unwrap();
         let mut request = url.into_client_request().unwrap();
         request.headers_mut().insert(
@@ -831,26 +953,25 @@ mod tests {
         let (ws_stream, _resp) = connect_async(request).await.unwrap();
 
         let sub_uuid = Uuid::new_v4();
-        let gql_stream = GraphqlWebSocket::new(
+        let gql_socket = GraphqlWebSocket::new(
             convert_websocket_stream(ws_stream, sub_uuid.to_string()),
             sub_uuid.to_string(),
             WebSocketProtocol::GraphqlWs,
             Some(serde_json_bytes::json!({
                 "token": "XXX"
             })),
-            None,
         )
         .await
         .unwrap();
 
         let sub = "subscription {\n  userWasCreated {\n    username\n  }\n}";
-        let (mut gql_sink, mut gql_read_stream) = gql_stream.split();
-        let _handle = tokio::task::spawn(async move {
-            gql_sink
-                .send(graphql::Request::builder().query(sub).build())
-                .await
-                .unwrap();
-        });
+        let mut gql_read_stream = gql_socket
+            .into_subscription(
+                graphql::Request::builder().query(sub).build(),
+                heartbeat_interval,
+            )
+            .await
+            .unwrap();
 
         let next_payload = gql_read_stream.next().await.unwrap();
         assert_eq!(next_payload, graphql::Response::builder()
@@ -873,7 +994,7 @@ mod tests {
                 .build()
         );
         assert!(
-            gql_read_stream.next().await.is_none(),
+            gql_read_stream.next().now_or_never().is_none(),
             "It should be completed"
         );
     }
@@ -899,25 +1020,20 @@ mod tests {
         let (ws_stream, _resp) = connect_async(request).await.unwrap();
 
         let sub_uuid = Uuid::new_v4();
-        let gql_stream = GraphqlWebSocket::new(
+        let gql_socket = GraphqlWebSocket::new(
             convert_websocket_stream(ws_stream, sub_uuid.to_string()),
             sub_uuid.to_string(),
             WebSocketProtocol::SubscriptionsTransportWs,
-            None,
             None,
         )
         .await
         .unwrap();
 
         let sub = "subscription {\n  userWasCreated {\n    username\n  }\n}";
-        let (mut gql_sink, mut gql_read_stream) = gql_stream.split();
-        let _handle = tokio::task::spawn(async move {
-            gql_sink
-                .send(graphql::Request::builder().query(sub).build())
-                .await
-                .unwrap();
-            gql_sink.close().await.unwrap();
-        });
+        let mut gql_read_stream = gql_socket
+            .into_subscription(graphql::Request::builder().query(sub).build(), None)
+            .await
+            .unwrap();
 
         let next_payload = gql_read_stream.next().await.unwrap();
         assert_eq!(next_payload, graphql::Response::builder()
@@ -940,7 +1056,7 @@ mod tests {
                 .build()
         );
         assert!(
-            gql_read_stream.next().await.is_none(),
+            gql_read_stream.next().now_or_never().is_none(),
             "It should be completed"
         );
     }

--- a/docs/source/executing-operations/subscription-support.mdx
+++ b/docs/source/executing-operations/subscription-support.mdx
@@ -101,7 +101,7 @@ subscription:
         reviews: # Overrides settings for the 'reviews' subgraph
           path: /ws # Absolute path that overrides '/subscriptions' defined above
           protocol: graphql_ws # The WebSocket-based subprotocol to use for subscription communication (Default: graphql_ws)
-          heartbeat_interval: enable # Optional (Default: disabled)
+          heartbeat_interval: 10s # Optional, with 'enable' equal to '5s' (Default: disabled)
 ```
 
 This example enables subscriptions in **passthrough mode**, which uses long-lived WebSocket connections.

--- a/docs/source/executing-operations/subscription-support.mdx
+++ b/docs/source/executing-operations/subscription-support.mdx
@@ -101,9 +101,11 @@ subscription:
         reviews: # Overrides settings for the 'reviews' subgraph
           path: /ws # Absolute path that overrides '/subscriptions' defined above
           protocol: graphql_ws # The WebSocket-based subprotocol to use for subscription communication (Default: graphql_ws)
+          heartbeat_interval: enable # Optional (Default: disabled)
 ```
 
 This example enables subscriptions in **passthrough mode**, which uses long-lived WebSocket connections.
+Note: If your subgraph implementation (e.g. [DGS](https://netflix.github.io/dgs/)) can close idle connection, set `heartbest_interval` to keep connection alive.
 
 The router supports the following WebSocket subprotocols, specified via the `protocol` option:
 
@@ -160,7 +162,7 @@ subscription:
         - accounts
 ```
 
-You can disable the heartbeat by setting `heartbeat_interval_ms: disabled`. This is useful for example if you're running in callback mode in an infrastructure based on lambda functions, where you prefer neither to send heartbeats nor to keep a lambda awake just to send heartbeats to subscriptions.
+You can disable the heartbeat by setting `heartbeat_interval: disabled`. This is useful for example if you're running in callback mode in an infrastructure based on lambda functions, where you prefer neither to send heartbeats nor to keep a lambda awake just to send heartbeats to subscriptions.
 
 <Caution>
 

--- a/docs/source/executing-operations/subscription-support.mdx
+++ b/docs/source/executing-operations/subscription-support.mdx
@@ -101,7 +101,7 @@ subscription:
         reviews: # Overrides settings for the 'reviews' subgraph
           path: /ws # Absolute path that overrides '/subscriptions' defined above
           protocol: graphql_ws # The WebSocket-based subprotocol to use for subscription communication (Default: graphql_ws)
-          heartbeat_interval: 10s # Optional, with 'enable' equal to '5s' (Default: disabled)
+          heartbeat_interval: 10s # Optional and 'disable' by default, also supports 'enable' (set 5s interval) and custom values for intervals, e.g. '100ms', '10s', '1m'.
 ```
 
 This example enables subscriptions in **passthrough mode**, which uses long-lived WebSocket connections.


### PR DESCRIPTION
Add the ability to enable heartbeat for cases where the subgraph drops idle connections.
For example, https://netflix.github.io/dgs/

Example of configuration:

```yaml
subscription:
  mode:
    passthrough:
      all:
        path: /graphql
        heartbeat_interval: enable #Optional
 ```

Fixes #4621

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
