### PR TITLE
Fix bug in subgraph extraction where directives weren't pre-inserted

### DIFF
--- a/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -397,10 +397,11 @@ fn extract_subgraphs_from_fed_2_supergraph(
         remove_inactive_requires_and_provides_from_subgraph(&mut subgraph.schema)?;
         remove_unused_types_from_subgraph(&mut subgraph.schema)?;
         for definition in all_executable_directive_definitions.iter() {
-            DirectiveDefinitionPosition {
+            let pos = DirectiveDefinitionPosition {
                 directive_name: definition.name.clone(),
-            }
-            .insert(&mut subgraph.schema, definition.clone())?;
+            };
+            pos.pre_insert(&mut subgraph.schema)?;
+            pos.insert(&mut subgraph.schema, definition.clone())?;
         }
     }
 

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/handles_fragments_with_directive_conditions.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/handles_fragments_with_directive_conditions.rs
@@ -1,10 +1,10 @@
 #[test]
-#[should_panic(expected = r#"Directive "@test" has not been pre-inserted"#)]
+#[should_panic(expected = "Subgraph unexpectedly does not use federation spec")]
 // TODO: investigate this failure
 fn fragment_with_intersecting_parent_type_and_directive_condition() {
     let planner = planner!(
         A: r#"
-          directive @test on FRAGMENT_SPREAD
+          directive @test on INLINE_FRAGMENT
           type Query {
             i: I
           }
@@ -21,7 +21,7 @@ fn fragment_with_intersecting_parent_type_and_directive_condition() {
           }
         "#,
         B: r#"
-          directive @test on FRAGMENT_SPREAD
+          directive @test on INLINE_FRAGMENT
           type Query {
             i2s: [I2]
           }
@@ -74,12 +74,12 @@ fn fragment_with_intersecting_parent_type_and_directive_condition() {
 }
 
 #[test]
-#[should_panic(expected = r#"Directive "@test" has not been pre-inserted"#)]
+#[should_panic(expected = "Subgraph unexpectedly does not use federation spec")]
 // TODO: investigate this failure
 fn nested_fragment_with_interseting_parent_type_and_directive_condition() {
     let planner = planner!(
         A: r#"
-          directive @test on FRAGMENT_SPREAD
+          directive @test on INLINE_FRAGMENT
           type Query {
             i: I
           }
@@ -96,7 +96,7 @@ fn nested_fragment_with_interseting_parent_type_and_directive_condition() {
           }
         "#,
         B: r#"
-          directive @test on FRAGMENT_SPREAD
+          directive @test on INLINE_FRAGMENT
           type Query {
             i2s: [I2]
           }

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/handles_operations_with_directives.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/handles_operations_with_directives.rs
@@ -39,7 +39,7 @@ const SUBGRAPH_B: &str = r#"
 "#;
 
 #[test]
-#[should_panic(expected = r#"Directive "@field" has not been pre-inserted"#)]
+#[should_panic(expected = "snapshot assertion")]
 // TODO: investigate this failure
 fn test_if_directives_at_the_operation_level_are_passed_down_to_subgraph_queries() {
     let planner = planner!(
@@ -59,7 +59,57 @@ fn test_if_directives_at_the_operation_level_are_passed_down_to_subgraph_queries
           }
         }
       "#,
-      @""
+      @r###"
+      QueryPlan {
+        Sequence {
+          Fetch(service: "subgraphA") {
+            {
+              foo @field {
+                __typename
+                id
+                bar @field
+                t @field {
+                  __typename
+                  id
+                }
+              }
+            }
+          },
+          Parallel {
+            Flatten(path: "foo.t") {
+              Fetch(service: "subgraphB") {
+                {
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
+                    f1 @field
+                  }
+                }
+              },
+            },
+            Flatten(path: "foo") {
+              Fetch(service: "subgraphB") {
+                {
+                  ... on Foo {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on Foo {
+                    baz @field
+                  }
+                }
+              },
+            },
+          },
+        },
+      }
+      "###
     );
     let a_fetch_nodes = find_fetch_nodes_for_subgraph("subgraphA", &plan);
     assert_eq!(a_fetch_nodes.len(), 1);
@@ -103,7 +153,7 @@ fn test_if_directives_at_the_operation_level_are_passed_down_to_subgraph_queries
 }
 
 #[test]
-#[should_panic(expected = r#"Directive "@field" has not been pre-inserted"#)]
+#[should_panic(expected = "snapshot assertion")]
 // TODO: investigate this failure
 fn test_if_directives_on_mutations_are_passed_down_to_subgraph_queries() {
     let planner = planner!(
@@ -120,7 +170,18 @@ fn test_if_directives_on_mutations_are_passed_down_to_subgraph_queries() {
           }
         }
       "#,
-      @r#""#
+      @r###"
+      QueryPlan {
+        Fetch(service: "subgraphA") {
+              mutation TestMutation__subgraphA__0 {
+            updateFoo(bar: "something") @field {
+              id @field
+              bar @field
+            }
+          }
+        },
+      }
+      "###
     );
 
     let fetch_nodes = find_fetch_nodes_for_subgraph("subgraphA", &plan);
@@ -137,7 +198,7 @@ fn test_if_directives_on_mutations_are_passed_down_to_subgraph_queries() {
 }
 
 #[test]
-#[should_panic(expected = r#"Directive "@noArgs" has not been pre-inserted"#)]
+#[should_panic(expected = "snapshot assertion")]
 // TODO: investigate this failure
 fn test_if_directives_with_arguments_applied_on_queries_are_ok() {
     let planner = planner!(
@@ -161,7 +222,15 @@ fn test_if_directives_with_arguments_applied_on_queries_are_ok() {
           test
         }
         "#,
-      @r#""#
+      @r###"
+      QueryPlan {
+        Fetch(service: "Subgraph1") {
+          {
+            test
+          }
+        },
+      }
+      "###
     );
 
     let fetch_nodes = find_fetch_nodes_for_subgraph("Subgraph1", &plan);
@@ -175,7 +244,7 @@ fn test_if_directives_with_arguments_applied_on_queries_are_ok() {
 }
 
 #[test]
-#[should_panic(expected = r#"Directive "@withArgs" has not been pre-inserted"#)]
+#[should_panic(expected = r#"unused variable: `$some_var`"#)]
 // TODO: investigate this failure
 fn subgraph_query_retains_the_query_variables_used_in_the_directives_applied_to_the_query() {
     let planner = planner!(

--- a/apollo-federation/tests/query_plan/supergraphs/fragment_with_intersecting_parent_type_and_directive_condition.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/fragment_with_intersecting_parent_type_and_directive_condition.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: aebf42f02d843ad0173bed996f1a5f6ddc8f980f
+# Composed from subgraphs with hash: 059bed56ce74dbb40643a1561b79514872f0ab60
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
@@ -20,7 +20,7 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-directive @test on FRAGMENT_SPREAD
+directive @test on INLINE_FRAGMENT
 
 interface I
   @join__type(graph: A)

--- a/apollo-federation/tests/query_plan/supergraphs/nested_fragment_with_interseting_parent_type_and_directive_condition.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/nested_fragment_with_interseting_parent_type_and_directive_condition.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: aebf42f02d843ad0173bed996f1a5f6ddc8f980f
+# Composed from subgraphs with hash: 059bed56ce74dbb40643a1561b79514872f0ab60
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
@@ -20,7 +20,7 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-directive @test on FRAGMENT_SPREAD
+directive @test on INLINE_FRAGMENT
 
 interface I
   @join__type(graph: A)


### PR DESCRIPTION
This PR:
- Fixes a bug in subgraph extraction where directives weren't being pre-inserted, leading to errors when subgraphs declared user-defined executable directives.
- Fixes a bug in tests where directives are being declared on `FRAGMENT_SPREAD` when they should really be declared on `INLINE_FRAGMENT` (the JS wasn't catching this for some reason, but the Rust validations did).

This PR updates tests that were encountering this pre-insertion error.
- The tests in `handles_fragments_with_directive_conditions.rs` now encounter a different error, more similar to FED-263 (which has been updated to include this file).
- The tests in `handles_operations_with_directives.rs` also now encounter a different error, which is specific to the functionality under test. FED-285 has been created to track it.