### PR TITLE
Fix various bugs in `can_rebase_on()` and `can_add_to()`

### DIFF
--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -20,6 +20,7 @@ use crate::error::FederationError;
 use crate::link::federation_spec_definition::get_federation_spec_definition_from_subgraph;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::ObjectTypeDefinitionPosition;
+use crate::schema::position::OutputTypeDefinitionPosition;
 use crate::schema::ValidFederationSchema;
 
 // TODO(@goto-bus-stop): this is precomputed in the QueryPlanner constructor. Can we expose that
@@ -85,10 +86,13 @@ impl Selection {
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
         schema: &ValidFederationSchema,
-    ) -> bool {
+    ) -> Result<bool, FederationError> {
         match self {
             Selection::Field(field) => field.can_add_to(parent_type, schema),
-            Selection::FragmentSpread(_) => true,
+            // Since `rebaseOn` never fails, we copy the logic here and always return `true`. But as
+            // mentioned in `rebaseOn`, this leaves it a bit to the caller to know what they're
+            // doing.
+            Selection::FragmentSpread(_) => Ok(true),
             Selection::InlineFragment(inline) => inline.can_add_to(parent_type, schema),
         }
     }
@@ -133,7 +137,7 @@ impl Field {
 
         let field_from_parent = parent_type.field(self.data().name().clone())?;
         return if field_from_parent.try_get(schema.schema()).is_some()
-            && self.can_rebase_on(parent_type, schema)
+            && self.can_rebase_on(parent_type)
         {
             let mut updated_field_data = self.data().clone();
             updated_field_data.schema = schema.clone();
@@ -160,11 +164,7 @@ impl Field {
     ///  that `parent_type` is indeed an implementation of `field_parent_type` because it's possible that this implementation relationship exists
     ///  in the supergraph, but not in any of the subgraph schema involved here. So we just let it be. Not that `rebase_on` will complain anyway
     ///  if the field name simply does not exist in `parent_type`.
-    fn can_rebase_on(
-        &self,
-        parent_type: &CompositeTypeDefinitionPosition,
-        schema: &ValidFederationSchema,
-    ) -> bool {
+    fn can_rebase_on(&self, parent_type: &CompositeTypeDefinitionPosition) -> bool {
         let field_parent_type = self.data().field_position.parent();
         // case 1
         if field_parent_type.type_name() == parent_type.type_name() {
@@ -173,7 +173,7 @@ impl Field {
         // case 2
         let is_interface_object_type =
             match ObjectTypeDefinitionPosition::try_from(field_parent_type.clone()) {
-                Ok(ref o) => is_interface_object(o, schema),
+                Ok(ref o) => is_interface_object(o, &self.data().schema),
                 Err(_) => false,
             };
         field_parent_type.is_interface_type() || is_interface_object_type
@@ -183,40 +183,40 @@ impl Field {
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
         schema: &ValidFederationSchema,
-    ) -> Option<CompositeTypeDefinitionPosition> {
+    ) -> Result<Option<OutputTypeDefinitionPosition>, FederationError> {
         let data = self.data();
         if data.field_position.parent() == *parent_type && data.schema == *schema {
             let base_ty_name = data
                 .field_position
-                .get(schema.schema())
-                .ok()?
+                .get(schema.schema())?
                 .ty
                 .inner_named_type();
-            return schema
-                .get_type(base_ty_name.clone())
-                .and_then(CompositeTypeDefinitionPosition::try_from)
-                .ok();
+            return Ok(Some(
+                data.schema.get_type(base_ty_name.clone())?.try_into()?,
+            ));
         }
         if data.name() == &TYPENAME_FIELD {
-            let type_name = parent_type
+            let Some(type_name) = parent_type
                 .introspection_typename_field()
-                .get(schema.schema())
-                .ok()?
-                .ty
-                .inner_named_type();
-            return schema.try_get_type(type_name.clone())?.try_into().ok();
+                .try_get(schema.schema())
+                .map(|field| field.ty.inner_named_type())
+            else {
+                return Ok(None);
+            };
+            return Ok(Some(schema.get_type(type_name.clone())?.try_into()?));
         }
-        if self.can_rebase_on(parent_type, schema) {
-            let type_name = parent_type
+        if self.can_rebase_on(parent_type) {
+            let Some(type_name) = parent_type
                 .field(data.field_position.field_name().clone())
-                .ok()?
-                .get(schema.schema())
-                .ok()?
-                .ty
-                .inner_named_type();
-            schema.try_get_type(type_name.clone())?.try_into().ok()
+                .ok()
+                .and_then(|field_pos| field_pos.get(schema.schema()).ok())
+                .map(|field| field.ty.inner_named_type())
+            else {
+                return Ok(None);
+            };
+            Ok(Some(schema.get_type(type_name.clone())?.try_into()?))
         } else {
-            None
+            Ok(None)
         }
     }
 }
@@ -288,26 +288,24 @@ impl FieldSelection {
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
         schema: &ValidFederationSchema,
-    ) -> bool {
-        if &self.field.data().schema == schema
-            && parent_type == &self.field.data().field_position.parent()
+    ) -> Result<bool, FederationError> {
+        if self.field.data().schema == *schema
+            && self.field.data().field_position.parent() == *parent_type
         {
-            return true;
+            return Ok(true);
         }
 
-        let Some(ty) = self.field.type_if_added_to(parent_type, schema) else {
-            return false;
+        let Some(ty) = self.field.type_if_added_to(parent_type, schema)? else {
+            return Ok(false);
         };
 
         if let Some(set) = &self.selection_set {
-            if set.type_position != ty {
-                return set
-                    .selections
-                    .values()
-                    .all(|sel| sel.can_add_to(parent_type, schema));
+            let ty: CompositeTypeDefinitionPosition = ty.try_into()?;
+            if !(set.schema == *schema && set.type_position == ty) {
+                return set.can_rebase_on(&ty, schema);
             }
         }
-        true
+        Ok(true)
     }
 }
 
@@ -420,10 +418,10 @@ impl InlineFragmentData {
         parent_type: &CompositeTypeDefinitionPosition,
         schema: &ValidFederationSchema,
     ) -> Option<CompositeTypeDefinitionPosition> {
-        if &self.parent_type_position == parent_type && &self.schema == schema {
+        if self.schema == *schema && self.parent_type_position == *parent_type {
             return Some(self.casted_type());
         }
-        match self.can_rebase_on(parent_type) {
+        match self.can_rebase_on(parent_type, schema) {
             (false, _) => None,
             (true, None) => Some(parent_type.clone()),
             (true, Some(ty)) => Some(ty),
@@ -433,16 +431,16 @@ impl InlineFragmentData {
     fn can_rebase_on(
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
+        schema: &ValidFederationSchema,
     ) -> (bool, Option<CompositeTypeDefinitionPosition>) {
         let Some(ty) = self.type_condition_position.as_ref() else {
             return (true, None);
         };
-        match self
-            .schema
+        match schema
             .get_type(ty.type_name().clone())
             .and_then(CompositeTypeDefinitionPosition::try_from)
         {
-            Ok(ty) if runtime_types_intersect(parent_type, &ty, &self.schema) => (true, Some(ty)),
+            Ok(ty) if runtime_types_intersect(parent_type, &ty, schema) => (true, Some(ty)),
             _ => (false, None),
         }
     }
@@ -584,28 +582,23 @@ impl InlineFragmentSelection {
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
         schema: &ValidFederationSchema,
-    ) -> bool {
-        if &self.inline_fragment.data().parent_type_position == parent_type
-            && self.inline_fragment.data().schema == *schema
+    ) -> Result<bool, FederationError> {
+        if self.inline_fragment.data().schema == *schema
+            && self.inline_fragment.data().parent_type_position == *parent_type
         {
-            return true;
+            return Ok(true);
         }
         let Some(ty) = self
             .inline_fragment
             .data()
             .casted_type_if_add_to(parent_type, schema)
         else {
-            return false;
+            return Ok(false);
         };
-        if self.selection_set.type_position != ty {
-            for sel in self.selection_set.selections.values() {
-                if !sel.can_add_to(&ty, schema) {
-                    return false;
-                }
-            }
-            true
+        if !(self.selection_set.schema == *schema && self.selection_set.type_position == ty) {
+            self.selection_set.can_rebase_on(&ty, schema)
         } else {
-            true
+            Ok(true)
         }
     }
 
@@ -651,10 +644,13 @@ impl SelectionSet {
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
         schema: &ValidFederationSchema,
-    ) -> bool {
-        self.selections
-            .values()
-            .all(|sel| sel.can_add_to(parent_type, schema))
+    ) -> Result<bool, FederationError> {
+        for selection in self.selections.values() {
+            if !selection.can_add_to(parent_type, schema)? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
     }
 }
 

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2089,7 +2089,7 @@ impl FetchDependencyGraph {
             && node
                 .selection_set
                 .selection_set
-                .can_rebase_on(&type_at_path, &parent.selection_set.selection_set.schema);
+                .can_rebase_on(&type_at_path, &parent.selection_set.selection_set.schema)?;
         Ok(new_node_is_unneeded)
     }
 

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -513,7 +513,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
                 .parameters
                 .federated_query_graph
                 .schema_by_source(&n.source)?;
-            if !selection.can_rebase_on(&parent_ty, schema) {
+            if !selection.can_rebase_on(&parent_ty, schema)? {
                 return Ok(false);
             }
             if check_has_inconsistent_runtime_types()? {

--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -477,9 +477,7 @@ fn it_executes_mutation_operations_in_sequence() {
 
 /// @requires references external field indirectly {
 #[test]
-#[should_panic(
-    expected = r#"Cannot add selection of field "U.k2" to selection set of parent type "U""#
-)]
+#[should_panic(expected = "snapshot assertion")]
 // TODO: investigate this failure (appears to be visiting wrong subgraph)
 fn key_where_at_external_is_not_at_top_level_of_selection_of_requires() {
     // Field issue where we were seeing a FetchGroup created where the fields used by the key to jump subgraphs

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
@@ -216,10 +216,6 @@ fn interface_union_interaction() {
 }
 
 #[test]
-#[should_panic(
-    expected = r#"Cannot add fragment of condition "A" (runtimes: [A]) to parent type "I" (runtimes: [B, C])"#
-)]
-// TODO: investigate this failure
 fn interface_union_interaction_but_no_need_to_type_explode() {
     let planner = planner!(
         Subgraph1: r#"
@@ -501,10 +497,6 @@ fn union_union_interaction() {
 }
 
 #[test]
-#[should_panic(
-    expected = r#"Cannot add fragment of condition "A" (runtimes: [A]) to parent type "U1" (runtimes: [B, C])"#
-)]
-// TODO: investigate this failure
 fn union_union_interaction_but_no_need_to_type_explode() {
     let planner = planner!(
         Subgraph1: r#"


### PR DESCRIPTION
This PR fixes a few separate issues in `can_rebase_on()` and `can_add_to()`:
- In `FieldSelection.can_add_to()`, when recursing into the selection set, the wrong type position was passed in (it should be the base type of the field's return type, not the field's parent type).
- In `Field.type_if_added_to()`, the result was mistakenly being converted to a `CompositeTypeDefinitionPosition` when it should be an `OutputTypeDefinitionPosition`.
- In `Field.can_rebase_on()`, the wrong schema was being passed into the call to `is_interface_object()` (it should be the field's, based on the JS code).
- In `InlineFragmentData.can_rebase_on()`, the wrong schema was being passed in when getting the casted type and executing `runtime_types_intersect()` (it should be the schema of the given parent type, based on the JS code).
- In `FieldSelection.can_add_to()` and `InlineFragmentSelection.can_add_to()`, the clause before recursing into the selection set (if it exists) should check both the schema and type position, not just the type position.
- Methods have been converted to return `Result<bool, FederationError>`, to more easily permit returning internal errors (previously these were being treated as the selection being unable to rebase). E.g. in `Field.type_if_added_to()`, fetching the field's return type and converting it to an output type should always succeed, and if the parent type/schema matches the field's, looking up the field in the schema should always succeed as well. Similarly, in `Field.can_add_to()`, when the field has a selection set, the field's return type should always be composite.
- Methods have also been cleaned up a bit:
  - Schema/type position checks have been made a bit more consistent structure-wise.
  - In `FieldSelection.can_add_to()` and `InlineFragmentSelection.can_add_to()`, recursing into the selection set has been changed to call `SelectionSet.can_rebase_on()`.
- Update tests.
  - Two tests in `merged_abstract_types_handling.rs` now succeed.
  - One test in `build_query_plan_tests.rs` now fails for a different reason. 