### PR TITLE
docs(subscription-support): Try to fix formatting of L3 header.

### DIFF
--- a/docs/source/executing-operations/subscription-support.mdx
+++ b/docs/source/executing-operations/subscription-support.mdx
@@ -173,6 +173,7 @@ If something crashes on your side for a specific subscription on specific events
 Also, when handling subscriptions with heartbeats disabled, make sure to store a subscription's request payload (including extensions data with callback URL and verifier) to be able to send the right events on the right callback URL when you start your lambda function triggered by an event.
 
 </Caution>
+
 ### Using a combination of modes
 
 If some of your subgraphs require [passthrough mode](#websocket-setup) and others require [callback mode](#http-callback-setup) for subscriptions, you can apply different modes to different subgraphs in your configuration:


### PR DESCRIPTION
This header wasn't rendering correctly in our documentation.  This attempts to fix that.


It was showing as this:

<img width="723" alt="image" src="https://github.com/apollographql/router/assets/841294/43d3d66d-a088-4e62-88cb-5690487faa0e">
