### PR TITLE
add back the operation name to the query planner cache key

### DIFF
--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -549,19 +549,28 @@ const FEDERATION_VERSION: &str = std::env!("FEDERATION_VERSION");
 impl std::fmt::Display for CachingQueryKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut hasher = Sha256::new();
+        hasher.update(self.operation.as_deref().unwrap_or("-"));
+        let operation = hex::encode(hasher.finalize());
+
+        let mut hasher = Sha256::new();
         hasher.update(&serde_json::to_vec(&self.metadata).expect("serialization should not fail"));
         hasher.update(
             &serde_json::to_vec(&self.plan_options).expect("serialization should not fail"),
         );
         let metadata = hex::encode(hasher.finalize());
 
-        write!(f, "plan:{}:{}:{}", FEDERATION_VERSION, self.hash, metadata,)
+        write!(
+            f,
+            "plan:{}:{}:{}:{}",
+            FEDERATION_VERSION, self.hash, operation, metadata,
+        )
     }
 }
 
 impl Hash for CachingQueryKey {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.hash.0.hash(state);
+        self.operation.hash(state);
         self.metadata.hash(state);
         self.plan_options.hash(state);
     }


### PR DESCRIPTION
The schema aware hash does not take the operation name into account, but the operation name is used in the operation signature, so if the same query is used with 2 different operation names, then they would get the same operation signature, which might disrupt the data in studio

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
