### PR TITLE
cross compile OSX x86_64 router builds from M1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,20 +43,13 @@ executors:
     environment:
       CARGO_BUILD_JOBS: 8
       RUST_TEST_THREADS: 8
-  arm_macos_build: &arm_macos_build_executor
+  macos_build: &macos_build_executor
     macos:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
       # We use the major.minor notation to bring in compatible patches.
       xcode: 14.2
     resource_class: macos.m1.medium.gen1
-  intel_macos_build: &intel_macos_build_executor
-    macos:
-      # See https://circleci.com/docs/xcode-policy along with the support matrix
-      # at https://circleci.com/docs/using-macos#supported-xcode-versions.
-      # We use the major.minor notation to bring in compatible patches.
-      xcode: 14.2
-    resource_class: macos.x86.medium.gen2
   macos_test: &macos_test_executor
     macos:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
@@ -167,7 +160,7 @@ commands:
       - when:
           condition:
             or:
-              - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
+              - equal: [ *macos_build_executor, << parameters.platform >> ]
               - equal: [ *macos_test_executor, << parameters.platform >> ]
           steps:
             - run:
@@ -178,20 +171,7 @@ commands:
             - run:
                 name: Write arch
                 command: |
-                  echo 'osx-aarch64' >> ~/.arch
-      - when:
-          condition:
-            equal: [ *intel_macos_build_executor, << parameters.platform >> ]
-          steps:
-            - run:
-                name: Make link to md5
-                command: |
-                  mkdir -p ~/.local/aliases
-                  ln -s /sbin/md5 ~/.local/aliases/md5sum
-            - run:
-                name: Write arch
-                command: |
-                  echo 'osx-x86' >> ~/.arch
+                  echo 'osx' >> ~/.arch
       - when:
           condition:
             or:
@@ -264,8 +244,7 @@ commands:
       - when:
           condition:
             or:
-              - equal: [ *intel_macos_build_executor, << parameters.platform >> ]
-              - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
+              - equal: [ *macos_build_executor, << parameters.platform >> ]
               - equal: [ *macos_test_executor, << parameters.platform >> ]
           steps:
             - run:
@@ -306,8 +285,7 @@ commands:
       - when:
           condition:
             or:
-              - equal: [ *intel_macos_build_executor, << parameters.platform >> ]
-              - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
+              - equal: [ *macos_build_executor, << parameters.platform >> ]
               - equal: [ *macos_test_executor, << parameters.platform >> ]
           steps:
             - run:
@@ -356,6 +334,15 @@ commands:
                 name: Special case for Windows because of ssh-agent
                 command: |
                   printf "[net]\ngit-fetch-with-cli = true" >> ~/.cargo/Cargo.toml
+      - when:
+          condition:
+            or:
+              - equal: [ *macos_build_executor, << parameters.platform >> ]
+          steps:
+            - run:
+                name: Special case for OSX x86_64 builds
+                command: |
+                  rustup target add x86_64-apple-darwin
 
   install_extra_tools:
     steps:
@@ -608,8 +595,7 @@ jobs:
       - when:
           condition:
             or:
-              - equal: [ *intel_macos_build_executor, << parameters.platform >> ]
-              - equal: [ *arm_macos_build_executor, << parameters.platform >> ]
+              - equal: [ *macos_build_executor, << parameters.platform >> ]
 
           steps:
             - when:
@@ -619,13 +605,28 @@ jobs:
                   - run: cargo xtask release prepare nightly
             - run:
                 command: >
-                  cargo xtask dist
+                  cargo xtask dist --target aarch64-apple-darwin
+            - run:
+                command: >
+                  cargo xtask dist --target x86_64-apple-darwin
             - run:
                 command: >
                   mkdir -p artifacts
             - run:
                 command: >
                   cargo xtask package
+                  --target aarch64-apple-darwin
+                  --apple-team-id ${APPLE_TEAM_ID}
+                  --apple-username ${APPLE_USERNAME}
+                  --cert-bundle-base64 ${MACOS_CERT_BUNDLE_BASE64}
+                  --cert-bundle-password ${MACOS_CERT_BUNDLE_PASSWORD}
+                  --keychain-password ${MACOS_KEYCHAIN_PASSWORD}
+                  --notarization-password ${MACOS_NOTARIZATION_PASSWORD}
+                  --output artifacts/
+            - run:
+                command: >
+                  cargo xtask package
+                  --target x86_64-apple-darwin
                   --apple-team-id ${APPLE_TEAM_ID}
                   --apple-username ${APPLE_USERNAME}
                   --cert-bundle-base64 ${MACOS_CERT_BUNDLE_BASE64}
