### PR TITLE
Add support for operation name on graphql metrics.

### DIFF
--- a/.changesets/exp_experimental_graphql_instruments.md
+++ b/.changesets/exp_experimental_graphql_instruments.md
@@ -1,6 +1,6 @@
-### Add graphql instruments ([PR #5215](https://github.com/apollographql/router/pull/5215))
+### Add graphql instruments ([PR #5215](https://github.com/apollographql/router/pull/5215), [PR #5257](https://github.com/apollographql/router/pull/5257))
 
-This PR adds experimental GraphQL instruments to telemetry as a commercial feature.
+This PR adds experimental GraphQL instruments to telemetry.
 
 It makes the following possible:
 ```
@@ -47,7 +47,9 @@ telemetry:
               - "topProducts"
 ```
 
-Note that users should not use this feature yet as it will have performance issues, may cause excessive metrics to be generated and we may change or remove this feature.
-It is for experimental purposes only and is not supported in production environments.
+Note that this will have a significant performance impact which will be addressed in a following release.
+Users should also be aware that large numbers of excessive metrics may be generated, and they should take care not to run up a large APM bill.
 
-By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5215
+For now, do not use these metrics in production.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5215 and https://github.com/apollographql/router/pull/5257

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -2801,6 +2801,11 @@ expression: "&schema"
           "nullable": true,
           "type": "boolean"
         },
+        "graphql.operation.name": {
+          "default": null,
+          "nullable": true,
+          "type": "boolean"
+        },
         "graphql.type.name": {
           "default": null,
           "description": "The GraphQL type name",
@@ -2879,6 +2884,24 @@ expression: "&schema"
           },
           "required": [
             "type_name"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "default": {
+              "description": "Optional default value.",
+              "nullable": true,
+              "type": "string"
+            },
+            "operation_name": {
+              "$ref": "#/definitions/OperationName",
+              "description": "#/definitions/OperationName"
+            }
+          },
+          "required": [
+            "operation_name"
           ],
           "type": "object"
         },
@@ -7635,6 +7658,11 @@ expression: "&schema"
         "graphql.list.length": {
           "default": null,
           "description": "If the field is a list, the length of the list",
+          "nullable": true,
+          "type": "boolean"
+        },
+        "graphql.operation.name": {
+          "default": null,
           "nullable": true,
           "type": "boolean"
         },

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -2803,6 +2803,7 @@ expression: "&schema"
         },
         "graphql.operation.name": {
           "default": null,
+          "description": "The GraphQL operation name",
           "nullable": true,
           "type": "boolean"
         },
@@ -7663,6 +7664,7 @@ expression: "&schema"
         },
         "graphql.operation.name": {
           "default": null,
+          "description": "The GraphQL operation name",
           "nullable": true,
           "type": "boolean"
         },

