### PR TITLE
Submit `lifecycle` metrics to Apollo

### DIFF
--- a/.changesets/fix_renee_lifecycle_metric.md
+++ b/.changesets/fix_renee_lifecycle_metric.md
@@ -1,0 +1,5 @@
+### Submit new metrics to Apollo ([PR #5270](https://github.com/apollographql/router/pull/5270))
+
+The router submits two new metrics to Apollo:
+- `apollo.router.lifecycle.api_schema` provides us feedback on the experimental Rust-based API schema generation.
+- `apollo.router.lifecycle.license` provides metrics on license expiration. We use this to improve the reliability of the license check mechanism.

--- a/apollo-router/src/metrics/filter.rs
+++ b/apollo-router/src/metrics/filter.rs
@@ -94,7 +94,7 @@ impl FilterMeterProvider {
             .delegate(delegate)
             .allow(
                 Regex::new(
-                    r"apollo\.(graphos\.cloud|router\.(operations?|config|schema|query))(\..*|$)",
+                    r"apollo\.(graphos\.cloud|router\.(operations?|lifecycle|config|schema|query))(\..*|$)",
                 )
                 .expect("regex should have been valid"),
             )
@@ -282,6 +282,10 @@ mod test {
             .u64_counter("apollo.router.unknown.test")
             .init()
             .add(1, &[]);
+        filtered
+            .u64_counter("apollo.router.lifecycle.api_schema")
+            .init()
+            .add(1, &[]);
         meter_provider.force_flush(&cx).unwrap();
 
         let metrics: Vec<_> = exporter
@@ -304,6 +308,10 @@ mod test {
         assert!(!metrics
             .iter()
             .any(|m| m.name == "apollo.router.unknown.test"));
+
+        assert!(metrics
+            .iter()
+            .any(|m| m.name == "apollo.router.lifecycle.api_schema"));
     }
 
     #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Rust API schema generation was enabled by default in #4931, but the metrics were not making it to us.

This change affects two metrics:
- `apollo.router.lifecycle.api_schema`
- `apollo.router.lifecycle.license`

Reviewers please check that it's okay for `.license` to be submitted as well.

Fixes ROUTER-332