### PR TITLE
Move PluginTestHarness out of telemetry for use in other plugins

### DIFF
--- a/apollo-router/src/logging/mod.rs
+++ b/apollo-router/src/logging/mod.rs
@@ -39,6 +39,9 @@ pub(crate) mod test {
     use serde_json::Value;
     use tracing_core::LevelFilter;
     use tracing_core::Subscriber;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    use crate::plugins::telemetry::dynamic_attribute::DynAttributeLayer;
 
     pub(crate) struct SnapshotSubscriber {
         buffer: Arc<Mutex<Vec<u8>>>,
@@ -99,15 +102,18 @@ pub(crate) mod test {
                 assertion,
             };
 
-            tracing_subscriber::fmt()
-                .json()
-                .with_max_level(level)
-                .without_time()
-                .with_target(false)
-                .with_file(false)
-                .with_line_number(false)
-                .with_writer(Mutex::new(collector))
-                .finish()
+            tracing_subscriber::registry::Registry::default()
+                .with(level)
+                .with(DynAttributeLayer::new())
+                .with(
+                    tracing_subscriber::fmt::Layer::default()
+                        .json()
+                        .without_time()
+                        .with_target(false)
+                        .with_file(false)
+                        .with_line_number(false)
+                        .with_writer(Mutex::new(collector)),
+                )
         }
     }
 }

--- a/apollo-router/src/plugins/mod.rs
+++ b/apollo-router/src/plugins/mod.rs
@@ -37,4 +37,6 @@ mod record_replay;
 pub(crate) mod rhai;
 pub(crate) mod subscription;
 pub(crate) mod telemetry;
+#[cfg(test)]
+pub(crate) mod test;
 pub(crate) mod traffic_shaping;

