### PR TITLE
Make test_supergraph_timeout more robust

### DIFF
--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -69,6 +69,7 @@ use crate::query_planner::BridgeQueryPlannerPool;
 use crate::router_factory::create_plugins;
 use crate::router_factory::Endpoint;
 use crate::router_factory::RouterFactory;
+use crate::services::execution;
 use crate::services::layers::persisted_queries::PersistedQueryLayer;
 use crate::services::layers::query_analysis::QueryAnalysisLayer;
 use crate::services::layers::static_page::home_page_content;
@@ -2319,9 +2320,31 @@ async fn test_supergraph_timeout() {
 
     // we do the entire supergraph rebuilding instead of using `from_supergraph_mock_callback_and_configuration`
     // because we need the plugins to apply on the supergraph
-    let plugins = create_plugins(&conf, &schema, planner.subgraph_schemas(), None, None)
+    let mut plugins = create_plugins(&conf, &schema, planner.subgraph_schemas(), None, None)
         .await
         .unwrap();
+
+    plugins.insert("delay".into(), Box::new(Delay));
+
+    struct Delay;
+
+    #[async_trait::async_trait]
+    impl crate::plugin::Plugin for Delay {
+        type Config = ();
+
+        async fn new(_: crate::plugin::PluginInit<()>) -> Result<Self, BoxError> {
+            Ok(Self)
+        }
+
+        fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
+            service
+                .map_future(|fut| async {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    fut.await
+                })
+                .boxed()
+        }
+    }
 
     let builder = PluggableSupergraphServiceBuilder::new(planner)
         .with_configuration(conf.clone())

--- a/apollo-router/src/axum_factory/tests.rs
+++ b/apollo-router/src/axum_factory/tests.rs
@@ -2295,6 +2295,7 @@ async fn test_supergraph_and_health_check_same_port_different_listener() {
 async fn test_supergraph_timeout() {
     let config = serde_json::json!({
         "supergraph": {
+            "listen": "127.0.0.1:0",
             "defer_support": false,
         },
         "traffic_shaping": {
@@ -2343,10 +2344,14 @@ async fn test_supergraph_timeout() {
     .make();
 
     // keep the server handle around otherwise it will immediately shutdown
-    let (_server, client) = init_with_config(service, conf.clone(), MultiMap::new())
+    let (server, client) = init_with_config(service, conf.clone(), MultiMap::new())
         .await
         .unwrap();
-    let url = "http://localhost:4000/";
+    let url = server
+        .graphql_listen_address()
+        .as_ref()
+        .unwrap()
+        .to_string();
 
     let response = client
         .post(url)

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -288,8 +288,7 @@ fn default_graphql_listen() -> ListenAddr {
     SocketAddr::from_str("127.0.0.1:4000").unwrap().into()
 }
 
-// This isn't dead code! we use it in buildstructor's fake_new
-#[allow(dead_code)]
+#[cfg(test)]
 fn test_listen() -> ListenAddr {
     SocketAddr::from_str("127.0.0.1:0").unwrap().into()
 }


### PR DESCRIPTION
* Use an available port number
* Add an artificial delay to make sure the short timeout is triggered

The latter is an attempt to fix the test sometimes returning HTTP 200 instead of the expect 504 Gateway Timeout. I suspect either that the future wrapped in timeout would return `Ready` immediately (our `plugins::traffic_shaping::timeout` only polls the `sleep` future when the main future returns `Pending`), or the normal flow would complete within a kernel tick (which is likely much less frequent than 1ns), so `sleep` would measure zero elapsed time.

Fixes https://github.com/apollographql/router/issues/4910

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
