### PR TITLE
Add metric for use of custom plugins

### DIFF
--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -13,6 +13,7 @@ use crate::uplink::license_enforcement::LicenseState;
 use crate::Configuration;
 
 type InstrumentMap = HashMap<String, (u64, HashMap<String, opentelemetry::Value>)>;
+
 pub(crate) struct Metrics {
     _instruments: Vec<opentelemetry::metrics::ObservableGauge<u64>>,
 }
@@ -44,7 +45,7 @@ impl Metrics {
                 .unwrap_or(&serde_json::Value::Null),
         );
         data.populate_license_instrument(license_state);
-
+        data.populate_user_plugins_instrument(configuration);
         data.into()
     }
 }
@@ -406,7 +407,37 @@ impl InstrumentData {
             ),
         );
     }
+
+    pub(crate) fn populate_user_plugins_instrument(&mut self, configuration: &Configuration) {
+        println!(
+            "custom plugins: {}",
+            configuration
+                .plugins
+                .plugins
+                .as_ref()
+                .map(|configuration| configuration.len())
+                .unwrap_or_default() as u64
+        );
+        self.data.insert(
+            "apollo.router.config.custom_plugins".to_string(),
+            (
+                configuration
+                    .plugins
+                    .plugins
+                    .as_ref()
+                    .map(|configuration| {
+                        configuration
+                            .keys()
+                            .filter(|k| !k.starts_with("cloud_router."))
+                            .count()
+                    })
+                    .unwrap_or_default() as u64,
+                [].into(),
+            ),
+        );
+    }
 }
+
 impl From<InstrumentData> for Metrics {
     fn from(data: InstrumentData) -> Self {
         Metrics {
@@ -433,6 +464,7 @@ impl From<InstrumentData> for Metrics {
 #[cfg(test)]
 mod test {
     use rust_embed::RustEmbed;
+    use serde_json::json;
 
     use crate::configuration::metrics::InstrumentData;
     use crate::configuration::metrics::Metrics;
@@ -479,6 +511,31 @@ mod test {
     fn test_license_halt() {
         let mut data = InstrumentData::default();
         data.populate_license_instrument(&LicenseState::LicensedHalt);
+        let _metrics: Metrics = data.into();
+        assert_non_zero_metrics_snapshot!();
+    }
+
+    #[test]
+    fn test_custom_plugin() {
+        let mut configuration = crate::Configuration::default();
+        let mut custom_plugins = serde_json::Map::new();
+        custom_plugins.insert("name".to_string(), json!("test"));
+        configuration.plugins.plugins = Some(custom_plugins);
+        let mut data = InstrumentData::default();
+        data.populate_user_plugins_instrument(&configuration);
+        let _metrics: Metrics = data.into();
+        assert_non_zero_metrics_snapshot!();
+    }
+
+    #[test]
+    fn test_ignore_cloud_router_plugins() {
+        let mut configuration = crate::Configuration::default();
+        let mut custom_plugins = serde_json::Map::new();
+        custom_plugins.insert("name".to_string(), json!("test"));
+        custom_plugins.insert("cloud_router.".to_string(), json!("test"));
+        configuration.plugins.plugins = Some(custom_plugins);
+        let mut data = InstrumentData::default();
+        data.populate_user_plugins_instrument(&configuration);
         let _metrics: Metrics = data.into();
         assert_non_zero_metrics_snapshot!();
     }

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__custom_plugin.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__custom_plugin.snap
@@ -1,0 +1,9 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.non_zero()"
+---
+- name: apollo.router.config.custom_plugins
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__ignore_cloud_router_plugins.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__ignore_cloud_router_plugins.snap
@@ -1,0 +1,9 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.non_zero()"
+---
+- name: apollo.router.config.custom_plugins
+  data:
+    datapoints:
+      - value: 1
+        attributes: {}


### PR DESCRIPTION
Adds a metric for configuration of custom plugins. This will help inform us of how may users are writing custom rust based plugins.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
