### PR TITLE
Reduce allocations in demand control plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6037,9 +6037,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.18"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0afe01b987fac84253ce8acd5c05af9941975e4dee5b4f2d826b6947be8ec2c7"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -6050,9 +6050,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.18"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d253e72f060451e9e5615a1686f3cb4ff87c4e70504c79bdab8fb3b010cd4e97"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -518,6 +518,7 @@ expression: "&schema"
       "description": "Configuration for chaos testing, trying to reproduce bugs that require uncommon conditions. You probably don’t want this in production!",
       "properties": {
         "force_reload": {
+          "default": null,
           "description": "Force a hot reload of the Router (as if the schema or configuration had changed) at a regular time interval.",
           "nullable": true,
           "type": "string"
@@ -533,11 +534,13 @@ expression: "&schema"
           "description": "#/definitions/UriEndpoint"
         },
         "password": {
+          "default": null,
           "description": "The optional password",
           "nullable": true,
           "type": "string"
         },
         "username": {
+          "default": null,
           "description": "The optional username",
           "nullable": true,
           "type": "string"
@@ -1406,6 +1409,7 @@ expression: "&schema"
           "nullable": true
         },
         "deduplicate_variables": {
+          "default": null,
           "description": "DEPRECATED, now always enabled: Enable variable deduplication optimization when sending requests to subgraphs (https://github.com/apollographql/router/issues/87)",
           "nullable": true,
           "type": "boolean"
@@ -1504,6 +1508,7 @@ expression: "&schema"
       "description": "Configuration for entity caching",
       "properties": {
         "enabled": {
+          "default": null,
           "description": "activates caching for all subgraphs, unless overriden in subgraph specific configuration",
           "nullable": true,
           "type": "boolean"
@@ -1673,6 +1678,7 @@ expression: "&schema"
           "type": "array"
         },
         "expose_headers": {
+          "default": null,
           "description": "Which response headers should be made available to scripts running in the browser, in response to a cross-origin request.",
           "items": {
             "type": "string"
@@ -1681,6 +1687,7 @@ expression: "&schema"
           "type": "array"
         },
         "match_origins": {
+          "default": null,
           "description": "`Regex`es you want to match the origins against to determine if they're allowed. Defaults to an empty list. Note that `origins` will be evaluated before `match_origins`",
           "items": {
             "type": "string"
@@ -1689,6 +1696,7 @@ expression: "&schema"
           "type": "array"
         },
         "max_age": {
+          "default": null,
           "description": "The `Access-Control-Max-Age` header value in time units",
           "type": "string"
         },
@@ -2066,6 +2074,7 @@ expression: "&schema"
           "type": "array"
         },
         "include_messages": {
+          "default": null,
           "description": "Will include the error message in a \"message\" attribute",
           "nullable": true,
           "type": "boolean"
@@ -2888,21 +2897,25 @@ expression: "&schema"
       "additionalProperties": false,
       "properties": {
         "ca": {
+          "default": null,
           "description": "The optional certificate authority (CA) certificate to be used in TLS configuration.",
           "nullable": true,
           "type": "string"
         },
         "cert": {
+          "default": null,
           "description": "The optional cert for tls config",
           "nullable": true,
           "type": "string"
         },
         "domain_name": {
+          "default": null,
           "description": "The optional domain name for tls config. Note that domain name is will be defaulted to match the endpoint is not explicitly set.",
           "nullable": true,
           "type": "string"
         },
         "key": {
+          "default": null,
           "description": "The optional private key file for TLS configuration.",
           "nullable": true,
           "type": "string"
@@ -3104,6 +3117,7 @@ expression: "&schema"
           "type": "boolean"
         },
         "graph_ref": {
+          "default": null,
           "description": "Graph reference This will allow you to redirect from the Apollo Router landing page back to Apollo Studio Explorer",
           "nullable": true,
           "type": "string"
@@ -3595,6 +3609,7 @@ expression: "&schema"
       "additionalProperties": false,
       "properties": {
         "algorithms": {
+          "default": null,
           "description": "List of accepted algorithms. Possible values are `HS256`, `HS384`, `HS512`, `ES256`, `ES384`, `RS256`, `RS384`, `RS512`, `PS256`, `PS384`, `PS512`, `EdDSA`",
           "items": {
             "type": "string"
@@ -3645,6 +3660,7 @@ expression: "&schema"
           "type": "integer"
         },
         "max_aliases": {
+          "default": null,
           "description": "If set, requests with operations with more aliases than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ALIASES_LIMIT\"}`",
           "format": "uint32",
           "minimum": 0.0,
@@ -3652,6 +3668,7 @@ expression: "&schema"
           "type": "integer"
         },
         "max_depth": {
+          "default": null,
           "description": "If set, requests with operations deeper than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nCounts depth of an operation, looking at its selection sets, including fields in fragments and inline fragments. The following example has a depth of 3.\n\n```graphql query getProduct { book { # 1 ...bookDetails } }\n\nfragment bookDetails on Book { details { # 2 ... on ProductDetailsBook { country # 3 } } } ```",
           "format": "uint32",
           "minimum": 0.0,
@@ -3659,6 +3676,7 @@ expression: "&schema"
           "type": "integer"
         },
         "max_height": {
+          "default": null,
           "description": "If set, requests with operations higher than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_DEPTH_LIMIT\"}`\n\nHeight is based on simple merging of fields using the same name or alias, but only within the same selection set. For example `name` here is only counted once and the query has height 3, not 4:\n\n```graphql query { name { first } name { last } } ```\n\nThis may change in a future version of Apollo Router to do [full field merging across fragments][merging] instead.\n\n[merging]: https://spec.graphql.org/October2021/#sec-Field-Selection-Merging]",
           "format": "uint32",
           "minimum": 0.0,
@@ -3666,6 +3684,7 @@ expression: "&schema"
           "type": "integer"
         },
         "max_root_fields": {
+          "default": null,
           "description": "If set, requests with operations with more root fields than this maximum are rejected with a HTTP 400 Bad Request response and GraphQL error with `\"extensions\": {\"code\": \"MAX_ROOT_FIELDS_LIMIT\"}`\n\nThis limit counts only the top level fields in a selection set, including fragments and inline fragments.",
           "format": "uint32",
           "minimum": 0.0,
@@ -3754,11 +3773,13 @@ expression: "&schema"
           "type": "object"
         },
         "service_name": {
+          "default": null,
           "description": "Set a service.name resource in your metrics",
           "nullable": true,
           "type": "string"
         },
         "service_namespace": {
+          "default": null,
           "description": "Set a service.namespace attribute in your metrics",
           "nullable": true,
           "type": "string"
@@ -3928,11 +3949,13 @@ expression: "&schema"
           "type": "object"
         },
         "service_name": {
+          "default": null,
           "description": "Set a service.name resource in your metrics",
           "nullable": true,
           "type": "string"
         },
         "service_namespace": {
+          "default": null,
           "description": "Set a service.namespace attribute in your metrics",
           "nullable": true,
           "type": "string"
@@ -4290,6 +4313,7 @@ expression: "&schema"
           "type": "boolean"
         },
         "timeout": {
+          "default": null,
           "description": "Redis request timeout (default: 2ms)",
           "nullable": true,
           "type": "string"
@@ -4366,6 +4390,7 @@ expression: "&schema"
           "description": "#/definitions/AvailableParallelism"
         },
         "experimental_paths_limit": {
+          "default": null,
           "description": "Before creating query plans, for each path of fields in the query we compute all the possible options to traverse that path via the subgraphs. Multiple options can arise because fields in the path can be provided by multiple subgraphs, and abstract types (i.e. unions and interfaces) returned by fields sometimes require the query planner to traverse through each constituent object type. The number of options generated in this computation can grow large if the schema or query are sufficiently complex, and that will increase the time spent planning.\n\nThis config allows specifying a per-path limit to the number of options considered. If any path's options exceeds this limit, query planning will abort and the operation will fail.\n\nThe default value is None, which specifies no limit.",
           "format": "uint32",
           "minimum": 0.0,
@@ -4373,6 +4398,7 @@ expression: "&schema"
           "type": "integer"
         },
         "experimental_plans_limit": {
+          "default": null,
           "description": "Sets a limit to the number of generated query plans. The planning process generates many different query plans as it explores the graph, and the list can grow large. By using this limit, we prevent that growth and still get a valid query plan, but it may not be the optimal one.\n\nThe default limit is set to 10000, but it may change in the future",
           "format": "uint32",
           "minimum": 0.0,
@@ -4385,6 +4411,7 @@ expression: "&schema"
           "type": "boolean"
         },
         "warmed_up_queries": {
+          "default": null,
           "description": "Warms up the cache on reloads by running the query plan over a list of the most used queries (from the in memory cache) Configures the number of queries warmed up. Defaults to 1/3 of the in memory cache",
           "format": "uint",
           "minimum": 0.0,
@@ -4484,6 +4511,7 @@ expression: "&schema"
           "type": "boolean"
         },
         "timeout": {
+          "default": null,
           "description": "Redis request timeout (default: 2ms)",
           "nullable": true,
           "type": "string"
@@ -4494,6 +4522,7 @@ expression: "&schema"
           "nullable": true
         },
         "ttl": {
+          "default": null,
           "description": "TTL for entries",
           "nullable": true,
           "type": "string"
@@ -4604,6 +4633,7 @@ expression: "&schema"
           "type": "number"
         },
         "ttl": {
+          "default": null,
           "description": "how long a single deposit should be considered. Must be between 1 and 60 seconds, default value is 10 seconds",
           "type": "string"
         }
@@ -4626,116 +4656,139 @@ expression: "&schema"
       "description": "Common attributes for http server and client. See https://opentelemetry.io/docs/specs/semconv/http/http-spans/#common-attributes",
       "properties": {
         "baggage": {
+          "default": null,
           "description": "All key values from trace baggage.",
           "nullable": true,
           "type": "boolean"
         },
         "dd.trace_id": {
+          "default": null,
           "description": "The datadog trace ID. This can be output in logs and used to correlate traces in Datadog.",
           "nullable": true,
           "type": "boolean"
         },
         "error.type": {
+          "default": null,
           "description": "Describes a class of error the operation ended with. Examples: * timeout * name_resolution_error * 500 Requirement level: Conditionally Required: If request has ended with an error.",
           "nullable": true,
           "type": "boolean"
         },
         "http.request.body.size": {
+          "default": null,
           "description": "The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size. Examples: * 3495 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "http.request.method": {
+          "default": null,
           "description": "HTTP request method. Examples: * GET * POST * HEAD Requirement level: Required",
           "nullable": true,
           "type": "boolean"
         },
         "http.response.body.size": {
+          "default": null,
           "description": "The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size. Examples: * 3495 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "http.response.status_code": {
+          "default": null,
           "description": "HTTP response status code. Examples: * 200 Requirement level: Conditionally Required: If and only if one was received/sent.",
           "nullable": true,
           "type": "boolean"
         },
         "http.route": {
+          "default": null,
           "description": "The matched route (path template in the format used by the respective server framework). Examples: * /graphql Requirement level: Conditionally Required: If and only if it’s available",
           "nullable": true,
           "type": "boolean"
         },
         "network.local.address": {
+          "default": null,
           "description": "Local socket address. Useful in case of a multi-IP host. Examples: * 10.1.2.80 * /tmp/my.sock Requirement level: Opt-In",
           "nullable": true,
           "type": "boolean"
         },
         "network.local.port": {
+          "default": null,
           "description": "Local socket port. Useful in case of a multi-port host. Examples: * 65123 Requirement level: Opt-In",
           "nullable": true,
           "type": "boolean"
         },
         "network.peer.address": {
+          "default": null,
           "description": "Peer address of the network connection - IP address or Unix domain socket name. Examples: * 10.1.2.80 * /tmp/my.sock Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "network.peer.port": {
+          "default": null,
           "description": "Peer port number of the network connection. Examples: * 65123 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "network.protocol.name": {
+          "default": null,
           "description": "OSI application layer or non-OSI equivalent. Examples: * http * spdy Requirement level: Recommended: if not default (http).",
           "nullable": true,
           "type": "boolean"
         },
         "network.protocol.version": {
+          "default": null,
           "description": "Version of the protocol specified in network.protocol.name. Examples: * 1.0 * 1.1 * 2 * 3 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "network.transport": {
+          "default": null,
           "description": "OSI transport layer. Examples: * tcp * udp Requirement level: Conditionally Required",
           "nullable": true,
           "type": "boolean"
         },
         "network.type": {
+          "default": null,
           "description": "OSI network layer or non-OSI equivalent. Examples: * ipv4 * ipv6 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "server.address": {
+          "default": null,
           "description": "Name of the local HTTP server that received the request. Examples: * example.com * 10.1.2.80 * /tmp/my.sock Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "server.port": {
+          "default": null,
           "description": "Port of the local HTTP server that received the request. Examples: * 80 * 8080 * 443 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "trace_id": {
+          "default": null,
           "description": "The OpenTelemetry trace ID. This can be output in logs.",
           "nullable": true,
           "type": "boolean"
         },
         "url.path": {
+          "default": null,
           "description": "The URI path component Examples: * /search Requirement level: Required",
           "nullable": true,
           "type": "boolean"
         },
         "url.query": {
+          "default": null,
           "description": "The URI query component Examples: * q=OpenTelemetry Requirement level: Conditionally Required: If and only if one was received/sent.",
           "nullable": true,
           "type": "boolean"
         },
         "url.scheme": {
+          "default": null,
           "description": "The URI scheme component identifying the used protocol. Examples: * http * https Requirement level: Required",
           "nullable": true,
           "type": "boolean"
         },
         "user_agent.original": {
+          "default": null,
           "description": "Value of the HTTP User-Agent header sent by the client. Examples: * CERN-LineMode/2.15 * libwww/2.17b3 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
@@ -5058,6 +5111,7 @@ expression: "&schema"
           "nullable": true
         },
         "timeout": {
+          "default": null,
           "description": "Enable timeout for incoming requests",
           "type": "string"
         }
@@ -5374,11 +5428,13 @@ expression: "&schema"
       "description": "Per subgraph configuration for entity caching",
       "properties": {
         "enabled": {
+          "default": null,
           "description": "activates caching for this subgraph, overrides the global configuration",
           "nullable": true,
           "type": "boolean"
         },
         "private_id": {
+          "default": null,
           "description": "Context key used to separate cache sections per user",
           "nullable": true,
           "type": "string"
@@ -5407,21 +5463,25 @@ expression: "&schema"
       "additionalProperties": false,
       "properties": {
         "subgraph.graphql.document": {
+          "default": null,
           "description": "The GraphQL document being executed. Examples: * query findBookById { bookById(id: ?) { name } } Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "subgraph.graphql.operation.name": {
+          "default": null,
           "description": "The name of the operation being executed. Examples: * findBookById Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "subgraph.graphql.operation.type": {
+          "default": null,
           "description": "The type of the operation being executed. Examples: * query * subscription * mutation Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "subgraph.name": {
+          "default": null,
           "description": "The name of the subgraph Examples: * products Requirement level: Required",
           "nullable": true,
           "type": "boolean"
@@ -6040,6 +6100,7 @@ expression: "&schema"
           "nullable": true
         },
         "timeout": {
+          "default": null,
           "description": "Enable timeout for incoming requests",
           "type": "string"
         }
@@ -6097,6 +6158,7 @@ expression: "&schema"
           "type": "boolean"
         },
         "max_opened_subscriptions": {
+          "default": null,
           "description": "This is a limit to only have maximum X opened subscriptions at the same time. By default if it's not set there is no limit.",
           "format": "uint",
           "minimum": 0.0,
@@ -6108,6 +6170,7 @@ expression: "&schema"
           "description": "#/definitions/SubscriptionModeConfig"
         },
         "queue_capacity": {
+          "default": null,
           "description": "It represent the capacity of the in memory queue to know how many events we can keep in a buffer",
           "format": "uint",
           "minimum": 0.0,
@@ -6153,6 +6216,7 @@ expression: "&schema"
           "type": "boolean"
         },
         "experimental_reuse_query_fragments": {
+          "default": null,
           "description": "Enable reuse of query fragments Default: depends on the federation version",
           "nullable": true,
           "type": "boolean"
@@ -6188,36 +6252,43 @@ expression: "&schema"
       "description": "Attributes for Cost",
       "properties": {
         "cost.actual": {
+          "default": null,
           "description": "The actual cost of the operation using the currently configured cost model",
           "nullable": true,
           "type": "boolean"
         },
         "cost.delta": {
+          "default": null,
           "description": "The delta (estimated - actual) cost of the operation using the currently configured cost model",
           "nullable": true,
           "type": "boolean"
         },
         "cost.estimated": {
+          "default": null,
           "description": "The estimated cost of the operation using the currently configured cost model",
           "nullable": true,
           "type": "boolean"
         },
         "cost.result": {
+          "default": null,
           "description": "The cost result, this is an error code returned by the cost calculation or COST_OK",
           "nullable": true,
           "type": "boolean"
         },
         "graphql.document": {
+          "default": null,
           "description": "The GraphQL document being executed. Examples: * query findBookById { bookById(id: ?) { name } } Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "graphql.operation.name": {
+          "default": null,
           "description": "The name of the operation being executed. Examples: * findBookById Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "graphql.operation.type": {
+          "default": null,
           "description": "The type of the operation being executed. Examples: * query * subscription * mutation Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
@@ -6689,6 +6760,7 @@ expression: "&schema"
       "description": "Configuration options pertaining to the subgraph server component.",
       "properties": {
         "certificate_authorities": {
+          "default": null,
           "description": "list of certificate authorities in PEM format",
           "nullable": true,
           "type": "string"
@@ -6884,11 +6956,13 @@ expression: "&schema"
           "description": "#/definitions/SamplerOption"
         },
         "service_name": {
+          "default": null,
           "description": "The trace service name",
           "nullable": true,
           "type": "string"
         },
         "service_namespace": {
+          "default": null,
           "description": "The trace service namespace",
           "nullable": true,
           "type": "string"
@@ -6923,6 +6997,7 @@ expression: "&schema"
           "description": "#/definitions/HeartbeatInterval"
         },
         "path": {
+          "default": null,
           "description": "Path on which WebSockets are listening",
           "nullable": true,
           "type": "string"
@@ -6997,116 +7072,139 @@ expression: "&schema"
       "description": "Common attributes for http server and client. See https://opentelemetry.io/docs/specs/semconv/http/http-spans/#common-attributes",
       "properties": {
         "baggage": {
+          "default": null,
           "description": "All key values from trace baggage.",
           "nullable": true,
           "type": "boolean"
         },
         "dd.trace_id": {
+          "default": null,
           "description": "The datadog trace ID. This can be output in logs and used to correlate traces in Datadog.",
           "nullable": true,
           "type": "boolean"
         },
         "error.type": {
+          "default": null,
           "description": "Describes a class of error the operation ended with. Examples: * timeout * name_resolution_error * 500 Requirement level: Conditionally Required: If request has ended with an error.",
           "nullable": true,
           "type": "boolean"
         },
         "http.request.body.size": {
+          "default": null,
           "description": "The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size. Examples: * 3495 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "http.request.method": {
+          "default": null,
           "description": "HTTP request method. Examples: * GET * POST * HEAD Requirement level: Required",
           "nullable": true,
           "type": "boolean"
         },
         "http.response.body.size": {
+          "default": null,
           "description": "The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size. Examples: * 3495 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "http.response.status_code": {
+          "default": null,
           "description": "HTTP response status code. Examples: * 200 Requirement level: Conditionally Required: If and only if one was received/sent.",
           "nullable": true,
           "type": "boolean"
         },
         "http.route": {
+          "default": null,
           "description": "The matched route (path template in the format used by the respective server framework). Examples: * /graphql Requirement level: Conditionally Required: If and only if it’s available",
           "nullable": true,
           "type": "boolean"
         },
         "network.local.address": {
+          "default": null,
           "description": "Local socket address. Useful in case of a multi-IP host. Examples: * 10.1.2.80 * /tmp/my.sock Requirement level: Opt-In",
           "nullable": true,
           "type": "boolean"
         },
         "network.local.port": {
+          "default": null,
           "description": "Local socket port. Useful in case of a multi-port host. Examples: * 65123 Requirement level: Opt-In",
           "nullable": true,
           "type": "boolean"
         },
         "network.peer.address": {
+          "default": null,
           "description": "Peer address of the network connection - IP address or Unix domain socket name. Examples: * 10.1.2.80 * /tmp/my.sock Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "network.peer.port": {
+          "default": null,
           "description": "Peer port number of the network connection. Examples: * 65123 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "network.protocol.name": {
+          "default": null,
           "description": "OSI application layer or non-OSI equivalent. Examples: * http * spdy Requirement level: Recommended: if not default (http).",
           "nullable": true,
           "type": "boolean"
         },
         "network.protocol.version": {
+          "default": null,
           "description": "Version of the protocol specified in network.protocol.name. Examples: * 1.0 * 1.1 * 2 * 3 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "network.transport": {
+          "default": null,
           "description": "OSI transport layer. Examples: * tcp * udp Requirement level: Conditionally Required",
           "nullable": true,
           "type": "boolean"
         },
         "network.type": {
+          "default": null,
           "description": "OSI network layer or non-OSI equivalent. Examples: * ipv4 * ipv6 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "server.address": {
+          "default": null,
           "description": "Name of the local HTTP server that received the request. Examples: * example.com * 10.1.2.80 * /tmp/my.sock Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "server.port": {
+          "default": null,
           "description": "Port of the local HTTP server that received the request. Examples: * 80 * 8080 * 443 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "trace_id": {
+          "default": null,
           "description": "The OpenTelemetry trace ID. This can be output in logs.",
           "nullable": true,
           "type": "boolean"
         },
         "url.path": {
+          "default": null,
           "description": "The URI path component Examples: * /search Requirement level: Required",
           "nullable": true,
           "type": "boolean"
         },
         "url.query": {
+          "default": null,
           "description": "The URI query component Examples: * q=OpenTelemetry Requirement level: Conditionally Required: If and only if one was received/sent.",
           "nullable": true,
           "type": "boolean"
         },
         "url.scheme": {
+          "default": null,
           "description": "The URI scheme component identifying the used protocol. Examples: * http * https Requirement level: Required",
           "nullable": true,
           "type": "boolean"
         },
         "user_agent.original": {
+          "default": null,
           "description": "Value of the HTTP User-Agent header sent by the client. Examples: * CERN-LineMode/2.15 * libwww/2.17b3 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
@@ -7122,116 +7220,139 @@ expression: "&schema"
       "description": "Common attributes for http server and client. See https://opentelemetry.io/docs/specs/semconv/http/http-spans/#common-attributes",
       "properties": {
         "baggage": {
+          "default": null,
           "description": "All key values from trace baggage.",
           "nullable": true,
           "type": "boolean"
         },
         "dd.trace_id": {
+          "default": null,
           "description": "The datadog trace ID. This can be output in logs and used to correlate traces in Datadog.",
           "nullable": true,
           "type": "boolean"
         },
         "error.type": {
+          "default": null,
           "description": "Describes a class of error the operation ended with. Examples: * timeout * name_resolution_error * 500 Requirement level: Conditionally Required: If request has ended with an error.",
           "nullable": true,
           "type": "boolean"
         },
         "http.request.body.size": {
+          "default": null,
           "description": "The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size. Examples: * 3495 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "http.request.method": {
+          "default": null,
           "description": "HTTP request method. Examples: * GET * POST * HEAD Requirement level: Required",
           "nullable": true,
           "type": "boolean"
         },
         "http.response.body.size": {
+          "default": null,
           "description": "The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size. Examples: * 3495 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "http.response.status_code": {
+          "default": null,
           "description": "HTTP response status code. Examples: * 200 Requirement level: Conditionally Required: If and only if one was received/sent.",
           "nullable": true,
           "type": "boolean"
         },
         "http.route": {
+          "default": null,
           "description": "The matched route (path template in the format used by the respective server framework). Examples: * /graphql Requirement level: Conditionally Required: If and only if it’s available",
           "nullable": true,
           "type": "boolean"
         },
         "network.local.address": {
+          "default": null,
           "description": "Local socket address. Useful in case of a multi-IP host. Examples: * 10.1.2.80 * /tmp/my.sock Requirement level: Opt-In",
           "nullable": true,
           "type": "boolean"
         },
         "network.local.port": {
+          "default": null,
           "description": "Local socket port. Useful in case of a multi-port host. Examples: * 65123 Requirement level: Opt-In",
           "nullable": true,
           "type": "boolean"
         },
         "network.peer.address": {
+          "default": null,
           "description": "Peer address of the network connection - IP address or Unix domain socket name. Examples: * 10.1.2.80 * /tmp/my.sock Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "network.peer.port": {
+          "default": null,
           "description": "Peer port number of the network connection. Examples: * 65123 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "network.protocol.name": {
+          "default": null,
           "description": "OSI application layer or non-OSI equivalent. Examples: * http * spdy Requirement level: Recommended: if not default (http).",
           "nullable": true,
           "type": "boolean"
         },
         "network.protocol.version": {
+          "default": null,
           "description": "Version of the protocol specified in network.protocol.name. Examples: * 1.0 * 1.1 * 2 * 3 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "network.transport": {
+          "default": null,
           "description": "OSI transport layer. Examples: * tcp * udp Requirement level: Conditionally Required",
           "nullable": true,
           "type": "boolean"
         },
         "network.type": {
+          "default": null,
           "description": "OSI network layer or non-OSI equivalent. Examples: * ipv4 * ipv6 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "server.address": {
+          "default": null,
           "description": "Name of the local HTTP server that received the request. Examples: * example.com * 10.1.2.80 * /tmp/my.sock Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "server.port": {
+          "default": null,
           "description": "Port of the local HTTP server that received the request. Examples: * 80 * 8080 * 443 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "trace_id": {
+          "default": null,
           "description": "The OpenTelemetry trace ID. This can be output in logs.",
           "nullable": true,
           "type": "boolean"
         },
         "url.path": {
+          "default": null,
           "description": "The URI path component Examples: * /search Requirement level: Required",
           "nullable": true,
           "type": "boolean"
         },
         "url.query": {
+          "default": null,
           "description": "The URI query component Examples: * q=OpenTelemetry Requirement level: Conditionally Required: If and only if one was received/sent.",
           "nullable": true,
           "type": "boolean"
         },
         "url.scheme": {
+          "default": null,
           "description": "The URI scheme component identifying the used protocol. Examples: * http * https Requirement level: Required",
           "nullable": true,
           "type": "boolean"
         },
         "user_agent.original": {
+          "default": null,
           "description": "Value of the HTTP User-Agent header sent by the client. Examples: * CERN-LineMode/2.15 * libwww/2.17b3 Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
@@ -7246,21 +7367,25 @@ expression: "&schema"
       },
       "properties": {
         "subgraph.graphql.document": {
+          "default": null,
           "description": "The GraphQL document being executed. Examples: * query findBookById { bookById(id: ?) { name } } Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "subgraph.graphql.operation.name": {
+          "default": null,
           "description": "The name of the operation being executed. Examples: * findBookById Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "subgraph.graphql.operation.type": {
+          "default": null,
           "description": "The type of the operation being executed. Examples: * query * subscription * mutation Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "subgraph.name": {
+          "default": null,
           "description": "The name of the subgraph Examples: * products Requirement level: Required",
           "nullable": true,
           "type": "boolean"
@@ -7275,21 +7400,25 @@ expression: "&schema"
       },
       "properties": {
         "subgraph.graphql.document": {
+          "default": null,
           "description": "The GraphQL document being executed. Examples: * query findBookById { bookById(id: ?) { name } } Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "subgraph.graphql.operation.name": {
+          "default": null,
           "description": "The name of the operation being executed. Examples: * findBookById Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "subgraph.graphql.operation.type": {
+          "default": null,
           "description": "The type of the operation being executed. Examples: * query * subscription * mutation Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "subgraph.name": {
+          "default": null,
           "description": "The name of the subgraph Examples: * products Requirement level: Required",
           "nullable": true,
           "type": "boolean"
@@ -7305,36 +7434,43 @@ expression: "&schema"
       "description": "Attributes for Cost",
       "properties": {
         "cost.actual": {
+          "default": null,
           "description": "The actual cost of the operation using the currently configured cost model",
           "nullable": true,
           "type": "boolean"
         },
         "cost.delta": {
+          "default": null,
           "description": "The delta (estimated - actual) cost of the operation using the currently configured cost model",
           "nullable": true,
           "type": "boolean"
         },
         "cost.estimated": {
+          "default": null,
           "description": "The estimated cost of the operation using the currently configured cost model",
           "nullable": true,
           "type": "boolean"
         },
         "cost.result": {
+          "default": null,
           "description": "The cost result, this is an error code returned by the cost calculation or COST_OK",
           "nullable": true,
           "type": "boolean"
         },
         "graphql.document": {
+          "default": null,
           "description": "The GraphQL document being executed. Examples: * query findBookById { bookById(id: ?) { name } } Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "graphql.operation.name": {
+          "default": null,
           "description": "The name of the operation being executed. Examples: * findBookById Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "graphql.operation.type": {
+          "default": null,
           "description": "The type of the operation being executed. Examples: * query * subscription * mutation Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
@@ -7350,36 +7486,43 @@ expression: "&schema"
       "description": "Attributes for Cost",
       "properties": {
         "cost.actual": {
+          "default": null,
           "description": "The actual cost of the operation using the currently configured cost model",
           "nullable": true,
           "type": "boolean"
         },
         "cost.delta": {
+          "default": null,
           "description": "The delta (estimated - actual) cost of the operation using the currently configured cost model",
           "nullable": true,
           "type": "boolean"
         },
         "cost.estimated": {
+          "default": null,
           "description": "The estimated cost of the operation using the currently configured cost model",
           "nullable": true,
           "type": "boolean"
         },
         "cost.result": {
+          "default": null,
           "description": "The cost result, this is an error code returned by the cost calculation or COST_OK",
           "nullable": true,
           "type": "boolean"
         },
         "graphql.document": {
+          "default": null,
           "description": "The GraphQL document being executed. Examples: * query findBookById { bookById(id: ?) { name } } Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "graphql.operation.name": {
+          "default": null,
           "description": "The name of the operation being executed. Examples: * findBookById Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"
         },
         "graphql.operation.type": {
+          "default": null,
           "description": "The type of the operation being executed. Examples: * query * subscription * mutation Requirement level: Recommended",
           "nullable": true,
           "type": "boolean"

--- a/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
@@ -1,12 +1,5 @@
-use apollo_compiler::ast::NamedType;
 use apollo_compiler::executable::Field;
-use apollo_compiler::executable::SelectionSet;
-use apollo_compiler::validation::Valid;
-use apollo_compiler::Parser;
-use apollo_compiler::Schema;
 use tower::BoxError;
-
-use super::DemandControlError;
 
 pub(in crate::plugins::demand_control) struct IncludeDirective {
     pub(in crate::plugins::demand_control) is_included: bool,
@@ -24,50 +17,6 @@ impl IncludeDirective {
             .map(|cond| Self { is_included: cond });
 
         Ok(directive)
-    }
-}
-
-pub(in crate::plugins::demand_control) struct RequiresDirective {
-    pub(in crate::plugins::demand_control) fields: SelectionSet,
-}
-
-impl RequiresDirective {
-    pub(in crate::plugins::demand_control) fn from_field(
-        field: &Field,
-        parent_type_name: &NamedType,
-        schema: &Valid<Schema>,
-    ) -> Result<Option<Self>, DemandControlError> {
-        // When a user marks a subgraph schema field with `@requires`, the composition process
-        // replaces `@requires(field: "<selection>")` with `@join__field(requires: "<selection>")`.
-        //
-        // Note we cannot use `field.definition` in this case: The operation executes against the
-        // API schema, so its definition pointers point into the API schema. To find the
-        // `@join__field()` directive, we must instead look up the field on the type with the same
-        // name in the supergraph.
-        let definition = schema
-            .type_field(parent_type_name, &field.name)
-            .map_err(|_err| {
-                DemandControlError::QueryParseFailure(format!(
-                    "Could not find the API schema type {}.{} in the supergraph. This looks like a bug",
-                    parent_type_name, &field.name
-                ))
-            })?;
-        let requires_arg = definition
-            .directives
-            .get("join__field")
-            .and_then(|requires| requires.argument_by_name("requires"))
-            .and_then(|arg| arg.as_str());
-
-        if let Some(arg) = requires_arg {
-            let field_set =
-                Parser::new().parse_field_set(schema, parent_type_name.clone(), arg, "")?;
-
-            Ok(Some(RequiresDirective {
-                fields: field_set.selection_set.clone(),
-            }))
-        } else {
-            Ok(None)
-        }
     }
 }
 


### PR DESCRIPTION
# Overview

We noticed a fairly significant drop in performance with demand control enabled during our load tests. After taking a look at some flamegraphs of the execution, the main two culprits seem to be
1. Parsing @requires directives during static estimation
2. Allocations/inserts with HashMaps when we zip responses with the schema

## Handling requires

As currently implemented, our handling of @requires is not necessary because we're only running the estimation on the query plan. At that point, the query planner has already converted any requirements to fetch nodes. This did bring to my attention that we should be hooking into the request pipeline earlier with the static estimation, which will need the requires implementation. The goal of demand control is to have that estimate block expensive requests _prior_ to query planning, otherwise, we're not really saving that much work. This requires further discussion.

This also means that we probably need two versions of our scoring, or at least to share a little less code so the query plan scoring doesn't do the expensive @requires parsing. In the first pass, I've removed it entirely to test how it affects throughput.

## Reducing allocations

There were a few low-hanging fruits here, mainly, initializing HashMaps and Vecs with capacity and using &str keys instead of String. This seems to have a pretty sizeable impact on the flamegraphs. I will confirm with the load tests.

<!-- ROUTER-224 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
