### PR TITLE
Fix fragment scoring

### DIFF
--- a/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/federated_ships_fragment_query.graphql
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/federated_ships_fragment_query.graphql
@@ -3,11 +3,15 @@ fragment nameAndLicense on User {
     name
 }
 
+fragment identifiedOwner on Ship {
+    owner {
+        ...nameAndLicense
+    }
+}
+
 {
     ships {
-        owner {
-            ...nameAndLicense
-        }
+        ...identifiedOwner
     }
     users {
         ...nameAndLicense

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -54,8 +54,9 @@ impl StaticCostCalculator {
     /// bound for cost anyway.
     fn score_field(
         field: &Field,
-        parent_type_name: &NamedType,
+        parent_type: &NamedType,
         schema: &Valid<Schema>,
+        executable: &ExecutableDocument,
     ) -> Result<f64, DemandControlError> {
         if StaticCostCalculator::skipped_by_directives(field) {
             return Ok(0.0);
@@ -83,17 +84,21 @@ impl StaticCostCalculator {
             &field.selection_set,
             field.ty().inner_named_type(),
             schema,
+            executable,
         )?;
 
         // If the field is marked with `@requires`, the required selection may not be included
         // in the query's selection. Adding that requirement's cost to the field ensures it's
         // accounted for.
         let requirements =
-            RequiresDirective::from_field(field, parent_type_name, schema)?.map(|d| d.fields);
+            RequiresDirective::from_field(field, parent_type, schema)?.map(|d| d.fields);
         let requirements_cost = match requirements {
-            Some(selection_set) => {
-                StaticCostCalculator::score_selection_set(&selection_set, parent_type_name, schema)?
-            }
+            Some(selection_set) => StaticCostCalculator::score_selection_set(
+                &selection_set,
+                parent_type,
+                schema,
+                executable,
+            )?,
             None => 0.0,
         };
 
@@ -110,25 +115,44 @@ impl StaticCostCalculator {
         Ok(cost)
     }
 
-    fn score_fragment_spread(_fragment_spread: &FragmentSpread) -> Result<f64, DemandControlError> {
-        Ok(0.0)
+    fn score_fragment_spread(
+        fragment_spread: &FragmentSpread,
+        parent_type: &NamedType,
+        schema: &Valid<Schema>,
+        executable: &ExecutableDocument,
+    ) -> Result<f64, DemandControlError> {
+        let fragment = fragment_spread.fragment_def(executable).ok_or(
+            DemandControlError::QueryParseFailure(format!(
+                "Parsed operation did not have a definition for fragment {}",
+                fragment_spread.fragment_name
+            )),
+        )?;
+        StaticCostCalculator::score_selection_set(
+            &fragment.selection_set,
+            parent_type,
+            schema,
+            executable,
+        )
     }
 
     fn score_inline_fragment(
         inline_fragment: &InlineFragment,
         parent_type: &NamedType,
         schema: &Valid<Schema>,
+        executable: &ExecutableDocument,
     ) -> Result<f64, DemandControlError> {
         StaticCostCalculator::score_selection_set(
             &inline_fragment.selection_set,
             parent_type,
             schema,
+            executable,
         )
     }
 
     fn score_operation(
         operation: &Operation,
         schema: &Valid<Schema>,
+        executable: &ExecutableDocument,
     ) -> Result<f64, DemandControlError> {
         let mut cost = if operation.is_mutation() { 10.0 } else { 0.0 };
 
@@ -143,6 +167,7 @@ impl StaticCostCalculator {
             &operation.selection_set,
             root_type_name,
             schema,
+            executable,
         )?;
 
         Ok(cost)
@@ -152,14 +177,20 @@ impl StaticCostCalculator {
         selection: &Selection,
         parent_type: &NamedType,
         schema: &Valid<Schema>,
+        executable: &ExecutableDocument,
     ) -> Result<f64, DemandControlError> {
         match selection {
-            Selection::Field(f) => StaticCostCalculator::score_field(f, parent_type, schema),
-            Selection::FragmentSpread(s) => StaticCostCalculator::score_fragment_spread(s),
+            Selection::Field(f) => {
+                StaticCostCalculator::score_field(f, parent_type, schema, executable)
+            }
+            Selection::FragmentSpread(s) => {
+                StaticCostCalculator::score_fragment_spread(s, parent_type, schema, executable)
+            }
             Selection::InlineFragment(i) => StaticCostCalculator::score_inline_fragment(
                 i,
                 i.type_condition.as_ref().unwrap_or(parent_type),
                 schema,
+                executable,
             ),
         }
     }
@@ -168,10 +199,16 @@ impl StaticCostCalculator {
         selection_set: &SelectionSet,
         parent_type_name: &NamedType,
         schema: &Valid<Schema>,
+        executable: &ExecutableDocument,
     ) -> Result<f64, DemandControlError> {
         let mut cost = 0.0;
         for selection in selection_set.selections.iter() {
-            cost += StaticCostCalculator::score_selection(selection, parent_type_name, schema)?;
+            cost += StaticCostCalculator::score_selection(
+                selection,
+                parent_type_name,
+                schema,
+                executable,
+            )?;
         }
         Ok(cost)
     }
@@ -303,10 +340,10 @@ impl StaticCostCalculator {
     ) -> Result<f64, DemandControlError> {
         let mut cost = 0.0;
         if let Some(op) = &query.anonymous_operation {
-            cost += StaticCostCalculator::score_operation(op, schema)?;
+            cost += StaticCostCalculator::score_operation(op, schema, query)?;
         }
         for (_name, op) in query.named_operations.iter() {
-            cost += StaticCostCalculator::score_operation(op, schema)?;
+            cost += StaticCostCalculator::score_operation(op, schema, query)?;
         }
         Ok(cost)
     }


### PR DESCRIPTION
This resolves an issue where fragments were always being scored as costless. The fragment test is now updated to ensure nontrivial fragments (ie. fragments containing objects) receive a nontrivial score.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
