### PR TITLE
docs: custom events telemetry

### DIFF
--- a/docs/shared/telemetry-performance.mdx
+++ b/docs/shared/telemetry-performance.mdx
@@ -1,0 +1,4 @@
+Keep in mind that the amount of telemetry you add can impact your router's performance.
+
+- Custom metrics, events, and attributes consume more processing resources than standard metrics. Adding too many (standard or custom) can slow your router down.
+- Configurations such as `events.*.request|error|response` that produce output for all router lifecycle services should only be used for development or debugging, not for production.

--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -128,9 +128,10 @@
         "Zipkin": "/configuration/telemetry/exporters/tracing/zipkin"
       },
       "Instrumentation": {
-        "Instruments" : "/configuration/telemetry/instrumentation/instruments",
-        "Spans" : "/configuration/telemetry/instrumentation/spans",
-        "Selectors" : "/configuration/telemetry/instrumentation/selectors",
+        "Instruments": "/configuration/telemetry/instrumentation/instruments",
+        "Events": "/configuration/telemetry/instrumentation/events",
+        "Spans": "/configuration/telemetry/instrumentation/spans",
+        "Selectors": "/configuration/telemetry/instrumentation/selectors",
         "Standard attributes": "/configuration/telemetry/instrumentation/standard-attributes",
         "Standard instruments": "/configuration/telemetry/instrumentation/standard-instruments"
       }

--- a/docs/source/configuration/telemetry/instrumentation/conditions.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/conditions.mdx
@@ -6,7 +6,7 @@ description: Set conditions for when events or instruments are triggered in the 
 
 <PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#observability"/>
 
-You can set conditions for when an [instrument](./instruments) should be mutated <!--or an [event](./events) -->should be triggered.
+You can set conditions for when an [instrument](./instruments) should be mutated or an [event](./events) should be triggered.
 
 
 ## Condition configuration

--- a/docs/source/configuration/telemetry/instrumentation/events.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/events.mdx
@@ -5,8 +5,9 @@ description: Capture standard and custom events from the Apollo Router's request
 ---
 
 import RouterServices from '../../../../shared/router-lifecycle-services.mdx';
+import TelemetryPerformanceNote from '../../../../shared/telemetry-performance.mdx';
 
-An **event** is used to signal when something of note happens in the [Apollo Router's request lifecycle](../../../customizations/overview/#the-request-lifecycle). Events are output to both logs and traces.
+An _event_ is used to signal when something of note happens in the [Apollo Router's request lifecycle](../../../customizations/overview/#the-request-lifecycle). Events are output to both logs and traces.
 
 You can configure events for each service in `router.yaml`. Events can be standard or custom, and they can be triggered by configurable conditions.
 
@@ -74,6 +75,12 @@ telemetry:
         my.event: # This key will automatically be added as a 'type' attribute of the event
           # Custom event configuration
 ```
+
+<Note>
+
+<TelemetryPerformanceNote/>
+
+</Note>
 
 ### `message`
 
@@ -185,9 +192,9 @@ telemetry:
             - request_header: "x-log-request"
         
     supergraph:
-        # ...
+        # Custom event configuration for supergraph service ...
     subgraph:
-        # ...
+        # Custom event configuration for subgraph service ...
 ```
 
 ## Event configuration reference

--- a/docs/source/configuration/telemetry/instrumentation/instruments.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/instruments.mdx
@@ -5,6 +5,7 @@ description: Create and customize instruments to collect data and report measure
 ---
 
 import RouterServices from '../../../../shared/router-lifecycle-services.mdx';
+import TelemetryPerformanceNote from '../../../../shared/telemetry-performance.mdx';
 
 <PremiumFeature linkWithAnchor="https://www.apollographql.com/pricing#observability"/>
 
@@ -99,6 +100,12 @@ telemetry:
           unit: count
           description: "my description"
 ```
+
+<Note>
+
+<TelemetryPerformanceNote/>
+
+</Note>
 
 #### Instrument naming conventions
 

--- a/docs/source/configuration/telemetry/instrumentation/selectors.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/selectors.mdx
@@ -5,7 +5,7 @@ description: Extract and select data from the Apollo Router's pipeline services 
 ---
 import RouterServices from '../../../../shared/router-lifecycle-services.mdx';
 
-A **selector** is used to extract data from the Apollo Router's request lifecycle (pipeline) services and attach them to telemetry, specifically [spans](./spans), [instruments](./instruments), [conditions](./conditions)<!-- and [events](./events)-->.
+A _selector_ is used to extract data from the Apollo Router's request lifecycle (pipeline) services and attach them to telemetry, specifically [spans](./spans), [instruments](./instruments), [conditions](./conditions) and [events](./events).
 
 Each service of the router pipeline (`router`, `supergraph`, `subgraph`) has its own available selectors.
 

--- a/docs/source/configuration/telemetry/instrumentation/standard-attributes.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/standard-attributes.mdx
@@ -6,7 +6,7 @@ description: Attach OpenTelemetry standard attributes to Apollo Router telemetry
 
 import RouterServices from '../../../../shared/router-lifecycle-services.mdx';
 
-[OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/) define a set of **standard attributes** that can be attached to [spans](./spans)<!--, [instruments](./instruments) and [events](./events)-->. These attributes are used to filter and group data in your application performance monitor (APM).
+[OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/) define a set of **standard attributes** that can be attached to [spans](./spans), [instruments](./instruments) and [events](./events). These attributes are used to filter and group data in your application performance monitor (APM).
 
 The attributes available depend on the service of the router pipeline.
 

--- a/docs/source/configuration/telemetry/overview.mdx
+++ b/docs/source/configuration/telemetry/overview.mdx
@@ -4,6 +4,8 @@ subtitle: Collect observable data to monitor your router and supergraph
 description: Observe and monitor the health and performance of the Apollo Router and the supergraph by collecting and exporting telemetry logs, metrics, and traces
 ---
 
+import TelemetryPerformanceNote from '../../../shared/telemetry-performance.mdx';
+
 In this overview, learn about:
 - How Apollo Router telemetry enables supergraph observability and debuggability
 - What data is captured in the router's logs, metrics, and traces
@@ -148,3 +150,9 @@ You can use [standard attributes](./instrumentation/standard-attributes) or [sel
 [Custom attributes for spans](./instrumentation/spans/#attributes) require a GraphOS [Dedicated or Enterprise plan](https://www.apollographql.com/pricing#observability).
 
 </PremiumFeature>
+
+## Best practices
+
+### Balancing telemetry and router performance
+
+<TelemetryPerformanceNote/>


### PR DESCRIPTION
Docs for https://github.com/apollographql/router/issues/4320 (PR https://github.com/apollographql/router/pull/4956):

- Unhide Events page and add to left-nav
- Add telemetry performance trade-off note
