### PR TITLE
connect: add `Connector` to query graph

### DIFF
--- a/apollo-federation/src/sources/connect/federated_query_graph/mod.rs
+++ b/apollo-federation/src/sources/connect/federated_query_graph/mod.rs
@@ -10,13 +10,12 @@ use crate::sources::connect::json_selection::JSONSelection;
 use crate::sources::connect::json_selection::Key;
 use crate::sources::connect::json_selection::PathSelection;
 use crate::sources::connect::json_selection::SubSelection;
+use crate::sources::connect::models;
+use crate::sources::connect::ConnectId;
 use crate::sources::source;
 use crate::sources::source::federated_query_graph::FederatedQueryGraphApi;
 use crate::sources::source::SourceId;
 use crate::ValidFederationSubgraph;
-
-use super::models;
-use super::ConnectId;
 
 pub(crate) mod builder;
 

--- a/apollo-federation/src/sources/connect/federated_query_graph/mod.rs
+++ b/apollo-federation/src/sources/connect/federated_query_graph/mod.rs
@@ -15,11 +15,15 @@ use crate::sources::source::federated_query_graph::FederatedQueryGraphApi;
 use crate::sources::source::SourceId;
 use crate::ValidFederationSubgraph;
 
+use super::models;
+use super::ConnectId;
+
 pub(crate) mod builder;
 
 #[derive(Debug)]
 pub(crate) struct FederatedQueryGraph {
     subgraphs_by_name: IndexMap<NodeStr, ValidFederationSubgraph>,
+    source_data: IndexMap<ConnectId, models::Connector>,
     // source_directives_by_name: IndexMap<NodeStr, SourceDirectiveArguments>,
     // connect_directives_by_source: IndexMap<ConnectId, ConnectDirectiveArguments>,
 }

--- a/apollo-federation/src/sources/connect/federated_query_graph/snapshots/apollo_federation__sources__connect__federated_query_graph__builder__tests__it_handles_a_cyclical_schema.snap
+++ b/apollo-federation/src/sources/connect/federated_query_graph/snapshots/apollo_federation__sources__connect__federated_query_graph__builder__tests__it_handles_a_cyclical_schema.snap
@@ -1,0 +1,174 @@
+---
+source: apollo-federation/src/sources/connect/federated_query_graph/builder.rs
+expression: connectors.source_data.values()
+---
+[
+    Connector {
+        id: ConnectId {
+            label: "connectors.json http: Get /users/1",
+            subgraph_name: "connectors",
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.me),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJson(
+            HttpJsonTransport {
+                base_url: "https://jsonplaceholder.typicode.com/",
+                path_template: URLPathTemplate {
+                    path: [
+                        ParameterValue {
+                            parts: [
+                                Text(
+                                    "users",
+                                ),
+                            ],
+                        },
+                        ParameterValue {
+                            parts: [
+                                Text(
+                                    "1",
+                                ),
+                            ],
+                        },
+                    ],
+                    query: {},
+                },
+                method: Get,
+                headers: {
+                    "X-Auth-Token": Some(
+                        As(
+                            "AuthToken",
+                        ),
+                    ),
+                    "user-agent": Some(
+                        Value(
+                            [
+                                "Firefox",
+                            ],
+                        ),
+                    ),
+                    "X-From-Env": None,
+                },
+                body: None,
+            },
+        ),
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "name",
+                        None,
+                    ),
+                    Group(
+                        Alias {
+                            name: "friends",
+                        },
+                        SubSelection {
+                            selections: [
+                                Field(
+                                    None,
+                                    "id",
+                                    None,
+                                ),
+                            ],
+                            star: None,
+                        },
+                    ),
+                ],
+                star: None,
+            },
+        ),
+    },
+    Connector {
+        id: ConnectId {
+            label: "connectors.json http: Get /users/1",
+            subgraph_name: "connectors",
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.user),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJson(
+            HttpJsonTransport {
+                base_url: "https://jsonplaceholder.typicode.com/",
+                path_template: URLPathTemplate {
+                    path: [
+                        ParameterValue {
+                            parts: [
+                                Text(
+                                    "users",
+                                ),
+                            ],
+                        },
+                        ParameterValue {
+                            parts: [
+                                Text(
+                                    "1",
+                                ),
+                            ],
+                        },
+                    ],
+                    query: {},
+                },
+                method: Get,
+                headers: {
+                    "X-Auth-Token": Some(
+                        As(
+                            "AuthToken",
+                        ),
+                    ),
+                    "user-agent": Some(
+                        Value(
+                            [
+                                "Firefox",
+                            ],
+                        ),
+                    ),
+                    "X-From-Env": None,
+                },
+                body: None,
+            },
+        ),
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "name",
+                        None,
+                    ),
+                    Group(
+                        Alias {
+                            name: "friends",
+                        },
+                        SubSelection {
+                            selections: [
+                                Field(
+                                    None,
+                                    "id",
+                                    None,
+                                ),
+                            ],
+                            star: None,
+                        },
+                    ),
+                ],
+                star: None,
+            },
+        ),
+    },
+]

