### PR TITLE
Update skip/include merging test to change order

### DIFF
--- a/apollo-federation/tests/query_plan/build_query_plan_tests/field_merging_with_skip_and_include.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/field_merging_with_skip_and_include.rs
@@ -139,8 +139,6 @@ fn merging_skip_and_include_directives_multiple_applications_identical() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: https://apollographql.atlassian.net/browse/FED-242
 fn merging_skip_and_include_directives_multiple_applications_differing_order() {
     let planner = planner!(
         SubgraphSkip: r#"
@@ -172,7 +170,7 @@ fn merging_skip_and_include_directives_multiple_applications_differing_order() {
           QueryPlan {
             Fetch(service: "SubgraphSkip") {
               {
-                hello @include(if: $includeField) @skip(if: $skipField) {
+                hello @skip(if: $skipField) @include(if: $includeField) {
                   world
                   goodbye
                 }


### PR DESCRIPTION
It turns out https://github.com/apollographql/router/pull/5343 fixed FED-242, but the final order of the `@skip`/`@include` directives has changed. Given that the order shouldn't have mattered to begin with, this difference with the JS codebase is probably fine.

To be clear, we maintain the user's directive order when there's not multiple equal fields with different directive order; when there are such fields, we have to pick some user order for the subgraph query for the sake of merging, and it appears that's changed in the Rust code. However, it's unlikely for users to have cared about which one got picked, given that they would have viewed merging the fields itself as a bug if they cared about directive order. Long-term, there is a strategy to assist users who care about directive order, though it's not something we have to worry about now.