### PR TITLE
fix: return internal errors as structured error responses

### DIFF
--- a/.changesets/fix_bryn_internal_server_error.md
+++ b/.changesets/fix_bryn_internal_server_error.md
@@ -1,8 +1,6 @@
-### Internal server error handling change ([PR #5159](https://github.com/apollographql/router/pull/5159))
+### 5xx Internal server error responses are structured errors ([PR #5159](https://github.com/apollographql/router/pull/5159))
 
-When an http 500 is returned we should not return the details of the error to the client. 
-Instead, they are now logged at ERROR level.
+An internal server error (5xx class) which occurs as a result of an unexpected/unrecoverable disruption to the GraphQL request lifecycle execution (e.g., a coprocessor failure, etc.) will now result in a structured GraphQL error (i.e., `{"errors": [...]}`) being returned to the client rather than a plain-text error as was the case previously.
 
-In addition, the error is now returned as a graphql error rather than a plaintext error, giving a better experience in sandbox.
-
+When these circumstances occur, the underling error message — which may be any number of internal disruptions — will still be logged at an `ERROR` level to the router logs for the administrator of the router to monitor and use for debugging purposes.
 By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5159

--- a/.changesets/fix_bryn_internal_server_error.md
+++ b/.changesets/fix_bryn_internal_server_error.md
@@ -1,0 +1,8 @@
+### Internal server error handling change ([PR #5159](https://github.com/apollographql/router/pull/5159))
+
+When an http 500 is returned we should not return the details of the error to the client. 
+Instead, they are now logged at ERROR level.
+
+In addition, the error is now returned as a graphql error rather than a plaintext error, giving a better experience in sandbox.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5159

--- a/apollo-router/tests/integration/coprocessor.rs
+++ b/apollo-router/tests/integration/coprocessor.rs
@@ -1,0 +1,23 @@
+use insta::assert_yaml_snapshot;
+use tower::BoxError;
+
+use crate::integration::IntegrationTest;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_error_not_propagated_to_client() -> Result<(), BoxError> {
+    let mut router = IntegrationTest::builder()
+        .config(include_str!("fixtures/broken_coprocessor.router.yaml"))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    let (_trace_id, response) = router.execute_default_query().await;
+    assert_eq!(response.status(), 500);
+    assert_yaml_snapshot!(response.text().await?);
+    router.assert_log_contains("INTERNAL_SERVER_ERROR").await;
+    router.graceful_shutdown().await;
+
+    Ok(())
+}

--- a/apollo-router/tests/integration/fixtures/broken_coprocessor.router.yaml
+++ b/apollo-router/tests/integration/fixtures/broken_coprocessor.router.yaml
@@ -1,6 +1,6 @@
 # This coprocessor doesn't point to anything
 coprocessor:
-  url: "http://unreachable.example.com"
+  url: "http://unreachable.example"
   router:
     request:
       body: true

--- a/apollo-router/tests/integration/fixtures/broken_coprocessor.router.yaml
+++ b/apollo-router/tests/integration/fixtures/broken_coprocessor.router.yaml
@@ -1,0 +1,6 @@
+# This coprocessor doesn't point to anything
+coprocessor:
+  url: "http://localhost:10000"
+  router:
+    request:
+      body: true

--- a/apollo-router/tests/integration/fixtures/broken_coprocessor.router.yaml
+++ b/apollo-router/tests/integration/fixtures/broken_coprocessor.router.yaml
@@ -1,6 +1,6 @@
 # This coprocessor doesn't point to anything
 coprocessor:
-  url: "http://localhost:10000"
+  url: "http://unreachable.example.com"
   router:
     request:
       body: true

--- a/apollo-router/tests/integration/mod.rs
+++ b/apollo-router/tests/integration/mod.rs
@@ -3,6 +3,7 @@ mod batching;
 pub(crate) mod common;
 pub(crate) use common::IntegrationTest;
 
+mod coprocessor;
 mod docs;
 mod file_upload;
 mod lifecycle;

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__coprocessor__error_not_propagated_to_client.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__coprocessor__error_not_propagated_to_client.snap
@@ -1,0 +1,5 @@
+---
+source: apollo-router/tests/integration/coprocessor.rs
+expression: response.text().await?
+---
+"{\"errors\":[{\"message\":\"internal server error\",\"extensions\":{\"code\":\"INTERNAL_SERVER_ERROR\"}}]}"


### PR DESCRIPTION
When an http 500 is returned we should not return the details of the error to the client. 
Instead, they are now logged at ERROR level.

In addition, the error is now returned as a graphql error rather than a plaintext error. This gives a better experience in sandbox.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
