### PR TITLE
Add demand control config metrics

### DIFF
--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -367,25 +367,23 @@ impl InstrumentData {
         // just maps a selected object to a boolean indicating whether it is present or not, and jsonpath_rust doesn't allow you
         // to select the name of a key. So, we grab the object at the path for the strategy, then grab the strategy name, which is
         // assumed to be the first (and only) key.
-        match JsonPathInst::from_str("$.experimental_demand_control[?(@.enabled == true)].strategy")
-            .expect("json path must be valid")
-            .find_slice(yaml)
-            .into_iter()
-            .next()
-            .as_deref()
+        if let Some(Value::Object(values)) =
+            JsonPathInst::from_str("$.experimental_demand_control[?(@.enabled == true)].strategy")
+                .expect("json path must be valid")
+                .find_slice(yaml)
+                .into_iter()
+                .next()
+                .as_deref()
         {
-            Some(Value::Object(values)) => {
-                if let Some(strategy_name) = values.keys().next() {
-                    let (_, demand_control_attributes) = self
-                        .data
-                        .entry("apollo.router.config.experimental_demand_control".to_string())
-                        .or_insert_with(|| (0, HashMap::new()));
+            if let Some(strategy_name) = values.keys().next() {
+                let (_, demand_control_attributes) = self
+                    .data
+                    .entry("apollo.router.config.experimental_demand_control".to_string())
+                    .or_insert_with(|| (0, HashMap::new()));
 
-                    demand_control_attributes
-                        .insert("opt.strategy".to_string(), strategy_name.clone().into());
-                }
+                demand_control_attributes
+                    .insert("opt.strategy".to_string(), strategy_name.clone().into());
             }
-            _ => {}
         };
     }
 

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -59,17 +59,14 @@ impl InstrumentData {
         path: &str,
         value: &Value,
     ) {
-        if let Some(Value::Object(values)) = JsonPathInst::from_str(path)
-            .expect("json path must be valid")
-            .find_slice(value)
-            .into_iter()
-            .next()
-            .as_deref()
-        {
-            if let Some(key) = values.keys().next() {
-                attributes.insert(attr_name.to_string(), key.clone().into());
+        if let Ok(json_path) = JsonPathInst::from_str(path) {
+            let value_at_path = json_path.find_slice(value).into_iter().next();
+            if let Some(Value::Object(children)) = value_at_path.as_deref() {
+                if let Some(first_key) = children.keys().next() {
+                    attributes.insert(attr_name.to_string(), first_key.clone().into());
+                }
             }
-        };
+        }
     }
 
     fn get_value_from_path(

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@demand_control.router.yaml.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__metrics@demand_control.router.yaml.snap
@@ -1,0 +1,11 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.non_zero()"
+---
+- name: apollo.router.config.experimental_demand_control
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          opt.mode: measure
+          opt.strategy: static_estimated

--- a/apollo-router/src/configuration/testdata/metrics/demand_control.router.yaml
+++ b/apollo-router/src/configuration/testdata/metrics/demand_control.router.yaml
@@ -1,0 +1,7 @@
+experimental_demand_control:
+  enabled: true
+  mode: measure
+  strategy:
+    static_estimated:
+      list_size: 30
+      max: 256


### PR DESCRIPTION
Adds config metric for demand control with important settings as attributes.

<!-- ROUTER-178 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
