### PR TITLE
replace null separator in apq cache key with : to match convention

### DIFF
--- a/.changesets/fix_apq_cache_key_to_match_redis_convention.md
+++ b/.changesets/fix_apq_cache_key_to_match_redis_convention.md
@@ -1,0 +1,7 @@
+### Replaces null separator in apq cache key with : to match redis convention
+
+This PR conforms the apq cache key to follow redis convention. This helps when using redis clients to properly display keys in nested form.
+
+query plan cache key was fixed in a similar pr: #4583
+
+By [@tapaderster](https://github.com/tapaderster) in https://github.com/apollographql/router/pull/4886

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -158,7 +158,7 @@ fn query_matches_hash(query: &str, hash: &[u8]) -> bool {
 }
 
 fn redis_key(query_hash: &str) -> String {
-    format!("apq\0{query_hash}")
+    format!("apq:{query_hash}")
 }
 
 pub(crate) fn calculate_hash_for_query(query: &str) -> String {

--- a/apollo-router/tests/integration/redis.rs
+++ b/apollo-router/tests/integration/redis.rs
@@ -165,7 +165,7 @@ mod test {
         let query_hash = "4c45433039407593557f8a982dafd316a66ec03f0e1ed5fa1b7ef8060d76e8ec";
 
         client
-            .del::<String, _>(&format!("apq\x00{query_hash}"))
+            .del::<String, _>(&format!("apq:{query_hash}"))
             .await
             .unwrap();
 
@@ -196,8 +196,8 @@ mod test {
             res.errors.first().unwrap().message,
             "PersistedQueryNotFound"
         );
-
-        let r: Option<String> = client.get(&format!("apq\x00{query_hash}")).await.unwrap();
+;
+        let r: Option<String> = client.get(&format!("apq:{query_hash}")).await.unwrap();
         assert!(r.is_none());
 
         // Now we register the query
@@ -222,7 +222,7 @@ mod test {
         assert!(res.data.is_some());
         assert!(res.errors.is_empty());
 
-        let s: Option<String> = client.get(&format!("apq\x00{query_hash}")).await.unwrap();
+        let s: Option<String> = client.get(&format!("apq:{query_hash}")).await.unwrap();
         insta::assert_display_snapshot!(s.unwrap());
 
         // we start a new router with the same config

--- a/apollo-router/tests/integration/redis.rs
+++ b/apollo-router/tests/integration/redis.rs
@@ -196,7 +196,6 @@ mod test {
             res.errors.first().unwrap().message,
             "PersistedQueryNotFound"
         );
-;
         let r: Option<String> = client.get(&format!("apq:{query_hash}")).await.unwrap();
         assert!(r.is_none());
 


### PR DESCRIPTION
This PR conforms the apq cache key to follow redis convention. This helps when using redis clients to properly display keys in nested form.

query plan cache key was fixed in a similar pr: https://github.com/apollographql/router/pull/4583


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
