### PR TITLE
fixed `SelectionSet::make_selection` method to preserve insertion ordering

### DIFF
--- a/apollo-federation/src/query_plan/operation.rs
+++ b/apollo-federation/src/query_plan/operation.rs
@@ -416,19 +416,6 @@ pub(crate) mod normalized_selection_map {
         }
     }
 
-    impl<A> FromIterator<A> for SelectionMap
-    where
-        A: Into<Selection>,
-    {
-        fn from_iter<T: IntoIterator<Item = A>>(iter: T) -> Self {
-            let mut map = Self::new();
-            for selection in iter {
-                map.insert(selection.into());
-            }
-            map
-        }
-    }
-
     type IterMut<'a> = Map<
         indexmap::map::IterMut<'a, SelectionKey, Selection>,
         fn((&'a SelectionKey, &'a mut Selection)) -> (&'a SelectionKey, SelectionValue<'a>),
@@ -956,24 +943,6 @@ impl Selection {
     }
 }
 
-impl From<FieldSelection> for Selection {
-    fn from(value: FieldSelection) -> Self {
-        Self::Field(value.into())
-    }
-}
-
-impl From<FragmentSpreadSelection> for Selection {
-    fn from(value: FragmentSpreadSelection) -> Self {
-        Self::FragmentSpread(value.into())
-    }
-}
-
-impl From<InlineFragmentSelection> for Selection {
-    fn from(value: InlineFragmentSelection) -> Self {
-        Self::InlineFragment(value.into())
-    }
-}
-
 impl HasSelectionKey for Selection {
     fn key(&self) -> SelectionKey {
         match self {
@@ -1130,26 +1099,6 @@ mod normalized_field_selection {
             }
         }
 
-        /// Create a trivial field selection without any arguments or directives.
-        pub(crate) fn from_position(
-            schema: &ValidFederationSchema,
-            field_position: FieldDefinitionPosition,
-        ) -> Self {
-            Self::new(FieldData::from_position(schema, field_position))
-        }
-
-        /// Turn this `Field` into a `FieldSelection` with the given sub-selection. If this is
-        /// meant to be a leaf selection, use `None`.
-        pub(crate) fn with_subselection(
-            self,
-            selection_set: Option<SelectionSet>,
-        ) -> FieldSelection {
-            FieldSelection {
-                field: self,
-                selection_set,
-            }
-        }
-
         pub(crate) fn data(&self) -> &FieldData {
             &self.data
         }
@@ -1223,21 +1172,6 @@ mod normalized_field_selection {
     }
 
     impl FieldData {
-        /// Create a trivial field selection without any arguments or directives.
-        pub fn from_position(
-            schema: &ValidFederationSchema,
-            field_position: FieldDefinitionPosition,
-        ) -> Self {
-            Self {
-                schema: schema.clone(),
-                field_position,
-                alias: None,
-                arguments: Default::default(),
-                directives: Default::default(),
-                sibling_typename: None,
-            }
-        }
-
         pub(crate) fn name(&self) -> &Name {
             self.field_position.field_name()
         }
@@ -1865,7 +1799,6 @@ impl SelectionSet {
         }
     }
 
-    /// Build a selection set from a single selection.
     pub(crate) fn from_selection(
         type_position: CompositeTypeDefinitionPosition,
         selection: Selection,
@@ -1877,20 +1810,6 @@ impl SelectionSet {
             schema,
             type_position,
             selections: Arc::new(selection_map),
-        }
-    }
-
-    /// Build a selection set from the given selections. This does **not** handle merging of
-    /// selections with the same keys!
-    pub(crate) fn from_raw_selections<S: Into<Selection>>(
-        schema: ValidFederationSchema,
-        type_position: CompositeTypeDefinitionPosition,
-        selections: impl IntoIterator<Item = S>,
-    ) -> Self {
-        Self {
-            schema,
-            type_position,
-            selections: Arc::new(selections.into_iter().collect()),
         }
     }
 
@@ -5022,7 +4941,6 @@ mod tests {
     use super::normalize_operation;
     use super::Containment;
     use super::ContainmentOptions;
-    use super::Field;
     use super::Name;
     use super::NamedFragments;
     use super::Operation;
@@ -5030,7 +4948,6 @@ mod tests {
     use super::SelectionKey;
     use super::SelectionSet;
     use crate::schema::position::InterfaceTypeDefinitionPosition;
-    use crate::schema::position::ObjectTypeDefinitionPosition;
     use crate::schema::ValidFederationSchema;
     use crate::subgraph::Subgraph;
 
@@ -7131,71 +7048,5 @@ type T {
             get_value_at_path(&result, &[name!("foo"), name!("__typename")])
                 .expect("foo.__typename should exist");
         }
-    }
-
-    #[test]
-    fn make_selection_ordering() {
-        let schema = apollo_compiler::Schema::parse_and_validate(
-            r#"
-        interface Intf {
-            intfField: Int
-        }
-        type HasA implements Intf {
-            a: Boolean
-            intfField: Int
-        }
-        type Nested {
-            a: Int
-            b: Int
-            c: Int
-        }
-        type Query {
-            object: Nested
-            intf: Intf
-        }
-        "#,
-            "schema.graphql",
-        )
-        .unwrap();
-        let schema = ValidFederationSchema::new(schema).unwrap();
-        let position = ObjectTypeDefinitionPosition::new(name!("Query")).into();
-        let nested = ObjectTypeDefinitionPosition::new(name!("Nested"));
-
-        let selection = SelectionSet::make_selection(
-            &schema,
-            &position,
-            [
-                Selection::from_normalized_field(
-                    Field::from_position(&schema, position.field(name!("object")).unwrap()),
-                    Some(SelectionSet::from_raw_selections(
-                        schema.clone(),
-                        position.clone(),
-                        [
-                            Field::from_position(&schema, nested.field(name!("c")).into())
-                                .with_subselection(None),
-                            Field::from_position(&schema, nested.field(name!("a")).into())
-                                .with_subselection(None),
-                        ],
-                    )),
-                ),
-                Selection::from_normalized_field(
-                    Field::from_position(&schema, position.field(name!("object")).unwrap()),
-                    Some(SelectionSet::from_raw_selections(
-                        schema.clone(),
-                        position.clone(),
-                        [
-                            Field::from_position(&schema, nested.field(name!("b")).into())
-                                .with_subselection(None),
-                            Field::from_position(&schema, nested.field(name!("a")).into())
-                                .with_subselection(None),
-                        ],
-                    )),
-                ),
-            ]
-            .iter(),
-        )
-        .unwrap();
-
-        insta::assert_snapshot!(selection, @"object { c a b }");
     }
 }

--- a/apollo-federation/src/query_plan/operation.rs
+++ b/apollo-federation/src/query_plan/operation.rs
@@ -1741,9 +1741,9 @@ impl Operation {
 
 /// A simple MultiMap implementation using IndexMap with Vec<V> as its value type.
 /// - Preserves the insertion order of keys and values.
-struct MultiMap<K, V>(IndexMap<K, Vec<V>>);
+struct MultiIndexMap<K, V>(IndexMap<K, Vec<V>>);
 
-impl<K, V> Deref for MultiMap<K, V> {
+impl<K, V> Deref for MultiIndexMap<K, V> {
     type Target = IndexMap<K, Vec<V>>;
 
     fn deref(&self) -> &Self::Target {
@@ -1751,7 +1751,7 @@ impl<K, V> Deref for MultiMap<K, V> {
     }
 }
 
-impl<K, V> MultiMap<K, V>
+impl<K, V> MultiIndexMap<K, V>
 where
     K: Eq + Hash,
 {
@@ -2351,7 +2351,8 @@ impl SelectionSet {
         };
 
         // This case has a sub-selection. Merge all sub-selection updates.
-        let mut sub_selection_updates: MultiMap<SelectionKey, Selection> = MultiMap::new();
+        let mut sub_selection_updates: MultiIndexMap<SelectionKey, Selection> =
+            MultiIndexMap::new();
         for selection in [first, second].into_iter().chain(iter) {
             if let Some(sub_selection_set) = selection.selection_set()? {
                 sub_selection_updates.extend(
@@ -2424,7 +2425,7 @@ impl SelectionSet {
         let first_changed = first_changed?;
         // Copy the first half of the selections until the `index`-th item, since they are not
         // changed.
-        let mut updated_selections = MultiMap::new();
+        let mut updated_selections = MultiIndexMap::new();
         updated_selections.extend(
             self.selections
                 .iter()

--- a/apollo-federation/src/query_plan/operation.rs
+++ b/apollo-federation/src/query_plan/operation.rs
@@ -2380,7 +2380,7 @@ impl SelectionSet {
         selection_key_groups: impl Iterator<Item = impl Iterator<Item = &'a Selection>>,
     ) -> Result<SelectionSet, FederationError> {
         let mut result = SelectionMap::new();
-        for group in selection_key_groups.into_iter() {
+        for group in selection_key_groups {
             let selection = Self::make_selection(schema, parent_type, group)?;
             result.insert(selection);
         }
@@ -2485,7 +2485,7 @@ impl SelectionSet {
             });
             let typename_selection =
                 Selection::from_element(field_element.into(), /*subselection*/ None)?;
-            Ok([updated, typename_selection].into_iter().collect())
+            Ok([typename_selection, updated].into_iter().collect())
         })
     }
 


### PR DESCRIPTION
- Also, changed its return type to Result<Selection, ...>, instead of
  Result<Optional<Selection, ...>>

Related: https://github.com/apollographql/router/pull/5082

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests
