### PR TITLE
chore/nit: Fix warnings and trailing newlines in CircleCI Config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,14 +48,14 @@ executors:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
       # We use the major.minor notation to bring in compatible patches.
-      xcode: 14.2
+      xcode: "14.2.0"
     resource_class: macos.m1.medium.gen1
   macos_test: &macos_test_executor
     macos:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
       # at https://circleci.com/docs/using-macos#supported-xcode-versions.
       # We use the major.minor notation to bring in compatible patches.
-      xcode: 14.2
+      xcode: "14.2.0"
     resource_class: macos.m1.medium.gen1
   windows_build: &windows_build_executor
     machine:
@@ -201,7 +201,7 @@ commands:
             find xtask/src -type f | while read name; do md5sum $name; done | sort -k 2 | md5sum > ~/.xtask_version
             # The closest common ancestor to the default branch, so that test jobs can take advantage previous compiles
             git remote set-head origin -a
-            TARGET_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD)    
+            TARGET_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD)
             echo "Target branch is ${TARGET_BRANCH}"
             COMMON_ANCESTOR_REF=$(git merge-base HEAD "${TARGET_BRANCH}")
             echo "Common ancestor is ${COMMON_ANCESTOR_REF}"
@@ -715,8 +715,8 @@ jobs:
                   # save containers for analysis
                   mkdir built-containers
                   docker save -o built-containers/router_${VERSION}-debug.tar ${ROUTER_TAG}:${VERSION}-debug
-                  docker save -o built-containers/router_${VERSION}.tar ${ROUTER_TAG}:${VERSION}  
-                 
+                  docker save -o built-containers/router_${VERSION}.tar ${ROUTER_TAG}:${VERSION}
+
             - persist_to_workspace:
                 root: .
                 paths:
@@ -971,8 +971,8 @@ workflows:
           # Disables all PR comments from this job
           do-pr-comments: false
           # Scan job will return 1 if findings violating the Wiz policy are found.
-          # Toggle off to prevent any CI failures OR 
-          # contact Apollo's Security team to adjust what violates the 
+          # Toggle off to prevent any CI failures OR
+          # contact Apollo's Security team to adjust what violates the
           # Wiz policy used in this scan.
           fail-on-findings: true
           # Configure scan job to use a policy specific to apollo-router.
@@ -1069,7 +1069,7 @@ workflows:
               ignore: /.*/
             tags:
               only: /v.*/
-  
+
   security-scans:
     when:
       not: << pipeline.parameters.nightly >>


### PR DESCRIPTION
In practice, this file actually serves as a cache key for our configuration due to the incorporation of the file's hash in the [key/ID], which I need to bump in order to rotate the cache in CircleCI.  While I'm here, I might as well fix the editor warnings being emitted about this not being a valid version of Xcode, along with some trailing newlines!  While we had '14.2' as the value to bring in patch releases of Xcode, I'd rather we not have that level of indeterminism anyhow, so I'll just make it '14.2.0' which is the latest '14.2' release anyhow.

[key/ID]: https://github.com/apollographql/router/blob/0137e0cf848b9b22ef94fe14b32ed1a082d3f0b5/.circleci/config.yml#L73-L83
