### PR TITLE
PoC with experimental updated line/col support in apollo-compiler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,10 +193,9 @@ checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 [[package]]
 name = "apollo-compiler"
 version = "1.0.0-beta.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175659cea0232b38bfacd1505aed00221cc4028d848699ce9e3422c6bf87d90a"
+source = "git+https://github.com/dylan-apollo/apollo-rs.git?branch=dylan/line-column-range#88c033910f1f054a5b5cb1b6bacc74baa3672007"
 dependencies = [
- "apollo-parser",
+ "apollo-parser 0.7.7 (git+https://github.com/dylan-apollo/apollo-rs.git?branch=dylan/line-column-range)",
  "ariadne",
  "indexmap 2.2.3",
  "rowan",
@@ -214,7 +213,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee9f27b20841d14923dd5f0714a79f86360b23492d2f98ab5d1651471a56b7a4"
 dependencies = [
- "apollo-parser",
+ "apollo-parser 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror",
 ]
 
@@ -258,6 +257,16 @@ name = "apollo-parser"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bb7c8a9776825e5524b5ab3a7f478bf091a054180f244dff85814452cb87d90"
+dependencies = [
+ "memchr",
+ "rowan",
+ "thiserror",
+]
+
+[[package]]
+name = "apollo-parser"
+version = "0.7.7"
+source = "git+https://github.com/dylan-apollo/apollo-rs.git?branch=dylan/line-column-range#88c033910f1f054a5b5cb1b6bacc74baa3672007"
 dependencies = [
  "memchr",
  "rowan",
@@ -431,7 +440,7 @@ dependencies = [
 name = "apollo-router-benchmarks"
 version = "1.47.0"
 dependencies = [
- "apollo-parser",
+ "apollo-parser 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "apollo-router",
  "apollo-smith",
  "arbitrary",
@@ -482,7 +491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "441a51f1055d2eebcda41b55066de925502e11c97097c6d1bab0da5bdeb5c70f"
 dependencies = [
  "apollo-encoder",
- "apollo-parser",
+ "apollo-parser 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "arbitrary",
  "once_cell",
  "thiserror",
@@ -505,9 +514,9 @@ checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
 name = "ariadne"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd002a6223f12c7a95cdd4b1cb3a0149d22d37f7a9ecdb2cb691a071fe236c29"
+checksum = "44055e597c674aef7cb903b2b9f6e4cba1277ed0d2d61dae7cd52d7ffa81f8e2"
 dependencies = [
  "concolor",
  "unicode-width",
@@ -5821,7 +5830,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "apollo-compiler",
- "apollo-parser",
+ "apollo-parser 0.7.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "apollo-router",
  "apollo-smith",
  "async-trait",
@@ -8244,9 +8253,9 @@ dependencies = [
 
 [[package]]
 name = "yansi"
-version = "0.5.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ debug = 1
 # Dependencies used in more than one place are specified here in order to keep versions in sync:
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
 [workspace.dependencies]
-apollo-compiler = "=1.0.0-beta.16"
+apollo-compiler = { version = "=1.0.0-beta.16", git = "https://github.com/dylan-apollo/apollo-rs.git", branch = "dylan/line-column-range" }
 apollo-parser = "0.7.6"
 apollo-smith = { version = "0.5.0", features = ["parser-impl"] }
 async-trait = "0.1.77"

--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -23,7 +23,6 @@ pub use json_selection::Key;
 pub use json_selection::PathSelection;
 pub use json_selection::SubSelection;
 pub use models::validate;
-pub use models::GraphQLLocation;
 pub use models::ValidationError;
 pub use models::ValidationErrorCode;
 pub(crate) use spec::ConnectSpecDefinition;

--- a/apollo-federation/src/sources/connect/models/mod.rs
+++ b/apollo-federation/src/sources/connect/models/mod.rs
@@ -5,7 +5,6 @@ use indexmap::IndexMap;
 pub use validation::validate;
 pub use validation::Error as ValidationError;
 pub use validation::ErrorCode as ValidationErrorCode;
-pub use validation::GraphQLLocation;
 
 use super::spec::ConnectHTTPArguments;
 use super::spec::HTTPHeaderOption;

--- a/apollo-federation/src/sources/connect/models/validation.rs
+++ b/apollo-federation/src/sources/connect/models/validation.rs
@@ -179,7 +179,7 @@ fn validate_source(directive: &Component<Directive>, sources: &SourceMap) -> Sou
                         message: format!(
                             "baseURL argument for {name} was not a valid URL: {inner}"
                         ),
-                        locations: transform_location(&arg, sources),
+                        locations: transform_location(arg, sources),
                     })
                 }
                 Ok(url) => url,
@@ -253,7 +253,7 @@ fn validate_object(
                             object_name = object.name,
                             field_name = field.name,
                         ),
-                        locations: transform_location(&source_name, sources)
+                        locations: transform_location(source_name, sources)
                     });
             }
         }

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -626,18 +626,18 @@ impl IntoGraphQLErrors for ParseErrors {
             .errors
             .iter()
             .map(|diagnostic| {
+                let graphql_error = diagnostic.to_json();
                 Error::builder()
-                    .message(diagnostic.error.to_string())
+                    .message(graphql_error.message)
                     .locations(
-                        diagnostic
-                            .get_line_column()
-                            .map(|location| {
-                                vec![ErrorLocation {
-                                    line: location.line as u32,
-                                    column: location.column as u32,
-                                }]
+                        graphql_error
+                            .locations
+                            .into_iter()
+                            .map(|location| ErrorLocation {
+                                line: location.line as u32,
+                                column: location.column as u32,
                             })
-                            .unwrap_or_default(),
+                            .collect(),
                     )
                     .extension_code("GRAPHQL_PARSING_FAILED")
                     .build()

--- a/examples/supergraph-sdl/rust/Cargo.toml
+++ b/examples/supergraph-sdl/rust/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-apollo-compiler = "=1.0.0-beta.16"
+apollo-compiler.workspace = true
 apollo-router = { path = "../../../apollo-router" }
 async-trait = "0.1"
 tower = { version = "0.4", features = ["full"] }


### PR DESCRIPTION
Just demonstrating the required changes if https://github.com/apollographql/apollo-rs/pull/861 is accepted. This is based on my latest `connectors` branch so I can test what I need e2e. The only changes relevant to `dev` are in `apollo-router/src/error.rs` (which, maybe should be using the same `GraphQLError` struct as `apollo-compiler`)?