### PR TITLE
Implement basic static cost calculator for demand control

### DIFF
--- a/apollo-router/src/plugins/demand_control/basic_cost_calculator.rs
+++ b/apollo-router/src/plugins/demand_control/basic_cost_calculator.rs
@@ -1,0 +1,274 @@
+use anyhow::anyhow;
+use apollo_compiler::executable::ExecutableDocument;
+use apollo_compiler::executable::Field;
+use apollo_compiler::executable::FragmentSpread;
+use apollo_compiler::executable::InlineFragment;
+use apollo_compiler::executable::Operation;
+use apollo_compiler::executable::Selection;
+use apollo_compiler::Schema;
+use tower::BoxError;
+
+use super::CostCalculator;
+
+pub(crate) struct BasicCostCalculator {}
+
+impl BasicCostCalculator {
+    fn score_field(field: &Field, schema: &Schema) -> Result<f64, BoxError> {
+        let ty = field
+            .inner_type_def(schema)
+            .ok_or(anyhow!("Field {} was not found in schema", field))?;
+
+        let instance_count = if field.ty().is_list() { 100.0 } else { 1.0 };
+
+        let mut type_cost = if ty.is_interface() || ty.is_object() || ty.is_union() {
+            1.0
+        } else {
+            0.0
+        };
+        for selection in field.selection_set.selections.iter() {
+            type_cost += BasicCostCalculator::score_selection(selection, schema)?;
+        }
+
+        Ok(instance_count * type_cost)
+    }
+
+    fn score_fragment_spread(_fragment_spread: &FragmentSpread) -> Result<f64, BoxError> {
+        Ok(0.0)
+    }
+
+    fn score_inline_fragment(
+        inline_fragment: &InlineFragment,
+        schema: &Schema,
+    ) -> Result<f64, BoxError> {
+        let mut cost = 0.0;
+        for selection in inline_fragment.selection_set.selections.iter() {
+            cost += BasicCostCalculator::score_selection(selection, schema)?;
+        }
+        Ok(cost)
+    }
+
+    fn score_operation(operation: &Operation, schema: &Schema) -> Result<f64, BoxError> {
+        let mut cost = 0.0;
+        if operation.is_mutation() {
+            cost += 10.0;
+        }
+
+        for selection in operation.selection_set.selections.iter() {
+            cost += BasicCostCalculator::score_selection(selection, schema)?;
+        }
+
+        Ok(cost)
+    }
+
+    fn score_selection(selection: &Selection, schema: &Schema) -> Result<f64, BoxError> {
+        match selection {
+            Selection::Field(f) => BasicCostCalculator::score_field(f, schema),
+            Selection::FragmentSpread(s) => BasicCostCalculator::score_fragment_spread(s),
+            Selection::InlineFragment(i) => BasicCostCalculator::score_inline_fragment(i, schema),
+        }
+    }
+}
+
+impl CostCalculator for BasicCostCalculator {
+    fn estimated(query: &ExecutableDocument, schema: &Schema) -> Result<f64, BoxError> {
+        let mut cost = 0.0;
+        if let Some(op) = &query.anonymous_operation {
+            cost += BasicCostCalculator::score_operation(op, schema)?;
+        }
+        for (_name, op) in query.named_operations.iter() {
+            cost += BasicCostCalculator::score_operation(op, schema)?;
+        }
+        Ok(cost)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cost(schema_str: &str, query_str: &str) -> f64 {
+        let schema = Schema::parse_and_validate(schema_str, "").unwrap();
+        let query = ExecutableDocument::parse_and_validate(&schema, query_str, "").unwrap();
+        BasicCostCalculator::estimated(&query, &schema).unwrap()
+    }
+
+    #[test]
+    fn query_cost() {
+        let schema = "
+            type Query {
+                a(id: ID): String
+                b: Int
+            }
+        ";
+        let query = "
+            {
+                a(id: 2)
+            }
+        ";
+
+        assert_eq!(cost(schema, query), 0.0)
+    }
+
+    #[test]
+    fn mutation_cost() {
+        let schema = "
+            type Query {
+                a: Int
+            }
+            type Mutation {
+                doSomething: Int
+            }
+        ";
+        let query = "
+            mutation {
+                doSomething
+            }
+        ";
+
+        assert_eq!(cost(schema, query), 10.0)
+    }
+
+    #[test]
+    fn object_cost() {
+        let schema = "
+            type Query {
+                me: User!
+            }
+
+            type User {
+                name: String!
+                age: Int
+            }
+        ";
+        let query = "
+            {
+                me {
+                    name
+                }
+            }
+        ";
+
+        assert_eq!(cost(schema, query), 1.0)
+    }
+
+    #[test]
+    fn interface_cost() {
+        let schema = "
+            type Query {
+                favoriteBook: Book
+            }
+
+            interface Book {
+                title: String!
+                author: String!
+            }
+        ";
+        let query = "
+            {
+                favoriteBook {
+                    title
+                }
+            }
+        ";
+
+        assert_eq!(cost(schema, query), 1.0)
+    }
+
+    #[test]
+    fn union_cost() {
+        let schema = "
+            type Query {
+                fruit: Fruit!
+            }
+
+            type Apple {
+                weight: Float
+            }
+
+            type Orange {
+                weight: Float
+            }
+
+            union Fruit = Apple | Orange
+        ";
+        let query = "
+            {
+                fruit {
+                    ... on Apple {
+                        weight
+                    }
+                    ... on Orange {
+                        weight
+                    }
+                }
+            }
+        ";
+
+        assert_eq!(cost(schema, query), 1.0)
+    }
+
+    #[test]
+    fn list_cost() {
+        let schema = "
+            type Query {
+                products: [Product!]
+            }
+
+            type Product {
+                name: String
+                cost: Float
+            }
+        ";
+        let query = "
+            {
+                products {
+                    name
+                    cost
+                }
+            }
+        ";
+
+        assert_eq!(cost(schema, query), 100.0)
+    }
+
+    #[test]
+    fn nested_object_lists() {
+        let schema = "
+            type Query {
+                authors: [Author]
+                books: [Book]
+            }
+
+            type Author {
+                books: [Book]
+                name: String
+            }
+
+            type Book {
+                authors: [Author]
+                title: String
+            }
+        ";
+        let query = "
+            {
+                authors {
+                    books {
+                        title
+                    }
+                }
+            }
+        ";
+
+        // The scoring works recursively starting at the leaf nodes of the query.
+        //
+        // The leaf selection is a Book object, which has cost 1.
+        //
+        // The parent is itself a selection of an Author object, which has an overhead of 1, plus
+        // the cost of its children (assumed to be a list of 100 books). So the cost of each author
+        // is 101.
+        //
+        // The query selects a list of authors, which is also assumed to have 100 items. So the cost
+        // of the query overall is 101 * 100, or 10,100.
+        assert_eq!(cost(schema, query), 10100.0)
+    }
+}

--- a/apollo-router/src/plugins/demand_control/directives.rs
+++ b/apollo-router/src/plugins/demand_control/directives.rs
@@ -1,0 +1,43 @@
+use anyhow::anyhow;
+use apollo_compiler::executable::Field;
+use tower::BoxError;
+
+pub(super) struct IncludeDirective {
+    pub(super) is_included: bool,
+}
+
+impl IncludeDirective {
+    pub(super) fn from_field(field: &Field) -> Result<Option<Self>, BoxError> {
+        if let Some(directive) = field.directives.get("include") {
+            if let Some(condition) = directive.argument_by_name("if") {
+                Ok(Some(Self {
+                    is_included: condition.to_bool().unwrap_or(true),
+                }))
+            } else {
+                Err(anyhow!("Found @include directive with no if argument").into())
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+pub(super) struct SkipDirective {
+    pub(super) is_skipped: bool,
+}
+
+impl SkipDirective {
+    pub(super) fn from_field(field: &Field) -> Result<Option<Self>, BoxError> {
+        if let Some(directive) = field.directives.get("skip") {
+            if let Some(condition) = directive.argument_by_name("if") {
+                Ok(Some(Self {
+                    is_skipped: condition.to_bool().unwrap_or(false),
+                }))
+            } else {
+                Err(anyhow!("Found @skip directive with no if argument").into())
+            }
+        } else {
+            Ok(None)
+        }
+    }
+}

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -1,5 +1,6 @@
 //! Demand control plugin.
 mod basic_cost_calculator;
+mod directives;
 
 use apollo_compiler::executable::ExecutableDocument;
 use apollo_compiler::Schema;

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -1,4 +1,8 @@
 //! Demand control plugin.
+mod basic_cost_calculator;
+
+use apollo_compiler::executable::ExecutableDocument;
+use apollo_compiler::Schema;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tower::BoxError;
@@ -39,6 +43,10 @@ pub(crate) struct DemandControlConfig {
     /// The algorithm used to calculate the cost of an incoming request
     #[allow(dead_code)]
     algorithm: CostCalculationAlgorithm,
+}
+
+trait CostCalculator {
+    fn estimated(query: &ExecutableDocument, schema: &Schema) -> Result<f64, BoxError>;
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
# Basic Static Cost Estimation

Implements a basic cost calculator for demand control. Given a supergraph schema and a query, the query document is recursively scored with the mapping:

Operations:
- Mutation: 10
- Query: 0
- Subscription: 0

Fields:
- Object: 1
- Interface: 1
- Union: 1
- Scalar: 0
- Enum: 0

## Handling Directives

While traversing the document, the calculator accounts for uses of @skip and @include which exclude fields from the response, and thus the cost. The implementation does not account for applicable federation directives (the main one mentioned in the design is @requires).

## Handling Lists

Without user annotations about paging limitations, the static analysis cannot determine the length of list fields. Until we define paging directives to specify this, we assume a constant upper bound of 100 for all list fields. Future updates will include using a new directive to indicate the list size approximation as well as calculating a dynamic cost from the response data returned by the subgraphs.

Fixes [ROUTER-171](https://apollographql.atlassian.net/browse/ROUTER-171)

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
