### PR TITLE
docs: add metrics redirect

### DIFF
--- a/docs/source/_redirects
+++ b/docs/source/_redirects
@@ -7,3 +7,4 @@
 /configuration/spaceport* /docs/router/configuration/apollo-telemetry/
 /managed-federation/client%20awareness/ /docs/router/managed-federation/client-awareness/
 /configuration/logging /docs/router/configuration/telemetry/overview
+/configuration/metrics /docs/router/configuration/telemetry/overview


### PR DESCRIPTION
Adds a redirect for the previous metrics URL