### PR TITLE
Fix bug where recursive query planning ignored conditionals

### DIFF
--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -876,7 +876,6 @@ impl<'a> QueryPlanningTraversal<'a> {
     fn resolve_condition_plan(
         &self,
         edge: EdgeIndex,
-        // PORT_NOTE: The following parameters are not currently used.
         context: &OpGraphPathContext,
         excluded_destinations: &ExcludedDestinations,
         excluded_conditions: &ExcludedConditions,

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -877,7 +877,7 @@ impl<'a> QueryPlanningTraversal<'a> {
         &self,
         edge: EdgeIndex,
         // PORT_NOTE: The following parameters are not currently used.
-        _context: &OpGraphPathContext,
+        context: &OpGraphPathContext,
         excluded_destinations: &ExcludedDestinations,
         excluded_conditions: &ExcludedConditions,
     ) -> Result<ConditionResolution, FederationError> {
@@ -914,7 +914,7 @@ impl<'a> QueryPlanningTraversal<'a> {
             self.has_defers,
             self.root_kind,
             self.cost_processor,
-            Default::default(),
+            context.clone(),
             excluded_destinations.clone(),
             excluded_conditions.add_item(edge_conditions),
         )?

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/requires/include_skip.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/requires/include_skip.rs
@@ -67,7 +67,6 @@ fn it_handles_a_simple_at_requires_triggered_within_a_conditional() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
 // TODO: investigate this failure - context is not passed, expected [@include(if: $test)] but was []
 fn it_handles_an_at_requires_triggered_conditionally() {
     let planner = planner!(

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/requires/include_skip.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/requires/include_skip.rs
@@ -67,7 +67,6 @@ fn it_handles_a_simple_at_requires_triggered_within_a_conditional() {
 }
 
 #[test]
-// TODO: investigate this failure - context is not passed, expected [@include(if: $test)] but was []
 fn it_handles_an_at_requires_triggered_conditionally() {
     let planner = planner!(
         Subgraph1: r#"


### PR DESCRIPTION
This PR fixes a bug where recursive query planning would ignore conditionals (`@skip`/`@include`).