### PR TITLE
[JSONSelection] Fix precedence of parsing `NamedPathSelection` within `NamedSelection` rule

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/README.md
+++ b/apollo-federation/src/sources/connect/json_selection/README.md
@@ -490,6 +490,8 @@ id name friends: friend_ids { id: $ }
 
 Because `friend_ids` is an array, the `{ id: $ }` selection maps over each
 element of the array, with `$` taking on the value of each scalar ID in turn.
+See [the FAQ](#what-about-arrays) for more discussion of this array-handling
+behavior.
 
 The `$` variable is also essential for disambiguating a `KeyPath` consisting of
 only one key from a `NamedFieldSelection` with no `Alias`. For example,
@@ -655,11 +657,11 @@ Analogous to a JSON primitive value, with the only differences being that
 
 A numeric literal that is possibly negative and may contain a fractional
 component. The integer component is required unless a fractional component is
-present, and the fractional component can have zero digits when there the
-integer component is present (as in `-123.`), but the fractional component must
-have at least one digit when there is no integer component, since `.` is not a
-valid numeric literal by itself. Leading and trailing zeroes are essential for
-the fractional component, but leading zeroes are disallowed for the integer
+present, and the fractional component can have zero digits when the integer
+component is present (as in `-123.`), but the fractional component must have at
+least one digit when there is no integer component, since `.` is not a valid
+numeric literal by itself. Leading and trailing zeroes are essential for the
+fractional component, but leading zeroes are disallowed for the integer
 component, except when the integer component is exactly zero.
 
 ### `UnsignedInt ::=`

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -737,9 +737,8 @@ mod tests {
             )),
         );
 
-        assert_eq!(
-            selection!("hi: .hello.world"),
-            JSONSelection::Named(SubSelection {
+        {
+            let expected = JSONSelection::Named(SubSelection {
                 selections: vec![NamedSelection::Path(
                     Alias {
                         name: "hi".to_string(),
@@ -749,16 +748,24 @@ mod tests {
                             Key::Field("hello".to_string()),
                             Key::Field("world".to_string()),
                         ],
-                        None
+                        None,
                     ),
                 )],
                 star: None,
-            }),
-        );
+            });
 
-        assert_eq!(
-            selection!("before hi: .hello.world after"),
-            JSONSelection::Named(SubSelection {
+            assert_eq!(selection!("hi: .hello.world"), expected);
+            assert_eq!(selection!("hi: .hello .world"), expected);
+            assert_eq!(selection!("hi: . hello. world"), expected);
+            assert_eq!(selection!("hi: .hello . world"), expected);
+            assert_eq!(selection!("hi: hello.world"), expected);
+            assert_eq!(selection!("hi: hello. world"), expected);
+            assert_eq!(selection!("hi: hello .world"), expected);
+            assert_eq!(selection!("hi: hello . world"), expected);
+        }
+
+        {
+            let expected = JSONSelection::Named(SubSelection {
                 selections: vec![
                     NamedSelection::Field(None, "before".to_string(), None),
                     NamedSelection::Path(
@@ -770,50 +777,72 @@ mod tests {
                                 Key::Field("hello".to_string()),
                                 Key::Field("world".to_string()),
                             ],
-                            None
+                            None,
                         ),
                     ),
                     NamedSelection::Field(None, "after".to_string(), None),
                 ],
                 star: None,
-            }),
-        );
+            });
 
