### PR TITLE
fix(federation): normalize rebased fragment definitions

### DIFF
--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -847,7 +847,9 @@ impl Selection {
                     // Expand the fragment
                     let expanded_sub_selections =
                         fragment.selection_set.retain_fragments(fragments_to_keep)?;
-                    if *parent_type == fragment.spread.data().type_condition_position.clone() && fragment.spread.data().directives.is_empty() {
+                    if *parent_type == fragment.spread.data().type_condition_position.clone()
+                        && fragment.spread.data().directives.is_empty()
+                    {
                         // The fragment is of the same type as the parent, so we can just use
                         // the expanded sub-selections directly.
                         Ok(expanded_sub_selections.into())
@@ -994,7 +996,7 @@ impl NamedFragments {
                     &fragment.selection_set.type_position,
                     &fragments_to_keep,
                     &fragment.schema,
-                    NormalizeSelectionOption::NormalizeRecursively
+                    NormalizeSelectionOption::NormalizeRecursively,
                 )?;
         }
 

--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -847,7 +847,7 @@ impl Selection {
                     // Expand the fragment
                     let expanded_sub_selections =
                         fragment.selection_set.retain_fragments(fragments_to_keep)?;
-                    if *parent_type == fragment.spread.data().type_condition_position.clone()
+                    if *parent_type == fragment.spread.data().type_condition_position
                         && fragment.spread.data().directives.is_empty()
                     {
                         // The fragment is of the same type as the parent, so we can just use

--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -847,7 +847,7 @@ impl Selection {
                     // Expand the fragment
                     let expanded_sub_selections =
                         fragment.selection_set.retain_fragments(fragments_to_keep)?;
-                    if *parent_type == fragment.spread.data().type_condition_position {
+                    if *parent_type == fragment.spread.data().type_condition_position.clone() && fragment.spread.data().directives.is_empty() {
                         // The fragment is of the same type as the parent, so we can just use
                         // the expanded sub-selections directly.
                         Ok(expanded_sub_selections.into())
@@ -989,7 +989,13 @@ impl NamedFragments {
         for (_, fragment) in self.iter_mut() {
             Node::make_mut(fragment).selection_set = fragment
                 .selection_set
-                .retain_fragments(&fragments_to_keep)?;
+                .retain_fragments(&fragments_to_keep)?
+                .normalize(
+                    &fragment.selection_set.type_position,
+                    &fragments_to_keep,
+                    &fragment.schema,
+                    NormalizeSelectionOption::NormalizeRecursively
+                )?;
         }
 
         // Compute the new selection set based on the new reduced set of fragments.

--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -334,9 +334,6 @@ impl FragmentSpreadSelection {
             return Ok(Some(Selection::FragmentSpread(Arc::new(self.clone()))));
         }
 
-        // If we're rebasing on a _different_ schema, then we *must* have fragments, since reusing
-        // `self.fragments` would be incorrect. If we're on the same schema though, we're happy to default
-        // to `self.fragments`.
         let rebase_on_same_schema = self.spread.data().schema == *schema;
         let Some(named_fragment) = named_fragments.get(&self.spread.data().fragment_name) else {
             // If we're rebasing on another schema (think a subgraph), then named fragments will have been rebased on that, and some

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments_preservation.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments_preservation.rs
@@ -646,8 +646,6 @@ fn it_does_not_try_to_apply_fragments_that_are_not_valid_for_the_subgaph() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure - snapshot mismatch (complicated)
 fn it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_differs() {
     // This test is designed such that type `Outer` implements the interface `I` in `Subgraph1`
     // but not in `Subgraph2`, yet `I` exists in `Subgraph2` (but only `Inner` implements it
@@ -994,8 +992,6 @@ fn it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_diff
 }
 
 #[test]
-#[should_panic(expected = r#"snapshot assertion"#)]
-// TODO: investigate this failure
 fn it_handles_fragment_rebasing_in_a_subgraph_where_some_union_membership_relation_differs() {
     // This test is similar to the subtyping case (it tests the same problems), but test the case
     // of unions instead of interfaces.

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments_preservation.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/named_fragments_preservation.rs
@@ -752,7 +752,7 @@ fn it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_diff
               }
             },
             Parallel {
-              Flatten(path: "outer1") {
+              Flatten(path: "outer2") {
                 Fetch(service: "Subgraph1") {
                   {
                     ... on Outer {
@@ -769,7 +769,7 @@ fn it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_diff
                   }
                 },
               },
-              Flatten(path: "outer2") {
+              Flatten(path: "outer1") {
                 Fetch(service: "Subgraph1") {
                   {
                     ... on Outer {
@@ -850,7 +850,7 @@ fn it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_diff
               }
             },
             Parallel {
-              Flatten(path: "outer1") {
+              Flatten(path: "outer2") {
                 Fetch(service: "Subgraph1") {
                   {
                     ... on Outer {
@@ -867,7 +867,7 @@ fn it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_diff
                   }
                 },
               },
-              Flatten(path: "outer2") {
+              Flatten(path: "outer1") {
                 Fetch(service: "Subgraph1") {
                   {
                     ... on Outer {
@@ -950,7 +950,7 @@ fn it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_diff
               }
             },
             Parallel {
-              Flatten(path: "outer1") {
+              Flatten(path: "outer2") {
                 Fetch(service: "Subgraph1") {
                   {
                     ... on Outer {
@@ -967,7 +967,7 @@ fn it_handles_fragment_rebasing_in_a_subgraph_where_some_subtyping_relation_diff
                   }
                 },
               },
-              Flatten(path: "outer2") {
+              Flatten(path: "outer1") {
                 Fetch(service: "Subgraph1") {
                   {
                     ... on Outer {
@@ -1080,7 +1080,7 @@ fn it_handles_fragment_rebasing_in_a_subgraph_where_some_union_membership_relati
               }
             },
             Parallel {
-              Flatten(path: "outer1") {
+              Flatten(path: "outer2") {
                 Fetch(service: "Subgraph1") {
                   {
                     ... on Outer {
@@ -1095,7 +1095,7 @@ fn it_handles_fragment_rebasing_in_a_subgraph_where_some_union_membership_relati
                   }
                 },
               },
-              Flatten(path: "outer2") {
+              Flatten(path: "outer1") {
                 Fetch(service: "Subgraph1") {
                   {
                     ... on Outer {
@@ -1175,7 +1175,7 @@ fn it_handles_fragment_rebasing_in_a_subgraph_where_some_union_membership_relati
               }
             },
             Parallel {
-              Flatten(path: "outer1") {
+              Flatten(path: "outer2") {
                 Fetch(service: "Subgraph1") {
                   {
                     ... on Outer {
@@ -1190,7 +1190,7 @@ fn it_handles_fragment_rebasing_in_a_subgraph_where_some_union_membership_relati
                   }
                 },
               },
-              Flatten(path: "outer2") {
+              Flatten(path: "outer1") {
                 Fetch(service: "Subgraph1") {
                   {
                     ... on Outer {
@@ -1270,7 +1270,7 @@ fn it_handles_fragment_rebasing_in_a_subgraph_where_some_union_membership_relati
               }
             },
             Parallel {
-              Flatten(path: "outer1") {
+              Flatten(path: "outer2") {
                 Fetch(service: "Subgraph1") {
                   {
                     ... on Outer {
@@ -1285,7 +1285,7 @@ fn it_handles_fragment_rebasing_in_a_subgraph_where_some_union_membership_relati
                   }
                 },
               },
-              Flatten(path: "outer2") {
+              Flatten(path: "outer1") {
                 Fetch(service: "Subgraph1") {
                   {
                     ... on Outer {


### PR DESCRIPTION
JS code applies [normalization](https://github.com/apollographql/federation/blob/main/internals-js/src/operations.ts#L1462) on the rebased fragment definitions that eliminates the unnecessary inline spreads.

Fixes #[FED-261](https://apollographql.atlassian.net/browse/FED-261)

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[FED-261]: https://apollographql.atlassian.net/browse/FED-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