### PR TITLE
Support renaming of `@source` in validation.

### DIFF
--- a/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__duplicate_source_name.snap
+++ b/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__duplicate_source_name.snap
@@ -1,0 +1,5 @@
+---
+source: apollo-federation/src/sources/connect/models/validation.rs
+expression: "errors[0].to_string()"
+---
+every @source name must be unique; found duplicate source name v1

--- a/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__empty_source_name.snap
+++ b/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__empty_source_name.snap
@@ -1,0 +1,5 @@
+---
+source: apollo-federation/src/sources/connect/models/validation.rs
+expression: "errors[0].to_string()"
+---
+name argument to @source can't be empty

--- a/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__invalid_chars_in_source_name.snap
+++ b/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__invalid_chars_in_source_name.snap
@@ -1,0 +1,5 @@
+---
+source: apollo-federation/src/sources/connect/models/validation.rs
+expression: "errors[0].to_string()"
+---
+invalid characters in @source name u$ers, only alphanumeric and underscores are allowed

--- a/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__source_directive_rename.snap
+++ b/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__source_directive_rename.snap
@@ -1,0 +1,5 @@
+---
+source: apollo-federation/src/sources/connect/models/validation.rs
+expression: "errors[0].to_string()"
+---
+baseURL argument for @api "users" was not a valid URL: relative URL without a base

--- a/apollo-federation/src/sources/connect/models/test_data/source_directive_rename.graphql
+++ b/apollo-federation/src/sources/connect/models/test_data/source_directive_rename.graphql
@@ -1,0 +1,11 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect", { name: "@source", as: "@api" }]
+)
+@api(name: "users", http: {baseURL: "blahblahblah"})
+
+type Query {
+    resources: [String!]!
+    @connect(source: "users", http: {GET: "/resources"})
+}

--- a/apollo-federation/src/sources/connect/models/validation.rs
+++ b/apollo-federation/src/sources/connect/models/validation.rs
@@ -231,7 +231,7 @@ impl SourceName {
         }
     }
 
-    fn into_value_or_error(self) -> Result<String, ValidationError> {
+    pub fn into_value_or_error(self) -> Result<String, ValidationError> {
         match self {
             Self::Valid { name, .. } => Ok(name),
             Self::Invalid {

--- a/apollo-federation/src/sources/connect/models/validation.rs
+++ b/apollo-federation/src/sources/connect/models/validation.rs
@@ -238,7 +238,7 @@ impl SourceName {
                 name,
                 directive_name,
             } => Err(ValidationError::InvalidSourceName {
-                name,
+                source_name: name,
                 directive_name,
             }),
             Self::Empty { directive_name } => {
@@ -286,18 +286,18 @@ pub enum ValidationError {
     #[error("name argument to @{directive_name} can't be empty")]
     EmptySourceName { directive_name: DirectiveName },
     #[error(
-        "invalid characters in @{directive_name} name {name}, only alphanumeric and underscores are allowed"
+        "invalid characters in @{directive_name} name {source_name}, only alphanumeric and underscores are allowed"
     )]
     InvalidSourceName {
-        name: String,
+        source_name: String,
         directive_name: DirectiveName,
     },
     #[error(
         "every @{directive_name} name must be unique; found duplicate source name {source_name}"
     )]
     DuplicateSourceName {
-        directive_name: DirectiveName,
         source_name: String,
+        directive_name: DirectiveName,
     },
 }
 #[cfg(test)]


### PR DESCRIPTION
This also adopts the new name in error messages, with snapshot tests to confirm!

Also tweaked the error handling for invalid/no name so that other errors are still collected. This shouldn't matter in practice _yet_ because TypeScript should be validating the presence and type of the `name` argument... but this feels more future-proof.

TS side is at https://github.com/apollographql/federation/pull/3007