-        let before_path_nested_after_result = JSONSelection::Named(SubSelection {
-            selections: vec![
-                NamedSelection::Field(None, "before".to_string(), None),
-                NamedSelection::Path(
-                    Alias {
-                        name: "hi".to_string(),
-                    },
-                    PathSelection::from_slice(
-                        &[
-                            Key::Field("hello".to_string()),
-                            Key::Field("world".to_string()),
-                        ],
-                        Some(SubSelection {
-                            selections: vec![
-                                NamedSelection::Field(None, "nested".to_string(), None),
-                                NamedSelection::Field(None, "names".to_string(), None),
+            assert_eq!(selection!("before hi: .hello.world after"), expected);
+            assert_eq!(selection!("before hi: .hello .world after"), expected);
+            assert_eq!(selection!("before hi: .hello. world after"), expected);
+            assert_eq!(selection!("before hi: .hello . world after"), expected);
+            assert_eq!(selection!("before hi: . hello.world after"), expected);
+            assert_eq!(selection!("before hi: . hello .world after"), expected);
+            assert_eq!(selection!("before hi: . hello. world after"), expected);
+            assert_eq!(selection!("before hi: . hello . world after"), expected);
+            assert_eq!(selection!("before hi: hello.world after"), expected);
+            assert_eq!(selection!("before hi: hello .world after"), expected);
+            assert_eq!(selection!("before hi: hello. world after"), expected);
+            assert_eq!(selection!("before hi: hello . world after"), expected);
+        }
+
+        {
+            let expected = JSONSelection::Named(SubSelection {
+                selections: vec![
+                    NamedSelection::Field(None, "before".to_string(), None),
+                    NamedSelection::Path(
+                        Alias {
+                            name: "hi".to_string(),
+                        },
+                        PathSelection::from_slice(
+                            &[
+                                Key::Field("hello".to_string()),
+                                Key::Field("world".to_string()),
                             ],
-                            star: None,
-                        }),
+                            Some(SubSelection {
+                                selections: vec![
+                                    NamedSelection::Field(None, "nested".to_string(), None),
+                                    NamedSelection::Field(None, "names".to_string(), None),
+                                ],
+                                star: None,
+                            }),
+                        ),
                     ),
-                ),
-                NamedSelection::Field(None, "after".to_string(), None),
-            ],
-            star: None,
-        });
+                    NamedSelection::Field(None, "after".to_string(), None),
+                ],
+                star: None,
+            });
 
-        assert_eq!(
-            selection!("before hi: .hello.world { nested names } after"),
-            before_path_nested_after_result,
-        );
-
-        assert_eq!(
-            selection!("before hi:.hello.world{nested names}after"),
-            before_path_nested_after_result,
-        );
+            assert_eq!(
+                selection!("before hi: .hello.world { nested names } after"),
+                expected
+            );
+            assert_eq!(
+                selection!("before hi:.hello.world{nested names}after"),
+                expected
+            );
+            assert_eq!(
+                selection!("before hi: hello.world { nested names } after"),
+                expected
+            );
+            assert_eq!(
+                selection!("before hi:hello.world{nested names}after"),
+                expected
+            );
+        }
 
         assert_eq!(
             selection!(
@@ -914,20 +943,26 @@ mod tests {
             PathSelection::from_slice(&[Key::Field("hello".to_string())], None),
         );
 
-        check_path_selection(
-            ".hello.world",
-            PathSelection::from_slice(
+        {
+            let expected = PathSelection::from_slice(
                 &[
                     Key::Field("hello".to_string()),
                     Key::Field("world".to_string()),
                 ],
                 None,
-            ),
-        );
+            );
+            check_path_selection(".hello.world", expected.clone());
+            check_path_selection(".hello .world", expected.clone());
+            check_path_selection(".hello. world", expected.clone());
+            check_path_selection(".hello . world", expected.clone());
+            check_path_selection("hello.world", expected.clone());
+            check_path_selection("hello .world", expected.clone());
+            check_path_selection("hello. world", expected.clone());
+            check_path_selection("hello . world", expected.clone());
+        }
 
-        check_path_selection(
-            ".hello.world { hello }",
-            PathSelection::from_slice(
+        {
+            let expected = PathSelection::from_slice(
                 &[
                     Key::Field("hello".to_string()),
                     Key::Field("world".to_string()),
@@ -936,12 +971,23 @@ mod tests {
                     selections: vec![NamedSelection::Field(None, "hello".to_string(), None)],
                     star: None,
                 }),
-            ),
-        );
+            );
+            check_path_selection(".hello.world { hello }", expected.clone());
+            check_path_selection(".hello .world { hello }", expected.clone());
+            check_path_selection(".hello. world { hello }", expected.clone());
+            check_path_selection(".hello . world { hello }", expected.clone());
+            check_path_selection(". hello.world { hello }", expected.clone());
+            check_path_selection(". hello .world { hello }", expected.clone());
+            check_path_selection(". hello. world { hello }", expected.clone());
+            check_path_selection(". hello . world { hello }", expected.clone());
+            check_path_selection("hello.world { hello }", expected.clone());
+            check_path_selection("hello .world { hello }", expected.clone());
+            check_path_selection("hello. world { hello }", expected.clone());
+            check_path_selection("hello . world { hello }", expected.clone());
+        }
 
-        check_path_selection(
-            ".nested.'string literal'.\"property\".name",
-            PathSelection::from_slice(
+        {
+            let expected = PathSelection::from_slice(
                 &[
                     Key::Field("nested".to_string()),
                     Key::Quoted("string literal".to_string()),
@@ -949,12 +995,35 @@ mod tests {
                     Key::Field("name".to_string()),
                 ],
                 None,
-            ),
-        );
+            );
+            check_path_selection(
+                ".nested.'string literal'.\"property\".name",
+                expected.clone(),
+            );
+            check_path_selection(
+                "nested.'string literal'.\"property\".name",
+                expected.clone(),
+            );
+            check_path_selection(
+                "nested. 'string literal'.\"property\".name",
+                expected.clone(),
+            );
+            check_path_selection(
+                "nested.'string literal'. \"property\".name",
+                expected.clone(),
+            );
+            check_path_selection(
+                "nested.'string literal'.\"property\" .name",
+                expected.clone(),
+            );
+            check_path_selection(
+                "nested.'string literal'.\"property\". name",
+                expected.clone(),
+            );
+        }
 
-        check_path_selection(
-            ".nested.'string literal' { leggo: 'my ego' }",
-            PathSelection::from_slice(
+        {
+            let expected = PathSelection::from_slice(
                 &[
                     Key::Field("nested".to_string()),
                     Key::Quoted("string literal".to_string()),
@@ -969,8 +1038,28 @@ mod tests {
                     )],
                     star: None,
                 }),
-            ),
-        );
+            );
+
+            check_path_selection(
+                ".nested.'string literal' { leggo: 'my ego' }",
+                expected.clone(),
+            );
+
+            check_path_selection(
+                "nested.'string literal' { leggo: 'my ego' }",
+                expected.clone(),
+            );
+
+            check_path_selection(
+                "nested. 'string literal' { leggo: 'my ego' }",
+                expected.clone(),
+            );
+
+            check_path_selection(
+                "nested . 'string literal' { leggo: 'my ego' }",
+                expected.clone(),
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Thanks to @lennyburdette's [playground](https://silver-palm-tree-app.vercel.app/), I quickly found a bug with the parsing of `NamedPathSelection`. This PR adds a number of regression tests and fixes the bug.

I updated the [`README.md`](https://github.com/apollographql/router/blob/1db31250ef73137f6ce84d24d33bf42442e12f7c/apollo-federation/src/sources/connect/json_selection/README.md#namedpathselection-) to emphasize the importance of parsing `NamedPathSelection` before `NamedFieldSelection` and `NamedQuotedSelection`, so just read those changes if you're curious why this solution makes sense for a parser like this one.