### PR TITLE
Move path tree child fields that are on the node to the path tree itself

### DIFF
--- a/apollo-federation/src/source_aware/federated_query_graph/graph_path.rs
+++ b/apollo-federation/src/source_aware/federated_query_graph/graph_path.rs
@@ -28,9 +28,9 @@ pub(crate) struct Edge {
     operation_element: Option<Arc<OperationPathElement>>,
     edge: Option<EdgeIndex>,
     self_condition_resolutions_for_edge: IndexMap<SelfConditionIndex, ConditionResolutionId>,
-    source_entering_condition_resolutions_at_edge:
+    source_entering_condition_resolutions_at_head:
         IndexMap<SelfConditionIndex, ConditionResolutionInfo>,
-    condition_resolutions_at_edge: IndexMap<SelfConditionIndex, ConditionResolutionInfo>,
+    condition_resolutions_at_head: IndexMap<SelfConditionIndex, ConditionResolutionInfo>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, derive_more::From)]

--- a/apollo-federation/src/source_aware/federated_query_graph/path_tree.rs
+++ b/apollo-federation/src/source_aware/federated_query_graph/path_tree.rs
@@ -14,6 +14,9 @@ use crate::source_aware::federated_query_graph::SelfConditionIndex;
 pub(crate) struct FederatedPathTree {
     graph: Arc<FederatedQueryGraph>,
     node: NodeIndex,
+    source_entering_condition_resolutions_at_node:
+        IndexMap<SelfConditionIndex, ConditionResolutionInfo>,
+    condition_resolutions_at_node: IndexMap<SelfConditionIndex, ConditionResolutionInfo>,
     childs: Vec<Arc<Child>>,
 }
 
@@ -21,9 +24,6 @@ pub(crate) struct FederatedPathTree {
 pub(crate) struct Child {
     key: ChildKey,
     self_condition_resolutions_for_edge: IndexMap<SelfConditionIndex, ConditionResolutionId>,
-    source_entering_condition_resolutions_at_edge:
-        IndexMap<SelfConditionIndex, ConditionResolutionInfo>,
-    condition_resolutions_at_edge: IndexMap<SelfConditionIndex, ConditionResolutionInfo>,
     tree: Arc<FederatedPathTree>,
 }
 


### PR DESCRIPTION
<!-- FED-194 -->
<!-- FED-197 -->

Condition resolution really occurs on the edge's head, and not the edge. `FederatedGraphPath`s don't really make this distinction, and accordingly data for an edge and data for an edge's head are at the same "index". However, `FederatedPathTree`s do make this distinction, separating edge-specific data into `Child`. This PR moves data at the edge's head currently in `Child` upward to the `FederatedPathTree`.