### PR TITLE
Use the entire schema when hashing an introspection query

### DIFF
--- a/.changesets/fix_geal_schema_aware_hash_introspection.md
+++ b/.changesets/fix_geal_schema_aware_hash_introspection.md
@@ -1,0 +1,6 @@
+### Use the entire schema when hashing an introspection query ([Issue #5006](https://github.com/apollographql/router/issues/5006))
+
+in https://github.com/apollographql/router/pull/4883 (1.44.0), we introduced a query hashing scheme that stays stable across schema updates if the update does not affect the query. Unfortunately, it was not taking introspection queries into account.
+This fixes the hashing mechanism to add the schema string to hashed data if we encounter an introspection field, so the entire schema is taken into account
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/5007

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -595,7 +595,7 @@ impl Service<QueryPlannerRequest> for BridgeQueryPlanner {
                 }
                 Ok(modified_query) => {
                     let executable_document = modified_query
-                        .to_executable(api_schema_definitions)
+                        .to_executable_validate(api_schema_definitions)
                         // Assume transformation creates a valid document: ignore conversion errors
                         .map_err(|e| SpecError::ValidationError(e.into()))?;
                     let hash = QueryHashVisitor::hash_query(

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -379,7 +379,9 @@ impl BridgeQueryPlanner {
             .into_result()
         {
             Ok(mut plan) => {
-                plan.data.query_plan.hash_subqueries(&self.subgraph_schemas);
+                plan.data
+                    .query_plan
+                    .hash_subqueries(&self.subgraph_schemas, &self.schema.raw_sdl);
                 plan.data
                     .query_plan
                     .extract_authorization_metadata(&self.schema.definitions, &key);
@@ -583,8 +585,9 @@ impl Service<QueryPlannerRequest> for BridgeQueryPlanner {
                 Some(d) => d,
             };
 
-            let schema = &this.schema.api_schema().definitions;
-            match add_defer_labels(schema, &doc.ast) {
+            let api_schema = this.schema.api_schema();
+            let api_schema_definitions = &api_schema.definitions;
+            match add_defer_labels(api_schema_definitions, &doc.ast) {
                 Err(e) => {
                     return Err(QueryPlannerError::SpecError(SpecError::TransformError(
                         e.to_string(),
@@ -592,10 +595,12 @@ impl Service<QueryPlannerRequest> for BridgeQueryPlanner {
                 }
                 Ok(modified_query) => {
                     let executable_document = modified_query
-                        .to_executable_validate(schema)
+                        .to_executable(api_schema_definitions)
+                        // Assume transformation creates a valid document: ignore conversion errors
                         .map_err(|e| SpecError::ValidationError(e.into()))?;
                     let hash = QueryHashVisitor::hash_query(
-                        schema,
+                        api_schema_definitions,
+                        &api_schema.raw_sdl,
                         &executable_document,
                         operation_name.as_deref(),
                     )
@@ -715,6 +720,7 @@ impl BridgeQueryPlanner {
                 .map_err(|e| SpecError::ValidationError(e.into()))?;
             let hash = QueryHashVisitor::hash_query(
                 &self.schema.definitions,
+                &self.schema.raw_sdl,
                 &executable_document,
                 key.operation_name.as_deref(),
             )
@@ -807,9 +813,13 @@ struct QueryPlan {
 }
 
 impl QueryPlan {
-    fn hash_subqueries(&mut self, schemas: &HashMap<String, Arc<Valid<apollo_compiler::Schema>>>) {
+    fn hash_subqueries(
+        &mut self,
+        schemas: &HashMap<String, Arc<Valid<apollo_compiler::Schema>>>,
+        supergraph_schema_hash: &str,
+    ) {
         if let Some(node) = self.node.as_mut() {
-            node.hash_subqueries(schemas);
+            node.hash_subqueries(schemas, supergraph_schema_hash);
         }
     }
 

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -497,12 +497,20 @@ impl FetchNode {
         &self.operation_kind
     }
 
-    pub(crate) fn hash_subquery(&mut self, schema: &Valid<apollo_compiler::Schema>) {
+    pub(crate) fn hash_subquery(
+        &mut self,
+        schema: &Valid<apollo_compiler::Schema>,
+        supergraph_schema_hash: &str,
+    ) {
         let doc = ExecutableDocument::parse(schema, &self.operation, "query.graphql")
             .expect("subgraph queries should be valid");
 
-        if let Ok(hash) = QueryHashVisitor::hash_query(schema, &doc, self.operation_name.as_deref())
-        {
+        if let Ok(hash) = QueryHashVisitor::hash_query(
+            schema,
+            supergraph_schema_hash,
+            &doc,
+            self.operation_name.as_deref(),
+        ) {
             self.schema_aware_hash = Arc::new(QueryHash(hash));
         }
     }

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -280,8 +280,9 @@ impl Query {
                 return Err(SpecError::ParseError(errors.into()));
             }
         };
-        let schema = &schema.api_schema().definitions;
-        let executable_document = match ast.to_executable_validate(schema) {
+        let api_schema = schema.api_schema();
+        let api_schema_definitions = &api_schema.definitions;
+        let executable_document = match ast.to_executable_validate(api_schema_definitions) {
             Ok(doc) => doc,
             Err(errors) => {
                 return Err(SpecError::ValidationError(errors.into()));
@@ -292,8 +293,14 @@ impl Query {
         let recursion_limit = parser.recursion_reached();
         tracing::trace!(?recursion_limit, "recursion limit data");
 
-        let hash = QueryHashVisitor::hash_query(schema, &executable_document, operation_name)
-            .map_err(|e| SpecError::QueryHashing(e.to_string()))?;
+        let hash = QueryHashVisitor::hash_query(
+            api_schema_definitions,
+            &api_schema.raw_sdl,
+            &executable_document,
+            operation_name,
+        )
+        .map_err(|e| SpecError::QueryHashing(e.to_string()))?;
+
         Ok(Arc::new(ParsedDocumentInner {
             ast,
             executable: Arc::new(executable_document),
@@ -343,7 +350,7 @@ impl Query {
             .map(|operation| Operation::from_hir(operation, schema, &mut defer_stats, &fragments))
             .collect::<Result<Vec<_>, SpecError>>()?;
 
-        let mut visitor = QueryHashVisitor::new(&schema.definitions, document);
+        let mut visitor = QueryHashVisitor::new(&schema.definitions, &schema.raw_sdl, document);
         traverse::document(&mut visitor, document, operation_name).map_err(|e| {
             SpecError::QueryHashing(format!("could not calculate the query hash: {e}"))
         })?;

--- a/apollo-router/src/spec/query/change.rs
+++ b/apollo-router/src/spec/query/change.rs
@@ -366,12 +366,12 @@ impl<'a> Visitor for QueryHashVisitor<'a> {
         field_def: &ast::FieldDefinition,
         node: &executable::Field,
     ) -> Result<(), BoxError> {
-        if !self.seen_introspection {
-            if field_def.name == "__schema" || field_def.name == "__type" {
-                self.seen_introspection = true;
-                self.schema_str.hash(self);
-            }
+        if !self.seen_introspection && (field_def.name == "__schema" || field_def.name == "__type")
+        {
+            self.seen_introspection = true;
+            self.schema_str.hash(self);
         }
+
         self.hash_field(
             parent_type.to_string(),
             field_def.name.as_str().to_string(),

--- a/apollo-router/src/spec/query/change.rs
+++ b/apollo-router/src/spec/query/change.rs
@@ -967,7 +967,7 @@ mod tests {
     }
 
     #[test]
-    fn introspection_hash_changes_when_schema_updates() {
+    fn introspection() {
         let schema1: &str = r#"
         schema {
           query: Query
@@ -1002,9 +1002,6 @@ mod tests {
 
         let query = "{ __schema { types { name } } }";
 
-        assert!(
-            hash(schema1, query) != hash(schema2, query),
-            "introspection queries should not yield the same hash if the schema changed"
-        );
+        assert_ne!(hash(schema1, query), hash(schema2, query));
     }
 }

--- a/apollo-router/src/spec/query/change.rs
+++ b/apollo-router/src/spec/query/change.rs
@@ -965,4 +965,46 @@ mod tests {
         let query = "query { me { a } }";
         assert_ne!(hash(schema1, query), hash(schema2, query));
     }
+
+    #[test]
+    fn introspection_hash_changes_when_schema_updates() {
+        let schema1: &str = r#"
+        schema {
+          query: Query
+        }
+    
+        type Query {
+          me: User
+          customer: User
+        }
+    
+        type User {
+          id: ID
+          name: String
+        }
+        "#;
+
+        let schema2: &str = r#"
+        schema {
+            query: Query
+        }
+    
+        type Query {
+          me: NotUser
+        }
+    
+    
+        type NotUser {
+          id: ID!
+          name: String
+        }
+        "#;
+
+        let query = "{ __schema { types { name } } }";
+
+        assert!(
+            hash(schema1, query) != hash(schema2, query),
+            "introspection queries should not yield the same hash if the schema changed"
+        );
+    }
 }

--- a/docs/source/configuration/telemetry/instrumentation/standard-instruments.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/standard-instruments.mdx
@@ -74,13 +74,11 @@ The coprocessor operations metric has the following attributes:
 </Tip>
 
 - `apollo_router_uplink_fetch_duration_seconds_bucket` - Uplink request duration, attributes:
-
-- `url`: The Uplink URL that was polled
-- `query`: The query that the router sent to Uplink (`SupergraphSdl` or `License`)
-- `kind`: (`new`, `unchanged`, `http_error`, `uplink_error`)
-- `code`: The error code depending on type (if an error occurred)
-- `error`: The error message (if an error occurred)
-
+  - `url`: The Uplink URL that was polled
+  - `query`: The query that the router sent to Uplink (`SupergraphSdl` or `License`)
+  - `kind`: (`new`, `unchanged`, `http_error`, `uplink_error`)
+  - `code`: The error code depending on type (if an error occurred)
+  - `error`: The error message (if an error occurred)
 - `apollo_router_uplink_fetch_count_total`
   - `status`: (`success`, `failure`)
   - `query`: The query that the router sent to Uplink (`SupergraphSdl` or `License`)

--- a/docs/source/customizations/native.mdx
+++ b/docs/source/customizations/native.mdx
@@ -100,8 +100,8 @@ impl Plugin for HelloWorld {
 
     fn supergraph_service(
         &self,
-        service: router::BoxService,
-    ) -> router::BoxService {
+        service: supergraph::BoxService,
+    ) -> supergraph::BoxService {
         service
     }
 

--- a/docs/source/executing-operations/subscription-support.mdx
+++ b/docs/source/executing-operations/subscription-support.mdx
@@ -173,6 +173,7 @@ If something crashes on your side for a specific subscription on specific events
 Also, when handling subscriptions with heartbeats disabled, make sure to store a subscription's request payload (including extensions data with callback URL and verifier) to be able to send the right events on the right callback URL when you start your lambda function triggered by an event.
 
 </Caution>
+
 ### Using a combination of modes
 
 If some of your subgraphs require [passthrough mode](#websocket-setup) and others require [callback mode](#http-callback-setup) for subscriptions, you can apply different modes to different subgraphs in your configuration:


### PR DESCRIPTION
Fix #5006

in https://github.com/apollographql/router/pull/4883 we introduced a query hashing scheme that stays stable across schema updates if the update does not affect the query. Unfortunately, it was not taking introspection queries into account.
This fixes the hashing mechanism to add the schema string to hashed data if we encounter an introspection field. This is a temporary fix until we move introspection execution out of query planning. At that point, this hashing mechanism won't ever see introspection fields.

This PR starts from the 1.44.0 tag, since the bug was introduced there. It will be easy to update it to either 1.45 or the latest dev, depending on when we want to ship that fix
<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.

<!-- [ROUTER-240] -->

[ROUTER-240]: https://apollographql.atlassian.net/browse/ROUTER-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