### PR TITLE
Remove println accidentally added in 4923

### DIFF
--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -409,15 +409,6 @@ impl InstrumentData {
     }
 
     pub(crate) fn populate_user_plugins_instrument(&mut self, configuration: &Configuration) {
-        println!(
-            "custom plugins: {}",
-            configuration
-                .plugins
-                .plugins
-                .as_ref()
-                .map(|configuration| configuration.len())
-                .unwrap_or_default() as u64
-        );
         self.data.insert(
             "apollo.router.config.custom_plugins".to_string(),
             (


### PR DESCRIPTION
#4923 added a println that should not have been there.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
