### PR TITLE
connect: add static cost to connect fetch

### DIFF
--- a/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
@@ -31,7 +31,7 @@ use crate::query_plan::SequenceNode;
 /// (see `selectionCost` method),
 /// this can be though of as saying that resolving a single field is in general
 /// a tiny fraction of the actual cost of doing a subgraph fetch.
-const FETCH_COST: QueryPlanCost = 1000;
+pub(crate) const FETCH_COST: QueryPlanCost = 1000;
 
 /// Constant used during query plan cost computation
 /// as a multiplier to the cost of fetches made in sequences.

--- a/apollo-federation/src/sources/connect/fetch_dependency_graph/mod.rs
+++ b/apollo-federation/src/sources/connect/fetch_dependency_graph/mod.rs
@@ -8,6 +8,7 @@ use indexmap::IndexSet;
 use petgraph::prelude::EdgeIndex;
 
 use crate::error::FederationError;
+use crate::query_plan::fetch_dependency_graph_processor::FETCH_COST;
 use crate::source_aware::federated_query_graph;
 use crate::source_aware::federated_query_graph::graph_path::ConditionResolutionId;
 use crate::source_aware::federated_query_graph::graph_path::OperationPathElement;
@@ -330,7 +331,9 @@ impl FetchDependencyGraphApi for FetchDependencyGraph {
         _source_id: SourceId,
         _source_data: &source::fetch_dependency_graph::Node,
     ) -> Result<QueryPlanCost, FederationError> {
-        todo!()
+        // REST doesn't let you (normally) select only a subset of the response,
+        // so the cost is constant regardless of what was selected.
+        Ok(FETCH_COST)
     }
 
     fn to_plan_node(


### PR DESCRIPTION
This commit implements the `to_cost` method of the `FetchDependencyGraphApi` for the connector-specific fetch graph. For now, that cost is set to a static value mirroring the cost of a fetch in GraphQL so that the query planner can still consistently choose shorter paths when comparing between the two.

Later work might entail looking at the `JSONSelection` itself and calculating a scaling cost based on the selection.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