--- a/apollo-federation/src/sources/connect/federated_query_graph/snapshots/apollo_federation__sources__connect__federated_query_graph__builder__tests__it_handles_a_nested_schema.snap
+++ b/apollo-federation/src/sources/connect/federated_query_graph/snapshots/apollo_federation__sources__connect__federated_query_graph__builder__tests__it_handles_a_nested_schema.snap
@@ -1,0 +1,151 @@
+---
+source: apollo-federation/src/sources/connect/federated_query_graph/builder.rs
+expression: connectors.source_data.values()
+---
+[
+    Connector {
+        id: ConnectId {
+            label: "connectors.json http: Get /users",
+            subgraph_name: "connectors",
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.user),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJson(
+            HttpJsonTransport {
+                base_url: "https://jsonplaceholder.typicode.com/",
+                path_template: URLPathTemplate {
+                    path: [
+                        ParameterValue {
+                            parts: [
+                                Text(
+                                    "users",
+                                ),
+                            ],
+                        },
+                    ],
+                    query: {},
+                },
+                method: Get,
+                headers: {
+                    "X-Auth-Token": Some(
+                        As(
+                            "AuthToken",
+                        ),
+                    ),
+                    "user-agent": Some(
+                        Value(
+                            [
+                                "Firefox",
+                            ],
+                        ),
+                    ),
+                    "X-From-Env": None,
+                },
+                body: None,
+            },
+        ),
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        Some(
+                            Alias {
+                                name: "info",
+                            },
+                        ),
+                        "user_info",
+                        Some(
+                            SubSelection {
+                                selections: [
+                                    Quoted(
+                                        Alias {
+                                            name: "name",
+                                        },
+                                        "user full name",
+                                        None,
+                                    ),
+                                    Path(
+                                        Alias {
+                                            name: "address",
+                                        },
+                                        Key(
+                                            Field(
+                                                "addresses",
+                                            ),
+                                            Key(
+                                                Field(
+                                                    "main",
+                                                ),
+                                                Key(
+                                                    Field(
+                                                        "address",
+                                                    ),
+                                                    Selection(
+                                                        SubSelection {
+                                                            selections: [
+                                                                Field(
+                                                                    Some(
+                                                                        Alias {
+                                                                            name: "street",
+                                                                        },
+                                                                    ),
+                                                                    "street_line",
+                                                                    None,
+                                                                ),
+                                                                Field(
+                                                                    None,
+                                                                    "state",
+                                                                    None,
+                                                                ),
+                                                                Field(
+                                                                    None,
+                                                                    "zip",
+                                                                    None,
+                                                                ),
+                                                            ],
+                                                            star: None,
+                                                        },
+                                                    ),
+                                                ),
+                                            ),
+                                        ),
+                                    ),
+                                    Group(
+                                        Alias {
+                                            name: "avatar",
+                                        },
+                                        SubSelection {
+                                            selections: [
+                                                Field(
+                                                    None,
+                                                    "large",
+                                                    None,
+                                                ),
+                                                Field(
+                                                    None,
+                                                    "thumbnail",
+                                                    None,
+                                                ),
+                                            ],
+                                            star: None,
+                                        },
+                                    ),
+                                ],
+                                star: None,
+                            },
+                        ),
+                    ),
+                ],
+                star: None,
+            },
+        ),
+    },
+]

