### PR TITLE
Fix semantic merge conflict with https://github.com/apollographql/router/pull/5088

### DIFF
--- a/apollo-router/src/query_planner/subgraph_context.rs
+++ b/apollo-router/src/query_planner/subgraph_context.rs
@@ -209,7 +209,7 @@ pub(crate) fn build_operation_with_aliasing(
     subgraph_schema: &Valid<apollo_compiler::Schema>,
 ) -> Result<Valid<ExecutableDocument>, ContextBatchingError> {
     let ContextualArguments { arguments, count } = contextual_arguments;
-    let parsed_document = subgraph_operation.as_parsed(subgraph_schema);
+    let parsed_document = subgraph_operation.as_parsed();
 
     let mut ed = ExecutableDocument::new();
 


### PR DESCRIPTION
PR #5088 changed the signature of a method. It had a green CI run and git succedded at squashing/rebasing it, but the target `dev` branch gained a new call to that method in the mean time so the resulting merge has a compile error.

This would have been prevented if we ran CI on exactly what was about to be pushed to `dev`, instead of only on PR branch. The Rust project calls this [the "not rocket science" rule of software engineering](https://graydon.livejournal.com/186550.html).
