### PR TITLE
helm chart - make .Values.router optional

### DIFF
--- a/helm/chart/router/templates/configmap.yaml
+++ b/helm/chart/router/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.router.configuration }}
+{{- if and .Values.router .Values.router.configuration }}
 {{- $routerFullName := include "router.fullname" .  -}}
 {{/* NOTE: metrics configuration moved under telemetry.exporters in Router 1.35.0 */}}
 {{- $configuration := dict }}

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if or .Values.router.args .Values.router.configuration }}
+          {{- if and .Values.router (or .Values.router.args .Values.router.configuration) }}
           args:
             {{- if .Values.router.args }}
             {{- toYaml .Values.router.args | nindent 12 }}
@@ -115,18 +115,18 @@ spec:
           livenessProbe:
             httpGet:
               path: "/health?live"
-              port: {{ splitList ":" ((index .Values.router.configuration "health_check").listen | default ":8088") | last }}
+              port: {{ .Values.containerPorts.health }}
             initialDelaySeconds: {{  ((.Values.probes).liveness).initialDelaySeconds | default 0 }}
           readinessProbe:
             httpGet:
               path: "/health?ready"
-              port: {{ (splitList ":"  ((index .Values.router.configuration "health_check").listen | default ":8088")) | last }}
+              port: {{ .Values.containerPorts.health }}
             initialDelaySeconds: {{ ((.Values.probes).readiness).initialDelaySeconds | default 0 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.router.configuration  .Values.extraVolumeMounts }}
+          {{- if or (and .Values.router .Values.router.configuration) .Values.extraVolumeMounts }}
           volumeMounts:
-            {{- if .Values.router.configuration }}
+            {{- if and .Values.router .Values.router.configuration }}
             - name: router-configuration
               mountPath: /app/
               readOnly: true
@@ -139,9 +139,9 @@ spec:
       initContainers:
         {{- include "apollographql.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
       {{- end }}
-      {{- if or .Values.router.configuration .Values.extraVolumes }}
+      {{- if or (and .Values.router .Values.router.configuration) .Values.extraVolumes }}
       volumes:
-        {{- if .Values.router.configuration }}
+        {{- if and .Values.router .Values.router.configuration }}
         - name: router-configuration
           configMap:
             name: {{ include "router.fullname" . }}

--- a/helm/chart/router/templates/service.yaml
+++ b/helm/chart/router/templates/service.yaml
@@ -18,7 +18,7 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-    - port: {{ (splitList ":" (index .Values.router.configuration "health_check").listen | last ) | default "8088" }}
+    - port: {{ .Values.containerPorts.health }}
       targetPort: health
       protocol: TCP
       name: health

--- a/helm/chart/router/values.yaml
+++ b/helm/chart/router/values.yaml
@@ -6,14 +6,6 @@ replicaCount: 1
 
 # -- See https://www.apollographql.com/docs/router/configuration/overview/#yaml-config-file for yaml structure
 router:
-  configuration:
-    supergraph:
-      listen: 0.0.0.0:4000
-    health_check:
-      listen: 0.0.0.0:8088
-
-  args:
-    - --hot-reload
 
 managedFederation:
   # -- If using managed federation, the graph API key to identify router to Studio


### PR DESCRIPTION
- discussion #4934 (written by us) 
- get liveness & readiness port from containerPorts
- check if `.Values.router` exists before checking if `.Values.router.configuration` exist
- remove `.Values.router.configuration` & `.Values.router.args` from default `values.yaml` 


*Description here*

Fixes #4781 (found existing issue when looking into problem)

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
