### PR TITLE
Orbiter: don’t parse CLI arguments in tests

### DIFF
--- a/apollo-router/src/executable.rs
+++ b/apollo-router/src/executable.rs
@@ -681,6 +681,7 @@ impl Executable {
         }
 
         let router = RouterHttpServer::builder()
+            .is_telemetry_disabled(opt.is_telemetry_disabled())
             .configuration(configuration)
             .and_uplink(uplink_config)
             .schema(schema_source)

--- a/apollo-router/src/router/mod.rs
+++ b/apollo-router/src/router/mod.rs
@@ -129,6 +129,7 @@ impl RouterHttpServer {
         license: Option<LicenseSource>,
         shutdown: Option<ShutdownSource>,
         uplink: Option<UplinkConfig>,
+        is_telemetry_disabled: Option<bool>,
     ) -> RouterHttpServer {
         let (shutdown_sender, shutdown_receiver) = oneshot::channel::<()>();
         let event_stream = generate_event_stream(
@@ -141,7 +142,11 @@ impl RouterHttpServer {
         );
         let server_factory = AxumHttpServerFactory::new();
         let router_factory = OrbiterRouterSuperServiceFactory::new(YamlRouterFactory);
-        let state_machine = StateMachine::new(server_factory, router_factory);
+        let state_machine = StateMachine::new(
+            is_telemetry_disabled.unwrap_or(false),
+            server_factory,
+            router_factory,
+        );
         let listen_addresses = state_machine.listen_addresses.clone();
         let result = spawn(
             async move { state_machine.process_events(event_stream).await }

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -133,6 +133,7 @@ pub(crate) trait RouterSuperServiceFactory: Send + Sync + 'static {
 
     async fn create<'a>(
         &'a mut self,
+        is_telemetry_disabled: bool,
         configuration: Arc<Configuration>,
         schema: String,
         previous_router: Option<&'a Self::RouterFactory>,
@@ -150,6 +151,7 @@ impl RouterSuperServiceFactory for YamlRouterFactory {
 
     async fn create<'a>(
         &'a mut self,
+        _is_telemetry_disabled: bool,
         configuration: Arc<Configuration>,
         schema: String,
         previous_router: Option<&'a Self::RouterFactory>,
@@ -455,8 +457,15 @@ fn load_certs(certificates: &str) -> io::Result<Vec<rustls::Certificate>> {
 pub async fn create_test_service_factory_from_yaml(schema: &str, configuration: &str) {
     let config: Configuration = serde_yaml::from_str(configuration).unwrap();
 
+    let is_telemetry_disabled = false;
     let service = YamlRouterFactory
-        .create(Arc::new(config), schema.to_string(), None, None)
+        .create(
+            is_telemetry_disabled,
+            Arc::new(config),
+            schema.to_string(),
+            None,
+            None,
+        )
         .await;
     assert_eq!(
         service.map(|_| ()).unwrap_err().to_string().as_str(),
@@ -806,8 +815,15 @@ mod test {
     async fn create_service(config: Configuration) -> Result<(), BoxError> {
         let schema = include_str!("testdata/supergraph.graphql");
 
+        let is_telemetry_disabled = false;
         let service = YamlRouterFactory
-            .create(Arc::new(config), schema.to_string(), None, None)
+            .create(
+                is_telemetry_disabled,
+                Arc::new(config),
+                schema.to_string(),
+                None,
+                None,
+            )
             .await;
         service.map(|_| ())
     }

--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -360,6 +360,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
         let router_service_factory = state_machine
             .router_configurator
             .create(
+                state_machine.is_telemetry_disabled,
                 configuration.clone(),
                 schema.to_string(),
                 previous_router_service_factory,
@@ -441,6 +442,7 @@ where
     S: HttpServerFactory,
     FA: RouterSuperServiceFactory,
 {
+    is_telemetry_disabled: bool,
     http_server_factory: S,
     router_configurator: FA,
     pub(crate) listen_addresses: Arc<RwLock<ListenAddresses>>,
@@ -455,7 +457,11 @@ where
     FA: RouterSuperServiceFactory + Send,
     FA::RouterFactory: RouterFactory,
 {
-    pub(crate) fn new(http_server_factory: S, router_factory: FA) -> Self {
+    pub(crate) fn new(
+        is_telemetry_disabled: bool,
+        http_server_factory: S,
+        router_factory: FA,
+    ) -> Self {
         // Listen address is created locked so that if a consumer tries to examine the listen address before the state machine has reached running state they are blocked.
         let listen_addresses: Arc<RwLock<ListenAddresses>> = Default::default();
         let listen_addresses_guard = Some(
@@ -465,6 +471,7 @@ where
                 .expect("lock just created, qed"),
         );
         Self {
+            is_telemetry_disabled,
             http_server_factory,
             router_configurator: router_factory,
             listen_addresses,
@@ -489,6 +496,7 @@ where
                 .expect("lock just created, qed"),
         );
         Self {
+            is_telemetry_disabled: false,
             http_server_factory,
             router_configurator: router_factory,
             listen_addresses,
@@ -813,7 +821,9 @@ mod tests {
     async fn listen_addresses_are_locked() {
         let router_factory = create_mock_router_configurator(0);
         let (server_factory, _) = create_mock_server_factory(0, 0, 0, 0, 0);
-        let state_machine = StateMachine::new(server_factory, router_factory);
+        let is_telemetry_disabled = false;
+        let state_machine =
+            StateMachine::new(is_telemetry_disabled, server_factory, router_factory);
         assert!(state_machine.listen_addresses.try_read().is_err());
     }
 
@@ -978,7 +988,7 @@ mod tests {
         router_factory
             .expect_create()
             .times(1)
-            .returning(|_, _, _, _| Err(BoxError::from("Error")));
+            .returning(|_, _, _, _, _| Err(BoxError::from("Error")));
 
         let (server_factory, shutdown_receivers) = create_mock_server_factory(0, 1, 0, 1, 0);
 
@@ -1006,7 +1016,7 @@ mod tests {
             .expect_create()
             .times(1)
             .in_sequence(&mut seq)
-            .returning(|_, _, _, _| {
+            .returning(|_, _, _, _, _| {
                 let mut router = MockMyRouterFactory::new();
                 router.expect_clone().return_once(MockMyRouterFactory::new);
                 router.expect_web_endpoints().returning(MultiMap::new);
@@ -1016,7 +1026,7 @@ mod tests {
             .expect_create()
             .times(1)
             .in_sequence(&mut seq)
-            .returning(|_, _, _, _| Err(BoxError::from("error")));
+            .returning(|_, _, _, _, _| Err(BoxError::from("error")));
 
         let (server_factory, shutdown_receivers) = create_mock_server_factory(1, 1, 1, 1, 1);
         let minimal_schema = include_str!("testdata/minimal_supergraph.graphql");
@@ -1047,7 +1057,7 @@ mod tests {
             .expect_create()
             .times(1)
             .in_sequence(&mut seq)
-            .returning(|_, _, _, _| {
+            .returning(|_, _, _, _, _| {
                 let mut router = MockMyRouterFactory::new();
                 router.expect_clone().return_once(MockMyRouterFactory::new);
                 router.expect_web_endpoints().returning(MultiMap::new);
@@ -1057,13 +1067,13 @@ mod tests {
             .expect_create()
             .times(1)
             .in_sequence(&mut seq)
-            .returning(|_, _, _, _| Err(BoxError::from("error")));
+            .returning(|_, _, _, _, _| Err(BoxError::from("error")));
         router_factory
             .expect_create()
             .times(1)
             .in_sequence(&mut seq)
-            .withf(|configuration, _, _, _| configuration.homepage.enabled)
-            .returning(|_, _, _, _| {
+            .withf(|_, configuration, _, _, _| configuration.homepage.enabled)
+            .returning(|_, _, _, _, _| {
                 let mut router = MockMyRouterFactory::new();
                 router.expect_clone().return_once(MockMyRouterFactory::new);
                 router.expect_web_endpoints().returning(MultiMap::new);
@@ -1107,6 +1117,7 @@ mod tests {
 
             async fn create<'a>(
                 &'a mut self,
+                is_telemetry_disabled: bool,
                 configuration: Arc<Configuration>,
                 schema: String,
                 previous_router_service_factory: Option<&'a MockMyRouterFactory>,
@@ -1179,7 +1190,9 @@ mod tests {
         router_factory: MockMyRouterConfigurator,
         events: impl Stream<Item = Event> + Unpin,
     ) -> Result<(), ApolloRouterError> {
-        let state_machine = StateMachine::new(server_factory, router_factory);
+        let is_telemetry_disabled = false;
+        let state_machine =
+            StateMachine::new(is_telemetry_disabled, server_factory, router_factory);
         state_machine.process_events(events).await
     }
 
@@ -1274,7 +1287,7 @@ mod tests {
             } else {
                 expect_times_called
             })
-            .returning(move |_, _, _, _| {
+            .returning(move |_, _, _, _, _| {
                 let mut router = MockMyRouterFactory::new();
                 router.expect_clone().return_once(MockMyRouterFactory::new);
                 router.expect_web_endpoints().returning(MultiMap::new);
@@ -1287,7 +1300,7 @@ mod tests {
                 .expect_create()
                 .times(expect_times_called - 1)
                 .withf(
-                    move |_configuration: &Arc<Configuration>,
+                    move |_, _configuration: &Arc<Configuration>,
                           _,
                           previous_router_service_factory: &Option<&MockMyRouterFactory>,
                           _extra_plugins: &Option<Vec<(String, Box<dyn DynPlugin>)>>|
@@ -1295,7 +1308,7 @@ mod tests {
                             previous_router_service_factory.is_some()
                           },
                 )
-                .returning(move |_, _, _, _| {
+                .returning(move |_, _, _, _, _| {
                     let mut router = MockMyRouterFactory::new();
                     router.expect_clone().return_once(MockMyRouterFactory::new);
                     router.expect_web_endpoints().returning(MultiMap::new);


### PR DESCRIPTION
This unbreaks e.g. `cargo test -- -q`

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
