### PR TITLE
start the router on a random port in integration tests

### DIFF
--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -1,4 +1,3 @@
-use parking_lot::Mutex;
 use std::collections::HashMap;
 use std::fs;
 use std::net::IpAddr;
@@ -37,6 +36,7 @@ use opentelemetry_otlp::Protocol;
 use opentelemetry_otlp::SpanExporterBuilder;
 use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
+use parking_lot::Mutex;
 use reqwest::Request;
 use serde_json::json;
 use serde_json::Value;

--- a/apollo-router/tests/integration/lifecycle.rs
+++ b/apollo-router/tests/integration/lifecycle.rs
@@ -177,7 +177,7 @@ async fn test_shutdown_with_idle_connection() -> Result<(), BoxError> {
         .await;
     router.start().await;
     router.assert_started().await;
-    let _conn = std::net::TcpStream::connect(router.bind_address).unwrap();
+    let _conn = std::net::TcpStream::connect(router.bind_address.lock().clone().unwrap()).unwrap();
     router.execute_default_query().await;
     tokio::time::timeout(Duration::from_secs(1), router.graceful_shutdown())
         .await


### PR DESCRIPTION
This fixes the random port binding in integration tests. Previously, we were trying to allocate a random port then setting it in the router's configuration, which still caused races between routers on listen ports, so tests were still failing.
With this change, we tell the router to start on a random port, then extract the port number from the startup log lines.

TODO:
- the health check does not automatically listen on the same port and uses the address incorrectly (`Health check exposed at http://127.0.0.1:0/health`)
- prometheus automatically listens on the same port but reports the wrong port: `Prometheus endpoint exposed at http://127.0.0.1:0/metrics`

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
