### PR TITLE
fix rust version in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -545,7 +545,7 @@ jobs:
       - checkout
       - setup_environment:
           platform: << parameters.platform >>
-      #- xtask_check_compliance
+      - xtask_check_compliance
 
   test:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,7 +320,7 @@ commands:
             if [[ ! -d "$HOME/.cargo" ]]; then
               curl https://sh.rustup.rs -sSf -o rustup.sh
               chmod 755 ./rustup.sh
-              ./rustup.sh -y --profile minimal --component clippy --component rustfmt
+              ./rustup.sh -y --profile minimal --component clippy --component rustfmt --default-toolchain $(grep -Po '(?<=^channel = ")[^"]*(?=".*)' rust-toolchain.toml)
             fi
             echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"
 
@@ -545,7 +545,7 @@ jobs:
       - checkout
       - setup_environment:
           platform: << parameters.platform >>
-      - xtask_check_compliance
+      #- xtask_check_compliance
 
   test:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,7 +320,8 @@ commands:
             if [[ ! -d "$HOME/.cargo" ]]; then
               curl https://sh.rustup.rs -sSf -o rustup.sh
               chmod 755 ./rustup.sh
-              ./rustup.sh -y --profile minimal --component clippy --component rustfmt --default-toolchain $(grep -Eo '(?<=^channel = ")[^"]*(?=".*)' rust-toolchain.toml)
+              ./rustup.sh -y --profile minimal --component clippy --component rustfmt --default-toolchain none
+              $HOME/.cargo/bin/rustc -V
             fi
             echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,7 +320,7 @@ commands:
             if [[ ! -d "$HOME/.cargo" ]]; then
               curl https://sh.rustup.rs -sSf -o rustup.sh
               chmod 755 ./rustup.sh
-              ./rustup.sh -y --profile minimal --component clippy --component rustfmt --default-toolchain $(grep -Po '(?<=^channel = ")[^"]*(?=".*)' rust-toolchain.toml)
+              ./rustup.sh -y --profile minimal --component clippy --component rustfmt --default-toolchain $(grep -Eo '(?<=^channel = ")[^"]*(?=".*)' rust-toolchain.toml)
             fi
             echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> "$BASH_ENV"
 


### PR DESCRIPTION
When building an old version of the Router, we have a `rust-toolchain.toml` file that fixes the version used to build, but `rustup.sh` does not actually take that file into account: it installs the last stable, that is then cached, and then when building the router, we install on the fly the required version. This is not a big issue when working on the `dev` branch which always uses the last stable. But for older versions, we should cache the version actually used

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
