### PR TITLE
changelog: fix a few typos in headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,7 @@ Additionally, the router now verifies that a TTL is configured for all subgraphs
 
 By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/4882
 
-### Helm: include all standard labels in pod spec but complete sentence that stands on its own ([PR #4862](https://github.com/apollographql/router/pull/4862))
+### Helm: include all standard labels in pod spec ([PR #4862](https://github.com/apollographql/router/pull/4862))
 
 The templates for the router's Helm chart have been updated so that the  `helm.sh/chart`, `app.kubernetes.io/version`, and `app.kubernetes.io/managed-by` labels are now included on pods, as they already were for all other resources created by the Helm chart.
 
@@ -140,7 +140,7 @@ The specific change to the template is that the pod spec template now uses the `
 
 By [@glasser](https://github.com/glasser) in https://github.com/apollographql/router/pull/4862
 
-### Persisted queries return 4xx errors ([PR #4887](https://github.com/apollographql/router/pull/4887)
+### Persisted queries return 4xx errors ([PR #4887](https://github.com/apollographql/router/pull/4887))
 
 Previously, sending an invalid persisted query request could return a 200 status code to the client when they should have returned errors. These requests now return errors as 4xx status codes:
 


### PR DESCRIPTION
Two of my recent changes had sloppy headers.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

None, CHANGELOG.md change only.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
