### PR TITLE
Switch connectors validation locations to line/column

### DIFF
--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -21,7 +21,9 @@ pub use json_selection::Key;
 pub use json_selection::PathSelection;
 pub use json_selection::SubSelection;
 pub use models::validate;
+pub use models::GraphQLLocation;
 pub use models::ValidationError;
+pub use models::ValidationErrorCode;
 pub(crate) use spec::ConnectSpecDefinition;
 pub use url_path_template::URLPathTemplate;
 

--- a/apollo-federation/src/sources/connect/models/mod.rs
+++ b/apollo-federation/src/sources/connect/models/mod.rs
@@ -3,7 +3,9 @@ mod validation;
 use apollo_compiler::NodeStr;
 use indexmap::IndexMap;
 pub use validation::validate;
-pub use validation::ValidationError;
+pub use validation::Error as ValidationError;
+pub use validation::ErrorCode as ValidationErrorCode;
+pub use validation::GraphQLLocation;
 
 use super::spec::ConnectHTTPArguments;
 use super::spec::HTTPHeaderOption;

--- a/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__duplicate_source_name.snap
+++ b/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__duplicate_source_name.snap
@@ -2,4 +2,4 @@
 source: apollo-federation/src/sources/connect/models/validation.rs
 expression: "errors[0].to_string()"
 ---
-every @source name must be unique; found duplicate source name v1
+every @source name must be unique; found duplicate source name "v1"

--- a/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__incorrect_scheme.snap
+++ b/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__incorrect_scheme.snap
@@ -2,4 +2,4 @@
 source: apollo-federation/src/sources/connect/models/validation.rs
 expression: "errors[0].to_string()"
 ---
-invalid characters in @source name "u$ers", only alphanumeric and underscores are allowed
+baseURL argument for @source "v1" must be http or https, got file

--- a/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__multiple_errors.snap
+++ b/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__multiple_errors.snap
@@ -2,4 +2,4 @@
 source: apollo-federation/src/sources/connect/models/validation.rs
 expression: "errors[0].to_string()"
 ---
-invalid characters in @source name "u$ers", only alphanumeric and underscores are allowed
+baseURL argument for @source "u$ers" must be http or https, got ftp

--- a/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__unparseable_url.snap
+++ b/apollo-federation/src/sources/connect/models/snapshots/apollo_federation__sources__connect__models__validation__test_validate_source__unparseable_url.snap
@@ -2,4 +2,4 @@
 source: apollo-federation/src/sources/connect/models/validation.rs
 expression: "errors[0].to_string()"
 ---
-invalid characters in @source name "u$ers", only alphanumeric and underscores are allowed
+baseURL argument for @source "v1" was not a valid URL: relative URL without a base


### PR DESCRIPTION
These changes are to power https://github.com/apollographql/federation-rs/pull/499

Previously, errors attempted to refer to a part of the AST without passing nodes themselves (e.g., the `name` of a source directive), since they had to be translated into the JavaScript version of the AST. We couldn't use positions (offsets/line/column) because we did not have the _original_ source, only one that had been modified by the JavaScript composition code.

Now, we return line/column information to be directly consumed by `supergraph` binaries. This version of the connectors validation code is what's powering `supergraph@v2.8.0-connectors.5`