### PR TITLE
tests: Remove "is proto fresh" test in lieu of GitHub Action

### DIFF
--- a/apollo-router/src/plugins/telemetry/apollo_exporter.rs
+++ b/apollo-router/src/plugins/telemetry/apollo_exporter.rs
@@ -442,17 +442,3 @@ where
         None => serializer.serialize_none(),
     }
 }
-
-#[cfg(not(windows))] // git checkout converts \n to \r\n, making == below fail
-#[test]
-fn check_reports_proto_is_up_to_date() {
-    let proto_url = "https://usage-reporting.api.apollographql.com/proto/reports.proto";
-    let response = reqwest::blocking::get(proto_url).unwrap();
-    let content = response.text().unwrap();
-    // Not using assert_eq! as printing the entire file would be too verbose
-    assert!(
-        content == include_str!("proto/reports.proto"),
-        "Protobuf file is out of date. Run this command to update it:\n\n    \
-            curl -f {proto_url} > apollo-router/src/plugins/telemetry/proto/reports.proto\n\n"
-    );
-}


### PR DESCRIPTION
We'll have a GitHub Action do the maintenance on this file, rather than
having a test remind us that it's stale.  The test results in all PRs (and
all downstream users of this repository) suddenly getting failing tests
every time our infra-team deploys a new version of the proto, whereas the
GitHub Action can be a much more controlled burn.

The GitHub action that replaces this is in [#5030], and we will merge this test just as soon as that is validated.

[#5030]: https://github.com/apollographql/router/pull/5030