--- a/apollo-federation/src/sources/connect/federated_query_graph/snapshots/apollo_federation__sources__connect__federated_query_graph__builder__tests__it_handles_a_simple_schema.snap
+++ b/apollo-federation/src/sources/connect/federated_query_graph/snapshots/apollo_federation__sources__connect__federated_query_graph__builder__tests__it_handles_a_simple_schema.snap
@@ -1,0 +1,135 @@
+---
+source: apollo-federation/src/sources/connect/federated_query_graph/builder.rs
+expression: connectors.source_data.values()
+---
+[
+    Connector {
+        id: ConnectId {
+            label: "connectors.json http: Get /users",
+            subgraph_name: "connectors",
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.users),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJson(
+            HttpJsonTransport {
+                base_url: "https://jsonplaceholder.typicode.com/",
+                path_template: URLPathTemplate {
+                    path: [
+                        ParameterValue {
+                            parts: [
+                                Text(
+                                    "users",
+                                ),
+                            ],
+                        },
+                    ],
+                    query: {},
+                },
+                method: Get,
+                headers: {
+                    "X-Auth-Token": Some(
+                        As(
+                            "AuthToken",
+                        ),
+                    ),
+                    "user-agent": Some(
+                        Value(
+                            [
+                                "Firefox",
+                            ],
+                        ),
+                    ),
+                    "X-From-Env": None,
+                },
+                body: None,
+            },
+        ),
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "name",
+                        None,
+                    ),
+                ],
+                star: None,
+            },
+        ),
+    },
+    Connector {
+        id: ConnectId {
+            label: "connectors.json http: Get /posts",
+            subgraph_name: "connectors",
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.posts),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJson(
+            HttpJsonTransport {
+                base_url: "https://jsonplaceholder.typicode.com/",
+                path_template: URLPathTemplate {
+                    path: [
+                        ParameterValue {
+                            parts: [
+                                Text(
+                                    "posts",
+                                ),
+                            ],
+                        },
+                    ],
+                    query: {},
+                },
+                method: Get,
+                headers: {
+                    "X-Auth-Token": Some(
+                        As(
+                            "AuthToken",
+                        ),
+                    ),
+                    "user-agent": Some(
+                        Value(
+                            [
+                                "Firefox",
+                            ],
+                        ),
+                    ),
+                    "X-From-Env": None,
+                },
+                body: None,
+            },
+        ),
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "title",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "body",
+                        None,
+                    ),
+                ],
+                star: None,
+            },
+        ),
+    },
+]

