### PR TITLE
`null` extensions incorrectly disallowed on request

### DIFF
--- a/.changesets/fix_graphql_request_extensions.md
+++ b/.changesets/fix_graphql_request_extensions.md
@@ -1,0 +1,19 @@
+### `null` extensions incorrectly disallowed on request ([Issue #4856](https://github.com/apollographql/router/issues/4856))
+
+The [graphql over http spec](https://graphql.github.io/graphql-over-http/draft/#sel-EALFPCCBCEtC37P) mandates `null` is allowed for request extensions.
+
+We were previously rejecting such payloads, but now we will allow them. For example:
+
+```json
+{
+  "query": "{ topProducts { upc name reviews { id product { name } author { id name } } } }",
+  "variables": {
+    "date": "2022-01-01T00:00:00+00:00"
+  },
+  "extensions": null
+}
+```
+
+Fixes #4856
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/4865

--- a/apollo-router/src/snapshots/apollo_router__request__tests__extensions.snap
+++ b/apollo-router/src/snapshots/apollo_router__request__tests__extensions.snap
@@ -1,0 +1,11 @@
+---
+source: apollo-router/src/request.rs
+expression: expected_result
+---
+query: "{ topProducts { upc name reviews { id product { name } author { id name } } } }"
+variables:
+  date: "2022-01-01T00:00:00+00:00"
+extensions:
+  something_simple: else
+  something_complex:
+    nested: value

--- a/apollo-router/src/snapshots/apollo_router__request__tests__missing_extensions.snap
+++ b/apollo-router/src/snapshots/apollo_router__request__tests__missing_extensions.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/request.rs
+expression: expected_result
+---
+query: "{ topProducts { upc name reviews { id product { name } author { id name } } } }"
+variables:
+  date: "2022-01-01T00:00:00+00:00"

--- a/apollo-router/src/snapshots/apollo_router__request__tests__null_extensions.snap
+++ b/apollo-router/src/snapshots/apollo_router__request__tests__null_extensions.snap
@@ -1,0 +1,7 @@
+---
+source: apollo-router/src/request.rs
+expression: expected_result
+---
+query: "{ topProducts { upc name reviews { id product { name } author { id name } } } }"
+variables:
+  date: "2022-01-01T00:00:00+00:00"


### PR DESCRIPTION
According to the graphql over http spec we should be allowing `null` to be passed for extensions in the request. https://graphql.github.io/graphql-over-http/draft/#sel-EALFPCCBCEtC37P

Currently,w e reject the payload, which is an issue for some clients.

This is now fixed and tests added.

FIxes #4856

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
