### PR TITLE
Helm chart: include all standard labels in pod spec

### DIFF
--- a/.changesets/fix_glasser_selector_labels.md
+++ b/.changesets/fix_glasser_selector_labels.md
@@ -1,0 +1,6 @@
+### Helm: include all standard labels in pod spec but complete sentence that stands on its own ([PR #4862](https://github.com/apollographql/router/pull/4862))
+
+The `helm.sh/chart`, `app.kubernetes.io/version`, and `app.kubernetes.io/managed-by` labels are now included on pods just like they are in every other resource created by the Helm chart, because the pod spec template now uses the `router.labels` template function instead of the `router.selectorLabels` template function. This also means that you can remove a label from the selector without removing it from resource metadata by overriding the `router.selectorLabels` and `router.labels` functions and moving the label from the former to the latter.
+
+
+By [@glasser](https://github.com/glasser) in https://github.com/apollographql/router/pull/4862

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "router.selectorLabels" . | nindent 8 }}
+        {{- include "router.labels" . | nindent 8 }}
         {{- if .Values.extraLabels }}
         {{- include "apollographql.templatizeExtraLabels" . | trim | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
Every other use of `router.selectorLabels` is in an actual selector; every other `metadata.labels` uses `router.labels`.

The effect of this PR is to add `helm.sh/chart`, `app.kubernetes.io/version`, and `app.kubernetes.io/managed-by` labels to pods.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**


**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
