### PR TITLE
doc: clarify the resulting protocol of a subgraph connection when configuring experimental_http2

### DIFF
--- a/docs/source/configuration/traffic-shaping.mdx
+++ b/docs/source/configuration/traffic-shaping.mdx
@@ -185,6 +185,13 @@ Use the table below to look up the resulting protocol of a subgraph connection, 
 | `experimental_http2: disable` | HTTP/1.1           | HTTP/1.1 with TLS           |
 | `experimental_http2: enable`  | HTTP/1.1           | Either HTTP/1.1 or HTTP/2 with TLS, as determined by the TLS handshake with a subgraph |
 | `experimental_http2: http2only` | h2c              | HTTP/2 with TLS              |
+| `experimental_http2` not set | HTTP/1.1 | Either HTTP/1.1 or HTTP/2 with TLS, as determined by the TLS handshake with a subgraph |
+
+<Note>
+
+Configuring `experimental_http2: http2only` for a subgraph that doesn't support HTTP/2 results in a failed subgraph connection.
+
+</Note>
 
 ### Ordering
 

--- a/docs/source/configuration/traffic-shaping.mdx
+++ b/docs/source/configuration/traffic-shaping.mdx
@@ -1,5 +1,7 @@
 ---
 title: Traffic shaping in the Apollo Router
+subtitle: ' '
+description: "Tune the performance and reliability of traffic to and from the Apollo Router."
 ---
 
 The Apollo Router provides various features to improve the performance and reliability of
@@ -170,11 +172,19 @@ traffic_shaping:
 
 ### HTTP/2
 
-The router supports subgraph connections over
-- HTTP/2 with TLS. This is the default configuration.
+The router supports subgraph connections over:
+- HTTP/1.1
+- HTTP/1.1 with TLS
+- HTTP/2 with TLS
 - HTTP/2 Cleartext protocol (h2c). This uses HTTP/2 over plaintext connections.
 
-To use h2c, the subgraph URL must have the `http` scheme, and the `experimental_http2` option must be set to `http2only`.
+Use the table below to look up the resulting protocol of a subgraph connection, based on the subgraph URL and the `experimental_http2` option:
+
+|                           | URL with `http://` | URL with `https://`         |
+| ------------------------- | ------------------- | --------------------------- |
+| `experimental_http2: disable` | HTTP/1.1           | HTTP/1.1 with TLS           |
+| `experimental_http2: enable`  | HTTP/1.1           | Either HTTP/1.1 or HTTP/2 with TLS, as determined by the TLS handshake with a subgraph |
+| `experimental_http2: http2only` | h2c              | HTTP/2 with TLS              |
 
 ### Ordering
 


### PR DESCRIPTION
Add table to clarify the resulting HTTP protocol of a subgraph connection when configuring `experimental_http2`.

Resolves [DOC-11](https://apollographql.atlassian.net/browse/DOC-11)

[DOC-11]: https://apollographql.atlassian.net/browse/DOC-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