### PR TITLE
fix(federation): selection set modification fixes

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -1079,7 +1079,7 @@ mod field_selection {
             selection_set: Option<SelectionSet>,
         ) -> FieldSelection {
             if cfg!(debug_assertions) {
-                if let Some(selection_set) = selection_set.clone() {
+                if let Some(ref selection_set) = selection_set {
                     if let Ok(field_type) = self.data.output_base_type() {
                         if let Ok(field_type_position) =
                             CompositeTypeDefinitionPosition::try_from(field_type)

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -2654,8 +2654,7 @@ impl SelectionSet {
                                 RebaseErrorHandlingOption::ThrowError,
                             )
                         })
-                        .transpose()?
-                        .and_then(|selection_set| Some(selection_set.without_unnecessary_fragments()));
+                        .transpose()?.map(|selection_set| selection_set.without_unnecessary_fragments());
                     let selection = Selection::from_element(element, selection_set)?;
                     self.add_selection(&selection)?
                 }

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -2654,7 +2654,8 @@ impl SelectionSet {
                                 RebaseErrorHandlingOption::ThrowError,
                             )
                         })
-                        .transpose()?.map(|selection_set| selection_set.without_unnecessary_fragments());
+                        .transpose()?
+                        .map(|selection_set| selection_set.without_unnecessary_fragments());
                     let selection = Selection::from_element(element, selection_set)?;
                     self.add_selection(&selection)?
                 }

--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -812,10 +812,10 @@ impl SelectionSet {
                 &fragment,
                 /*directives*/ &Default::default(),
             );
-            optimized.add_selection(&fragment_selection.into())?;
+            optimized.add_local_selection(&fragment_selection.into())?;
         }
 
-        optimized.add_selection_set(&not_covered_so_far)?;
+        optimized.add_local_selection_set(&not_covered_so_far)?;
         Ok(SelectionSet::make_selection_set(
             &self.schema,
             parent_type,

--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -812,10 +812,10 @@ impl SelectionSet {
                 &fragment,
                 /*directives*/ &Default::default(),
             );
-            Arc::make_mut(&mut optimized.selections).insert(fragment_selection.into());
+            optimized.add_selection(&fragment_selection.into())?;
         }
 
-        Arc::make_mut(&mut optimized.selections).extend_ref(&not_covered_so_far.selections);
+        optimized.add_selection_set(&not_covered_so_far)?;
         Ok(SelectionSet::make_selection_set(
             &self.schema,
             parent_type,

--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -458,7 +458,7 @@ impl InlineFragment {
         schema: &ValidFederationSchema,
         error_handling: RebaseErrorHandlingOption,
     ) -> Result<Option<InlineFragment>, FederationError> {
-        if &self.data().parent_type_position == parent_type {
+        if self.data().schema == *schema && self.data().parent_type_position == *parent_type {
             return Ok(Some(self.clone()));
         }
 
@@ -493,6 +493,7 @@ impl InlineFragment {
         } else {
             let mut rebased_fragment_data = self.data().clone();
             rebased_fragment_data.type_condition_position = rebased_condition;
+            rebased_fragment_data.schema = schema.clone();
             Ok(Some(InlineFragment::new(rebased_fragment_data)))
         }
     }

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2138,7 +2138,7 @@ impl FetchSelectionSet {
             &self.selection_set.schema,
             RebaseErrorHandlingOption::ThrowError,
         )?;
-        Arc::make_mut(&mut self.selection_set).merge_into(iter::once(&rebased_selections))?;
+        Arc::make_mut(&mut self.selection_set).add_selection_set(&rebased_selections)?;
         Ok(())
     }
 }
@@ -2165,7 +2165,7 @@ impl FetchInputs {
                     selection.type_position.clone(),
                 ))
             });
-        Arc::make_mut(type_selections).merge_into(std::iter::once(selection))
+        Arc::make_mut(type_selections).add_selection_set(selection)
         // PORT_NOTE: `onUpdateCallback` call is moved to `FetchDependencyGraphNode::on_inputs_updated`.
     }
 
@@ -2570,7 +2570,7 @@ fn compute_nodes_for_key_resolution<'a>(
         crate::operation::RebaseErrorHandlingOption::ThrowError,
     )?;
 
-    input_selections.merge_into(std::iter::once(&edge_conditions))?;
+    input_selections.add_selection_set(&edge_conditions)?;
 
     let new_node = FetchDependencyGraph::node_weight_mut(&mut dependency_graph.graph, new_node_id)?;
     new_node.add_inputs(
@@ -3511,7 +3511,7 @@ fn inputs_for_require(
         &fetch_dependency_graph.supergraph_schema,
         RebaseErrorHandlingOption::ThrowError,
     )?;
-    full_selection_set.merge_into(iter::once(&rebased_conditions))?;
+    full_selection_set.add_selection_set(&rebased_conditions)?;
     if include_key_inputs {
         let Some(key_condition) = fetch_dependency_graph
             .federated_query_graph
@@ -3555,7 +3555,7 @@ fn inputs_for_require(
                 target_subgraph,
                 RebaseErrorHandlingOption::ThrowError,
             )?;
-            full_selection_set.merge_into(iter::once(&key_condition_as_input))?;
+            full_selection_set.add_selection_set(&key_condition_as_input)?;
         } else {
             let rebased_key_condition = key_condition.rebase_on(
                 &input_type,
@@ -3563,7 +3563,7 @@ fn inputs_for_require(
                 &fetch_dependency_graph.supergraph_schema,
                 RebaseErrorHandlingOption::ThrowError,
             )?;
-            full_selection_set.merge_into(iter::once(&rebased_key_condition))?;
+            full_selection_set.add_selection_set(&rebased_key_condition)?;
         }
 
         // Note that `key_inputs` are used to ensure those input are fetch on the original group, the one having `edge`. In
@@ -3572,7 +3572,7 @@ fn inputs_for_require(
         // subgraph does not know in that particular case.
         let mut key_inputs =
             SelectionSet::for_composite_type(edge_conditions.schema.clone(), input_type.clone());
-        key_inputs.merge_into(iter::once(&key_condition))?;
+        key_inputs.add_selection_set(&key_condition)?;
 
         Ok((
             wrap_input_selections(

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -692,7 +692,11 @@ fn compute_plan_internal(
             deferred.extend(local_deferred);
             let new_selection = dependency_graph.defer_tracking.primary_selection;
             match primary_selection.as_mut() {
-                Some(selection) => selection.merge_into(new_selection.iter())?,
+                Some(selection) => {
+                    if let Some(new_selection) = new_selection {
+                        selection.add_selection_set(&new_selection)?
+                    }
+                }
                 None => primary_selection = new_selection,
             }
         }

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -694,7 +694,7 @@ fn compute_plan_internal(
             match primary_selection.as_mut() {
                 Some(selection) => {
                     if let Some(new_selection) = new_selection {
-                        selection.add_selection_set(&new_selection)?
+                        selection.add_local_selection_set(&new_selection)?
                     }
                 }
                 None => primary_selection = new_selection,

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
@@ -82,8 +82,6 @@ fn union_interface_interaction() {
 }
 
 #[test]
-#[should_panic(expected = "unexpected inline fragment without sub-selections")]
-// TODO: investigate this failure
 fn union_interface_interaction_but_no_need_to_type_explode() {
     let planner = planner!(
         Subgraph1: r#"
@@ -369,8 +367,6 @@ fn interface_interface_interaction() {
 }
 
 #[test]
-#[should_panic(expected = "unexpected inline fragment without sub-selections")]
-// TODO: investigate this failure
 fn interface_interface_interaction_but_no_need_to_type_explode() {
     let planner = planner!(
         Subgraph1: r#"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
@@ -1,8 +1,6 @@
 mod include_skip;
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO will be fixed with selection set updates in https://apollographql.atlassian.net/browse/FED-241
 fn handles_simple_requires() {
     let planner = planner!(
         Subgraph1: r#"
@@ -1304,8 +1302,6 @@ fn it_handes_diamond_shape_depedencies() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO will be fixed with selection set updates in https://apollographql.atlassian.net/browse/FED-241
 fn it_can_require_at_inaccessible_fields() {
     let planner = planner!(
         Subgraph1: r#"


### PR DESCRIPTION
Adds debug assertions to ensure that we point to the same schemas/type positions when constructing/modifying `SelectionSet`s.

Bug fixes
* when rebasing inline fragments we were not checking whether we point to the same schema
* when rebasing inline fragments we were not updating target schema
* when adding selections through `add_at_path` we were not checking for `None`/empty selection sets for composite types (i.e. invalid selection sets that don't have anything to merge)
* add back removal of "unnecessary" inline fragments to `add_at_path` flow (as we should only apply it if we have a single path element)

Fixes 
* [FED-241](https://apollographql.atlassian.net/browse/FED-241)
* [FED-248](https://apollographql.atlassian.net/browse/FED-248)
* [FED-269](https://apollographql.atlassian.net/browse/FED-269)

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[FED-241]: https://apollographql.atlassian.net/browse/FED-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FED-248]: https://apollographql.atlassian.net/browse/FED-248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FED-269]: https://apollographql.atlassian.net/browse/FED-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