### PR TITLE
Update the version of the router-bridge (v1.46.0 version of #5064)

### DIFF
--- a/.changesets/maint_garypen_router_258_update_router_bridge.md
+++ b/.changesets/maint_garypen_router_258_update_router_bridge.md
@@ -1,0 +1,7 @@
+### Update the version of the router-bridge ([PR #5064](https://github.com/apollographql/router/pull/5064))
+
+Update our router-bridge version to pull in fixes.
+
+The router is now using: router-bridge = "=0.5.21+v2.7.5"
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/5064

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5704,9 +5704,9 @@ dependencies = [
 
 [[package]]
 name = "router-bridge"
-version = "0.5.20+v2.7.4"
+version = "0.5.21+v2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5179aaf2c3c9ca2d76e2c5f6fbfe30a4e1d4c64cae0d269d0395b351f4993fbb"
+checksum = "b2142445fe3fe2aae7a3c3c5083d1211a448a0dabb489a14dd90d427cf6c0b13"
 dependencies = [
  "anyhow",
  "async-channel 1.9.0",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -183,7 +183,7 @@ regex = "1.10.3"
 reqwest.workspace = true
 
 # note: this dependency should _always_ be pinned, prefix the version with an `=`
-router-bridge = "=0.5.20+v2.7.4"
+router-bridge = "=0.5.21+v2.7.5"
 
 rust-embed = "8.2.0"
 rustls = "0.21.11"

--- a/apollo-router/tests/integration/redis.rs
+++ b/apollo-router/tests/integration/redis.rs
@@ -28,7 +28,7 @@ mod test {
         // 2. run `docker compose up -d` and connect to the redis container by running `docker-compose exec redis /bin/bash`.
         // 3. Run the `redis-cli` command from the shell and start the redis `monitor` command.
         // 4. Run this test and yank the updated cache key from the redis logs.
-        let known_cache_key = "plan:v2.7.4:16385ebef77959fcdc520ad507eb1f7f7df28f1d54a0569e3adabcb4cd00d7ce:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:5c7a72fa35639949328548d77b56dba2e77d0dfa90c19b69978da119e996bb92";
+        let known_cache_key = "plan:v2.7.5:16385ebef77959fcdc520ad507eb1f7f7df28f1d54a0569e3adabcb4cd00d7ce:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:5c7a72fa35639949328548d77b56dba2e77d0dfa90c19b69978da119e996bb92";
 
         let config = RedisConfig::from_url("redis://127.0.0.1:6379").unwrap();
         let client = RedisClient::new(config, None, None, None);

--- a/docs/source/federation-version-support.mdx
+++ b/docs/source/federation-version-support.mdx
@@ -35,7 +35,15 @@ The table below shows which version of federation each router release is compile
     <tbody>
     <tr>
         <td>
-            v1.45.0 and later (<a href="https://github.com/apollographql/router/releases">see latest releases</a>)
+            v1.46.0 and later (<a href="https://github.com/apollographql/router/releases">see latest releases</a>)
+        </td>
+        <td>
+            2.7.5
+        </td>
+    </tr>
+    <tr>
+        <td>
+            v1.45.0
         </td>
         <td>
             2.7.2

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -20,7 +20,7 @@ reqwest = { workspace = true, features = ["json", "blocking"] }
 serde_json.workspace = true
 tokio.workspace = true
 # note: this dependency should _always_ be pinned, prefix the version with an `=`
-router-bridge = "=0.5.20+v2.7.4"
+router-bridge = "=0.5.21+v2.7.5"
 
 [dev-dependencies]
 anyhow = "1"


### PR DESCRIPTION
This lands https://github.com/apollographql/router/pull/5064 onto the release branch
