### PR TITLE
chore(federation): migrate CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 /docs/ @apollographql/docs
+/apollo-federation/ @dariuszkuc @sachindshinde @goto-bus-stop @SimonSapin

--- a/apollo-federation/CODEOWNERS
+++ b/apollo-federation/CODEOWNERS
@@ -1,1 +1,0 @@
-* @dariuszkuc @sachindshinde @goto-bus-stop @SimonSapin


### PR DESCRIPTION
`CODEOWNERS` files in subdirectories don't do anything. this moves the fed-next codeowners into the router's codeowners file, which will request review of apollo-federation folks on new apollo-federation PRs. Do we still want this? I personally would like to continue to get review requests by default just to be able to track things easily in github notifications.