### PR TITLE
ci: Only validate Helm against Kubernetes versions with "previous patches"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -408,7 +408,7 @@ commands:
             # Create list of kube versions
             CURRENT_KUBE_VERSIONS=$(curl -s -L https://raw.githubusercontent.com/kubernetes/website/main/data/releases/schedule.yaml \
               | yq -o json '.' \
-              | jq --raw-output '.schedules[] | select((now | strftime("%Y-%m-%dT00:00:00Z")) as $date | .releaseDate < $date and .endOfLifeDate > $date) | .previousPatches[].release')
+              | jq --raw-output '.schedules[] | select((now | strftime("%Y-%m-%dT00:00:00Z")) as $date | .releaseDate < $date and .endOfLifeDate > $date) | select(.previousPatches != null) | .previousPatches[].release')
 
             TEMPLATE_DIR=$(mktemp -d)
             MINOR_VERSION="${kube_version%.*}"


### PR DESCRIPTION
We test our Helm chart against known stable Kubernetes versions.  [Kubernetes v1.30.0] came out last night, however, the [manifest] on which we rely in order to uses a particularly odd format when this happens, leaving both `previousPatches` empty, but also not a nice representation of "current version" that we can rely on without doing some funny inference.  (YAML comes into play here)

This fix wouldn't be necessary after the first patch (v1.30.1), but the work to fix this in a better way is disproportional to just not testing the very first patch version of a new Kubernetes minor, which is probably a totally fine trade-off for the first month of a brand new Kubernetes release.  (v1.30.1 already shows in the manifest as coming on 2024-05-15).

For now, this unblocks CI.  We could consider other approaches in the future.

[manifest]: https://raw.githubusercontent.com/kubernetes/website/main/data/releases/schedule.yaml
[Kubernetes v1.30.0]: https://github.com/kubernetes/kubernetes/releases/tag/v1.30.0