### PR TITLE
Don't try to process empty batches of requests

### DIFF
--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -518,6 +518,14 @@ impl RouterService {
                                     "failed to decode a valid GraphQL request from path {e}"
                                 ),
                             })?;
+                        if result.is_empty() {
+                            return Err(TranslateError {
+                                status: StatusCode::BAD_REQUEST,
+                                error: "failed to decode a valid GraphQL request from path",
+                                extension_code: "INVALID_GRAPHQL_REQUEST",
+                                extension_details: "failed to decode a valid GraphQL request from path: empty array ".to_string()
+                            });
+                        }
                         is_batch = true;
                     } else if !q.is_empty() && q.as_bytes()[0] == b'[' {
                         let extension_details = if self.batching.enabled
@@ -579,6 +587,16 @@ impl RouterService {
                                 "failed to deserialize the request body into JSON: {e}"
                             ),
                         })?;
+                    if result.is_empty() {
+                        return Err(TranslateError {
+                            status: StatusCode::BAD_REQUEST,
+                            error: "failed to decode a valid GraphQL request from path",
+                            extension_code: "INVALID_GRAPHQL_REQUEST",
+                            extension_details:
+                                "failed to decode a valid GraphQL request from path: empty array "
+                                    .to_string(),
+                        });
+                    }
                     is_batch = true;
                 } else if !bytes.is_empty() && bytes[0] == b'[' {
                     let extension_details = if self.batching.enabled


### PR DESCRIPTION
During testing we found an existing issue with batching support which causes the router to panic if an empty batch is submitted to the router.

This is only a problem if batching support is enabled.

We now explicitly check for empty batches and return a helpful error message if they are detected.

