### PR TITLE
add some tests for experimental_query_planner_mode unsupported feature rejections, 

### DIFF
--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -849,6 +849,7 @@ mod test {
     use tower_http::BoxError;
 
     use crate::configuration::Configuration;
+    use crate::configuration::QueryPlannerMode;
     use crate::plugin::Plugin;
     use crate::plugin::PluginInit;
     use crate::register_plugin;
@@ -856,6 +857,7 @@ mod test {
     use crate::router_factory::inject_schema_id;
     use crate::router_factory::RouterSuperServiceFactory;
     use crate::router_factory::YamlRouterFactory;
+    use crate::spec::Schema;
 
     #[derive(Debug)]
     struct PluginError;
@@ -996,12 +998,7 @@ mod test {
     }
 
     #[test]
-    fn test_can_use_with_experimental_query_planner() {
-        use crate::configuration::Configuration;
-        use crate::configuration::QueryPlannerMode;
-        use crate::spec::Schema;
-
-        // @CONTEXT
+    fn test_cannot_use_context_with_experimental_query_planner() {
         let config = Configuration {
             experimental_query_planner_mode: QueryPlannerMode::Both,
             ..Default::default()
@@ -1028,7 +1025,10 @@ mod test {
             can_use_with_experimental_query_planner(Arc::new(config), schema.clone()).is_ok(),
             "experimental_query_planner_mode: legacy should be able to be used with @context"
         );
+    }
 
+    #[test]
+    fn test_cannot_use_progressive_overrides_with_experimental_query_planner() {
         // PROGRESSIVE OVERRIDES
         let config = Configuration {
             experimental_query_planner_mode: QueryPlannerMode::Both,
@@ -1056,8 +1056,10 @@ mod test {
             can_use_with_experimental_query_planner(Arc::new(config), schema.clone()).is_ok(),
             "experimental_query_planner_mode: legacy should be able to be used with progressive overrides"
         );
+    }
 
-        // FED1 SUPERGPRAPH
+    #[test]
+    fn test_cannot_use_fed1_supergraphs_with_experimental_query_planner() {
         let config = Configuration {
             experimental_query_planner_mode: QueryPlannerMode::Both,
             ..Default::default()
@@ -1084,7 +1086,10 @@ mod test {
             can_use_with_experimental_query_planner(Arc::new(config), schema.clone()).is_ok(),
             "experimental_query_planner_mode: legacy should be able to be used with fed1 supergraph"
         );
-        // FED2 SUPERGRAPH
+    }
+
+    #[test]
+    fn test_can_use_fed2_supergraphs_with_experimental_query_planner() {
         let config = Configuration {
             experimental_query_planner_mode: QueryPlannerMode::Both,
             ..Default::default()

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -54,7 +54,7 @@ use crate::ListenAddr;
 pub(crate) const STARTING_SPAN_NAME: &str = "starting";
 pub(crate) const OVERRIDE_LABEL_ARG_NAME: &str = "overrideLabel";
 pub(crate) const CONTEXT_DIRECTIVE: &str = "context";
-pub(crate) const JOIN_DIRECTIVE: &str = "join__directive";
+pub(crate) const JOIN_FIELD: &str = "join__field";
 
 #[derive(Clone)]
 /// A path and a handler to be exposed as a web_endpoint for plugins
@@ -772,7 +772,7 @@ fn can_use_with_experimental_query_planner(
                     let join_field_directives = field
                         .directives
                         .iter()
-                        .filter(|d| d.name.as_str() == JOIN_DIRECTIVE)
+                        .filter(|d| d.name.as_str() == JOIN_FIELD)
                         .collect::<Vec<_>>();
                     if !join_field_directives.is_empty() {
                         Some(join_field_directives)
@@ -785,6 +785,8 @@ fn can_use_with_experimental_query_planner(
                     if let Some(override_label_arg) =
                         join_directive.argument_by_name(OVERRIDE_LABEL_ARG_NAME)
                     {
+                        // Any argument value for `overrideLabel` that's not
+                        // null can be considered as progressive override usage
                         if !override_label_arg.is_null() {
                             return true;
                         }
@@ -850,6 +852,7 @@ mod test {
     use crate::plugin::Plugin;
     use crate::plugin::PluginInit;
     use crate::register_plugin;
+    use crate::router_factory::can_use_with_experimental_query_planner;
     use crate::router_factory::inject_schema_id;
     use crate::router_factory::RouterSuperServiceFactory;
     use crate::router_factory::YamlRouterFactory;
@@ -989,6 +992,124 @@ mod test {
         assert_eq!(
             &config.apollo.schema_id,
             "8e2021d131b23684671c3b85f82dfca836908c6a541bbd5c3772c66e7f8429d8"
+        );
+    }
+
+    #[test]
+    fn test_can_use_with_experimental_query_planner() {
+        use crate::configuration::Configuration;
+        use crate::configuration::QueryPlannerMode;
+        use crate::spec::Schema;
+
+        // @CONTEXT
+        let config = Configuration {
+            experimental_query_planner_mode: QueryPlannerMode::Both,
+            ..Default::default()
+        };
+        let schema = include_str!("testdata/supergraph_with_context.graphql");
+        let schema = Arc::new(Schema::parse_test(schema, &config).unwrap());
+        assert!(
+            can_use_with_experimental_query_planner(Arc::new(config), schema.clone()).is_err(),
+            "experimental_query_planner_mode: both cannot be used with @context"
+        );
+        let config = Configuration {
+            experimental_query_planner_mode: QueryPlannerMode::New,
+            ..Default::default()
+        };
+        assert!(
+            can_use_with_experimental_query_planner(Arc::new(config), schema.clone()).is_err(),
+            "experimental_query_planner_mode: new cannot be used with @context"
+        );
+        let config = Configuration {
+            experimental_query_planner_mode: QueryPlannerMode::Legacy,
+            ..Default::default()
+        };
+        assert!(
+            can_use_with_experimental_query_planner(Arc::new(config), schema.clone()).is_ok(),
+            "experimental_query_planner_mode: legacy should be able to be used with @context"
+        );
+
+        // PROGRESSIVE OVERRIDES
+        let config = Configuration {
+            experimental_query_planner_mode: QueryPlannerMode::Both,
+            ..Default::default()
+        };
+        let schema = include_str!("testdata/supergraph_with_override_label.graphql");
+        let schema = Arc::new(Schema::parse_test(schema, &config).unwrap());
+        assert!(
+            can_use_with_experimental_query_planner(Arc::new(config), schema.clone()).is_err(),
+            "experimental_query_planner_mode: both cannot be used with progressive overrides"
+        );
+        let config = Configuration {
+            experimental_query_planner_mode: QueryPlannerMode::New,
+            ..Default::default()
+        };
+        assert!(
+            can_use_with_experimental_query_planner(Arc::new(config), schema.clone()).is_err(),
+            "experimental_query_planner_mode: new cannot be used with progressive overrides"
+        );
+        let config = Configuration {
+            experimental_query_planner_mode: QueryPlannerMode::Legacy,
+            ..Default::default()
+        };
+        assert!(
+            can_use_with_experimental_query_planner(Arc::new(config), schema.clone()).is_ok(),
+            "experimental_query_planner_mode: legacy should be able to be used with progressive overrides"
+        );
+
+        // FED1 SUPERGPRAPH
+        let config = Configuration {
+            experimental_query_planner_mode: QueryPlannerMode::Both,
+            ..Default::default()
+        };
+        let schema = include_str!("testdata/supergraph.graphql");
+        let schema = Arc::new(Schema::parse_test(schema, &config).unwrap());
+        assert!(
+            can_use_with_experimental_query_planner(Arc::new(config), schema.clone()).is_err(),
+            "experimental_query_planner_mode: both cannot be used with fed1 supergraph"
+        );
+        let config = Configuration {
+            experimental_query_planner_mode: QueryPlannerMode::New,
+            ..Default::default()
+        };
+        assert!(
+            can_use_with_experimental_query_planner(Arc::new(config), schema.clone()).is_err(),
+            "experimental_query_planner_mode: new cannot be used with fed1 supergraph"
+        );
+        let config = Configuration {
+            experimental_query_planner_mode: QueryPlannerMode::Legacy,
+            ..Default::default()
+        };
+        assert!(
+            can_use_with_experimental_query_planner(Arc::new(config), schema.clone()).is_ok(),
+            "experimental_query_planner_mode: legacy should be able to be used with fed1 supergraph"
+        );
+        // FED2 SUPERGRAPH
+        let config = Configuration {
+            experimental_query_planner_mode: QueryPlannerMode::Both,
+            ..Default::default()
+        };
+        let schema = include_str!("testdata/minimal_fed2_supergraph.graphql");
+        let schema = Arc::new(Schema::parse_test(schema, &config).unwrap());
+        assert!(
+            can_use_with_experimental_query_planner(Arc::new(config), schema.clone()).is_ok(),
+            "experimental_query_planner_mode: both can be used"
+        );
+        let config = Configuration {
+            experimental_query_planner_mode: QueryPlannerMode::New,
+            ..Default::default()
+        };
+        assert!(
+            can_use_with_experimental_query_planner(Arc::new(config), schema.clone()).is_ok(),
+            "experimental_query_planner_mode: new can be used"
+        );
+        let config = Configuration {
+            experimental_query_planner_mode: QueryPlannerMode::Legacy,
+            ..Default::default()
+        };
+        assert!(
+            can_use_with_experimental_query_planner(Arc::new(config), schema.clone()).is_ok(),
+            "experimental_query_planner_mode: legacy can be used"
         );
     }
 }

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -214,7 +214,6 @@ impl QueryAnalysisLayer {
             }
         }
     }
-
 }
 
 pub(crate) type ParsedDocument = Arc<ParsedDocumentInner>;

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -214,6 +214,7 @@ impl QueryAnalysisLayer {
             }
         }
     }
+
 }
 
 pub(crate) type ParsedDocument = Arc<ParsedDocumentInner>;

--- a/apollo-router/src/testdata/supergraph_with_context.graphql
+++ b/apollo-router/src/testdata/supergraph_with_context.graphql
@@ -1,0 +1,86 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/context/v0.1")
+{
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @context(name: String!) repeatable on INTERFACE | OBJECT
+
+directive @context__fromContext(field: String) on ARGUMENT_DEFINITION
+
+enum link__Purpose {
+  """
+  \`SECURITY\` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  \`EXECUTION\` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar link__Import
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "https://Subgraph1")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "https://Subgraph2")
+}
+
+scalar join__FieldSet
+
+scalar join__DirectiveArguments
+
+scalar join__FieldValue
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar context__context
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T! @join__field(graph: SUBGRAPH1)
+  a: Int! @join__field(graph: SUBGRAPH2)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @context(name: "Subgraph1__context")
+{
+  id: ID!
+  u: U!
+  prop: String!
+}
+
+type U
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  field: Int! @join__field(graph: SUBGRAPH1, contextArguments: [{context: "Subgraph1__context", name: "a", type: "String", selection: "{ prop }"}])
+}

--- a/apollo-router/src/testdata/supergraph_with_override_label.graphql
+++ b/apollo-router/src/testdata/supergraph_with_override_label.graphql
@@ -1,0 +1,70 @@
+schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+{
+    query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+    name: String!
+    type: String!
+    context: String!
+    selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+    SUBGRAPH1 @join__graph(name: "Subgraph1", url: "https://Subgraph1")
+    SUBGRAPH2 @join__graph(name: "Subgraph2", url: "https://Subgraph2")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+    """
+    `SECURITY` features provide metadata necessary to securely resolve fields.
+    """
+    SECURITY
+
+    """
+    `EXECUTION` features provide metadata necessary for operation execution.
+    """
+    EXECUTION
+}
+
+type Query
+    @join__type(graph: SUBGRAPH1)
+    @join__type(graph: SUBGRAPH2)
+{
+    t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+    @join__type(graph: SUBGRAPH1, key: "k")
+    @join__type(graph: SUBGRAPH2, key: "k")
+{
+    k: ID
+    a: Int @join__field(graph: SUBGRAPH1, override: "Subgraph2", overrideLabel: "foo") @join__field(graph: SUBGRAPH2, overrideLabel: "foo")
+    b: Int @join__field(graph: SUBGRAPH2)
+}


### PR DESCRIPTION
A follow up to #5335

Just to ensure we are not rejecting acceptable supergraphs, along with the correct directive name used for in progressive overrides search.