### PR TITLE
fix: fixed `add_at_path` to rebase incoming `element`

### DIFF
--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -482,7 +482,7 @@ fn it_executes_mutation_operations_in_sequence() {
 #[should_panic(
     expected = r#"Cannot add selection of field "U.k2" to selection set of parent type "U""#
 )]
-// TODO: investigate this failure
+// TODO: investigate this failure (appears to be visiting wrong subgraph)
 fn key_where_at_external_is_not_at_top_level_of_selection_of_requires() {
     // Field issue where we were seeing a FetchGroup created where the fields used by the key to jump subgraphs
     // were not properly fetched. In the below test, this test will ensure that 'k2' is properly collected

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
@@ -144,9 +144,6 @@ fn can_use_a_key_on_an_interface_object_from_an_interface_object_type() {
 }
 
 #[test]
-#[should_panic(
-    expected = "Cannot add selection of field \"I.y\" to selection set of parent type \"I\""
-)]
 fn only_uses_an_interface_object_if_it_can() {
     let planner = planner!(
         S1: SUBGRAPH1,
@@ -177,7 +174,9 @@ fn only_uses_an_interface_object_if_it_can() {
 }
 
 #[test]
-#[should_panic(expected = "Interface type referencers unexpectedly missing type")]
+#[should_panic(
+    expected = "Cannot add selection of field \"I.__typename\" to selection set of parent type \"I\" that is potentially an interface object type at runtime"
+)]
 fn does_not_rely_on_an_interface_object_directly_for_typename() {
     let planner = planner!(
         S1: SUBGRAPH1,
@@ -298,9 +297,7 @@ fn does_not_rely_on_an_interface_object_directly_if_a_specific_implementation_is
 }
 
 #[test]
-#[should_panic(
-    expected = "Cannot add selection of field \"I.y\" to selection set of parent type \"I\""
-)]
+#[should_panic(expected = "assertion `left == right` failed\n  left: 0\n right: 1")]
 fn can_use_a_key_on_an_interface_object_type_even_for_a_concrete_implementation() {
     let planner = planner!(
         S1: SUBGRAPH1,
@@ -522,9 +519,7 @@ fn it_avoids_buffering_interface_object_results_that_may_have_to_be_filtered_wit
 }
 
 #[test]
-#[should_panic(
-    expected = "Cannot add selection of field \"I.x\" to selection set of parent type \"I\""
-)]
+#[should_panic(expected = "snapshot assertion")]
 fn it_handles_requires_on_concrete_type_of_field_provided_by_interface_object() {
     let planner = planner!(
         S1: r#"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/interface_type_explosion.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/interface_type_explosion.rs
@@ -2,7 +2,7 @@
 #[should_panic(
     expected = r#"Cannot add selection of field "S.y" to selection set of parent type "S""#
 )]
-// TODO: investigate this failure
+// TODO: investigate this failure (appears to be visiting wrong subgraph)
 // Note that Rover composition warns:
 // ```text
 // HINT: [INCONSISTENT_OBJECT_VALUE_TYPE_FIELD]: Field "S.y" of non-entity object type "S"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments.rs
@@ -252,9 +252,6 @@ fn another_mix_of_fragments_indirection_and_unions() {
 }
 
 #[test]
-#[should_panic(
-    expected = r#"Cannot add selection of field "T1.id" to selection set of parent type "I""#
-)]
 // TODO: investigate this failure
 fn handles_fragments_with_interface_field_subtyping() {
     let planner = planner!(


### PR DESCRIPTION
In add_at_path, we rebase sub-selections, but didn't rebase the current element itself.

The JS version's workflow is a bit different. It constructs a new field without rebasing and then call normalize, which rebases as well.

Fixes https://apollographql.atlassian.net/browse/FED-251 (partially)

There are some failures with the same error message remain, but the issue seems to be in the fetch dependency graph, instead (visiting wrong subgraph).

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [X] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
