### PR TITLE
Sending query planner metrics to Apollo

### DIFF
--- a/.changesets/config_bryn_transmit_query_planning_metrics.md
+++ b/.changesets/config_bryn_transmit_query_planning_metrics.md
@@ -1,0 +1,9 @@
+### Sending query planner metrics to Apollo ([PR #5267](https://github.com/apollographql/router/pull/5267))
+
+To allow us to measure how much of an improvement the new query planner implementation makes, we are now transmitting metrics that start with:
+
+`apollo.router.query_planning.*` to Apollo.
+
+These metrics do not leak any sensitive information, but will greatly help us to improve query planning in the Router.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5267

--- a/apollo-router/src/metrics/filter.rs
+++ b/apollo-router/src/metrics/filter.rs
@@ -94,7 +94,7 @@ impl FilterMeterProvider {
             .delegate(delegate)
             .allow(
                 Regex::new(
-                    r"apollo\.(graphos\.cloud|router\.(operations?|config|schema|query))(\..*|$)",
+                    r"apollo\.(graphos\.cloud|router\.(operations?|config|schema|query|query_planning))(\..*|$)",
                 )
                 .expect("regex should have been valid"),
             )
@@ -280,6 +280,10 @@ mod test {
             .add(1, &[]);
         filtered
             .u64_counter("apollo.router.unknown.test")
+            .init()
+            .add(1, &[]);
+        filtered
+            .u64_counter("apollo.router.query_planning.test")
             .init()
             .add(1, &[]);
         meter_provider.force_flush(&cx).unwrap();

--- a/apollo-router/src/query_planner/bridge_query_planner_pool.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner_pool.rs
@@ -197,8 +197,7 @@ impl tower::Service<QueryPlannerRequest> for BridgeQueryPlannerPool {
             f64_histogram!(
                 "apollo.router.query_planning.total.duration",
                 "Duration of the time the router waited for a query plan, including both the queue time and planning time.",
-                start.elapsed().as_secs_f64(),
-                []
+                start.elapsed().as_secs_f64()
             );
 
             res


### PR DESCRIPTION
This does not leak any sensitive data, but does allow us to gather metrics on query planner time so that we can see where the rust query planner is making a difference.


REVIEWERS:
* Please check my assertion that no sensitive data is leaked on these metrics.
* Also has `apollo_router.query_planning.warmup.duration` been removed?

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
