### PR TITLE
Move QP "both" mode comparison to a background thread with bounded queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,7 @@ dependencies = [
  "console",
  "console-subscriber",
  "cookie",
+ "crossbeam-channel",
  "dashmap",
  "derivative",
  "derive_more",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -68,7 +68,7 @@ askama = "0.12.1"
 access-json = "0.1.0"
 anyhow = "1.0.80"
 apollo-compiler.workspace = true
-apollo-federation = { path = "../apollo-federation", version = "=1.48.0"}
+apollo-federation = { path = "../apollo-federation", version = "=1.48.0" }
 arc-swap = "1.6.0"
 async-channel = "1.9.0"
 async-compression = { version = "0.4.6", features = [
@@ -91,6 +91,7 @@ clap = { version = "4.5.1", default-features = false, features = [
 ] }
 console-subscriber = { version = "0.2.0", optional = true }
 cookie = { version = "0.18.0", default-features = false }
+crossbeam-channel = "0.5"
 ci_info = { version = "0.14.14", features = ["serde-1"] }
 dashmap = { version = "5.5.3", features = ["serde"] }
 derivative = "2.2.0"

--- a/apollo-router/src/error.rs
+++ b/apollo-router/src/error.rs
@@ -529,16 +529,21 @@ impl std::fmt::Display for PlanErrors {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_fmt(format_args!(
             "query validation errors: {}",
-            self.errors
-                .iter()
-                .map(|e| e
-                    .message
-                    .clone()
-                    .unwrap_or_else(|| "UNKNWON ERROR".to_string()))
-                .collect::<Vec<String>>()
-                .join(", ")
+            format_bridge_errors(&self.errors)
         ))
     }
+}
+
+pub(crate) fn format_bridge_errors(errors: &[router_bridge::planner::PlanError]) -> String {
+    errors
+        .iter()
+        .map(|e| {
+            e.message
+                .clone()
+                .unwrap_or_else(|| "UNKNWON ERROR".to_string())
+        })
+        .collect::<Vec<String>>()
+        .join(", ")
 }
 
 /// Error in the schema.

--- a/apollo-router/src/plugins/file_uploads/rearrange_query_plan.rs
+++ b/apollo-router/src/plugins/file_uploads/rearrange_query_plan.rs
@@ -1,6 +1,7 @@
 use std::cmp;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use indexmap::IndexMap;
 use indexmap::IndexSet;
@@ -39,7 +40,7 @@ pub(super) fn rearrange_query_plan(
 
     let root = rearrange_plan_node(root, &mut IndexMap::new(), &variable_ranges)?;
     Ok(QueryPlan {
-        root,
+        root: Arc::new(root),
         usage_reporting: query_plan.usage_reporting.clone(),
         formatted_query_plan: query_plan.formatted_query_plan.clone(),
         query: query_plan.query.clone(),

--- a/apollo-router/src/plugins/record_replay/recording.rs
+++ b/apollo-router/src/plugins/record_replay/recording.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -16,7 +17,7 @@ pub(crate) struct Recording {
     pub(crate) supergraph_sdl: String,
     pub(crate) client_request: RequestDetails,
     pub(crate) client_response: ResponseDetails,
-    pub(crate) formatted_query_plan: Option<String>,
+    pub(crate) formatted_query_plan: Option<Arc<String>>,
     pub(crate) subgraph_fetches: Option<Subgraphs>,
 }
 

--- a/apollo-router/src/plugins/record_replay/replay.rs
+++ b/apollo-router/src/plugins/record_replay/replay.rs
@@ -257,7 +257,7 @@ impl Plugin for Replay {
 
 #[derive(Debug)]
 pub(crate) enum ReplayReport {
-    QueryPlanDifference(String, String),
+    QueryPlanDifference(Arc<String>, Arc<String>),
     ClientResponseChunkDifference(usize, String, String),
     SubgraphRequestMissed(String, String),
     HeaderDifference {

--- a/apollo-router/src/plugins/rhai/engine.rs
+++ b/apollo-router/src/plugins/rhai/engine.rs
@@ -1242,7 +1242,8 @@ mod router_plugin {
             request
                 .query_plan
                 .formatted_query_plan
-                .clone()
+                .as_deref()
+                .cloned()
                 .unwrap_or_default()
         })
     }

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -85,9 +85,10 @@ fn init_query_plan_from_redis(
     cache_entry: &mut Result<QueryPlannerContent, Arc<QueryPlannerError>>,
 ) -> Result<(), String> {
     if let Ok(QueryPlannerContent::Plan { plan }) = cache_entry {
-        Arc::make_mut(plan)
-            .root
-            .init_parsed_operations(subgraph_schemas)
+        // Arc freshly deserialized from Redis should be unique, so this doesn’t clone:
+        let plan = Arc::make_mut(plan);
+        let root = Arc::make_mut(&mut plan.root);
+        root.init_parsed_operations(subgraph_schemas)
             .map_err(|e| format!("Invalid subgraph operation: {e}"))?
     }
     Ok(())

--- a/apollo-router/src/query_planner/convert.rs
+++ b/apollo-router/src/query_planner/convert.rs
@@ -3,21 +3,18 @@ use std::sync::Arc;
 use apollo_compiler::executable;
 use apollo_federation::query_plan as next;
 
-use crate::query_planner::bridge_query_planner as bridge;
 use crate::query_planner::fetch::SubgraphOperation;
 use crate::query_planner::plan;
 use crate::query_planner::rewrites;
 use crate::query_planner::selection;
 use crate::query_planner::subscription;
 
-impl From<&'_ next::QueryPlan> for bridge::QueryPlan {
-    fn from(value: &'_ next::QueryPlan) -> Self {
-        let next::QueryPlan {
-            node,
-            statistics: _,
-        } = value;
-        Self { node: option(node) }
-    }
+pub(crate) fn convert_root_query_plan_node(js: &next::QueryPlan) -> Option<plan::PlanNode> {
+    let next::QueryPlan {
+        node,
+        statistics: _,
+    } = js;
+    option(node)
 }
 
 impl From<&'_ next::TopLevelPlanNode> for plan::PlanNode {

--- a/apollo-router/src/query_planner/plan.rs
+++ b/apollo-router/src/query_planner/plan.rs
@@ -37,9 +37,9 @@ pub(crate) struct QueryKey {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct QueryPlan {
     pub(crate) usage_reporting: Arc<UsageReporting>,
-    pub(crate) root: PlanNode,
+    pub(crate) root: Arc<PlanNode>,
     /// String representation of the query plan (not a json representation)
-    pub(crate) formatted_query_plan: Option<String>,
+    pub(crate) formatted_query_plan: Option<Arc<String>>,
     pub(crate) query: Arc<Query>,
 }
 
@@ -59,7 +59,7 @@ impl QueryPlan {
                     referenced_fields_by_type: Default::default(),
                 })
                 .into(),
-            root: root.unwrap_or_else(|| PlanNode::Sequence { nodes: Vec::new() }),
+            root: Arc::new(root.unwrap_or_else(|| PlanNode::Sequence { nodes: Vec::new() })),
             formatted_query_plan: Default::default(),
             query: Arc::new(Query::empty()),
         }

--- a/apollo-router/src/query_planner/tests.rs
+++ b/apollo-router/src/query_planner/tests.rs
@@ -321,7 +321,7 @@ async fn defer() {
                         })),
                     }))),
                 }],
