### PR TITLE
added InlineFragmentSelection::new constructor

### DIFF
--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -49,6 +49,7 @@ use crate::query_plan::operation::Field;
 use crate::query_plan::operation::FieldData;
 use crate::query_plan::operation::InlineFragment;
 use crate::query_plan::operation::InlineFragmentData;
+use crate::query_plan::operation::InlineFragmentSelection;
 use crate::query_plan::operation::NamedFragments;
 use crate::query_plan::operation::Operation;
 use crate::query_plan::operation::RebaseErrorHandlingOption;
@@ -2969,8 +2970,8 @@ fn wrap_input_selections(
                }
             */
             let parent_type_position = fragment.data().parent_type_position.clone();
-            let selection = Selection::from_inline_fragment(fragment, sub_selections);
-            SelectionSet::from_selection(parent_type_position, selection)
+            let selection = InlineFragmentSelection::new(fragment, sub_selections);
+            SelectionSet::from_selection(parent_type_position, selection.into())
         },
     )
 }

--- a/apollo-federation/src/query_plan/optimize.rs
+++ b/apollo-federation/src/query_plan/optimize.rs
@@ -1172,11 +1172,7 @@ impl InlineFragmentSelection {
         // above, this recursion will "ignore" those as `FragmentSpreadSelection`'s `optimize()` is
         // a no-op).
         optimized = optimized.optimize(fragments, validator)?;
-        Ok(InlineFragmentSelection {
-            inline_fragment: self.inline_fragment.clone(),
-            selection_set: optimized,
-        }
-        .into())
+        Ok(InlineFragmentSelection::new(self.inline_fragment.clone(), optimized).into())
     }
 }
 


### PR DESCRIPTION
- removed Selection::from_inline_fragment method, since `new` is more direct.
- moved the assertion check in `from_inline_fragment` into the `new`.
- refactored calls to the removed method
- refactored all direct InlineFragmentSelection construction to use `new`.
- fixed a few `InlineFragmentSelection` generation code with potentially wrong sub-selection type. (But, no tests are affected at this time.)

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
