### PR TITLE
connect: impl `can_reuse_node` for FetchDependencyGraph

### DIFF
--- a/apollo-federation/src/source_aware/federated_query_graph/path_tree.rs
+++ b/apollo-federation/src/source_aware/federated_query_graph/path_tree.rs
@@ -29,6 +29,6 @@ pub(crate) struct Child {
 
 #[derive(Debug)]
 pub(crate) struct ChildKey {
-    operation_element: Option<Arc<OperationPathElement>>,
-    edge: Option<EdgeIndex>,
+    pub(crate) operation_element: Option<Arc<OperationPathElement>>,
+    pub(crate) edge: Option<EdgeIndex>,
 }

--- a/apollo-federation/src/sources/connect/fetch_dependency_graph/mod.rs
+++ b/apollo-federation/src/sources/connect/fetch_dependency_graph/mod.rs
@@ -34,7 +34,7 @@ use crate::sources::source::SourceId;
 pub(crate) struct FetchDependencyGraph;
 
 impl FetchDependencyGraphApi for FetchDependencyGraph {
-    fn can_reuse_node<'path_tree>(
+    fn edges_that_can_reuse_node<'path_tree>(
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
         merge_at: &[FetchDataPathElement],

--- a/apollo-federation/src/sources/graphql/fetch_dependency_graph/mod.rs
+++ b/apollo-federation/src/sources/graphql/fetch_dependency_graph/mod.rs
@@ -29,7 +29,7 @@ pub(crate) struct FetchDependencyGraph {
 }
 
 impl FetchDependencyGraphApi for FetchDependencyGraph {
-    fn can_reuse_node<'path_tree>(
+    fn edges_that_can_reuse_node<'path_tree>(
         &self,
         _query_graph: Arc<FederatedQueryGraph>,
         _merge_at: &[FetchDataPathElement],

--- a/apollo-federation/src/sources/source/fetch_dependency_graph/mod.rs
+++ b/apollo-federation/src/sources/source/fetch_dependency_graph/mod.rs
@@ -27,7 +27,7 @@ pub(crate) enum FetchDependencyGraph {
 
 #[enum_dispatch]
 pub(crate) trait FetchDependencyGraphApi {
-    fn can_reuse_node<'path_tree>(
+    fn edges_that_can_reuse_node<'path_tree>(
         &self,
         query_graph: Arc<FederatedQueryGraph>,
         merge_at: &[FetchDataPathElement],


### PR DESCRIPTION
This commit implements the method `can_reuse_node` of the `FetchDependencyGraphApi` trait for the connect-specific `FetchDependencyGraph`.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
