### PR TITLE
Disable GraphOS tests when apollo key not present

### DIFF
--- a/.changesets/maint_bryn_disable_tests_apollo_key_missing.md
+++ b/.changesets/maint_bryn_disable_tests_apollo_key_missing.md
@@ -1,0 +1,6 @@
+### Disable GraphOS tests when apollo key not present ([PR #5362](https://github.com/apollographql/router/pull/5362))
+
+A number of tests require APOLLO_KEY and APOLLO_GRAPH_REF to be present to execute successfully.
+These are now skipped if these env variables are not present.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5362

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -1150,3 +1150,14 @@ fn merge_overrides(
 
     serde_yaml::to_string(&config).unwrap()
 }
+
+#[allow(dead_code)]
+pub fn graph_os_enabled() -> bool {
+    matches!(
+        (
+            std::env::var("TEST_APOLLO_KEY"),
+            std::env::var("TEST_APOLLO_GRAPH_REF"),
+        ),
+        (Ok(_), Ok(_))
+    )
+}

--- a/apollo-router/tests/integration/coprocessor.rs
+++ b/apollo-router/tests/integration/coprocessor.rs
@@ -1,23 +1,25 @@
 use insta::assert_yaml_snapshot;
 use tower::BoxError;
 
+use crate::integration::common::graph_os_enabled;
 use crate::integration::IntegrationTest;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_error_not_propagated_to_client() -> Result<(), BoxError> {
-    let mut router = IntegrationTest::builder()
-        .config(include_str!("fixtures/broken_coprocessor.router.yaml"))
-        .build()
-        .await;
+    if graph_os_enabled() {
+        let mut router = IntegrationTest::builder()
+            .config(include_str!("fixtures/broken_coprocessor.router.yaml"))
+            .build()
+            .await;
 
-    router.start().await;
-    router.assert_started().await;
+        router.start().await;
+        router.assert_started().await;
 
-    let (_trace_id, response) = router.execute_default_query().await;
-    assert_eq!(response.status(), 500);
-    assert_yaml_snapshot!(response.text().await?);
-    router.assert_log_contains("INTERNAL_SERVER_ERROR").await;
-    router.graceful_shutdown().await;
-
+        let (_trace_id, response) = router.execute_default_query().await;
+        assert_eq!(response.status(), 500);
+        assert_yaml_snapshot!(response.text().await?);
+        router.assert_log_contains("INTERNAL_SERVER_ERROR").await;
+        router.graceful_shutdown().await;
+    }
     Ok(())
 }

