### PR TITLE
Use slices instead of vecs in Arcs for `merge_at`

### DIFF
--- a/apollo-federation/src/source_aware/fetch_dependency_graph/mod.rs
+++ b/apollo-federation/src/source_aware/fetch_dependency_graph/mod.rs
@@ -32,7 +32,7 @@ type FetchDependencyGraphPetgraph =
 
 #[derive(Debug)]
 pub(crate) struct FetchDependencyGraphNode {
-    merge_at: Arc<Vec<FetchDataPathElement>>,
+    merge_at: Arc<[FetchDataPathElement]>,
     source_entering_edge: EdgeIndex,
     operation_variables: IndexSet<Name>,
     depends_on_condition_resolutions: IndexSet<ConditionResolutionId>,

--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -168,7 +168,7 @@ impl SourceFetchDependencyGraphApi for ConnectFetchDependencyGraph {
     fn add_node<'path_tree>(
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
-        _merge_at: Arc<Vec<FetchDataPathElement>>,
+        _merge_at: Arc<[FetchDataPathElement]>,
         _source_entering_edge: EdgeIndex,
         _self_condition_resolution: Option<ConditionResolutionId>,
         _path_tree_edges: Vec<&'path_tree FederatedPathTreeChildKey>,
@@ -185,7 +185,7 @@ impl SourceFetchDependencyGraphApi for ConnectFetchDependencyGraph {
     fn new_path(
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
-        _merge_at: Arc<Vec<FetchDataPathElement>>,
+        _merge_at: Arc<[FetchDataPathElement]>,
         _source_entering_edge: EdgeIndex,
         _self_condition_resolution: Option<ConditionResolutionId>,
     ) -> Result<SourcePath, FederationError> {
@@ -223,7 +223,7 @@ impl SourceFetchDependencyGraphApi for ConnectFetchDependencyGraph {
 
 #[derive(Debug)]
 pub(crate) struct ConnectFetchDependencyGraphNode {
-    merge_at: Arc<Vec<FetchDataPathElement>>,
+    merge_at: Arc<[FetchDataPathElement]>,
     source_entering_edge: EdgeIndex,
     field_response_name: Name,
     field_arguments: IndexMap<Name, Value>,
@@ -232,7 +232,7 @@ pub(crate) struct ConnectFetchDependencyGraphNode {
 
 #[derive(Debug)]
 pub(crate) struct ConnectPath {
-    merge_at: Arc<Vec<FetchDataPathElement>>,
+    merge_at: Arc<[FetchDataPathElement]>,
     source_entering_edge: EdgeIndex,
     source_id: SourceId,
     field: Option<ConnectPathField>,

--- a/apollo-federation/src/sources/graphql/mod.rs
+++ b/apollo-federation/src/sources/graphql/mod.rs
@@ -132,7 +132,7 @@ impl SourceFetchDependencyGraphApi for GraphqlFetchDependencyGraph {
     fn add_node<'path_tree>(
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
-        _merge_at: Arc<Vec<FetchDataPathElement>>,
+        _merge_at: Arc<[FetchDataPathElement]>,
         _source_entering_edge: EdgeIndex,
         _self_condition_resolution: Option<ConditionResolutionId>,
         _path_tree_edges: Vec<&'path_tree FederatedPathTreeChildKey>,
@@ -149,7 +149,7 @@ impl SourceFetchDependencyGraphApi for GraphqlFetchDependencyGraph {
     fn new_path(
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
-        _merge_at: Arc<Vec<FetchDataPathElement>>,
+        _merge_at: Arc<[FetchDataPathElement]>,
         _source_entering_edge: EdgeIndex,
         _self_condition_resolution: Option<ConditionResolutionId>,
     ) -> Result<SourcePath, FederationError> {
@@ -188,12 +188,12 @@ impl SourceFetchDependencyGraphApi for GraphqlFetchDependencyGraph {
 #[derive(Debug)]
 pub(crate) enum GraphqlFetchDependencyGraphNode {
     OperationRoot {
-        merge_at: Arc<Vec<FetchDataPathElement>>,
+        merge_at: Arc<[FetchDataPathElement]>,
         source_entering_edge: EdgeIndex,
         selection_set: SelectionSet,
     },
     EntitiesField {
-        merge_at: Arc<Vec<FetchDataPathElement>>,
+        merge_at: Arc<[FetchDataPathElement]>,
         source_entering_edge: EdgeIndex,
         key_condition_resolution: Option<ConditionResolutionId>,
         selection_set: SelectionSet,
@@ -202,7 +202,7 @@ pub(crate) enum GraphqlFetchDependencyGraphNode {
 
 #[derive(Debug)]
 pub(crate) struct GraphqlPath {
-    merge_at: Arc<Vec<FetchDataPathElement>>,
+    merge_at: Arc<[FetchDataPathElement]>,
     source_entering_edge: EdgeIndex,
     source_id: SourceId,
     operation_path: Vec<OperationPathElement>,

--- a/apollo-federation/src/sources/mod.rs
+++ b/apollo-federation/src/sources/mod.rs
@@ -179,7 +179,7 @@ pub(crate) trait SourceFetchDependencyGraphApi {
     fn add_node<'path_tree>(
         &self,
         query_graph: Arc<FederatedQueryGraph>,
-        merge_at: Arc<Vec<FetchDataPathElement>>,
+        merge_at: Arc<[FetchDataPathElement]>,
         source_entering_edge: EdgeIndex,
         self_condition_resolution: Option<ConditionResolutionId>,
         path_tree_edges: Vec<&'path_tree FederatedPathTreeChildKey>,
@@ -194,7 +194,7 @@ pub(crate) trait SourceFetchDependencyGraphApi {
     fn new_path(
         &self,
         query_graph: Arc<FederatedQueryGraph>,
-        merge_at: Arc<Vec<FetchDataPathElement>>,
+        merge_at: Arc<[FetchDataPathElement]>,
         source_entering_edge: EdgeIndex,
         self_condition_resolution: Option<ConditionResolutionId>,
     ) -> Result<SourcePath, FederationError>;


### PR DESCRIPTION
<!-- FED-194 -->
<!-- FED-197 -->

This PR addresses post-merge feedback given in https://github.com/apollographql/router/pull/5111#discussion_r1593506479 . Specifically, it uses slices instead of `Vec`s in `Arc`s for `merge_at`/response paths.