### PR TITLE
json_selection: fix pretty print duplicate $

### DIFF
--- a/apollo-federation/src/sources/connect/fetch_dependency_graph/mod.rs
+++ b/apollo-federation/src/sources/connect/fetch_dependency_graph/mod.rs
@@ -768,6 +768,7 @@ mod tests {
         use crate::sources::connect::json_selection::Alias;
         use crate::sources::connect::json_selection::Key;
         use crate::sources::connect::json_selection::NamedSelection;
+        use crate::sources::connect::json_selection::PrettyPrintable;
         use crate::sources::connect::ConnectId;
         use crate::sources::connect::JSONSelection;
         use crate::sources::source;
@@ -1175,7 +1176,7 @@ mod tests {
             assert_eq!(result.source_entering_edge, source_entering_edge);
             assert_eq!(result.field_response_name.as_str(), "_simple_path_test");
             assert_eq!(result.field_arguments, IndexMap::new());
-            assert_snapshot!(result.selection.unwrap().pretty_print(None).unwrap(), @r###"
+            assert_snapshot!(result.selection.unwrap().pretty_print().unwrap(), @r###"
             {
               a
               b
@@ -1264,7 +1265,7 @@ mod tests {
             assert_eq!(result.source_entering_edge, source_entering_edge);
             assert_eq!(result.field_response_name.as_str(), "_nested_path_test");
             assert_eq!(result.field_arguments, IndexMap::new());
-            assert_snapshot!(result.selection.unwrap().pretty_print(None).unwrap(), @r###"
+            assert_snapshot!(result.selection.unwrap().pretty_print().unwrap(), @r###"
             {
               a
               b {
@@ -1407,7 +1408,7 @@ mod tests {
                 "_merge_nested_path_test"
             );
             assert_eq!(result.field_arguments, IndexMap::new());
-            assert_snapshot!(result.selection.unwrap().pretty_print(None).unwrap(), @r###"
+            assert_snapshot!(result.selection.unwrap().pretty_print().unwrap(), @r###"
             .foo.bar {
               qux: .qaax
               qax: .qaax {

--- a/apollo-federation/src/sources/connect/json_selection/mod.rs
+++ b/apollo-federation/src/sources/connect/json_selection/mod.rs
@@ -2,6 +2,8 @@ mod apply_to;
 mod graphql;
 mod helpers;
 mod parser;
+mod pretty;
 
 pub use apply_to::*;
 pub use parser::*;
+pub use pretty::*;

--- a/apollo-federation/src/sources/connect/json_selection/mod.rs
+++ b/apollo-federation/src/sources/connect/json_selection/mod.rs
@@ -6,4 +6,8 @@ mod pretty;
 
 pub use apply_to::*;
 pub use parser::*;
+// Pretty code is currently only used in tests, so this cfg is to suppress the
+// unused lint warning. If pretty code is needed in not test code, feel free to
+// remove the `#[cfg(test)]`.
+#[cfg(test)]
 pub use pretty::*;

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -63,22 +63,6 @@ impl JSONSelection {
             JSONSelection::Path(path) => path.next_mut_subselection(),
         }
     }
-
-    /// Prints the JSON selection as though it were a prettified string
-    pub fn pretty_print(&self, indentation: Option<usize>) -> Result<String, std::fmt::Error> {
-        let mut result = String::new();
-
-        match self {
-            JSONSelection::Named(named) => {
-                write!(result, "{}", named.pretty_print(indentation)?)
-            }
-            JSONSelection::Path(path) => {
-                write!(result, "{}", path.pretty_print(indentation)?)
-            }
-        }?;
-
-        Ok(result)
-    }
 }
 
 // NamedSelection       ::= NamedPathSelection | NamedFieldSelection | NamedQuotedSelection | NamedGroupSelection
@@ -96,7 +80,7 @@ pub enum NamedSelection {
 }
 
 impl NamedSelection {
-    fn parse(input: &str) -> IResult<&str, Self> {
+    pub(crate) fn parse(input: &str) -> IResult<&str, Self> {
         alt((
             // We must try parsing NamedPathSelection before NamedFieldSelection
             // and NamedQuotedSelection because a NamedPathSelection without a
@@ -200,48 +184,6 @@ impl NamedSelection {
             _ => None,
         }
     }
-
-    pub fn pretty_print(&self, indentation: Option<usize>) -> Result<String, std::fmt::Error> {
-        let mut result = String::new();
-        let indentation = indentation.unwrap_or_default();
-        let indent_chars = (0..indentation * 2).map(|_| ' ').collect::<String>();
-
-        write!(result, "{indent_chars}")?;
-        match self {
-            NamedSelection::Field(Some(Alias { name }), ident, Some(sub)) => {
-                let sub = sub.pretty_print(Some(indentation))?;
-                write!(result, "{name}: {ident} {sub}")
-            }
-            NamedSelection::Field(Some(Alias { name }), ident, None) => {
-                writeln!(result, "{name}: {ident}")
-            }
-            NamedSelection::Field(None, ident, Some(sub)) => {
-                let sub = sub.pretty_print(Some(indentation))?;
-                write!(result, "{ident} {sub}")
-            }
-            NamedSelection::Field(None, ident, None) => writeln!(result, "{ident}"),
-
-            NamedSelection::Quoted(Alias { name }, literal, Some(sub)) => {
-                let sub = sub.pretty_print(Some(indentation))?;
-                write!(result, r#"{name}: "{literal}" {sub}"#)
-            }
-            NamedSelection::Quoted(Alias { name }, literal, None) => {
-                writeln!(result, r#"{name}: "{literal}""#)
-            }
-
-            NamedSelection::Path(Alias { name }, path) => {
-                let path = path.pretty_print(Some(indentation))?;
-                write!(result, "{name}: {}", path.trim_start())
-            }
-
-            NamedSelection::Group(Alias { name }, sub) => {
-                let sub = sub.pretty_print(Some(indentation))?;
-                write!(result, "{name}: {sub}")
-            }
-        }?;
-
-        Ok(result)
-    }
 }
 
 // PathSelection ::= (VarPath | KeyPath) SubSelection?
@@ -260,7 +202,7 @@ pub enum PathSelection {
 }
 
 impl PathSelection {
-    fn parse(input: &str) -> IResult<&str, Self> {
+    pub(crate) fn parse(input: &str) -> IResult<&str, Self> {
         match Self::parse_with_depth(input, 0) {
             Ok((remainder, Self::Empty)) => Err(nom::Err::Error(nom::error::Error::new(
                 remainder,
@@ -378,28 +320,6 @@ impl PathSelection {
             PathSelection::Empty => None,
         }
     }
-
-    pub fn pretty_print(&self, indentation: Option<usize>) -> Result<String, std::fmt::Error> {
-        let mut result = String::new();
-
-        match self {
-            PathSelection::Var(var, path) => {
-                let rest = path.pretty_print(indentation)?;
-                write!(result, "{var}{rest}")?;
-            }
-            PathSelection::Key(key, path) => {
-                let rest = path.pretty_print(indentation)?;
-                write!(result, "{key}{rest}")?;
-            }
-            PathSelection::Selection(sub) => {
-                let sub = sub.pretty_print(indentation)?;
-                write!(result, " {sub}")?;
-            }
-            PathSelection::Empty => {}
-        }
-
-        Ok(result)
-    }
 }
 
 // SubSelection ::= "{" NakedSubSelection "}"
@@ -411,7 +331,7 @@ pub struct SubSelection {
 }
 
 impl SubSelection {
-    fn parse(input: &str) -> IResult<&str, Self> {
+    pub(crate) fn parse(input: &str) -> IResult<&str, Self> {
         tuple((
             spaces_or_comments,
             char('{'),
@@ -427,29 +347,6 @@ impl SubSelection {
         ))(input)
         .map(|(input, (_, _, selections, star, _, _, _))| (input, Self { selections, star }))
     }
-
-    pub fn pretty_print(&self, indentation: Option<usize>) -> Result<String, std::fmt::Error> {
-        let mut result = String::new();
-        let indentation = indentation.unwrap_or_default();
-        let indent_chars = (0..indentation * 2).map(|_| ' ').collect::<String>();
-
-        // Note: We purposefully do not indent the opening brace
-        writeln!(result, "{{")?;
-        for selection in &self.selections {
-            let selection = selection.pretty_print(Some(indentation + 1))?;
-
-            // Indent the lines to match our level of indentation
-            writeln!(result, "{}", selection.trim_end())?;
-        }
-
-        if let Some(star) = self.star.as_ref() {
-            let star = star.pretty_print(Some(indentation + 1))?;
-            writeln!(result, "{star}")?;
-        }
-
-        writeln!(result, "{indent_chars}}}")?;
-        Ok(result)
-    }
 }
 
 // StarSelection ::= Alias? "*" SubSelection?
@@ -458,7 +355,7 @@ impl SubSelection {
 pub struct StarSelection(pub Option<Alias>, pub Option<Box<SubSelection>>);
 
 impl StarSelection {
-    fn parse(input: &str) -> IResult<&str, Self> {
+    pub(crate) fn parse(input: &str) -> IResult<&str, Self> {
         tuple((
             // The spaces_or_comments separators are necessary here because
             // Alias::parse and SubSelection::parse only consume surrounding
@@ -472,26 +369,6 @@ impl StarSelection {
         .map(|(remainder, (alias, _, _, _, selection))| {
             (remainder, Self(alias, selection.map(Box::new)))
         })
-    }
-
-    pub fn pretty_print(&self, indentation: Option<usize>) -> Result<String, std::fmt::Error> {
-        let mut result = String::new();
-        let indentation = indentation.unwrap_or_default();
-        let indent_chars = (0..indentation * 2).map(|_| ' ').collect::<String>();
-
-        write!(result, "{indent_chars}")?;
-        if let Some(alias) = self.0.as_ref() {
-            write!(result, "{}: ", alias.name)?;
-        }
-
-        write!(result, "*")?;
-
-        if let Some(sub) = self.1.as_ref() {
-            let sub = sub.pretty_print(Some(indentation + 1))?;
-            write!(result, " {sub}")?;
-        }
-
-        Ok(result)
     }
 }
 

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -385,7 +385,7 @@ impl PathSelection {
         match self {
             PathSelection::Var(var, path) => {
                 let rest = path.pretty_print(indentation)?;
-                write!(result, "${var}{rest}")?;
+                write!(result, "{var}{rest}")?;
             }
             PathSelection::Key(key, path) => {
                 let rest = path.pretty_print(indentation)?;

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -1,5 +1,4 @@
 use std::fmt::Display;
-use std::fmt::Write;
 
 use nom::branch::alt;
 use nom::character::complete::char;

--- a/apollo-federation/src/sources/connect/json_selection/pretty.rs
+++ b/apollo-federation/src/sources/connect/json_selection/pretty.rs
@@ -7,13 +7,12 @@
 
 use std::fmt::Write;
 
+use crate::sources::connect::json_selection::Alias;
 use crate::sources::connect::json_selection::JSONSelection;
+use crate::sources::connect::json_selection::NamedSelection;
 use crate::sources::connect::json_selection::PathSelection;
+use crate::sources::connect::json_selection::StarSelection;
 use crate::sources::connect::json_selection::SubSelection;
-
-use super::Alias;
-use super::NamedSelection;
-use super::StarSelection;
 
 /// Pretty print trait
 ///
@@ -215,10 +214,12 @@ impl PrettyPrintable for StarSelection {
 
 #[cfg(test)]
 mod tests {
-    use crate::sources::connect::{
-        json_selection::{pretty::indent_chars, NamedSelection, PrettyPrintable, StarSelection},
-        PathSelection, SubSelection,
-    };
+    use crate::sources::connect::json_selection::pretty::indent_chars;
+    use crate::sources::connect::json_selection::NamedSelection;
+    use crate::sources::connect::json_selection::PrettyPrintable;
+    use crate::sources::connect::json_selection::StarSelection;
+    use crate::sources::connect::PathSelection;
+    use crate::sources::connect::SubSelection;
 
     // Test all valid pretty print permutations
     fn test_permutations(selection: impl PrettyPrintable, expected: &str) {

--- a/apollo-federation/src/sources/connect/json_selection/pretty.rs
+++ b/apollo-federation/src/sources/connect/json_selection/pretty.rs
@@ -1,0 +1,376 @@
+//! Pretty printing utility methods
+//!
+//! Working with raw JSONSelections when doing snapshot testing is difficult to
+//! read and makes the snapshots themselves quite large. This module adds a new
+//! pretty printing trait which is then implemented on the various sub types
+//! of the JSONSelection tree.
+
+use std::fmt::Write;
+
+use crate::sources::connect::json_selection::JSONSelection;
+use crate::sources::connect::json_selection::PathSelection;
+use crate::sources::connect::json_selection::SubSelection;
+
+use super::Alias;
+use super::NamedSelection;
+use super::StarSelection;
+
+/// Pretty print trait
+///
+/// This trait marks a type as supporting pretty printing itself outside of a
+/// Display implementation, which might be more useful for snapshots.
+pub trait PrettyPrintable {
+    /// Pretty print the struct
+    fn pretty_print(&self) -> Result<String, std::fmt::Error> {
+        self.pretty_print_with_indentation(true, 0)
+    }
+
+    /// Pretty print the struct, with indentation
+    ///
+    /// Each indentation level is marked with 2 spaces, with `inline` signifying
+    /// that the first line should be not indented.
+    fn pretty_print_with_indentation(
+        &self,
+        inline: bool,
+        indentation: usize,
+    ) -> Result<String, std::fmt::Error>;
+}
+
+/// Helper method to generate indentation
+fn indent_chars(indent: usize) -> String {
+    (0..indent * 2).map(|_| ' ').collect::<String>()
+}
+
+impl PrettyPrintable for JSONSelection {
+    fn pretty_print_with_indentation(
+        &self,
+        inline: bool,
+        indentation: usize,
+    ) -> Result<String, std::fmt::Error> {
+        let mut result = String::new();
+
+        match self {
+            JSONSelection::Named(named) => {
+                write!(
+                    result,
+                    "{}",
+                    named.pretty_print_with_indentation(inline, indentation)?
+                )
+            }
+            JSONSelection::Path(path) => {
+                write!(
+                    result,
+                    "{}",
+                    path.pretty_print_with_indentation(inline, indentation)?
+                )
+            }
+        }?;
+
+        Ok(result)
+    }
+}
+
+impl PrettyPrintable for SubSelection {
+    fn pretty_print_with_indentation(
+        &self,
+        inline: bool,
+        indentation: usize,
+    ) -> Result<String, std::fmt::Error> {
+        let mut result = String::new();
+        let indent_chars = indent_chars(indentation);
+        if !inline {
+            write!(result, "{indent_chars}")?;
+        }
+
+        writeln!(result, "{{")?;
+        for selection in &self.selections {
+            let selection = selection.pretty_print_with_indentation(false, indentation + 1)?;
+
+            // Indent the lines to match our level of indentation
+            writeln!(result, "{}", selection)?;
+        }
+
+        if let Some(star) = self.star.as_ref() {
+            let star = star.pretty_print_with_indentation(false, indentation + 1)?;
+            writeln!(result, "{star}")?;
+        }
+
+        write!(result, "{indent_chars}}}")?;
+        Ok(result)
+    }
+}
+
+impl PrettyPrintable for PathSelection {
+    fn pretty_print_with_indentation(
+        &self,
+        inline: bool,
+        indentation: usize,
+    ) -> Result<String, std::fmt::Error> {
+        let mut result = String::new();
+
+        if !inline {
+            let indent_chars = indent_chars(indentation);
+            write!(result, "{indent_chars}")?;
+        }
+
+        match self {
+            PathSelection::Var(var, path) => {
+                let rest = path.pretty_print_with_indentation(true, indentation)?;
+                write!(result, "{var}{rest}")?;
+            }
+            PathSelection::Key(key, path) => {
+                let rest = path.pretty_print_with_indentation(true, indentation)?;
+                write!(result, "{key}{rest}")?;
+            }
+            PathSelection::Selection(sub) => {
+                let sub = sub.pretty_print_with_indentation(true, indentation)?;
+                write!(result, " {sub}")?;
+            }
+            PathSelection::Empty => {}
+        }
+
+        Ok(result)
+    }
+}
+
+impl PrettyPrintable for NamedSelection {
+    fn pretty_print_with_indentation(
+        &self,
+        inline: bool,
+        indentation: usize,
+    ) -> Result<String, std::fmt::Error> {
+        let mut result = String::new();
+        if !inline {
+            let indent_chars = indent_chars(indentation);
+            write!(result, "{indent_chars}")?;
+        }
+
+        match self {
+            NamedSelection::Field(Some(Alias { name }), ident, Some(sub)) => {
+                let sub = sub.pretty_print_with_indentation(true, indentation)?;
+                write!(result, "{name}: {ident} {sub}")
+            }
+            NamedSelection::Field(Some(Alias { name }), ident, None) => {
+                write!(result, "{name}: {ident}")
+            }
+            NamedSelection::Field(None, ident, Some(sub)) => {
+                let sub = sub.pretty_print_with_indentation(true, indentation)?;
+                write!(result, "{ident} {sub}")
+            }
+            NamedSelection::Field(None, ident, None) => write!(result, "{ident}"),
+
+            NamedSelection::Quoted(Alias { name }, literal, Some(sub)) => {
+                let sub = sub.pretty_print_with_indentation(true, indentation)?;
+                write!(result, r#"{name}: "{literal}" {sub}"#)
+            }
+            NamedSelection::Quoted(Alias { name }, literal, None) => {
+                write!(result, r#"{name}: "{literal}""#)
+            }
+
+            NamedSelection::Path(Alias { name }, path) => {
+                let path = path.pretty_print_with_indentation(true, indentation)?;
+
+                // If the path selection is a sub, then we need to remove the extra space that gets appended by the
+                // pretty printer for it.
+                write!(result, "{name}: {}", path.trim_start())
+            }
+
+            NamedSelection::Group(Alias { name }, sub) => {
+                let sub = sub.pretty_print_with_indentation(true, indentation)?;
+                write!(result, "{name}: {sub}")
+            }
+        }?;
+
+        Ok(result)
+    }
+}
+
+impl PrettyPrintable for StarSelection {
+    fn pretty_print_with_indentation(
+        &self,
+        inline: bool,
+        indentation: usize,
+    ) -> Result<String, std::fmt::Error> {
+        let mut result = String::new();
+        let indent_chars = indent_chars(indentation);
+
+        if !inline {
+            write!(result, "{indent_chars}")?;
+        }
+
+        if let Some(alias) = self.0.as_ref() {
+            write!(result, "{}: ", alias.name)?;
+        }
+
+        write!(result, "*")?;
+
+        if let Some(sub) = self.1.as_ref() {
+            let sub = sub.pretty_print_with_indentation(true, indentation)?;
+            write!(result, " {sub}")?;
+        }
+
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sources::connect::{
+        json_selection::{pretty::indent_chars, NamedSelection, PrettyPrintable, StarSelection},
+        PathSelection, SubSelection,
+    };
+
+    // Test all valid pretty print permutations
+    fn test_permutations(selection: impl PrettyPrintable, expected: &str) {
+        let indentation = 4;
+        let expected_indented = expected
+            .lines()
+            .map(|line| format!("{}{line}", indent_chars(indentation)))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let prettified = selection.pretty_print().unwrap();
+        assert_eq!(
+            prettified, expected,
+            "pretty printing did not match: {prettified} != {expected}"
+        );
+
+        let prettified_inline = selection
+            .pretty_print_with_indentation(true, indentation)
+            .unwrap();
+        assert_eq!(
+            prettified_inline,
+            expected_indented.trim_start(),
+            "pretty printing inline did not match: {prettified_inline} != {}",
+            expected_indented.trim_start()
+        );
+
+        let prettified_indented = selection
+            .pretty_print_with_indentation(false, indentation)
+            .unwrap();
+        assert_eq!(
+            prettified_indented, expected_indented,
+            "pretty printing indented did not match: {prettified_indented} != {expected_indented}"
+        );
+    }
+
+    #[test]
+    fn it_prints_a_star_selection() {
+        let (unmatched, star_selection) = StarSelection::parse("rest: *").unwrap();
+        assert!(unmatched.is_empty());
+
+        test_permutations(star_selection, "rest: *");
+    }
+
+    #[test]
+    fn it_prints_a_star_selection_with_subselection() {
+        let (unmatched, star_selection) = StarSelection::parse("rest: * { a b }").unwrap();
+        assert!(unmatched.is_empty());
+
+        test_permutations(star_selection, "rest: * {\n  a\n  b\n}");
+    }
+
+    #[test]
+    fn it_prints_a_named_selection() {
+        let selections = [
+            // Field
+            "cool",
+            "cool: beans",
+            "cool: beans {\n  whoa\n}",
+            // Path
+            "cool: .one.two.three",
+            // Quoted
+            r#"cool: "b e a n s""#,
+            "cool: \"b e a n s\" {\n  a\n  b\n}",
+            // Group
+            "cool: {\n  a\n  b\n}",
+        ];
+        for selection in selections {
+            let (unmatched, named_selection) = NamedSelection::parse(selection).unwrap();
+            assert!(
+                unmatched.is_empty(),
+                "static named selection was not fully parsed: '{selection}' ({named_selection:?}) had unmatched '{unmatched}'"
+            );
+
+            test_permutations(named_selection, selection);
+        }
+    }
+
+    #[test]
+    fn it_prints_a_path_selection() {
+        let paths = [
+            // Var
+            "$.one.two.three",
+            "$this.a.b",
+            "$id.first {\n  username\n}",
+            // Key
+            ".first",
+            ".a.b.c.d.e",
+            ".one.two.three {\n  a\n  b\n}",
+        ];
+        for path in paths {
+            let (unmatched, path_selection) = PathSelection::parse(path).unwrap();
+            assert!(
+                unmatched.is_empty(),
+                "static path was not fully parsed: '{path}' ({path_selection:?}) had unmatched '{unmatched}'"
+            );
+
+            test_permutations(path_selection, path);
+        }
+    }
+
+    #[test]
+    fn it_prints_a_sub_selection() {
+        let sub = "{\n  a\n  b\n}";
+        let (unmatched, sub_selection) = SubSelection::parse(sub).unwrap();
+        assert!(
+            unmatched.is_empty(),
+            "static path was not fully parsed: '{sub}' ({sub_selection:?}) had unmatched '{unmatched}'"
+        );
+
+        test_permutations(sub_selection, sub);
+    }
+
+    #[test]
+    fn it_prints_a_nested_sub_selection() {
+        let sub = "{
+          a {
+            b {
+              c
+            }
+          }
+        }";
+        let sub_indented = "{\n  a {\n    b {\n      c\n    }\n  }\n}";
+        let sub_super_indented = "        {\n          a {\n            b {\n              c\n            }\n          }\n        }";
+
+        let (unmatched, sub_selection) = SubSelection::parse(sub).unwrap();
+        assert!(
+            unmatched.is_empty(),
+            "static nested sub was not fully parsed: '{sub}' ({sub_selection:?}) had unmatched '{unmatched}'"
+        );
+
+        let pretty = sub_selection.pretty_print().unwrap();
+        assert_eq!(
+            pretty, sub_indented,
+            "nested sub pretty printing did not match: {pretty} != {sub_indented}"
+        );
+
+        let pretty = sub_selection
+            .pretty_print_with_indentation(true, 4)
+            .unwrap();
+        assert_eq!(
+            pretty,
+            sub_super_indented.trim_start(),
+            "nested inline sub pretty printing did not match: {pretty} != {}",
+            sub_super_indented.trim_start()
+        );
+
+        let pretty = sub_selection
+            .pretty_print_with_indentation(false, 4)
+            .unwrap();
+        assert_eq!(
+            pretty, sub_super_indented,
+            "nested inline sub pretty printing did not match: {pretty} != {sub_super_indented}",
+        );
+    }
+}

--- a/apollo-federation/src/sources/connect/json_selection/pretty.rs
+++ b/apollo-federation/src/sources/connect/json_selection/pretty.rs
@@ -37,7 +37,7 @@ pub trait PrettyPrintable {
 
 /// Helper method to generate indentation
 fn indent_chars(indent: usize) -> String {
-    (0..indent * 2).map(|_| ' ').collect::<String>()
+    "  ".repeat(indent)
 }
 
 impl PrettyPrintable for JSONSelection {


### PR DESCRIPTION
Fixes an issue where a path with a variable would duplicate the $.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
