### PR TITLE
generate the JSON schema only once

### DIFF
--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -74,7 +74,7 @@ static SUPERGRAPH_ENDPOINT_REGEX: Lazy<Regex> = Lazy::new(|| {
 });
 
 /// Configuration error.
-#[derive(Debug, Error, Display)]
+#[derive(Debug, Clone, Error, Display)]
 #[non_exhaustive]
 pub enum ConfigurationError {
     /// could not expand variable: {key}, {cause}
@@ -94,7 +94,7 @@ pub enum ConfigurationError {
         error: String,
     },
     /// could not deserialize configuration: {0}
-    DeserializeConfigError(serde_json::Error),
+    DeserializeConfigError(String),
 
     /// APOLLO_ROUTER_CONFIG_SUPPORTED_MODES must be of the format env,file,... Possible modes are 'env' and 'file'.
     InvalidExpansionModeConfig,


### PR DESCRIPTION
Surprisingly, the most expensive part of running tests in the router is in JSON schema compilation. Every time we validate a configuration, we generate the JSON configuration schema (which is about 31k lines at this point) then compile a JSONSchema structure used to validate the configuration.
This computation can be done only once per execution without losing anything, as it only depends on the configuration schema, which is generated from the router's code and native plugins.

*Description here*

Fixes #**issue_number**

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
