### PR TITLE
fix annoying integration test warning on macOS

### DIFF
--- a/.changesets/maint_garypen_fix_telemetry_integration_test_macos.md
+++ b/.changesets/maint_garypen_fix_telemetry_integration_test_macos.md
@@ -1,0 +1,5 @@
+### fix annoying integration test warning on macOS ([PR #4919](https://github.com/apollographql/router/pull/4919))
+
+For a little while we have had a warning with integration tests on macOS. This fixes the warning.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/4919

--- a/apollo-router/tests/integration/mod.rs
+++ b/apollo-router/tests/integration/mod.rs
@@ -1,8 +1,6 @@
 #[path = "../common.rs"]
 pub(crate) mod common;
 pub(crate) use common::IntegrationTest;
-pub(crate) use common::Telemetry;
-pub(crate) use common::ValueExt;
 
 mod docs;
 mod file_upload;

--- a/apollo-router/tests/integration/telemetry/jaeger.rs
+++ b/apollo-router/tests/integration/telemetry/jaeger.rs
@@ -1,4 +1,4 @@
-#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#![cfg(all(target_os = "linux", target_arch = "x86_64", test))]
 extern crate core;
 
 use std::collections::HashSet;
@@ -9,9 +9,9 @@ use serde_json::json;
 use serde_json::Value;
 use tower::BoxError;
 
+use crate::integration::common::Telemetry;
+use crate::integration::common::ValueExt;
 use crate::integration::IntegrationTest;
-use crate::integration::Telemetry;
-use crate::integration::ValueExt;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_reload() -> Result<(), BoxError> {

--- a/apollo-router/tests/integration/telemetry/otlp.rs
+++ b/apollo-router/tests/integration/telemetry/otlp.rs
@@ -1,4 +1,4 @@
-#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#![cfg(all(target_os = "linux", target_arch = "x86_64", test))]
 extern crate core;
 
 use std::collections::HashSet;
@@ -18,9 +18,9 @@ use wiremock::Mock;
 use wiremock::MockServer;
 use wiremock::ResponseTemplate;
 
+use crate::integration::common::Telemetry;
+use crate::integration::common::ValueExt;
 use crate::integration::IntegrationTest;
-use crate::integration::Telemetry;
-use crate::integration::ValueExt;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_basic() -> Result<(), BoxError> {

--- a/apollo-router/tests/integration/telemetry/zipkin.rs
+++ b/apollo-router/tests/integration/telemetry/zipkin.rs
@@ -1,4 +1,4 @@
-#![cfg(all(target_os = "linux", target_arch = "x86_64"))]
+#![cfg(all(target_os = "linux", target_arch = "x86_64", test))]
 extern crate core;
 
 use std::collections::HashSet;
@@ -9,9 +9,9 @@ use serde_json::json;
 use serde_json::Value;
 use tower::BoxError;
 
+use crate::integration::common::Telemetry;
+use crate::integration::common::ValueExt;
 use crate::integration::IntegrationTest;
-use crate::integration::Telemetry;
-use crate::integration::ValueExt;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_basic() -> Result<(), BoxError> {


### PR DESCRIPTION
For a little while we have had a warning with integration tests on macOS. This fixes the warning.
