### PR TITLE
apollo-federation: accept supergraphs with join@v0.4

### DIFF
--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -55,15 +55,6 @@ pub(crate) fn validate_supergraph_for_query_planning(
     validate_supergraph(supergraph_schema, &JOIN_VERSIONS)
 }
 
-pub(crate) fn validate_supergraph_for_non_query_planning(
-    supergraph_schema: &FederationSchema,
-) -> Result<SupergraphSpecs, FederationError> {
-    validate_supergraph(
-        supergraph_schema,
-        &link::join_spec_definition::NON_QUERY_PLANNING_JOIN_VERSIONS,
-    )
-}
-
 /// Checks that required supergraph directives are in the schema, and returns which ones were used.
 pub(crate) fn validate_supergraph(
     supergraph_schema: &FederationSchema,
@@ -108,7 +99,7 @@ impl Supergraph {
         let schema = schema.into_inner();
         let schema = FederationSchema::new(schema)?;
 
-        let _ = validate_supergraph_for_non_query_planning(&schema)?;
+        let _ = validate_supergraph_for_query_planning(&schema)?;
 
         Ok(Self {
             // We know it's valid because the input was.

--- a/apollo-federation/src/link/join_spec_definition.rs
+++ b/apollo-federation/src/link/join_spec_definition.rs
@@ -337,19 +337,12 @@ lazy_static! {
             Some(Version { major: 2, minor: 0 }),
         ));
         definitions.add(JoinSpecDefinition::new(
-            Version { major: 0, minor: 5 },
-            Some(Version { major: 2, minor: 8 }),
-        ));
-        definitions
-    };
-
-    /// Versions supported for purpose other than query planning.
-    /// TODO: remove once v0.4 is properly implemented in query planning
-    pub(crate) static ref NON_QUERY_PLANNING_JOIN_VERSIONS: SpecDefinitions<JoinSpecDefinition> = {
-        let mut definitions = JOIN_VERSIONS.clone();
-        definitions.add(JoinSpecDefinition::new(
             Version { major: 0, minor: 4 },
             Some(Version { major: 2, minor: 7 }),
+        ));
+        definitions.add(JoinSpecDefinition::new(
+            Version { major: 0, minor: 5 },
+            Some(Version { major: 2, minor: 8 }),
         ));
         definitions
     };


### PR DESCRIPTION
We didn't accept v0.4 join in query planning validation, meaning supergraphs using v0.4 could not be planned. This version of join spec doesn't have an affect on query planning, but is a composition concern, so accepting this version doesn't have an impact on the created plans.