### PR TITLE
Fix equality-checking logic for operation elements

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -1040,9 +1040,11 @@ mod field_selection {
 
     impl Field {
         pub(crate) fn new(data: FieldData) -> Self {
+            let mut arguments = data.arguments.as_ref().clone();
+            sort_arguments(&mut arguments);
             Self {
                 key: data.key(),
-                sorted_arguments: Arc::new(sort_arguments(&data.arguments)),
+                sorted_arguments: Arc::new(arguments),
                 data,
             }
         }
@@ -1203,9 +1205,11 @@ mod field_selection {
 
     impl HasSelectionKey for FieldData {
         fn key(&self) -> SelectionKey {
+            let mut directives = self.directives.as_ref().clone();
+            sort_directives(&mut directives);
             SelectionKey::Field {
                 response_name: self.response_name(),
-                directives: Arc::new(sort_directives(&self.directives)),
+                directives: Arc::new(directives),
             }
         }
     }
@@ -1307,9 +1311,11 @@ mod fragment_spread_selection {
                     deferred_id: self.selection_id.clone(),
                 }
             } else {
+                let mut directives = self.directives.as_ref().clone();
+                sort_directives(&mut directives);
                 SelectionKey::FragmentSpread {
                     fragment_name: self.fragment_name.clone(),
-                    directives: Arc::new(sort_directives(&self.directives)),
+                    directives: Arc::new(directives),
                 }
             }
         }
@@ -1605,12 +1611,14 @@ mod inline_fragment_selection {
                     deferred_id: self.selection_id.clone(),
                 }
             } else {
+                let mut directives = self.directives.as_ref().clone();
+                sort_directives(&mut directives);
                 SelectionKey::InlineFragment {
                     type_condition: self
                         .type_condition_position
                         .as_ref()
                         .map(|pos| pos.type_name().clone()),
-                    directives: Arc::new(sort_directives(&self.directives)),
+                    directives: Arc::new(directives),
                 }
             }
         }

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -919,6 +919,8 @@ impl Fragment {
 
 mod field_selection {
     use std::collections::HashSet;
+    use std::hash::Hash;
+    use std::hash::Hasher;
     use std::sync::Arc;
 
     use apollo_compiler::ast;
@@ -927,7 +929,8 @@ mod field_selection {
     use apollo_compiler::Node;
 
     use crate::error::FederationError;
-    use crate::operation::directives_with_sorted_arguments;
+    use crate::operation::sort_arguments;
+    use crate::operation::sort_directives;
     use crate::operation::HasSelectionKey;
     use crate::operation::SelectionKey;
     use crate::operation::SelectionSet;
@@ -1004,10 +1007,11 @@ mod field_selection {
 
     /// The non-selection-set data of `FieldSelection`, used with operation paths and graph
     /// paths.
-    #[derive(Clone, PartialEq, Eq, Hash)]
+    #[derive(Clone)]
     pub(crate) struct Field {
         data: FieldData,
         key: SelectionKey,
+        sorted_arguments: Arc<Vec<Node<executable::Argument>>>,
     }
 
     impl std::fmt::Debug for Field {
@@ -1016,10 +1020,29 @@ mod field_selection {
         }
     }
 
+    impl PartialEq for Field {
+        fn eq(&self, other: &Self) -> bool {
+            self.data.field_position.field_name() == other.data.field_position.field_name()
+                && self.key == other.key
+                && self.sorted_arguments == other.sorted_arguments
+        }
+    }
+
+    impl Eq for Field {}
+
+    impl Hash for Field {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            self.data.field_position.field_name().hash(state);
+            self.key.hash(state);
+            self.sorted_arguments.hash(state);
+        }
+    }
+
     impl Field {
         pub(crate) fn new(data: FieldData) -> Self {
             Self {
                 key: data.key(),
+                sorted_arguments: Arc::new(sort_arguments(&data.arguments)),
                 data,
             }
         }
@@ -1125,7 +1148,7 @@ mod field_selection {
         }
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    #[derive(Debug, Clone)]
     pub(crate) struct FieldData {
         pub(crate) schema: ValidFederationSchema,
         pub(crate) field_position: FieldDefinitionPosition,
@@ -1182,7 +1205,7 @@ mod field_selection {
         fn key(&self) -> SelectionKey {
             SelectionKey::Field {
                 response_name: self.response_name(),
-                directives: Arc::new(directives_with_sorted_arguments(&self.directives)),
+                directives: Arc::new(sort_directives(&self.directives)),
             }
         }
     }
@@ -1198,8 +1221,8 @@ mod fragment_spread_selection {
     use apollo_compiler::executable;
     use apollo_compiler::executable::Name;
 
-    use crate::operation::directives_with_sorted_arguments;
     use crate::operation::is_deferred_selection;
+    use crate::operation::sort_directives;
     use crate::operation::HasSelectionKey;
     use crate::operation::SelectionId;
     use crate::operation::SelectionKey;
@@ -1222,7 +1245,7 @@ mod fragment_spread_selection {
     /// An analogue of the apollo-compiler type `FragmentSpread` with these changes:
     /// - Stores the schema (may be useful for directives).
     /// - Encloses collection types in `Arc`s to facilitate cheaper cloning.
-    #[derive(Clone, PartialEq, Eq)]
+    #[derive(Clone)]
     pub(crate) struct FragmentSpread {
         data: FragmentSpreadData,
         key: SelectionKey,
@@ -1233,6 +1256,14 @@ mod fragment_spread_selection {
             self.data.fmt(f)
         }
     }
+
+    impl PartialEq for FragmentSpread {
+        fn eq(&self, other: &Self) -> bool {
+            self.key == other.key
+        }
+    }
+
+    impl Eq for FragmentSpread {}
 
     impl FragmentSpread {
         pub(crate) fn new(data: FragmentSpreadData) -> Self {
@@ -1253,7 +1284,7 @@ mod fragment_spread_selection {
         }
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    #[derive(Debug, Clone)]
     pub(crate) struct FragmentSpreadData {
         pub(crate) schema: ValidFederationSchema,
         pub(crate) fragment_name: Name,
@@ -1278,7 +1309,7 @@ mod fragment_spread_selection {
             } else {
                 SelectionKey::FragmentSpread {
                     fragment_name: self.fragment_name.clone(),
-                    directives: Arc::new(directives_with_sorted_arguments(&self.directives)),
+                    directives: Arc::new(sort_directives(&self.directives)),
                 }
             }
         }
@@ -1387,6 +1418,8 @@ impl FragmentSpreadData {
 
 mod inline_fragment_selection {
     use std::collections::HashSet;
+    use std::hash::Hash;
+    use std::hash::Hasher;
     use std::sync::Arc;
 
     use apollo_compiler::executable;
@@ -1396,8 +1429,8 @@ mod inline_fragment_selection {
     use crate::error::FederationError;
     use crate::link::graphql_definition::defer_directive_arguments;
     use crate::link::graphql_definition::DeferDirectiveArguments;
-    use crate::operation::directives_with_sorted_arguments;
     use crate::operation::is_deferred_selection;
+    use crate::operation::sort_directives;
     use crate::operation::HasSelectionKey;
     use crate::operation::SelectionId;
     use crate::operation::SelectionKey;
@@ -1455,7 +1488,7 @@ mod inline_fragment_selection {
 
     /// The non-selection-set data of `InlineFragmentSelection`, used with operation paths and
     /// graph paths.
-    #[derive(Clone, PartialEq, Eq, Hash)]
+    #[derive(Clone)]
     pub(crate) struct InlineFragment {
         data: InlineFragmentData,
         key: SelectionKey,
@@ -1464,6 +1497,20 @@ mod inline_fragment_selection {
     impl std::fmt::Debug for InlineFragment {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             self.data.fmt(f)
+        }
+    }
+
+    impl PartialEq for InlineFragment {
+        fn eq(&self, other: &Self) -> bool {
+            self.key == other.key
+        }
+    }
+
+    impl Eq for InlineFragment {}
+
+    impl Hash for InlineFragment {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            self.key.hash(state);
         }
     }
 
@@ -1524,7 +1571,7 @@ mod inline_fragment_selection {
         }
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    #[derive(Debug, Clone)]
     pub(crate) struct InlineFragmentData {
         pub(crate) schema: ValidFederationSchema,
         pub(crate) parent_type_position: CompositeTypeDefinitionPosition,
@@ -1563,7 +1610,7 @@ mod inline_fragment_selection {
                         .type_condition_position
                         .as_ref()
                         .map(|pos| pos.type_name().clone()),
-                    directives: Arc::new(directives_with_sorted_arguments(&self.directives)),
+                    directives: Arc::new(sort_directives(&self.directives)),
                 }
             }
         }
@@ -4387,23 +4434,6 @@ impl Display for InlineFragment {
         }
         data.directives.serialize().no_indent().fmt(f)
     }
-}
-
-fn directives_with_sorted_arguments(
-    directives: &executable::DirectiveList,
-) -> executable::DirectiveList {
-    let mut directives = directives.clone();
-    for directive in &mut directives {
-        directive
-            .make_mut()
-            .arguments
-            .sort_by(|a1, a2| a1.name.cmp(&a2.name))
-    }
-    directives
-}
-
-fn is_deferred_selection(directives: &executable::DirectiveList) -> bool {
-    directives.has("defer")
 }
 
 /// Normalizes the selection set of the specified operation.


### PR DESCRIPTION
This PR fixes equality/hash logic for operation elements. Specifically:

1. Equality shouldn't care about order in map-likes (i.e. argument order in fields and directives, and field order in object values).
    1.  The previous code for key equality used sorted arguments in directives, but it wasn't recursively sorting values in directive arguments.
    2. The previous code for field/inline fragment/fragment spread equality wasn't comparing using sorted map-likes.
    3.  As part of fixing the above, the new code has added a `sorted_arguments` field to `Field`.

2. Equality shouldn't care about directive order (this is specifically a choice of federation, and not GraphQL).
    1. The previous code for key equality wasn't sorting directives.
    2. The previous code for field/inline fragment/fragment spread equality wasn't sorting directives.
    3. Note that sorting directives is more complicated than sorting arguments/object value fields, since a directive may be repeated on a schema element. This in particular means that we need to establish an order between arbitrary GraphQL values. The ordering I've written in this PR isn't set in stone; it just needs to be consistent and ideally fast.
    4. The new code for field/inline fragment/fragment spread equality reuses the directive list in `SelectionKey`.
5. Equality shouldn't care about selection ID unless `@defer` is present (due to delivery groups being created per selection).
    1. The previous code for field/inline fragment/fragment spread equality was always comparing selection IDs, regardless of `@defer` presence.
    2. The new code for field/inline fragment/fragment spread equality reuses the selection ID from `SelectionKey` (which only stores the selection ID if `@defer` is present).
6. Equality shouldn't care about element's schemas, parent types, type kinds, or sibling typename presence.
    1. The previous code for field/inline fragment/fragment spread equality was comparing schemas, parent types, type kinds, and sibling typename presence.
    2. To be clear, I've made these changes because the JS codebase explicitly avoids comparing these properties in its equality logic. My guess is to permit e.g. cross-schema comparison, type covariance, FieldsInSetCanMerge checks, and interface objects, though I'd have to check the callsites to be sure.
