### PR TITLE
ci: fix CMake install by explicitly using `cmake.install` on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,8 +258,7 @@ commands:
             - run:
                 name: Install CMake
                 command: |
-                  choco install cmake -y
-                  echo 'export PATH="/c/Program Files/CMake/bin:$PATH"' >> "$BASH_ENV"
+                  choco install cmake.install -y --installargs 'ADD_CMAKE_TO_PATH=User'
                   exit $LASTEXITCODE
       - when:
           condition:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,8 @@ commands:
             - run:
                 name: Install CMake
                 command: |
-                  choco install cmake.install -y --installargs 'ADD_CMAKE_TO_PATH=User'
+                  choco install cmake.install -y
+                  echo 'export PATH="/c/Program Files/CMake/bin:$PATH"' >> "$BASH_ENV"
                   exit $LASTEXITCODE
       - when:
           condition:


### PR DESCRIPTION
CI is failing on `choco install cmake` because it can't find the `cmake.install` dependency. Weirdly it does find that package if you install it directly. As I understand it, these packages follow an established chocolatey pattern and so it's not an implementation detail, so we should be able to rely on `cmake.install` directly.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
