### PR TITLE
Create scaffolding for new demand control plugin

### DIFF
--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1395,6 +1395,33 @@ expression: "&schema"
       },
       "additionalProperties": false
     },
+    "experimental_demand_control": {
+      "description": "Demand control configuration",
+      "type": "object",
+      "required": [
+        "algorithm",
+        "enabled"
+      ],
+      "properties": {
+        "algorithm": {
+          "description": "The algorithm used to calculate the cost of an incoming request",
+          "oneOf": [
+            {
+              "description": "A simple, statically-defined cost mapping for operations and types.\n\nOperation costs: - Mutation: 10 - Query: 0 - Subscription 0\n\nType costs: - Object: 1 - Interface: 1 - Union: 1 - Scalar: 0 - Enum: 0",
+              "type": "string",
+              "enum": [
+                "basic"
+              ]
+            }
+          ]
+        },
+        "enabled": {
+          "description": "Enable demand control",
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
+    },
     "experimental_graphql_validation_mode": {
       "description": "Set the GraphQL validation implementation to use.",
       "default": "both",

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -11,7 +11,7 @@ use crate::register_plugin;
 use crate::services::execution::BoxService;
 
 /// Algorithm for calculating the cost of an incoming query.
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub(crate) enum CostCalculationAlgorithm {
     /// A simple, statically-defined cost mapping for operations and types.
@@ -27,12 +27,11 @@ pub(crate) enum CostCalculationAlgorithm {
     /// - Union: 1
     /// - Scalar: 0
     /// - Enum: 0
-    #[default]
-    Default,
+    Basic,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
-#[serde(default, deny_unknown_fields)]
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct DemandControlConfig {
     enabled: bool,
     algorithm: CostCalculationAlgorithm,

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -12,7 +12,7 @@ use crate::services::execution::BoxService;
 
 /// Algorithm for calculating the cost of an incoming query.
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields, rename_all = "lowercase")]
+#[serde(deny_unknown_fields, rename_all = "snake_case")]
 pub(crate) enum CostCalculationAlgorithm {
     /// A simple, statically-defined cost mapping for operations and types.
     ///

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -1,0 +1,62 @@
+//! Demand control plugin.
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tower::BoxError;
+use tower::ServiceBuilder;
+use tower::ServiceExt;
+
+use crate::plugin::Plugin;
+use crate::plugin::PluginInit;
+use crate::services::execution::BoxService;
+
+/// Algorithm for calculating the cost of an incoming query.
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields, rename_all = "lowercase")]
+pub(crate) enum CostCalculationAlgorithm {
+    /// A simple, statically-defined cost mapping for operations and types.
+    ///
+    /// Operation costs:
+    /// - Mutation: 10
+    /// - Query: 0
+    /// - Subscription 0
+    ///
+    /// Type costs:
+    /// - Object: 1
+    /// - Interface: 1
+    /// - Union: 1
+    /// - Scalar: 0
+    /// - Enum: 0
+    #[default]
+    Default,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema)]
+#[serde(default, deny_unknown_fields)]
+pub(crate) struct DemandControlConfig {
+    enabled: bool,
+    algorithm: CostCalculationAlgorithm,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct DemandControl {
+    config: DemandControlConfig,
+}
+
+#[async_trait::async_trait]
+impl Plugin for DemandControl {
+    type Config = DemandControlConfig;
+
+    async fn new(init: PluginInit<Self::Config>) -> Result<Self, BoxError> {
+        Ok(DemandControl {
+            config: init.config,
+        })
+    }
+
+    fn execution_service(&self, service: BoxService) -> BoxService {
+        if !self.config.enabled {
+            service
+        } else {
+            ServiceBuilder::new().service(service).boxed()
+        }
+    }
+}

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -30,10 +30,13 @@ pub(crate) enum CostCalculationAlgorithm {
     Basic,
 }
 
+/// Demand control configuration
 #[derive(Clone, Debug, Deserialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct DemandControlConfig {
+    /// Enable demand control
     enabled: bool,
+    /// The algorithm used to calculate the cost of an incoming request
     #[allow(dead_code)]
     algorithm: CostCalculationAlgorithm,
 }

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -7,6 +7,7 @@ use tower::ServiceExt;
 
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
+use crate::register_plugin;
 use crate::services::execution::BoxService;
 
 /// Algorithm for calculating the cost of an incoming query.
@@ -60,3 +61,5 @@ impl Plugin for DemandControl {
         }
     }
 }
+
+register_plugin!("apollo", "experimental_demand_control", DemandControl);

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -34,6 +34,7 @@ pub(crate) enum CostCalculationAlgorithm {
 #[serde(deny_unknown_fields)]
 pub(crate) struct DemandControlConfig {
     enabled: bool,
+    #[allow(dead_code)]
     algorithm: CostCalculationAlgorithm,
 }
 

--- a/apollo-router/src/plugins/mod.rs
+++ b/apollo-router/src/plugins/mod.rs
@@ -25,6 +25,7 @@ pub(crate) mod authorization;
 pub(crate) mod cache;
 mod coprocessor;
 pub(crate) mod csrf;
+mod demand_control;
 mod expose_query_plan;
 pub(crate) mod file_uploads;
 mod forbid_mutations;

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -626,6 +626,7 @@ pub(crate) async fn create_plugins(
     // This relative ordering is documented in `docs/source/customizations/native.mdx`:
     add_optional_apollo_plugin!("rhai");
     add_optional_apollo_plugin!("coprocessor");
+    add_optional_apollo_plugin!("experimental_demand_control");
     add_user_plugins!();
 
     // Macros above remove from `apollo_plugin_factories`, so anything left at the end

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -382,6 +382,10 @@ impl LicenseEnforcementReport {
                 .path("$.preview_file_uploads")
                 .name("File uploads plugin")
                 .build(),
+            ConfigurationRestriction::builder()
+                .path("$.experimental_demand_control")
+                .name("Demand control plugin")
+                .build(),
         ]
     }
 

--- a/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config.snap
+++ b/apollo-router/src/uplink/snapshots/apollo_router__uplink__license_enforcement__test__restricted_features_via_config.snap
@@ -47,3 +47,6 @@ Configuration yaml:
 
 * File uploads plugin
   .preview_file_uploads
+
+* Demand control plugin
+  .experimental_demand_control

--- a/apollo-router/src/uplink/testdata/restricted.router.yaml
+++ b/apollo-router/src/uplink/testdata/restricted.router.yaml
@@ -77,3 +77,7 @@ preview_file_uploads:
     multipart:
       enabled: true
       mode: stream
+
+experimental_demand_control:
+  enabled: true
+  algorithm: default

--- a/apollo-router/src/uplink/testdata/restricted.router.yaml
+++ b/apollo-router/src/uplink/testdata/restricted.router.yaml
@@ -80,4 +80,4 @@ preview_file_uploads:
 
 experimental_demand_control:
   enabled: true
-  algorithm: default
+  algorithm: basic


### PR DESCRIPTION
Created scaffolding for new demand control plugin with a simple config. The max cost setting is planned to come from the limits block of the configuration, so it is not included in this change. The plugin is currently not registered so it does not appear in the config schema during development

Fixes [ROUTER-181](https://apollographql.atlassian.net/browse/ROUTER-181)

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-181]: https://apollographql.atlassian.net/browse/ROUTER-181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