### PR TITLE
add support of chunk responses for selectors and instrument in telemetry

### DIFF
--- a/apollo-router/src/plugins/telemetry/config_new/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/attributes.rs
@@ -514,6 +514,7 @@ impl DefaultForLevel for HttpServerAttributes {
 impl Selectors for RouterAttributes {
     type Request = router::Request;
     type Response = router::Response;
+    type ChunkResponse = ();
 
     fn on_request(&self, request: &router::Request) -> Vec<KeyValue> {
         let mut attrs = self.common.on_request(request);
@@ -561,6 +562,7 @@ impl Selectors for RouterAttributes {
 impl Selectors for HttpCommonAttributes {
     type Request = router::Request;
     type Response = router::Response;
+    type ChunkResponse = ();
 
     fn on_request(&self, request: &router::Request) -> Vec<KeyValue> {
         let mut attrs = Vec::new();
@@ -678,6 +680,7 @@ impl Selectors for HttpCommonAttributes {
 impl Selectors for HttpServerAttributes {
     type Request = router::Request;
     type Response = router::Response;
+    type ChunkResponse = ();
 
     fn on_request(&self, request: &router::Request) -> Vec<KeyValue> {
         let mut attrs = Vec::new();
@@ -854,6 +857,7 @@ impl HttpServerAttributes {
 impl Selectors for SupergraphAttributes {
     type Request = supergraph::Request;
     type Response = supergraph::Response;
+    type ChunkResponse = crate::graphql::Response;
 
     fn on_request(&self, request: &supergraph::Request) -> Vec<KeyValue> {
         let mut attrs = Vec::new();
@@ -902,6 +906,7 @@ impl Selectors for SupergraphAttributes {
 impl Selectors for SubgraphAttributes {
     type Request = subgraph::Request;
     type Response = subgraph::Response;
+    type ChunkResponse = ();
 
     fn on_request(&self, request: &subgraph::Request) -> Vec<KeyValue> {
         let mut attrs = Vec::new();

--- a/apollo-router/src/plugins/telemetry/config_new/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/events.rs
@@ -149,6 +149,7 @@ impl Instrumented
 {
     type Request = router::Request;
     type Response = router::Response;
+    type ChunkResponse = ();
 
     fn on_request(&self, request: &Self::Request) {
         if self.request != EventLevel::Off {
@@ -251,6 +252,7 @@ impl Instrumented
 {
     type Request = supergraph::Request;
     type Response = supergraph::Response;
+    type ChunkResponse = crate::graphql::Response;
 
     fn on_request(&self, request: &Self::Request) {
         if self.request != EventLevel::Off {
@@ -304,6 +306,12 @@ impl Instrumented
         }
     }
 
+    fn on_chunk_response(&self, response: &Self::ChunkResponse, ctx: &Context) {
+        for custom_event in &self.custom {
+            custom_event.on_chunk_response(response, ctx);
+        }
+    }
+
     fn on_error(&self, error: &BoxError, ctx: &Context) {
         if self.error != EventLevel::Off {
             let mut attrs = HashMap::with_capacity(1);
@@ -321,6 +329,7 @@ impl Instrumented
 {
     type Request = subgraph::Request;
     type Response = subgraph::Response;
+    type ChunkResponse = ();
 
     fn on_request(&self, request: &Self::Request) {
         if self.request != EventLevel::Off {
@@ -446,6 +455,8 @@ pub(crate) enum EventOn {
     Request,
     /// Log the event on response
     Response,
+    /// Log the event on every chunks in the response
+    ChunkResponse,
     /// Log the event on error
     Error,
 }
@@ -472,13 +483,16 @@ where
     attributes: Vec<opentelemetry_api::KeyValue>,
 }
 
-impl<A, T, Request, Response> Instrumented for CustomEvent<Request, Response, A, T>
+impl<A, T, Request, Response, ChunkResponse> Instrumented for CustomEvent<Request, Response, A, T>
 where
-    A: Selectors<Request = Request, Response = Response> + Default,
-    T: Selector<Request = Request, Response = Response> + Debug + Debug,
+    A: Selectors<Request = Request, Response = Response, ChunkResponse = ChunkResponse> + Default,
+    T: Selector<Request = Request, Response = Response, ChunkResponse = ChunkResponse>
+        + Debug
+        + Debug,
 {
     type Request = Request;
     type Response = Response;
+    type ChunkResponse = ChunkResponse;
 
     fn on_request(&self, request: &Self::Request) {
         let mut inner = self.inner.lock();
@@ -509,6 +523,23 @@ where
         }
         if let Some(selectors) = &inner.selectors {
             let mut new_attributes = selectors.on_response(response);
+            inner.attributes.append(&mut new_attributes);
+        }
+
+        inner.send_event();
+    }
+
+    fn on_chunk_response(&self, response: &Self::ChunkResponse, ctx: &Context) {
+        let mut inner = self.inner.lock();
+        if inner.event_on != EventOn::ChunkResponse {
+            return;
+        }
+
+        if !inner.condition.evaluate_chunk_response(response, ctx) {
+            return;
+        }
+        if let Some(selectors) = &inner.selectors {
+            let mut new_attributes = selectors.on_chunk_response(response, ctx);
             inner.attributes.append(&mut new_attributes);
         }
 

--- a/apollo-router/src/plugins/telemetry/config_new/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/mod.rs
@@ -10,6 +10,7 @@ use super::otel::OpenTelemetrySpanExt;
 use super::otlp::TelemetryDataKind;
 use crate::plugins::telemetry::config::AttributeValue;
 use crate::plugins::telemetry::config_new::attributes::DefaultAttributeRequirementLevel;
+use crate::Context;
 
 /// These modules contain a new config structure for telemetry that will progressively move to
 pub(crate) mod attributes;
@@ -27,17 +28,30 @@ pub(crate) mod spans;
 pub(crate) trait Selectors {
     type Request;
     type Response;
+    type ChunkResponse;
+
     fn on_request(&self, request: &Self::Request) -> Vec<KeyValue>;
     fn on_response(&self, response: &Self::Response) -> Vec<KeyValue>;
+    fn on_chunk_response(&self, _response: &Self::ChunkResponse, _ctx: &Context) -> Vec<KeyValue> {
+        Vec::with_capacity(0)
+    }
     fn on_error(&self, error: &BoxError) -> Vec<KeyValue>;
 }
 
 pub(crate) trait Selector {
     type Request;
     type Response;
+    type ChunkResponse;
 
     fn on_request(&self, request: &Self::Request) -> Option<opentelemetry::Value>;
     fn on_response(&self, response: &Self::Response) -> Option<opentelemetry::Value>;
+    fn on_chunk_response(
+        &self,
+        _response: &Self::ChunkResponse,
+        _ctx: &Context,
+    ) -> Option<opentelemetry::Value> {
+        None
+    }
 }
 
 pub(crate) trait DefaultForLevel {


### PR DESCRIPTION
Giving the ability to compute new attributes everytime we receive a new chunk in supergraph response. Would be really helpful to create observability for subscriptions and defer.

Naming is not definitive. I need feedback. I would vote for something like `on_event` for traits and for configuration I have no idea, for now it's prefixed with `chunk_` like for example for instrument value it's `chunk_unit` which is not that great IMHO.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
