### PR TITLE
[batching] make batching look less racy

### DIFF
--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -443,7 +443,7 @@ impl RouterService {
                 // custom rust plugins, rhai scripts, and coprocessors can cancel requests at any time and return a GraphQL
                 // error wrapped in an `Ok` or in a `BoxError` wrapped in an `Err`.
                 let batch_query_opt = context.extensions().lock().remove::<BatchQuery>();
-                if let Some(mut batch_query) = batch_query_opt {
+                if let Some(batch_query) = batch_query_opt {
                     // Only proceed with signalling cancelled if the batch_query is not finished
                     if !batch_query.finished() {
                         tracing::debug!("cancelling batch query in supergraph response");

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -1012,26 +1012,26 @@ async fn call_http(
     // we have the context extensions lock held. That would be very bad...
     // We grab the (potential) BatchQuery and then operate on it later
     let opt_batch_query = {
-        let mut extensions_guard = context.extensions().lock();
+        let extensions_guard = context.extensions().lock();
 
         // We need to make sure to remove the BatchQuery from the context as it holds a sender to
         // the owning batch
         extensions_guard
             .get::<Batching>()
             .and_then(|batching_config| batching_config.batch_include(service_name).then_some(()))
-            .and_then(|_| extensions_guard.remove::<BatchQuery>())
+            .and_then(|_| extensions_guard.get::<BatchQuery>().cloned())
             .and_then(|bq| (!bq.finished()).then_some(bq))
         //TODO: I'm not sure that we need to check if bq is finished.
     };
 
     // If we have a batch query, then it's time for batching
-    let result = if let Some(mut query) = opt_batch_query {
+    let result = if let Some(query) = opt_batch_query {
         // Let the owning batch know that this query is ready to process, getting back the channel
         // from which we'll eventually receive our response.
         let response_rx = query.signal_progress(client_factory, request, body).await?;
 
         //Re-insert our BatchQuery
-        context.extensions().lock().insert::<BatchQuery>(query);
+        // context.extensions().lock().insert::<BatchQuery>(query);
 
         // Park this query until we have our response and pass it back up
         response_rx

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -1025,13 +1025,10 @@ async fn call_http(
     };
 
     // If we have a batch query, then it's time for batching
-    let result = if let Some(query) = opt_batch_query {
+    if let Some(query) = opt_batch_query {
         // Let the owning batch know that this query is ready to process, getting back the channel
         // from which we'll eventually receive our response.
         let response_rx = query.signal_progress(client_factory, request, body).await?;
-
-        //Re-insert our BatchQuery
-        // context.extensions().lock().insert::<BatchQuery>(query);
 
         // Park this query until we have our response and pass it back up
         response_rx
@@ -1044,9 +1041,7 @@ async fn call_http(
         tracing::debug!("we called http");
         let client = client_factory.create(service_name);
         call_single_http(request, body, context, client, service_name).await
-    };
-
-    result
+    }
 }
 
 /// call_single_http makes http calls with modified graphql::Request (body)

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -634,10 +634,6 @@ async fn plan_query(
         ))
         .await?;
 
-    // We need to operate on the BatchQuery without holding on to the extension lock, but using the
-    // batched query requires awaiting it, which would hold the lock for too long.
-    //
-    // We remove the BatchQuery here and then reinsert it after we've done our call to fix that.
     let batching = context.extensions().lock().get::<BatchQuery>().cloned();
     if let Some(batch_query) = batching {
         if let Some(QueryPlannerContent::Plan { plan, .. }) = &qpr.content {
@@ -648,8 +644,6 @@ async fn plan_query(
                 .map_err(|e| CacheResolverError::BatchingError(e.to_string()))?;
             tracing::debug!("batch registered: {}", batch_query);
         }
-
-        // context.extensions().lock().insert(batch_query);
     }
 
     Ok(qpr)

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -638,8 +638,8 @@ async fn plan_query(
     // batched query requires awaiting it, which would hold the lock for too long.
     //
     // We remove the BatchQuery here and then reinsert it after we've done our call to fix that.
-    let batching = context.extensions().lock().remove::<BatchQuery>();
-    if let Some(mut batch_query) = batching {
+    let batching = context.extensions().lock().get::<BatchQuery>().cloned();
+    if let Some(batch_query) = batching {
         if let Some(QueryPlannerContent::Plan { plan, .. }) = &qpr.content {
             let query_hashes = plan.root.query_hashes()?;
             batch_query
@@ -649,7 +649,7 @@ async fn plan_query(
             tracing::debug!("batch registered: {}", batch_query);
         }
 
-        context.extensions().lock().insert(batch_query);
+        // context.extensions().lock().insert(batch_query);
     }
 
     Ok(qpr)


### PR DESCRIPTION
It turns out that it's tricky. We need to use tokio async mutex to stop the compiler complaining that parking lot mutex guard isn't send.

We still need the parking lot mutex, because we can't make query_for_index() async or that causes a different Send/Sync issue.

Other problems are avoided by using:
 - AtomicUsize to track remaining
 - Arc/Mutex on Sender to allow for cloning and interior mutability

I'm not 100% convinced this is an improvement, since the code is slower and more complex and I don't actually think there is a race in the existing code *unless* someone is doing something very funky with the batching extensions(). So, I'll put it on a branch and seek specific feedback on this change.
