### PR TITLE
Update intra-source builder API to restrict source adding

### DIFF
--- a/apollo-federation/src/source_aware/federated_query_graph/builder.rs
+++ b/apollo-federation/src/source_aware/federated_query_graph/builder.rs
@@ -45,8 +45,7 @@ struct IntraSourceQueryGraphBuilder {
     is_for_query_planning: bool,
     non_entity_supergraph_types_to_nodes:
         IndexMap<ObjectTypeDefinitionPosition, IndexSet<NodeIndex>>,
-    current_source_kind: Option<SourceKind>,
-    current_source_id: Option<SourceId>,
+    source_kind: SourceKind,
 }
 
 pub(crate) trait IntraSourceQueryGraphBuilderApi {
@@ -56,15 +55,31 @@ pub(crate) trait IntraSourceQueryGraphBuilderApi {
 
     fn is_for_query_planning(&self) -> bool;
 
-    fn add_and_set_current_source(&mut self, source: SourceId) -> Result<(), FederationError>;
+    fn add_source(
+        &mut self,
+        source: SourceId,
+    ) -> Result<impl IntraSourceQueryGraphSubBuilderApi, FederationError>;
+}
 
-    fn get_current_source(&self) -> Result<SourceId, FederationError>;
+struct IntraSourceQueryGraphSubBuilder<'a> {
+    source_id: Option<SourceId>,
+    builder: &'a mut IntraSourceQueryGraphBuilder,
+}
+
+pub(crate) trait IntraSourceQueryGraphSubBuilderApi {
+    fn source_query_graph(
+        &mut self,
+    ) -> Result<&mut source::federated_query_graph::FederatedQueryGraph, FederationError>;
+
+    fn is_for_query_planning(&self) -> bool;
+
+    fn get_source(&self) -> Result<SourceId, FederationError>;
 
     fn add_self_condition(
         &mut self,
         supergraph_type_name: NamedType,
         field_set: &str,
-    ) -> Result<SelfConditionIndex, FederationError>;
+    ) -> Result<Option<SelfConditionIndex>, FederationError>;
 
     fn add_abstract_node(
         &mut self,

--- a/apollo-federation/src/sources/connect/federated_query_graph/builder.rs
+++ b/apollo-federation/src/sources/connect/federated_query_graph/builder.rs
@@ -9,6 +9,7 @@ use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
 use crate::schema::position::TypeDefinitionPosition;
 use crate::schema::ValidFederationSchema;
 use crate::source_aware::federated_query_graph::builder::IntraSourceQueryGraphBuilderApi;
+use crate::source_aware::federated_query_graph::builder::IntraSourceQueryGraphSubBuilderApi;
 use crate::sources::connect::federated_query_graph::ConcreteFieldEdge;
 use crate::sources::connect::federated_query_graph::ConcreteNode;
 use crate::sources::connect::federated_query_graph::EnumNode;
@@ -43,13 +44,13 @@ impl FederatedQueryGraphBuilderApi for FederatedQueryGraphBuilder {
 
         for (id, connect) in connectors {
             // Inform the builder that every node / edge from here out are part of the current connect directive
-            builder.add_and_set_current_source(SourceId::Connect(id.clone()))?;
+            let mut sub_builder = builder.add_source(SourceId::Connect(id.clone()))?;
 
             // Save the connector to the backing query graph for use later in execution
             {
                 let source::federated_query_graph::FederatedQueryGraph::Connect(
                     connect_query_graph,
-                ) = builder.source_query_graph()?
+                ) = sub_builder.source_query_graph()?
                 else {
                     return Err(FederationError::internal(
                         "connect builder called with non-connect query graph",
@@ -69,7 +70,7 @@ impl FederatedQueryGraphBuilderApi for FederatedQueryGraphBuilder {
             };
 
             // Make a node for the entrypoint of this field
-            let parent_node = builder.add_concrete_node(
+            let parent_node = sub_builder.add_concrete_node(
                 field_def_pos.type_name.clone(),
                 ConcreteNode::ConnectParent {
                     subgraph_type: field_def_pos.parent().clone(),
@@ -78,7 +79,7 @@ impl FederatedQueryGraphBuilderApi for FederatedQueryGraphBuilder {
             )?;
 
             // Mark this entrypoint as being externally accessible to other resolvers
-            builder.add_source_entering_edge(
+            sub_builder.add_source_entering_edge(
                 parent_node,
                 None,
                 SourceEnteringEdge::ConnectParent {
@@ -97,11 +98,11 @@ impl FederatedQueryGraphBuilderApi for FederatedQueryGraphBuilder {
                 connect.selection,
                 field_output_type_pos,
                 &subgraph.schema,
-                builder,
+                &mut sub_builder,
             )?;
 
             // Make an edge from the parent into our new subgraph
-            builder.add_concrete_field_edge(
+            sub_builder.add_concrete_field_edge(
                 parent_node,
                 field_node,
                 field_def_pos.field_name.clone(),
@@ -125,7 +126,7 @@ fn process_selection(
     selection: JSONSelection,
     field_output_type_pos: TypeDefinitionPosition,
     subgraph_schema: &ValidFederationSchema,
-    builder: &mut impl IntraSourceQueryGraphBuilderApi,
+    sub_builder: &mut impl IntraSourceQueryGraphSubBuilderApi,
 ) -> Result<NodeIndex<u32>, FederationError> {
     // Keep a cache to reuse nodes
     let mut node_cache: IndexMap<Name, NodeIndex<u32>> = IndexMap::new();
@@ -141,7 +142,7 @@ fn process_selection(
             return Err(FederationError::internal("scalar wasn't really a scalar"));
         };
 
-        return builder.add_scalar_node(
+        return sub_builder.add_scalar_node(
             field_ty.name().clone(),
             ScalarNode::CustomScalarSelectionRoot {
                 subgraph_type: scalar_field_ty,
@@ -156,7 +157,7 @@ fn process_selection(
         JSONSelection::Path(path) => match field_output_type_pos {
             TypeDefinitionPosition::Enum(enum_type) => {
                 // Create the node for this enum
-                builder.add_enum_node(
+                sub_builder.add_enum_node(
                     field_ty.name().clone(),
                     EnumNode::SelectionRoot {
                         subgraph_type: enum_type,
@@ -167,7 +168,7 @@ fn process_selection(
             }
             TypeDefinitionPosition::Scalar(scalar_type) => {
                 // Create the node for this enum
-                builder.add_scalar_node(
+                sub_builder.add_scalar_node(
                     field_ty.name().clone(),
                     ScalarNode::SelectionRoot {
                         subgraph_type: scalar_type,
@@ -189,7 +190,7 @@ fn process_selection(
                     sub,
                     field_output_type_pos,
                     subgraph_schema,
-                    builder,
+                    sub_builder,
                     &mut node_cache,
                     Some(path.collect_paths()),
                 )
@@ -208,7 +209,7 @@ fn process_selection(
                 &sub,
                 field_output_type_pos,
                 subgraph_schema,
-                builder,
+                sub_builder,
                 &mut node_cache,
                 Some(Vec::new()),
             )
@@ -220,7 +221,7 @@ fn process_subselection(
     sub: &SubSelection,
     field_output_type_pos: TypeDefinitionPosition,
     subgraph_schema: &ValidFederationSchema,
-    builder: &mut impl IntraSourceQueryGraphBuilderApi,
+    sub_builder: &mut impl IntraSourceQueryGraphSubBuilderApi,
     node_cache: &mut IndexMap<Name, NodeIndex<u32>>,
     properties_path: Option<Vec<Key>>,
 ) -> Result<NodeIndex<u32>, FederationError> {
@@ -237,7 +238,7 @@ fn process_subselection(
     let field_type_pos = object_pos.field(field_ty.name().clone());
 
     // Create the root node for this object
-    let object_node = builder.add_concrete_node(
+    let object_node = sub_builder.add_concrete_node(
         field_ty.name().clone(),
         properties_path
             .map(|props| ConcreteNode::SelectionRoot {
@@ -282,7 +283,7 @@ fn process_subselection(
                 let enum_node = match node_cache.entry(r#enum.type_name.clone()) {
                     Entry::Occupied(e) => e.into_mut(),
                     Entry::Vacant(e) => {
-                        let node = builder.add_enum_node(
+                        let node = sub_builder.add_enum_node(
                             r#enum.type_name.clone(),
                             EnumNode::SelectionChild {
                                 subgraph_type: r#enum.clone(),
@@ -295,7 +296,7 @@ fn process_subselection(
                 };
 
                 // Link the field to the object node
-                builder.add_concrete_field_edge(
+                sub_builder.add_concrete_field_edge(
                     object_node,
                     *enum_node,
                     selection_field.name.clone(),
@@ -326,7 +327,7 @@ fn process_subselection(
                 let scalar_node = match node_cache.entry(scalar.type_name.clone()) {
                     Entry::Occupied(e) => e.into_mut(),
                     Entry::Vacant(e) => {
-                        let node = builder.add_scalar_node(
+                        let node = sub_builder.add_scalar_node(
                             scalar.type_name.clone(),
                             ScalarNode::SelectionChild {
                                 subgraph_type: scalar.clone(),
@@ -339,7 +340,7 @@ fn process_subselection(
                 };
 
                 // Link the field to the object node
-                builder.add_concrete_field_edge(
+                sub_builder.add_concrete_field_edge(
                     object_node,
                     *scalar_node,
                     selection_field.name.clone(),
@@ -365,13 +366,13 @@ fn process_subselection(
                     subselection,
                     other,
                     subgraph_schema,
-                    builder,
+                    sub_builder,
                     node_cache,
                     None,
                 )?;
 
                 // Link the field to the object node
-                builder.add_concrete_field_edge(
+                sub_builder.add_concrete_field_edge(
                     object_node,
                     subselection_node,
                     selection_field.name.clone(),
@@ -718,6 +719,7 @@ mod tests {
         use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
         use crate::schema::position::ObjectOrInterfaceFieldDirectivePosition;
         use crate::source_aware::federated_query_graph::builder::IntraSourceQueryGraphBuilderApi;
+        use crate::source_aware::federated_query_graph::builder::IntraSourceQueryGraphSubBuilderApi;
         use crate::source_aware::federated_query_graph::SelfConditionIndex;
         use crate::sources::connect;
         use crate::sources::connect::federated_query_graph::ConcreteFieldEdge;
@@ -783,9 +785,7 @@ mod tests {
         /// Mock implementation of [IntraSourceQueryGraphBuilder]
         pub struct MockSourceQueryGraphBuilder {
             graph: Graph<MockNode, MockEdge>,
-            current_source: Option<SourceId>,
             entering_node: NodeIndex<u32>,
-
             query_graph: source::federated_query_graph::FederatedQueryGraph,
         }
         impl MockSourceQueryGraphBuilder {
@@ -821,7 +821,6 @@ mod tests {
 
                 Self {
                     graph,
-                    current_source: None,
                     entering_node,
                     query_graph,
                 }
@@ -946,13 +945,40 @@ mod tests {
         }
 
         impl IntraSourceQueryGraphBuilderApi for MockSourceQueryGraphBuilder {
-            fn add_and_set_current_source(
+            fn source_query_graph(
+                &mut self,
+            ) -> Result<&mut source::federated_query_graph::FederatedQueryGraph, FederationError>
+            {
+                Ok(&mut self.query_graph)
+            }
+
+            fn is_for_query_planning(&self) -> bool {
+                todo!()
+            }
+
+            fn add_source(
                 &mut self,
                 source: SourceId,
-            ) -> Result<(), FederationError> {
-                self.current_source = Some(source);
+            ) -> Result<MockSourceQueryGraphSubBuilder, FederationError> {
+                Ok(MockSourceQueryGraphSubBuilder {
+                    source_id: source,
+                    builder: self,
+                })
+            }
+        }
 
-                Ok(())
+        /// Mock implementation of [IntraSourceQueryGraphSubBuilder]
+        pub struct MockSourceQueryGraphSubBuilder<'a> {
+            source_id: SourceId,
+            builder: &'a mut MockSourceQueryGraphBuilder,
+        }
+
+        impl<'a> IntraSourceQueryGraphSubBuilderApi for MockSourceQueryGraphSubBuilder<'a> {
+            fn source_query_graph(
+                &mut self,
+            ) -> Result<&mut source::federated_query_graph::FederatedQueryGraph, FederationError>
+            {
+                Ok(&mut self.builder.query_graph)
             }
 
             // We only support concrete types for now
@@ -966,10 +992,10 @@ mod tests {
                     unreachable!()
                 };
 
-                Ok(self.graph.add_node(MockNode {
+                Ok(self.builder.graph.add_node(MockNode {
                     prefix: "Node".to_string(),
                     type_name: supergraph_type_name,
-                    source_id: self.current_source.as_ref().unwrap().clone(),
+                    source_id: self.source_id.clone(),
                 }))
             }
 
@@ -990,7 +1016,7 @@ mod tests {
                     ConcreteFieldEdge::Selection { property_path, .. } => property_path,
                     _ => Vec::new(),
                 };
-                Ok(self.graph.add_edge(
+                Ok(self.builder.graph.add_edge(
                     head,
                     tail,
                     MockEdge {
@@ -1005,10 +1031,10 @@ mod tests {
                 supergraph_type_name: NamedType,
                 _source_data: source::federated_query_graph::ScalarNode,
             ) -> Result<NodeIndex, FederationError> {
-                Ok(self.graph.add_node(MockNode {
+                Ok(self.builder.graph.add_node(MockNode {
                     prefix: "Scalar".to_string(),
                     type_name: supergraph_type_name,
-                    source_id: self.current_source.as_ref().unwrap().clone(),
+                    source_id: self.source_id.clone(),
                 }))
             }
 
@@ -1025,8 +1051,8 @@ mod tests {
                     unreachable!()
                 };
 
-                Ok(self.graph.add_edge(
-                    self.entering_node,
+                Ok(self.builder.graph.add_edge(
+                    self.builder.entering_node,
                     tail,
                     MockEdge {
                         field_name: subgraph_type.type_name,
@@ -1035,18 +1061,11 @@ mod tests {
                 ))
             }
 
-            fn source_query_graph(
-                &mut self,
-            ) -> Result<&mut source::federated_query_graph::FederatedQueryGraph, FederationError>
-            {
-                Ok(&mut self.query_graph)
-            }
-
             // ---------------------------------
             // -- Everything below is todo!() --
             // ---------------------------------
 
-            fn get_current_source(&self) -> Result<SourceId, FederationError> {
+            fn get_source(&self) -> Result<SourceId, FederationError> {
                 todo!()
             }
 
@@ -1054,7 +1073,7 @@ mod tests {
                 &mut self,
                 _supergraph_type_name: NamedType,
                 _field_set: &str,
-            ) -> Result<SelfConditionIndex, FederationError> {
+            ) -> Result<Option<SelfConditionIndex>, FederationError> {
                 todo!()
             }
 


### PR DESCRIPTION
<!-- FED-198 -->

This PR enacts changes in the intra-source builder API discussed earlier last week to create a sub-builder, which imposes the restriction that only one source can be added at a time (previously this restriction had to be checked at runtime).