### PR TITLE
chore(deps,security): update rustls to v0.21.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5889,9 +5889,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "log",
  "ring 0.17.5",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -183,7 +183,7 @@ reqwest.workspace = true
 # note: this dependency should _always_ be pinned, prefix the version with an `=`
 router-bridge = "=0.5.18+v2.7.2"
 rust-embed = "8.2.0"
-rustls = "0.21.10"
+rustls = "0.21.11"
 rustls-native-certs = "0.6.3"
 rustls-pemfile = "1.0.4"
 schemars.workspace = true


### PR DESCRIPTION
> [!IMPORTANT]
>
> Read below for important details.  While the Router is unaffected, this patch will be applied in Router v1.45.0 which will release on Monday, April 22, 2024.

While the Router **does** use `rustls`, [RUSTSEC-2024-0336] (also known as [CVE-2024-32650] and [GHSA-6g7w-8wpp-frhj]) **DOES NOT affect the Router** since it uses `tokio-rustls` which is specifically called out in the advisory as unaffected.

Despite the lack of impact, we update `rustls` version v0.21.10 to [rustls v0.21.11] which includes a patch.

[RUSTSEC-2024-0336]: https://rustsec.org/advisories/RUSTSEC-2024-0336.html
[CVE-2024-32650]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-32650
[GHSA-6g7w-8wpp-frhj]: https://github.com/advisories/GHSA-6g7w-8wpp-frhj
[rustls v0.21.11]: https://github.com/rustls/rustls/releases/tag/v%2F0.21.11