### PR TITLE
Port some more QP tests

### DIFF
--- a/apollo-federation/tests/query_plan/build_query_plan_support.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_support.rs
@@ -25,19 +25,22 @@ const IMPLICIT_LINK_DIRECTIVE: &str = r#"@link(url: "https://specs.apollo.dev/fe
 /// This can all be remove when composition is implemented in Rust.
 macro_rules! planner {
     (
-        $( config = $config: expr, )?
+        config = $config: expr,
         $( $subgraph_name: tt: $subgraph_schema: expr),+
         $(,)?
     ) => {{
-        #[allow(unused_mut)]
-        let mut config = Default::default();
-        $( config = $config )?
         $crate::query_plan::build_query_plan_support::api_schema_and_planner(
             insta::_function_name!(),
-            config,
+            $config,
             &[ $( (subgraph_name!($subgraph_name), $subgraph_schema) ),+ ],
         )
     }};
+    (
+        $( $subgraph_name: tt: $subgraph_schema: expr),+
+        $(,)?
+    ) => {
+        planner!(config = Default::default(), $( $subgraph_name: $subgraph_schema),+)
+    };
 }
 
 macro_rules! subgraph_name {

--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -32,6 +32,7 @@ fn some_name() {
 */
 
 mod fetch_operation_names;
+mod named_fragments_preservation;
 mod provides;
 mod requires;
 mod shareable_root_fields;
@@ -210,5 +211,211 @@ fn field_covariance_and_type_explosion() {
       },
     }
     "###
+    );
+}
+
+#[test]
+#[should_panic(expected = "not yet implemented")]
+// TODO: investigate this failure
+fn handles_non_intersecting_fragment_conditions() {
+    let planner = planner!(
+        Subgraph1: r#"
+            interface Fruit {
+              edible: Boolean!
+            }
+    
+            type Banana implements Fruit {
+              edible: Boolean!
+              inBunch: Boolean!
+            }
+    
+            type Apple implements Fruit {
+              edible: Boolean!
+              hasStem: Boolean!
+            }
+    
+            type Query {
+              fruit: Fruit!
+            }
+          "#,
+    );
+    assert_plan!(
+        &planner,
+        r#"
+            fragment OrangeYouGladIDidntSayBanana on Fruit {
+              ... on Banana {
+                inBunch
+              }
+              ... on Apple {
+                hasStem
+              }
+            }
+    
+            query Fruitiness {
+              fruit {
+                ... on Apple {
+                  ...OrangeYouGladIDidntSayBanana
+                }
+              }
+            }
+          "#,
+          @r#"
+          QueryPlan {
+            Fetch(service: "Subgraph1") {
+              {
+                fruit {
+                  __typename
+                  ... on Apple {
+                    hasStem
+                  }
+                }
+              }
+            },
+          }
+          "#
+    );
+}
+
+#[test]
+#[should_panic(expected = "snapshot assertion")]
+// TODO: investigate this failure
+fn avoids_unnecessary_fetches() {
+    // This test is a reduced example demonstrating a previous issue with the computation of query plans cost.
+    // The general idea is that "Subgraph 3" has a declaration that is kind of useless (it declares entity A
+    // that only provides it's own key, so there is never a good reason to use it), but the query planner
+    // doesn't know that and will "test" plans including fetch to that subgraphs in its exhaustive search
+    // of all options. In theory, the query plan costing mechanism should eliminate such plans in favor of
+    // plans not having this inefficient, but an issue in the plan cost computation led to such inefficient
+    // to have the same cost as the more efficient one and to be picked (just because it was the first computed).
+    // This test ensures this costing bug is fixed.
+
+    let planner = planner!(
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+    
+          type T @key(fields: "idT") {
+            idT: ID!
+            a: A
+          }
+    
+          type A @key(fields: "idA2") {
+            idA2: ID!
+          }
+          "#,
+        Subgraph2: r#"
+          type T @key(fields: "idT") {
+            idT: ID!
+            u: U
+          }
+    
+          type U @key(fields: "idU") {
+            idU: ID!
+          }
+          "#,
+        Subgraph3: r#"
+          type A @key(fields: "idA1") {
+            idA1: ID!
+          }
+          "#,
+        Subgraph4: r#"
+          type A @key(fields: "idA1") @key(fields: "idA2") {
+            idA1: ID!
+            idA2: ID!
+          }
+          "#,
+        Subgraph5: r#"
+          type U @key(fields: "idU") {
+            idU: ID!
+            v: Int
+          }
+          "#,
+    );
+
+    assert_plan!(
+        &planner,
+        r#"
+          {
+            t {
+              u {
+                v
+              }
+              a {
+                idA1
+              }
+            }
+          }
+        "#,
+        @r#"
+        QueryPlan {
+          Sequence {
+            Fetch(service: "Subgraph1") {
+              {
+                t {
+                  __typename
+                  idT
+                  a {
+                    __typename
+                    idA2
+                  }
+                }
+              }
+            },
+            Parallel {
+              Sequence {
+                Flatten(path: "t") {
+                  Fetch(service: "Subgraph2") {
+                    {
+                      ... on T {
+                        __typename
+                        idT
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        u {
+                          __typename
+                          idU
+                        }
+                      }
+                    }
+                  },
+                },
+                Flatten(path: "t.u") {
+                  Fetch(service: "Subgraph5") {
+                    {
+                      ... on U {
+                        __typename
+                        idU
+                      }
+                    } =>
+                    {
+                      ... on U {
+                        v
+                      }
+                    }
+                  },
+                },
+              },
+              Flatten(path: "t.a") {
+                Fetch(service: "Subgraph4") {
+                  {
+                    ... on A {
+                      __typename
+                      idA2
+                    }
+                  } =>
+                  {
+                    ... on A {
+                      idA1
+                    }
+                  }
+                },
+              },
+            },
+          },
+        }
+        "#
     );
 }

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments_preservation.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments_preservation.rs
@@ -1,0 +1,1317 @@
+use apollo_federation::query_plan::query_planner::QueryPlannerConfig;
+
+#[test]
+#[should_panic(expected = "not yet implemented")]
+// TODO: investigate this failure
+fn it_works_with_nested_fragments_1() {
+    let planner = planner!(
+        Subgraph1: r#"
+          type Query {
+            a: Anything
+          }
+  
+          union Anything = A1 | A2 | A3
+  
+          interface Foo {
+            foo: String
+            child: Foo
+            child2: Foo
+          }
+  
+          type A1 implements Foo {
+            foo: String
+            child: Foo
+            child2: Foo
+          }
+  
+          type A2 implements Foo {
+            foo: String
+            child: Foo
+            child2: Foo
+          }
+  
+          type A3 implements Foo {
+            foo: String
+            child: Foo
+            child2: Foo
+          }
+        "#,
+    );
+    assert_plan!(
+        &planner,
+        r#"
+          query {
+            a {
+              ... on A1 {
+                ...FooSelect
+              }
+              ... on A2 {
+                ...FooSelect
+              }
+              ... on A3 {
+                ...FooSelect
+              }
+            }
+          }
+  
+          fragment FooSelect on Foo {
+            __typename
+            foo
+            child {
+              ...FooChildSelect
+            }
+            child2 {
+              ...FooChildSelect
+            }
+          }
+  
+          fragment FooChildSelect on Foo {
+            __typename
+            foo
+            child {
+              child {
+                child {
+                  foo
+                }
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Fetch(service: "Subgraph1") {
+            {
+              a {
+                __typename
+                ... on A1 {
+                  ...FooSelect
+                }
+                ... on A2 {
+                  ...FooSelect
+                }
+                ... on A3 {
+                  ...FooSelect
+                }
+              }
+            }
+            
+            fragment FooChildSelect on Foo {
+              __typename
+              foo
+              child {
+                __typename
+                child {
+                  __typename
+                  child {
+                    __typename
+                    foo
+                  }
+                }
+              }
+            }
+            
+            fragment FooSelect on Foo {
+              __typename
+              foo
+              child {
+                ...FooChildSelect
+              }
+              child2 {
+                ...FooChildSelect
+              }
+            }
+          },
+        }
+      "###
+    );
+}
+
+#[test]
+#[should_panic(expected = "not yet implemented")]
+// TODO: investigate this failure
+fn it_avoid_fragments_usable_only_once() {
+    let planner = planner!(
+            Subgraph1: r#"
+          type Query {
+            t: T
+          }
+  
+          type T @key(fields: "id") {
+            id: ID!
+            v1: V
+          }
+  
+          type V @shareable {
+            a: Int
+            b: Int
+            c: Int
+          }
+        "#,
+            Subgraph2: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            v2: V
+            v3: V
+          }
+  
+          type V @shareable {
+            a: Int
+            b: Int
+            c: Int
+          }
+        "#,
+    );
+
+    // We use a fragment which does save some on the original query, but as each
+    // field gets to a different subgraph, the fragment would only be used one
+    // on each sub-fetch and we make sure the fragment is not used in that case.
+    assert_plan!(
+        &planner,
+        r#"
+          query {
+            t {
+              v1 {
+                ...OnV
+              }
+              v2 {
+                ...OnV
+              }
+            }
+          }
+  
+          fragment OnV on V {
+            a
+            b
+            c
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Sequence {
+            Fetch(service: "Subgraph1") {
+              {
+                t {
+                  __typename
+                  id
+                  v1 {
+                    a
+                    b
+                    c
+                  }
+                }
+              }
+            },
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2") {
+                {
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
+                    v2 {
+                      a
+                      b
+                      c
+                    }
+                  }
+                }
+              },
+            },
+          },
+        }
+      "###
+    );
+
+    // But double-check that if we query 2 fields from the same subgraph, then
+    // the fragment gets used now.
+    assert_plan!(
+        &planner,
+        r#"
+          query {
+            t {
+              v2 {
+                ...OnV
+              }
+              v3 {
+                ...OnV
+              }
+            }
+          }
+  
+          fragment OnV on V {
+            a
+            b
+            c
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Sequence {
+            Fetch(service: "Subgraph1") {
+              {
+                t {
+                  __typename
+                  id
+                }
+              }
+            },
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2") {
+                {
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
+                    v2 {
+                      ...OnV
+                    }
+                    v3 {
+                      ...OnV
+                    }
+                  }
+                }
+                
+                fragment OnV on V {
+                  a
+                  b
+                  c
+                }
+              },
+            },
+          },
+        }
+      "###
+    );
+}
+
+#[test]
+#[should_panic(expected = "not yet implemented")]
+// TODO: investigate this failure
+
+fn respects_query_planner_option_reuse_query_fragments_true() {
+    respects_query_planner_option_reuse_query_fragments(true)
+}
+#[test]
+#[should_panic(expected = "not yet implemented")]
+// TODO: investigate this failure
+
+fn respects_query_planner_option_reuse_query_fragments_false() {
+    respects_query_planner_option_reuse_query_fragments(false)
+}
+
+fn respects_query_planner_option_reuse_query_fragments(reuse_query_fragments: bool) {
+    let planner = planner!(
+      config = QueryPlannerConfig {reuse_query_fragments, ..Default::default()},
+      Subgraph1: r#"
+            type Query {
+              t: T
+            }
+  
+            type T {
+              a1: A
+              a2: A
+            }
+  
+            type A {
+              x: Int
+              y: Int
+            }
+        "#,
+    );
+    let query = r#"
+            query {
+              t {
+                a1 {
+                  ...Selection
+                }
+                a2 {
+                  ...Selection
+                }
+              }
+            }
+  
+            fragment Selection on A {
+              x
+              y
+            }
+          "#;
+    if reuse_query_fragments {
+        assert_plan!(
+            &planner,
+            query,
+            @r#"
+        QueryPlan {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                a1 {
+                  ...Selection
+                }
+                a2 {
+                  ...Selection
+                }
+              }
+            }
+            
+            fragment Selection on A {
+              x
+              y
+            }
+          },
+        }
+            "#
+        );
+    } else {
+        assert_plan!(
+            &planner,
+            query,
+            @r#"
+        QueryPlan {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                a1 {
+                  x
+                  y
+                }
+                a2 {
+                  x
+                  y
+                }
+              }
+            }
+          },
+        }
+            "#
+        );
+    }
+}
+
+#[test]
+#[should_panic(expected = "not yet implemented")]
+// TODO: investigate this failure
+fn it_works_with_nested_fragments_when_only_the_nested_fragment_gets_preserved() {
+    let planner = planner!(
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            a: V
+            b: V
+          }
+
+          type V {
+            v1: Int
+            v2: Int
+          }
+        "#,
+    );
+    assert_plan!(
+        &planner,
+        r#"
+          {
+            t {
+              ...OnT
+            }
+          }
+
+          fragment OnT on T {
+            a {
+              ...OnV
+            }
+            b {
+              ...OnV
+            }
+          }
+
+          fragment OnV on V {
+            v1
+            v2
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                a {
+                  ...OnV
+                }
+                b {
+                  ...OnV
+                }
+              }
+            }
+
+            fragment OnV on V {
+              v1
+              v2
+            }
+          },
+        }
+      "###
+    );
+}
+
+#[test]
+#[should_panic(
+    expected = "Error: variable `$if` of type `Boolean` cannot be used for argument `if` of type `Boolean!`"
+)]
+// TODO: investigate this failure
+fn it_preserves_directives_when_fragment_not_used() {
+    // (because used only once)
+    let planner = planner!(
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            a: Int
+            b: Int
+          }
+        "#,
+    );
+    assert_plan!(
+        &planner,
+        r#"
+          query test($if: Boolean) {
+            t {
+              id
+              ...OnT @include(if: $if)
+            }
+          }
+
+          fragment OnT on T {
+            a
+            b
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                id
+                ... on T @include(if: $if) {
+                  a
+                  b
+                }
+              }
+            }
+          },
+        }
+      "###
+    );
+}
+
+#[test]
+#[should_panic(
+    expected = "variable `$test1` of type `Boolean` cannot be used for argument `if` of type `Boolean!`"
+)]
+// TODO: investigate this failure
+fn it_preserves_directives_when_fragment_is_reused() {
+    let planner = planner!(
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            a: Int
+            b: Int
+          }
+        "#,
+    );
+    assert_plan!(
+        &planner,
+        r#"
+          query test($test1: Boolean, $test2: Boolean) {
+            t {
+              id
+              ...OnT @include(if: $test1)
+              ...OnT @include(if: $test2)
+            }
+          }
+
+          fragment OnT on T {
+            a
+            b
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                id
+                ...OnT @include(if: $test1)
+                ...OnT @include(if: $test2)
+              }
+            }
+
+            fragment OnT on T {
+              a
+              b
+            }
+          },
+        }
+      "###
+    );
+}
+
+#[test]
+#[should_panic(expected = "Interface type \"I\" has no field \"b\"")]
+// TODO: investigate this failure
+fn it_does_not_try_to_apply_fragments_that_are_not_valid_for_the_subgaph() {
+    // Slightly artificial example for simplicity, but this highlight the problem.
+    // In that example, the only queried subgraph is the first one (there is in fact
+    // no way to ever reach the 2nd one), so the plan should mostly simply forward
+    // the query to the 1st subgraph, but a subtlety is that the named fragment used
+    // in the query is *not* valid for Subgraph1, because it queries `b` on `I`, but
+    // there is no `I.b` in Subgraph1.
+    // So including the named fragment in the fetch would be erroneous: the subgraph
+    // server would reject it when validating the query, and we must make sure it
+    // is not reused.
+    let planner = planner!(
+        Subgraph1: r#"
+          type Query {
+            i1: I
+            i2: I
+          }
+
+          interface I {
+            a: Int
+          }
+
+          type T implements I {
+            a: Int
+            b: Int
+          }
+        "#,
+        Subgraph2: r#"
+          interface I {
+            a: Int
+            b: Int
+          }
+        "#,
+    );
+    assert_plan!(
+        &planner,
+        r#"
+          query {
+            i1 {
+              ... on T {
+                ...Frag
+              }
+            }
+            i2 {
+              ... on T {
+                ...Frag
+              }
+            }
+          }
+
+          fragment Frag on I {
+            b
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Fetch(service: "Subgraph1") {
+            {
+              i1 {
+                __typename
+                ... on T {
+                  b
+                }
+              }
+              i2 {
+                __typename
+                ... on T {
+                  b
+                }
+              }
+            }
+          },
+        }
+      "###
+    );
+}
+
+#[test]
+#[should_panic(expected = "not yet implemented")]
+// TODO: investigate this failure
+fn it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_differs() {
+    // This test is designed such that type `Outer` implements the interface `I` in `Subgraph1`
+    // but not in `Subgraph2`, yet `I` exists in `Subgraph2` (but only `Inner` implements it
+    // there). Further, the operations we test have a fragment on I (`IFrag` below) that is
+    // used "in the context of `Outer`" (at the top-level of fragment `OuterFrag`).
+    //
+    // What this all means is that `IFrag` can be rebased in `Subgraph2` "as is" because `I`
+    // exists there with all its fields, but as we rebase `OuterFrag` on `Subgraph2`, we
+    // cannot use `...IFrag` inside it (at the top-level), because `I` and `Outer` do
+    // no intersect in `Subgraph2` and this would be an invalid selection.
+    //
+    // Previous versions of the code were not handling this case and were error out by
+    // creating the invalid selection (#2721), and this test ensures this is fixed.
+    let planner = planner!(
+        Subgraph1: r#"
+          type V @shareable {
+            x: Int
+          }
+
+          interface I {
+            v: V
+          }
+
+          type Outer implements I @key(fields: "id") {
+            id: ID!
+            v: V
+          }
+        "#,
+        Subgraph2: r#"
+          type Query {
+            outer1: Outer
+            outer2: Outer
+          }
+
+          type V @shareable {
+            x: Int
+          }
+
+          interface I {
+            v: V
+            w: Int
+          }
+
+          type Inner implements I {
+            v: V
+            w: Int
+          }
+
+          type Outer @key(fields: "id") {
+            id: ID!
+            inner: Inner
+            w: Int
+          }
+        "#,
+    );
+    assert_plan!(
+        &planner,
+        r#"
+          query {
+            outer1 {
+              ...OuterFrag
+            }
+            outer2 {
+              ...OuterFrag
+            }
+          }
+
+          fragment OuterFrag on Outer {
+            ...IFrag
+            inner {
+              ...IFrag
+            }
+          }
+
+          fragment IFrag on I {
+            v {
+              x
+            }
+          }
+        "#,
+        @r#"
+        QueryPlan {
+          Sequence {
+            Fetch(service: "Subgraph2") {
+              {
+                outer1 {
+                  __typename
+                  ...OuterFrag
+                  id
+                }
+                outer2 {
+                  __typename
+                  ...OuterFrag
+                  id
+                }
+              }
+
+              fragment OuterFrag on Outer {
+                inner {
+                  v {
+                    x
+                  }
+                }
+              }
+            },
+            Parallel {
+              Flatten(path: "outer1") {
+                Fetch(service: "Subgraph1") {
+                  {
+                    ... on Outer {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Outer {
+                      v {
+                        x
+                      }
+                    }
+                  }
+                },
+              },
+              Flatten(path: "outer2") {
+                Fetch(service: "Subgraph1") {
+                  {
+                    ... on Outer {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Outer {
+                      v {
+                        x
+                      }
+                    }
+                  }
+                },
+              },
+            },
+          },
+        }
+        "#
+    );
+
+    // We very slighly modify the operation to add an artificial indirection within `IFrag`.
+    // This does not really change the query, and should result in the same plan, but
+    // ensure the code handle correctly such indirection.
+    assert_plan!(
+        &planner,
+        r#"
+          query {
+            outer1 {
+              ...OuterFrag
+            }
+            outer2 {
+              ...OuterFrag
+            }
+          }
+
+          fragment OuterFrag on Outer {
+            ...IFrag
+            inner {
+              ...IFrag
+            }
+          }
+
+          fragment IFrag on I {
+            ...IFragDelegate
+          }
+
+          fragment IFragDelegate on I {
+            v {
+              x
+            }
+          }
+        "#,
+        @r#"
+        QueryPlan {
+          Sequence {
+            Fetch(service: "Subgraph2") {
+              {
+                outer1 {
+                  __typename
+                  ...OuterFrag
+                  id
+                }
+                outer2 {
+                  __typename
+                  ...OuterFrag
+                  id
+                }
+              }
+
+              fragment OuterFrag on Outer {
+                inner {
+                  v {
+                    x
+                  }
+                }
+              }
+            },
+            Parallel {
+              Flatten(path: "outer1") {
+                Fetch(service: "Subgraph1") {
+                  {
+                    ... on Outer {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Outer {
+                      v {
+                        x
+                      }
+                    }
+                  }
+                },
+              },
+              Flatten(path: "outer2") {
+                Fetch(service: "Subgraph1") {
+                  {
+                    ... on Outer {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Outer {
+                      v {
+                        x
+                      }
+                    }
+                  }
+                },
+              },
+            },
+          },
+        }
+        "#
+    );
+
+    // The previous cases tests the cases where nothing in the `...IFrag` spread at the
+    // top-level of `OuterFrag` applied at all: it all gets eliminated in the plan. But
+    // in the schema of `Subgraph2`, while `Outer` does not implement `I` (and does not
+    // have `v` in particular), it does contains field `w` that `I` also have, so we
+    // add that field to `IFrag` and make sure we still correctly query that field.
+
+    assert_plan!(
+        &planner,
+        r#"
+          query {
+            outer1 {
+              ...OuterFrag
+            }
+            outer2 {
+              ...OuterFrag
+            }
+          }
+
+          fragment OuterFrag on Outer {
+            ...IFrag
+            inner {
+              ...IFrag
+            }
+          }
+
+          fragment IFrag on I {
+            v {
+              x
+            }
+            w
+          }
+        "#,
+        @r#"
+        QueryPlan {
+          Sequence {
+            Fetch(service: "Subgraph2") {
+              {
+                outer1 {
+                  __typename
+                  ...OuterFrag
+                  id
+                }
+                outer2 {
+                  __typename
+                  ...OuterFrag
+                  id
+                }
+              }
+
+              fragment OuterFrag on Outer {
+                w
+                inner {
+                  v {
+                    x
+                  }
+                  w
+                }
+              }
+            },
+            Parallel {
+              Flatten(path: "outer1") {
+                Fetch(service: "Subgraph1") {
+                  {
+                    ... on Outer {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Outer {
+                      v {
+                        x
+                      }
+                    }
+                  }
+                },
+              },
+              Flatten(path: "outer2") {
+                Fetch(service: "Subgraph1") {
+                  {
+                    ... on Outer {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Outer {
+                      v {
+                        x
+                      }
+                    }
+                  }
+                },
+              },
+            },
+          },
+        }
+        "#
+    );
+}
+
+#[test]
+#[should_panic(expected = "not yet implemented")]
+// TODO: investigate this failure
+fn it_handles_fragment_rebasing_in_a_subgraph_where_some_union_membership_relation_differs() {
+    // This test is similar to the subtyping case (it tests the same problems), but test the case
+    // of unions instead of interfaces.
+    let planner = planner!(
+        Subgraph1: r#"
+          type V @shareable {
+            x: Int
+          }
+
+          union U = Outer
+
+          type Outer @key(fields: "id") {
+            id: ID!
+            v: Int
+          }
+        "#,
+        Subgraph2: r#"
+          type Query {
+            outer1: Outer
+            outer2: Outer
+          }
+
+          union U = Inner
+
+          type Inner {
+            v: Int
+            w: Int
+          }
+
+          type Outer @key(fields: "id") {
+            id: ID!
+            inner: Inner
+            w: Int
+          }
+        "#,
+    );
+    assert_plan!(
+        &planner,
+        r#"
+          query {
+            outer1 {
+              ...OuterFrag
+            }
+            outer2 {
+              ...OuterFrag
+            }
+          }
+
+          fragment OuterFrag on Outer {
+            ...UFrag
+            inner {
+              ...UFrag
+            }
+          }
+
+          fragment UFrag on U {
+            ... on Outer {
+              v
+            }
+            ... on Inner {
+              v
+            }
+          }
+        "#,
+        @r#"
+        QueryPlan {
+          Sequence {
+            Fetch(service: "Subgraph2") {
+              {
+                outer1 {
+                  __typename
+                  ...OuterFrag
+                  id
+                }
+                outer2 {
+                  __typename
+                  ...OuterFrag
+                  id
+                }
+              }
+
+              fragment OuterFrag on Outer {
+                inner {
+                  v
+                }
+              }
+            },
+            Parallel {
+              Flatten(path: "outer1") {
+                Fetch(service: "Subgraph1") {
+                  {
+                    ... on Outer {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Outer {
+                      v
+                    }
+                  }
+                },
+              },
+              Flatten(path: "outer2") {
+                Fetch(service: "Subgraph1") {
+                  {
+                    ... on Outer {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Outer {
+                      v
+                    }
+                  }
+                },
+              },
+            },
+          },
+        }
+        "#
+    );
+
+    // We very slighly modify the operation to add an artificial indirection within `IFrag`.
+    // This does not really change the query, and should result in the same plan, but
+    // ensure the code handle correctly such indirection.
+    assert_plan!(
+        &planner,
+        r#"
+          query {
+            outer1 {
+              ...OuterFrag
+            }
+            outer2 {
+              ...OuterFrag
+            }
+          }
+
+          fragment OuterFrag on Outer {
+            ...UFrag
+            inner {
+              ...UFrag
+            }
+          }
+
+          fragment UFrag on U {
+            ...UFragDelegate
+          }
+
+          fragment UFragDelegate on U {
+            ... on Outer {
+              v
+            }
+            ... on Inner {
+              v
+            }
+          }
+        "#,
+        @r#"
+        QueryPlan {
+          Sequence {
+            Fetch(service: "Subgraph2") {
+              {
+                outer1 {
+                  __typename
+                  ...OuterFrag
+                  id
+                }
+                outer2 {
+                  __typename
+                  ...OuterFrag
+                  id
+                }
+              }
+
+              fragment OuterFrag on Outer {
+                inner {
+                  v
+                }
+              }
+            },
+            Parallel {
+              Flatten(path: "outer1") {
+                Fetch(service: "Subgraph1") {
+                  {
+                    ... on Outer {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Outer {
+                      v
+                    }
+                  }
+                },
+              },
+              Flatten(path: "outer2") {
+                Fetch(service: "Subgraph1") {
+                  {
+                    ... on Outer {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Outer {
+                      v
+                    }
+                  }
+                },
+              },
+            },
+          },
+        }
+        "#
+    );
+
+    // The previous cases tests the cases where nothing in the `...IFrag` spread at the
+    // top-level of `OuterFrag` applied at all: it all gets eliminated in the plan. But
+    // in the schema of `Subgraph2`, while `Outer` does not implement `I` (and does not
+    // have `v` in particular), it does contains field `w` that `I` also have, so we
+    // add that field to `IFrag` and make sure we still correctly query that field.
+    assert_plan!(
+        &planner,
+        r#"
+          query {
+            outer1 {
+              ...OuterFrag
+            }
+            outer2 {
+              ...OuterFrag
+            }
+          }
+
+          fragment OuterFrag on Outer {
+            ...UFrag
+            inner {
+              ...UFrag
+            }
+          }
+
+          fragment UFrag on U {
+            ... on Outer {
+              v
+              w
+            }
+            ... on Inner {
+              v
+            }
+          }
+        "#,
+        @r#"
+        QueryPlan {
+          Sequence {
+            Fetch(service: "Subgraph2") {
+              {
+                outer1 {
+                  __typename
+                  ...OuterFrag
+                  id
+                }
+                outer2 {
+                  __typename
+                  ...OuterFrag
+                  id
+                }
+              }
+
+              fragment OuterFrag on Outer {
+                w
+                inner {
+                  v
+                }
+              }
+            },
+            Parallel {
+              Flatten(path: "outer1") {
+                Fetch(service: "Subgraph1") {
+                  {
+                    ... on Outer {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Outer {
+                      v
+                    }
+                  }
+                },
+              },
+              Flatten(path: "outer2") {
+                Fetch(service: "Subgraph1") {
+                  {
+                    ... on Outer {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Outer {
+                      v
+                    }
+                  }
+                },
+              },
+            },
+          },
+        }
+        "#
+    );
+}

--- a/apollo-federation/tests/query_plan/supergraphs/avoids_unnecessary_fetches.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/avoids_unnecessary_fetches.graphql
@@ -1,0 +1,82 @@
+# Composed from subgraphs with hash: 18e2cb5dae85e435398e8667f6866178c8022706
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type A
+  @join__type(graph: SUBGRAPH1, key: "idA2")
+  @join__type(graph: SUBGRAPH3, key: "idA1")
+  @join__type(graph: SUBGRAPH4, key: "idA1")
+  @join__type(graph: SUBGRAPH4, key: "idA2")
+{
+  idA2: ID! @join__field(graph: SUBGRAPH1) @join__field(graph: SUBGRAPH4)
+  idA1: ID! @join__field(graph: SUBGRAPH3) @join__field(graph: SUBGRAPH4)
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+  SUBGRAPH3 @join__graph(name: "Subgraph3", url: "none")
+  SUBGRAPH4 @join__graph(name: "Subgraph4", url: "none")
+  SUBGRAPH5 @join__graph(name: "Subgraph5", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__type(graph: SUBGRAPH3)
+  @join__type(graph: SUBGRAPH4)
+  @join__type(graph: SUBGRAPH5)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "idT")
+  @join__type(graph: SUBGRAPH2, key: "idT")
+{
+  idT: ID!
+  a: A @join__field(graph: SUBGRAPH1)
+  u: U @join__field(graph: SUBGRAPH2)
+}
+
+type U
+  @join__type(graph: SUBGRAPH2, key: "idU")
+  @join__type(graph: SUBGRAPH5, key: "idU")
+{
+  idU: ID!
+  v: Int @join__field(graph: SUBGRAPH5)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/handles_non_intersecting_fragment_conditions.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_non_intersecting_fragment_conditions.graphql
@@ -1,0 +1,69 @@
+# Composed from subgraphs with hash: 555913ed43f0ae0b3eae434a8b46b930fecd9e09
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Apple implements Fruit
+  @join__implements(graph: SUBGRAPH1, interface: "Fruit")
+  @join__type(graph: SUBGRAPH1)
+{
+  edible: Boolean!
+  hasStem: Boolean!
+}
+
+type Banana implements Fruit
+  @join__implements(graph: SUBGRAPH1, interface: "Fruit")
+  @join__type(graph: SUBGRAPH1)
+{
+  edible: Boolean!
+  inBunch: Boolean!
+}
+
+interface Fruit
+  @join__type(graph: SUBGRAPH1)
+{
+  edible: Boolean!
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  fruit: Fruit!
+}

--- a/apollo-federation/tests/query_plan/supergraphs/it_avoid_fragments_usable_only_once.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_avoid_fragments_usable_only_once.graphql
@@ -1,0 +1,68 @@
+# Composed from subgraphs with hash: 61f7aebc1284fd8dc840de895884ee5b7fd836c2
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v1: V @join__field(graph: SUBGRAPH1)
+  v2: V @join__field(graph: SUBGRAPH2)
+  v3: V @join__field(graph: SUBGRAPH2)
+}
+
+type V
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  a: Int
+  b: Int
+  c: Int
+}

--- a/apollo-federation/tests/query_plan/supergraphs/it_does_not_try_to_apply_fragments_that_are_not_valid_for_the_subgaph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_does_not_try_to_apply_fragments_that_are_not_valid_for_the_subgaph.graphql
@@ -1,0 +1,66 @@
+# Composed from subgraphs with hash: 7216df3d57d6ea85890cb4557bc1400d2a32faf0
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+interface I
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  a: Int
+  b: Int @join__field(graph: SUBGRAPH2)
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  i1: I @join__field(graph: SUBGRAPH1)
+  i2: I @join__field(graph: SUBGRAPH1)
+}
+
+type T implements I
+  @join__implements(graph: SUBGRAPH1, interface: "I")
+  @join__type(graph: SUBGRAPH1)
+{
+  a: Int
+  b: Int
+}

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_differs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_differs.graphql
@@ -1,0 +1,84 @@
+# Composed from subgraphs with hash: 85ca2a0ec950344b1f685478ac0ea4f36e5b7692
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+interface I
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  v: V
+  w: Int @join__field(graph: SUBGRAPH2)
+}
+
+type Inner implements I
+  @join__implements(graph: SUBGRAPH2, interface: "I")
+  @join__type(graph: SUBGRAPH2)
+{
+  v: V
+  w: Int
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Outer implements I
+  @join__implements(graph: SUBGRAPH1, interface: "I")
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v: V @join__field(graph: SUBGRAPH1)
+  inner: Inner @join__field(graph: SUBGRAPH2)
+  w: Int @join__field(graph: SUBGRAPH2)
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  outer1: Outer @join__field(graph: SUBGRAPH2)
+  outer2: Outer @join__field(graph: SUBGRAPH2)
+}
+
+type V
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  x: Int
+}

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_fragment_rebasing_in_a_subgraph_where_some_union_membership_relation_differs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_fragment_rebasing_in_a_subgraph_where_some_union_membership_relation_differs.graphql
@@ -1,0 +1,80 @@
+# Composed from subgraphs with hash: 532639290329813c32101df1b46a23c760db68fc
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Inner
+  @join__type(graph: SUBGRAPH2)
+{
+  v: Int
+  w: Int
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Outer
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v: Int @join__field(graph: SUBGRAPH1)
+  inner: Inner @join__field(graph: SUBGRAPH2)
+  w: Int @join__field(graph: SUBGRAPH2)
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  outer1: Outer @join__field(graph: SUBGRAPH2)
+  outer2: Outer @join__field(graph: SUBGRAPH2)
+}
+
+union U
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__unionMember(graph: SUBGRAPH1, member: "Outer")
+  @join__unionMember(graph: SUBGRAPH2, member: "Inner")
+ = Outer | Inner
+
+type V
+  @join__type(graph: SUBGRAPH1)
+{
+  x: Int
+}

--- a/apollo-federation/tests/query_plan/supergraphs/it_preserves_directives_when_fragment_is_reused.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_preserves_directives_when_fragment_is_reused.graphql
@@ -1,0 +1,55 @@
+# Composed from subgraphs with hash: b6ebc4ffa76637f33269672e1a49739b3b7091a8
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  t: T
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  a: Int
+  b: Int
+}

--- a/apollo-federation/tests/query_plan/supergraphs/it_preserves_directives_when_fragment_not_used.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_preserves_directives_when_fragment_not_used.graphql
@@ -1,0 +1,55 @@
+# Composed from subgraphs with hash: b6ebc4ffa76637f33269672e1a49739b3b7091a8
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  t: T
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  a: Int
+  b: Int
+}

--- a/apollo-federation/tests/query_plan/supergraphs/it_works_with_nested_fragments_1.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_works_with_nested_fragments_1.graphql
@@ -1,0 +1,89 @@
+# Composed from subgraphs with hash: e0dfa4222558f28e0ecb3e26077458471e69267b
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type A1 implements Foo
+  @join__implements(graph: SUBGRAPH1, interface: "Foo")
+  @join__type(graph: SUBGRAPH1)
+{
+  foo: String
+  child: Foo
+  child2: Foo
+}
+
+type A2 implements Foo
+  @join__implements(graph: SUBGRAPH1, interface: "Foo")
+  @join__type(graph: SUBGRAPH1)
+{
+  foo: String
+  child: Foo
+  child2: Foo
+}
+
+type A3 implements Foo
+  @join__implements(graph: SUBGRAPH1, interface: "Foo")
+  @join__type(graph: SUBGRAPH1)
+{
+  foo: String
+  child: Foo
+  child2: Foo
+}
+
+union Anything
+  @join__type(graph: SUBGRAPH1)
+  @join__unionMember(graph: SUBGRAPH1, member: "A1")
+  @join__unionMember(graph: SUBGRAPH1, member: "A2")
+  @join__unionMember(graph: SUBGRAPH1, member: "A3")
+ = A1 | A2 | A3
+
+interface Foo
+  @join__type(graph: SUBGRAPH1)
+{
+  foo: String
+  child: Foo
+  child2: Foo
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  a: Anything
+}

--- a/apollo-federation/tests/query_plan/supergraphs/it_works_with_nested_fragments_when_only_the_nested_fragment_gets_preserved.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_works_with_nested_fragments_when_only_the_nested_fragment_gets_preserved.graphql
@@ -1,0 +1,62 @@
+# Composed from subgraphs with hash: 425c9d41052b9208347cddf5826dfcaed779900a
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  t: T
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  a: V
+  b: V
+}
+
+type V
+  @join__type(graph: SUBGRAPH1)
+{
+  v1: Int
+  v2: Int
+}

--- a/apollo-federation/tests/query_plan/supergraphs/respects_query_planner_option_reuse_query_fragments.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/respects_query_planner_option_reuse_query_fragments.graphql
@@ -1,0 +1,61 @@
+# Composed from subgraphs with hash: 4b0a2b41b9cbccb8bde234dc0285c3372e220fa1
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type A
+  @join__type(graph: SUBGRAPH1)
+{
+  x: Int
+  y: Int
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  t: T
+}
+
+type T
+  @join__type(graph: SUBGRAPH1)
+{
+  a1: A
+  a2: A
+}


### PR DESCRIPTION
Part of FED-221, porting some more tests from `query-planner-js/src/__tests__/buildPlan.test.ts`

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
