### PR TITLE
chore(federation): refactor RebasedFragments

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -2407,7 +2407,7 @@ impl SelectionSet {
     pub(crate) fn add_typename_field_for_abstract_types(
         &self,
         parent_type_if_abstract: Option<AbstractType>,
-        fragments: &Option<&mut RebasedFragments>,
+        fragments: Option<&NamedFragments>,
     ) -> Result<SelectionSet, FederationError> {
         let mut selection_map = SelectionMap::new();
         if let Some(parent) = parent_type_if_abstract {
@@ -3130,7 +3130,7 @@ fn gen_alias_name(base_name: &Name, unavailable_names: &HashMap<Name, SeenRespon
 pub(crate) fn subselection_type_if_abstract(
     selection: &Selection,
     schema: &ValidFederationSchema,
-    fragments: &Option<&mut RebasedFragments>,
+    fragments: Option<&NamedFragments>,
 ) -> Option<AbstractType> {
     match selection {
         Selection::Field(field) => {
@@ -3149,11 +3149,7 @@ pub(crate) fn subselection_type_if_abstract(
         }
         Selection::FragmentSpread(fragment_spread) => {
             let fragment = fragments
-                .as_ref()
-                .and_then(|r| {
-                    r.original_fragments
-                        .get(&fragment_spread.spread.data().fragment_name)
-                })
+                .and_then(|fragments| fragments.get(&fragment_spread.spread.data().fragment_name))
                 .ok_or(crate::error::SingleFederationError::InvalidGraphQL {
                     message: "missing fragment".to_string(),
                 })
@@ -4088,7 +4084,7 @@ impl NamedFragments {
         }
         let updated = self.map_to_expanded_selection_sets(|ss| {
             ss.add_typename_field_for_abstract_types(
-                /*parent_type_if_abstract*/ None, /*fragments*/ &None,
+                /*parent_type_if_abstract*/ None, /*fragments*/ None,
             )
         })?;
         // PORT_NOTE: The JS version asserts if `updated` is empty or not. But, we really want to

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -4099,55 +4099,6 @@ impl NamedFragments {
     }
 }
 
-/// Tracks fragments from the original operation, along with versions rebased on other subgraphs.
-// XXX(@goto-bus-stop): improve/replace/reduce this structure. My notes:
-// This gets cloned only in recursive query planning. Then whenever `.for_subgraph()` ends up being
-// called, it always clones the `rebased_fragments` map. `.for_subgraph()` is called whenever the
-// plan is turned into plan nodes by the FetchDependencyGraphToQueryPlanProcessor.
-// This suggests that we can remove the Arc wrapper for `rebased_fragments` because we end up cloning the inner data anyways.
-//
-// This data structure is also used as an argument in several `crate::operation` functions. This
-// seems wrong. The only useful method on this structure is `.for_subgraph()`, which is only used
-// by the fetch dependency graph when creating plan nodes. That necessarily implies that all other
-// uses of this structure only access `.original_fragments`. In that case, we should pass around
-// the `NamedFragments` itself, not this wrapper structure.
-//
-// `.for_subgraph()` also requires a mutable reference to fill in the data. But
-// `.rebased_fragments` is really a cache, so requiring a mutable reference isn't an ideal API.
-// Conceptually you are just computing something and getting the result. Perhaps we can use a
-// concurrent map, or prepopulate the HashMap for all subgraphs, or precompute the whole thing for
-// all subgraphs (or precompute a hash map of subgraph names to OnceLocks).
-#[derive(Clone)]
-pub(crate) struct RebasedFragments {
-    pub(crate) original_fragments: NamedFragments,
-    // JS PORT NOTE: In JS implementation values were optional
-    /// Map key: subgraph name
-    rebased_fragments: Arc<HashMap<NodeStr, NamedFragments>>,
-}
-
-impl RebasedFragments {
-    pub(crate) fn new(fragments: NamedFragments) -> Self {
-        Self {
-            original_fragments: fragments,
-            rebased_fragments: Arc::new(HashMap::new()),
-        }
-    }
-
-    pub(crate) fn for_subgraph(
-        &mut self,
-        subgraph_name: impl Into<NodeStr>,
-        subgraph_schema: &ValidFederationSchema,
-    ) -> &NamedFragments {
-        Arc::make_mut(&mut self.rebased_fragments)
-            .entry(subgraph_name.into())
-            .or_insert_with(|| {
-                self.original_fragments
-                    .rebase_on(subgraph_schema)
-                    .unwrap_or_default()
-            })
-    }
-}
-
 impl TryFrom<&Operation> for executable::Operation {
     type Error = FederationError;
 

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -1768,8 +1768,13 @@ impl FetchDependencyGraphNode {
         if self.selection_set.selection_set.selections.is_empty() {
             return Ok(None);
         }
-        let (selection, output_rewrites) =
-            self.finalize_selection(variable_definitions, handled_conditions, &fragments)?;
+        let (selection, output_rewrites) = self.finalize_selection(
+            variable_definitions,
+            handled_conditions,
+            fragments
+                .as_ref()
+                .map(|fragments| &fragments.original_fragments),
+        )?;
         let input_nodes = self
             .inputs
             .as_ref()
@@ -1837,7 +1842,7 @@ impl FetchDependencyGraphNode {
         &self,
         variable_definitions: &[Node<VariableDefinition>],
         handled_conditions: &Conditions,
-        fragments: &Option<&mut RebasedFragments>,
+        fragments: Option<&NamedFragments>,
     ) -> Result<(SelectionSet, Vec<Arc<FetchDataRewrite>>), FederationError> {
         // Finalizing the selection involves the following:
         // 1. removing any @include/@skip that are not necessary

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -414,7 +414,7 @@ impl<'a> QueryPlanningTraversal<'a> {
                 let new_selection_set = Arc::new(
                     selection_set
                         .add_back_typename_in_attachments()?
-                        .add_typename_field_for_abstract_types(None, &None)?,
+                        .add_typename_field_for_abstract_types(None, None)?,
                 );
                 self.record_closed_branch(ClosedBranch(
                     new_options


### PR DESCRIPTION
This is not urgent, I mostly wanted to see the effect on QueryPlanningParameters.
I think it may be important to *not* clone QueryPlanningParameters for recursive planning. The JS version does create a new QueryPlanningParameters structure but it contains references to all the same data from the original. In Rust we deeply clone it. In JS, there is some mutable state on the structure: changes made to it propagate to the "parent" plan, but in Rust they do not. This could be causing conditions bugs today?

`RebasedFragments` is a cache of fragments rebased on different
subgraphs. It's only used internally in the query planner and not by
any of the operation types, so this moves the structure out of the general
`operation` module and into the `query_plan` module.

`RebasedFragments` would be cloned to do recursive planning for
conditions. This would mean multiple Arc references to the rebased
cache would be alive, and calls to `for_subgraph` would clone the cache.
Different instances of `RebasedFragments` are independent, so the cache
could be out of sync and cause duplicate work.

This changes `RebasedFragments` to be passed by reference, so it's never
cloned. It uses runtime borrow-checking to fill the cache.
`RebasedFragments` instances are only used for one `build_query_plan`
call, which is fully synchronous and single-threaded, so we can
guarantee that conflicting borrows do not happen.