--- a/apollo-federation/src/sources/connect/federated_query_graph/snapshots/apollo_federation__sources__connect__federated_query_graph__builder__tests__it_handles_an_aliased_schema.snap
+++ b/apollo-federation/src/sources/connect/federated_query_graph/snapshots/apollo_federation__sources__connect__federated_query_graph__builder__tests__it_handles_an_aliased_schema.snap
@@ -1,0 +1,145 @@
+---
+source: apollo-federation/src/sources/connect/federated_query_graph/builder.rs
+expression: connectors.source_data.values()
+---
+[
+    Connector {
+        id: ConnectId {
+            label: "connectors.json http: Get /users",
+            subgraph_name: "connectors",
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.users),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJson(
+            HttpJsonTransport {
+                base_url: "https://jsonplaceholder.typicode.com/",
+                path_template: URLPathTemplate {
+                    path: [
+                        ParameterValue {
+                            parts: [
+                                Text(
+                                    "users",
+                                ),
+                            ],
+                        },
+                    ],
+                    query: {},
+                },
+                method: Get,
+                headers: {
+                    "X-Auth-Token": Some(
+                        As(
+                            "AuthToken",
+                        ),
+                    ),
+                    "user-agent": Some(
+                        Value(
+                            [
+                                "Firefox",
+                            ],
+                        ),
+                    ),
+                    "X-From-Env": None,
+                },
+                body: None,
+            },
+        ),
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        Some(
+                            Alias {
+                                name: "name",
+                            },
+                        ),
+                        "username",
+                        None,
+                    ),
+                ],
+                star: None,
+            },
+        ),
+    },
+    Connector {
+        id: ConnectId {
+            label: "connectors.json http: Get /posts",
+            subgraph_name: "connectors",
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.posts),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJson(
+            HttpJsonTransport {
+                base_url: "https://jsonplaceholder.typicode.com/",
+                path_template: URLPathTemplate {
+                    path: [
+                        ParameterValue {
+                            parts: [
+                                Text(
+                                    "posts",
+                                ),
+                            ],
+                        },
+                    ],
+                    query: {},
+                },
+                method: Get,
+                headers: {
+                    "X-Auth-Token": Some(
+                        As(
+                            "AuthToken",
+                        ),
+                    ),
+                    "user-agent": Some(
+                        Value(
+                            [
+                                "Firefox",
+                            ],
+                        ),
+                    ),
+                    "X-From-Env": None,
+                },
+                body: None,
+            },
+        ),
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Quoted(
+                        Alias {
+                            name: "title",
+                        },
+                        "body title",
+                        None,
+                    ),
+                    Field(
+                        Some(
+                            Alias {
+                                name: "body",
+                            },
+                        ),
+                        "summary",
+                        None,
+                    ),
+                ],
+                star: None,
+            },
+        ),
+    },
+]

--- a/apollo-federation/src/sources/connect/models/mod.rs
+++ b/apollo-federation/src/sources/connect/models/mod.rs
@@ -19,14 +19,14 @@ use crate::sources::connect::ConnectSpecDefinition;
 
 // --- Connector ---------------------------------------------------------------
 
-#[cfg_attr(test, derive(Debug))]
+#[derive(Debug, Clone)]
 pub(crate) struct Connector {
     pub(crate) id: ConnectId,
     transport: Transport,
     pub(crate) selection: JSONSelection,
 }
 
-#[cfg_attr(test, derive(Debug))]
+#[derive(Debug, Clone)]
 enum Transport {
     HttpJson(HttpJsonTransport),
 }
@@ -103,7 +103,7 @@ fn make_label(subgraph_name: &NodeStr, source: Option<NodeStr>, transport: &Tran
 
 // --- HTTP JSON ---------------------------------------------------------------
 
-#[cfg_attr(test, derive(Debug))]
+#[derive(Debug, Clone)]
 struct HttpJsonTransport {
     base_url: NodeStr,
     path_template: URLPathTemplate,
@@ -159,8 +159,7 @@ impl HttpJsonTransport {
 }
 
 /// The HTTP arguments needed for a connect request
-#[cfg_attr(test, derive(Debug))]
-#[derive(strum_macros::Display)]
+#[derive(Debug, Clone, strum_macros::Display)]
 pub(crate) enum HTTPMethod {
     Get,
     Post,

--- a/apollo-federation/src/sources/connect/spec/schema.rs
+++ b/apollo-federation/src/sources/connect/spec/schema.rs
@@ -61,8 +61,7 @@ pub(crate) struct SourceHTTPArguments {
 pub(crate) struct HTTPHeaderMappings(pub(crate) IndexMap<NodeStr, Option<HTTPHeaderOption>>);
 
 /// Configuration option for an HTTP header
-#[cfg_attr(test, derive(Debug))]
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(crate) enum HTTPHeaderOption {
     /// The alias for the header name used when making a request
     ///


### PR DESCRIPTION
This commit adds parsed `@connect` directives (modeled as `Connector`) to the query graph for connect-specific graphs. This should make it so that later execution can use the already parsed directive information when constructing requests.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
