### PR TITLE
Rust validation backwards compatibility fixes

### DIFF
--- a/.changesets/feat_geal_remove_legacy_validation.md
+++ b/.changesets/feat_geal_remove_legacy_validation.md
@@ -2,6 +2,8 @@
 
 GraphQL query validation was initially performed by the query planner in JavaScript, which caused some performance issues. Here, we are introducing a new Rust-based validation process using `apollo-compiler` from the `apollo-rs` project. This validation is also happening much earlier in the process, inside the "router service" instead of the query planner, which will reduce the load on the query planner and give back some room in the query planner cache.
 
+Because validation now happens early, some error paths deeper inside the router will no longer be hit, causing observable differences in error messages. The new messages should be clearer and more useful.
+
 This new validation process has been running in production for months concurrently with the JavaScript version, allowing us to detect and fix any discrepancies in the new implementation. We now have enough confidence in the new Rust-based validation to entirely switch off the less performant, JavaScript validation.
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4551

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,9 +192,9 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
 name = "apollo-compiler"
-version = "1.0.0-beta.15"
+version = "1.0.0-beta.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79df4ab329753d36476653850519fe92d1b34854dd4337f6abf42a64963ac0ce"
+checksum = "175659cea0232b38bfacd1505aed00221cc4028d848699ce9e3422c6bf87d90a"
 dependencies = [
  "apollo-parser",
  "ariadne",
@@ -220,9 +220,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-federation"
-version = "0.0.10"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e3b0774618a4febe307d2ace6714583e13cd7948cdadb2b4a937ccdc166333"
+checksum = "e9fc457f3e836a60ea3d4e1a25a8b42c5c62ddf13a2131c194d94f752c7a1475"
 dependencies = [
  "apollo-compiler",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ debug = 1
 # Dependencies used in more than one place are specified here in order to keep versions in sync:
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
 [workspace.dependencies]
-apollo-compiler = "=1.0.0-beta.15"
+apollo-compiler = "=1.0.0-beta.16"
 apollo-parser = "0.7.6"
 apollo-smith = { version = "0.5.0", features = ["parser-impl"] }
 async-trait = "0.1.77"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -65,7 +65,7 @@ askama = "0.12.1"
 access-json = "0.1.0"
 anyhow = "1.0.80"
 apollo-compiler.workspace = true
-apollo-federation = "=0.0.10"
+apollo-federation = "=0.0.11"
 arc-swap = "1.6.0"
 async-channel = "1.9.0"
 async-compression = { version = "0.4.6", features = [

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -539,7 +539,7 @@ pub(crate) enum SchemaError {
 /// Collection of schema validation errors.
 #[derive(Debug)]
 pub(crate) struct ParseErrors {
-    pub(crate) errors: apollo_compiler::validation::DiagnosticList,
+    pub(crate) errors: DiagnosticList,
 }
 
 impl std::fmt::Display for ParseErrors {

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -619,7 +619,7 @@ impl IntoGraphQLErrors for ValidationErrors {
 impl From<DiagnosticList> for ValidationErrors {
     fn from(errors: DiagnosticList) -> Self {
         Self {
-            errors: errors.iter().map(|e| e.to_json()).collect(),
+            errors: errors.iter().map(|e| e.unstable_to_json_compat()).collect(),
         }
     }
 }

--- a/apollo-router/src/plugins/authorization/mod.rs
+++ b/apollo-router/src/plugins/authorization/mod.rs
@@ -437,7 +437,7 @@ impl AuthorizationPlugin {
             AuthenticatedVisitor::new(&schema.definitions, doc, &schema.implementers_map, dry_run)
         {
             let modified_query = transform::document(&mut visitor, doc)
-                .map_err(|e| SpecError::ParsingError(e.to_string()))?;
+                .map_err(|e| SpecError::TransformError(e.to_string()))?;
 
             if visitor.query_requires_authentication {
                 if is_authenticated {
@@ -476,7 +476,7 @@ impl AuthorizationPlugin {
             dry_run,
         ) {
             let modified_query = transform::document(&mut visitor, doc)
-                .map_err(|e| SpecError::ParsingError(e.to_string()))?;
+                .map_err(|e| SpecError::TransformError(e.to_string()))?;
             if visitor.query_requires_scopes {
                 tracing::debug!("the query required scopes, the requests present scopes: {scopes:?}, modified query:\n{modified_query}\nunauthorized paths: {:?}",
                 visitor
@@ -511,7 +511,7 @@ impl AuthorizationPlugin {
             dry_run,
         ) {
             let modified_query = transform::document(&mut visitor, doc)
-                .map_err(|e| SpecError::ParsingError(e.to_string()))?;
+                .map_err(|e| SpecError::TransformError(e.to_string()))?;
 
             if visitor.query_requires_policies {
                 tracing::debug!("the query required policies, the requests present policies: {policies:?}, modified query:\n{modified_query}\nunauthorized paths: {:?}",

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -592,7 +592,7 @@ impl Service<QueryPlannerRequest> for BridgeQueryPlanner {
             let schema = &this.schema.api_schema().definitions;
             match add_defer_labels(schema, &doc.ast) {
                 Err(e) => {
-                    return Err(QueryPlannerError::SpecError(SpecError::ParsingError(
+                    return Err(QueryPlannerError::SpecError(SpecError::TransformError(
                         e.to_string(),
                     )))
                 }

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -367,10 +367,11 @@ where
         let doc = match request.context.extensions().lock().get::<ParsedDocument>() {
             None => {
                 return Err(CacheResolverError::RetrievalError(Arc::new(
-                    QueryPlannerError::SpecError(SpecError::ParsingError(
+                    // TODO: dedicated error variant?
+                    QueryPlannerError::SpecError(SpecError::TransformError(
                         "missing parsed document".to_string(),
                     )),
-                )))
+                )));
             }
             Some(d) => d.clone(),
         };

--- a/apollo-router/src/router/mod.rs
+++ b/apollo-router/src/router/mod.rs
@@ -492,7 +492,7 @@ mod tests {
         let response = router_handle.request(request).await.unwrap();
 
         assert_eq!(
-            "type `User` does not have a field `name`", response.errors[0].message,
+            r#"Cannot query field "name" on type "User"."#, response.errors[0].message,
             "{response:?}"
         );
         assert_eq!(
@@ -554,8 +554,8 @@ mod tests {
         let response = router_handle.request(request).await.unwrap();
 
         assert_eq!(
-            "type `User` does not have a field `name`",
-            response.errors[0].message
+            r#"Cannot query field "name" on type "User"."#,
+            response.errors[0].message,
         );
         assert_eq!(
             "GRAPHQL_VALIDATION_FAILED",

--- a/apollo-router/src/spec/mod.rs
+++ b/apollo-router/src/spec/mod.rs
@@ -60,7 +60,7 @@ pub(crate) const GRAPHQL_VALIDATION_FAILURE_ERROR_KEY: &str = "## GraphQLValidat
 impl SpecError {
     pub(crate) const fn get_error_key(&self) -> &'static str {
         match self {
-            SpecError::ParsingError(_) => "## GraphQLParseFailure\n",
+            SpecError::ParsingError(_) | SpecError::ParseError(_) => "## GraphQLParseFailure\n",
             SpecError::UnknownOperation(_) => "## GraphQLUnknownOperationName\n",
             _ => GRAPHQL_VALIDATION_FAILURE_ERROR_KEY,
         }

--- a/apollo-router/src/spec/mod.rs
+++ b/apollo-router/src/spec/mod.rs
@@ -41,8 +41,11 @@ pub(crate) enum SpecError {
     InvalidType(String),
     /// cannot query field '{0}' on type '{1}'
     InvalidField(String, String),
+    // This branch used to be used for parse errors, and is now used primarily for errors
+    // during the query filtering / transform stage. It's also used for a handful of other
+    // random string errors.
     /// parsing error: {0}
-    ParsingError(String),
+    TransformError(String),
     /// parsing error: {0}
     ParseError(ValidationErrors),
     /// validation error: {0}
@@ -60,7 +63,7 @@ pub(crate) const GRAPHQL_VALIDATION_FAILURE_ERROR_KEY: &str = "## GraphQLValidat
 impl SpecError {
     pub(crate) const fn get_error_key(&self) -> &'static str {
         match self {
-            SpecError::ParsingError(_) | SpecError::ParseError(_) => "## GraphQLParseFailure\n",
+            SpecError::TransformError(_) | SpecError::ParseError(_) => "## GraphQLParseFailure\n",
             SpecError::UnknownOperation(_) => "## GraphQLUnknownOperationName\n",
             _ => GRAPHQL_VALIDATION_FAILURE_ERROR_KEY,
         }
@@ -77,7 +80,7 @@ impl ErrorExtension for SpecError {
             SpecError::RecursionLimitExceeded => "RECURSION_LIMIT_EXCEEDED",
             SpecError::InvalidType(_) => "INVALID_TYPE",
             SpecError::InvalidField(_, _) => "INVALID_FIELD",
-            SpecError::ParsingError(_) => "PARSING_ERROR",
+            SpecError::TransformError(_) => "PARSING_ERROR",
             SpecError::ParseError(_) => "PARSING_ERROR",
             SpecError::ValidationError(_) => "GRAPHQL_VALIDATION_FAILED",
             SpecError::UnknownOperation(_) => "GRAPHQL_VALIDATION_FAILED",

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -277,7 +277,7 @@ impl Query {
         let ast = match parser.parse_ast(query, "query.graphql") {
             Ok(ast) => ast,
             Err(errors) => {
-                return Err(SpecError::ValidationError(errors.into()));
+                return Err(SpecError::ParseError(errors.into()));
             }
         };
         let schema = &schema.api_schema().definitions;

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -345,7 +345,7 @@ impl Query {
 
         let mut visitor = QueryHashVisitor::new(&schema.definitions, document);
         traverse::document(&mut visitor, document, operation_name).map_err(|e| {
-            SpecError::ParsingError(format!("could not calculate the query hash: {e}"))
+            SpecError::QueryHashing(format!("could not calculate the query hash: {e}"))
         })?;
         let hash = visitor.finish();
 

--- a/apollo-router/src/spec/query/subselections.rs
+++ b/apollo-router/src/spec/query/subselections.rs
@@ -109,7 +109,7 @@ pub(crate) fn collect_subselections(
     }
     if defer_stats.conditional_defer_variable_names.len() > MAX_DEFER_VARIABLES {
         // TODO: dedicated error variant?
-        return Err(SpecError::ParsingError(
+        return Err(SpecError::TransformError(
             "@defer conditional on too many different variables".into(),
         ));
     }
@@ -131,7 +131,7 @@ pub(crate) fn collect_subselections(
                 &FieldType::new_named((&type_name).try_into().unwrap()),
                 &operation.selection_set,
             )
-            .map_err(|err| SpecError::ParsingError(err.to_owned()))?;
+            .map_err(|err| SpecError::TransformError(err.to_owned()))?;
             debug_assert!(shared.path.is_empty());
             if !primary.is_empty() {
                 shared.subselections.insert(

--- a/apollo-router/tests/integration/validation.rs
+++ b/apollo-router/tests/integration/validation.rs
@@ -89,3 +89,82 @@ async fn test_syntax_error() {
     }
     "###);
 }
+
+#[tokio::test]
+async fn test_validation_error() {
+    let request = serde_json::json!({"query": "{...a} fragment unused on Query { me { id } } fragment a on Query{me {id} topProducts(first: 5.5) {id}}"});
+    let request = apollo_router::services::router::Request::fake_builder()
+        .body(request.to_string())
+        .method(hyper::Method::POST)
+        .header("content-type", "application/json")
+        .build()
+        .unwrap();
+    let response = apollo_router::TestHarness::builder()
+        .schema(include_str!("../fixtures/supergraph.graphql"))
+        .build_router()
+        .await
+        .unwrap()
+        .oneshot(request)
+        .await
+        .unwrap()
+        .next_response()
+        .await
+        .unwrap()
+        .unwrap();
+
+    let v: serde_json::Value = serde_json::from_slice(&response).unwrap();
+    insta::assert_json_snapshot!(v, @r###"
+    {
+      "errors": [
+        {
+          "message": "Fragment \"unused\" is never used.",
+          "locations": [
+            {
+              "line": 1,
+              "column": 8
+            }
+          ],
+          "extensions": {
+            "code": "GRAPHQL_VALIDATION_FAILED"
+          }
+        },
+        {
+          "message": "Field \"topProducts\" of type \"Product\" must have a selection of subfields. Did you mean \"topProducts { ... }\"?",
+          "locations": [
+            {
+              "line": 1,
+              "column": 75
+            }
+          ],
+          "extensions": {
+            "code": "GRAPHQL_VALIDATION_FAILED"
+          }
+        },
+        {
+          "message": "Int cannot represent value: 5.5",
+          "locations": [
+            {
+              "line": 1,
+              "column": 94
+            }
+          ],
+          "extensions": {
+            "code": "GRAPHQL_VALIDATION_FAILED"
+          }
+        },
+        {
+          "message": "Cannot query field \"id\" on type \"Product\".",
+          "locations": [
+            {
+              "line": 1,
+              "column": 100
+            }
+          ],
+          "extensions": {
+            "code": "GRAPHQL_VALIDATION_FAILED"
+          }
+        }
+      ]
+    }
+    "###);
+}

--- a/apollo-router/tests/integration/validation.rs
+++ b/apollo-router/tests/integration/validation.rs
@@ -46,7 +46,6 @@ async fn test_request_extensions_is_null() {
     );
 }
 
-/// <https://github.com/apollographql/router/issues/3388>
 #[tokio::test]
 async fn test_syntax_error() {
     let request = serde_json::json!({"query": "{__typename"});

--- a/apollo-router/tests/integration/validation.rs
+++ b/apollo-router/tests/integration/validation.rs
@@ -74,7 +74,7 @@ async fn test_syntax_error() {
     {
       "errors": [
         {
-          "message": "syntax error: expected R_CURLY, got EOF",
+          "message": "parsing error: syntax error: expected R_CURLY, got EOF",
           "locations": [
             {
               "line": 1,

--- a/apollo-router/tests/integration_tests.rs
+++ b/apollo-router/tests/integration_tests.rs
@@ -115,7 +115,7 @@ async fn api_schema_hides_field() {
 
     let message = &actual.errors[0].message;
     assert!(
-        message.contains("type `Product` does not have a field `inStock`"),
+        message.contains(r#"Cannot query field "inStock" on type "Product"."#),
         "{message}"
     );
     assert_eq!(

--- a/apollo-router/tests/snapshots/integration_tests__defer_path_with_disabled_config.snap
+++ b/apollo-router/tests/snapshots/integration_tests__defer_path_with_disabled_config.snap
@@ -5,7 +5,7 @@ expression: stream.next().await.unwrap().unwrap()
 {
   "errors": [
     {
-      "message": "cannot find directive `@defer` in this document",
+      "message": "Unknown directive \"@defer\".",
       "locations": [
         {
           "line": 4,

--- a/apollo-router/tests/snapshots/integration_tests__validation_errors_from_rust.snap
+++ b/apollo-router/tests/snapshots/integration_tests__validation_errors_from_rust.snap
@@ -4,7 +4,7 @@ expression: response.errors
 ---
 [
   {
-    "message": "the argument `notAnArg` is not supported by `Product.name`",
+    "message": "Unknown argument \"notAnArg\" on field \"Product.name\".",
     "locations": [
       {
         "line": 1,
@@ -16,7 +16,7 @@ expression: response.errors
     }
   },
   {
-    "message": "fragment `Unused` must be used in an operation",
+    "message": "Fragment \"Unused\" is never used.",
     "locations": [
       {
         "line": 1,

--- a/examples/supergraph-sdl/rust/Cargo.toml
+++ b/examples/supergraph-sdl/rust/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-apollo-compiler = "=1.0.0-beta.15"
+apollo-compiler = "1.0.0-beta.16"
 apollo-router = { path = "../../../apollo-router" }
 async-trait = "0.1"
 tower = { version = "0.4", features = ["full"] }


### PR DESCRIPTION
Error messages are now mostly the same as the graphql-js messages from before (where possible). GraphQL syntax errors are reported as `PARSING_ERROR` again instead of as `GRAPHQL_VALIDATION_ERROR`.

`SpecError::ParsingError` is replaced by `SpecError::ParseError` which contains structured error information similar to `SpecError::ValidationError`. The other uses of `ParsingError` are replaced by `TransformError`, as most of them are in query transforms/filtering. The error messages for `TransformError` remain the same.

There will still be differences in error messages, especially when querying undefined fields etc, because previously those would hit an error case deep inside the router whereas now they will be rejected early on. This is an easily explainable difference with obvious benefits for users, so I think it's acceptable.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
