### PR TITLE
Implemented FederatedQueryGraphBuilderApi::process_subgraph_schema for FederatedQueryGraphBuilder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,7 @@ version = "1.47.0"
 dependencies = [
  "apollo-compiler",
  "derive_more",
+ "either",
  "enum_dispatch",
  "hex",
  "indexmap 2.2.3",
@@ -2429,9 +2430,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "elliptic-curve"

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -28,6 +28,7 @@ url = "2"
 nom = "7.1.3"
 serde = "1.0.198"
 itertools = "0.12.1"
+either = "1.12"
 
 [dev-dependencies]
 hex.workspace = true

--- a/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -1495,7 +1495,7 @@ impl IntoIterator for FederationSubgraphs {
 
 // TODO(@goto-bus-stop): consider an appropriate name for this in the public API
 // TODO(@goto-bus-stop): should this exist separately from the `crate::subgraph::Subgraph` type?
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ValidFederationSubgraph {
     pub name: String,
     pub url: String,

--- a/apollo-federation/src/source_aware/federated_query_graph/builder.rs
+++ b/apollo-federation/src/source_aware/federated_query_graph/builder.rs
@@ -40,6 +40,7 @@ pub(crate) fn build_federated_query_graph(
     let builders: source::federated_query_graph::builder::FederatedQueryGraphBuilders =
         Default::default();
     builders.process_subgraph_schemas(subgraphs, &mut intra_source_builder)?;
+
     let mut graph = intra_source_builder.graph;
 
     let supergraph_query_type_pos = ObjectTypeDefinitionPosition {
@@ -92,6 +93,21 @@ pub(crate) struct IntraSourceQueryGraphBuilder {
         IndexMap<CompositeTypeDefinitionPosition, IndexSet<SelfConditionIndex>>,
     source_ids: IndexSet<SourceId>,
     source_kind: Option<SourceKind>,
+}
+
+#[cfg(test)]
+impl IntraSourceQueryGraphBuilder {
+    pub(crate) fn construct(
+        supergraph_schema: ValidFederationSchema,
+        api_schema: ValidFederationSchema,
+        is_for_query_planning: bool,
+    ) -> Self {
+        Self::new(supergraph_schema, api_schema, is_for_query_planning)
+    }
+
+    pub(crate) fn get_graph(&self) -> &FederatedQueryGraph {
+        &self.graph
+    }
 }
 
 impl IntraSourceQueryGraphBuilder {

--- a/apollo-federation/src/sources/graphql/federated_query_graph/builder.rs
+++ b/apollo-federation/src/sources/graphql/federated_query_graph/builder.rs
@@ -133,7 +133,7 @@ fn process_type(
             .filter(|field| is_field_ignored(field.clone().into(), subgraph_schema))
             .try_for_each(|subgraph_field| {
                 subgraph_schema
-                    .get_type(subgraph_field.field_name.clone())
+                    .get_type(subgraph_field.type_name.clone())
                     .and_then(OutputTypeDefinitionPosition::try_from)
                     .and_then(|ty| process_type(ty, subgraph_schema, builder, existing_types))
                     .and_then(|next_index| {

--- a/apollo-federation/src/sources/graphql/federated_query_graph/builder.rs
+++ b/apollo-federation/src/sources/graphql/federated_query_graph/builder.rs
@@ -15,13 +15,12 @@ use crate::schema::ValidFederationSchema;
 use crate::source_aware::federated_query_graph::builder::{
     IntraSourceQueryGraphBuilderApi, IntraSourceQueryGraphSubBuilderApi,
 };
+use crate::sources::graphql::federated_query_graph::{ConcreteFieldEdge, TypeConditionEdge};
 use crate::sources::graphql::GraphqlId;
 use crate::sources::source;
 use crate::sources::source::federated_query_graph::builder::FederatedQueryGraphBuilderApi;
 use crate::sources::source::federated_query_graph::{EnumNode, ScalarNode};
 use crate::ValidFederationSubgraph;
-
-use super::{ConcreteFieldEdge, TypeConditionEdge};
 
 #[derive(Default)]
 pub(crate) struct FederatedQueryGraphBuilder;

--- a/apollo-federation/src/sources/graphql/federated_query_graph/builder.rs
+++ b/apollo-federation/src/sources/graphql/federated_query_graph/builder.rs
@@ -1,7 +1,27 @@
+use std::collections::HashMap;
+
+use apollo_compiler::{name, NodeStr};
+use indexmap::IndexSet;
+use itertools::Either;
+use petgraph::prelude::NodeIndex;
+use strum::IntoEnumIterator;
+
 use crate::error::FederationError;
-use crate::source_aware::federated_query_graph::builder::IntraSourceQueryGraphBuilderApi;
+use crate::schema::position::{
+    AbstractTypeDefinitionPosition, FieldDefinitionPosition, ObjectTypeDefinitionPosition,
+    OutputTypeDefinitionPosition, SchemaRootDefinitionKind, SchemaRootDefinitionPosition,
+};
+use crate::schema::ValidFederationSchema;
+use crate::source_aware::federated_query_graph::builder::{
+    IntraSourceQueryGraphBuilderApi, IntraSourceQueryGraphSubBuilderApi,
+};
+use crate::sources::graphql::GraphqlId;
+use crate::sources::source;
 use crate::sources::source::federated_query_graph::builder::FederatedQueryGraphBuilderApi;
+use crate::sources::source::federated_query_graph::{EnumNode, ScalarNode};
 use crate::ValidFederationSubgraph;
+
+use super::{ConcreteFieldEdge, TypeConditionEdge};
 
 #[derive(Default)]
 pub(crate) struct FederatedQueryGraphBuilder;
@@ -9,9 +29,183 @@ pub(crate) struct FederatedQueryGraphBuilder;
 impl FederatedQueryGraphBuilderApi for FederatedQueryGraphBuilder {
     fn process_subgraph_schema(
         &self,
-        _subgraph: ValidFederationSubgraph,
-        _builder: &mut impl IntraSourceQueryGraphBuilderApi,
+        subgraph: ValidFederationSubgraph,
+        builder: &mut impl IntraSourceQueryGraphBuilderApi,
     ) -> Result<(), FederationError> {
-        todo!()
+        let src_id = GraphqlId::from(NodeStr::new(&subgraph.name));
+        let schema = &subgraph.schema;
+        if let source::federated_query_graph::FederatedQueryGraph::Graphql(graph) =
+            builder.source_query_graph()?
+        {
+            graph
+                .subgraphs_by_source
+                .insert(src_id.clone(), subgraph.clone());
+        }
+        let mut existing_types: HashMap<OutputTypeDefinitionPosition, NodeIndex> = HashMap::new();
+        let mut sub_builder = builder.add_source(src_id.into())?;
+        for root_kind in SchemaRootDefinitionKind::iter() {
+            let position = SchemaRootDefinitionPosition { root_kind };
+            let Some(position) = position.try_get(schema.schema()) else {
+                continue;
+            };
+            let ty: OutputTypeDefinitionPosition =
+                schema.get_type(position.name.clone())?.try_into()?;
+            if is_source_entering_type_ignored(&ty, schema) {
+                continue;
+            }
+            process_type(ty, schema, &mut sub_builder, &mut existing_types)?;
+        }
+        if let Some(metadata) = schema.subgraph_metadata() {
+            let key_name = metadata
+                .federation_spec_definition()
+                .key_directive_definition(schema)?;
+            schema
+                .referencers()
+                .get_directive(&key_name.name)?
+                .object_types
+                .iter()
+                .map(|ty| OutputTypeDefinitionPosition::from(ty.clone()))
+                .filter(|ty| is_source_entering_type_ignored(ty, schema))
+                .try_for_each(|ty| {
+                    process_type(ty, schema, &mut sub_builder, &mut existing_types).map(drop)
+                })?;
+        }
+        Ok(())
     }
+}
+
+fn process_type(
+    output_type_definition_position: OutputTypeDefinitionPosition,
+    subgraph_schema: &ValidFederationSchema,
+    builder: &mut impl IntraSourceQueryGraphSubBuilderApi,
+    existing_types: &mut HashMap<OutputTypeDefinitionPosition, NodeIndex>,
+) -> Result<NodeIndex, FederationError> {
+    if let Some(index) = existing_types.get(&output_type_definition_position) {
+        return Ok(*index);
+    }
+    let type_name = output_type_definition_position
+        .get(subgraph_schema.schema())?
+        .name()
+        .clone();
+    let (ty, index) = match output_type_definition_position.clone() {
+        OutputTypeDefinitionPosition::Scalar(ty) => (
+            None,
+            builder.add_scalar_node(type_name, ScalarNode::Graphql(ty.into()))?,
+        ),
+        OutputTypeDefinitionPosition::Enum(ty) => (
+            None,
+            builder.add_enum_node(type_name, EnumNode::Graphql(ty.into()))?,
+        ),
+        OutputTypeDefinitionPosition::Object(subgraph_type) => {
+            let ty = Some(Either::Left(subgraph_type.clone()));
+            let node = super::ConcreteNode {
+                subgraph_type,
+                provides_directive: None,
+            };
+            (ty, builder.add_concrete_node(type_name, node.into())?)
+        }
+        OutputTypeDefinitionPosition::Interface(ty) => {
+            let subgraph_type = AbstractTypeDefinitionPosition::from(ty);
+            let ty = Some(Either::Right(subgraph_type.clone()));
+            let node = super::AbstractNode {
+                subgraph_type,
+                provides_directive: None,
+            };
+            (ty, builder.add_abstract_node(type_name, node.into())?)
+        }
+        OutputTypeDefinitionPosition::Union(ty) => {
+            let subgraph_type = AbstractTypeDefinitionPosition::from(ty);
+            let ty = Some(Either::Right(subgraph_type.clone()));
+            let node = super::AbstractNode {
+                subgraph_type,
+                provides_directive: None,
+            };
+            (ty, builder.add_abstract_node(type_name, node.into())?)
+        }
+    };
+    existing_types.insert(output_type_definition_position, index);
+    match ty {
+        Some(Either::Left(concrete_ty)) => concrete_ty
+            .field_positions(subgraph_schema.schema())?
+            .filter(|field| is_field_ignored(field.clone().into(), subgraph_schema))
+            .try_for_each(|subgraph_field| {
+                subgraph_schema
+                    .get_type(subgraph_field.field_name.clone())
+                    .and_then(OutputTypeDefinitionPosition::try_from)
+                    .and_then(|ty| process_type(ty, subgraph_schema, builder, existing_types))
+                    .and_then(|next_index| {
+                        builder
+                            .add_concrete_field_edge(
+                                index,
+                                next_index,
+                                subgraph_field.field_name.clone(),
+                                IndexSet::new(),
+                                ConcreteFieldEdge {
+                                    subgraph_field,
+                                    requires_condition: None,
+                                }
+                                .into(),
+                            )
+                            .map(drop)
+                    })
+            })?,
+        Some(Either::Right(abstract_ty)) => subgraph_schema
+            .possible_runtime_types(abstract_ty.into())?
+            .into_iter()
+            .try_for_each(|ty| {
+                process_type(ty.clone().into(), subgraph_schema, builder, existing_types).and_then(
+                    |next_index| {
+                        builder
+                            .add_type_condition_edge(
+                                index,
+                                next_index,
+                                TypeConditionEdge::new(ty.into()).into(),
+                            )
+                            .map(drop)
+                    },
+                )
+            })?,
+        None => {}
+    }
+    Ok(index)
+}
+
+fn is_field_ignored(
+    field_definition_position: FieldDefinitionPosition,
+    subgraph_schema: &ValidFederationSchema,
+) -> bool {
+    if field_definition_position.field_name().starts_with("__") {
+        return true;
+    }
+
+    if let FieldDefinitionPosition::Object(position) = &field_definition_position {
+        let query_def = ObjectTypeDefinitionPosition {
+            type_name: name!("Query"),
+        };
+        let entities = query_def.field(name!("_entities"));
+        let service = query_def.field(name!("_service"));
+        if [entities, service].contains(position) {
+            return true;
+        }
+    }
+
+    subgraph_schema
+        .subgraph_metadata()
+        .unwrap()
+        .external_metadata()
+        .is_external(&field_definition_position)
+        .unwrap_or_default()
+}
+
+fn is_source_entering_type_ignored(
+    output_type_definition_position: &OutputTypeDefinitionPosition,
+    subgraph_schema: &ValidFederationSchema,
+) -> bool {
+    let OutputTypeDefinitionPosition::Object(ty) = output_type_definition_position else {
+        return false;
+    };
+    let Ok(mut fields) = ty.field_positions(subgraph_schema.schema()) else {
+        return false;
+    };
+    fields.all(|field| is_field_ignored(field.into(), subgraph_schema))
 }

--- a/apollo-federation/src/sources/graphql/federated_query_graph/builder.rs
+++ b/apollo-federation/src/sources/graphql/federated_query_graph/builder.rs
@@ -27,6 +27,8 @@ use crate::sources::source::federated_query_graph::EnumNode;
 use crate::sources::source::federated_query_graph::ScalarNode;
 use crate::ValidFederationSubgraph;
 
+use super::{ConcreteFieldEdge, TypeConditionEdge};
+
 #[derive(Default)]
 pub(crate) struct FederatedQueryGraphBuilder;
 

--- a/apollo-federation/src/sources/graphql/federated_query_graph/builder.rs
+++ b/apollo-federation/src/sources/graphql/federated_query_graph/builder.rs
@@ -134,7 +134,7 @@ fn process_type(
         Some(Either::Left(concrete_ty)) => concrete_ty
             .field_positions(subgraph_schema.schema())?
             .try_for_each(|subgraph_field| {
-            if !is_field_ignored(subgraph_field.clone().into(), subgraph_schema)? {
+            if is_field_ignored(subgraph_field.clone().into(), subgraph_schema)? {
                 return Ok(());
             }
             subgraph_field

--- a/apollo-federation/src/sources/graphql/federated_query_graph/builder.rs
+++ b/apollo-federation/src/sources/graphql/federated_query_graph/builder.rs
@@ -18,6 +18,7 @@ use crate::schema::position::SchemaRootDefinitionPosition;
 use crate::schema::ValidFederationSchema;
 use crate::source_aware::federated_query_graph::builder::IntraSourceQueryGraphBuilderApi;
 use crate::source_aware::federated_query_graph::builder::IntraSourceQueryGraphSubBuilderApi;
+use crate::sources::graphql::federated_query_graph::ConcreteFieldEdge;
 use crate::sources::graphql::federated_query_graph::TypeConditionEdge;
 use crate::sources::graphql::GraphqlId;
 use crate::sources::source;
@@ -25,8 +26,6 @@ use crate::sources::source::federated_query_graph::builder::FederatedQueryGraphB
 use crate::sources::source::federated_query_graph::EnumNode;
 use crate::sources::source::federated_query_graph::ScalarNode;
 use crate::ValidFederationSubgraph;
-
-use super::ConcreteFieldEdge;
 
 #[derive(Default)]
 pub(crate) struct FederatedQueryGraphBuilder;

--- a/apollo-federation/src/sources/graphql/federated_query_graph/builder.rs
+++ b/apollo-federation/src/sources/graphql/federated_query_graph/builder.rs
@@ -1,25 +1,29 @@
 use std::collections::HashMap;
 
-use apollo_compiler::{name, NodeStr};
+use apollo_compiler::name;
+use apollo_compiler::NodeStr;
 use indexmap::IndexSet;
 use itertools::Either;
 use petgraph::prelude::NodeIndex;
 use strum::IntoEnumIterator;
 
 use crate::error::FederationError;
-use crate::schema::position::{
-    AbstractTypeDefinitionPosition, FieldDefinitionPosition, ObjectTypeDefinitionPosition,
-    OutputTypeDefinitionPosition, SchemaRootDefinitionKind, SchemaRootDefinitionPosition,
-};
+use crate::schema::position::AbstractTypeDefinitionPosition;
+use crate::schema::position::FieldDefinitionPosition;
+use crate::schema::position::ObjectTypeDefinitionPosition;
+use crate::schema::position::OutputTypeDefinitionPosition;
+use crate::schema::position::SchemaRootDefinitionKind;
+use crate::schema::position::SchemaRootDefinitionPosition;
 use crate::schema::ValidFederationSchema;
-use crate::source_aware::federated_query_graph::builder::{
-    IntraSourceQueryGraphBuilderApi, IntraSourceQueryGraphSubBuilderApi,
-};
-use crate::sources::graphql::federated_query_graph::{ConcreteFieldEdge, TypeConditionEdge};
+use crate::source_aware::federated_query_graph::builder::IntraSourceQueryGraphBuilderApi;
+use crate::source_aware::federated_query_graph::builder::IntraSourceQueryGraphSubBuilderApi;
+use crate::sources::graphql::federated_query_graph::ConcreteFieldEdge;
+use crate::sources::graphql::federated_query_graph::TypeConditionEdge;
 use crate::sources::graphql::GraphqlId;
 use crate::sources::source;
 use crate::sources::source::federated_query_graph::builder::FederatedQueryGraphBuilderApi;
-use crate::sources::source::federated_query_graph::{EnumNode, ScalarNode};
+use crate::sources::source::federated_query_graph::EnumNode;
+use crate::sources::source::federated_query_graph::ScalarNode;
 use crate::ValidFederationSubgraph;
 
 #[derive(Default)]

--- a/apollo-federation/src/sources/graphql/federated_query_graph/mod.rs
+++ b/apollo-federation/src/sources/graphql/federated_query_graph/mod.rs
@@ -43,17 +43,17 @@ pub(crate) struct ConcreteNode {
     provides_directive: Option<ObjectOrInterfaceFieldDirectivePosition>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub(crate) struct EnumNode {
     subgraph_type: EnumTypeDefinitionPosition,
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub(crate) struct ScalarNode {
     subgraph_type: ScalarTypeDefinitionPosition,
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub(crate) struct AbstractFieldEdge {
     subgraph_field: AbstractFieldDefinitionPosition,
 }
@@ -64,9 +64,15 @@ pub(crate) struct ConcreteFieldEdge {
     requires_condition: Option<SelfConditionIndex>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::From)]
 pub(crate) struct TypeConditionEdge {
     subgraph_type: CompositeTypeDefinitionPosition,
+}
+
+impl TypeConditionEdge {
+    pub(crate) fn new(subgraph_type: CompositeTypeDefinitionPosition) -> Self {
+        Self { subgraph_type }
+    }
 }
 
 #[derive(Debug)]

--- a/apollo-federation/src/sources/graphql/federated_query_graph/schemas/simple.graphql
+++ b/apollo-federation/src/sources/graphql/federated_query_graph/schemas/simple.graphql
@@ -1,0 +1,52 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+enum join__Graph {
+  GRAPHQL @join__graph(name: "graphql", url: "http://example.com")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Foo @join__type(graph: GRAPHQL, key: "id") {
+    id: ID!,
+}
+
+type Query @join__type(graph: GRAPHQL) {
+    foo: Foo,
+}

--- a/apollo-federation/src/sources/graphql/mod.rs
+++ b/apollo-federation/src/sources/graphql/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod federated_query_graph;
 pub(crate) mod fetch_dependency_graph;
 pub mod query_plan;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, derive_more::From)]
 pub struct GraphqlId {
     pub subgraph_name: NodeStr,
 }

--- a/apollo-federation/src/sources/source/mod.rs
+++ b/apollo-federation/src/sources/source/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 use std::fmt::Formatter;
+
 use apollo_compiler::NodeStr;
 
 use crate::sources::connect::ConnectId;

--- a/apollo-federation/src/sources/source/mod.rs
+++ b/apollo-federation/src/sources/source/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 use std::fmt::Formatter;
+use apollo_compiler::NodeStr;
 
 use crate::sources::connect::ConnectId;
 use crate::sources::graphql::GraphqlId;
@@ -18,10 +19,16 @@ pub enum SourceKind {
     Connect,
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, derive_more::From)]
 pub enum SourceId {
     Graphql(GraphqlId),
     Connect(ConnectId),
+}
+
+impl From<NodeStr> for SourceId {
+    fn from(value: NodeStr) -> Self {
+        Self::Graphql(value.into())
+    }
 }
 
 impl SourceId {

--- a/apollo-federation/src/sources/source/mod.rs
+++ b/apollo-federation/src/sources/source/mod.rs
@@ -2,8 +2,6 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use apollo_compiler::NodeStr;
 
-use apollo_compiler::NodeStr;
-
 use crate::sources::connect::ConnectId;
 use crate::sources::graphql::GraphqlId;
 

--- a/apollo-federation/src/sources/source/mod.rs
+++ b/apollo-federation/src/sources/source/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 use std::fmt::Formatter;
+use apollo_compiler::NodeStr;
 
 use apollo_compiler::NodeStr;
 


### PR DESCRIPTION
This PR addresses FED-200, which outlines the implementation of `FederatedQueryGraphBuilderApi::process_subgraph_schema` for `FederatedQueryGraphBuilder`.

I want to point out that I added a dependency to the `either` crate. This was already a transitive dependency (used by `itertools`). It was helpful for this implementation. I also noticed that it would be useful in other places as well. For example, it would be nice to have a method like `FederationSchema::possible_runtime_types` but which returned a non-consuming iterator rather than a freshly allocated `IndexSet`. Since `either::Either` implements iterator so long as both sides are iterators, we could copy the existing `possible_runtime_types` method and use `Either`s for each branch. I'm sure there are other places where we could make similar low-hanging-fruit optimizations.