--- a/apollo-router/src/plugins/telemetry/logging/mod.rs
+++ b/apollo-router/src/plugins/telemetry/logging/mod.rs
@@ -1,18 +1,12 @@
 //TODO move telemetry logging functionality to this file
 #[cfg(test)]
 mod test {
-    use std::any::TypeId;
-
-    use tower::BoxError;
-    use tower::ServiceBuilder;
-    use tower_service::Service;
     use tracing_futures::WithSubscriber;
 
     use crate::assert_snapshot_subscriber;
     use crate::graphql;
-    use crate::plugin::DynPlugin;
-    use crate::plugin::Plugin;
     use crate::plugins::telemetry::Telemetry;
+    use crate::plugins::test::PluginTestHarness;
     use crate::services::router;
     use crate::services::subgraph;
     use crate::services::supergraph;
@@ -110,7 +104,7 @@ mod test {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_when_header() {
         let test_harness: PluginTestHarness<Telemetry> = PluginTestHarness::builder()
-            .yaml(include_str!(
+            .config(include_str!(
                 "testdata/experimental_when_header.router.yaml"
             ))
             .build()
@@ -142,89 +136,5 @@ mod test {
         }
         .with_subscriber(assert_snapshot_subscriber!())
         .await
-    }
-
-    // Maybe factor this out after making it more usable
-    // The difference with this and the `TestHarness` is that this has much less of the router being wired up and is useful for testing a single plugin in isolation.
-    // In particular the `TestHarness` isn't good for testing things with logging.
-    // For now let's try and increase the coverage of the telemetry plugin using this and see how it goes.
-
-    struct PluginTestHarness<T: Plugin> {
-        plugin: Box<dyn DynPlugin>,
-        phantom: std::marker::PhantomData<T>,
-    }
-    #[buildstructor::buildstructor]
-    impl<T: Plugin> PluginTestHarness<T> {
-        #[builder]
-        async fn new(yaml: Option<&'static str>) -> Self {
-            let factory = crate::plugin::plugins()
-                .find(|factory| factory.type_id == TypeId::of::<T>())
-                .expect("plugin not registered");
-            let name = &factory.name.replace("apollo.", "");
-            let config = yaml
-                .map(|yaml| serde_yaml::from_str::<serde_json::Value>(yaml).unwrap())
-                .map(|mut config| {
-                    config
-                        .as_object_mut()
-                        .expect("invalid yaml")
-                        .remove(name)
-                        .expect("no config for plugin")
-                })
-                .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
-
-            let plugin = factory
-                .create_instance_without_schema(&config)
-                .await
-                .expect("failed to create plugin");
-
-            Self {
-                plugin,
-                phantom: Default::default(),
-            }
-        }
-
-        #[allow(dead_code)]
-        async fn call_router(
-            &self,
-            request: router::Request,
-            response_fn: fn(router::Request) -> router::Response,
-        ) -> Result<router::Response, BoxError> {
-            let service: router::BoxService = router::BoxService::new(
-                ServiceBuilder::new()
-                    .service_fn(move |req: router::Request| async move { Ok((response_fn)(req)) }),
-            );
-
-            self.plugin.router_service(service).call(request).await
-        }
-
-        async fn call_supergraph(
-            &self,
-            request: supergraph::Request,
-            response_fn: fn(supergraph::Request) -> supergraph::Response,
-        ) -> Result<supergraph::Response, BoxError> {
-            let service: supergraph::BoxService =
-                supergraph::BoxService::new(ServiceBuilder::new().service_fn(
-                    move |req: supergraph::Request| async move { Ok((response_fn)(req)) },
-                ));
-
-            self.plugin.supergraph_service(service).call(request).await
-        }
-
-        async fn call_subgraph(
-            &self,
-            request: subgraph::Request,
-            response_fn: fn(subgraph::Request) -> subgraph::Response,
-        ) -> Result<subgraph::Response, BoxError> {
-            let name = request.subgraph_name.clone();
-            let service: subgraph::BoxService =
-                subgraph::BoxService::new(ServiceBuilder::new().service_fn(
-                    move |req: subgraph::Request| async move { Ok((response_fn)(req)) },
-                ));
-
-            self.plugin
-                .subgraph_service(&name.expect("subgraph name must be populated"), service)
-                .call(request)
-                .await
-        }
     }
 }

--- a/apollo-router/src/plugins/test.rs
+++ b/apollo-router/src/plugins/test.rs
@@ -1,0 +1,185 @@
+use std::any::TypeId;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use apollo_compiler::validation::Valid;
+use serde_json::Value;
+use tower::BoxError;
+use tower::ServiceBuilder;
+use tower_service::Service;
+
+use crate::plugin::DynPlugin;
+use crate::plugin::Plugin;
+use crate::plugin::PluginInit;
+use crate::query_planner::BridgeQueryPlanner;
+use crate::services::http;
+use crate::services::router;
+use crate::services::subgraph;
+use crate::services::supergraph;
+use crate::Configuration;
+use crate::Notify;
+
+/// Test harness for plugins
+/// The difference between this and the regular TestHarness is that this is more suited for unit testing.
+/// It doesn't create the entire router stack, and is mostly just a convenient way to call a plugin service given an optional config and a schema.
+///
+/// Here is a basic example that calls a router service and checks that validates logs are generated for the telemetry plugin.
+///
+/// ```
+///  #[tokio::test(flavor = "multi_thread")]
+///     async fn test_router_service() {
+///         let test_harness: PluginTestHarness<Telemetry> = PluginTestHarness::builder().build().await;
+///
+///         async {
+///             let mut response = test_harness
+///                 .call_router(
+///                     router::Request::fake_builder()
+///                         .body("query { foo }")
+///                         .build()
+///                         .expect("expecting valid request"),
+///                     |_r| {
+///                         tracing::info!("response");
+///                         router::Response::fake_builder()
+///                             .header("custom-header", "val1")
+///                             .data(serde_json::json!({"data": "res"}))
+///                             .build()
+///                             .expect("expecting valid response")
+///                     },
+///                 )
+///                 .await
+///                 .expect("expecting successful response");
+///
+///             response.next_response().await;
+///         }
+///         .with_subscriber(assert_snapshot_subscriber!())
+///         .await
+///     }
+/// ```
+///
+/// You can pass in a configuration and a schema to the test harness. If you pass in a schema, the test harness will create a query planner and use the schema to extract subgraph schemas.
+///
+///
+pub(crate) struct PluginTestHarness<T: Plugin> {
+    plugin: Box<dyn DynPlugin>,
+    phantom: std::marker::PhantomData<T>,
+}
+#[buildstructor::buildstructor]
+impl<T: Plugin> PluginTestHarness<T> {
+    #[builder]
+    pub(crate) async fn new<'a, 'b>(config: Option<&'a str>, schema: Option<&'b str>) -> Self {
+        let factory = crate::plugin::plugins()
+            .find(|factory| factory.type_id == TypeId::of::<T>())
+            .expect("plugin not registered");
+
+        let config = Configuration::from_str(config.unwrap_or_default())
+            .expect("valid config required for test");
+
+        let name = &factory.name.replace("apollo.", "");
+        let config_for_plugin = config
+            .validated_yaml
+            .clone()
+            .expect("invalid yaml")
+            .as_object()
+            .expect("invalid yaml")
+            .get(name)
+            .cloned()
+            .unwrap_or(Value::Object(Default::default()));
+
+        let (supergraph_sdl, parsed_schema, subgraph_schemas) = if let Some(schema) = schema {
+            let planner = BridgeQueryPlanner::new(schema.to_string(), Arc::new(config))
+                .await
+                .unwrap();
+            (
+                schema.to_string(),
+                planner.schema().definitions.clone(),
+                planner.subgraph_schemas(),
+            )
+        } else {
+            (
+                "".to_string(),
+                Valid::assume_valid(apollo_compiler::Schema::new()),
+                Default::default(),
+            )
+        };
+
+        let plugin_init = PluginInit::builder()
+            .config(config_for_plugin.clone())
+            .supergraph_sdl(Arc::new(supergraph_sdl))
+            .supergraph_schema(Arc::new(parsed_schema))
+            .subgraph_schemas(subgraph_schemas)
+            .notify(Notify::default())
+            .build();
+
+        let plugin = factory
+            .create_instance(plugin_init)
+            .await
+            .expect("failed to create plugin");
+
+        Self {
+            plugin,
+            phantom: Default::default(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn call_router(
+        &self,
+        request: router::Request,
+        response_fn: fn(router::Request) -> router::Response,
+    ) -> Result<router::Response, BoxError> {
+        let service: router::BoxService = router::BoxService::new(
+            ServiceBuilder::new()
+                .service_fn(move |req: router::Request| async move { Ok((response_fn)(req)) }),
+        );
+
+        self.plugin.router_service(service).call(request).await
+    }
+
+    pub(crate) async fn call_supergraph(
+        &self,
+        request: supergraph::Request,
+        response_fn: fn(supergraph::Request) -> supergraph::Response,
+    ) -> Result<supergraph::Response, BoxError> {
+        let service: supergraph::BoxService = supergraph::BoxService::new(
+            ServiceBuilder::new()
+                .service_fn(move |req: supergraph::Request| async move { Ok((response_fn)(req)) }),
+        );
+
+        self.plugin.supergraph_service(service).call(request).await
+    }
+
+    #[allow(dead_code)]
+    pub(crate) async fn call_subgraph(
+        &self,
+        request: subgraph::Request,
+        response_fn: fn(subgraph::Request) -> subgraph::Response,
+    ) -> Result<subgraph::Response, BoxError> {
+        let name = request.subgraph_name.clone();
+        let service: subgraph::BoxService = subgraph::BoxService::new(
+            ServiceBuilder::new()
+                .service_fn(move |req: subgraph::Request| async move { Ok((response_fn)(req)) }),
+        );
+
+        self.plugin
+            .subgraph_service(&name.expect("subgraph name must be populated"), service)
+            .call(request)
+            .await
+    }
+    #[allow(dead_code)]
+    pub(crate) async fn call_http_client(
+        &self,
+        subgraph_name: &str,
+        request: http::HttpRequest,
+        response_fn: fn(http::HttpRequest) -> http::HttpResponse,
+    ) -> Result<http::HttpResponse, BoxError> {
+        let service: http::BoxService = http::BoxService::new(
+            ServiceBuilder::new()
+                .service_fn(move |req: http::HttpRequest| async move { Ok((response_fn)(req)) }),
+        );
+
+        self.plugin
+            .http_client_service(subgraph_name, service)
+            .call(request)
+            .await
+    }
+}


### PR DESCRIPTION
This is suited for unit testing where you wish to inspect the request and response both at the start of the pipeline and at the destination service.

The existing TestHarness is about firing up the entire router stack.
Alternatives that we have tried are mocking, which never ends well.

This test harness is super simple, and allows you to create a plugin, fire a fake request through, perform assertion on the request during the pipeline execution, return a fake response, perform validation on the returned response.

It's only used in telemetry at the moment, but it'll be useful for demand control.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
