### PR TITLE
chore(federation): add and use some more ergonomic operation types constructors

### DIFF
--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2430,7 +2430,7 @@ fn wrap_input_selections(
                }
             */
             let parent_type_position = fragment.data().parent_type_position.clone();
-            let selection = Selection::from_normalized_inline_fragment(fragment, sub_selections);
+            let selection = Selection::from_inline_fragment(fragment, sub_selections);
             SelectionSet::from_selection(parent_type_position, selection)
         },
     )

--- a/apollo-federation/src/query_plan/operation.rs
+++ b/apollo-federation/src/query_plan/operation.rs
@@ -2615,8 +2615,8 @@ impl SelectionSet {
             })
             .collect::<Result<Vec<_>, _>>()?;
         Ok(SelectionSet::from_raw_selections(
-            self.schema.clone(),
-            self.type_position.clone(),
+            schema.clone(),
+            parent_type.clone(),
             rebased_results,
         ))
     }


### PR DESCRIPTION
Over time we added some shorthand constructors for operation types, but we also still constructed many things manually. This PR uses some of the existing constructors instead of writing out the whole struct, and adds several more.

In particular I think the spots that had a lot of `)))})` nesting are now easier to read.

The constructors on `Selection` types are also aimed towards usage in tests.

This is a bit of a weird PR since it doesn't have a clear end goal but I already made these changes on another branch to write a test that turned out to be unnecessary. It will also help with tests in https://github.com/apollographql/router/pull/5119.