### PR TITLE
Prevent formatting in hot path

### DIFF
--- a/.changesets/fix_bryn_demand_control_formatting_hot_path.md
+++ b/.changesets/fix_bryn_demand_control_formatting_hot_path.md
@@ -1,0 +1,5 @@
+### Prevent formatting in hot path ([PR #5405](https://github.com/apollographql/router/pull/5405))
+
+This PR removed unneeded formatting in the hot path for demand control. Improving performance.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5405

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -68,12 +68,12 @@ impl StaticCostCalculator {
             return Ok(0.0);
         }
 
-        let ty = field
-            .inner_type_def(schema)
-            .ok_or(DemandControlError::QueryParseFailure(format!(
+        let ty = field.inner_type_def(schema).ok_or_else(|| {
+            DemandControlError::QueryParseFailure(format!(
                 "Field {} was found in query, but its type is missing from the schema.",
                 field.name
-            )))?;
+            ))
+        })?;
 
         // Determine how many instances we're scoring. If there's no user-provided
         // information, assume lists have 100 items.
@@ -137,12 +137,12 @@ impl StaticCostCalculator {
         executable: &ExecutableDocument,
         should_estimate_requires: bool,
     ) -> Result<f64, DemandControlError> {
-        let fragment = fragment_spread.fragment_def(executable).ok_or(
+        let fragment = fragment_spread.fragment_def(executable).ok_or_else(|| {
             DemandControlError::QueryParseFailure(format!(
                 "Parsed operation did not have a definition for fragment {}",
                 fragment_spread.fragment_name
-            )),
-        )?;
+            ))
+        })?;
         self.score_selection_set(
             &fragment.selection_set,
             parent_type,


### PR DESCRIPTION
The following pattern was being used in the hot path for demand control:

```
field.inner_type_def(schema).ok_or(
            DemandControlError::QueryParseFailure(format!(
                "Field {} was found in query, but its type is missing from the schema.",
                field.name
            ))
        )?;
```

This was causing formatting and heap allocations for every visit of a field.
Changed to:
```
field.inner_type_def(schema).ok_or_else(|| {
            DemandControlError::QueryParseFailure(format!(
                "Field {} was found in query, but its type is missing from the schema.",
                field.name
            ))
        })?;
```
Surprised clippy didn't notice this

Flamegraph before:
<img width="2541" alt="image" src="https://github.com/apollographql/router/assets/747836/1bcfc119-4171-4e4b-a30f-a04518df2984">
demand-control-instrumented | basic | 4608 | 4000 | 7000 | True | 6 | 501 | 78.637681
-- | -- | -- | -- | -- | -- | -- | -- | --


After:
<img width="2542" alt="image" src="https://github.com/apollographql/router/assets/747836/9535295b-d4bd-48ea-93c0-893e79fe9721">

simulation | scenario | rps | minRps | maxRps | success | min_latency_ms | max_latency_ms | mean_latency_ms
-- | -- | -- | -- | -- | -- | -- | -- | --
demand-control-instrumented | basic | 5816 | 4000 | 7000 | True | 5 | 501 | 22.942708




<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
