### PR TITLE
fix(federation): fix initial indentation in printed query plans

### DIFF
--- a/apollo-federation/src/query_plan/display.rs
+++ b/apollo-federation/src/query_plan/display.rs
@@ -340,9 +340,16 @@ fn write_selections(
         }
     }
     state.write("{")?;
-    write_indented_lines(state, selections, |state, sel| {
-        state.write(sel.serialize().initial_indent_level(state.indent_level()))
-    })?;
+
+    // Manually indent and write the newline
+    // to prevent a duplicate indent from `.new_line()` and `.initial_indent_level()`.
+    state.indent_no_new_line();
+    state.write("\n")?;
+    for sel in selections {
+        state.write(sel.serialize().initial_indent_level(state.indent_level()))?;
+    }
+    state.dedent()?;
+
     state.write("}")
 }
 

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -749,7 +749,7 @@ type User
         QueryPlan {
           Fetch(service: "accounts") {
             {
-                    userById(id: 1) {
+              userById(id: 1) {
                 name
                 email
               }
@@ -806,7 +806,7 @@ type User
         QueryPlan {
           Fetch(service: "A") {
             {
-                    a {
+              a {
                 b {
                   x
                   y


### PR DESCRIPTION
`.new_line()` and `.initial_indent_level()` both add indentation to the first line of each selection. This patch special-cases selection set printing so it only uses `.initial_indent_level()` to print indentation.
