### PR TITLE
Add missing `From`/`TryFrom`s for schema positions

### DIFF
--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -104,6 +104,32 @@ impl Display for QueryGraphNodeType {
     }
 }
 
+impl TryFrom<QueryGraphNodeType> for CompositeTypeDefinitionPosition {
+    type Error = FederationError;
+
+    fn try_from(value: QueryGraphNodeType) -> Result<Self, Self::Error> {
+        match value {
+            QueryGraphNodeType::SchemaType(ty) => ty.try_into(),
+            QueryGraphNodeType::FederatedRootType(_) => Err(FederationError::internal(format!(
+                r#"Type "{value}" was unexpectedly not a composite type"#
+            ))),
+        }
+    }
+}
+
+impl TryFrom<QueryGraphNodeType> for ObjectTypeDefinitionPosition {
+    type Error = FederationError;
+
+    fn try_from(value: QueryGraphNodeType) -> Result<Self, Self::Error> {
+        match value {
+            QueryGraphNodeType::SchemaType(ty) => ty.try_into(),
+            QueryGraphNodeType::FederatedRootType(_) => Err(FederationError::internal(format!(
+                r#"Type "{value}" was unexpectedly not an object type"#
+            ))),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) struct QueryGraphEdge {
     /// Indicates what kind of edge this is and what the edge does/represents. For instance, if the


### PR DESCRIPTION
In `position.rs`, we've been adding `From`/`TryFrom`s for `*TypeDefinitionPosition`s as they end up being used. However, since we're working on two separate branches now (`dev` and `connectors`), this leads to merge conflicts if both `dev` and `connectors` add them separately.

This PR adds the missing `From`/`TryFrom`s, and additionally:
- Sorts the `From`/`TryFrom`s
- Updates old code to align on newer patterns  (e.g. `FederationError::internal()` and `r#""#`).
  - We also do this for some methods in `impl *TypeDefinitionPosition`s.
- Moves the `TryFrom<QueryGraphNodeType>`s to  `query_graph/mod.rs` (since `QueryGraphNodeType` is more of a query-graph specific type, and the type itself is going away in the source-aware refactor).