### PR TITLE
Remove the potential to panic during operation parse/validate

### DIFF
--- a/apollo-router/tests/integration/redis.rs
+++ b/apollo-router/tests/integration/redis.rs
@@ -28,7 +28,7 @@ mod test {
         // 2. run `docker compose up -d` and connect to the redis container by running `docker-compose exec redis /bin/bash`.
         // 3. Run the `redis-cli` command from the shell and start the redis `monitor` command.
         // 4. Run this test and yank the updated cache key from the redis logs.
-        let known_cache_key = "plan:v2.7.4:16385ebef77959fcdc520ad507eb1f7f7df28f1d54a0569e3adabcb4cd00d7ce:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:5c7a72fa35639949328548d77b56dba2e77d0dfa90c19b69978da119e996bb92";
+        let known_cache_key = "plan:v2.7.5:16385ebef77959fcdc520ad507eb1f7f7df28f1d54a0569e3adabcb4cd00d7ce:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:5c7a72fa35639949328548d77b56dba2e77d0dfa90c19b69978da119e996bb92";
 
         let config = RedisConfig::from_url("redis://127.0.0.1:6379").unwrap();
         let client = RedisClient::new(config, None, None, None);

--- a/apollo-router/tests/integration/redis.rs
+++ b/apollo-router/tests/integration/redis.rs
@@ -28,7 +28,7 @@ mod test {
         // 2. run `docker compose up -d` and connect to the redis container by running `docker-compose exec redis /bin/bash`.
         // 3. Run the `redis-cli` command from the shell and start the redis `monitor` command.
         // 4. Run this test and yank the updated cache key from the redis logs.
-        let known_cache_key = "plan:v2.7.5:16385ebef77959fcdc520ad507eb1f7f7df28f1d54a0569e3adabcb4cd00d7ce:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:5c7a72fa35639949328548d77b56dba2e77d0dfa90c19b69978da119e996bb92";
+        let known_cache_key = "plan:v2.7.4:16385ebef77959fcdc520ad507eb1f7f7df28f1d54a0569e3adabcb4cd00d7ce:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:5c7a72fa35639949328548d77b56dba2e77d0dfa90c19b69978da119e996bb92";
 
         let config = RedisConfig::from_url("redis://127.0.0.1:6379").unwrap();
         let client = RedisClient::new(config, None, None, None);


### PR DESCRIPTION
DO NOT MERGE THIS PR. THIS IS A BACKUP PR TO POTENTIALLY FACILITATE A ROUTER RELEASE IF THE MORE COMPLETE FIX IS NOT AVAILABLE IN THE RIGHT TIMEFRAME.

The possibility that an ExecutableDocument::parse_and_validate() will fail, means there is a possibility that a router will panic when `as_parsed()` or `as_serialized()` is invoked.

We remove the potential to panic by logging errors for any detected errors and continuing to use the Valid (but incomplete) document, which is the behaviour we had before this change.

Summary: This restores the preceding behaviour of the router with the additional error logging of detected errors.
