### PR TITLE
fix(telemetry): add support of response_context selector when it's in error

### DIFF
--- a/.changesets/fix_bnjjj_fix_selector_context.md
+++ b/.changesets/fix_bnjjj_fix_selector_context.md
@@ -1,6 +1,6 @@
 ### Add support of response_context selector when it's in error ([PR #5288](https://github.com/apollographql/router/pull/5288))
 
-It gives the ability to configure custom instruments like this:
+Provides the ability to configure custom instruments. For example:
 
 ```yaml
 http.server.request.timeout:

--- a/.changesets/fix_bnjjj_fix_selector_context.md
+++ b/.changesets/fix_bnjjj_fix_selector_context.md
@@ -1,0 +1,20 @@
+### Add support of response_context selector when it's in error ([PR #5288](https://github.com/apollographql/router/pull/5288))
+
+It gives the ability to configure custom instruments like this:
+
+```yaml
+http.server.request.timeout:
+  type: counter
+  value: unit
+  description: "request in timeout"
+  unit: request
+  attributes:
+    graphql.operation.name:
+      response_context: operation_name
+  condition:
+    eq:
+    - "request timed out"
+    - error: reason
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/5288

--- a/apollo-router/src/plugins/telemetry/config_new/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/attributes.rs
@@ -556,9 +556,9 @@ impl Selectors for RouterAttributes {
         attrs
     }
 
-    fn on_error(&self, error: &BoxError) -> Vec<KeyValue> {
-        let mut attrs = self.common.on_error(error);
-        attrs.extend(self.server.on_error(error));
+    fn on_error(&self, error: &BoxError, ctx: &Context) -> Vec<KeyValue> {
+        let mut attrs = self.common.on_error(error, ctx);
+        attrs.extend(self.server.on_error(error, ctx));
         attrs
     }
 }
@@ -660,7 +660,7 @@ impl Selectors for HttpCommonAttributes {
         attrs
     }
 
