### PR TITLE
make match arm exhaustive in fetch_dependency display

### DIFF
--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -1684,7 +1684,7 @@ impl std::fmt::Display for FetchInputs {
                 // We can safely unwrap because we know the len >= 1.
                 self.selection_sets_per_parent_type.values().next().unwrap()
             ),
-            2.. => {
+            _ => {
                 write!(f, "[")?;
                 let mut iter = self.selection_sets_per_parent_type.values();
                 // We can safely unwrap because we know the len >= 1.


### PR DESCRIPTION
Future clippy (nightly) complained that the match arms weren't exhaustive, so may as well fix this.

I think it's correct to replace 2.. with _.
