### PR TITLE
fix(telemetry): do not create custom events if level is off

### DIFF
--- a/.changesets/fix_bnjjj_fix_custom_events_off.md
+++ b/.changesets/fix_bnjjj_fix_custom_events_off.md
@@ -1,0 +1,26 @@
+### Do not create custom events in telemetry if level is off ([PR #5165](https://github.com/apollographql/router/pull/5165))
+
+Don't create custom events and attributes if you set the level to `off` 
+
+example of configuration:
+
+```yaml
+telemetry:
+  instrumentation:
+    events:
+      router:
+        # Standard events
+        request: info
+        response: info
+        error: info
+
+        # Custom events
+        my.disabled_request_event:
+          message: "my event message"
+          level: off # Disabled because we set the level to off
+          on: request
+          attributes:
+            http.request.body.size: true
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/5165

--- a/apollo-router/src/plugins/telemetry/config_new/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/events.rs
@@ -46,15 +46,18 @@ impl Events {
             .router
             .custom
             .iter()
-            .map(|(event_name, event_cfg)| CustomEvent {
-                inner: Mutex::new(CustomEventInner {
-                    name: event_name.clone(),
-                    level: event_cfg.level,
-                    event_on: event_cfg.on,
-                    message: event_cfg.message.clone(),
-                    selectors: event_cfg.attributes.clone().into(),
-                    condition: event_cfg.condition.clone(),
-                    attributes: Vec::new(),
+            .filter_map(|(event_name, event_cfg)| match &event_cfg.level {
+                EventLevel::Off => None,
+                _ => Some(CustomEvent {
+                    inner: Mutex::new(CustomEventInner {
+                        name: event_name.clone(),
+                        level: event_cfg.level,
+                        event_on: event_cfg.on,
+                        message: event_cfg.message.clone(),
+                        selectors: event_cfg.attributes.clone().into(),
+                        condition: event_cfg.condition.clone(),
+                        attributes: Vec::new(),
+                    }),
                 }),
             })
             .collect();
@@ -72,15 +75,18 @@ impl Events {
             .supergraph
             .custom
             .iter()
-            .map(|(event_name, event_cfg)| CustomEvent {
-                inner: Mutex::new(CustomEventInner {
-                    name: event_name.clone(),
-                    level: event_cfg.level,
-                    event_on: event_cfg.on,
-                    message: event_cfg.message.clone(),
-                    selectors: event_cfg.attributes.clone().into(),
-                    condition: event_cfg.condition.clone(),
-                    attributes: Vec::new(),
+            .filter_map(|(event_name, event_cfg)| match &event_cfg.level {
+                EventLevel::Off => None,
+                _ => Some(CustomEvent {
+                    inner: Mutex::new(CustomEventInner {
+                        name: event_name.clone(),
+                        level: event_cfg.level,
+                        event_on: event_cfg.on,
+                        message: event_cfg.message.clone(),
+                        selectors: event_cfg.attributes.clone().into(),
+                        condition: event_cfg.condition.clone(),
+                        attributes: Vec::new(),
+                    }),
                 }),
             })
             .collect();
@@ -98,15 +104,18 @@ impl Events {
             .subgraph
             .custom
             .iter()
-            .map(|(event_name, event_cfg)| CustomEvent {
-                inner: Mutex::new(CustomEventInner {
-                    name: event_name.clone(),
-                    level: event_cfg.level,
-                    event_on: event_cfg.on,
-                    message: event_cfg.message.clone(),
-                    selectors: event_cfg.attributes.clone().into(),
-                    condition: event_cfg.condition.clone(),
-                    attributes: Vec::new(),
+            .filter_map(|(event_name, event_cfg)| match &event_cfg.level {
+                EventLevel::Off => None,
+                _ => Some(CustomEvent {
+                    inner: Mutex::new(CustomEventInner {
+                        name: event_name.clone(),
+                        level: event_cfg.level,
+                        event_on: event_cfg.on,
+                        message: event_cfg.message.clone(),
+                        selectors: event_cfg.attributes.clone().into(),
+                        condition: event_cfg.condition.clone(),
+                        attributes: Vec::new(),
+                    }),
                 }),
             })
             .collect();

--- a/apollo-router/src/plugins/telemetry/testdata/custom_events.router.yaml
+++ b/apollo-router/src/plugins/telemetry/testdata/custom_events.router.yaml
@@ -11,6 +11,17 @@ telemetry:
         error: info
 
         # Custom events
+        my.disabled_request_event:
+          message: "my event message"
+          level: off
+          on: request
+          attributes:
+            http.request.body.size: true
+          # Only log when the x-log-request header is `log` 
+          condition:
+            eq:
+              - "log"
+              - request_header: "x-log-request"
         my.request_event:
           message: "my event message"
           level: info
@@ -40,6 +51,15 @@ telemetry:
         error: info
 
         # Custom events
+        my.disabled_request.event:
+          message: "my event message"
+          level: off
+          on: request
+          # Only log when the x-log-request header is `log` 
+          condition:
+            eq:
+              - "log"
+              - request_header: "x-log-request"
         my.request.event:
           message: "my event message"
           level: info
@@ -64,6 +84,10 @@ telemetry:
         error: error
 
         # Custom events
+        my.disabled_request.event:
+          message: "my event message"
+          level: off
+          on: request
         my.request.event:
           message: "my event message"
           level: info

--- a/docs/source/configuration/telemetry/instrumentation/events.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/events.mdx
@@ -114,7 +114,7 @@ telemetry:
 
 ### `level`
 
-Custom events have a level, `trace`, `debug`, `info`, `warn` or `error`. The level determines the severity of the event.
+Custom events have a level, `trace`, `debug`, `info`, `warn`, `error` or `off` (if you want to disable this event). The level determines the severity of the event.
 
 To set the level:
 ```yaml title="future.router.yaml"
@@ -122,7 +122,7 @@ telemetry:
   events:
     router:
       acme.event:
-        level: info # trace, debug, info, warn, error
+        level: info # trace, debug, info, warn, error, off
         # ...
 ```
 
@@ -204,8 +204,8 @@ telemetry:
 | Option             | Values                                                                       | Default | Description                                                 |
 |--------------------|------------------------------------------------------------------------------|---------|-------------------------------------------------------------|
 | `<attribute-name>` |                                                                              |         | The name of the custom attribute.                           |
-| `attributes`       | [standard attributes](./standard-attributes) or [selectors](./selectors) |         | The attributes of the custom log event.                     |
-| `condition`        | [conditions](./conditions)                                                 |         | The condition that must be met for the event to be emitted. |
+| `attributes`       | [standard attributes](./standard-attributes) or [selectors](./selectors)     |         | The attributes of the custom log event.                     |
+| `condition`        | [conditions](./conditions)                                                   |         | The condition that must be met for the event to be emitted. |
 | `error`            | `trace`\|`info`\|`warn`\|`error`\| `off`                                     | `off`   | The level of the error log event.                           |
 | `level`            | `trace`\|`info`\|`warn`\|`error`\| `off`                                     | `off`   | The level of the custom log event.                          |
 | `message`          |                                                                              |         | The message of the custom log event.                        |


### PR DESCRIPTION
Don't create custom events and attributes if you set the level to `off` 

example of configuration:

```yaml
telemetry:
  instrumentation:
    events:
      router:
        # Standard events
        request: info
        response: info
        error: info

        # Custom events
        my.disabled_request_event:
          message: "my event message"
          level: off # Disabled because we set the level to off
          on: request
          attributes:
            http.request.body.size: true
```

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
