### PR TITLE
Port computeRootSerialDependencyGraph

### DIFF
--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -244,7 +244,7 @@ impl Display for QueryGraphEdgeTransition {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub struct QueryGraph {
     /// The "current" source of the query graph. For query graphs representing a single source
     /// graph, this will only ever be one value, but it will change for "federated" query graphs

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -104,7 +104,7 @@ impl Display for QueryGraphNodeType {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub(crate) struct QueryGraphEdge {
     /// Indicates what kind of edge this is and what the edge does/represents. For instance, if the
     /// edge represents a field, the `transition` will be a `FieldCollection` transition and will
@@ -244,7 +244,7 @@ impl Display for QueryGraphEdgeTransition {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct QueryGraph {
     /// The "current" source of the query graph. For query graphs representing a single source
     /// graph, this will only ever be one value, but it will change for "federated" query graphs

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -166,39 +166,6 @@ where
         self.graph.node_weight(self.node).unwrap()
     }
 
-    pub(crate) fn concat(&mut self, other: &Self) -> Result<(), FederationError> {
-        if self.graph != other.graph {
-            // assert(other.graph === this.graph, 'Cannot concat path tree build on another graph');
-            todo!("Return error")
-        }
-        // TODO(TylerBloom): The JS code used the indices of the vertices for this comparision.
-        // Verify that comparing the source NodeStrs is an equivalent (or good enough) comparision.
-        if self.vertex().source != other.vertex().source {
-            // assert(other.vertex.index === this.vertex.index, () => `Cannot concat path tree rooted at vertex ${other.vertex} into tree rooted at other vertex ${this.vertex}`);
-            todo!("Return error")
-        }
-        self.merge_loc
-        todo!()
-        /*
-  concat(other: PathTree<TTrigger, RV, TNullEdge>): PathTree<TTrigger, RV, TNullEdge> {
-    if (!other.childs.length) {
-      return this;
-    }
-    if (!this.childs.length) {
-      return other;
-    }
-
-    const localSelections = this.mergeLocalSelectionsWith(other);
-    // MergeLocalSelectionsWith:
-    // return this.localSelections
-    //   ? (other.localSelections ? this.localSelections.concat(other.localSelections) : this.localSelections)
-    //   : other.localSelections;
-    const newChilds = this.childs.concat(other.childs);
-    return new PathTree(this.graph, this.vertex, localSelections, this.triggerEquality, newChilds);
-  }
-        */
-    }
-
     fn from_paths<'inputs>(
         graph: Arc<QueryGraph>,
         node: NodeIndex,

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -166,6 +166,39 @@ where
         self.graph.node_weight(self.node).unwrap()
     }
 
+    pub(crate) fn concat(&mut self, other: &Self) -> Result<(), FederationError> {
+        if self.graph != other.graph {
+            // assert(other.graph === this.graph, 'Cannot concat path tree build on another graph');
+            todo!("Return error")
+        }
+        // TODO(TylerBloom): The JS code used the indices of the vertices for this comparision.
+        // Verify that comparing the source NodeStrs is an equivalent (or good enough) comparision.
+        if self.vertex().source != other.vertex().source {
+            // assert(other.vertex.index === this.vertex.index, () => `Cannot concat path tree rooted at vertex ${other.vertex} into tree rooted at other vertex ${this.vertex}`);
+            todo!("Return error")
+        }
+        self.merge_loc
+        todo!()
+        /*
+  concat(other: PathTree<TTrigger, RV, TNullEdge>): PathTree<TTrigger, RV, TNullEdge> {
+    if (!other.childs.length) {
+      return this;
+    }
+    if (!this.childs.length) {
+      return other;
+    }
+
+    const localSelections = this.mergeLocalSelectionsWith(other);
+    // MergeLocalSelectionsWith:
+    // return this.localSelections
+    //   ? (other.localSelections ? this.localSelections.concat(other.localSelections) : this.localSelections)
+    //   : other.localSelections;
+    const newChilds = this.childs.concat(other.childs);
+    return new PathTree(this.graph, this.vertex, localSelections, this.triggerEquality, newChilds);
+  }
+        */
+    }
+
     fn from_paths<'inputs>(
         graph: Arc<QueryGraph>,
         node: NodeIndex,

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -492,7 +492,9 @@ impl FetchDependencyGraph {
         self.fetch_id_generation.next_id()
     }
 
-    pub(crate) fn root_node_by_subgraph_iter(&self) -> impl Iterator<Item = (&NodeStr, &NodeIndex)> {
+    pub(crate) fn root_node_by_subgraph_iter(
+        &self,
+    ) -> impl Iterator<Item = (&NodeStr, &NodeIndex)> {
         self.root_nodes_by_subgraph.iter()
     }
 

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -488,6 +488,14 @@ impl FetchDependencyGraph {
         }
     }
 
+    pub(crate) fn next_fetch_id(&self) -> u64 {
+        self.fetch_id_generation.next_id()
+    }
+
+    pub(crate) fn root_node_by_subgraph_iter(&self) -> impl Iterator<Item = (&NodeStr, &NodeIndex)> {
+        self.root_nodes_by_subgraph.iter()
+    }
+
     /// Must be called every time the "shape" of the graph is modified
     /// to know that the graph may not be minimal/optimized anymore.
     fn on_modification(&mut self) {

--- a/apollo-federation/src/query_plan/operation.rs
+++ b/apollo-federation/src/query_plan/operation.rs
@@ -685,7 +685,7 @@ impl Containment {
 
 /// An analogue of the apollo-compiler type `Selection` that stores our other selection analogues
 /// instead of the apollo-compiler types.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, derive_more::IsVariant)]
 pub(crate) enum Selection {
     Field(Arc<FieldSelection>),
     FragmentSpread(Arc<FragmentSpreadSelection>),

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -499,7 +499,6 @@ impl QueryPlanner {
     }
 }
 
-#[allow(dead_code, unused, unreachable_code, unconditional_panic)]
 fn compute_root_serial_dependency_graph(
     parameters: &QueryPlanningParameters,
     has_defers: bool,
@@ -509,8 +508,6 @@ fn compute_root_serial_dependency_graph(
         supergraph_schema,
         federated_query_graph,
         operation,
-        head,
-        config,
         ..
     } = parameters;
     let root_type: Option<CompositeTypeDefinitionPosition> = if has_defers {
@@ -580,7 +577,6 @@ fn compute_root_serial_dependency_graph(
     Ok(digest)
 }
 
-#[allow(unreachable_code)]
 fn split_top_level_fields(
     selection_set: SelectionSet,
 ) -> Box<dyn 'static + Iterator<Item = SelectionSet>> {
@@ -601,7 +597,7 @@ fn split_top_level_fields(
                     .into_iter()
                     .flat_map(split_top_level_fields)
                     .map(|_set| todo!("Port mapping that uses selectionSetOfElement")),
-                    // return splitTopLevelFields(selection.selectionSet).map(s => selectionSetOfElement(selection.element, s));
+                // return splitTopLevelFields(selection.selectionSet).map(s => selectionSetOfElement(selection.element, s));
             )
         };
         digest

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -503,7 +503,6 @@ fn compute_root_serial_dependency_graph(
     parameters: &QueryPlanningParameters,
     has_defers: bool,
 ) -> Result<Vec<FetchDependencyGraph>, FederationError> {
-    // FINDME
     let QueryPlanningParameters {
         supergraph_schema,
         federated_query_graph,
@@ -597,7 +596,6 @@ fn split_top_level_fields(
                     .into_iter()
                     .flat_map(split_top_level_fields)
                     .map(|_set| todo!("Port mapping that uses selectionSetOfElement")),
-                // return splitTopLevelFields(selection.selectionSet).map(s => selectionSetOfElement(selection.element, s));
             )
         };
         digest
@@ -653,26 +651,6 @@ pub(crate) fn compute_root_fetch_groups(
     }
     Ok(())
 }
-
-/*
-function computeRootFetchGroups(dependencyGraph: FetchDependencyGraph, pathTree: OpRootPathTree, rootKind: SchemaRootKind, typeConditionedFetching: boolean): FetchDependencyGraph {
-  // The root of the pathTree is one of the "fake" root of the subgraphs graph, which belongs to no subgraph but points to each ones.
-  // So we "unpack" the first level of the tree to find out our top level groups (and initialize our stack).
-  // Note that we can safely ignore the triggers of that first level as it will all be free transition, and we know we cannot have conditions.
-  for (const [edge, _trigger, _conditions, child] of pathTree.childElements()) {
-    assert(edge !== null, `The root edge should not be null`);
-    const subgraphName = edge.tail.source;
-    // The edge tail type is one of the subgraph root type, so it has to be an ObjectType.
-    const rootType = edge.tail.type as ObjectType;
-    const group = dependencyGraph.getOrCreateRootFetchGroup({ subgraphName, rootKind, parentType: rootType });
-    // If a type is in a subgraph, it has to be in the supergraph.
-    // A root type has to be a Composite type.
-    const rootTypeInSupergraph = dependencyGraph.supergraphSchemaType(rootType.name) as CompositeType;
-    computeGroupsForTree(dependencyGraph, child, group, GroupPath.empty(typeConditionedFetching, rootTypeInSupergraph), emptyDeferContext);
-  }
-  return dependencyGraph;
-}
-*/
 
 fn compute_root_parallel_dependency_graph(
     parameters: &QueryPlanningParameters,

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -558,8 +558,10 @@ fn compute_root_serial_dependency_graph(
                 &prev_path,
             )?;
         } else {
-            // TODO(@TylerBloom): Verify that this is correct? It could be the case that we just
-            // need to grab `.starting_id_generation`.
+            // PORT_NOTE: It is unclear if they correct thing to do here is get the next ID, use
+            // the current ID that is inside the fetch dep graph's ID generator, or to use the
+            // starting ID. Because this method ensure uniqueness between IDs, this approach was
+            // taken; however, it could be the case that this causes unforseen issues.
             starting_fetch_id = fetch_dependency_graph.next_fetch_id();
             digest.push(std::mem::replace(
                 &mut fetch_dependency_graph,

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -8,17 +8,18 @@ use apollo_compiler::ExecutableDocument;
 use apollo_compiler::NodeStr;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
-use petgraph::adj::NodeIndex;
+use petgraph::csr::NodeIndex;
+use petgraph::stable_graph::IndexType;
 
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
 use crate::link::federation_spec_definition::FederationSpecDefinition;
 use crate::link::federation_spec_definition::FEDERATION_INTERFACEOBJECT_DIRECTIVE_NAME_IN_SPEC;
 use crate::link::spec::Identity;
-use crate::query_graph::QueryGraphNodeType;
 use crate::query_graph::build_federated_query_graph;
-use crate::query_graph::QueryGraph;
 use crate::query_graph::path_tree::OpPathTree;
+use crate::query_graph::QueryGraph;
+use crate::query_graph::QueryGraphNodeType;
 use crate::query_plan::fetch_dependency_graph::FetchDependencyGraph;
 use crate::query_plan::fetch_dependency_graph_processor::FetchDependencyGraphProcessor;
 use crate::query_plan::fetch_dependency_graph_processor::FetchDependencyGraphToCostProcessor;
@@ -37,6 +38,7 @@ use crate::query_plan::QueryPlan;
 use crate::query_plan::SequenceNode;
 use crate::query_plan::TopLevelPlanNode;
 use crate::schema::position::AbstractTypeDefinitionPosition;
+use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::position::ObjectTypeDefinitionPosition;
 use crate::schema::position::OutputTypeDefinitionPosition;
@@ -47,6 +49,8 @@ use crate::ApiSchemaOptions;
 use crate::Supergraph;
 
 use super::fetch_dependency_graph::compute_nodes_for_tree;
+use super::operation::Selection;
+use super::operation::SelectionKey;
 
 #[derive(Debug, Clone, Hash)]
 pub struct QueryPlannerConfig {
@@ -509,32 +513,34 @@ fn compute_root_serial_dependency_graph(
         config,
         ..
     } = parameters;
-    let root_type = if has_defers {
+    let root_type: Option<CompositeTypeDefinitionPosition> = if has_defers {
         supergraph_schema
             .schema()
             .root_operation(operation.root_kind.into())
+            .and_then(|name| supergraph_schema.get_type(name.clone()).ok())
+            .and_then(|ty| ty.try_into().ok())
     } else {
         None
     };
     // We have to serially compute a plan for each top-level selection.
-    let mut split_roots = split_top_level_fields(&operation.selection_set);
+    let mut split_roots = split_top_level_fields(operation.selection_set.clone());
     let mut digest = Vec::new();
     let mut starting_fetch_id = 0;
-    let selection = split_roots
+    let selection_set = split_roots
         .next()
         .ok_or_else(|| FederationError::internal("Empty top level fields"))?;
     let BestQueryPlanInfo {
         mut fetch_dependency_graph,
         path_tree: mut prev_path,
         ..
-    } = compute_root_parallel_best_plan(parameters, selection, has_defers)?;
+    } = compute_root_parallel_best_plan(parameters, selection_set, has_defers)?;
     let mut prev_subgraph = only_root_subgraph(&fetch_dependency_graph)?;
-    for selection in split_roots {
+    for selection_set in split_roots {
         let BestQueryPlanInfo {
             fetch_dependency_graph: new_dep_graph,
             path_tree: new_path,
             ..
-        } = compute_root_parallel_best_plan(parameters, selection, has_defers)?;
+        } = compute_root_parallel_best_plan(parameters, selection_set, has_defers)?;
         let new_subgraph = only_root_subgraph(&new_dep_graph)?;
         if new_subgraph == prev_subgraph {
             // The new operation (think 'mutation' operation) is on the same subgraph than the previous one, so we can concat them in a single fetch
@@ -546,20 +552,26 @@ fn compute_root_serial_dependency_graph(
             // }
             // then we should _not_ merge the 2 `mut1` fields (contrarily to what happens on queried fields).
 
-            Arc::make_mut(&mut prev_path).concat(&new_path);
-            todo!(); // prevPaths = prevPaths.concat(newPaths);
+            prev_path = OpPathTree::merge(&prev_path, &new_path);
             fetch_dependency_graph = FetchDependencyGraph::new(
                 supergraph_schema.clone(),
                 federated_query_graph.clone(),
-                todo!(),
+                root_type.clone(),
                 starting_fetch_id,
             );
-            compute_root_fetch_groups(operation.root_kind, &mut fetch_dependency_graph, &prev_path)?;
+            compute_root_fetch_groups(
+                operation.root_kind,
+                &mut fetch_dependency_graph,
+                &prev_path,
+            )?;
         } else {
             // TODO(@TylerBloom): Verify that this is correct? It could be the case that we just
             // need to grab `.starting_id_generation`.
             starting_fetch_id = fetch_dependency_graph.next_fetch_id();
-            digest.push(std::mem::replace(&mut fetch_dependency_graph, new_dep_graph));
+            digest.push(std::mem::replace(
+                &mut fetch_dependency_graph,
+                new_dep_graph,
+            ));
             prev_path = new_path;
             prev_subgraph = new_subgraph;
         }
@@ -569,34 +581,48 @@ fn compute_root_serial_dependency_graph(
 }
 
 #[allow(unreachable_code)]
-fn split_top_level_fields(_selection: &SelectionSet) -> impl Iterator<Item = SelectionSet> {
-    /*
-      return selectionSet.selections().flatMap(selection => {
-        if (selection.kind === 'FieldSelection') {
-          return [selectionSetOf(selectionSet.parentType, selection)];
+fn split_top_level_fields(
+    selection_set: SelectionSet,
+) -> Box<dyn 'static + Iterator<Item = SelectionSet>> {
+    let parent_type = selection_set.type_position.clone();
+    let selections: IndexMap<SelectionKey, Selection> = (**selection_set.selections).clone();
+    Box::new(selections.into_values().flat_map(move |sel| {
+        let digest: Box<dyn 'static + Iterator<Item = SelectionSet>> = if sel.is_field() {
+            Box::new(std::iter::once(SelectionSet::from_selection(
+                parent_type.clone(),
+                sel.clone(),
+            )))
         } else {
-          return splitTopLevelFields(selection.selectionSet).map(s => selectionSetOfElement(selection.element, s));
-        }
-      });
-    */
-    todo!();
-    std::iter::once(_selection.clone())
+            Box::new(
+                sel.selection_set()
+                    .ok()
+                    .flatten()
+                    .cloned()
+                    .into_iter()
+                    .flat_map(split_top_level_fields)
+                    .map(|_set| todo!("Port mapping that uses selectionSetOfElement")),
+                    // return splitTopLevelFields(selection.selectionSet).map(s => selectionSetOfElement(selection.element, s));
+            )
+        };
+        digest
+    }))
 }
 
 fn only_root_subgraph(graph: &FetchDependencyGraph) -> Result<NodeIndex, FederationError> {
     let mut iter = graph.root_node_by_subgraph_iter();
-    let (Some((_, _index)), None) = (iter.next(), iter.next()) else {
-        return Err(FederationError::internal(format!("{graph} should have only one root.")));
+    let (Some((_, index)), None) = (iter.next(), iter.next()) else {
+        return Err(FederationError::internal(format!(
+            "{graph} should have only one root."
+        )));
     };
-    todo!() // Ok(*index)
+    Ok(index.index() as u32)
 }
 
 pub(crate) fn compute_root_fetch_groups(
     root_kind: SchemaRootDefinitionKind,
     dependency_graph: &mut FetchDependencyGraph,
     path: &OpPathTree,
-    ) -> Result<(), FederationError>
-{
+) -> Result<(), FederationError> {
     // The root of the pathTree is one of the "fake" root of the subgraphs graph,
     // which belongs to no subgraph but points to each ones.
     // So we "unpack" the first level of the tree to find out our top level groups

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -33,6 +33,7 @@ use crate::query_plan::generate::PlanBuilder;
 use crate::query_plan::operation::Operation;
 use crate::query_plan::operation::Selection;
 use crate::query_plan::operation::SelectionSet;
+use crate::query_plan::query_planner::compute_root_fetch_groups;
 use crate::query_plan::query_planner::QueryPlannerConfig;
 use crate::query_plan::query_planner::QueryPlanningStatistics;
 use crate::query_plan::QueryPlanCost;
@@ -41,8 +42,6 @@ use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::ObjectTypeDefinitionPosition;
 use crate::schema::position::SchemaRootDefinitionKind;
 use crate::schema::ValidFederationSchema;
-
-use super::query_planner::compute_root_fetch_groups;
 
 // PORT_NOTE: Named `PlanningParameters` in the JS codebase, but there was no particular reason to
 // leave out to the `Query` prefix, so it's been added for consistency. Similar to `GraphPath`, we

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -39,9 +39,10 @@ use crate::query_plan::QueryPlanCost;
 use crate::schema::position::AbstractTypeDefinitionPosition;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::ObjectTypeDefinitionPosition;
-use crate::schema::position::OutputTypeDefinitionPosition;
 use crate::schema::position::SchemaRootDefinitionKind;
 use crate::schema::ValidFederationSchema;
+
+use super::query_planner::compute_root_fetch_groups;
 
 // PORT_NOTE: Named `PlanningParameters` in the JS codebase, but there was no particular reason to
 // leave out to the `Query` prefix, so it's been added for consistency. Similar to `GraphPath`, we
@@ -844,41 +845,7 @@ impl<'a> QueryPlanningTraversal<'a> {
             QueryGraphNodeType::FederatedRootType(_)
         );
         if is_root_path_tree {
-            // The root of the pathTree is one of the "fake" root of the subgraphs graph,
-            // which belongs to no subgraph but points to each ones.
-            // So we "unpack" the first level of the tree to find out our top level groups
-            // (and initialize our stack).
-            // Note that we can safely ignore the triggers of that first level
-            // as it will all be free transition, and we know we cannot have conditions.
-            for child in &path_tree.childs {
-                let edge = child.edge.expect("The root edge should not be None");
-                let (_source_node, target_node) = path_tree.graph.edge_endpoints(edge)?;
-                let target_node = path_tree.graph.node_weight(target_node)?;
-                let subgraph_name = &target_node.source;
-                let root_type = match &target_node.type_ {
-                    QueryGraphNodeType::SchemaType(OutputTypeDefinitionPosition::Object(
-                        object,
-                    )) => object.clone().into(),
-                    ty => {
-                        return Err(FederationError::internal(format!(
-                            "expected an object type for the root of a subgraph, found {ty}"
-                        )))
-                    }
-                };
-                let fetch_dependency_node = dependency_graph.get_or_create_root_node(
-                    subgraph_name,
-                    self.root_kind,
-                    root_type,
-                )?;
-                compute_nodes_for_tree(
-                    dependency_graph,
-                    &child.tree,
-                    fetch_dependency_node,
-                    Default::default(),
-                    Default::default(),
-                    &Default::default(),
-                )?;
-            }
+            compute_root_fetch_groups(self.root_kind, dependency_graph, path_tree)?;
         } else {
             let query_graph_node = path_tree.graph.node_weight(path_tree.node)?;
             let subgraph_name = &query_graph_node.source;


### PR DESCRIPTION
This PR addresses FED-127.

The key function that was ported was [`computeRootSerialDependencyGraph`](https://github.com/apollographql/federation/blob/main/query-planner-js/src/buildPlan.ts#L3600). There are two places where I would like feedback on. I've left comments with my notes. Outside those few lines, everything else is ready for review.