### PR TITLE
transient in memory cache

### DIFF
--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -55,6 +55,7 @@ pub(crate) use self::schema::generate_config_schema;
 pub(crate) use self::schema::generate_upgrade;
 use self::subgraph::SubgraphConfiguration;
 use crate::cache::DEFAULT_CACHE_CAPACITY;
+use crate::cache::DEFAULT_TRANSIENT_CACHE_CAPACITY;
 use crate::configuration::schema::Mode;
 use crate::graphql;
 use crate::notification::Notify;
@@ -942,12 +943,15 @@ pub(crate) struct Cache {
 pub(crate) struct InMemoryCache {
     /// Number of entries in the Least Recently Used cache
     pub(crate) limit: NonZeroUsize,
+    /// Number of entries in the Least Recently Used transient cache
+    pub(crate) transient_limit: NonZeroUsize,
 }
 
 impl Default for InMemoryCache {
     fn default() -> Self {
         Self {
             limit: DEFAULT_CACHE_CAPACITY,
+            transient_limit: DEFAULT_TRANSIENT_CACHE_CAPACITY,
         }
     }
 }


### PR DESCRIPTION
This adds another level of in memory cache, to mitigate issues with unique or infrequent queries pushing frequently used queries out of the in memory cache.
If a query has only been seen once, then it is stored inthe transient cache (short term, small number of entries, LRU).
If that query is requested again, and is still present in the transient cache, then it is added to the long term, larger in memory cache, to the redis cache as well, and removed from the transient cache. If that query is requested again but not present in the transient cache, then we test the larger in memory cache and redis

*Description here*

Fixes #**issue_number**

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
