### PR TITLE
Use subgraph.name attribute not apollo.subgraph.name

### DIFF
--- a/.changesets/fix_garypen_router_236_dd_mapping.md
+++ b/.changesets/fix_garypen_router_236_dd_mapping.md
@@ -2,6 +2,8 @@
 
 The Datadog exporter does some explicit mapping of attributes and was using a value "apollo.subgraph.name" that the latest versions of the router don't use. The correct choice is "subgraph.name".
 
-Update the mapping to reflect this change.
+This meant that subgraph name mapping did not work correctly in 1.45.0.
+
+Update the mapping to reflect the change and fix subgraph name mapping for Datadog.
 
 By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/5012

--- a/.changesets/fix_garypen_router_236_dd_mapping.md
+++ b/.changesets/fix_garypen_router_236_dd_mapping.md
@@ -1,0 +1,7 @@
+### Use subgraph.name attribute not apollo.subgraph.name ([PR #5012](https://github.com/apollographql/router/pull/5012))
+
+The Datadog exporter does some explicit mapping of attributes and was using a value "apollo.subgraph.name" that the latest versions of the router don't use. The correct choice is "subgraph.name".
+
+Update the mapping to reflect this change.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/5012

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -29,7 +29,7 @@ lazy_static! {
         map.insert("request", "http.route");
         map.insert("supergraph", "graphql.operation.name");
         map.insert("query_planning", "graphql.operation.name");
-        map.insert("subgraph", "apollo.subgraph.name");
+        map.insert("subgraph", "subgraph.name");
         map.insert("subgraph_request", "graphql.operation.name");
         map
     };


### PR DESCRIPTION
The DD exporter does some explicit mapping of attributes and was using a value "apollo.subgraph.name" that the latest versions of the router don't use. The correct choice is "subgraph.name".

Update the mapping to reflect this change.