### PR TITLE
apollo-federation: QueryPlanner::api_schema() getter

### DIFF
--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -482,6 +482,11 @@ impl QueryPlanner {
             statistics: parameters.statistics,
         })
     }
+
+    /// Get Query Planner's API Schema.
+    pub fn api_schema(&self) -> &ValidFederationSchema {
+        &self.api_schema
+    }
 }
 
 fn compute_root_serial_dependency_graph(


### PR DESCRIPTION
An accessor for Rust query planner's API schema.