### PR TITLE
make the coprocessor URL configurable per stage

### DIFF
--- a/.changesets/feat_geal_coprocessor_urls.md
+++ b/.changesets/feat_geal_coprocessor_urls.md
@@ -12,7 +12,7 @@ coprocessor:
       headers: true
   supergraph::
     request:
-      body; true
+      body: true
       url: http://127.0.0.1:8082
 ```
 

--- a/.changesets/feat_geal_coprocessor_urls.md
+++ b/.changesets/feat_geal_coprocessor_urls.md
@@ -1,0 +1,20 @@
+### make the coprocessor URL configurable per stage ([PR #5005](https://github.com/apollographql/router/pull/5005))
+
+This makes it possible to have different coprocessor URLs per stage. The initial URL configuration still serves as a global default, but it can be overriden per stage.
+
+As an example, we can have a router request and supergraph request coprocessors with different URLs:
+
+```yaml title="router.yaml"
+coprocessor:
+  url: http://127.0.0.1:8081
+  router:
+    request:
+      headers: true
+  supergraph::
+    request:
+      body; true
+      url: http://127.0.0.1:8082
+```
+
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/5005

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -832,7 +832,8 @@ expression: "&schema"
               "sdl": false,
               "method": false,
               "query_plan": false,
-              "detached": false
+              "detached": false,
+              "url": null
             },
             "response": {
               "headers": false,
@@ -840,7 +841,8 @@ expression: "&schema"
               "body": false,
               "sdl": false,
               "status_code": false,
-              "detached": false
+              "detached": false,
+              "url": null
             }
           },
           "type": "object",
@@ -854,7 +856,8 @@ expression: "&schema"
                 "sdl": false,
                 "method": false,
                 "query_plan": false,
-                "detached": false
+                "detached": false,
+                "url": null
               },
               "type": "object",
               "properties": {
@@ -892,6 +895,12 @@ expression: "&schema"
                   "description": "Send the SDL",
                   "default": false,
                   "type": "boolean"
+                },
+                "url": {
+                  "description": "The url you'd like to offload processing to",
+                  "default": null,
+                  "type": "string",
+                  "nullable": true
                 }
               },
               "additionalProperties": false
@@ -904,7 +913,8 @@ expression: "&schema"
                 "body": false,
                 "sdl": false,
                 "status_code": false,
-                "detached": false
+                "detached": false,
+                "url": null
               },
               "type": "object",
               "properties": {
@@ -937,6 +947,12 @@ expression: "&schema"
                   "description": "Send the HTTP status",
                   "default": false,
                   "type": "boolean"
+                },
+                "url": {
+                  "description": "The url you'd like to offload processing to",
+                  "default": null,
+                  "type": "string",
+                  "nullable": true
                 }
               },
               "additionalProperties": false
@@ -953,7 +969,8 @@ expression: "&schema"
               "sdl": false,
               "path": false,
               "method": false,
-              "detached": false
+              "detached": false,
+              "url": null
             },
             "response": {
               "headers": false,
@@ -961,7 +978,8 @@ expression: "&schema"
               "body": false,
               "sdl": false,
               "status_code": false,
-              "detached": false
+              "detached": false,
+              "url": null
             }
           },
           "type": "object",
@@ -975,7 +993,8 @@ expression: "&schema"
                 "sdl": false,
                 "path": false,
                 "method": false,
-                "detached": false
+                "detached": false,
+                "url": null
               },
               "type": "object",
               "properties": {
@@ -1013,6 +1032,12 @@ expression: "&schema"
                   "description": "Send the SDL",
                   "default": false,
                   "type": "boolean"
+                },
+                "url": {
+                  "description": "The url you'd like to offload processing to",
+                  "default": null,
+                  "type": "string",
+                  "nullable": true
                 }
               },
               "additionalProperties": false
@@ -1025,7 +1050,8 @@ expression: "&schema"
                 "body": false,
                 "sdl": false,
                 "status_code": false,
-                "detached": false
+                "detached": false,
+                "url": null
               },
               "type": "object",
               "properties": {
@@ -1058,6 +1084,12 @@ expression: "&schema"
                   "description": "Send the HTTP status",
                   "default": false,
                   "type": "boolean"
+                },
+                "url": {
+                  "description": "The url you'd like to offload processing to",
+                  "default": null,
+                  "type": "string",
+                  "nullable": true
                 }
               },
               "additionalProperties": false
@@ -1075,7 +1107,8 @@ expression: "&schema"
                 "uri": false,
                 "method": false,
                 "service_name": false,
-                "detached": false
+                "detached": false,
+                "url": null
               },
               "response": {
                 "headers": false,
@@ -1083,7 +1116,8 @@ expression: "&schema"
                 "body": false,
                 "service_name": false,
                 "status_code": false,
-                "detached": false
+                "detached": false,
+                "url": null
               }
             }
           },
@@ -1099,7 +1133,8 @@ expression: "&schema"
                   "uri": false,
                   "method": false,
                   "service_name": false,
-                  "detached": false
+                  "detached": false,
+                  "url": null
                 },
                 "response": {
                   "headers": false,
@@ -1107,7 +1142,8 @@ expression: "&schema"
                   "body": false,
                   "service_name": false,
                   "status_code": false,
-                  "detached": false
+                  "detached": false,
+                  "url": null
                 }
               },
               "type": "object",
@@ -1121,7 +1157,8 @@ expression: "&schema"
                     "uri": false,
                     "method": false,
                     "service_name": false,
-                    "detached": false
+                    "detached": false,
+                    "url": null
                   },
                   "type": "object",
                   "properties": {
@@ -1159,6 +1196,12 @@ expression: "&schema"
                       "description": "Send the subgraph URI",
                       "default": false,
                       "type": "boolean"
+                    },
+                    "url": {
+                      "description": "The url you'd like to offload processing to",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
                     }
                   },
                   "additionalProperties": false
@@ -1171,7 +1214,8 @@ expression: "&schema"
                     "body": false,
                     "service_name": false,
                     "status_code": false,
-                    "detached": false
+                    "detached": false,
+                    "url": null
                   },
                   "type": "object",
                   "properties": {
@@ -1204,6 +1248,12 @@ expression: "&schema"
                       "description": "Send the http status",
                       "default": false,
                       "type": "boolean"
+                    },
+                    "url": {
+                      "description": "The url you'd like to offload processing to",
+                      "default": null,
+                      "type": "string",
+                      "nullable": true
                     }
                   },
                   "additionalProperties": false
@@ -1223,7 +1273,8 @@ expression: "&schema"
               "body": false,
               "sdl": false,
               "method": false,
-              "detached": false
+              "detached": false,
+              "url": null
             },
             "response": {
               "headers": false,
@@ -1231,7 +1282,8 @@ expression: "&schema"
               "body": false,
               "sdl": false,
               "status_code": false,
-              "detached": false
+              "detached": false,
+              "url": null
             }
           },
           "type": "object",
@@ -1244,7 +1296,8 @@ expression: "&schema"
                 "body": false,
                 "sdl": false,
                 "method": false,
-                "detached": false
+                "detached": false,
+                "url": null
               },
               "type": "object",
               "properties": {
@@ -1277,6 +1330,12 @@ expression: "&schema"
                   "description": "Send the SDL",
                   "default": false,
                   "type": "boolean"
+                },
+                "url": {
+                  "description": "The url you'd like to offload processing to",
+                  "default": null,
+                  "type": "string",
+                  "nullable": true
                 }
               },
               "additionalProperties": false
@@ -1289,7 +1348,8 @@ expression: "&schema"
                 "body": false,
                 "sdl": false,
                 "status_code": false,
-                "detached": false
+                "detached": false,
+                "url": null
               },
               "type": "object",
               "properties": {
@@ -1322,6 +1382,12 @@ expression: "&schema"
                   "description": "Send the HTTP status",
                   "default": false,
                   "type": "boolean"
+                },
+                "url": {
+                  "description": "The url you'd like to offload processing to",
+                  "default": null,
+                  "type": "string",
+                  "nullable": true
                 }
               },
               "additionalProperties": false

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -899,8 +899,7 @@ expression: "&schema"
                 "url": {
                   "description": "The url you'd like to offload processing to",
                   "default": null,
-                  "type": "string",
-                  "nullable": true
+                  "type": "string"
                 }
               },
               "additionalProperties": false
@@ -951,8 +950,7 @@ expression: "&schema"
                 "url": {
                   "description": "The url you'd like to offload processing to",
                   "default": null,
-                  "type": "string",
-                  "nullable": true
+                  "type": "string"
                 }
               },
               "additionalProperties": false
@@ -1036,8 +1034,7 @@ expression: "&schema"
                 "url": {
                   "description": "The url you'd like to offload processing to",
                   "default": null,
-                  "type": "string",
-                  "nullable": true
+                  "type": "string"
                 }
               },
               "additionalProperties": false
@@ -1088,8 +1085,7 @@ expression: "&schema"
                 "url": {
                   "description": "The url you'd like to offload processing to",
                   "default": null,
-                  "type": "string",
-                  "nullable": true
+                  "type": "string"
                 }
               },
               "additionalProperties": false
@@ -1200,8 +1196,7 @@ expression: "&schema"
                     "url": {
                       "description": "The url you'd like to offload processing to",
                       "default": null,
-                      "type": "string",
-                      "nullable": true
+                      "type": "string"
                     }
                   },
                   "additionalProperties": false
@@ -1252,8 +1247,7 @@ expression: "&schema"
                     "url": {
                       "description": "The url you'd like to offload processing to",
                       "default": null,
-                      "type": "string",
-                      "nullable": true
+                      "type": "string"
                     }
                   },
                   "additionalProperties": false
@@ -1334,8 +1328,7 @@ expression: "&schema"
                 "url": {
                   "description": "The url you'd like to offload processing to",
                   "default": null,
-                  "type": "string",
-                  "nullable": true
+                  "type": "string"
                 }
               },
               "additionalProperties": false
@@ -1386,8 +1379,7 @@ expression: "&schema"
                 "url": {
                   "description": "The url you'd like to offload processing to",
                   "default": null,
-                  "type": "string",
-                  "nullable": true
+                  "type": "string"
                 }
               },
               "additionalProperties": false

--- a/apollo-router/src/plugins/coprocessor/execution.rs
+++ b/apollo-router/src/plugins/coprocessor/execution.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
 use tower_service::Service;
+use url::Url;
 
 use super::externalize_header_map;
 use super::*;
@@ -38,7 +39,8 @@ pub(super) struct ExecutionRequestConf {
     /// Handles the request without waiting for the coprocessor to respond
     pub(super) detached: bool,
     /// The url you'd like to offload processing to
-    pub(super) url: Option<String>,
+    #[schemars(with = "String")]
+    pub(super) url: Option<Url>,
 }
 
 /// What information is passed to a router request/response stage
@@ -58,7 +60,8 @@ pub(super) struct ExecutionResponseConf {
     /// Handles the response without waiting for the coprocessor to respond
     pub(super) detached: bool,
     /// The url you'd like to offload processing to
-    pub(super) url: Option<String>,
+    #[schemars(with = "String")]
+    pub(super) url: Option<Url>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, JsonSchema)]
@@ -75,7 +78,7 @@ impl ExecutionStage {
         &self,
         http_client: C,
         service: execution::BoxService,
-        coprocessor_url: String,
+        coprocessor_url: Url,
         sdl: Arc<String>,
     ) -> execution::BoxService
     where
@@ -196,7 +199,7 @@ impl ExecutionStage {
 
 async fn process_execution_request_stage<C>(
     http_client: C,
-    coprocessor_url: String,
+    coprocessor_url: Url,
     sdl: Arc<String>,
     mut request: execution::Request,
     request_config: ExecutionRequestConf,
@@ -354,7 +357,7 @@ where
 
 async fn process_execution_response_stage<C>(
     http_client: C,
-    coprocessor_url: String,
+    coprocessor_url: Url,
     sdl: Arc<String>,
     mut response: execution::Response,
     response_config: ExecutionResponseConf,
@@ -804,7 +807,7 @@ mod tests {
         let service = execution_stage.as_service(
             mock_http_client,
             mock_execution_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -869,7 +872,7 @@ mod tests {
         let service = execution_stage.as_service(
             mock_http_client,
             mock_execution_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -926,7 +929,7 @@ mod tests {
         let service = execution_stage.as_service(
             mock_http_client,
             mock_execution_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -1048,7 +1051,7 @@ mod tests {
         let service = execution_stage.as_service(
             mock_http_client,
             mock_execution_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -1159,7 +1162,7 @@ mod tests {
         let service = execution_stage.as_service(
             mock_http_client,
             mock_execution_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -1222,7 +1225,7 @@ mod tests {
         let service = execution_stage.as_service(
             mock_http_client,
             mock_execution_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 

--- a/apollo-router/src/plugins/coprocessor/mod.rs
+++ b/apollo-router/src/plugins/coprocessor/mod.rs
@@ -29,6 +29,7 @@ use tower::BoxError;
 use tower::Service;
 use tower::ServiceBuilder;
 use tower::ServiceExt;
+use url::Url;
 
 use crate::error::Error;
 use crate::layers::async_checkpoint::OneShotAsyncCheckpointLayer;
@@ -229,7 +230,8 @@ pub(super) struct RouterRequestConf {
     /// Handles the request without waiting for the coprocessor to respond
     pub(super) detached: bool,
     /// The url you'd like to offload processing to
-    pub(super) url: Option<String>,
+    #[schemars(with = "String")]
+    pub(super) url: Option<Url>,
 }
 
 /// What information is passed to a router request/response stage
@@ -249,7 +251,8 @@ pub(super) struct RouterResponseConf {
     /// Handles the response without waiting for the coprocessor to respond
     pub(super) detached: bool,
     /// The url you'd like to offload processing to
-    pub(super) url: Option<String>,
+    #[schemars(with = "String")]
+    pub(super) url: Option<Url>,
 }
 
 /// What information is passed to a subgraph request/response stage
@@ -271,7 +274,8 @@ pub(super) struct SubgraphRequestConf {
     /// Handles the request without waiting for the coprocessor to respond
     pub(super) detached: bool,
     /// The url you'd like to offload processing to
-    pub(super) url: Option<String>,
+    #[schemars(with = "String")]
+    pub(super) url: Option<Url>,
 }
 
 /// What information is passed to a subgraph request/response stage
@@ -291,7 +295,8 @@ pub(super) struct SubgraphResponseConf {
     /// Handles the response without waiting for the coprocessor to respond
     pub(super) detached: bool,
     /// The url you'd like to offload processing to
-    pub(super) url: Option<String>,
+    #[schemars(with = "String")]
+    pub(super) url: Option<Url>,
 }
 
 /// Configures the externalization plugin
@@ -299,7 +304,8 @@ pub(super) struct SubgraphResponseConf {
 #[serde(deny_unknown_fields)]
 struct Conf {
     /// The url you'd like to offload processing to
-    url: String,
+    #[schemars(with = "String")]
+    url: Url,
     /// The timeout for external requests
     #[serde(deserialize_with = "humantime_serde::deserialize")]
     #[schemars(with = "String", default = "default_timeout")]
@@ -337,7 +343,7 @@ impl RouterStage {
         &self,
         http_client: C,
         service: router::BoxService,
-        coprocessor_url: String,
+        coprocessor_url: Url,
         sdl: Arc<String>,
     ) -> router::BoxService
     where
@@ -478,7 +484,7 @@ impl SubgraphStage {
         &self,
         http_client: C,
         service: subgraph::BoxService,
-        coprocessor_url: String,
+        coprocessor_url: Url,
         service_name: String,
     ) -> subgraph::BoxService
     where
@@ -597,7 +603,7 @@ impl SubgraphStage {
 // -----------------------------------------------------------------------------------------
 async fn process_router_request_stage<C>(
     http_client: C,
-    coprocessor_url: String,
+    coprocessor_url: Url,
     sdl: Arc<String>,
     mut request: router::Request,
     request_config: RouterRequestConf,
@@ -766,7 +772,7 @@ where
 
 async fn process_router_response_stage<C>(
     http_client: C,
-    coprocessor_url: String,
+    coprocessor_url: Url,
     sdl: Arc<String>,
     mut response: router::Response,
     response_config: RouterResponseConf,
@@ -1029,7 +1035,7 @@ where
 
 async fn process_subgraph_request_stage<C>(
     http_client: C,
-    coprocessor_url: String,
+    coprocessor_url: Url,
     service_name: String,
     mut request: subgraph::Request,
     request_config: SubgraphRequestConf,
@@ -1190,7 +1196,7 @@ where
 
 async fn process_subgraph_response_stage<C>(
     http_client: C,
-    coprocessor_url: String,
+    coprocessor_url: Url,
     service_name: String,
     mut response: subgraph::Response,
     response_config: SubgraphResponseConf,

--- a/apollo-router/src/plugins/coprocessor/supergraph.rs
+++ b/apollo-router/src/plugins/coprocessor/supergraph.rs
@@ -9,6 +9,7 @@ use serde::Serialize;
 use tower::BoxError;
 use tower::ServiceBuilder;
 use tower_service::Service;
+use url::Url;
 
 use super::externalize_header_map;
 use super::*;
@@ -36,7 +37,8 @@ pub(super) struct SupergraphRequestConf {
     /// Handles the request without waiting for the coprocessor to respond
     pub(super) detached: bool,
     /// The url you'd like to offload processing to
-    pub(super) url: Option<String>,
+    #[schemars(with = "String")]
+    pub(super) url: Option<Url>,
 }
 
 /// What information is passed to a router request/response stage
@@ -57,7 +59,7 @@ pub(super) struct SupergraphResponseConf {
     pub(super) detached: bool,
     /// The url you'd like to offload processing to
     #[schemars(with = "String")]
-    pub(super) url: Option<url::Url>,
+    pub(super) url: Option<Url>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, JsonSchema)]
@@ -74,7 +76,7 @@ impl SupergraphStage {
         &self,
         http_client: C,
         service: supergraph::BoxService,
-        coprocessor_url: String,
+        coprocessor_url: Url,
         sdl: Arc<String>,
     ) -> supergraph::BoxService
     where
@@ -193,7 +195,7 @@ impl SupergraphStage {
 
 async fn process_supergraph_request_stage<C>(
     http_client: C,
-    coprocessor_url: String,
+    coprocessor_url: Url,
     sdl: Arc<String>,
     mut request: supergraph::Request,
     request_config: SupergraphRequestConf,
@@ -347,7 +349,7 @@ where
 
 async fn process_supergraph_response_stage<C>(
     http_client: C,
-    coprocessor_url: String,
+    coprocessor_url: Url,
     sdl: Arc<String>,
     mut response: supergraph::Response,
     response_config: SupergraphResponseConf,
@@ -795,7 +797,7 @@ mod tests {
         let service = supergraph_stage.as_service(
             mock_http_client,
             mock_supergraph_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -860,7 +862,7 @@ mod tests {
         let service = supergraph_stage.as_service(
             mock_http_client,
             mock_supergraph_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -985,7 +987,7 @@ mod tests {
         let service = supergraph_stage.as_service(
             mock_http_client,
             mock_supergraph_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -1096,7 +1098,7 @@ mod tests {
         let service = supergraph_stage.as_service(
             mock_http_client,
             mock_supergraph_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -1155,7 +1157,7 @@ mod tests {
         let service = supergraph_stage.as_service(
             mock_http_client,
             mock_supergraph_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -1213,7 +1215,7 @@ mod tests {
         let service = supergraph_stage.as_service(
             mock_http_client,
             mock_supergraph_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 

--- a/apollo-router/src/plugins/coprocessor/supergraph.rs
+++ b/apollo-router/src/plugins/coprocessor/supergraph.rs
@@ -56,7 +56,8 @@ pub(super) struct SupergraphResponseConf {
     /// Handles the response without waiting for the coprocessor to respond
     pub(super) detached: bool,
     /// The url you'd like to offload processing to
-    pub(super) url: Option<String>,
+    #[schemars(with = "String")]
+    pub(super) url: Option<url::Url>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize, JsonSchema)]

--- a/apollo-router/src/plugins/coprocessor/test.rs
+++ b/apollo-router/src/plugins/coprocessor/test.rs
@@ -16,6 +16,7 @@ mod tests {
     use serde_json::json;
     use tower::BoxError;
     use tower::ServiceExt;
+    use url::Url;
 
     use super::super::*;
     use crate::plugin::test::MockHttpClientService;
@@ -131,7 +132,7 @@ mod tests {
         let service = router_stage.as_service(
             mock_http_client,
             mock_router_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -189,7 +190,7 @@ mod tests {
         let service = router_stage.as_service(
             mock_http_client,
             mock_router_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -246,7 +247,7 @@ mod tests {
         let service = router_stage.as_service(
             mock_http_client,
             mock_router_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -300,7 +301,7 @@ mod tests {
         let service = subgraph_stage.as_service(
             mock_http_client,
             mock_subgraph_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             "my_subgraph_service_name".to_string(),
         );
 
@@ -426,7 +427,7 @@ mod tests {
         let service = subgraph_stage.as_service(
             mock_http_client,
             mock_subgraph_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             "my_subgraph_service_name".to_string(),
         );
 
@@ -488,7 +489,7 @@ mod tests {
         let service = subgraph_stage.as_service(
             mock_http_client,
             mock_subgraph_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             "my_subgraph_service_name".to_string(),
         );
 
@@ -542,7 +543,7 @@ mod tests {
         let service = subgraph_stage.as_service(
             mock_http_client,
             mock_subgraph_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             "my_subgraph_service_name".to_string(),
         );
 
@@ -599,7 +600,7 @@ mod tests {
         let service = subgraph_stage.as_service(
             mock_http_client,
             mock_subgraph_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             "my_subgraph_service_name".to_string(),
         );
 
@@ -697,7 +698,7 @@ mod tests {
         let service = subgraph_stage.as_service(
             mock_http_client,
             mock_subgraph_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             "my_subgraph_service_name".to_string(),
         );
 
@@ -759,7 +760,7 @@ mod tests {
         let service = subgraph_stage.as_service(
             mock_http_client,
             mock_subgraph_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             "my_subgraph_service_name".to_string(),
         );
 
@@ -883,7 +884,7 @@ mod tests {
         let service = router_stage.as_service(
             mock_http_client,
             mock_router_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -1009,7 +1010,7 @@ mod tests {
         let service = router_stage.as_service(
             mock_http_client,
             mock_router_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -1080,7 +1081,7 @@ mod tests {
         let service = router_stage.as_service(
             mock_http_client,
             mock_router_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -1159,7 +1160,7 @@ mod tests {
         let service = router_stage.as_service(
             mock_http_client,
             mock_router_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -1200,7 +1201,7 @@ mod tests {
                 sdl: true,
                 path: true,
                 method: true,
-                url: Some("http://example.com".to_string()),
+                url: Some(Url::parse("http://example.com").unwrap()),
                 ..Default::default()
             },
             response: Default::default(),
@@ -1302,7 +1303,7 @@ mod tests {
         let service = router_stage.as_service(
             mock_http_client,
             mock_router_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -1406,7 +1407,7 @@ mod tests {
         let service = router_stage.as_service(
             mock_http_client,
             mock_router_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -1466,7 +1467,7 @@ mod tests {
         let service = router_stage.as_service(
             mock_http_client,
             mock_router_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 
@@ -1502,7 +1503,7 @@ mod tests {
         let service = router_stage.as_service(
             mock_http_client,
             mock_router_service.boxed(),
-            "http://test".to_string(),
+            Url::parse("http://test").unwrap(),
             Arc::new("".to_string()),
         );
 

--- a/apollo-router/src/services/external.rs
+++ b/apollo-router/src/services/external.rs
@@ -20,6 +20,7 @@ use serde::Serialize;
 use strum_macros::Display;
 use tower::BoxError;
 use tower::Service;
+use url::Url;
 
 use crate::plugins::telemetry::otel::OpenTelemetrySpanExt;
 use crate::plugins::telemetry::reload::prepare_context;
@@ -265,7 +266,7 @@ where
         }
     }
 
-    pub(crate) async fn call<C>(self, mut client: C, uri: &str) -> Result<Self, BoxError>
+    pub(crate) async fn call<C>(self, mut client: C, url: &Url) -> Result<Self, BoxError>
     where
         C: Service<hyper::Request<Body>, Response = hyper::Response<Body>, Error = BoxError>
             + Clone
@@ -276,7 +277,7 @@ where
         tracing::debug!("forwarding json: {}", serde_json::to_string(&self)?);
 
         let mut request = hyper::Request::builder()
-            .uri(uri)
+            .uri(&url.to_string())
             .method(Method::POST)
             .header(ACCEPT, "application/json")
             .header(CONTENT_TYPE, "application/json")

--- a/docs/shared/coproc-typical-config.mdx
+++ b/docs/shared/coproc-typical-config.mdx
@@ -11,6 +11,7 @@ coprocessor:
       sdl: false
       path: false
       method: false
+      url: "http://example.com/router-request-coprocessor-url"
     response: # By including this key, the `RouterService` sends a coprocessor request whenever it's about to send response data to a client (including incremental data via @defer).
       detached: false # optional. if set to true, the router will handle the response without waiting for the coprocessor to respond
       headers: true
@@ -18,6 +19,7 @@ coprocessor:
       context: false
       sdl: false
       status_code: false
+      url: "http://example.com/router-response-coprocessor-url"
   supergraph: # This coprocessor hooks into the `SupergraphService`
     request: # By including this key, the `SupergraphService` sends a coprocessor request whenever it first receives a client request.
       detached: false # optional. if set to true, the router will handle the request without waiting for the coprocessor to respond
@@ -26,6 +28,7 @@ coprocessor:
       context: false
       sdl: false
       method: false
+      url: "http://example.com/supergraph-request-coprocessor-url"
     response: # By including this key, the `SupergraphService` sends a coprocessor request whenever it's about to send response data to a client (including incremental data via @defer).
       detached: false # optional. if set to true, the router will handle the response without waiting for the coprocessor to respond
       headers: true
@@ -33,6 +36,7 @@ coprocessor:
       context: false
       sdl: false
       status_code: false
+      url: "http://example.com/supergraph-response-coprocessor-url"
   execution: # This coprocessor hooks into the `ExecutionService`
     request: # By including this key, the `ExecutionService` sends a coprocessor request whenever it first receives a client request.
       detached: false # optional. if set to true, the router will handle the request without waiting for the coprocessor to respond
@@ -42,6 +46,7 @@ coprocessor:
       sdl: false
       method: false
       query_plan: false
+      url: "http://example.com/execution-request-coprocessor-url"
     response: # By including this key, the `ExecutionService` sends a coprocessor request whenever it's about to send response data to a client (including incremental data via @defer).
       detached: false # optional. if set to true, the router will handle the response without waiting for the coprocessor to respond
       headers: true
@@ -49,6 +54,7 @@ coprocessor:
       context: false
       sdl: false
       status_code: false
+      url: "http://example.com/execution-response-coprocessor-url"
   subgraph:
     all:
       request: # By including this key, the `SubgraphService` sends a coprocessor request whenever it is about to make a request to a subgraph.
@@ -59,6 +65,7 @@ coprocessor:
         uri: false
         method: false
         service_name: false
+        url: "http://example.com/subgraph-request-coprocessor-url"
       response: # By including this key, the `SubgraphService` sends a coprocessor request whenever receives a subgraph response.
         detached: false # optional. if set to true, the router will handle the response without waiting for the coprocessor to respond
         headers: true
@@ -66,4 +73,6 @@ coprocessor:
         context: false
         service_name: false
         status_code: false
+        url: "http://example.com/subgraph-response-coprocessor-url"
+
 ```

--- a/docs/source/customizations/coprocessor.mdx
+++ b/docs/source/customizations/coprocessor.mdx
@@ -87,6 +87,7 @@ coprocessor:
   router:
     request:
       headers: false
+      # url: http://127.0.0.1:8082 # the URL can be overriden per coprocessor stage
 ```
 
 In this case, the `RouterService` only sends a coprocessor request whenever it receives a client request. The coprocessor request body includes _no_ data related to the client request (only "control" data, which is [covered below](#coprocessor-request-format)).


### PR DESCRIPTION
This makes it possible to have different coprocessor URLs per stage. The initial URL configuration still serves as a global default, but it can be overriden per stage

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
