### PR TITLE
Adjust source-specific fetch dependency graph node to avoid clones (part 2)

### DIFF
--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -223,7 +223,7 @@ impl SourceFetchDependencyGraphApi for ConnectFetchDependencyGraph {
 
 #[derive(Debug)]
 pub(crate) struct ConnectFetchDependencyGraphNode {
-    merge_at: Vec<FetchDataPathElement>,
+    merge_at: Arc<Vec<FetchDataPathElement>>,
     source_entering_edge: EdgeIndex,
     field_response_name: Name,
     field_arguments: IndexMap<Name, Value>,

--- a/apollo-federation/src/sources/graphql/mod.rs
+++ b/apollo-federation/src/sources/graphql/mod.rs
@@ -188,12 +188,12 @@ impl SourceFetchDependencyGraphApi for GraphqlFetchDependencyGraph {
 #[derive(Debug)]
 pub(crate) enum GraphqlFetchDependencyGraphNode {
     OperationRoot {
-        merge_at: Vec<FetchDataPathElement>,
+        merge_at: Arc<Vec<FetchDataPathElement>>,
         source_entering_edge: EdgeIndex,
         selection_set: SelectionSet,
     },
     EntitiesField {
-        merge_at: Vec<FetchDataPathElement>,
+        merge_at: Arc<Vec<FetchDataPathElement>>,
         source_entering_edge: EdgeIndex,
         key_condition_resolution: Option<ConditionResolutionId>,
         selection_set: SelectionSet,


### PR DESCRIPTION
<!-- FED-194 -->
<!-- FED-197 -->

In #5111 , I forgot to update source-specific fetch dependency graph node data to avoid clones.