@@ -958,7 +959,7 @@ workflows:
           matrix:
             parameters:
               platform:
-                [ intel_macos_build, arm_macos_build, windows_build, amd_linux_build, arm_linux_build ]
+                [ macos_build, windows_build, amd_linux_build, arm_linux_build ]
       - secops/wiz-docker:
           context:
             - platform-docker-ro
@@ -1055,7 +1056,7 @@ workflows:
           matrix:
             parameters:
               platform:
-                [ intel_macos_build, arm_macos_build, windows_build, amd_linux_build, arm_linux_build ]
+                [ macos_build, windows_build, amd_linux_build, arm_linux_build ]
           filters:
             branches:
               ignore: /.*/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,7 +3423,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.9",
+ "socket2 0.5.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -5735,8 +5735,9 @@ dependencies = [
 
 [[package]]
 name = "router-bridge"
-version = "0.5.17+v2.7.2"
-source = "git+https://github.com/apollographql/federation-rs.git?branch=geal/osx-x86-no-snapshot#0f2c4e07fff45d4d06094990e44b95b82827aa91"
+version = "0.5.18+v2.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673a5f56dd761938c87c89d33affb6f53e0129457d14bf12389f0cb4ebe74cfd"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5736,8 +5736,7 @@ dependencies = [
 [[package]]
 name = "router-bridge"
 version = "0.5.17+v2.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f183e217179b38a4283e76ca62e3149ebe96512e9b1bd6b3933abab863f9a2c"
+source = "git+https://github.com/apollographql/federation-rs.git?branch=geal/osx-x86-no-snapshot#0f2c4e07fff45d4d06094990e44b95b82827aa91"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -187,8 +187,7 @@ reqwest = { version = "0.11.24", default-features = false, features = [
     "stream",
 ] }
 # note: this dependency should _always_ be pinned, prefix the version with an `=`
-#router-bridge = "=0.5.17+v2.7.2"
-router-bridge = { version = "=0.5.17+v2.7.2", git = "https://github.com/apollographql/federation-rs.git", branch = "geal/osx-x86-no-snapshot" }
+router-bridge = "=0.5.18+v2.7.2"
 rust-embed = "8.2.0"
 rustls = "0.21.10"
 rustls-native-certs = "0.6.3"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -188,7 +188,7 @@ reqwest = { version = "0.11.24", default-features = false, features = [
 ] }
 # note: this dependency should _always_ be pinned, prefix the version with an `=`
 #router-bridge = "=0.5.17+v2.7.2"
-router-bridge = { git = "https://github.com/apollographql/federation-rs.git", branch = "geal/osx-x86-no-snapshot" }
+router-bridge = { version = "=0.5.17+v2.7.2", git = "https://github.com/apollographql/federation-rs.git", branch = "geal/osx-x86-no-snapshot" }
 rust-embed = "8.2.0"
 rustls = "0.21.10"
 rustls-native-certs = "0.6.3"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -187,7 +187,8 @@ reqwest = { version = "0.11.24", default-features = false, features = [
     "stream",
 ] }
 # note: this dependency should _always_ be pinned, prefix the version with an `=`
-router-bridge = "=0.5.17+v2.7.2"
+#router-bridge = "=0.5.17+v2.7.2"
+router-bridge = { git = "https://github.com/apollographql/federation-rs.git", branch = "geal/osx-x86-no-snapshot" }
 rust-embed = "8.2.0"
 rustls = "0.21.10"
 rustls-native-certs = "0.6.3"


### PR DESCRIPTION
CircleCI OSX x86_64 workers are deprecated and will be removed in June. To get ahead of that, we are now building those versions from the M1 workers.
This required a change in router-bridge, to start the deno instance of the query planner without snapshots: https://github.com/apollographql/federation-rs/commit/6c23a0785d874b4787dd5025c0da8c4916cdd50d

In our tests, this did not really affect the startup time, this change is safe to use.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
