### PR TITLE
docs: Update "errors" to include traffic-shaping timeouts' 504 status

### DIFF
--- a/docs/source/errors.mdx
+++ b/docs/source/errors.mdx
@@ -42,6 +42,7 @@ A request's HTTP `Accept` header didn't contain any of the router's supported mi
 - `multipart/mixed;subscriptionSpec=1.0`.
 
 </Property>
+
 <Property name="429" short="Too many requests">
 
 Request traffic exceeded configured rate limits. See [client side traffic shaping](./configuration/traffic-shaping/#client-side-traffic-shaping).
@@ -55,6 +56,12 @@ The request was canceled because the client closed the connection, possibly due 
 <Property name="500" short="Internal server error">
 
 The router encountered an unexpected issue. [Report](https://github.com/apollographql/router/issues/new?assignees=&labels=raised+by+user&projects=&template=bug_report.md&title=) this possible bug to the router team.
+
+</Property>
+
+<Property name="504" short="Request timed out">
+
+The request was not able to complete within a configured amount of time.  See [client side traffic shaping timeouts](./configuration/traffic-shaping/#timeouts).
 
 </Property>
 </PropertyList>


### PR DESCRIPTION
Define the HTTP status code 504 per the [implementation].

[implementation]: https://github.com/apollographql/router/blob/ab069ef2df14d41c37b8087f4aa9a3b60fc38242/apollo-router/src/plugins/traffic_shaping/timeout/error.rs#L28