--- a/apollo-router/tests/integration/coprocessor.rs
+++ b/apollo-router/tests/integration/coprocessor.rs
@@ -6,20 +6,21 @@ use crate::integration::IntegrationTest;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_error_not_propagated_to_client() -> Result<(), BoxError> {
-    if graph_os_enabled() {
-        let mut router = IntegrationTest::builder()
-            .config(include_str!("fixtures/broken_coprocessor.router.yaml"))
-            .build()
-            .await;
-
-        router.start().await;
-        router.assert_started().await;
-
-        let (_trace_id, response) = router.execute_default_query().await;
-        assert_eq!(response.status(), 500);
-        assert_yaml_snapshot!(response.text().await?);
-        router.assert_log_contains("INTERNAL_SERVER_ERROR").await;
-        router.graceful_shutdown().await;
+    if !graph_os_enabled() {
+        return Ok(());
     }
+    let mut router = IntegrationTest::builder()
+        .config(include_str!("fixtures/broken_coprocessor.router.yaml"))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    let (_trace_id, response) = router.execute_default_query().await;
+    assert_eq!(response.status(), 500);
+    assert_yaml_snapshot!(response.text().await?);
+    router.assert_log_contains("INTERNAL_SERVER_ERROR").await;
+    router.graceful_shutdown().await;
     Ok(())
 }

--- a/apollo-router/tests/integration/redis.rs
+++ b/apollo-router/tests/integration/redis.rs
@@ -959,29 +959,30 @@ async fn query_planner_redis_update_reuse_query_fragments() {
 }
 
 async fn test_redis_query_plan_config_update(updated_config: &str, new_cache_key: &str) {
-    if graph_os_enabled() {
-        // This test shows that the redis key changes when the query planner config changes.
-        // The test starts a router with a specific config, executes a query, and checks the redis cache key.
-        // Then it updates the config, executes the query again, and checks the redis cache key.
-        let mut router = IntegrationTest::builder()
-            .config(include_str!(
-                "fixtures/query_planner_redis_config_update.router.yaml"
-            ))
-            .build()
-            .await;
-
-        router.start().await;
-        router.assert_started().await;
-        router.clear_redis_cache().await;
-
-        let starting_key = "plan:0:v2.8.0:a9e605fa09adc5a4b824e690b4de6f160d47d84ede5956b58a7d300cca1f7204:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:1910d63916aae7a1066cb8c7d622fc3a8e363ed1b6ac8e214deed4046abae85c";
-        router.execute_default_query().await;
-        router.assert_redis_cache_contains(starting_key, None).await;
-        router.update_config(updated_config).await;
-        router.assert_reloaded().await;
-        router.execute_default_query().await;
-        router
-            .assert_redis_cache_contains(new_cache_key, Some(starting_key))
-            .await;
+    if !graph_os_enabled() {
+        return;
     }
+    // This test shows that the redis key changes when the query planner config changes.
+    // The test starts a router with a specific config, executes a query, and checks the redis cache key.
+    // Then it updates the config, executes the query again, and checks the redis cache key.
+    let mut router = IntegrationTest::builder()
+        .config(include_str!(
+            "fixtures/query_planner_redis_config_update.router.yaml"
+        ))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+    router.clear_redis_cache().await;
+
+    let starting_key = "plan:0:v2.8.0:a9e605fa09adc5a4b824e690b4de6f160d47d84ede5956b58a7d300cca1f7204:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:1910d63916aae7a1066cb8c7d622fc3a8e363ed1b6ac8e214deed4046abae85c";
+    router.execute_default_query().await;
+    router.assert_redis_cache_contains(starting_key, None).await;
+    router.update_config(updated_config).await;
+    router.assert_reloaded().await;
+    router.execute_default_query().await;
+    router
+        .assert_redis_cache_contains(new_cache_key, Some(starting_key))
+        .await;
 }

--- a/apollo-router/tests/integration/redis.rs
+++ b/apollo-router/tests/integration/redis.rs
@@ -19,6 +19,7 @@ use serde_json::Value;
 use tower::BoxError;
 use tower::ServiceExt;
 
+use crate::integration::common::graph_os_enabled;
 use crate::integration::IntegrationTest;
 
 #[tokio::test(flavor = "multi_thread")]
@@ -958,27 +959,29 @@ async fn query_planner_redis_update_reuse_query_fragments() {
 }
 
 async fn test_redis_query_plan_config_update(updated_config: &str, new_cache_key: &str) {
-    // This test shows that the redis key changes when the query planner config changes.
-    // The test starts a router with a specific config, executes a query, and checks the redis cache key.
-    // Then it updates the config, executes the query again, and checks the redis cache key.
-    let mut router = IntegrationTest::builder()
-        .config(include_str!(
-            "fixtures/query_planner_redis_config_update.router.yaml"
-        ))
-        .build()
-        .await;
+    if graph_os_enabled() {
+        // This test shows that the redis key changes when the query planner config changes.
+        // The test starts a router with a specific config, executes a query, and checks the redis cache key.
+        // Then it updates the config, executes the query again, and checks the redis cache key.
+        let mut router = IntegrationTest::builder()
+            .config(include_str!(
+                "fixtures/query_planner_redis_config_update.router.yaml"
+            ))
+            .build()
+            .await;
 
-    router.start().await;
-    router.assert_started().await;
-    router.clear_redis_cache().await;
+        router.start().await;
+        router.assert_started().await;
+        router.clear_redis_cache().await;
 
-    let starting_key = "plan:0:v2.8.0:a9e605fa09adc5a4b824e690b4de6f160d47d84ede5956b58a7d300cca1f7204:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:1910d63916aae7a1066cb8c7d622fc3a8e363ed1b6ac8e214deed4046abae85c";
-    router.execute_default_query().await;
-    router.assert_redis_cache_contains(starting_key, None).await;
-    router.update_config(updated_config).await;
-    router.assert_reloaded().await;
-    router.execute_default_query().await;
-    router
-        .assert_redis_cache_contains(new_cache_key, Some(starting_key))
-        .await;
+        let starting_key = "plan:0:v2.8.0:a9e605fa09adc5a4b824e690b4de6f160d47d84ede5956b58a7d300cca1f7204:3973e022e93220f9212c18d0d0c543ae7c309e46640da93a4a0314de999f5112:1910d63916aae7a1066cb8c7d622fc3a8e363ed1b6ac8e214deed4046abae85c";
+        router.execute_default_query().await;
+        router.assert_redis_cache_contains(starting_key, None).await;
+        router.update_config(updated_config).await;
+        router.assert_reloaded().await;
+        router.execute_default_query().await;
+        router
+            .assert_redis_cache_contains(new_cache_key, Some(starting_key))
+            .await;
+    }
 }

--- a/apollo-router/tests/integration/telemetry/metrics.rs
+++ b/apollo-router/tests/integration/telemetry/metrics.rs
@@ -190,32 +190,33 @@ async fn test_bad_queries() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_graphql_metrics() {
-    if graph_os_enabled() {
-        let mut router = IntegrationTest::builder()
-            .config(include_str!("fixtures/graphql.router.yaml"))
-            .build()
-            .await;
+    if !graph_os_enabled() {
+        return;
+    }
+    let mut router = IntegrationTest::builder()
+        .config(include_str!("fixtures/graphql.router.yaml"))
+        .build()
+        .await;
 
-        router.start().await;
-        router.assert_started().await;
-        router.execute_default_query().await;
-        router
+    router.start().await;
+    router.assert_started().await;
+    router.execute_default_query().await;
+    router
             .assert_metrics_contains(r#"graphql_field_list_length_sum{graphql_field_name="topProducts",graphql_field_type="Product",graphql_type_name="Query",otel_scope_name="apollo/router"} 3"#, None)
             .await;
-        router
+    router
             .assert_metrics_contains(r#"graphql_field_list_length_bucket{graphql_field_name="topProducts",graphql_field_type="Product",graphql_type_name="Query",otel_scope_name="apollo/router",le="5"} 1"#, None)
             .await;
-        router
+    router
             .assert_metrics_contains(r#"graphql_field_execution_total{graphql_field_name="name",graphql_field_type="String",graphql_type_name="Product",otel_scope_name="apollo/router"} 3"#, None)
             .await;
-        router
+    router
             .assert_metrics_contains(r#"graphql_field_execution_total{graphql_field_name="topProducts",graphql_field_type="Product",graphql_type_name="Query",otel_scope_name="apollo/router"} 1"#, None)
             .await;
-        router
+    router
             .assert_metrics_contains(r#"custom_counter_total{graphql_field_name="name",graphql_field_type="String",graphql_type_name="Product",otel_scope_name="apollo/router"} 3"#, None)
             .await;
-        router
+    router
             .assert_metrics_contains(r#"custom_histogram_sum{graphql_field_name="topProducts",graphql_field_type="Product",graphql_type_name="Query",otel_scope_name="apollo/router"} 3"#, None)
             .await;
-    }
 }

--- a/apollo-router/tests/integration/telemetry/metrics.rs
+++ b/apollo-router/tests/integration/telemetry/metrics.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use serde_json::json;
 
+use crate::integration::common::graph_os_enabled;
 use crate::integration::IntegrationTest;
 
 const PROMETHEUS_CONFIG: &str = include_str!("fixtures/prometheus.router.yaml");
@@ -189,30 +190,32 @@ async fn test_bad_queries() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_graphql_metrics() {
-    let mut router = IntegrationTest::builder()
-        .config(include_str!("fixtures/graphql.router.yaml"))
-        .build()
-        .await;
+    if graph_os_enabled() {
+        let mut router = IntegrationTest::builder()
+            .config(include_str!("fixtures/graphql.router.yaml"))
+            .build()
+            .await;
 
-    router.start().await;
-    router.assert_started().await;
-    router.execute_default_query().await;
-    router
-        .assert_metrics_contains(r#"graphql_field_list_length_sum{graphql_field_name="topProducts",graphql_field_type="Product",graphql_type_name="Query",otel_scope_name="apollo/router"} 3"#, None)
-        .await;
-    router
-        .assert_metrics_contains(r#"graphql_field_list_length_bucket{graphql_field_name="topProducts",graphql_field_type="Product",graphql_type_name="Query",otel_scope_name="apollo/router",le="5"} 1"#, None)
-        .await;
-    router
-        .assert_metrics_contains(r#"graphql_field_execution_total{graphql_field_name="name",graphql_field_type="String",graphql_type_name="Product",otel_scope_name="apollo/router"} 3"#, None)
-        .await;
-    router
-        .assert_metrics_contains(r#"graphql_field_execution_total{graphql_field_name="topProducts",graphql_field_type="Product",graphql_type_name="Query",otel_scope_name="apollo/router"} 1"#, None)
-        .await;
-    router
-        .assert_metrics_contains(r#"custom_counter_total{graphql_field_name="name",graphql_field_type="String",graphql_type_name="Product",otel_scope_name="apollo/router"} 3"#, None)
-        .await;
-    router
-        .assert_metrics_contains(r#"custom_histogram_sum{graphql_field_name="topProducts",graphql_field_type="Product",graphql_type_name="Query",otel_scope_name="apollo/router"} 3"#, None)
-        .await;
+        router.start().await;
+        router.assert_started().await;
+        router.execute_default_query().await;
+        router
+            .assert_metrics_contains(r#"graphql_field_list_length_sum{graphql_field_name="topProducts",graphql_field_type="Product",graphql_type_name="Query",otel_scope_name="apollo/router"} 3"#, None)
+            .await;
+        router
+            .assert_metrics_contains(r#"graphql_field_list_length_bucket{graphql_field_name="topProducts",graphql_field_type="Product",graphql_type_name="Query",otel_scope_name="apollo/router",le="5"} 1"#, None)
+            .await;
+        router
+            .assert_metrics_contains(r#"graphql_field_execution_total{graphql_field_name="name",graphql_field_type="String",graphql_type_name="Product",otel_scope_name="apollo/router"} 3"#, None)
+            .await;
+        router
+            .assert_metrics_contains(r#"graphql_field_execution_total{graphql_field_name="topProducts",graphql_field_type="Product",graphql_type_name="Query",otel_scope_name="apollo/router"} 1"#, None)
+            .await;
+        router
+            .assert_metrics_contains(r#"custom_counter_total{graphql_field_name="name",graphql_field_type="String",graphql_type_name="Product",otel_scope_name="apollo/router"} 3"#, None)
+            .await;
+        router
+            .assert_metrics_contains(r#"custom_histogram_sum{graphql_field_name="topProducts",graphql_field_type="Product",graphql_type_name="Query",otel_scope_name="apollo/router"} 3"#, None)
+            .await;
+    }
 }


### PR DESCRIPTION
A number of tests require APOLLO_KEY and APOLLO_GRAPH_REF to be present to execute successfully.
These are now skipped if these are not present.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
