### PR TITLE
Adjust privacy of `JSONSelection` struct internals

### DIFF
--- a/apollo-federation/src/sources/connect/federated_query_graph/builder.rs
+++ b/apollo-federation/src/sources/connect/federated_query_graph/builder.rs
@@ -253,7 +253,7 @@ fn process_subselection(
     )?;
 
     // Handle all named selections
-    for selection in sub.selections.iter() {
+    for selection in sub.selections_iter() {
         // Make sure that we have a field on the object type that matches the alias (or the name itself)
         let alias = selection.name();
         let Some(selection_field) = object_type.fields.get(alias) else {
@@ -389,7 +389,7 @@ fn process_subselection(
     }
 
     // Handle the optional star selection
-    if let Some(_star) = sub.star.as_ref() {
+    if sub.has_star() {
         return Err(FederationError::internal(
             "star selection is not yet supported",
         ));

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -31,6 +31,13 @@ pub enum JSONSelection {
 }
 
 impl JSONSelection {
+    pub fn empty() -> Self {
+        JSONSelection::Named(SubSelection {
+            selections: vec![],
+            star: None,
+        })
+    }
+
     pub fn parse(input: &str) -> IResult<&str, Self> {
         alt((
             all_consuming(map(
@@ -325,8 +332,8 @@ impl PathSelection {
 
 #[derive(Debug, PartialEq, Clone, Serialize, Default)]
 pub struct SubSelection {
-    pub selections: Vec<NamedSelection>,
-    pub star: Option<StarSelection>,
+    pub(super) selections: Vec<NamedSelection>,
+    pub(super) star: Option<StarSelection>,
 }
 
 impl SubSelection {
@@ -346,14 +353,71 @@ impl SubSelection {
         ))(input)
         .map(|(input, (_, _, selections, star, _, _, _))| (input, Self { selections, star }))
     }
+
+    pub fn selections_iter(&self) -> impl Iterator<Item = &NamedSelection> {
+        self.selections.iter()
+    }
+
+    pub fn has_star(&self) -> bool {
+        self.star.is_some()
+    }
+
+    pub fn set_star(&mut self, star: Option<StarSelection>) {
+        self.star = star;
+    }
+
+    pub fn append_selection(&mut self, selection: NamedSelection) {
+        self.selections.push(selection);
+    }
+
+    pub fn last_selection_mut(&mut self) -> Option<&mut NamedSelection> {
+        self.selections.last_mut()
+    }
+
+    // Since we enforce that new selections may only be appended to
+    // self.selections, we can provide an index-based search method that returns
+    // an unforgeable NamedSelectionIndex, which can later be used to access the
+    // selection using either get_at_index or get_at_index_mut.
+    // TODO In the future, this method could make use of an internal lookup
+    // table to avoid linear search.
+    pub fn index_of_named_selection(&self, name: &str) -> Option<NamedSelectionIndex> {
+        self.selections
+            .iter()
+            .position(|selection| selection.name() == name)
+            .map(|pos| NamedSelectionIndex { pos })
+    }
+
+    pub fn get_at_index(&self, index: &NamedSelectionIndex) -> &NamedSelection {
+        self.selections
+            .get(index.pos)
+            .expect("NamedSelectionIndex out of bounds")
+    }
+
+    pub fn get_at_index_mut(&mut self, index: &NamedSelectionIndex) -> &mut NamedSelection {
+        self.selections
+            .get_mut(index.pos)
+            .expect("NamedSelectionIndex out of bounds")
+    }
+}
+
+pub struct NamedSelectionIndex {
+    // Intentionally private so NamedSelectionIndex cannot be forged.
+    pos: usize,
 }
 
 // StarSelection ::= Alias? "*" SubSelection?
 
 #[derive(Debug, PartialEq, Clone, Serialize)]
-pub struct StarSelection(pub Option<Alias>, pub Option<Box<SubSelection>>);
+pub struct StarSelection(
+    pub(super) Option<Alias>,
+    pub(super) Option<Box<SubSelection>>,
+);
 
 impl StarSelection {
+    pub(crate) fn new(alias: Option<Alias>, sub: Option<SubSelection>) -> Self {
+        Self(alias, sub.map(Box::new))
+    }
+
     pub(crate) fn parse(input: &str) -> IResult<&str, Self> {
         tuple((
             // The spaces_or_comments separators are necessary here because
@@ -375,10 +439,16 @@ impl StarSelection {
 
 #[derive(Debug, PartialEq, Clone, Serialize)]
 pub struct Alias {
-    pub(crate) name: String,
+    pub(super) name: String,
 }
 
 impl Alias {
+    pub fn new(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+        }
+    }
+
     fn parse(input: &str) -> IResult<&str, Self> {
         tuple((
             spaces_or_comments,
@@ -388,6 +458,10 @@ impl Alias {
             spaces_or_comments,
         ))(input)
         .map(|(input, (_, name, _, _, _))| (input, Self { name }))
+    }
+
+    pub fn name(&self) -> &str {
+        self.name.as_str()
     }
 }
 

--- a/apollo-router/src/plugins/connectors/fetch.rs
+++ b/apollo-router/src/plugins/connectors/fetch.rs
@@ -8,7 +8,6 @@ use apollo_federation::schema::ObjectOrInterfaceFieldDirectivePosition;
 use apollo_federation::sources::connect;
 use apollo_federation::sources::connect::ConnectId;
 use apollo_federation::sources::connect::JSONSelection;
-use apollo_federation::sources::connect::SubSelection;
 use apollo_federation::sources::source;
 
 use crate::query_planner::fetch::FetchNode;
@@ -38,10 +37,7 @@ impl From<FetchNode> for source::query_plan::FetchNode {
             },
             field_response_name: name!("Field"),
             field_arguments: Default::default(),
-            selection: JSONSelection::Named(SubSelection {
-                selections: vec![],
-                star: None,
-            }),
+            selection: JSONSelection::empty(),
         })
     }
 }


### PR DESCRIPTION
Resolves Jira issue CNN-152.
Closes #5249.

Although keeping the `JSONSelection` structures immutable would have been (and still may be) ideal, we currently have a few algorithms that rely on incrementally constructing those structures (specifically populating `SubSelection` with new `NamedSelection` items), so we need to support a limited form of mutability.

To make that mutability safe(r), I decided to replace all direct access to struct fields with public methods, which enforce the invariant that `NamedSelection` items may only be _appended_ to a `&mut SubSelection`. This enforcement works by making the fields of the `SubSelection` struct (and other `JSONSelection`-related structs) `pub(super)`, which means they are accessible and constructible only within the `json_selection/` directory (which is important so the `ApplyTo` trait can still access the fields).

Since `SubSelection` is now guaranteed to be append-only, I was also able to expose a `SubSelection::index_of_named_selection` method, which returns an unforgeable and permanently valid `NamedSelectionIndex` wrapper struct, allowing safe and infallible access via `SubSelection::get_at_index` and `SubSelection::get_at_index_mut`. This indirection is helpful for placating the borrow checker, which refuses to accept any variation of a method like
```rust
SubSelection::get_mut(&mut self, i: usize) -> Option<&mut NamedSelection>
```
as a replacement for `subselection.selections.get_mut(i)`, due to the complexities of working with exclusive mutable references.

It might have been nice to restrict the constructability of enum variants as well (especially for `PathSelection`), but there's no way to do that in Rust without also removing the ability to match against the variants, which seems too onerous (and difficult to replicate with public functions).