### PR TITLE
merge BridgeQueryPlanner new() and new_from_planner()

### DIFF
--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -413,7 +413,7 @@ mod tests {
         let config: Arc<Configuration> = Arc::new(Default::default());
         let (_schema, query) = parse_schema_and_operation(schema_str, query_str, &config);
 
-        let mut planner = BridgeQueryPlanner::new(schema_str.to_string(), config.clone())
+        let mut planner = BridgeQueryPlanner::new(schema_str.to_string(), config.clone(), None)
             .await
             .unwrap();
 

--- a/apollo-router/src/plugins/test.rs
+++ b/apollo-router/src/plugins/test.rs
@@ -88,7 +88,7 @@ impl<T: Plugin> PluginTestHarness<T> {
             .unwrap_or(Value::Object(Default::default()));
 
         let (supergraph_sdl, parsed_schema, subgraph_schemas) = if let Some(schema) = schema {
-            let planner = BridgeQueryPlanner::new(schema.to_string(), Arc::new(config))
+            let planner = BridgeQueryPlanner::new(schema.to_string(), Arc::new(config), None)
                 .await
                 .unwrap();
             (

--- a/apollo-router/src/query_planner/bridge_query_planner_pool.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner_pool.rs
@@ -66,13 +66,10 @@ impl BridgeQueryPlannerPool {
             let sdl = schema.clone();
             let configuration = configuration.clone();
 
-            if let Some(old_planner) = old_planners_iterator.next() {
-                join_set.spawn(async move {
-                    BridgeQueryPlanner::new_from_planner(old_planner, sdl, configuration).await
-                });
-            } else {
-                join_set.spawn(async move { BridgeQueryPlanner::new(sdl, configuration).await });
-            }
+            let old_planner = old_planners_iterator.next();
+            join_set.spawn(async move {
+                BridgeQueryPlanner::new(sdl, configuration, old_planner).await
+            });
         });
 
         let mut bridge_query_planners = Vec::new();

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -425,9 +425,10 @@ async fn defer_if_condition() {
     let schema = include_str!("testdata/defer_clause.graphql");
     // we need to use the planner here instead of Schema::parse_test because that one uses the router bridge's api_schema function
     // does not keep the defer directive definition
-    let planner = BridgeQueryPlanner::new(schema.to_string(), Arc::new(Configuration::default()))
-        .await
-        .unwrap();
+    let planner =
+        BridgeQueryPlanner::new(schema.to_string(), Arc::new(Configuration::default()), None)
+            .await
+            .unwrap();
     let schema = planner.schema();
 
     let root: PlanNode =


### PR DESCRIPTION
Both of those functions were used to initialize a planner with a new schema, but their implementation diverged with the introduction of the API schema generation and the new planner. THis merges both functions so we use the same code path in all cases

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
