### PR TITLE
Rust QP: only todo!() in with_normalized_defer if defer is used

### DIFF
--- a/apollo-federation/src/query_plan/operation.rs
+++ b/apollo-federation/src/query_plan/operation.rs
@@ -204,17 +204,29 @@ impl Operation {
     // PORT_NOTE(@goto-bus-stop): It might make sense for the returned data structure to *be* the
     // `DeferNormalizer` from the JS side
     pub(crate) fn with_normalized_defer(self) -> NormalizedDefer {
-        todo!()
+        if self.has_defer() {
+            todo!("@defer not implemented");
+        } else {
+            NormalizedDefer {
+                operation: self,
+                has_defers: false,
+                assigned_defer_labels: HashSet::new(),
+                defer_conditions: IndexMap::new(),
+            }
+        }
     }
 
-    pub(crate) fn without_defer(self) -> Self {
-        if self.selection_set.has_defer()
+    fn has_defer(&self) -> bool {
+        self.selection_set.has_defer()
             || self
                 .named_fragments
                 .fragments
                 .values()
                 .any(|f| f.has_defer())
-        {
+    }
+
+    pub(crate) fn without_defer(self) -> Self {
+        if self.has_defer() {
             todo!("@defer not implemented");
         }
 

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -309,8 +309,16 @@ impl PlannerMode {
 
                     (Ok(js_plan), Ok(rust_plan)) => {
                         is_matched = js_plan.data.query_plan == rust_plan.into();
-                        if !is_matched {
-                            // TODO: tracing::debug!(diff)
+                        if is_matched {
+                            tracing::debug!("JS and Rust query plans match! 🎉");
+                        } else {
+                            tracing::warn!("JS v.s. Rust query plan mismatch");
+                            if let Some(formatted) = &js_plan.data.formatted_query_plan {
+                                tracing::debug!(
+                                    "Diff:\n{}",
+                                    render_diff(&diff::lines(formatted, &rust_plan.to_string()))
+                                );
+                            }
                         }
                     }
                 }

--- a/examples/graphql/supergraph-fed2.graphql
+++ b/examples/graphql/supergraph-fed2.graphql
@@ -1,0 +1,98 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+  mutation: Mutation
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ACCOUNTS @join__graph(name: "accounts", url: "https://accounts.demo.starstuff.dev/")
+  INVENTORY @join__graph(name: "inventory", url: "https://inventory.demo.starstuff.dev/")
+  PRODUCTS @join__graph(name: "products", url: "https://products.demo.starstuff.dev/")
+  REVIEWS @join__graph(name: "reviews", url: "https://reviews.demo.starstuff.dev/")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Mutation
+  @join__type(graph: PRODUCTS)
+  @join__type(graph: REVIEWS)
+{
+  createProduct(upc: ID!, name: String): Product @join__field(graph: PRODUCTS)
+  createReview(upc: ID!, id: ID!, body: String): Review @join__field(graph: REVIEWS)
+}
+
+type Product
+  @join__type(graph: ACCOUNTS, key: "upc", extension: true)
+  @join__type(graph: INVENTORY, key: "upc")
+  @join__type(graph: PRODUCTS, key: "upc")
+  @join__type(graph: REVIEWS, key: "upc")
+{
+  upc: String!
+  weight: Int @join__field(graph: INVENTORY, external: true) @join__field(graph: PRODUCTS)
+  price: Int @join__field(graph: INVENTORY, external: true) @join__field(graph: PRODUCTS)
+  inStock: Boolean @join__field(graph: INVENTORY)
+  shippingEstimate: Int @join__field(graph: INVENTORY, requires: "price weight")
+  name: String @join__field(graph: PRODUCTS)
+  reviews: [Review] @join__field(graph: REVIEWS)
+  reviewsForAuthor(authorID: ID!): [Review] @join__field(graph: REVIEWS)
+}
+
+type Query
+  @join__type(graph: ACCOUNTS)
+  @join__type(graph: INVENTORY)
+  @join__type(graph: PRODUCTS)
+  @join__type(graph: REVIEWS)
+{
+  me: User @join__field(graph: ACCOUNTS)
+  recommendedProducts: [Product] @join__field(graph: ACCOUNTS)
+  topProducts(first: Int = 5): [Product] @join__field(graph: PRODUCTS)
+}
+
+type Review
+  @join__type(graph: REVIEWS, key: "id")
+{
+  id: ID!
+  body: String
+  author: User @join__field(graph: REVIEWS, provides: "username")
+  product: Product
+}
+
+type User
+  @join__type(graph: ACCOUNTS, key: "id")
+  @join__type(graph: REVIEWS, key: "id")
+{
+  id: ID!
+  name: String @join__field(graph: ACCOUNTS)
+  username: String @join__field(graph: ACCOUNTS) @join__field(graph: REVIEWS, external: true)
+  reviews: [Review] @join__field(graph: REVIEWS)
+}


### PR DESCRIPTION
Reproduction which now returns an empty query plan instead of panicking:

```yaml
# router.yaml
experimental_query_planner_mode: both
```
```sh
cargo run -- --dev -c router.yaml -s examples/graphql/supergraph-fed2.graphql --log=debug
```
```sh
curl --request POST \
  --header 'content-type: application/json' \
  --url 'http://127.0.0.1:4000/' \
  --data '{"query":"{topProducts {name}}"}'
```

The federation 2 starstuff schema is copied from https://github.com/apollographql/starstuff/blob/cdcdd5a3650d0ddf3dbb5e80f8b0212b5c4fe3ac/supergraph.graphql