### PR TITLE
chore(federation): Un-arc SelectionMap 

### DIFF
--- a/apollo-federation/src/query_plan/conditions.rs
+++ b/apollo-federation/src/query_plan/conditions.rs
@@ -234,7 +234,7 @@ pub(crate) fn remove_conditions_from_selection_set(
             Ok(SelectionSet {
                 schema: selection_set.schema.clone(),
                 type_position: selection_set.type_position.clone(),
-                selections: Arc::new(selection_map),
+                selections: selection_map,
             })
         }
     }

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -1499,13 +1499,13 @@ fn operation_for_entities_fetch(
         .get_type(query_type_name.clone())?
         .try_into()?;
 
-    let mut map = SelectionMap::new();
-    map.insert(entities_call);
+    let mut selections = SelectionMap::new();
+    selections.insert(entities_call);
 
     let selection_set = SelectionSet {
         schema: subgraph_schema.clone(),
         type_position,
-        selections: Arc::new(map),
+        selections,
     };
 
     Ok(Operation {
@@ -1669,7 +1669,7 @@ impl FetchInputs {
         Ok(SelectionSet {
             schema: self.supergraph_schema.clone(),
             type_position: type_position.clone(),
-            selections: Arc::new(selections),
+            selections,
         })
     }
 }

--- a/apollo-federation/src/query_plan/operation.rs
+++ b/apollo-federation/src/query_plan/operation.rs
@@ -439,6 +439,15 @@ pub(crate) mod normalized_selection_map {
         fn((&'a SelectionKey, &'a mut Selection)) -> (&'a SelectionKey, SelectionValue<'a>),
     >;
 
+    impl<'a> IntoIterator for &'a mut SelectionMap {
+        type Item = <IterMut<'a> as Iterator>::Item;
+        type IntoIter = IterMut<'a>;
+
+        fn into_iter(self) -> Self::IntoIter {
+            self.iter_mut()
+        }
+    }
+
     /// A mutable reference to a `Selection` value in a `SelectionMap`, which
     /// also disallows changing key-related data (to maintain the invariant that a value's key is
     /// the same as it's map entry's key).
@@ -2161,7 +2170,7 @@ impl SelectionSet {
             }
         }
 
-        for (key, self_selection) in self.selections.iter_mut() {
+        for (key, self_selection) in &mut self.selections {
             match self_selection {
                 SelectionValue::Field(mut self_field_selection) => {
                     if let Some(other_field_selections) = fields.shift_remove(key) {
@@ -2298,7 +2307,7 @@ impl SelectionSet {
         let mut typename_field_key: Option<SelectionKey> = None;
         let mut sibling_field_key: Option<SelectionKey> = None;
 
-        for (key, entry) in self.selections.iter_mut() {
+        for (key, entry) in &mut self.selections {
             match entry {
                 SelectionValue::Field(mut field_selection) => {
                     if field_selection.get().field.data().name() == &TYPENAME_FIELD


### PR DESCRIPTION
SelectionMap is not used as a standalone type independent of
SelectionSet. Keeping it in an Arc makes SelectionSet methods harder to
implement, and doesn't save any cloning that I can find. It doesn't really
make sense, I think, to have the selection *map* in particular be shared
between different selection *sets*.

Where cloning and structural sharing is important, `Arc<SelectionSet>`
should be used instead.