### PR TITLE
[batching] fix subgraph unwrapping

### DIFF
--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -805,11 +805,15 @@ pub(crate) async fn process_batch(
     }
 
     tracing::debug!("parts: {parts:?}, content_type: {content_type:?}, body: {body:?}");
-    let value = serde_json::from_slice(&body.unwrap().unwrap()).map_err(|error| {
+    let value = serde_json::from_slice(&body.ok_or(BoxError::from(
         FetchError::SubrequestMalformedResponse {
             service: service.to_string(),
-            reason: error.to_string(),
-        }
+            reason: "no body in response".to_string(),
+        },
+    ))??)
+    .map_err(|error| FetchError::SubrequestMalformedResponse {
+        service: service.to_string(),
+        reason: error.to_string(),
     })?;
 
     tracing::debug!("json value from body is: {value:?}");

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -805,16 +805,15 @@ pub(crate) async fn process_batch(
     }
 
     tracing::debug!("parts: {parts:?}, content_type: {content_type:?}, body: {body:?}");
-    let value = serde_json::from_slice(&body.ok_or(BoxError::from(
-        FetchError::SubrequestMalformedResponse {
+    let value =
+        serde_json::from_slice(&body.ok_or(FetchError::SubrequestMalformedResponse {
             service: service.to_string(),
             reason: "no body in response".to_string(),
-        },
-    ))??)
-    .map_err(|error| FetchError::SubrequestMalformedResponse {
-        service: service.to_string(),
-        reason: error.to_string(),
-    })?;
+        })??)
+        .map_err(|error| FetchError::SubrequestMalformedResponse {
+            service: service.to_string(),
+            reason: error.to_string(),
+        })?;
 
     tracing::debug!("json value from body is: {value:?}");
 

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -1041,7 +1041,7 @@ pub(crate) async fn call_http(
 
     let (parts, _) = subgraph_request.into_parts();
     let body = serde_json::to_string(&body).expect("JSON serialization should not fail");
-    tracing::info!("our JSON body: {body:?}");
+    tracing::debug!("our JSON body: {body:?}");
     let mut request = http::Request::from_parts(parts, Body::from(body));
 
     request


### PR DESCRIPTION
Without this fix a null body would cause the router to panic.

With this fix, if a body is null, then the router returns an error to the user.
