### PR TITLE
query_panner -> query_planner

### DIFF
--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -451,7 +451,7 @@ impl InstrumentData {
                 .into(),
             );
             self.data.insert(
-                "apollo.router.config.query_panner.parallelism".to_string(),
+                "apollo.router.config.query_planner.parallelism".to_string(),
                 (
                     configuration
                         .supergraph

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@query_planner_parallelism_auto.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@query_planner_parallelism_auto.router.yaml.snap
@@ -2,7 +2,7 @@
 source: apollo-router/src/configuration/metrics.rs
 expression: "&metrics.non_zero()"
 ---
-- name: apollo.router.config.query_panner.parallelism
+- name: apollo.router.config.query_planner.parallelism
   data:
     datapoints:
       - value: 8

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@query_planner_parallelism_static.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@query_planner_parallelism_static.router.yaml.snap
@@ -2,7 +2,7 @@
 source: apollo-router/src/configuration/metrics.rs
 expression: "&metrics.non_zero()"
 ---
-- name: apollo.router.config.query_panner.parallelism
+- name: apollo.router.config.query_planner.parallelism
   data:
     datapoints:
       - value: 10


### PR DESCRIPTION
Fix typo `query_panner` -> `query_planner`