### PR TITLE
Run federation tests by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-default-members = ["apollo-router"]
+default-members = ["apollo-router", "apollo-federation"]
 members = [
     "apollo-router",
     "apollo-router-benchmarks",


### PR DESCRIPTION
Add apollo-federation crate to workspace default members, which are selected by commands like `cargo test` when `-p <package>` or `--workspace` is not used.