-    fn on_error(&self, _error: &BoxError) -> Vec<KeyValue> {
+    fn on_error(&self, _error: &BoxError, _ctx: &Context) -> Vec<KeyValue> {
         let mut attrs = Vec::new();
         if let Some(true) = &self.error_type {
             attrs.push(KeyValue::new(
@@ -815,7 +815,7 @@ impl Selectors for HttpServerAttributes {
         Vec::default()
     }
 
-    fn on_error(&self, _error: &BoxError) -> Vec<KeyValue> {
+    fn on_error(&self, _error: &BoxError, _ctx: &Context) -> Vec<KeyValue> {
         Vec::default()
     }
 }
@@ -914,7 +914,7 @@ impl Selectors for SupergraphAttributes {
         attrs
     }
 
-    fn on_error(&self, _error: &BoxError) -> Vec<KeyValue> {
+    fn on_error(&self, _error: &BoxError, _ctx: &Context) -> Vec<KeyValue> {
         Vec::default()
     }
 }
@@ -965,7 +965,7 @@ impl Selectors for SubgraphAttributes {
         Vec::default()
     }
 
-    fn on_error(&self, _error: &BoxError) -> Vec<KeyValue> {
+    fn on_error(&self, _error: &BoxError, _ctx: &Context) -> Vec<KeyValue> {
         Vec::default()
     }
 }
@@ -1313,7 +1313,7 @@ mod test {
             )
         );
 
-        let attributes = common.on_error(&anyhow!("test error").into());
+        let attributes = common.on_error(&anyhow!("test error").into(), &Default::default());
         assert_eq!(
             attributes
                 .iter()
@@ -1421,7 +1421,7 @@ mod test {
             Some(&(StatusCode::BAD_REQUEST.as_u16() as i64).into())
         );
 
-        let attributes = common.on_error(&anyhow!("test error").into());
+        let attributes = common.on_error(&anyhow!("test error").into(), &Default::default());
         assert_eq!(
             attributes
                 .iter()

--- a/apollo-router/src/plugins/telemetry/config_new/conditions.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/conditions.rs
@@ -243,27 +243,27 @@ where
         }
     }
 
-    pub(crate) fn evaluate_error(&self, error: &BoxError) -> bool {
+    pub(crate) fn evaluate_error(&self, error: &BoxError, ctx: &Context) -> bool {
         match self {
             Condition::Eq(eq) => {
-                let left = eq[0].on_error(error);
-                let right = eq[1].on_error(error);
+                let left = eq[0].on_error(error, ctx);
+                let right = eq[1].on_error(error, ctx);
                 left == right
             }
             Condition::Gt(gt) => {
-                let left_att = gt[0].on_error(error).map(AttributeValue::from);
-                let right_att = gt[1].on_error(error).map(AttributeValue::from);
+                let left_att = gt[0].on_error(error, ctx).map(AttributeValue::from);
+                let right_att = gt[1].on_error(error, ctx).map(AttributeValue::from);
                 left_att.zip(right_att).map_or(false, |(l, r)| l > r)
             }
             Condition::Lt(gt) => {
-                let left_att = gt[0].on_error(error).map(AttributeValue::from);
-                let right_att = gt[1].on_error(error).map(AttributeValue::from);
+                let left_att = gt[0].on_error(error, ctx).map(AttributeValue::from);
+                let right_att = gt[1].on_error(error, ctx).map(AttributeValue::from);
                 left_att.zip(right_att).map_or(false, |(l, r)| l < r)
             }
-            Condition::Exists(exist) => exist.on_error(error).is_some(),
-            Condition::All(all) => all.iter().all(|c| c.evaluate_error(error)),
-            Condition::Any(any) => any.iter().any(|c| c.evaluate_error(error)),
-            Condition::Not(not) => !not.evaluate_error(error),
+            Condition::Exists(exist) => exist.on_error(error, ctx).is_some(),
+            Condition::All(all) => all.iter().all(|c| c.evaluate_error(error, ctx)),
+            Condition::Any(any) => any.iter().any(|c| c.evaluate_error(error, ctx)),
+            Condition::Not(not) => !not.evaluate_error(error, ctx),
             Condition::True => true,
             Condition::False => false,
         }
@@ -425,10 +425,10 @@ where
         }
     }
 
-    fn on_error(&self, error: &BoxError) -> Option<Value> {
+    fn on_error(&self, error: &BoxError, ctx: &Context) -> Option<Value> {
         match self {
             SelectorOrValue::Value(value) => Some(value.clone().into()),
-            SelectorOrValue::Selector(selector) => selector.on_error(error),
+            SelectorOrValue::Selector(selector) => selector.on_error(error, ctx),
         }
     }
 
@@ -502,7 +502,11 @@ mod test {
             }
         }
 
-        fn on_error(&self, error: &tower::BoxError) -> Option<opentelemetry::Value> {
+        fn on_error(
+            &self,
+            error: &tower::BoxError,
+            _ctx: &Context,
+        ) -> Option<opentelemetry::Value> {
             if error.to_string() != "<empty>" {
                 Some("error".into())
             } else {
@@ -818,7 +822,10 @@ where {
             self.evaluate_event_response(&value, &Context::new())
         }
         fn error(&mut self, value: Option<&str>) -> bool {
-            self.evaluate_error(&BoxError::from(value.unwrap_or("<empty>")))
+            self.evaluate_error(
+                &BoxError::from(value.unwrap_or("<empty>")),
+                &Default::default(),
+            )
         }
         fn field(&mut self, value: Option<i64>) -> bool {
             match value {

--- a/apollo-router/src/plugins/telemetry/config_new/cost/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/cost/mod.rs
@@ -59,7 +59,7 @@ impl Selectors for SupergraphCostAttributes {
         Vec::default()
     }
 
-    fn on_error(&self, _error: &BoxError) -> Vec<KeyValue> {
+    fn on_error(&self, _error: &BoxError, _ctx: &Context) -> Vec<KeyValue> {
         Vec::default()
     }
 

--- a/apollo-router/src/plugins/telemetry/config_new/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/events.rs
@@ -555,13 +555,13 @@ where
         inner.send_event();
     }
 
-    fn on_error(&self, error: &BoxError, _ctx: &Context) {
+    fn on_error(&self, error: &BoxError, ctx: &Context) {
         let mut inner = self.inner.lock();
         if inner.event_on != EventOn::Error {
             return;
         }
         if let Some(selectors) = &inner.selectors {
-            let mut new_attributes = selectors.on_error(error);
+            let mut new_attributes = selectors.on_error(error, ctx);
             inner.attributes.append(&mut new_attributes);
         }
 

--- a/apollo-router/src/plugins/telemetry/config_new/extendable.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/extendable.rs
@@ -214,8 +214,16 @@ where
         attrs
     }
 
-    fn on_error(&self, error: &BoxError) -> Vec<KeyValue> {
-        self.attributes.on_error(error)
+    fn on_error(&self, error: &BoxError, ctx: &Context) -> Vec<KeyValue> {
+        let mut attrs = self.attributes.on_error(error, ctx);
+        let custom_attributes = self.custom.iter().filter_map(|(key, value)| {
+            value
+                .on_error(error, ctx)
+                .map(|v| KeyValue::new(key.clone(), v))
+        });
+        attrs.extend(custom_attributes);
+
+        attrs
     }
 
     fn on_response_event(&self, response: &Self::EventResponse, ctx: &Context) -> Vec<KeyValue> {

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/router/custom_counter_on_error/metrics.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/router/custom_counter_on_error/metrics.snap
@@ -1,0 +1,32 @@
+---
+source: apollo-router/src/plugins/telemetry/config_new/instruments.rs
+description: Custom counter should be incremented on timeout error with operation_name attribute
+expression: "&metrics.all()"
+info:
+  telemetry:
+    instrumentation:
+      instruments:
+        router:
+          http.server.active_requests: false
+          http.server.request.duration: false
+          http.server.request.timeout:
+            type: counter
+            value: unit
+            description: request in timeout
+            unit: request
+            attributes:
+              graphql.operation.name:
+                response_context: operation_name
+            condition:
+              eq:
+                - request timed out
+                - error: reason
+---
+- name: http.server.request.timeout
+  description: request in timeout
+  unit: request
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          graphql.operation.name: TestQuery

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/router/custom_counter_on_error/router.yaml
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/router/custom_counter_on_error/router.yaml
@@ -1,0 +1,18 @@
+telemetry:
+  instrumentation:
+    instruments:
+      router:
+        http.server.active_requests: false
+        http.server.request.duration: false
+        http.server.request.timeout:
+          type: counter
+          value: unit
+          description: "request in timeout"
+          unit: request
+          attributes:
+            graphql.operation.name:
+              response_context: operation_name
+          condition:
+            eq:
+            - "request timed out"
+            - error: reason

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/router/custom_counter_on_error/test.yaml
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/router/custom_counter_on_error/test.yaml
@@ -1,0 +1,17 @@
+description: Custom counter should be incremented on timeout error with operation_name attribute
+events:
+  - - context:
+        map:
+          operation_name: TestQuery
+    - router_request:
+        uri: "/hello"
+        method: POST
+        body: |
+          hello
+    - router_error:
+        error: request timed out
+  - - router_request:
+        uri: "/hello"
+        method: POST
+        body: |
+          hello

--- a/apollo-router/src/plugins/telemetry/config_new/graphql/attributes.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/graphql/attributes.rs
@@ -67,7 +67,7 @@ impl Selectors for GraphQLAttributes {
         Vec::default()
     }
 
-    fn on_error(&self, _error: &BoxError) -> Vec<KeyValue> {
+    fn on_error(&self, _error: &BoxError, _ctx: &Context) -> Vec<KeyValue> {
         Vec::default()
     }
 

--- a/apollo-router/src/plugins/telemetry/config_new/graphql/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/graphql/selectors.rs
@@ -93,7 +93,7 @@ impl Selector for GraphQLSelector {
         None
     }
 
-    fn on_error(&self, _error: &BoxError) -> Option<opentelemetry::Value> {
+    fn on_error(&self, _error: &BoxError, _ctx: &Context) -> Option<opentelemetry::Value> {
         None
     }
 

--- a/apollo-router/src/plugins/telemetry/config_new/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/mod.rs
@@ -39,7 +39,7 @@ pub(crate) trait Selectors {
     fn on_response_event(&self, _response: &Self::EventResponse, _ctx: &Context) -> Vec<KeyValue> {
         Vec::with_capacity(0)
     }
-    fn on_error(&self, error: &BoxError) -> Vec<KeyValue>;
+    fn on_error(&self, error: &BoxError, ctx: &Context) -> Vec<KeyValue>;
     fn on_response_field(&self, _typed_value: &TypedValue, _ctx: &Context) -> Vec<KeyValue> {
         Vec::with_capacity(0)
     }
@@ -59,7 +59,7 @@ pub(crate) trait Selector {
     ) -> Option<opentelemetry::Value> {
         None
     }
-    fn on_error(&self, error: &BoxError) -> Option<opentelemetry::Value>;
+    fn on_error(&self, error: &BoxError, ctx: &Context) -> Option<opentelemetry::Value>;
     fn on_response_field(
         &self,
         _typed_value: &TypedValue,

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -487,7 +487,12 @@ impl Plugin for Telemetry {
                         } else if let Err(err) = &response {
                             span.record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
                             span.set_span_dyn_attributes(
-                                config.instrumentation.spans.router.attributes.on_error(err),
+                                config
+                                    .instrumentation
+                                    .spans
+                                    .router
+                                    .attributes
+                                    .on_error(err, &ctx),
                             );
                             custom_instruments.on_error(err, &ctx);
                             custom_events.on_error(err, &ctx);
@@ -606,7 +611,7 @@ impl Plugin for Telemetry {
                                 custom_graphql_instruments.on_response(resp);
                             },
                             Err(err) => {
-                                span.set_span_dyn_attributes(config.instrumentation.spans.supergraph.attributes.on_error(err));
+                                span.set_span_dyn_attributes(config.instrumentation.spans.supergraph.attributes.on_error(err, &ctx));
                                 custom_instruments.on_error(err, &ctx);
                                 supergraph_events.on_error(err, &ctx);
                                 custom_graphql_instruments.on_error(err, &ctx);
@@ -737,7 +742,11 @@ impl Plugin for Telemetry {
                                 span.record(OTEL_STATUS_CODE, OTEL_STATUS_CODE_ERROR);
 
                                 span.set_span_dyn_attributes(
-                                    conf.instrumentation.spans.subgraph.attributes.on_error(err),
+                                    conf.instrumentation
+                                        .spans
+                                        .subgraph
+                                        .attributes
+                                        .on_error(err, &context),
                                 );
                                 custom_instruments.on_error(err, &context);
                                 custom_events.on_error(err, &context);


### PR DESCRIPTION
It gives the ability to configure custom instruments like this:

```yaml
http.server.request.timeout:
  type: counter
  value: unit
  description: "request in timeout"
  unit: request
  attributes:
    graphql.operation.name:
      response_context: operation_name
  condition:
    eq:
    - "request timed out"
    - error: reason
```

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