--- a/apollo-router/src/plugins/telemetry/config_new/graphql/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/graphql/attributes.rs
@@ -30,6 +30,7 @@ pub(crate) struct GraphQLAttributes {
     /// If the field is a list, the length of the list
     #[serde(rename = "graphql.list.length")]
     pub(crate) list_length: Option<bool>,
+    /// The GraphQL operation name
     #[serde(rename = "graphql.operation.name")]
     pub(crate) operation_name: Option<bool>,
     /// The GraphQL type name

--- a/apollo-router/src/plugins/telemetry/config_new/graphql/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/graphql/attributes.rs
@@ -9,6 +9,7 @@ use crate::plugins::telemetry::config_new::graphql::selectors::FieldType;
 use crate::plugins::telemetry::config_new::graphql::selectors::GraphQLSelector;
 use crate::plugins::telemetry::config_new::graphql::selectors::ListLength;
 use crate::plugins::telemetry::config_new::graphql::selectors::TypeName;
+use crate::plugins::telemetry::config_new::selectors::OperationName;
 use crate::plugins::telemetry::config_new::DefaultAttributeRequirementLevel;
 use crate::plugins::telemetry::config_new::DefaultForLevel;
 use crate::plugins::telemetry::config_new::Selector;
@@ -29,6 +30,8 @@ pub(crate) struct GraphQLAttributes {
     /// If the field is a list, the length of the list
     #[serde(rename = "graphql.list.length")]
     pub(crate) list_length: Option<bool>,
+    #[serde(rename = "graphql.operation.name")]
+    pub(crate) operation_name: Option<bool>,
     /// The GraphQL type name
     #[serde(rename = "graphql.type.name")]
     pub(crate) type_name: Option<bool>,
@@ -105,17 +108,29 @@ impl Selectors for GraphQLAttributes {
                 attrs.push(KeyValue::new("graphql.list.length", length));
             }
         }
+        if let Some(true) = self.operation_name {
+            if let Some(length) = (GraphQLSelector::OperationName {
+                operation_name: OperationName::String,
+                default: None,
+            })
+            .on_response_field(typed_value, ctx)
+            {
+                attrs.push(KeyValue::new("graphql.operation.name", length));
+            }
+        }
         attrs
     }
 }
 
 #[cfg(test)]
 mod test {
+    use crate::context::OPERATION_NAME;
     use crate::plugins::demand_control::cost_calculator::schema_aware_response::TypedValue;
     use crate::plugins::telemetry::config_new::test::field;
     use crate::plugins::telemetry::config_new::test::ty;
     use crate::plugins::telemetry::config_new::DefaultForLevel;
     use crate::plugins::telemetry::config_new::Selectors;
+    use crate::Context;
 
     #[test]
     fn test_default_for_level() {
@@ -128,6 +143,7 @@ mod test {
         assert_eq!(attributes.field_type, Some(true));
         assert_eq!(attributes.type_name, Some(true));
         assert_eq!(attributes.list_length, None);
+        assert_eq!(attributes.operation_name, None);
     }
 
     #[test]
@@ -136,18 +152,22 @@ mod test {
             field_name: Some(true),
             field_type: Some(true),
             list_length: Some(true),
+            operation_name: Some(true),
             type_name: Some(true),
         };
         let typed_value = TypedValue::Bool(ty(), field(), &true);
-        let ctx = Default::default();
+        let ctx = Context::default();
+        let _ = ctx.insert(OPERATION_NAME, "operation_name".to_string());
         let result = attributes.on_response_field(&typed_value, &ctx);
-        assert_eq!(result.len(), 3);
+        assert_eq!(result.len(), 4);
         assert_eq!(result[0].key.as_str(), "graphql.field.name");
         assert_eq!(result[0].value.as_str(), "field_name");
         assert_eq!(result[1].key.as_str(), "graphql.field.type");
         assert_eq!(result[1].value.as_str(), "field_type");
         assert_eq!(result[2].key.as_str(), "graphql.type.name");
         assert_eq!(result[2].value.as_str(), "type_name");
+        assert_eq!(result[3].key.as_str(), "graphql.operation.name");
+        assert_eq!(result[3].value.as_str(), "operation_name");
     }
 
     #[test]
@@ -156,6 +176,7 @@ mod test {
             field_name: Some(true),
             field_type: Some(true),
             list_length: Some(true),
+            operation_name: Some(true),
             type_name: Some(true),
         };
         let typed_value = TypedValue::List(
@@ -167,9 +188,10 @@ mod test {
                 TypedValue::Bool(ty(), field(), &true),
             ],
         );
-        let ctx = Default::default();
+        let ctx = Context::default();
+        let _ = ctx.insert(OPERATION_NAME, "operation_name".to_string());
         let result = attributes.on_response_field(&typed_value, &ctx);
-        assert_eq!(result.len(), 4);
+        assert_eq!(result.len(), 5);
         assert_eq!(result[0].key.as_str(), "graphql.field.name");
         assert_eq!(result[0].value.as_str(), "field_name");
         assert_eq!(result[1].key.as_str(), "graphql.field.type");
@@ -178,5 +200,7 @@ mod test {
         assert_eq!(result[2].value.as_str(), "type_name");
         assert_eq!(result[3].key.as_str(), "graphql.list.length");
         assert_eq!(result[3].value.as_str(), "3");
+        assert_eq!(result[4].key.as_str(), "graphql.operation.name");
+        assert_eq!(result[4].value.as_str(), "operation_name");
     }
 }


### PR DESCRIPTION
Adds `operation_name` selector and `graphql.operation.name` attribute to graphql metrics.

This is not enabled by default as cardinality could be high, but it does allow graphql operation to be used in selector and therefore conditions.

```
telemetry:
  instrumentation:
    instruments:
      graphql:
        list.length:
          attributes:
            graphql.operation.name: true
```

```
telemetry:
  instrumentation:
    instruments:
      graphql:
        my.field.usage:
          unit: "unit"
          value: field_unit
          condition:
            eq:
              - operation_name: string
              - "ExampleQuery"
          type: counter
          description: "description"

          attributes:
            graphql.list.length: true
            graphql.field.name: true
            graphql.operation.name: true
```

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
