### PR TITLE
Fix bugs in selection set locality checking and inconsistent abstract type checking

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -830,22 +830,6 @@ impl Selection {
             Ok(self.clone())
         }
     }
-
-    pub(crate) fn any_element(
-        &self,
-        parent_type_position: CompositeTypeDefinitionPosition,
-        predicate: &mut impl FnMut(OpPathElement) -> Result<bool, FederationError>,
-    ) -> Result<bool, FederationError> {
-        match self {
-            Selection::Field(field_selection) => field_selection.any_element(predicate),
-            Selection::InlineFragment(inline_fragment_selection) => {
-                inline_fragment_selection.any_element(predicate)
-            }
-            Selection::FragmentSpread(fragment_spread_selection) => {
-                fragment_spread_selection.any_element(parent_type_position, predicate)
-            }
-        }
-    }
 }
 
 impl From<FieldSelection> for Selection {
@@ -1450,24 +1434,6 @@ impl FragmentSpreadSelection {
         } else {
             unreachable!("We should always be able to either rebase the fragment spread OR throw an exception");
         }
-    }
-
-    pub(crate) fn any_element(
-        &self,
-        parent_type_position: CompositeTypeDefinitionPosition,
-        predicate: &mut impl FnMut(OpPathElement) -> Result<bool, FederationError>,
-    ) -> Result<bool, FederationError> {
-        let inline_fragment = InlineFragment::new(InlineFragmentData {
-            schema: self.spread.data().schema.clone(),
-            parent_type_position,
-            type_condition_position: Some(self.spread.data().type_condition_position.clone()),
-            directives: self.spread.data().directives.clone(),
-            selection_id: self.spread.data().selection_id.clone(),
-        });
-        if predicate(inline_fragment.into())? {
-            return Ok(true);
-        }
-        self.selection_set.any_element(predicate)
     }
 }
 
@@ -3069,23 +3035,6 @@ impl SelectionSet {
             selections: Arc::new(final_selections),
         }
     }
-
-    /// Returns true if any elements in this selection set or its descendants returns true for the
-    /// given predicate. Note that fragment spread selections are converted to inline fragment
-    /// elements, and their fragment selection sets are recursed into.
-    // PORT_NOTE: The JS codebase calls this "some()", but that's easy to confuse with "Some" in
-    // Rust.
-    pub(crate) fn any_element(
-        &self,
-        predicate: &mut impl FnMut(OpPathElement) -> Result<bool, FederationError>,
-    ) -> Result<bool, FederationError> {
-        for selection in self.selections.values() {
-            if selection.any_element(self.type_position.clone(), predicate)? {
-                return Ok(true);
-            }
-        }
-        Ok(false)
-    }
 }
 
 impl IntoIterator for SelectionSet {
@@ -3413,21 +3362,6 @@ impl FieldSelection {
 
     pub(crate) fn has_defer(&self) -> bool {
         self.field.has_defer() || self.selection_set.as_ref().is_some_and(|s| s.has_defer())
-    }
-
-    pub(crate) fn any_element(
-        &self,
-        predicate: &mut impl FnMut(OpPathElement) -> Result<bool, FederationError>,
-    ) -> Result<bool, FederationError> {
-        if predicate(self.field.clone().into())? {
-            return Ok(true);
-        }
-        if let Some(selection_set) = &self.selection_set {
-            if selection_set.any_element(predicate)? {
-                return Ok(true);
-            }
-        }
-        Ok(false)
     }
 }
 
@@ -3871,16 +3805,6 @@ impl InlineFragmentSelection {
         inline_fragment.directives.is_empty()
             && (inline_fragment_type_condition.is_none()
                 || inline_fragment_type_condition.is_some_and(|t| t == *maybe_parent))
-    }
-
-    pub(crate) fn any_element(
-        &self,
-        predicate: &mut impl FnMut(OpPathElement) -> Result<bool, FederationError>,
-    ) -> Result<bool, FederationError> {
-        if predicate(self.inline_fragment.clone().into())? {
-            return Ok(true);
-        }
-        self.selection_set.any_element(predicate)
     }
 }
 

--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -648,12 +648,16 @@ impl SelectionSet {
         ))
     }
 
