### PR TITLE
Add support for condition processing to subgraph batching

### DIFF
--- a/apollo-router/src/query_planner/plan.rs
+++ b/apollo-router/src/query_planner/plan.rs
@@ -74,6 +74,14 @@ impl QueryPlan {
             None => false,
         }
     }
+
+    pub(crate) fn query_hashes(
+        &self,
+        operation: Option<&str>,
+        variables: &Object,
+    ) -> Result<Vec<Arc<QueryHash>>, CacheResolverError> {
+        self.root.query_hashes(operation, variables, &self.query)
+    }
 }
 
 /// Query plans are composed of a set of nodes.
@@ -206,7 +214,12 @@ impl PlanNode {
     /// supported, but it may be that PlanNode::Condition must eventually be supported (or other
     /// new nodes types that are introduced). Explicitly fail each type to provide extra error
     /// details and don't use _ so that future node types must be handled here.
-    pub(crate) fn query_hashes(&self) -> Result<Vec<Arc<QueryHash>>, CacheResolverError> {
+    pub(crate) fn query_hashes(
+        &self,
+        operation: Option<&str>,
+        variables: &Object,
+        query: &Query,
+    ) -> Result<Vec<Arc<QueryHash>>, CacheResolverError> {
         let mut query_hashes = vec![];
         let mut new_targets = vec![self];
 
@@ -241,11 +254,36 @@ impl PlanNode {
                                 .to_string(),
                         ))
                     }
-                    PlanNode::Condition { .. } => {
-                        return Err(CacheResolverError::BatchingError(
-                            "unexpected condition node encountered during query_hash processing"
-                                .to_string(),
-                        ))
+                    PlanNode::Condition {
+                        if_clause,
+                        else_clause,
+                        condition,
+                    } => {
+                        if query
+                            .variable_value(operation, condition.as_str(), variables)
+                            .map(|v| *v == Value::Bool(true))
+                            .unwrap_or(true)
+                        {
+                            if let Some(node) = if_clause {
+                                todo!()
+                                /*
+                                // If requires.is_empty() we can batch it!
+                                if let PlanNode::Fetch(fetch_node) = node {
+                                    if fetch_node.requires.is_empty() {
+                                        query_hashes.push(fetch_node.schema_aware_hash.clone());
+                                    }
+                                }
+                                    */
+                            }
+                        } else if let Some(node) = else_clause {
+                            todo!()
+                            /*
+                            // If requires.is_empty() we can batch it!
+                            if node.requires.is_empty() {
+                                query_hashes.push(node.schema_aware_hash.clone());
+                            }
+                                    */
+                        }
                     }
                 }
             }

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -250,6 +250,17 @@ async fn service_call(
                     *response.response.status_mut() = StatusCode::NOT_ACCEPTABLE;
                     return Ok(response);
                 }
+                // This is the correct place to perform query batch analysis
+                // XXX: Migrated here from plan_query.
+                let batching = context.extensions().lock().get::<BatchQuery>().cloned();
+                if let Some(batch_query) = batching {
+                    let query_hashes = plan.query_hashes(operation_name.as_deref(), &variables)?;
+                    batch_query
+                        .set_query_hashes(query_hashes)
+                        .await
+                        .map_err(|e| CacheResolverError::BatchingError(e.to_string()))?;
+                    tracing::debug!("batch registered: {}", batch_query);
+                }
             }
 
             let ClientRequestAccepts {
@@ -631,18 +642,6 @@ async fn plan_query(
             "otel.kind" = "INTERNAL"
         ))
         .await?;
-
-    let batching = context.extensions().lock().get::<BatchQuery>().cloned();
-    if let Some(batch_query) = batching {
-        if let Some(QueryPlannerContent::Plan { plan, .. }) = &qpr.content {
-            let query_hashes = plan.root.query_hashes()?;
-            batch_query
-                .set_query_hashes(query_hashes)
-                .await
-                .map_err(|e| CacheResolverError::BatchingError(e.to_string()))?;
-            tracing::debug!("batch registered: {}", batch_query);
-        }
-    }
 
     Ok(qpr)
 }


### PR DESCRIPTION
In consultation with federation team, I had been under the impression that we didn't need support for ConditionNode in the batching implementation.

It turns out that in certain use cases, ConditionNode will arrive in a batch and we need to decide how to deal with it.

This is a partially implemented solution to start discussion.

