### PR TITLE
fixed SelectionSet::add_selection to set its member's parent type consistently

### DIFF
--- a/apollo-federation/src/query_plan/operation.rs
+++ b/apollo-federation/src/query_plan/operation.rs
@@ -2782,12 +2782,7 @@ impl SelectionSet {
     /// Inserts a `Selection` into the inner map. Should a selection with the same key already
     /// exist in the map, the existing selection and the given selection are merged, replacing the
     /// existing selection while keeping the same insertion index.
-    fn add_selection(
-        &mut self,
-        parent_type: &CompositeTypeDefinitionPosition,
-        schema: &ValidFederationSchema,
-        selection: Selection,
-    ) -> Result<(), FederationError> {
+    fn add_selection(&mut self, selection: Selection) -> Result<(), FederationError> {
         let selections = Arc::make_mut(&mut self.selections);
 
         let key = selection.key();
@@ -2797,8 +2792,8 @@ impl SelectionSet {
                 // `existing_selection` and `selection` both have the same selection key,
                 // so the merged selection will also have the same selection key.
                 let selection = SelectionSet::make_selection(
-                    schema,
-                    parent_type,
+                    &self.schema,
+                    &self.type_position,
                     to_merge.iter(),
                     /*named_fragments*/ &Default::default(),
                 )?;
@@ -2892,33 +2887,28 @@ impl SelectionSet {
                     })
                     .transpose()?;
                 let selection = Selection::from_element(element, selection_set)?;
-                let schema = self.schema.clone();
-                let parent_type_position = self.type_position.clone();
                 // TODO move the rebasing to add_selection/merge_into
                 if let Some(rebased_selection) = selection.rebase_on(
-                    &parent_type_position,
+                    &self.type_position,
                     &NamedFragments::default(),
-                    &schema,
+                    &self.schema,
                     RebaseErrorHandlingOption::ThrowError,
                 )? {
-                    self.add_selection(&ele.parent_type_position(), &schema, rebased_selection)?
+                    self.add_selection(rebased_selection)?
                 }
             }
             // If we don't have any path, we rebase and merge in the given subselections at the root.
             None => {
                 if let Some(sel) = selection_set {
                     // TODO move the rebasing to add_selection/merge_into
-                    let schema = self.schema.clone();
-                    let parent_type = self.type_position.clone();
-                    let selection_type = &sel.type_position;
                     sel.selections.values().cloned().try_for_each(|s| {
                         if let Some(rebased) = s.rebase_on(
-                            &parent_type,
+                            &self.type_position,
                             &NamedFragments::default(),
-                            &schema,
+                            &self.schema,
                             RebaseErrorHandlingOption::ThrowError,
                         )? {
-                            self.add_selection(selection_type, &schema, rebased)
+                            self.add_selection(rebased)
                         } else {
                             Ok(())
                         }

--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -278,7 +278,7 @@ fn handles_non_intersecting_fragment_conditions() {
 
 #[test]
 #[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure
+// TODO: investigate this failure (parallel fetch ordering difference)
 fn avoids_unnecessary_fetches() {
     // This test is a reduced example demonstrating a previous issue with the computation of query plans cost.
     // The general idea is that "Subgraph 3" has a declaration that is kind of useless (it declares entity A

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments_preservation.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments_preservation.rs
@@ -648,9 +648,7 @@ fn it_does_not_try_to_apply_fragments_that_are_not_valid_for_the_subgaph() {
 }
 
 #[test]
-#[should_panic(
-    expected = "Cannot add selection of field \"Outer.v\" to selection set of parent type \"I\""
-)]
+#[should_panic(expected = "snapshot assertion")]
 // TODO: investigate this failure - snapshot mismatch (complicated)
 fn it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_differs() {
     // This test is designed such that type `Outer` implements the interface `I` in `Subgraph1`

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/provides.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/provides.rs
@@ -112,7 +112,7 @@ fn it_works_with_nested_provides() {
 }
 
 #[test]
-#[should_panic(expected = "An internal error has occurred, please report this bug to Apollo")] // TODO: fix bug FED-230
+#[should_panic(expected = "snapshot assertion")]
 fn it_works_on_interfaces() {
     let planner = planner!(
         Subgraph1: r#"


### PR DESCRIPTION
The issue was that add_selection could set its sub-selection items' parent type as their originating parent type, instead of the rebased parent type (`self.type_position`).

This is the real fix for FED-230.

Fixed crashes in tests
- `it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_differs` (in named_fragments_preservation.rs)
- `it_works_on_interfaces` (in provides.rs)


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [X] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
