### PR TITLE
chore(tests): provide more threads to each integration test in nextest config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,21 +28,18 @@ executors:
     resource_class: xlarge
     environment:
       CARGO_BUILD_JOBS: 4
-      RUST_TEST_THREADS: 6
   arm_linux_build: &arm_linux_build_executor
     machine:
       image: ubuntu-2004:2024.01.1
     resource_class: arm.large
     environment:
       CARGO_BUILD_JOBS: 8
-      RUST_TEST_THREADS: 8
   arm_linux_test: &arm_linux_test_executor
     machine:
       image: ubuntu-2004:2024.01.1
     resource_class: arm.xlarge
     environment:
       CARGO_BUILD_JOBS: 8
-      RUST_TEST_THREADS: 8
   macos_build: &macos_build_executor
     macos:
       # See https://circleci.com/docs/xcode-policy along with the support matrix
@@ -505,10 +502,10 @@ commands:
           condition:
             equal: [ "dev", "<< pipeline.git.branch >>" ]
           steps:
-          - save_cache:
-              key: "<< pipeline.parameters.merge_version >>-test-<< parameters.variant >>"
-              paths:
-                - target
+            - save_cache:
+                key: "<< pipeline.parameters.merge_version >>-test-<< parameters.variant >>"
+                paths:
+                  - target
       - store_test_results:
           # The results from nextest that power the CircleCI Insights.
           path: ./target/nextest/ci/junit.xml
@@ -540,7 +537,7 @@ jobs:
     steps:
       - when:
           condition:
-            equal: [*amd_linux_helm_executor, << parameters.platform >>]
+            equal: [ *amd_linux_helm_executor, << parameters.platform >> ]
           steps:
             - checkout
             - xtask_check_helm
@@ -838,7 +835,7 @@ jobs:
             not:
               equal: [ "https://github.com/apollographql/router", << pipeline.project.git_url >> ]
           steps:
-             - run:
+            - run:
                 command: >
                   echo "Not publishing any github release."
       - when:

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -15,3 +15,8 @@ path = "junit.xml"
 [[profile.default.overrides]]
 filter = 'package(apollo-router) & kind(test)'
 threads-required = 2
+
+# Scaffold test takes all the test threads as it runs rustc.
+[[profile.default.overrides]]
+filter = 'package(apollo-router-scaffold)'
+threads-required = 'num-test-threads'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -9,3 +9,9 @@ fail-fast = false
 # Write to output for persistence to CircleCI
 [profile.ci.junit]
 path = "junit.xml"
+
+# Integration tests require more than one thread. The default setting of 1 will cause too many integration tests to run
+# at the same time and causes tests to fail.
+[[profile.default.overrides]]
+filter = 'package(apollo-router) & kind(test)'
+threads-required = 2

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,7 +11,8 @@ fail-fast = false
 path = "junit.xml"
 
 # Integration tests require more than one thread. The default setting of 1 will cause too many integration tests to run
-# at the same time and causes tests to fail.
+# at the same time and causes tests to fail where timing is involved.
+# This filter applies only to to the integration tests in the apollo-router package.
 [[profile.default.overrides]]
 filter = 'package(apollo-router) & kind(test)'
 threads-required = 2

--- a/apollo-router-scaffold/src/lib.rs
+++ b/apollo-router-scaffold/src/lib.rs
@@ -45,6 +45,7 @@ mod test {
     // this test takes a while, I hope the above test name
     // let users know they should not worry and wait a bit.
     // Hang in there!
+    // Note that we configure nextest to use all threads for this test as invoking rustc will use all available CPU and cause timing tests to fail.
     fn test_scaffold() {
         let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
         let repo_root = manifest_dir.parent().unwrap();


### PR DESCRIPTION
Nextest by default will try to run a test on each CPU core available. However this isn't suitable for integration tests as the router will be using multiple threads. This is leading to many test failures in CI.  

In addition the scaffold test really shouldn't be run at the same time as any other test as it invokes rustc. This manifests as tests taking 3 minutes or more if they are unlucky enough to get scheduled at the same time.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
