### PR TITLE
Zipkin service name not populated

### DIFF
--- a/.changesets/fix_bryn_zipkin_service_name.md
+++ b/.changesets/fix_bryn_zipkin_service_name.md
@@ -1,0 +1,17 @@
+### Zipkin service name not populated ([Issue #4807](https://github.com/apollographql/router/issues/4807))
+
+Zipkin trace exporter now respects service name configuration from yaml or environment variables.
+
+For instance to set the service name to `my-app`, you can use the following configuration in your `router.yaml` file:
+```yaml
+telemetry:
+  exporters:
+    tracing:
+      common:
+        service_name: my-app
+      zipkin:
+        enabled: true
+        endpoint: default
+```
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/4816

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ executors:
       - image: cimg/base:stable
       - image: cimg/redis:7.2.4
       - image: jaegertracing/all-in-one:1.54.0
+      - image: openzipkin/zipkin:2.23.2
     resource_class: xlarge
     environment:
       CARGO_BUILD_JOBS: 4

--- a/apollo-router/tests/fixtures/zipkin.router.yaml
+++ b/apollo-router/tests/fixtures/zipkin.router.yaml
@@ -1,6 +1,9 @@
 telemetry:
   exporters:
     tracing:
+      experimental_response_trace_id:
+        enabled: true
+        header_name: apollo-custom-trace-id
       common:
         service_name: router
       zipkin:

--- a/apollo-router/tests/zipkin_test.rs
+++ b/apollo-router/tests/zipkin_test.rs
@@ -1,0 +1,119 @@
+#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+
+extern crate core;
+
+mod common;
+
+use std::time::Duration;
+
+use anyhow::anyhow;
+use serde_json::json;
+use serde_json::Value;
+use tower::BoxError;
+
+use crate::common::IntegrationTest;
+use crate::common::Telemetry;
+use crate::common::ValueExt;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_basic() -> Result<(), BoxError> {
+    let mut router = IntegrationTest::builder()
+        .telemetry(Telemetry::Zipkin)
+        .config(include_str!("fixtures/zipkin.router.yaml"))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    let query = json!({"query":"query ExampleQuery {topProducts{name}}","variables":{}});
+    for _ in 0..2 {
+        let (id, result) = router.execute_query(&query).await;
+        assert!(!result
+            .headers()
+            .get("apollo-custom-trace-id")
+            .unwrap()
+            .is_empty());
+        validate_trace(
+            id,
+            &query,
+            Some("ExampleQuery"),
+            &["my_app", "router", "products"],
+            false,
+        )
+        .await?;
+        router.touch_config().await;
+        router.assert_reloaded().await;
+    }
+    router.graceful_shutdown().await;
+    Ok(())
+}
+
+async fn validate_trace(
+    id: String,
+    query: &Value,
+    operation_name: Option<&str>,
+    services: &[&'static str],
+    custom_span_instrumentation: bool,
+) -> Result<(), BoxError> {
+    let params = url::form_urlencoded::Serializer::new(String::new())
+        .append_pair("service", services.first().expect("expected root service"))
+        .finish();
+
+    let url = format!("http://localhost:9411/api/v2/trace/{id}?{params}");
+    for _ in 0..10 {
+        if find_valid_trace(
+            &url,
+            query,
+            operation_name,
+            services,
+            custom_span_instrumentation,
+        )
+        .await
+        .is_ok()
+        {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+    }
+    find_valid_trace(
+        &url,
+        query,
+        operation_name,
+        services,
+        custom_span_instrumentation,
+    )
+    .await?;
+    Ok(())
+}
+
+async fn find_valid_trace(
+    url: &str,
+    _query: &Value,
+    _operation_name: Option<&str>,
+    _services: &[&'static str],
+    _custom_span_instrumentation: bool,
+) -> Result<(), BoxError> {
+    // A valid trace has:
+    // * A valid service name
+    // * All three services
+    // * The correct spans
+    // * All spans are parented
+    // * Required attributes of 'router' span has been set
+
+    // For now just validate service name.
+    let trace: Value = reqwest::get(url)
+        .await
+        .map_err(|e| anyhow!("failed to contact zipkin; {}", e))?
+        .json()
+        .await?;
+    tracing::debug!("{}", serde_json::to_string_pretty(&trace)?);
+    let service_name = trace.select_path("$..localEndpoint.serviceName")?;
+
+    assert_eq!(
+        service_name.get(0),
+        Some(&&Value::String("router".to_string()))
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Zipkin exporter ignores service-name from the trace config. We have to explicitly set it.

Added integration test for zipkin

Fixes #4807


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
