### PR TITLE
drop the ExtensionsGuard earlier

### DIFF
--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -262,9 +262,13 @@ where
         Box::pin(async move {
             let context = request.context.clone();
             qp.plan(request).await.map(|response| {
-                if let Some(usage_reporting) =
-                    context.extensions().lock().get::<Arc<UsageReporting>>()
-                {
+                if let Some(usage_reporting) = {
+                    context
+                        .extensions()
+                        .lock()
+                        .get::<Arc<UsageReporting>>()
+                        .cloned()
+                } {
                     let _ = response.context.insert(
                         "apollo_operation_id",
                         stats_report_key_hash(usage_reporting.stats_report_key.as_str()),


### PR DESCRIPTION
Now that UsageReporting is stored in an Arc, we can just clone it and drop the lock, then insert what we want in the context outside of the lock

This fixes a bug often triggerd in CI: 

```
thread 'test_plugin_ordering' panicked at apollo-router/src/context/extensions/sync.rs:66:21:
ExtensionsGuard held for 11ms. This is probably a bug that will stall the Router and cause performance problems. Run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

https://app.circleci.com/pipelines/github/apollographql/router/19639/workflows/34bc93f3-6a17-4514-9a5c-66a725f47f72/jobs/131057?invite=true#step-117-304313_184

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
