### PR TITLE
connect: Implement PathApi for connect::federated_query_graph::Path

### DIFF
--- a/apollo-federation/src/sources/connect/fetch_dependency_graph/mod.rs
+++ b/apollo-federation/src/sources/connect/fetch_dependency_graph/mod.rs
@@ -406,165 +406,167 @@ impl PathApi for Path {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    mod fetch {
+        use std::sync::Arc;
 
-    use apollo_compiler::ast::Name;
-    use apollo_compiler::name;
-    use indexmap::IndexMap;
-    use insta::assert_debug_snapshot;
-    use petgraph::graph::DiGraph;
-    use petgraph::prelude::EdgeIndex;
+        use apollo_compiler::ast::Name;
+        use apollo_compiler::name;
+        use indexmap::IndexMap;
+        use insta::assert_debug_snapshot;
+        use petgraph::graph::DiGraph;
+        use petgraph::prelude::EdgeIndex;
 
-    use super::FetchDependencyGraph;
-    use crate::schema::position::ObjectFieldDefinitionPosition;
-    use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
-    use crate::schema::position::ObjectOrInterfaceFieldDirectivePosition;
-    use crate::schema::position::ObjectTypeDefinitionPosition;
-    use crate::source_aware::federated_query_graph;
-    use crate::source_aware::federated_query_graph::FederatedQueryGraph;
-    use crate::sources::connect::federated_query_graph::ConcreteFieldEdge;
-    use crate::sources::connect::federated_query_graph::ConcreteNode;
-    use crate::sources::connect::federated_query_graph::SourceEnteringEdge;
-    use crate::sources::connect::json_selection::Key;
-    use crate::sources::connect::ConnectId;
-    use crate::sources::source::fetch_dependency_graph::FetchDependencyGraphApi;
-    use crate::sources::source::SourceId;
+        use crate::schema::position::ObjectFieldDefinitionPosition;
+        use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
+        use crate::schema::position::ObjectOrInterfaceFieldDirectivePosition;
+        use crate::schema::position::ObjectTypeDefinitionPosition;
+        use crate::source_aware::federated_query_graph;
+        use crate::source_aware::federated_query_graph::FederatedQueryGraph;
+        use crate::sources::connect::federated_query_graph::ConcreteFieldEdge;
+        use crate::sources::connect::federated_query_graph::ConcreteNode;
+        use crate::sources::connect::federated_query_graph::SourceEnteringEdge;
+        use crate::sources::connect::fetch_dependency_graph::FetchDependencyGraph;
+        use crate::sources::connect::json_selection::Key;
+        use crate::sources::connect::ConnectId;
+        use crate::sources::source::fetch_dependency_graph::FetchDependencyGraphApi;
+        use crate::sources::source::SourceId;
 
-    struct SetupInfo {
-        fetch_graph: FetchDependencyGraph,
-        query_graph: Arc<FederatedQueryGraph>,
-        source_id: SourceId,
-        source_entry_edges: Vec<EdgeIndex>,
-        non_source_entry_edges: Vec<EdgeIndex>,
-    }
-    fn setup() -> SetupInfo {
-        let mut graph = DiGraph::new();
+        struct SetupInfo {
+            fetch_graph: FetchDependencyGraph,
+            query_graph: Arc<FederatedQueryGraph>,
+            source_id: SourceId,
+            source_entry_edges: Vec<EdgeIndex>,
+            non_source_entry_edges: Vec<EdgeIndex>,
+        }
+        fn setup() -> SetupInfo {
+            let mut graph = DiGraph::new();
 
-        // Fill in some dummy data
-        // Root
-        // |- Post (entry edge)
-        // |- User (entry edge)
-        // |- View
-        let source_id = SourceId::Connect(ConnectId {
-            label: "test connect".to_string(),
-            subgraph_name: "CONNECT".into(),
-            directive: ObjectOrInterfaceFieldDirectivePosition {
-                field: ObjectOrInterfaceFieldDefinitionPosition::Object(
-                    ObjectFieldDefinitionPosition {
-                        type_name: name!("TestObject"),
-                        field_name: name!("testField"),
-                    },
-                ),
-                directive_name: name!("connect"),
-                directive_index: 0,
-            },
-        });
+            // Fill in some dummy data
+            // Root
+            // |- Post (entry edge)
+            // |- User (entry edge)
+            // |- View
+            let source_id = SourceId::Connect(ConnectId {
+                label: "test connect".to_string(),
+                subgraph_name: "CONNECT".into(),
+                directive: ObjectOrInterfaceFieldDirectivePosition {
+                    field: ObjectOrInterfaceFieldDefinitionPosition::Object(
+                        ObjectFieldDefinitionPosition {
+                            type_name: name!("TestObject"),
+                            field_name: name!("testField"),
+                        },
+                    ),
+                    directive_name: name!("connect"),
+                    directive_index: 0,
+                },
+            });
 
-        // Create a root
-        let query = graph.add_node(federated_query_graph::Node::Concrete {
-            supergraph_type: ObjectTypeDefinitionPosition {
-                type_name: name!("Query"),
-            },
-            field_edges: IndexMap::new(),
-            source_exiting_edge: None,
-            source_id: source_id.clone(),
-            source_data: ConcreteNode::SelectionRoot {
-                subgraph_type: ObjectTypeDefinitionPosition {
+            // Create a root
+            let query = graph.add_node(federated_query_graph::Node::Concrete {
+                supergraph_type: ObjectTypeDefinitionPosition {
                     type_name: name!("Query"),
                 },
-                property_path: Vec::new(),
-            }
-            .into(),
-        });
-
-        // Make the nodes with entrypoints
-        let mut edges = Vec::new();
-        let entrypoints = 2;
-        for (index, type_name) in ["Post", "User", "View"].into_iter().enumerate() {
-            let node_type = ObjectTypeDefinitionPosition {
-                type_name: Name::new(type_name).unwrap(),
-            };
-
-            let node = graph.add_node(federated_query_graph::Node::Concrete {
-                supergraph_type: node_type.clone(),
                 field_edges: IndexMap::new(),
                 source_exiting_edge: None,
                 source_id: source_id.clone(),
                 source_data: ConcreteNode::SelectionRoot {
-                    subgraph_type: node_type.clone(),
-                    property_path: vec![Key::Field(type_name.to_lowercase().to_string())],
+                    subgraph_type: ObjectTypeDefinitionPosition {
+                        type_name: name!("Query"),
+                    },
+                    property_path: Vec::new(),
                 }
                 .into(),
             });
 
-            let field = ObjectFieldDefinitionPosition {
-                type_name: Name::new(type_name).unwrap(),
-                field_name: Name::new(type_name.to_lowercase()).unwrap(),
-            };
-            edges.push(
-                graph.add_edge(
-                    query,
-                    node,
-                    federated_query_graph::Edge::ConcreteField {
-                        supergraph_field: field.clone(),
-                        self_conditions: None,
-                        source_id: source_id.clone(),
-                        source_data: ConcreteFieldEdge::Connect {
-                            subgraph_field: field.clone(),
-                        }
-                        .into(),
-                    },
-                ),
-            );
+            // Make the nodes with entrypoints
+            let mut edges = Vec::new();
+            let entrypoints = 2;
+            for (index, type_name) in ["Post", "User", "View"].into_iter().enumerate() {
+                let node_type = ObjectTypeDefinitionPosition {
+                    type_name: Name::new(type_name).unwrap(),
+                };
 
-            // Optionally add the entrypoint
-            if index < entrypoints {
+                let node = graph.add_node(federated_query_graph::Node::Concrete {
+                    supergraph_type: node_type.clone(),
+                    field_edges: IndexMap::new(),
+                    source_exiting_edge: None,
+                    source_id: source_id.clone(),
+                    source_data: ConcreteNode::SelectionRoot {
+                        subgraph_type: node_type.clone(),
+                        property_path: vec![Key::Field(type_name.to_lowercase().to_string())],
+                    }
+                    .into(),
+                });
+
+                let field = ObjectFieldDefinitionPosition {
+                    type_name: Name::new(type_name).unwrap(),
+                    field_name: Name::new(type_name.to_lowercase()).unwrap(),
+                };
                 edges.push(
                     graph.add_edge(
                         query,
                         node,
-                        federated_query_graph::Edge::SourceEntering {
-                            supergraph_type: node_type.clone(),
+                        federated_query_graph::Edge::ConcreteField {
+                            supergraph_field: field.clone(),
                             self_conditions: None,
-                            tail_source_id: source_id.clone(),
-                            source_data: SourceEnteringEdge::ConnectParent {
-                                subgraph_type: node_type,
+                            source_id: source_id.clone(),
+                            source_data: ConcreteFieldEdge::Connect {
+                                subgraph_field: field.clone(),
                             }
                             .into(),
                         },
                     ),
                 );
+
+                // Optionally add the entrypoint
+                if index < entrypoints {
+                    edges.push(
+                        graph.add_edge(
+                            query,
+                            node,
+                            federated_query_graph::Edge::SourceEntering {
+                                supergraph_type: node_type.clone(),
+                                self_conditions: None,
+                                tail_source_id: source_id.clone(),
+                                source_data: SourceEnteringEdge::ConnectParent {
+                                    subgraph_type: node_type,
+                                }
+                                .into(),
+                            },
+                        ),
+                    );
+                }
+            }
+
+            let (entry, non_entry) = edges.into_iter().partition(|&edge_index| {
+                matches!(
+                    graph.edge_weight(edge_index),
+                    Some(federated_query_graph::Edge::SourceEntering { .. })
+                )
+            });
+            SetupInfo {
+                fetch_graph: FetchDependencyGraph,
+                query_graph: Arc::new(FederatedQueryGraph::with_graph(graph)),
+                source_id,
+                source_entry_edges: entry,
+                non_source_entry_edges: non_entry,
             }
         }
 
-        let (entry, non_entry) = edges.into_iter().partition(|&edge_index| {
-            matches!(
-                graph.edge_weight(edge_index),
-                Some(federated_query_graph::Edge::SourceEntering { .. })
-            )
-        });
-        SetupInfo {
-            fetch_graph: FetchDependencyGraph,
-            query_graph: Arc::new(FederatedQueryGraph::with_graph(graph)),
-            source_id,
-            source_entry_edges: entry,
-            non_source_entry_edges: non_entry,
-        }
-    }
+        #[test]
+        fn it_handles_a_new_path() {
+            let SetupInfo {
+                fetch_graph,
+                query_graph,
+                source_entry_edges,
+                ..
+            } = setup();
 
-    #[test]
-    fn it_handles_a_new_path() {
-        let SetupInfo {
-            fetch_graph,
-            query_graph,
-            source_entry_edges,
-            ..
-        } = setup();
-
-        // Make sure that the first edge is what we expect
-        let last_edge_index = *source_entry_edges.last().unwrap();
-        let (query_root_index, post_index) = query_graph.edge_endpoints(last_edge_index).unwrap();
-        assert_debug_snapshot!(query_graph.node_weight(query_root_index).unwrap(), @r###"
+            // Make sure that the first edge is what we expect
+            let last_edge_index = *source_entry_edges.last().unwrap();
+            let (query_root_index, post_index) =
+                query_graph.edge_endpoints(last_edge_index).unwrap();
+            assert_debug_snapshot!(query_graph.node_weight(query_root_index).unwrap(), @r###"
         Concrete {
             supergraph_type: Object(Query),
             field_edges: {},
@@ -588,7 +590,7 @@ mod tests {
             ),
         }
         "###);
-        assert_debug_snapshot!(query_graph.node_weight(post_index).unwrap(), @r###"
+            assert_debug_snapshot!(query_graph.node_weight(post_index).unwrap(), @r###"
         Concrete {
             supergraph_type: Object(User),
             field_edges: {},
@@ -617,13 +619,13 @@ mod tests {
         }
         "###);
 
-        let path = fetch_graph
-            .new_path(query_graph, Arc::new([]), last_edge_index, None)
-            .unwrap();
+            let path = fetch_graph
+                .new_path(query_graph, Arc::new([]), last_edge_index, None)
+                .unwrap();
 
-        assert_debug_snapshot!(
-            path,
-            @r###"
+            assert_debug_snapshot!(
+                path,
+                @r###"
         Connect(
             Path {
                 merge_at: [],
@@ -643,22 +645,23 @@ mod tests {
             },
         )
         "###
-        );
-    }
+            );
+        }
 
-    #[test]
-    fn it_fails_with_invalid_entrypoint() {
-        let SetupInfo {
-            fetch_graph,
-            query_graph,
-            non_source_entry_edges,
-            ..
-        } = setup();
+        #[test]
+        fn it_fails_with_invalid_entrypoint() {
+            let SetupInfo {
+                fetch_graph,
+                query_graph,
+                non_source_entry_edges,
+                ..
+            } = setup();
 
-        // Make sure that the first edge is what we expect
-        let last_edge_index = *non_source_entry_edges.last().unwrap();
-        let (query_root_index, view_index) = query_graph.edge_endpoints(last_edge_index).unwrap();
-        assert_debug_snapshot!(query_graph.node_weight(query_root_index).unwrap(), @r###"
+            // Make sure that the first edge is what we expect
+            let last_edge_index = *non_source_entry_edges.last().unwrap();
+            let (query_root_index, view_index) =
+                query_graph.edge_endpoints(last_edge_index).unwrap();
+            assert_debug_snapshot!(query_graph.node_weight(query_root_index).unwrap(), @r###"
         Concrete {
             supergraph_type: Object(Query),
             field_edges: {},
@@ -682,7 +685,7 @@ mod tests {
             ),
         }
         "###);
-        assert_debug_snapshot!(query_graph.node_weight(view_index).unwrap(), @r###"
+            assert_debug_snapshot!(query_graph.node_weight(view_index).unwrap(), @r###"
         Concrete {
             supergraph_type: Object(View),
             field_edges: {},
@@ -711,12 +714,12 @@ mod tests {
         }
         "###);
 
-        // Make sure that we fail since we do not have an entering edge
-        let path = fetch_graph.new_path(query_graph, Arc::new([]), last_edge_index, None);
+            // Make sure that we fail since we do not have an entering edge
+            let path = fetch_graph.new_path(query_graph, Arc::new([]), last_edge_index, None);
 
-        assert_debug_snapshot!(
-            path,
-            @r###"
+            assert_debug_snapshot!(
+                path,
+                @r###"
         Err(
             SingleFederationError(
                 Internal {
@@ -725,26 +728,26 @@ mod tests {
             ),
         )
         "###
-        );
-    }
+            );
+        }
 
-    #[test]
-    fn it_fails_with_invalid_edge() {
-        let SetupInfo {
-            fetch_graph,
-            query_graph,
-            ..
-        } = setup();
+        #[test]
+        fn it_fails_with_invalid_edge() {
+            let SetupInfo {
+                fetch_graph,
+                query_graph,
+                ..
+            } = setup();
 
-        // Make sure that the first edge is what we expect
-        let invalid_index = EdgeIndex::end();
+            // Make sure that the first edge is what we expect
+            let invalid_index = EdgeIndex::end();
 
-        // Make sure that we fail since we pass in an invalid edge
-        let path = fetch_graph.new_path(query_graph, Arc::new([]), invalid_index, None);
+            // Make sure that we fail since we pass in an invalid edge
+            let path = fetch_graph.new_path(query_graph, Arc::new([]), invalid_index, None);
 
-        assert_debug_snapshot!(
-            path,
-            @r###"
+            assert_debug_snapshot!(
+                path,
+                @r###"
         Err(
             SingleFederationError(
                 Internal {
@@ -753,6 +756,552 @@ mod tests {
             ),
         )
         "###
-        );
+            );
+        }
+    }
+
+    mod path {
+        use std::sync::Arc;
+
+        use apollo_compiler::ast::DirectiveList;
+        use apollo_compiler::name;
+        use apollo_compiler::Schema;
+        use indexmap::IndexMap;
+        use insta::assert_debug_snapshot;
+        use petgraph::graph::DiGraph;
+        use petgraph::prelude::EdgeIndex;
+        use petgraph::prelude::NodeIndex;
+
+        use crate::query_plan::operation::Field;
+        use crate::query_plan::operation::FieldData;
+        use crate::schema::position::EnumTypeDefinitionPosition;
+        use crate::schema::position::FieldDefinitionPosition;
+        use crate::schema::position::ObjectFieldDefinitionPosition;
+        use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
+        use crate::schema::position::ObjectOrInterfaceFieldDirectivePosition;
+        use crate::schema::position::ObjectTypeDefinitionPosition;
+        use crate::schema::position::ScalarTypeDefinitionPosition;
+        use crate::schema::ValidFederationSchema;
+        use crate::source_aware::federated_query_graph;
+        use crate::source_aware::federated_query_graph::graph_path::OperationPathElement;
+        use crate::source_aware::federated_query_graph::FederatedQueryGraph;
+        use crate::sources::connect;
+        use crate::sources::connect::json_selection::Key;
+        use crate::sources::connect::ConnectId;
+        use crate::sources::connect::JSONSelection;
+        use crate::sources::source;
+        use crate::sources::source::fetch_dependency_graph::PathApi;
+        use crate::sources::source::SourceId;
+
+        struct SetupInfo {
+            graph: DiGraph<federated_query_graph::Node, federated_query_graph::Edge>,
+            schema: ValidFederationSchema,
+            source_id: SourceId,
+        }
+        fn setup() -> SetupInfo {
+            let mut graph = DiGraph::new();
+            let source_id = SourceId::Connect(ConnectId {
+                label: "test connect".to_string(),
+                subgraph_name: "CONNECT".into(),
+                directive: ObjectOrInterfaceFieldDirectivePosition {
+                    field: ObjectOrInterfaceFieldDefinitionPosition::Object(
+                        ObjectFieldDefinitionPosition {
+                            type_name: name!("TestObject"),
+                            field_name: name!("testField"),
+                        },
+                    ),
+                    directive_name: name!("connect"),
+                    directive_index: 0,
+                },
+            });
+
+            // Create a dummy schema for tests
+            let schema =
+                Schema::parse(include_str!("../tests/schemas/simple.graphql"), "").unwrap();
+            let schema = schema.validate().unwrap();
+            let schema = ValidFederationSchema::new(schema).unwrap();
+
+            // Fill in some dummy data
+            graph.add_node(federated_query_graph::Node::Concrete {
+                supergraph_type: ObjectTypeDefinitionPosition {
+                    type_name: name!("Query"),
+                },
+                field_edges: IndexMap::new(),
+                source_exiting_edge: None,
+                source_id: source_id.clone(),
+                source_data: source::federated_query_graph::ConcreteNode::Connect(
+                    connect::federated_query_graph::ConcreteNode::SelectionRoot {
+                        subgraph_type: ObjectTypeDefinitionPosition {
+                            type_name: name!("Query"),
+                        },
+                        property_path: Vec::new(),
+                    },
+                ),
+            });
+
+            let source_id = SourceId::Connect(ConnectId {
+                label: "test connect".to_string(),
+                subgraph_name: "CONNECT".into(),
+                directive: ObjectOrInterfaceFieldDirectivePosition {
+                    field: ObjectOrInterfaceFieldDefinitionPosition::Object(
+                        ObjectFieldDefinitionPosition {
+                            type_name: name!("TestObject"),
+                            field_name: name!("testField"),
+                        },
+                    ),
+                    directive_name: name!("connect"),
+                    directive_index: 0,
+                },
+            });
+
+            SetupInfo {
+                graph,
+                schema,
+                source_id,
+            }
+        }
+
+        #[test]
+        fn it_adds_operation_element_with_no_field_with_concrete() {
+            let SetupInfo {
+                schema,
+                source_id,
+                mut graph,
+                ..
+            } = setup();
+
+            let node_type = ObjectTypeDefinitionPosition {
+                type_name: name!("NoFieldConcreteNode"),
+            };
+            let field_pos = ObjectFieldDefinitionPosition {
+                type_name: name!("NoFieldTypeName"),
+                field_name: name!("NoFieldFieldName"),
+            };
+            let node = graph.add_node(federated_query_graph::Node::Concrete {
+                supergraph_type: node_type.clone(),
+                field_edges: IndexMap::new(),
+                source_exiting_edge: None,
+                source_id: source_id.clone(),
+                source_data: source::federated_query_graph::ConcreteNode::Connect(
+                    connect::federated_query_graph::ConcreteNode::SelectionRoot {
+                        subgraph_type: node_type.clone(),
+                        property_path: vec![Key::Field("no_field_concrete".to_string())],
+                    },
+                ),
+            });
+
+            let edge = graph.add_edge(
+                NodeIndex::new(0),
+                node,
+                federated_query_graph::Edge::ConcreteField {
+                    supergraph_field: field_pos.clone(),
+                    self_conditions: None,
+                    source_id: source_id.clone(),
+                    source_data: source::federated_query_graph::ConcreteFieldEdge::Connect(
+                        connect::federated_query_graph::ConcreteFieldEdge::Connect {
+                            subgraph_field: field_pos.clone(),
+                        },
+                    ),
+                },
+            );
+            let path = connect::fetch_dependency_graph::Path {
+                merge_at: Arc::new([]),
+                source_entering_edge: EdgeIndex::end(),
+                source_id,
+                field: None,
+            };
+            let operation_element = Arc::new(OperationPathElement::Field(Field::new(FieldData {
+                schema,
+                field_position: FieldDefinitionPosition::Object(field_pos),
+                alias: Some(name!("NoFieldTestAlias")),
+                arguments: Arc::new(Vec::new()),
+                directives: Arc::new(DirectiveList::new()),
+                sibling_typename: None,
+            })));
+
+            let result = path
+                .add_operation_element(
+                    Arc::new(FederatedQueryGraph::with_graph(graph)),
+                    operation_element,
+                    Some(edge),
+                    IndexMap::new(),
+                )
+                .unwrap();
+
+            assert_debug_snapshot!(result, @r###"
+            Connect(
+                Path {
+                    merge_at: [],
+                    source_entering_edge: EdgeIndex(4294967295),
+                    source_id: Connect(
+                        ConnectId {
+                            label: "test connect",
+                            subgraph_name: "CONNECT",
+                            directive: ObjectOrInterfaceFieldDirectivePosition {
+                                field: Object(TestObject.testField),
+                                directive_name: "connect",
+                                directive_index: 0,
+                            },
+                        },
+                    ),
+                    field: Some(
+                        PathField {
+                            response_name: "NoFieldTestAlias",
+                            arguments: {},
+                            selections: Selections {
+                                head_property_path: [
+                                    Field(
+                                        "no_field_concrete",
+                                    ),
+                                ],
+                                named_selections: [],
+                                tail_selection: None,
+                            },
+                        },
+                    ),
+                },
+            )
+            "###);
+        }
+
+        #[test]
+        fn it_adds_operation_element_with_no_field_with_enum() {
+            let SetupInfo {
+                schema,
+                source_id,
+                mut graph,
+                ..
+            } = setup();
+
+            let node_type = EnumTypeDefinitionPosition {
+                type_name: name!("NoFieldEnumNode"),
+            };
+            let field_pos = ObjectFieldDefinitionPosition {
+                type_name: name!("NoFieldTypeName"),
+                field_name: name!("NoFieldFieldName"),
+            };
+            let node = graph.add_node(federated_query_graph::Node::Enum {
+                supergraph_type: node_type.clone(),
+                source_id: source_id.clone(),
+                source_data: source::federated_query_graph::EnumNode::Connect(
+                    connect::federated_query_graph::EnumNode::SelectionRoot {
+                        subgraph_type: node_type.clone(),
+                        property_path: vec![Key::Field("no_field_enum".to_string())],
+                    },
+                ),
+            });
+
+            let edge = graph.add_edge(
+                NodeIndex::new(0),
+                node,
+                federated_query_graph::Edge::ConcreteField {
+                    supergraph_field: field_pos.clone(),
+                    self_conditions: None,
+                    source_id: source_id.clone(),
+                    source_data: source::federated_query_graph::ConcreteFieldEdge::Connect(
+                        connect::federated_query_graph::ConcreteFieldEdge::Connect {
+                            subgraph_field: field_pos.clone(),
+                        },
+                    ),
+                },
+            );
+            let path = connect::fetch_dependency_graph::Path {
+                merge_at: Arc::new([]),
+                source_entering_edge: EdgeIndex::end(),
+                source_id,
+                field: None,
+            };
+            let operation_element = Arc::new(OperationPathElement::Field(Field::new(FieldData {
+                schema,
+                field_position: FieldDefinitionPosition::Object(field_pos),
+                alias: Some(name!("NoFieldTestAlias")),
+                arguments: Arc::new(Vec::new()),
+                directives: Arc::new(DirectiveList::new()),
+                sibling_typename: None,
+            })));
+
+            let result = path
+                .add_operation_element(
+                    Arc::new(FederatedQueryGraph::with_graph(graph)),
+                    operation_element,
+                    Some(edge),
+                    IndexMap::new(),
+                )
+                .unwrap();
+
+            assert_debug_snapshot!(result, @r###"
+            Connect(
+                Path {
+                    merge_at: [],
+                    source_entering_edge: EdgeIndex(4294967295),
+                    source_id: Connect(
+                        ConnectId {
+                            label: "test connect",
+                            subgraph_name: "CONNECT",
+                            directive: ObjectOrInterfaceFieldDirectivePosition {
+                                field: Object(TestObject.testField),
+                                directive_name: "connect",
+                                directive_index: 0,
+                            },
+                        },
+                    ),
+                    field: Some(
+                        PathField {
+                            response_name: "NoFieldTestAlias",
+                            arguments: {},
+                            selections: Selections {
+                                head_property_path: [
+                                    Field(
+                                        "no_field_enum",
+                                    ),
+                                ],
+                                named_selections: [],
+                                tail_selection: None,
+                            },
+                        },
+                    ),
+                },
+            )
+            "###);
+        }
+
+        #[test]
+        fn it_adds_operation_element_with_no_field_with_custom_scalar() {
+            let SetupInfo {
+                schema,
+                source_id,
+                mut graph,
+                ..
+            } = setup();
+
+            let (_, selection) = JSONSelection::parse(".one.two.three").unwrap();
+            let node_type = ScalarTypeDefinitionPosition {
+                type_name: name!("NoFieldCustomScalarNode"),
+            };
+            let field_pos = ObjectFieldDefinitionPosition {
+                type_name: name!("NoFieldTypeName"),
+                field_name: name!("NoFieldFieldName"),
+            };
+            let node = graph.add_node(federated_query_graph::Node::Scalar {
+                supergraph_type: node_type.clone(),
+                source_id: source_id.clone(),
+                source_data: source::federated_query_graph::ScalarNode::Connect(
+                    connect::federated_query_graph::ScalarNode::CustomScalarSelectionRoot {
+                        subgraph_type: node_type.clone(),
+                        selection,
+                    },
+                ),
+            });
+
+            let edge = graph.add_edge(
+                NodeIndex::new(0),
+                node,
+                federated_query_graph::Edge::ConcreteField {
+                    supergraph_field: field_pos.clone(),
+                    self_conditions: None,
+                    source_id: source_id.clone(),
+                    source_data: source::federated_query_graph::ConcreteFieldEdge::Connect(
+                        connect::federated_query_graph::ConcreteFieldEdge::Connect {
+                            subgraph_field: field_pos.clone(),
+                        },
+                    ),
+                },
+            );
+            let path = connect::fetch_dependency_graph::Path {
+                merge_at: Arc::new([]),
+                source_entering_edge: EdgeIndex::end(),
+                source_id,
+                field: None,
+            };
+            let operation_element = Arc::new(OperationPathElement::Field(Field::new(FieldData {
+                schema,
+                field_position: FieldDefinitionPosition::Object(field_pos),
+                alias: Some(name!("NoFieldTestAlias")),
+                arguments: Arc::new(Vec::new()),
+                directives: Arc::new(DirectiveList::new()),
+                sibling_typename: None,
+            })));
+
+            let result = path
+                .add_operation_element(
+                    Arc::new(FederatedQueryGraph::with_graph(graph)),
+                    operation_element,
+                    Some(edge),
+                    IndexMap::new(),
+                )
+                .unwrap();
+
+            assert_debug_snapshot!(result, @r###"
+            Connect(
+                Path {
+                    merge_at: [],
+                    source_entering_edge: EdgeIndex(4294967295),
+                    source_id: Connect(
+                        ConnectId {
+                            label: "test connect",
+                            subgraph_name: "CONNECT",
+                            directive: ObjectOrInterfaceFieldDirectivePosition {
+                                field: Object(TestObject.testField),
+                                directive_name: "connect",
+                                directive_index: 0,
+                            },
+                        },
+                    ),
+                    field: Some(
+                        PathField {
+                            response_name: "NoFieldTestAlias",
+                            arguments: {},
+                            selections: CustomScalarRoot {
+                                selection: Path(
+                                    Key(
+                                        Field(
+                                            "one",
+                                        ),
+                                        Key(
+                                            Field(
+                                                "two",
+                                            ),
+                                            Key(
+                                                Field(
+                                                    "three",
+                                                ),
+                                                Empty,
+                                            ),
+                                        ),
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                },
+            )
+            "###);
+        }
+
+        #[test]
+        fn it_adds_operation_element_with_existing_field_with_selection() {
+            let SetupInfo {
+                schema,
+                source_id,
+                mut graph,
+                ..
+            } = setup();
+
+            let node_type = EnumTypeDefinitionPosition {
+                type_name: name!("FieldEnumNode"),
+            };
+            let field_pos = ObjectFieldDefinitionPosition {
+                type_name: name!("FieldTypeName"),
+                field_name: name!("FieldFieldName"),
+            };
+            let node = graph.add_node(federated_query_graph::Node::Enum {
+                supergraph_type: node_type.clone(),
+                source_id: source_id.clone(),
+                source_data: source::federated_query_graph::EnumNode::Connect(
+                    connect::federated_query_graph::EnumNode::SelectionRoot {
+                        subgraph_type: node_type.clone(),
+                        property_path: vec![Key::Field("field_enum".to_string())],
+                    },
+                ),
+            });
+
+            let edge = graph.add_edge(
+                NodeIndex::new(0),
+                node,
+                federated_query_graph::Edge::ConcreteField {
+                    supergraph_field: field_pos.clone(),
+                    self_conditions: None,
+                    source_id: source_id.clone(),
+                    source_data: source::federated_query_graph::ConcreteFieldEdge::Connect(
+                        connect::federated_query_graph::ConcreteFieldEdge::Selection {
+                            subgraph_field: field_pos.clone(),
+                            property_path: vec!["one", "two", "three"]
+                                .into_iter()
+                                .map(|prop| Key::Field(prop.to_string()))
+                                .collect(),
+                        },
+                    ),
+                },
+            );
+            let path = connect::fetch_dependency_graph::Path {
+                merge_at: Arc::new([]),
+                source_entering_edge: EdgeIndex::end(),
+                source_id,
+                field: Some(connect::fetch_dependency_graph::PathField {
+                    response_name: name!("ConnectPathResponseName"),
+                    arguments: IndexMap::new(),
+                    selections: connect::fetch_dependency_graph::PathSelections::Selections {
+                        head_property_path: Vec::new(),
+                        named_selections: Vec::new(),
+                        tail_selection: None,
+                    },
+                }),
+            };
+            let operation_element = Arc::new(OperationPathElement::Field(Field::new(FieldData {
+                schema,
+                field_position: FieldDefinitionPosition::Object(field_pos),
+                alias: Some(name!("FieldTestAlias")),
+                arguments: Arc::new(Vec::new()),
+                directives: Arc::new(DirectiveList::new()),
+                sibling_typename: None,
+            })));
+
+            let result = path
+                .add_operation_element(
+                    Arc::new(FederatedQueryGraph::with_graph(graph)),
+                    operation_element,
+                    Some(edge),
+                    IndexMap::new(),
+                )
+                .unwrap();
+
+            assert_debug_snapshot!(result, @r###"
+            Connect(
+                Path {
+                    merge_at: [],
+                    source_entering_edge: EdgeIndex(4294967295),
+                    source_id: Connect(
+                        ConnectId {
+                            label: "test connect",
+                            subgraph_name: "CONNECT",
+                            directive: ObjectOrInterfaceFieldDirectivePosition {
+                                field: Object(TestObject.testField),
+                                directive_name: "connect",
+                                directive_index: 0,
+                            },
+                        },
+                    ),
+                    field: Some(
+                        PathField {
+                            response_name: "ConnectPathResponseName",
+                            arguments: {},
+                            selections: Selections {
+                                head_property_path: [],
+                                named_selections: [],
+                                tail_selection: Some(
+                                    (
+                                        "FieldTestAlias",
+                                        Selection {
+                                            property_path: [
+                                                Field(
+                                                    "one",
+                                                ),
+                                                Field(
+                                                    "two",
+                                                ),
+                                                Field(
+                                                    "three",
+                                                ),
+                                            ],
+                                        },
+                                    ),
+                                ),
+                            },
+                        },
+                    ),
+                },
+            )
+            "###);
+        }
     }
 }

--- a/apollo-federation/src/sources/connect/fetch_dependency_graph/mod.rs
+++ b/apollo-federation/src/sources/connect/fetch_dependency_graph/mod.rs
@@ -806,7 +806,7 @@ mod tests {
                 directive: ObjectOrInterfaceFieldDirectivePosition {
                     field: ObjectOrInterfaceFieldDefinitionPosition::Object(
                         ObjectFieldDefinitionPosition {
-                            type_name: name!("TestObject"),
+                            type_name: name!("_testObject"),
                             field_name: name!("testField"),
                         },
                     ),
@@ -824,7 +824,7 @@ mod tests {
             // Fill in some dummy data
             graph.add_node(federated_query_graph::Node::Concrete {
                 supergraph_type: ObjectTypeDefinitionPosition {
-                    type_name: name!("Query"),
+                    type_name: name!("_query"),
                 },
                 field_edges: IndexMap::new(),
                 source_exiting_edge: None,
@@ -832,26 +832,11 @@ mod tests {
                 source_data: source::federated_query_graph::ConcreteNode::Connect(
                     connect::federated_query_graph::ConcreteNode::SelectionRoot {
                         subgraph_type: ObjectTypeDefinitionPosition {
-                            type_name: name!("Query"),
+                            type_name: name!("_query"),
                         },
                         property_path: Vec::new(),
                     },
                 ),
-            });
-
-            let source_id = SourceId::Connect(ConnectId {
-                label: "test connect".to_string(),
-                subgraph_name: "CONNECT".into(),
-                directive: ObjectOrInterfaceFieldDirectivePosition {
-                    field: ObjectOrInterfaceFieldDefinitionPosition::Object(
-                        ObjectFieldDefinitionPosition {
-                            type_name: name!("TestObject"),
-                            field_name: name!("testField"),
-                        },
-                    ),
-                    directive_name: name!("connect"),
-                    directive_index: 0,
-                },
             });
 
             SetupInfo {
@@ -871,11 +856,11 @@ mod tests {
             } = setup();
 
             let node_type = ObjectTypeDefinitionPosition {
-                type_name: name!("NoFieldConcreteNode"),
+                type_name: name!("_noFieldConcreteNode"),
             };
             let field_pos = ObjectFieldDefinitionPosition {
-                type_name: name!("NoFieldTypeName"),
-                field_name: name!("NoFieldFieldName"),
+                type_name: name!("_noFieldTypeName"),
+                field_name: name!("_noFieldFieldName"),
             };
             let node = graph.add_node(federated_query_graph::Node::Concrete {
                 supergraph_type: node_type.clone(),
@@ -913,7 +898,7 @@ mod tests {
             let operation_element = Arc::new(OperationPathElement::Field(Field::new(FieldData {
                 schema,
                 field_position: FieldDefinitionPosition::Object(field_pos),
-                alias: Some(name!("NoFieldTestAlias")),
+                alias: Some(name!("_noFieldTestAlias")),
                 arguments: Arc::new(Vec::new()),
                 directives: Arc::new(DirectiveList::new()),
                 sibling_typename: None,
@@ -938,7 +923,7 @@ mod tests {
                             label: "test connect",
                             subgraph_name: "CONNECT",
                             directive: ObjectOrInterfaceFieldDirectivePosition {
-                                field: Object(TestObject.testField),
+                                field: Object(_testObject.testField),
                                 directive_name: "connect",
                                 directive_index: 0,
                             },
@@ -946,7 +931,7 @@ mod tests {
                     ),
                     field: Some(
                         PathField {
-                            response_name: "NoFieldTestAlias",
+                            response_name: "_noFieldTestAlias",
                             arguments: {},
                             selections: Selections {
                                 head_property_path: [
@@ -974,11 +959,11 @@ mod tests {
             } = setup();
 
             let node_type = EnumTypeDefinitionPosition {
-                type_name: name!("NoFieldEnumNode"),
+                type_name: name!("_noFieldEnumNode"),
             };
             let field_pos = ObjectFieldDefinitionPosition {
-                type_name: name!("NoFieldTypeName"),
-                field_name: name!("NoFieldFieldName"),
+                type_name: name!("_noFieldTypeName"),
+                field_name: name!("_noFieldFieldName"),
             };
             let node = graph.add_node(federated_query_graph::Node::Enum {
                 supergraph_type: node_type.clone(),
@@ -1014,7 +999,7 @@ mod tests {
             let operation_element = Arc::new(OperationPathElement::Field(Field::new(FieldData {
                 schema,
                 field_position: FieldDefinitionPosition::Object(field_pos),
-                alias: Some(name!("NoFieldTestAlias")),
+                alias: Some(name!("_noFieldTestAlias")),
                 arguments: Arc::new(Vec::new()),
                 directives: Arc::new(DirectiveList::new()),
                 sibling_typename: None,
@@ -1039,7 +1024,7 @@ mod tests {
                             label: "test connect",
                             subgraph_name: "CONNECT",
                             directive: ObjectOrInterfaceFieldDirectivePosition {
-                                field: Object(TestObject.testField),
+                                field: Object(_testObject.testField),
                                 directive_name: "connect",
                                 directive_index: 0,
                             },
@@ -1047,7 +1032,7 @@ mod tests {
                     ),
                     field: Some(
                         PathField {
-                            response_name: "NoFieldTestAlias",
+                            response_name: "_noFieldTestAlias",
                             arguments: {},
                             selections: Selections {
                                 head_property_path: [
@@ -1076,11 +1061,11 @@ mod tests {
 
             let (_, selection) = JSONSelection::parse(".one.two.three").unwrap();
             let node_type = ScalarTypeDefinitionPosition {
-                type_name: name!("NoFieldCustomScalarNode"),
+                type_name: name!("_noFieldCustomScalarNode"),
             };
             let field_pos = ObjectFieldDefinitionPosition {
-                type_name: name!("NoFieldTypeName"),
-                field_name: name!("NoFieldFieldName"),
+                type_name: name!("_noFieldTypeName"),
+                field_name: name!("_noFieldFieldName"),
             };
             let node = graph.add_node(federated_query_graph::Node::Scalar {
                 supergraph_type: node_type.clone(),
@@ -1116,7 +1101,7 @@ mod tests {
             let operation_element = Arc::new(OperationPathElement::Field(Field::new(FieldData {
                 schema,
                 field_position: FieldDefinitionPosition::Object(field_pos),
-                alias: Some(name!("NoFieldTestAlias")),
+                alias: Some(name!("_noFieldTestAlias")),
                 arguments: Arc::new(Vec::new()),
                 directives: Arc::new(DirectiveList::new()),
                 sibling_typename: None,
@@ -1141,7 +1126,7 @@ mod tests {
                             label: "test connect",
                             subgraph_name: "CONNECT",
                             directive: ObjectOrInterfaceFieldDirectivePosition {
-                                field: Object(TestObject.testField),
+                                field: Object(_testObject.testField),
                                 directive_name: "connect",
                                 directive_index: 0,
                             },
@@ -1149,7 +1134,7 @@ mod tests {
                     ),
                     field: Some(
                         PathField {
-                            response_name: "NoFieldTestAlias",
+                            response_name: "_noFieldTestAlias",
                             arguments: {},
                             selections: CustomScalarRoot {
                                 selection: Path(
@@ -1188,11 +1173,11 @@ mod tests {
             } = setup();
 
             let node_type = EnumTypeDefinitionPosition {
-                type_name: name!("FieldEnumNode"),
+                type_name: name!("_fieldEnumNode"),
             };
             let field_pos = ObjectFieldDefinitionPosition {
-                type_name: name!("FieldTypeName"),
-                field_name: name!("FieldFieldName"),
+                type_name: name!("_fieldTypeName"),
+                field_name: name!("_fieldFieldName"),
             };
             let node = graph.add_node(federated_query_graph::Node::Enum {
                 supergraph_type: node_type.clone(),
@@ -1228,7 +1213,7 @@ mod tests {
                 source_entering_edge: EdgeIndex::end(),
                 source_id,
                 field: Some(connect::fetch_dependency_graph::PathField {
-                    response_name: name!("ConnectPathResponseName"),
+                    response_name: name!("_connectPathResponseName"),
                     arguments: IndexMap::new(),
                     selections: connect::fetch_dependency_graph::PathSelections::Selections {
                         head_property_path: Vec::new(),
@@ -1240,7 +1225,7 @@ mod tests {
             let operation_element = Arc::new(OperationPathElement::Field(Field::new(FieldData {
                 schema,
                 field_position: FieldDefinitionPosition::Object(field_pos),
-                alias: Some(name!("FieldTestAlias")),
+                alias: Some(name!("_fieldTestAlias")),
                 arguments: Arc::new(Vec::new()),
                 directives: Arc::new(DirectiveList::new()),
                 sibling_typename: None,
@@ -1265,7 +1250,7 @@ mod tests {
                             label: "test connect",
                             subgraph_name: "CONNECT",
                             directive: ObjectOrInterfaceFieldDirectivePosition {
-                                field: Object(TestObject.testField),
+                                field: Object(_testObject.testField),
                                 directive_name: "connect",
                                 directive_index: 0,
                             },
@@ -1273,14 +1258,14 @@ mod tests {
                     ),
                     field: Some(
                         PathField {
-                            response_name: "ConnectPathResponseName",
+                            response_name: "_connectPathResponseName",
                             arguments: {},
                             selections: Selections {
                                 head_property_path: [],
                                 named_selections: [],
                                 tail_selection: Some(
                                     (
-                                        "FieldTestAlias",
+                                        "_fieldTestAlias",
                                         Selection {
                                             property_path: [
                                                 Field(


### PR DESCRIPTION
This commit implements the `SourcePathApi` trait for `ConnectPath`, opening the door to adding connect-specific path information to the query planning stack.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
