### PR TITLE
Add list size configuration for static demand control

### DIFF
--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1619,9 +1619,16 @@ expression: "&schema"
                 "static_estimated": {
                   "type": "object",
                   "required": [
+                    "list_size",
                     "max"
                   ],
                   "properties": {
+                    "list_size": {
+                      "description": "The assumed length of lists returned by the operation.",
+                      "type": "integer",
+                      "format": "uint32",
+                      "minimum": 0.0
+                    },
                     "max": {
                       "description": "The maximum cost of a query",
                       "type": "number",

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -117,7 +117,7 @@ impl StaticCostCalculator {
     }
 
     fn score_fragment_spread(_fragment_spread: &FragmentSpread) -> Result<f64, DemandControlError> {
-        todo!("This needs to read the fragment from the schema and score it")
+        Ok(0.0)
     }
 
     fn score_inline_fragment(

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -53,6 +53,8 @@ pub(crate) enum StrategyConfig {
     /// - Scalar: 0
     /// - Enum: 0
     StaticEstimated {
+        /// The assumed length of lists returned by the operation.
+        list_size: u32,
         /// The maximum cost of a query
         max: f64,
     },

--- a/apollo-router/src/plugins/demand_control/strategy/mod.rs
+++ b/apollo-router/src/plugins/demand_control/strategy/mod.rs
@@ -91,9 +91,12 @@ impl StrategyFactory {
 
     pub(crate) fn create(&self) -> Strategy {
         let strategy: Arc<dyn StrategyImpl> = match &self.config.strategy {
-            StrategyConfig::StaticEstimated { max } => Arc::new(StaticEstimated {
+            StrategyConfig::StaticEstimated { list_size, max } => Arc::new(StaticEstimated {
                 max: *max,
-                cost_calculator: StaticCostCalculator::new(self.subgraph_schemas.clone()),
+                cost_calculator: StaticCostCalculator::new(
+                    self.subgraph_schemas.clone(),
+                    *list_size,
+                ),
             }),
             #[cfg(test)]
             StrategyConfig::Test { stage, error } => Arc::new(test::Test {

--- a/apollo-router/src/uplink/testdata/restricted.router.yaml
+++ b/apollo-router/src/uplink/testdata/restricted.router.yaml
@@ -83,4 +83,5 @@ experimental_demand_control:
   mode: measure
   strategy:
     static_estimated:
+      list_size: 30
       max: 256


### PR DESCRIPTION
Before we implement a directive to indicate paging in lists, we are using a statically defined assumed size for lists returned in each response. Since there's no real one-size-fits-all value for this, the initial setup will require users to set an assumed list size in the configuration for the static cost estimator.

<!-- Fixes [ROUTER-239](https://apollographql.atlassian.net/browse/ROUTER-239) -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-239]: https://apollographql.atlassian.net/browse/ROUTER-239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