### PR TITLE
fix(telemetry): metrics overflow is logged as a warning rather than error

### DIFF
--- a/.changesets/fix_bnjjj_fix_5173.md
+++ b/.changesets/fix_bnjjj_fix_5173.md
@@ -1,0 +1,7 @@
+### Metrics overflow is logged as a warning rather than error ([Issue #5173](https://github.com/apollographql/router/issues/5173))
+
+If a metric has too high a cardinality the following warning will be displayed as a warning instead of an errorl:
+
+`OpenTelemetry metric error occurred: Metrics error: Warning: Maximum data points for metric stream exceeded/ Entry added to overflow`
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/5287

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -22,6 +22,7 @@ use http::StatusCode;
 use multimap::MultiMap;
 use once_cell::sync::OnceCell;
 use opentelemetry::global::GlobalTracerProvider;
+use opentelemetry::metrics::MetricsError;
 use opentelemetry::propagation::text_map_propagator::FieldIter;
 use opentelemetry::propagation::Extractor;
 use opentelemetry::propagation::Injector;
@@ -1799,7 +1800,13 @@ fn handle_error_internal<T: Into<opentelemetry::global::Error>>(
                 ::tracing::error!("OpenTelemetry trace error occurred: {}", err)
             }
             opentelemetry::global::Error::Metric(err) => {
-                ::tracing::error!("OpenTelemetry metric error occurred: {}", err)
+                if let MetricsError::Other(msg) = &err {
+                    if msg.contains("Warning") {
+                        ::tracing::warn!("OpenTelemetry metric warning occurred: {}", msg);
+                        return;
+                    }
+                }
+                ::tracing::error!("OpenTelemetry metric error occurred: {}", err);
             }
             opentelemetry::global::Error::Other(err) => {
                 ::tracing::error!("OpenTelemetry error occurred: {}", err)


### PR DESCRIPTION
If a metric has too high a cardinality the following warning will be displayed as a warning instead of an errorl:

`OpenTelemetry metric error occurred: Metrics error: Warning: Maximum data points for metric stream exceeded/ Entry added to overflow`

Fixes #5173 

<!-- ROUTER-283 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
