### PR TITLE
Flaky test: license_expander_claim_pause_claim test

### DIFF
--- a/apollo-router/src/uplink/license_stream.rs
+++ b/apollo-router/src/uplink/license_stream.rs
@@ -448,9 +448,9 @@ mod test {
 
         tokio::task::spawn(async move {
             // This simulates a new claim coming in before in between the warning and halt
-            let _ = tx.send(license_with_claim(15, 45)).await;
-            tokio::time::sleep(Duration::from_millis(20)).await;
-            let _ = tx.send(license_with_claim(15, 30)).await;
+            let _ = tx.send(license_with_claim(100, 300)).await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            let _ = tx.send(license_with_claim(100, 300)).await;
         });
         let events = events_stream.collect::<Vec<_>>().await;
         assert_eq!(


### PR DESCRIPTION
This increases the timing windows for the `license_expander_claim_pause_claim test`. This test is failing semi regularly particularly on windows as the timer resolution is 15ms.

This test is particularly prone to failure as we are expecting a `want` state to be entered before proceeding.

Hopefully this will improve the reliability of the test.


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
