### PR TITLE
FED-239: fixed and simplified `subselection_type_if_abstract`

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -2407,7 +2407,6 @@ impl SelectionSet {
     pub(crate) fn add_typename_field_for_abstract_types(
         &self,
         parent_type_if_abstract: Option<AbstractType>,
-        fragments: &Option<&mut RebasedFragments>,
     ) -> Result<SelectionSet, FederationError> {
         let mut selection_map = SelectionMap::new();
         if let Some(parent) = parent_type_if_abstract {
@@ -2421,10 +2420,9 @@ impl SelectionSet {
         }
         for selection in self.selections.values() {
             selection_map.insert(if let Some(selection_set) = selection.selection_set()? {
-                let type_if_abstract =
-                    subselection_type_if_abstract(selection, &self.schema, fragments);
-                let updated_selection_set = selection_set
-                    .add_typename_field_for_abstract_types(type_if_abstract, fragments)?;
+                let type_if_abstract = subselection_type_if_abstract(selection);
+                let updated_selection_set =
+                    selection_set.add_typename_field_for_abstract_types(type_if_abstract)?;
 
                 if updated_selection_set == *selection_set {
                     selection.clone()
@@ -3127,56 +3125,17 @@ fn gen_alias_name(base_name: &Name, unavailable_names: &HashMap<Name, SeenRespon
     }
 }
 
-pub(crate) fn subselection_type_if_abstract(
-    selection: &Selection,
-    schema: &ValidFederationSchema,
-    fragments: &Option<&mut RebasedFragments>,
-) -> Option<AbstractType> {
-    match selection {
-        Selection::Field(field) => {
-            match schema
-                .get_type(field.field.data().field_position.type_name().clone())
-                .ok()?
-            {
-                crate::schema::position::TypeDefinitionPosition::Interface(i) => {
-                    Some(AbstractType::Interface(i))
-                }
-                crate::schema::position::TypeDefinitionPosition::Union(u) => {
-                    Some(AbstractType::Union(u))
-                }
-                _ => None,
-            }
-        }
-        Selection::FragmentSpread(fragment_spread) => {
-            let fragment = fragments
-                .as_ref()
-                .and_then(|r| {
-                    r.original_fragments
-                        .get(&fragment_spread.spread.data().fragment_name)
-                })
-                .ok_or(crate::error::SingleFederationError::InvalidGraphQL {
-                    message: "missing fragment".to_string(),
-                })
-                //FIXME: return error
-                .ok()?;
-            match fragment.type_condition_position.clone() {
-                CompositeTypeDefinitionPosition::Interface(i) => Some(AbstractType::Interface(i)),
-                CompositeTypeDefinitionPosition::Union(u) => Some(AbstractType::Union(u)),
-                CompositeTypeDefinitionPosition::Object(_) => None,
-            }
-        }
-        Selection::InlineFragment(inline_fragment) => {
-            match inline_fragment
-                .inline_fragment
-                .data()
-                .type_condition_position
-                .clone()?
-            {
-                CompositeTypeDefinitionPosition::Interface(i) => Some(AbstractType::Interface(i)),
-                CompositeTypeDefinitionPosition::Union(u) => Some(AbstractType::Union(u)),
-                CompositeTypeDefinitionPosition::Object(_) => None,
-            }
-        }
+pub(crate) fn subselection_type_if_abstract(selection: &Selection) -> Option<AbstractType> {
+    let sub_selection_type = selection
+        .element()
+        .ok()?
+        .sub_selection_type_position()
+        .ok()
+        .flatten()?;
+    match sub_selection_type {
+        CompositeTypeDefinitionPosition::Interface(interface_type) => Some(interface_type.into()),
+        CompositeTypeDefinitionPosition::Union(union_type) => Some(union_type.into()),
+        CompositeTypeDefinitionPosition::Object(_) => None,
     }
 }
 
@@ -4087,9 +4046,7 @@ impl NamedFragments {
             return Ok(self.clone());
         }
         let updated = self.map_to_expanded_selection_sets(|ss| {
-            ss.add_typename_field_for_abstract_types(
-                /*parent_type_if_abstract*/ None, /*fragments*/ &None,
-            )
+            ss.add_typename_field_for_abstract_types(/*parent_type_if_abstract*/ None)
         })?;
         // PORT_NOTE: The JS version asserts if `updated` is empty or not. But, we really want to
         // check the `updated` has the same set of fragments. To avoid performance hit, only the

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -1769,7 +1769,7 @@ impl FetchDependencyGraphNode {
             return Ok(None);
         }
         let (selection, output_rewrites) =
-            self.finalize_selection(variable_definitions, handled_conditions, &fragments)?;
+            self.finalize_selection(variable_definitions, handled_conditions)?;
         let input_nodes = self
             .inputs
             .as_ref()
@@ -1837,7 +1837,6 @@ impl FetchDependencyGraphNode {
         &self,
         variable_definitions: &[Node<VariableDefinition>],
         handled_conditions: &Conditions,
-        fragments: &Option<&mut RebasedFragments>,
     ) -> Result<(SelectionSet, Vec<Arc<FetchDataRewrite>>), FederationError> {
         // Finalizing the selection involves the following:
         // 1. removing any @include/@skip that are not necessary
@@ -1861,7 +1860,7 @@ impl FetchDependencyGraphNode {
             handled_conditions,
         )?;
         let selection_with_typenames =
-            selection_without_conditions.add_typename_field_for_abstract_types(None, fragments)?;
+            selection_without_conditions.add_typename_field_for_abstract_types(None)?;
 
         let (updated_selection, output_rewrites) =
             selection_with_typenames.add_aliases_for_non_merging_fields()?;

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -927,6 +927,7 @@ type User
             Fetch(service: "reviews") {
               {
                 bestRatedProducts {
+                  __typename
                   ... on Book {
                     __typename
                     id

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -414,7 +414,7 @@ impl<'a> QueryPlanningTraversal<'a> {
                 let new_selection_set = Arc::new(
                     selection_set
                         .add_back_typename_in_attachments()?
-                        .add_typename_field_for_abstract_types(None, &None)?,
+                        .add_typename_field_for_abstract_types(None)?,
                 );
                 self.record_closed_branch(ClosedBranch(
                     new_options

--- a/apollo-federation/src/schema/definitions.rs
+++ b/apollo-federation/src/schema/definitions.rs
@@ -9,6 +9,7 @@ use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::position::TypeDefinitionPosition;
 use crate::schema::position::UnionTypeDefinitionPosition;
 
+#[derive(derive_more::From)]
 pub(crate) enum AbstractType {
     Interface(InterfaceTypeDefinitionPosition),
     Union(UnionTypeDefinitionPosition),

--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -209,6 +209,7 @@ fn field_covariance_and_type_explosion() {
       Fetch(service: "Subgraph1") {
         {
           dummy {
+            __typename
             field {
               __typename
               ... on Object {
@@ -226,8 +227,6 @@ fn field_covariance_and_type_explosion() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure - unexpected inline spread
 fn handles_non_intersecting_fragment_conditions() {
     let planner = planner!(
         Subgraph1: r#"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/interface_type_explosion.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/interface_type_explosion.rs
@@ -94,8 +94,8 @@ fn handles_non_matching_value_types_under_interface_field() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure
+#[should_panic(expected = "assertion `left == right` failed")]
+// TODO: investigate this failure (`evaluated_plan_count` is 0, when it's expected to be 1.)
 fn skip_type_explosion_early_if_unnecessary() {
     let planner = planner!(
         Subgraph1: r#"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
@@ -152,8 +152,6 @@ fn union_interface_interaction_but_no_need_to_type_explode() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure
 fn interface_union_interaction() {
     let planner = planner!(
         Subgraph1: r#"
@@ -446,8 +444,6 @@ fn interface_interface_interaction_but_no_need_to_type_explode() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure
 fn union_union_interaction() {
     let planner = planner!(
         Subgraph1: r#"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments_preservation.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments_preservation.rs
@@ -1,8 +1,6 @@
 use apollo_federation::query_plan::query_planner::QueryPlannerConfig;
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure - missing `__typename` under `a`
 fn it_works_with_nested_fragments_1() {
     let planner = planner!(
         Subgraph1: r#"
@@ -94,7 +92,7 @@ fn it_works_with_nested_fragments_1() {
                 }
               }
             }
-            
+
             fragment FooChildSelect on Foo {
               __typename
               foo
@@ -109,7 +107,7 @@ fn it_works_with_nested_fragments_1() {
                 }
               }
             }
-            
+
             fragment FooSelect on Foo {
               __typename
               foo
@@ -571,8 +569,6 @@ fn it_preserves_directives_when_fragment_is_reused() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure
 fn it_does_not_try_to_apply_fragments_that_are_not_valid_for_the_subgaph() {
     // Slightly artificial example for simplicity, but this highlight the problem.
     // In that example, the only queried subgraph is the first one (there is in fact

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/provides.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/provides.rs
@@ -307,6 +307,7 @@ fn it_works_on_unions() {
         Fetch(service: "Subgraph1") {
           {
             noProvides {
+              __typename
               ... on T1 {
                 __typename
                 id
@@ -376,6 +377,7 @@ fn it_works_on_unions() {
       Fetch(service: "Subgraph1") {
         {
           withProvidesForT1 {
+            __typename
             ... on T1 {
               a
             }


### PR DESCRIPTION
- Several tests have improved.
- One snapshot failure became an assert_eq failure, but that's a known issue.
- Some expected plans were missing `__typename` lines. I added them since the JS version of their tests have it.

Fixes FED-239

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
