### PR TITLE
feat(pq): use 4xx status code on PQ errors

### DIFF
--- a/.changesets/fix_glasser_pq_error_status_codes.md
+++ b/.changesets/fix_glasser_pq_error_status_codes.md
@@ -1,0 +1,15 @@
+### Persisted Query errors are now 4xx errors ([PR #4887](https://github.com/apollographql/router/pull/4887)
+
+Previously, sending various kinds of invalid Persisted Query requests returned a 200 status code to the client. Now, these errors return 4xx status codes:
+
+- Sending a PQ ID that is unknown returns 404 (Not Found).
+- Sending freeform GraphQL when no freeform GraphQL is allowed returns
+  400 (Bad Request).
+- Sending both a PQ ID and freeform GraphQL in the same request (if the
+  APQ feature is not also enabled) returns 400 (Bad Request).
+- Sending freeform GraphQL that is not in the safelist when the safelist
+  is enabled returns (403 Forbidden).
+- A particular internal error that shouldn't happen returns 500 (Internal
+  Server Error).
+
+  By [@glasser](https://github.com/glasser) in https://github.com/apollographql/router/pull/4887


### PR DESCRIPTION
Previously, sending a request that failed for a PQ-related reason would return a 200 status code. Now, various PQ-related errors lead to non-200 status codes:

- Sending a PQ ID that is unknown yields 404 Not Found
- Sending freeform GraphQL when no freeform GraphQL is allowed yields 400 Bad Request
- Sending both a PQ ID and freeform GraphQL in the same request (if the APQ feature is not also enabled) yields 400 Bad Request
- Sending freeform GraphQL that is not in the safelist when the safelist is enabled yields 403 Forbidden
- A particular internal error that shouldn't happen yields 500 Internal Server Error


**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

This could be considered to be not backwards compatible; we are in the process of reaching out to the current users of this Enterprise-only feature before releasing it.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