-    /// Returns true if the selection set would select cleanly from the given type in the
-    /// current schema.
-    pub fn can_rebase_on(&self, parent_type: &CompositeTypeDefinitionPosition) -> bool {
+    /// Returns true if the selection set would select cleanly from the given type in the given
+    /// schema.
+    pub fn can_rebase_on(
+        &self,
+        parent_type: &CompositeTypeDefinitionPosition,
+        schema: &ValidFederationSchema,
+    ) -> bool {
         self.selections
             .values()
-            .all(|sel| sel.can_add_to(parent_type, &self.schema))
+            .all(|sel| sel.can_add_to(parent_type, schema))
     }
 }
 

--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -648,16 +648,12 @@ impl SelectionSet {
         ))
     }
 
-    /// Returns true if the selection set would select cleanly from the given type in the given
-    /// schema.
-    pub fn can_rebase_on(
-        &self,
-        parent_type: &CompositeTypeDefinitionPosition,
-        schema: &ValidFederationSchema,
-    ) -> bool {
+    /// Returns true if the selection set would select cleanly from the given type in the
+    /// current schema.
+    pub fn can_rebase_on(&self, parent_type: &CompositeTypeDefinitionPosition) -> bool {
         self.selections
             .values()
-            .all(|sel| sel.can_add_to(parent_type, schema))
+            .all(|sel| sel.can_add_to(parent_type, &self.schema))
     }
 }
 

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -1577,21 +1577,19 @@ impl FetchDependencyGraph {
         };
         let type_at_path = self.type_at_path(
             &parent.selection_set.selection_set.type_position,
-            &parent.selection_set.selection_set.schema,
             parent_op_path,
         )?;
         let new_node_is_unneeded = parent_relation.path_in_parent.is_some()
             && node
                 .selection_set
                 .selection_set
