### PR TITLE
Implement evaluated_plan_count statistic

### DIFF
--- a/apollo-federation/tests/query_plan/build_query_plan_tests/debug_max_evaluated_plans_configuration.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/debug_max_evaluated_plans_configuration.rs
@@ -26,8 +26,6 @@ const SUBGRAPH: &str = r#"
 "#;
 
 #[test]
-#[should_panic(expected = "assertion `left == right` failed")]
-// TODO: investigate this failure
 fn works_when_unset() {
     // This test is mostly a sanity check to make sure that "by default", we do have 16 plans
     // (all combination of the 2 choices for 4 fields). It's not entirely impossible that
@@ -67,12 +65,10 @@ fn works_when_unset() {
         }
       "###
     );
-    assert_eq!(plan.statistics.evaluated_plan_count, 16);
+    assert_eq!(plan.statistics.evaluated_plan_count.get(), 16);
 }
 
 #[test]
-#[should_panic(expected = "assertion `left == right` failed")]
-// TODO: investigate this failure
 fn allows_setting_down_to_1() {
     let max_evaluated_plans = NonZeroU32::new(1).unwrap();
     let planner = planner!(
@@ -123,12 +119,10 @@ fn allows_setting_down_to_1() {
         }
       "###
     );
-    assert_eq!(plan.statistics.evaluated_plan_count, 16);
+    assert_eq!(plan.statistics.evaluated_plan_count.get(), 1);
 }
 
 #[test]
-#[should_panic(expected = "assertion `left == right` failed")]
-// TODO: investigate this failure
 fn can_be_set_to_an_arbitrary_number() {
     let max_evaluated_plans = NonZeroU32::new(10).unwrap();
     let planner = planner!(
@@ -173,7 +167,7 @@ fn can_be_set_to_an_arbitrary_number() {
     // Note that in this particular example, since we have binary choices only and due to the way
     // we cut branches when we're above the max, the number of evaluated plans can only be a power
     // of 2. Here, we just want it to be the nearest power of 2 below our limit.
-    assert_eq!(plan.statistics.evaluated_plan_count, 8);
+    assert_eq!(plan.statistics.evaluated_plan_count.get(), 8);
 }
 
 #[test]
@@ -396,8 +390,6 @@ fn does_not_error_on_some_complex_fetch_group_dependencies() {
 }
 
 #[test]
-#[should_panic(expected = "assertion `left == right` failed")]
-// TODO: investigate this failure
 fn does_not_evaluate_plans_relying_on_a_key_field_to_fetch_that_same_field() {
     let planner = planner!(
         Subgraph1: r#"
@@ -472,7 +464,7 @@ fn does_not_evaluate_plans_relying_on_a_key_field_to_fetch_that_same_field() {
     // this test ensure this is not considered anymore (considering that later plan
     // was not incorrect, but it was adding to the options to evaluate which in some
     // cases could impact query planning performance quite a bit).
-    assert_eq!(plan.statistics.evaluated_plan_count, 1);
+    assert_eq!(plan.statistics.evaluated_plan_count.get(), 1);
 }
 
 #[test]
@@ -546,5 +538,5 @@ fn avoid_considering_indirect_paths_from_the_root_when_a_more_direct_one_exists(
     // As said above, we legit have 2 options for `id` and `v0`, and we cannot know which are best before we evaluate the
     // plans completely. But for the multiple `v1`, we should recognize that going through the 1st subgraph (and taking a
     // key) is never exactly a good idea.
-    assert_eq!(plan.statistics.evaluated_plan_count, 4);
+    assert_eq!(plan.statistics.evaluated_plan_count.get(), 4);
 }

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/interface_type_explosion.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/interface_type_explosion.rs
@@ -84,8 +84,6 @@ fn handles_non_matching_value_types_under_interface_field() {
 }
 
 #[test]
-#[should_panic(expected = "assertion `left == right` failed")]
-// TODO: investigate this failure (`evaluated_plan_count` is 0, when it's expected to be 1.)
 fn skip_type_explosion_early_if_unnecessary() {
     let planner = planner!(
         Subgraph1: r#"
@@ -153,5 +151,5 @@ fn skip_type_explosion_early_if_unnecessary() {
         }
       "###
     );
-    assert_eq!(plan.statistics.evaluated_plan_count, 1);
+    assert_eq!(plan.statistics.evaluated_plan_count.get(), 1);
 }

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/introspection_typename_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/introspection_typename_handling.rs
@@ -150,7 +150,7 @@ fn it_does_not_needlessly_consider_options_for_typename() {
         }
       "###
     );
-    assert_eq!(plan.statistics.evaluated_plan_count, 1);
+    assert_eq!(plan.statistics.evaluated_plan_count.get(), 1);
 
     // Almost the same test, but we artificially create a case where the result set
     // for `s` has a __typename alongside just an inline fragments. This should
@@ -208,5 +208,5 @@ fn it_does_not_needlessly_consider_options_for_typename() {
         }
       "###
     );
-    assert_eq!(plan.statistics.evaluated_plan_count, 1);
+    assert_eq!(plan.statistics.evaluated_plan_count.get(), 1);
 }


### PR DESCRIPTION
Fixes most of FED-272

To avoid the risk of incrementing a cloned counter and then dropping it, this PR removes `derive(Clone)` on `QueryPlanningStatistics` and pass it around by reference instead.

I tried make this a `&mut QueryPlanningStatistics` exclusive reference, but that would require changing every use of `&QueryPlanningParameters` to be a `&mut` exclusive reference too.
This proved difficult as parameters are shared in multiple places.

Instead, the counter is now a `Cell<usize>` so that it can be incremented through a shared reference.
This causes `QueryPlanningStatistics` and `QueryPlanningParameters` to be `!Sync` but that’s ok: they only exist within one single-threaded call to `build_query_plan()`.

The `QueryPlanner` itself is still `Sync` and multiple threads can run separate `build_query_plan()` calls.


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
