### PR TITLE
move back the router-bridge version in the router's Cargo.toml

### DIFF
--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -180,7 +180,8 @@ rand = "0.8.5"
 rhai = { version = "=1.17.1", features = ["sync", "serde", "internals"] }
 regex = "1.10.3"
 reqwest.workspace = true
-router-bridge.workspace = true
+# note: this dependency should _always_ be pinned, prefix the version with an `=`
+router-bridge = "=0.5.18+v2.7.2"
 rust-embed = "8.2.0"
 rustls = "0.21.10"
 rustls-native-certs = "0.6.3"

--- a/apollo-router/build/main.rs
+++ b/apollo-router/build/main.rs
@@ -5,21 +5,12 @@ mod studio;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cargo_manifest: serde_json::Value = basic_toml::from_str(
-        &fs::read_to_string(
-            PathBuf::from(&env!("CARGO_MANIFEST_DIR"))
-                .parent()
-                .unwrap()
-                .join("Cargo.toml"),
-        )
-        .expect("could not read Cargo.toml"),
+        &fs::read_to_string(PathBuf::from(&env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
+            .expect("could not read Cargo.toml"),
     )
     .expect("could not parse Cargo.toml");
 
     let router_bridge = cargo_manifest
-        .get("workspace")
-        .expect("Cargo.toml does not contain workspace")
-        .as_object()
-        .expect("Cargo.toml workspace key is not an object")
         .get("dependencies")
         .expect("Cargo.toml does not contain dependencies")
         .as_object()

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -1484,20 +1484,11 @@ mod tests {
     #[test]
     fn router_bridge_dependency_is_pinned() {
         let cargo_manifest: serde_json::Value = basic_toml::from_str(
-            &fs::read_to_string(
-                PathBuf::from(&env!("CARGO_MANIFEST_DIR"))
-                    .parent()
-                    .unwrap()
-                    .join("Cargo.toml"),
-            )
-            .expect("could not read Cargo.toml"),
+            &fs::read_to_string(PathBuf::from(&env!("CARGO_MANIFEST_DIR")).join("Cargo.toml"))
+                .expect("could not read Cargo.toml"),
         )
         .expect("could not parse Cargo.toml");
         let router_bridge_version = cargo_manifest
-            .get("workspace")
-            .expect("Cargo.toml does not contain workspace")
-            .as_object()
-            .expect("Cargo.toml workspace key is not an object")
             .get("dependencies")
             .expect("Cargo.toml does not contain dependencies")
             .as_object()


### PR DESCRIPTION
When running `cargo publish`, the build script looks for a workspace Cargo.toml that does not exist because that does not execute from inside the repository

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
