### PR TITLE
Adjust connect nodes in fetch dependency graphs

### DIFF
--- a/apollo-federation/src/sources/connect/fetch_dependency_graph/mod.rs
+++ b/apollo-federation/src/sources/connect/fetch_dependency_graph/mod.rs
@@ -123,7 +123,7 @@ pub(crate) struct Node {
     merge_at: Arc<[FetchDataPathElement]>,
     source_entering_edge: EdgeIndex,
     field_response_name: Name,
-    field_arguments: IndexMap<Name, Value>,
+    field_arguments: IndexMap<Name, NodeElement<Value>>,
     selection: JSONSelection,
 }
 

--- a/apollo-federation/src/sources/connect/fetch_dependency_graph/mod.rs
+++ b/apollo-federation/src/sources/connect/fetch_dependency_graph/mod.rs
@@ -124,7 +124,7 @@ pub(crate) struct Node {
     source_entering_edge: EdgeIndex,
     field_response_name: Name,
     field_arguments: IndexMap<Name, NodeElement<Value>>,
-    selection: JSONSelection,
+    selection: Option<JSONSelection>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
<!-- FED-194 -->
<!-- FED-197 -->

This PR adds an `apollo_compiler` `Node<>` wrapper around `Value` in `connect::fetch_dependency_graph::Node` (I forgot to do it in a previous PR which added it to other data structure storing arguments). This PR also changes the selection be optional in `connect::fetch_dependency_graph::Node`.