### PR TITLE
add router reload metrics

### DIFF
--- a/apollo-router/src/state_machine.rs
+++ b/apollo-router/src/state_machine.rs
@@ -229,7 +229,7 @@ impl<FA: RouterSuperServiceFactory> State<FA> {
                     .await;
 
                     u64_counter!(
-                        "apollo_router_reload",
+                        "apollo.router.reload",
                         "Amount of times the router reloaded",
                         1,
                         new_schema = schema_reload,


### PR DESCRIPTION
This PR adds a new metric, `apollo_router_reload` to track when the router **actually** reloads, versus only having state change events.

This metric has tags to verify which event caused the reload, as well as a `success` tag. Let me know what you think!