### PR TITLE
[docs] Remove supergraph selector response body

### DIFF
--- a/docs/source/configuration/telemetry/instrumentation/selectors.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/selectors.mdx
@@ -50,7 +50,6 @@ The supergraph service is executed after query parsing but before query executio
 | `operation_kind`   | No          | `query`\|`mutation`\|`subscription` | The operation kind from the query    |
 | `query`            | Yes         | `query`\|`hash`                     | The graphql query                    |
 | `query_variable`   | Yes         |                                     | The name of a graphql query variable |
-| `response_body`    | Yes         |                                     | Json Path into the response body     |
 | `request_header`   | Yes         |                                     | The name of a request header         |
 | `response_header`  | Yes         |                                     | The name of a response header        |
 | `request_context`  | Yes         |                                     | The name of a request context key    |


### PR DESCRIPTION
This attribute is not yet implemented, we are tracking the work to do that in https://github.com/apollographql/router/issues/4830

However until we actually implement it we should remove from the docs