-                .can_rebase_on(&type_at_path, &parent.selection_set.selection_set.schema);
+                .can_rebase_on(&type_at_path);
         Ok(new_node_is_unneeded)
     }
 
     fn type_at_path(
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
-        schema: &ValidFederationSchema,
         path: &Arc<OpPath>,
     ) -> Result<CompositeTypeDefinitionPosition, FederationError> {
         let mut type_ = parent_type.clone();
@@ -1599,9 +1597,11 @@ impl FetchDependencyGraph {
             match &**element {
                 OpPathElement::Field(field) => {
                     let field_position = type_.field(field.data().name().clone())?;
-                    let field_definition = field_position.get(schema.schema())?;
+                    let field_definition = field_position.get(field.data().schema.schema())?;
                     let field_type = field_definition.ty.inner_named_type();
-                    type_ = schema
+                    type_ = field
+                        .data()
+                        .schema
                         .get_type(field_type.clone())?
                         .try_into()
                         .map_or_else(
@@ -1617,25 +1617,14 @@ impl FetchDependencyGraph {
                 OpPathElement::InlineFragment(fragment) => {
                     if let Some(type_condition_position) = &fragment.data().type_condition_position
                     {
-                        type_ = schema
-                            .get_type(type_condition_position.type_name().clone())?
-                            .try_into()
-                            .map_or_else(
-                                |_| {
-                                    Err(FederationError::internal(format!(
-                                        "Invalid call from {} starting at {}: {} is not composite",
-                                        path, parent_type, type_condition_position
-                                    )))
-                                },
-                                Ok,
-                            )?;
+                        type_ = type_condition_position.clone();
                     } else {
                         continue;
                     }
                 }
             }
         }
-        Ok(type_)
+        Ok(type_.clone())
     }
 }
 

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -279,7 +279,7 @@ impl QueryPlanner {
             let Some(expected_runtimes) = sources.next() else {
                 return false;
             };
-            sources.all(|runtimes| runtimes == expected_runtimes)
+            !sources.all(|runtimes| runtimes == expected_runtimes)
         };
 
         let abstract_types_with_inconsistent_runtime_types = supergraph

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -279,7 +279,7 @@ impl QueryPlanner {
             let Some(expected_runtimes) = sources.next() else {
                 return false;
             };
-            !sources.all(|runtimes| runtimes == expected_runtimes)
+            sources.all(|runtimes| runtimes == expected_runtimes)
         };
 
         let abstract_types_with_inconsistent_runtime_types = supergraph

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -472,7 +472,25 @@ impl<'a> QueryPlanningTraversal<'a> {
         //   later condition is that `selection` is originally a supergraph selection, but that we're looking to apply "as-is" to a subgraph.
         //   But suppose it has a `... on I` where `I` is an interface. Then it's possible that `I` includes "more" types in the supergraph
         //   than in the subgraph, and so we might have to type-explode it. If so, we cannot use the selection "as-is".
-        let mut has_checked_inconsistent_abstract_types = false;
+        // PORT_NOTE: The JS code performs the last check lazily. Instead of that, this check is
+        // skipped if `nodes` is empty.
+        if !nodes.is_empty()
+            && selection.any_element(&mut |element| match element {
+                OpPathElement::InlineFragment(inline_fragment) => {
+                    match &inline_fragment.data().type_condition_position {
+                        Some(type_condition) => Ok(self
+                            .parameters
+                            .abstract_types_with_inconsistent_runtime_types
+                            .iter()
+                            .any(|ty| ty.type_name() == type_condition.type_name())),
+                        None => Ok(false),
+                    }
+                }
+                _ => Ok(false),
+            })?
+        {
+            return Ok(false);
+        }
         for node in nodes {
             let n = self.parameters.federated_query_graph.node_weight(*node)?;
             let parent_ty = match &n.type_ {
@@ -491,24 +509,6 @@ impl<'a> QueryPlanningTraversal<'a> {
             if n.has_reachable_cross_subgraph_edges || !selection.can_rebase_on(&parent_ty, schema)
             {
                 return Ok(false);
-            }
-            if !has_checked_inconsistent_abstract_types {
-                if selection.any_element(&mut |element| match element {
-                    OpPathElement::InlineFragment(inline_fragment) => {
-                        match &inline_fragment.data().type_condition_position {
-                            Some(type_condition) => Ok(self
-                                .parameters
-                                .abstract_types_with_inconsistent_runtime_types
-                                .iter()
-                                .any(|ty| ty.type_name() == type_condition.type_name())),
-                            None => Ok(false),
-                        }
-                    }
-                    _ => Ok(false),
-                })? {
-                    return Ok(false);
-                }
-                has_checked_inconsistent_abstract_types = true;
             }
         }
         Ok(true)

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -472,25 +472,7 @@ impl<'a> QueryPlanningTraversal<'a> {
         //   later condition is that `selection` is originally a supergraph selection, but that we're looking to apply "as-is" to a subgraph.
         //   But suppose it has a `... on I` where `I` is an interface. Then it's possible that `I` includes "more" types in the supergraph
         //   than in the subgraph, and so we might have to type-explode it. If so, we cannot use the selection "as-is".
-        // PORT_NOTE: The JS code performs the last check lazily. Instead of that, this check is
-        // skipped if `nodes` is empty.
-        if !nodes.is_empty()
-            && selection.any_element(&mut |element| match element {
-                OpPathElement::InlineFragment(inline_fragment) => {
-                    match &inline_fragment.data().type_condition_position {
-                        Some(type_condition) => Ok(self
-                            .parameters
-                            .abstract_types_with_inconsistent_runtime_types
-                            .iter()
-                            .any(|ty| ty.type_name() == type_condition.type_name())),
-                        None => Ok(false),
-                    }
-                }
-                _ => Ok(false),
-            })?
-        {
-            return Ok(false);
-        }
+        let mut has_checked_inconsistent_abstract_types = false;
         for node in nodes {
             let n = self.parameters.federated_query_graph.node_weight(*node)?;
             let parent_ty = match &n.type_ {
@@ -509,6 +491,24 @@ impl<'a> QueryPlanningTraversal<'a> {
             if n.has_reachable_cross_subgraph_edges || !selection.can_rebase_on(&parent_ty, schema)
             {
                 return Ok(false);
+            }
+            if !has_checked_inconsistent_abstract_types {
+                if selection.any_element(&mut |element| match element {
+                    OpPathElement::InlineFragment(inline_fragment) => {
+                        match &inline_fragment.data().type_condition_position {
+                            Some(type_condition) => Ok(self
+                                .parameters
+                                .abstract_types_with_inconsistent_runtime_types
+                                .iter()
+                                .any(|ty| ty.type_name() == type_condition.type_name())),
+                            None => Ok(false),
+                        }
+                    }
+                    _ => Ok(false),
+                })? {
+                    return Ok(false);
+                }
+                has_checked_inconsistent_abstract_types = true;
             }
         }
         Ok(true)

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -493,6 +493,9 @@ impl<'a> QueryPlanningTraversal<'a> {
         }
         for node in nodes {
             let n = self.parameters.federated_query_graph.node_weight(*node)?;
+            if n.has_reachable_cross_subgraph_edges {
+                return Ok(false);
+            }
             let parent_ty = match &n.type_ {
                 QueryGraphNodeType::SchemaType(ty) => {
                     match CompositeTypeDefinitionPosition::try_from(ty.clone()) {
@@ -506,8 +509,7 @@ impl<'a> QueryPlanningTraversal<'a> {
                 .parameters
                 .federated_query_graph
                 .schema_by_source(&n.source)?;
-            if n.has_reachable_cross_subgraph_edges || !selection.can_rebase_on(&parent_ty, schema)
-            {
+            if !selection.can_rebase_on(&parent_ty, schema) {
                 return Ok(false);
             }
         }

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -472,25 +472,29 @@ impl<'a> QueryPlanningTraversal<'a> {
         //   later condition is that `selection` is originally a supergraph selection, but that we're looking to apply "as-is" to a subgraph.
         //   But suppose it has a `... on I` where `I` is an interface. Then it's possible that `I` includes "more" types in the supergraph
         //   than in the subgraph, and so we might have to type-explode it. If so, we cannot use the selection "as-is".
-        // PORT_NOTE: The JS code performs the last check lazily. Instead of that, this check is
-        // skipped if `nodes` is empty.
-        if !nodes.is_empty()
-            && selection.any_element(&mut |element| match element {
-                OpPathElement::InlineFragment(inline_fragment) => {
-                    match &inline_fragment.data().type_condition_position {
-                        Some(type_condition) => Ok(self
-                            .parameters
-                            .abstract_types_with_inconsistent_runtime_types
-                            .iter()
-                            .any(|ty| ty.type_name() == type_condition.type_name())),
-                        None => Ok(false),
+        let mut has_inconsistent_abstract_types: Option<bool> = None;
+        let mut check_has_inconsistent_runtime_types = || match has_inconsistent_abstract_types {
+            Some(has_inconsistent_abstract_types) => {
+                Ok::<bool, FederationError>(has_inconsistent_abstract_types)
+            }
+            None => {
+                let check_result = selection.any_element(&mut |element| match element {
+                    OpPathElement::InlineFragment(inline_fragment) => {
+                        match &inline_fragment.data().type_condition_position {
+                            Some(type_condition) => Ok(self
+                                .parameters
+                                .abstract_types_with_inconsistent_runtime_types
+                                .iter()
+                                .any(|ty| ty.type_name() == type_condition.type_name())),
+                            None => Ok(false),
+                        }
                     }
-                }
-                _ => Ok(false),
-            })?
-        {
-            return Ok(false);
-        }
+                    _ => Ok(false),
+                })?;
+                has_inconsistent_abstract_types = Some(check_result);
+                Ok(check_result)
+            }
+        };
         for node in nodes {
             let n = self.parameters.federated_query_graph.node_weight(*node)?;
             if n.has_reachable_cross_subgraph_edges {
@@ -510,6 +514,9 @@ impl<'a> QueryPlanningTraversal<'a> {
                 .federated_query_graph
                 .schema_by_source(&n.source)?;
             if !selection.can_rebase_on(&parent_ty, schema) {
+                return Ok(false);
+            }
+            if check_has_inconsistent_runtime_types()? {
                 return Ok(false);
             }
         }

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -475,19 +475,19 @@ impl<'a> QueryPlanningTraversal<'a> {
         // PORT_NOTE: The JS code performs the last check lazily. Instead of that, this check is
         // skipped if `nodes` is empty.
         if !nodes.is_empty()
-            && selection.selections.values().any(|val| match val {
-                Selection::InlineFragment(fragment) => {
-                    match &fragment.inline_fragment.data().type_condition_position {
-                        Some(type_condition) => self
+            && selection.any_element(&mut |element| match element {
+                OpPathElement::InlineFragment(inline_fragment) => {
+                    match &inline_fragment.data().type_condition_position {
+                        Some(type_condition) => Ok(self
                             .parameters
                             .abstract_types_with_inconsistent_runtime_types
                             .iter()
-                            .any(|ty| ty.type_name() == type_condition.type_name()),
-                        None => false,
+                            .any(|ty| ty.type_name() == type_condition.type_name())),
+                        None => Ok(false),
                     }
                 }
-                _ => false,
-            })
+                _ => Ok(false),
+            })?
         {
             return Ok(false);
         }

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -502,7 +502,12 @@ impl<'a> QueryPlanningTraversal<'a> {
                 }
                 QueryGraphNodeType::FederatedRootType(_) => return Ok(false),
             };
-            if n.has_reachable_cross_subgraph_edges || !selection.can_rebase_on(&parent_ty) {
+            let schema = self
+                .parameters
+                .federated_query_graph
+                .schema_by_source(&n.source)?;
+            if n.has_reachable_cross_subgraph_edges || !selection.can_rebase_on(&parent_ty, schema)
+            {
                 return Ok(false);
             }
         }

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -472,27 +472,12 @@ impl<'a> QueryPlanningTraversal<'a> {
         //   later condition is that `selection` is originally a supergraph selection, but that we're looking to apply "as-is" to a subgraph.
         //   But suppose it has a `... on I` where `I` is an interface. Then it's possible that `I` includes "more" types in the supergraph
         //   than in the subgraph, and so we might have to type-explode it. If so, we cannot use the selection "as-is".
-        // PORT_NOTE: The JS code performs the last check lazily. Instead of that, this check is
-        // skipped if `nodes` is empty.
-        if !nodes.is_empty()
-            && selection.selections.values().any(|val| match val {
-                Selection::InlineFragment(fragment) => {
-                    match &fragment.inline_fragment.data().type_condition_position {
-                        Some(type_condition) => self
-                            .parameters
-                            .abstract_types_with_inconsistent_runtime_types
-                            .iter()
-                            .any(|ty| ty.type_name() == type_condition.type_name()),
-                        None => false,
-                    }
-                }
-                _ => false,
-            })
-        {
-            return Ok(false);
-        }
+        let mut has_checked_inconsistent_abstract_types = false;
         for node in nodes {
             let n = self.parameters.federated_query_graph.node_weight(*node)?;
+            if n.has_reachable_cross_subgraph_edges {
+                return Ok(false);
+            }
             let parent_ty = match &n.type_ {
                 QueryGraphNodeType::SchemaType(ty) => {
                     match CompositeTypeDefinitionPosition::try_from(ty.clone()) {
@@ -502,8 +487,30 @@ impl<'a> QueryPlanningTraversal<'a> {
                 }
                 QueryGraphNodeType::FederatedRootType(_) => return Ok(false),
             };
-            if n.has_reachable_cross_subgraph_edges || !selection.can_rebase_on(&parent_ty) {
+            let schema = self
+                .parameters
+                .federated_query_graph
+                .schema_by_source(&n.source)?;
+            if !selection.can_rebase_on(&parent_ty, schema) {
                 return Ok(false);
+            }
+            if !has_checked_inconsistent_abstract_types {
+                if selection.any_element(&mut |element| match element {
+                    OpPathElement::InlineFragment(inline_fragment) => {
+                        match &inline_fragment.data().type_condition_position {
+                            Some(type_condition) => Ok(self
+                                .parameters
+                                .abstract_types_with_inconsistent_runtime_types
+                                .iter()
+                                .any(|ty| ty.type_name() == type_condition.type_name())),
+                            None => Ok(false),
+                        }
+                    }
+                    _ => Ok(false),
+                })? {
+                    return Ok(false);
+                }
+                has_checked_inconsistent_abstract_types = true;
             }
         }
         Ok(true)

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/interface_type_explosion.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/interface_type_explosion.rs
@@ -1,14 +1,4 @@
 #[test]
-#[should_panic(
-    expected = r#"Cannot add selection of field "S.y" to selection set of parent type "S""#
-)]
-// TODO: investigate this failure (appears to be visiting wrong subgraph)
-// Note that Rover composition warns:
-// ```text
-// HINT: [INCONSISTENT_OBJECT_VALUE_TYPE_FIELD]: Field "S.y" of non-entity object type "S"
-// is defined in some but not all subgraphs that define "S":
-// "S.y" is defined in subgraph "Subgraph2" but not in subgraph "Subgraph1".
-// ```
 fn handles_non_matching_value_types_under_interface_field() {
     let planner = planner!(
         Subgraph1: r#"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/interface_type_explosion.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/interface_type_explosion.rs
@@ -1,4 +1,14 @@
 #[test]
+#[should_panic(
+    expected = r#"Cannot add selection of field "S.y" to selection set of parent type "S""#
+)]
+// TODO: investigate this failure (appears to be visiting wrong subgraph)
+// Note that Rover composition warns:
+// ```text
+// HINT: [INCONSISTENT_OBJECT_VALUE_TYPE_FIELD]: Field "S.y" of non-entity object type "S"
+// is defined in some but not all subgraphs that define "S":
+// "S.y" is defined in subgraph "Subgraph2" but not in subgraph "Subgraph1".
+// ```
 fn handles_non_matching_value_types_under_interface_field() {
     let planner = planner!(
         Subgraph1: r#"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/introspection_typename_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/introspection_typename_handling.rs
@@ -64,7 +64,7 @@ fn it_preservers_aliased_typename() {
 }
 
 #[test]
-#[should_panic(expected = "Invalid empty selection set")]
+#[should_panic(expected = "snapshot assertion")]
 // TODO: investigate this failure
 fn it_does_not_needlessly_consider_options_for_typename() {
     let planner = planner!(

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/introspection_typename_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/introspection_typename_handling.rs
@@ -64,7 +64,7 @@ fn it_preservers_aliased_typename() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
+#[should_panic(expected = "Invalid empty selection set")]
 // TODO: investigate this failure
 fn it_does_not_needlessly_consider_options_for_typename() {
     let planner = planner!(

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
@@ -6,8 +6,6 @@
  */
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure
 fn union_interface_interaction() {
     let planner = planner!(
         Subgraph1: r#"
@@ -289,8 +287,6 @@ fn interface_union_interaction_but_no_need_to_type_explode() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure
 fn interface_interface_interaction() {
     let planner = planner!(
         Subgraph1: r#"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
@@ -287,6 +287,8 @@ fn interface_union_interaction_but_no_need_to_type_explode() {
 }
 
 #[test]
+#[should_panic(expected = "snapshot assertion")]
+// TODO: investigate this failure
 fn interface_interface_interaction() {
     let planner = planner!(
         Subgraph1: r#"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
@@ -6,6 +6,8 @@
  */
 
 #[test]
+#[should_panic(expected = "snapshot assertion")]
+// TODO: investigate this failure
 fn union_interface_interaction() {
     let planner = planner!(
         Subgraph1: r#"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
@@ -6,8 +6,6 @@
  */
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure
 fn union_interface_interaction() {
     let planner = planner!(
         Subgraph1: r#"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
@@ -287,8 +287,6 @@ fn interface_union_interaction_but_no_need_to_type_explode() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure
 fn interface_interface_interaction() {
     let planner = planner!(
         Subgraph1: r#"


### PR DESCRIPTION
This PR:
- Makes bugfixes to `selection_set_is_fully_local_from_all_nodes()`.
  - It was only checking for inconsistent abstract types at top-level, when it should be checking every element.
    - I've added a method called `any_element()` to help facilitate this (this was called `some()` in the JS codebase).
  - The call to `can_rebase_on()` wasn't checking whether the selection set could be rebased on the node's schema.
  - As a matter of efficiency, we should early return when the node's `has_reachable_cross_subgraph_edges` is `true`, as it's much faster to check than rebasing. I've accordingly rearranged the checks so it's first (mirroring the JS codebase).
  - Similarly for efficiency, the JS codebase had ordered the check for inconsistent abstract runtime types until after rebasing. I've accordingly changed the code to do the same.
- Makes a bugfix to the logic that computes inconsistent abstract runtime types.
  - The `is_inconsistent()` function in particular had inverted its output, and needed a `!`.
- Makes a bugfix to `can_rebase_on()`.
  - This method should accept a schema to rebase upon. (It's the schema containing the provided type.) It was assuming that it was the selection set's schema, but that wasn't the case for the two existing callsites of `can_rebase_on()`.
- Makes bugfixes to `type_at_path()`.
  - While reading the other callsite of `can_rebase_on()` (which is currently `is_node_unneeded()`), I was looking for the appropriate schema, and I noticed `type_at_path()` should have been taking in a schema. After reading its code, I noticed it was using the wrong schema (the schemas of the operation elements). It should only be using the schema of the passed-in type, and the schemas of the operation elements should be ignored. I've updated the code accordingly (it was also missing an assert in the case of type conditions).
- Updates tests.
  - 2 tests in `merged_abstract_types_handling.rs` now succeed.
  - 1 test in `interface_type_explosion.rs` now succeeds, specifically `handles_non_matching_value_types_under_interface_field()`.
  - 1 test in `introspection_typename_handling.rs` now fails for a different reason, specifically `it_does_not_needlessly_consider_options_for_typename()`.

EDIT: For reasons that I don't understand, the original code of this PR repeatedly failed CI specifically on macOS, specifically for 46 router tests with the error message `'GraphQL endpoint exposed' not detected in logs` (most of them integration tests). These tests continued to fail, despite at least 10 re-runs. After stepping through the changes one at a time, moving the inconsistent abstract type check to the end of the loop is what triggered the issue. It appears that moving the inconsistent abstract type check into a closure somehow fixes it. I'm going to check in a later PR whether I can remove the wrapping closure, with the hopes it might be some kind of strange CI caching issue.