### PR TITLE
apollo-federation: remove unused impl ConditionResolver for CachingConditionResolver

### DIFF
--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -54,19 +54,6 @@ impl ConditionResolution {
 //            But in Rust, `QueryPlanningTraversal` implements `ConditionResolver` trait itself,
 //            using `ConditionResolverCache` struct below.
 //            However, `CachingConditionResolver` may still be used in the composition in the future.
-pub(crate) struct CachingConditionResolver;
-
-impl ConditionResolver for CachingConditionResolver {
-    fn resolve(
-        &mut self,
-        _edge: EdgeIndex,
-        _context: &OpGraphPathContext,
-        _excluded_destinations: &ExcludedDestinations,
-        _excluded_conditions: &ExcludedConditions,
-    ) -> Result<ConditionResolution, FederationError> {
-        todo!()
-    }
-}
 
 #[derive(Debug)]
 pub(crate) enum ConditionResolutionCacheResult {

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -1,3 +1,6 @@
+// PORT_NOTE: Unlike in JS version, `QueryPlanningTraversal` does not have a
+//            `CachingConditionResolver` as a field, but instead implements the `ConditionResolver`
+//            trait directly using `ConditionResolverCache`.
 use std::sync::Arc;
 
 use indexmap::IndexMap;
@@ -49,11 +52,6 @@ impl ConditionResolution {
         Self::Unsatisfied { reason: None }
     }
 }
-
-// PORT_NOTE: In JS version, `QueryPlanningTraversal` has a caching condition resolver as a field.
-//            But in Rust, `QueryPlanningTraversal` implements `ConditionResolver` trait itself,
-//            using `ConditionResolverCache` struct below.
-//            However, `CachingConditionResolver` may still be used in the composition in the future.
 
 #[derive(Debug)]
 pub(crate) enum ConditionResolutionCacheResult {


### PR DESCRIPTION
Since `QueryPlanningTraversal` directly implements `ConditionResolver` trait, let's remove the todo stub. Should composition need it in the future (I think it will do the same as `QueryPlanningTraversal` though), we can include it again.

Changelog is not necessary, as this does not affect the router.