### PR TITLE
Fixed a few normalize issues

### DIFF
--- a/apollo-federation/src/query_plan/operation.rs
+++ b/apollo-federation/src/query_plan/operation.rs
@@ -4086,9 +4086,12 @@ impl InlineFragmentSelection {
         // We preserve the current fragment, so we only recurse within the sub-selection if we're asked to be recursive.
         // (note that even if we're not recursive, we may still have some "lifting" to do)
         let normalized_selection_set = if NormalizeSelectionOption::NormalizeRecursively == option {
-            let normalized =
-                self.selection_set
-                    .normalize(parent_type, named_fragments, schema, option)?;
+            let normalized = self.selection_set.normalize(
+                self.casted_type(),
+                named_fragments,
+                schema,
+                option,
+            )?;
             // It could be that nothing was satisfiable.
             if normalized.is_empty() {
                 if self.inline_fragment.data().directives.is_empty() {
@@ -4125,12 +4128,13 @@ impl InlineFragmentSelection {
                         }),
                         None,
                     );
-
+                    // Return `... on <rebased condition> { __typename @include(if: false) }`
+                    let rebased_casted_type = rebased_fragment.data().casted_type();
                     return Ok(Some(SelectionOrSet::Selection(
                         Selection::from_inline_fragment(
                             rebased_fragment,
                             SelectionSet::from_selection(
-                                parent_type.clone(),
+                                rebased_casted_type,
                                 typename_field_selection,
                             ),
                         ),

--- a/apollo-federation/src/query_plan/operation.rs
+++ b/apollo-federation/src/query_plan/operation.rs
@@ -701,6 +701,10 @@ impl Selection {
         inline_fragment: InlineFragment,
         sub_selections: SelectionSet,
     ) -> Self {
+        assert_eq!(
+            inline_fragment.data().casted_type(),
+            sub_selections.type_position
+        );
         let inline_fragment_selection = InlineFragmentSelection {
             inline_fragment,
             selection_set: sub_selections,

--- a/apollo-federation/src/query_plan/optimize.rs
+++ b/apollo-federation/src/query_plan/optimize.rs
@@ -959,6 +959,7 @@ impl NamedFragments {
         //   - Its usage count should be correctly calculated as if dropped fragments were expanded.
         // - We take advantage of the fact that `NamedFragments` is already sorted in dependency
         //   order.
+        // PORT_NOTE: The `computeFragmentsToKeep` function is implemented here.
         let min_usage_to_optimize: i32 = min_usage_to_optimize.try_into().unwrap_or(i32::MAX);
         let original_size = self.size();
         for fragment in self.iter_rev() {
@@ -992,7 +993,22 @@ impl NamedFragments {
         }
 
         // Compute the new selection set based on the new reduced set of fragments.
-        selection_set.retain_fragments(self)
+        // Note that optimizing all fragments to potentially re-expand some is not entirely
+        // optimal, but it's unclear how to do otherwise, and it probably don't matter too much in
+        // practice (we only call this optimization on the final computed query plan, so not a very
+        // hot path; plus in most cases we won't even reach that point either because there is no
+        // fragment, or none will have been optimized away so we'll exit above).
+        let reduced_selection_set = selection_set.retain_fragments(self)?;
+
+        // Expanding fragments could create some "inefficiencies" that we wouldn't have if we
+        // hadn't re-optimized the fragments to de-optimize it later, so we do a final "normalize"
+        // pass to remove those.
+        reduced_selection_set.normalize(
+            &reduced_selection_set.type_position,
+            self,
+            &selection_set.schema,
+            NormalizeSelectionOption::NormalizeRecursively,
+        )
     }
 
     fn update_usages(usages: &mut HashMap<Name, i32>, fragment: &Node<Fragment>, usage_count: i32) {

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments_preservation.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments_preservation.rs
@@ -996,8 +996,8 @@ fn it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_diff
 }
 
 #[test]
-#[should_panic(expected = "called `Result::unwrap()` on an `Err` value")]
-// TODO: investigate this failure (Object type "Outer" has no field "v")
+#[should_panic(expected = "snapshot assertion")]
+// TODO: investigate this failure
 fn it_handles_fragment_rebasing_in_a_subgraph_where_some_union_membership_relation_differs() {
     // This test is similar to the subtyping case (it tests the same problems), but test the case
     // of unions instead of interfaces.

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments_preservation.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments_preservation.rs
@@ -569,9 +569,7 @@ fn it_preserves_directives_when_fragment_is_reused() {
 }
 
 #[test]
-#[should_panic(
-    expected = "Cannot add selection of field \"I.b\" to selection set of parent type \"I\""
-)]
+#[should_panic(expected = "snapshot assertion")]
 // TODO: investigate this failure
 fn it_does_not_try_to_apply_fragments_that_are_not_valid_for_the_subgaph() {
     // Slightly artificial example for simplicity, but this highlight the problem.


### PR DESCRIPTION
Added `normalize` call in `normalize_operation`.

Fixed a bug in NamedFragments::reduce

- normalize selection sets after retain_fragments call

Fixed InlineFragmentSelection::normalize

- Normalize sub-selections with the correct type

Sorry for mixing a few different changes in this PR. Unfortunately, those issues are intertwined in tests. Gathering them in one PR to minimize spurious test changes.

This depends on https://github.com/apollographql/router/pull/5284 in order to pass all tests.
This PR will improve a few tests failing in https://github.com/apollographql/router/pull/5214.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

