### PR TITLE
fixed a logic bug in `check_can_reuse_fragment_and_track_it` (one-liner)

### DIFF
--- a/apollo-federation/src/query_plan/optimize.rs
+++ b/apollo-federation/src/query_plan/optimize.rs
@@ -419,7 +419,7 @@ impl FieldsConflictMultiBranchValidator {
             return Ok(true); // Nothing to check; Trivially ok.
         };
 
-        if validator.do_merge_with_all(self.validators.iter().map(Arc::as_ref))? {
+        if !validator.do_merge_with_all(self.validators.iter().map(Arc::as_ref))? {
             return Ok(false);
         }
 


### PR DESCRIPTION
I just noticed this bug in the code that I merged in https://github.com/apollographql/router/pull/5195. (This is why we need tests. But, tests are coming soon!)