-            },
+            }.into(),
             usage_reporting: UsageReporting {
                 stats_report_key: "this is a test report key".to_string(),
                 referenced_fields_by_type: Default::default(),
@@ -437,7 +437,7 @@ async fn defer_if_condition() {
             .unwrap();
     let schema = planner.schema();
 
-    let root: PlanNode =
+    let root: Arc<PlanNode> =
         serde_json::from_str(include_str!("testdata/defer_clause_plan.json")).unwrap();
 
     let query_plan = QueryPlan {
@@ -1812,7 +1812,8 @@ fn broken_plan_does_not_panic() {
             context_rewrites: None,
             schema_aware_hash: Default::default(),
             authorization: Default::default(),
-        }),
+        })
+        .into(),
         formatted_query_plan: Default::default(),
         usage_reporting: UsageReporting {
             stats_report_key: "this is a test report key".to_string(),
@@ -1824,8 +1825,7 @@ fn broken_plan_does_not_panic() {
     let subgraph_schema = apollo_compiler::Schema::parse_and_validate(subgraph_schema, "").unwrap();
     let mut subgraph_schemas = HashMap::new();
     subgraph_schemas.insert("X".to_owned(), Arc::new(subgraph_schema));
-    let result = plan
-        .root
+    let result = Arc::make_mut(&mut plan.root)
         .init_parsed_operations_and_hash_subqueries(&subgraph_schemas, "");
     assert_eq!(
         result.unwrap_err().to_string(),

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -414,11 +414,11 @@ async fn subscription_task(
     let sender = sub_params.client_sender;
 
     // Get the rest of the query_plan to execute for subscription events
-    let query_plan = match &query_plan.root {
+    let query_plan = match &*query_plan.root {
         crate::query_planner::PlanNode::Subscription { rest, .. } => rest.clone().map(|r| {
             Arc::new(QueryPlan {
                 usage_reporting: query_plan.usage_reporting.clone(),
-                root: *r,
+                root: Arc::new(*r),
                 formatted_query_plan: query_plan.formatted_query_plan.clone(),
                 query: query_plan.query.clone(),
             })


### PR DESCRIPTION
Before this PR on query plan cache miss we would, sequentially:
* Run the Rust QP
* Run the JS QP
* Compare results
* Return the result from JS

After this PR, in the main code path:
* Run the JS QP
* Spawn a background job with that result (shared in `Arc`) and the input document
* Return the result from JS

Meanwhile, the Rust QP and the result comparison runs in the background on a dedicated thread pool. Jobs are dropped if the bounded queue is full. To limit resource consumption at the moment the "pool" is a single thread, and the queue size is 10. Both of these parameters are `const` items in the code (not exposed in Router YAML config at this time).

To try it out, create a `router.yaml` file:

```yaml
experimental_query_planner_mode: both
```

Then run:

```
cargo run -- --dev -c router.yaml -s examples/graphql/supergraph-fed2.graphql
```

And in a separate terminal:

```
curl --request POST \
  --header 'content-type: application/json' \
  --url 'http://127.0.0.1:4000/' \
  --data '{"query":"{topProducts {name}}"}'
```
Should return a response of:
```
{"data":{"topProducts":[{"name":"Table"},{"name":"Couch"},{"name":"Chair"}]}}
```

Expected in the output of the first terminal (router logs):

```
WARN  JS v.s. Rust query plan mismatch
```

We can add to the Router command line to enable DEBUG level logs and show the diff of formatted query plans:

```
--log=apollo_router::query_planner::bridge_query_planner=debug
```
```
WARN  JS v.s. Rust query plan mismatch
DEBUG  Diff of formatted plans:
 QueryPlan {
   Fetch(service: "products") {
     {
       topProducts {
         name
       }
     }
   },
 }
```
No line has a `+` or `-` prefix, so the formatted strings are identical. This is still considered a mismatch because the comparison function is `derive(PartialEq)`. We can increase the log level to TRACE to see the `derive(Debug)` output, which is likely too verbose for any non-trivial query plan:

```
--log=apollo_router::query_planner::bridge_query_planner=trace
```
```
WARN  JS v.s. Rust query plan mismatch
2024-06-04T20:48:34.805692Z WARN  JS v.s. Rust query plan mismatch
2024-06-04T20:48:34.805801Z DEBUG  Diff of formatted plans:
 QueryPlan {
   Fetch(service: "products") {
     {
       topProducts {
         name
       }
     }
   },
 }

TRACE  JS query plan Debug: Some(
    Fetch(
        FetchNode {
            service_name: "products",
            requires: [],
            variable_usages: [],
            operation: "{topProducts{name}}",
            operation_name: None,
            operation_kind: Query,
            id: None,
            input_rewrites: None,
            output_rewrites: None,
            context_rewrites: None,
            schema_aware_hash: QueryHash(
                "8e0d7c1104748fe6a45011035f772e2b107dd851dc80d0b51c9987b830a9267b",
            ),
            authorization: CacheKeyMetadata {
                is_authenticated: false,
                scopes: [],
                policies: [],
            },
        },
    ),
)
TRACE  Rust query plan Debug: Some(
    Fetch(
        FetchNode {
            service_name: "products",
            requires: [],
            variable_usages: [],
            operation: "{\n  topProducts {\n    name\n  }\n}\n",
            operation_name: None,
            operation_kind: Query,
            id: None,
            input_rewrites: None,
            output_rewrites: None,
            context_rewrites: None,
            schema_aware_hash: QueryHash(
                "",
            ),
            authorization: CacheKeyMetadata {
                is_authenticated: false,
                scopes: [],
                policies: [],
            },
        },
    ),
)
```

Differences are whitespace in the `operation` string, and `schema_aware_hash` being only filled in on one side. Clearly `derive(PartialEq)` is not a good comparison function, but making a better one is for another PR.