### PR TITLE
Update a few snapshots with out of order `Parallel` nodes

### DIFF
--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -287,8 +287,6 @@ fn handles_non_intersecting_fragment_conditions() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure (parallel fetch ordering difference)
 fn avoids_unnecessary_fetches() {
     // This test is a reduced example demonstrating a previous issue with the computation of query plans cost.
     // The general idea is that "Subgraph 3" has a declaration that is kind of useless (it declares entity A
@@ -373,6 +371,21 @@ fn avoids_unnecessary_fetches() {
               }
             },
             Parallel {
+              Flatten(path: "t.a") {
+                Fetch(service: "Subgraph4") {
+                  {
+                    ... on A {
+                      __typename
+                      idA2
+                    }
+                  } =>
+                  {
+                    ... on A {
+                      idA1
+                    }
+                  }
+                },
+              },
               Sequence {
                 Flatten(path: "t") {
                   Fetch(service: "Subgraph2") {
@@ -408,21 +421,6 @@ fn avoids_unnecessary_fetches() {
                   },
                 },
               },
-              Flatten(path: "t.a") {
-                Fetch(service: "Subgraph4") {
-                  {
-                    ... on A {
-                      __typename
-                      idA2
-                    }
-                  } =>
-                  {
-                    ... on A {
-                      idA1
-                    }
-                  }
-                },
-              },
             },
           },
         }
@@ -439,7 +437,7 @@ fn it_executes_mutation_operations_in_sequence() {
           type Query {
             q1: Int
           }
-  
+
           type Mutation {
             m1: Int
           }
@@ -492,11 +490,11 @@ fn key_where_at_external_is_not_at_top_level_of_selection_of_requires() {
           type Query {
             u: U!
           }
-  
+
           type U @key(fields: "k1 { id }") {
             k1: K
           }
-  
+
           type K @key(fields: "id") {
             id: ID!
           }
@@ -509,11 +507,11 @@ fn key_where_at_external_is_not_at_top_level_of_selection_of_requires() {
             f: ID! @requires(fields: "v { v }")
             f2: Int!
           }
-  
+
           type K @key(fields: "id") {
             id: ID!
           }
-  
+
           type V @key(fields: "id") {
             id: ID!
             v: String! @external
@@ -525,11 +523,11 @@ fn key_where_at_external_is_not_at_top_level_of_selection_of_requires() {
             k2: ID!
             v: V!
           }
-  
+
           type K @key(fields: "id") {
             id: ID!
           }
-  
+
           type V @key(fields: "id") {
             id: ID!
             v: String!

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
@@ -14,21 +14,21 @@ fn union_interface_interaction() {
           type Query {
             u: U
           }
-  
+
           union U = A | B | C
-  
+
           interface I {
             v: Int
           }
-  
+
           type A {
             v: Int @shareable
           }
-  
+
           type B implements I {
             v: Int
           }
-  
+
           type C implements I {
             v: Int
           }
@@ -37,7 +37,7 @@ fn union_interface_interaction() {
           interface I {
             v: Int
           }
-  
+
           type A implements I {
             v: Int @shareable
           }
@@ -90,28 +90,28 @@ fn union_interface_interaction_but_no_need_to_type_explode() {
           type Query {
             u: U
           }
-  
+
           union U = B | C
-  
+
           interface I {
             v: Int
           }
-  
+
           type A implements I {
             v: Int @shareable
           }
-  
+
           type B implements I {
             v: Int
           }
-  
+
           type C implements I {
             v: Int
           }
         "#,
         Subgraph2: r#"
           union U = A
-  
+
           type A {
             v: Int @shareable
           }
@@ -158,28 +158,28 @@ fn interface_union_interaction() {
           type Query {
             i: I
           }
-  
+
           union U = B | C
-  
+
           interface I {
             v: Int
           }
-  
+
           type A implements I {
             v: Int @shareable
           }
-  
+
           type B implements I {
             v: Int
           }
-  
+
           type C implements I {
             v: Int
           }
         "#,
         Subgraph2: r#"
           union U = A
-  
+
           type A {
             v: Int @shareable
           }
@@ -230,21 +230,21 @@ fn interface_union_interaction_but_no_need_to_type_explode() {
           type Query {
             i: I
           }
-  
+
           union U = A | B | C
-  
+
           interface I {
             v: Int
           }
-  
+
           type A {
             v: Int @shareable
           }
-  
+
           type B implements I {
             v: Int
           }
-  
+
           type C implements I {
             v: Int
           }
@@ -253,7 +253,7 @@ fn interface_union_interaction_but_no_need_to_type_explode() {
           interface I {
             v: Int
           }
-  
+
           type A implements I {
             v: Int @shareable
           }
@@ -299,23 +299,23 @@ fn interface_interface_interaction() {
           type Query {
             i1: I1
           }
-  
+
           interface I1 {
             v: Int
           }
-  
+
           interface I2 {
             v: Int
           }
-  
+
           type A implements I1 {
             v: Int @shareable
           }
-  
+
           type B implements I1 & I2 {
             v: Int
           }
-  
+
           type C implements I1 & I2 {
             v: Int
           }
@@ -324,7 +324,7 @@ fn interface_interface_interaction() {
           interface I2 {
             v: Int
           }
-  
+
           type A implements I2 {
             v: Int @shareable
           }
@@ -377,23 +377,23 @@ fn interface_interface_interaction_but_no_need_to_type_explode() {
           type Query {
             i1: I1
           }
-  
+
           interface I1 {
             v: Int
           }
-  
+
           interface I2 {
             v: Int
           }
-  
+
           type A implements I2 {
             v: Int @shareable
           }
-  
+
           type B implements I1 & I2 {
             v: Int
           }
-  
+
           type C implements I1 & I2 {
             v: Int
           }
@@ -402,7 +402,7 @@ fn interface_interface_interaction_but_no_need_to_type_explode() {
           interface I1 {
             v: Int
           }
-  
+
           type A implements I1 {
             v: Int @shareable
           }
@@ -450,25 +450,25 @@ fn union_union_interaction() {
           type Query {
             u1: U1
           }
-  
+
           union U1 = A | B | C
           union U2 = B | C
-  
+
           type A {
             v: Int @shareable
           }
-  
+
           type B {
             v: Int
           }
-  
+
           type C {
             v: Int
           }
         "#,
         Subgraph2: r#"
           union U2 = A
-  
+
           type A {
             v: Int @shareable
           }
@@ -519,25 +519,25 @@ fn union_union_interaction_but_no_need_to_type_explode() {
           type Query {
             u1: U1
           }
-  
+
           union U1 = B | C
           union U2 = A | B | C
-  
+
           type A {
             v: Int @shareable
           }
-  
+
           type B {
             v: Int
           }
-  
+
           type C {
             v: Int
           }
         "#,
         Subgraph2: r#"
           union U1 = A
-  
+
           type A {
             v: Int @shareable
           }
@@ -581,19 +581,19 @@ fn handles_spread_unions_correctly() {
         type Query {
           u: U
         }
-  
+
         union U = A | B
-  
+
         type A @key(fields: "id") {
           id: ID!
           a1: Int
         }
-  
+
         type B {
           id: ID!
           b: Int
         }
-  
+
         type C @key(fields: "id") {
           id: ID!
           c1: Int
@@ -603,14 +603,14 @@ fn handles_spread_unions_correctly() {
         type Query {
           otherQuery: U
         }
-  
+
         union U = A | C
-  
+
         type A @key(fields: "id") {
           id: ID!
           a2: Int
         }
-  
+
         type C @key(fields: "id") {
           id: ID!
           c2: Int
@@ -656,13 +656,13 @@ fn handles_case_of_key_chains_in_parallel_requires() {
         type Query {
           t: T
         }
-  
+
         union T = T1 | T2
-  
+
         type T1 @key(fields: "id1") {
           id1: ID!
         }
-  
+
         type T2 @key(fields: "id") {
           id: ID!
           y: Int
@@ -679,7 +679,7 @@ fn handles_case_of_key_chains_in_parallel_requires() {
           id2: ID!
           x: Int
         }
-  
+
         type T2 @key(fields: "id") {
           id: ID!
           y: Int @external
@@ -786,24 +786,24 @@ fn handles_types_with_no_common_supertype_at_the_same_merge_at() {
         type Query {
           t: T
         }
-  
+
         union T = T1 | T2
-  
+
         type T1 @key(fields: "id") {
           id: ID!
           sub: Foo
         }
-  
+
         type Foo @key(fields: "id") {
           id: ID!
           x: Int
         }
-  
+
         type T2 @key(fields: "id") {
           id: ID!
           sub: Bar
         }
-  
+
         type Bar @key(fields: "id") {
           id: ID!
           x: Int
@@ -814,7 +814,7 @@ fn handles_types_with_no_common_supertype_at_the_same_merge_at() {
           id: ID!
           y: Int
         }
-  
+
         type Bar @key(fields: "id") {
           id: ID!
           y: Int
@@ -900,19 +900,19 @@ fn does_not_error_out_handling_fragments_when_interface_subtyping_is_involved() 
         type Query {
           a: A!
         }
-  
+
         interface IA {
           b: IB!
         }
-  
+
         type A implements IA {
           b: B!
         }
-  
+
         interface IB {
           v1: Int!
         }
-  
+
         type B implements IB {
           v1: Int!
           v2: Int!
@@ -929,19 +929,19 @@ fn does_not_error_out_handling_fragments_when_interface_subtyping_is_involved() 
             ...F3
           }
         }
-  
+
         fragment F1 on A {
           b {
             v2
           }
         }
-  
+
         fragment F2 on IA {
           b {
             v1
           }
         }
-  
+
         fragment F3 on IA {
           b {
             __typename

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments.rs
@@ -5,17 +5,17 @@ fn handles_mix_of_fragments_indirection_and_unions() {
           type Query {
             parent: Parent
           }
-  
+
           union CatOrPerson = Cat | Parent | Child
-  
+
           type Parent {
             childs: [Child]
           }
-  
+
           type Child {
             id: ID!
           }
-  
+
           type Cat {
             name: String
           }
@@ -29,15 +29,15 @@ fn handles_mix_of_fragments_indirection_and_unions() {
               ...F_indirection1_parent
             }
           }
-  
+
           fragment F_indirection1_parent on Parent {
             ...F_indirection2_catOrPerson
           }
-  
+
           fragment F_indirection2_catOrPerson on CatOrPerson {
             ...F_catOrPerson
           }
-  
+
           fragment F_catOrPerson on CatOrPerson {
             __typename
             ... on Cat {
@@ -70,7 +70,7 @@ fn handles_mix_of_fragments_indirection_and_unions() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
+// #[should_panic(expected = "snapshot assertion")]
 // TODO: investigate this failure
 fn another_mix_of_fragments_indirection_and_unions() {
     // This tests that the issue reported on https://github.com/apollographql/router/issues/3172 is resolved.
@@ -80,31 +80,31 @@ fn another_mix_of_fragments_indirection_and_unions() {
           type Query {
             owner: Owner!
           }
-  
+
           interface OItf {
             id: ID!
             v0: String!
           }
-  
+
           type Owner implements OItf {
             id: ID!
             v0: String!
             u: [U]
           }
-  
+
           union U = T1 | T2
-  
+
           interface I {
             id1: ID!
             id2: ID!
           }
-  
+
           type T1 implements I {
             id1: ID!
             id2: ID!
             owner: Owner!
           }
-  
+
           type T2 implements I {
             id1: ID!
             id2: ID!
@@ -126,7 +126,7 @@ fn another_mix_of_fragments_indirection_and_unions() {
               }
             }
           }
-  
+
           fragment Fragment1 on T1 {
             owner {
               ... on Owner {
@@ -134,16 +134,16 @@ fn another_mix_of_fragments_indirection_and_unions() {
               }
             }
           }
-  
+
           fragment Fragment2 on T2 {
             ...Fragment4
             id1
           }
-  
+
           fragment Fragment3 on OItf {
             v0
           }
-  
+
           fragment Fragment4 on I {
             id1
             id2
@@ -169,7 +169,7 @@ fn another_mix_of_fragments_indirection_and_unions() {
                 }
               }
             }
-            
+
             fragment Fragment4 on I {
               __typename
               id1
@@ -195,7 +195,7 @@ fn another_mix_of_fragments_indirection_and_unions() {
               }
             }
           }
-  
+
           fragment Fragment1 on T1 {
             owner {
               ... on Owner {
@@ -203,16 +203,16 @@ fn another_mix_of_fragments_indirection_and_unions() {
               }
             }
           }
-  
+
           fragment Fragment2 on T2 {
             ...Fragment4
             id1
           }
-  
+
           fragment Fragment3 on OItf {
             v0
           }
-  
+
           fragment Fragment4 on I {
             id1
             id2
@@ -240,7 +240,7 @@ fn another_mix_of_fragments_indirection_and_unions() {
                 }
               }
             }
-            
+
             fragment Fragment4 on I {
               id1
               id2
@@ -259,17 +259,17 @@ fn handles_fragments_with_interface_field_subtyping() {
           type Query {
             t1: T1!
           }
-  
+
           interface I {
             id: ID!
             other: I!
           }
-  
+
           type T1 implements I {
             id: ID!
             other: T1!
           }
-  
+
           type T2 implements I {
             id: ID!
             other: T2!
@@ -284,7 +284,7 @@ fn handles_fragments_with_interface_field_subtyping() {
               ...Fragment1
             }
           }
-  
+
           fragment Fragment1 on I {
             other {
               ... on T1 {
@@ -314,8 +314,6 @@ fn handles_fragments_with_interface_field_subtyping() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure
 fn can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_root_fetch() {
     let planner = planner!(
         Subgraph1: r#"
@@ -323,7 +321,7 @@ fn can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_root_fetch
             t1: T
             t2: T
           }
-  
+
           type T @key(fields: "id") {
             id: ID!
             v0: Int
@@ -349,7 +347,7 @@ fn can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_root_fetch
               ...allTFields
             }
           }
-  
+
           fragment allTFields on T {
             v0
             v1
@@ -373,7 +371,7 @@ fn can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_root_fetch
                   id
                 }
               }
-              
+
               fragment allTFields on T {
                 v0
                 v1
@@ -381,7 +379,7 @@ fn can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_root_fetch
               }
             },
             Parallel {
-              Flatten(path: "t1") {
+              Flatten(path: "t2") {
                 Fetch(service: "Subgraph2") {
                   {
                     ... on T {
@@ -396,7 +394,7 @@ fn can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_root_fetch
                   }
                 },
               },
-              Flatten(path: "t2") {
+              Flatten(path: "t1") {
                 Fetch(service: "Subgraph2") {
                   {
                     ... on T {
@@ -419,15 +417,13 @@ fn can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_root_fetch
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure
 fn can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_entity_fetch() {
     let planner = planner!(
         Subgraph1: r#"
           type Query {
             t: T
           }
-  
+
           type T @key(fields: "id") {
             id: ID!
           }
@@ -438,7 +434,7 @@ fn can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_entity_fet
             u1: U
             u2: U
           }
-  
+
           type U @key(fields: "id") {
             id: ID!
             v0: Int
@@ -467,7 +463,7 @@ fn can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_entity_fet
               }
             }
           }
-  
+
           fragment allUFields on U {
             v0
             v1
@@ -508,7 +504,7 @@ fn can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_entity_fet
                     }
                   }
                 }
-                
+
                 fragment allUFields on U {
                   v0
                   v1
@@ -516,7 +512,7 @@ fn can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_entity_fet
               },
             },
             Parallel {
-              Flatten(path: "t.u1") {
+              Flatten(path: "t.u2") {
                 Fetch(service: "Subgraph3") {
                   {
                     ... on U {
@@ -532,7 +528,7 @@ fn can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_entity_fet
                   }
                 },
               },
-              Flatten(path: "t.u2") {
+              Flatten(path: "t.u1") {
                 Fetch(service: "Subgraph3") {
                   {
                     ... on U {

--- a/apollo-federation/tests/query_plan/supergraphs/another_mix_of_fragments_indirection_and_unions.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/another_mix_of_fragments_indirection_and_unions.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: 2f671bb979a14c102228ff786ac9ef42dc25c89c
+# Composed from subgraphs with hash: 025701346c4869b221f7700ee29514f70ca1bb6c
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_entity_fetch.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_entity_fetch.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: 6567db79b879bcecba3e1ee676677541bb916031
+# Composed from subgraphs with hash: 69f84bc4036179c07a518c8c9b871bd0850f1606
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_root_fetch.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/can_reuse_fragments_in_subgraph_where_they_only_partially_apply_in_root_fetch.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: 64ebe1a06ccfd10e0d5f65e680330d3b9700cf65
+# Composed from subgraphs with hash: fdeaf767c1e72134946220497d72c7db3cebbe19
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/does_not_error_out_handling_fragments_when_interface_subtyping_is_involved.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/does_not_error_out_handling_fragments_when_interface_subtyping_is_involved.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: 34ba23dc9701595fe83aa0ac34dd570c26879dbc
+# Composed from subgraphs with hash: b62548892fe6cba44778c9e402abb8ddf8edbac9
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/handles_case_of_key_chains_in_parallel_requires.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_case_of_key_chains_in_parallel_requires.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: 59e97208bdb7dd50bfb778ca0fe3a04f266b606c
+# Composed from subgraphs with hash: 31c0bf4aeea8c73b60a47e91ea9bcc475127782a
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/handles_fragments_with_interface_field_subtyping.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_fragments_with_interface_field_subtyping.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: b6f2b17d79f93e53ae3144b1574824b5709ddca4
+# Composed from subgraphs with hash: ed9e25c79dbfc98582011fc534e6998d77ec556c
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/handles_mix_of_fragments_indirection_and_unions.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_mix_of_fragments_indirection_and_unions.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: 37341ec5595cae2bd6d528e630f0463777cbfeb4
+# Composed from subgraphs with hash: 857413268aa91cd215bfa7f9a717a01afcb77048
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/handles_spread_unions_correctly.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_spread_unions_correctly.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: 44b33f44b355f65c78ba5fd32bce70a2f9984745
+# Composed from subgraphs with hash: cac8f01c24f23138d810fe086c24cf3e3c9b724e
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/handles_types_with_no_common_supertype_at_the_same_merge_at.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_types_with_no_common_supertype_at_the_same_merge_at.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: f0ddb66dbf933d91db1ae149aa35ddb880a27b0f
+# Composed from subgraphs with hash: 914913e8f6d05467f239b8984f8875df35e9ec9c
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/interface_interface_interaction.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/interface_interface_interaction.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: d6611b606628ab87c5618e5ce93e82a43b8e4c31
+# Composed from subgraphs with hash: d0de8bd2759f8c48a97e2e09f5b1cd8bad7e6e78
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/interface_interface_interaction_but_no_need_to_type_explode.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/interface_interface_interaction_but_no_need_to_type_explode.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: b9552a2c38efc92319dafdd568b494fc93f04d12
+# Composed from subgraphs with hash: 7089406367e2cc6e6d0864f78d01407a184ffa92
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/interface_union_interaction.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/interface_union_interaction.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: ea120590082aff862baaa191f5eae64bc26da7a8
+# Composed from subgraphs with hash: 34d04b226bb8991dcd8a063656dbf04b18555a0c
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/interface_union_interaction_but_no_need_to_type_explode.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/interface_union_interaction_but_no_need_to_type_explode.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: b5396d0fb6ff1627250afb2ae3673de324532511
+# Composed from subgraphs with hash: 5c7d149e1ef1b997ab3395128beb7403f1f11dfe
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/it_executes_mutation_operations_in_sequence.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_executes_mutation_operations_in_sequence.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: bbd19dfc30939350a09f55b27b5c337dcb19ab4c
+# Composed from subgraphs with hash: fea1be241ad3c07fc4036893012a86c4e17ea159
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/key_where_at_external_is_not_at_top_level_of_selection_of_requires.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/key_where_at_external_is_not_at_top_level_of_selection_of_requires.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: 5a150d7ceb9f2f0b8381182723d92da000754454
+# Composed from subgraphs with hash: c1a3645bcd1d5de8ffaaafc2db246bb829597152
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/union_interface_interaction.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/union_interface_interaction.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: 6af958d7dcdc1ba402bf260740d98197e5c9850a
+# Composed from subgraphs with hash: 9355e80c20445d59cd2d9a8cd04db6a6bebb3ce0
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/union_interface_interaction_but_no_need_to_type_explode.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/union_interface_interaction_but_no_need_to_type_explode.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: 4a2934ceeedfaf3ee0219cabed4e1db9cc7dfcd4
+# Composed from subgraphs with hash: 16225ee3e1f3aaff3e1fe3e4cfe3298d8095f608
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/union_union_interaction.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/union_union_interaction.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: ad80a1ea338426b9a1668003f0c5d563e79e9db7
+# Composed from subgraphs with hash: 0fdc118d2b5e2aed1f67357115b1614c2a230888
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/union_union_interaction_but_no_need_to_type_explode.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/union_union_interaction_but_no_need_to_type_explode.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: e8e068ca7cee7591de3201be596fe316d9ece03f
+# Composed from subgraphs with hash: 03fe71c2f384dc3668709b401037d4139e6cd4e5
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)


### PR DESCRIPTION
Addresses FED-249

Updated the snapshots of a few tests where the parallel query nodes were out of order. The solution to these tests was to update the snapshot.

There is one test ([here](https://github.com/apollographql/router/blob/fe84831a643548e6d1bd3762cc121885063272e0/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs#L785)) called out in the ticket that is caused by a different issue. This issue is addressed by the changes in @duckki 's [PR for FED-55](https://github.com/apollographql/router/pull/5345).

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
