### PR TITLE
Add map of subgraph schemas to QueryPlan

### DIFF
--- a/apollo-router/src/plugins/file_uploads/rearrange_query_plan.rs
+++ b/apollo-router/src/plugins/file_uploads/rearrange_query_plan.rs
@@ -42,6 +42,7 @@ pub(super) fn rearrange_query_plan(
         usage_reporting: query_plan.usage_reporting.clone(),
         formatted_query_plan: query_plan.formatted_query_plan.clone(),
         query: query_plan.query.clone(),
+        subgraph_schemas: query_plan.subgraph_schemas.clone(),
     })
 }
 

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -663,6 +663,7 @@ mod tests {
                     }
                     .into(),
                     query: Arc::new(Query::empty()),
+                    subgraph_schemas: Arc::new(HashMap::new()),
                 };
                 let qp_content = QueryPlannerContent::Plan {
                     plan: Arc::new(query_plan),

--- a/apollo-router/src/query_planner/plan.rs
+++ b/apollo-router/src/query_planner/plan.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use router_bridge::planner::PlanOptions;
@@ -34,6 +35,7 @@ pub struct QueryPlan {
     /// String representation of the query plan (not a json representation)
     pub(crate) formatted_query_plan: Option<String>,
     pub(crate) query: Arc<Query>,
+    pub(crate) subgraph_schemas: Arc<HashMap<String, String>>,
 }
 
 /// This default impl is useful for test users
@@ -55,6 +57,7 @@ impl QueryPlan {
             root: root.unwrap_or_else(|| PlanNode::Sequence { nodes: Vec::new() }),
             formatted_query_plan: Default::default(),
             query: Arc::new(Query::empty()),
+            subgraph_schemas: Arc::new(HashMap::new()),
         }
     }
 }

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -84,6 +84,7 @@ async fn mock_subgraph_service_withf_panics_should_be_reported_as_service_closed
             referenced_fields_by_type: Default::default(),
         }
         .into(),
+        subgraph_schemas: Arc::new(HashMap::new()),
     };
 
     let mut mock_products_service = plugin::test::MockSubgraphService::new();
@@ -137,6 +138,7 @@ async fn fetch_includes_operation_name() {
         }
         .into(),
         query: Arc::new(Query::empty()),
+        subgraph_schemas: Arc::new(HashMap::new()),
     };
 
     let succeeded: Arc<AtomicBool> = Default::default();
@@ -195,6 +197,7 @@ async fn fetch_makes_post_requests() {
         }
         .into(),
         query: Arc::new(Query::empty()),
+        subgraph_schemas: Arc::new(HashMap::new()),
     };
 
     let succeeded: Arc<AtomicBool> = Default::default();
@@ -319,6 +322,7 @@ async fn defer() {
                 referenced_fields_by_type: Default::default(),
             }.into(),
             query: Arc::new(Query::empty()),
+            subgraph_schemas: Arc::new(HashMap::new()),
         };
 
     let mut mock_x_service = plugin::test::MockSubgraphService::new();
@@ -441,6 +445,7 @@ async fn defer_if_condition() {
             .unwrap(),
         ),
         formatted_query_plan: None,
+        subgraph_schemas: Arc::new(HashMap::new()),
     };
 
     let mocked_accounts = MockSubgraph::builder()
@@ -619,6 +624,7 @@ async fn dependent_mutations() {
         }
         .into(),
         query: Arc::new(Query::empty()),
+        subgraph_schemas: Arc::new(HashMap::new()),
     };
 
     let mut mock_a_service = plugin::test::MockSubgraphService::new();

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -370,6 +370,7 @@ async fn subscription_task(
                 root: *r,
                 formatted_query_plan: query_plan.formatted_query_plan.clone(),
                 query: query_plan.query.clone(),
+                subgraph_schemas: query_plan.subgraph_schemas.clone(),
             })
         }),
         _ => {


### PR DESCRIPTION
This change makes the individual subgraph schemas from the query planner accessible to plugins by adding them to the query plan. This enables the demand control plugin to parse and score subgraph operations from each fetch node in the plan.

Precursor to [ROUTER-174](https://apollographql.atlassian.net/browse/ROUTER-174)

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-174]: https://apollographql.atlassian.net/browse/ROUTER-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