### PR TITLE
Make router user the owner of the docker image's /dist/data directory

### DIFF
--- a/.changesets/fix_garypen_revive_docker_heaptrack.md
+++ b/.changesets/fix_garypen_revive_docker_heaptrack.md
@@ -1,0 +1,7 @@
+### Make 'router' user the owner of the docker image's /dist/data directory ([PR #4898](https://github.com/apollographql/router/pull/4898))
+
+Since we made our images more secure, we run our router process as user 'router'. If we are running under 'heaptrack', e.g.: in a debug image, then we cannot write to /dist/data because it is owned by 'root'.
+
+This changes the ownership of /dist/data from 'root' to 'router' to allow writes to succeed.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/4898

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -39,7 +39,8 @@ RUN \
 RUN \
   if [ "${DEBUG_IMAGE}" = "true" ]; then \
     apt-get install -y heaptrack && \
-    mkdir data; \
+    mkdir data && \
+    chown router data; \
   fi
 
 # Clean up apt lists

--- a/dockerfiles/diy/dockerfiles/Dockerfile.repo
+++ b/dockerfiles/diy/dockerfiles/Dockerfile.repo
@@ -58,7 +58,8 @@ RUN \
     heaptrack-gui \
     x11-apps \
     iputils-ping && \
-    mkdir data; \
+    mkdir data && \
+    chown router data; \
   fi
 
 # Clean up apt lists


### PR DESCRIPTION
Since we made our images more secure, we run our router process as user 'router'. If we are running under 'heaptrack', e.g.: in a debug image, then we cannot write to /dist/data because it is owned by 'root'.

This changes the ownership of /dist/data from 'root' to 'router' to allow writes to succeed.

