### PR TITLE
feat(telemetry): add description and units to standard instruments

### DIFF
--- a/.changesets/feat_bnjjj_add_missing_units_desc_instruments.md
+++ b/.changesets/feat_bnjjj_add_missing_units_desc_instruments.md
@@ -1,0 +1,5 @@
+### Add description and units to standard instruments ([PR #5407](https://github.com/apollographql/router/pull/5407))
+
+This PR adds description and units to standard instruments available in the router. These descriptions and units have been copy pasted directly from the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/) and are needed for better integrations with APMs.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/5407

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/router/attribute.error.type/metrics.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/router/attribute.error.type/metrics.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/plugins/telemetry/config_new/instruments.rs
-description: Custom counter
+description: error.type attribute
 expression: "&metrics.all()"
 info:
   telemetry:
@@ -13,6 +13,8 @@ info:
               error.type: true
 ---
 - name: http.server.request.duration
+  description: Duration of HTTP server requests.
+  unit: s
   data:
     datapoints:
       - sum: 0.1

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/router/attribute.on_graphql_error/metrics.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/router/attribute.on_graphql_error/metrics.snap
@@ -14,6 +14,8 @@ info:
                 on_graphql_error: true
 ---
 - name: http.server.request.duration
+  description: Duration of HTTP server requests.
+  unit: s
   data:
     datapoints:
       - sum: 0.1

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/router/http.server.active_requests/metrics.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/router/http.server.active_requests/metrics.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/plugins/telemetry/config_new/instruments.rs
-description: Test standard router metrics
+description: Active requests metrics
 expression: "&metrics.all()"
 info:
   telemetry:
@@ -9,8 +9,12 @@ info:
         router:
           http.server.active_requests: true
           http.server.request.duration: false
+        subgraph:
+          http.client.request.duration: false
 ---
 - name: http.server.active_requests
+  description: Number of active HTTP server requests.
+  unit: request
   data:
     datapoints:
       - value: 0

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/router/http.server.request.body.size/metrics.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/router/http.server.request.body.size/metrics.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/plugins/telemetry/config_new/instruments.rs
-description: Test server request body size metrics
+description: Server request body size metrics
 expression: "&metrics.all()"
 info:
   telemetry:
@@ -12,6 +12,8 @@ info:
           http.server.request.body.size: true
 ---
 - name: http.server.request.body.size
+  description: Size of HTTP server request bodies.
+  unit: By
   data:
     datapoints:
       - sum: 35

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/router/http.server.request.body.size_with_custom_attributes/metrics.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/router/http.server.request.body.size_with_custom_attributes/metrics.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/plugins/telemetry/config_new/instruments.rs
-description: Test server request body size metrics
+description: Server request body size metrics
 expression: "&metrics.all()"
 info:
   telemetry:
@@ -12,6 +12,8 @@ info:
           http.server.request.body.size: true
 ---
 - name: http.server.request.body.size
+  description: Size of HTTP server request bodies.
+  unit: By
   data:
     datapoints:
       - sum: 35

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/router/http.server.request.duration/metrics.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/router/http.server.request.duration/metrics.snap
@@ -11,6 +11,8 @@ info:
           http.server.request.duration: true
 ---
 - name: http.server.request.duration
+  description: Duration of HTTP server requests.
+  unit: s
   data:
     datapoints:
       - sum: 0.1

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/router/http.server.request.duration_with_custom_attributes/metrics.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/router/http.server.request.duration_with_custom_attributes/metrics.snap
@@ -14,6 +14,8 @@ info:
                 request_method: true
 ---
 - name: http.server.request.duration
+  description: Duration of HTTP server requests.
+  unit: s
   data:
     datapoints:
       - sum: 0.1

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/router/http.server.response.body.size/metrics.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/router/http.server.response.body.size/metrics.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-router/src/plugins/telemetry/config_new/instruments.rs
-description: Test server request body size metrics
+description: Server request body size metrics
 expression: "&metrics.all()"
 info:
   telemetry:
@@ -12,6 +12,8 @@ info:
           http.server.response.body.size: true
 ---
 - name: http.server.response.body.size
+  description: Size of HTTP server response bodies
+  unit: By
   data:
     datapoints:
       - sum: 35

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/router/http.server.response.body.size/metrics.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/router/http.server.response.body.size/metrics.snap
@@ -12,7 +12,7 @@ info:
           http.server.response.body.size: true
 ---
 - name: http.server.response.body.size
-  description: Size of HTTP server response bodies
+  description: Size of HTTP server response bodies.
   unit: By
   data:
     datapoints:

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -93,7 +93,13 @@ impl InstrumentsConfig {
                 inner: Mutex::new(CustomHistogramInner {
                     increment: Increment::Duration(Instant::now()),
                     condition: Condition::True,
-                    histogram: Some(meter.f64_histogram("http.server.request.duration").init()),
+                    histogram: Some(
+                        meter
+                            .f64_histogram("http.server.request.duration")
+                            .with_unit(Unit::new("s"))
+                            .with_description("Duration of HTTP server requests.")
+                            .init(),
+                    ),
                     attributes: Vec::new(),
                     selector: None,
                     selectors: match &self.router.attributes.http_server_request_duration {
@@ -126,7 +132,11 @@ impl InstrumentsConfig {
                             increment: Increment::Custom(None),
                             condition: Condition::True,
                             histogram: Some(
-                                meter.f64_histogram("http.server.request.body.size").init(),
+                                meter
+                                    .f64_histogram("http.server.request.body.size")
+                                    .with_unit(Unit::new("By"))
+                                    .with_description("Size of HTTP server request bodies.")
+                                    .init(),
                             ),
                             attributes: Vec::with_capacity(nb_attributes),
                             selector: Some(Arc::new(RouterSelector::RequestHeader {
@@ -160,7 +170,11 @@ impl InstrumentsConfig {
                             increment: Increment::Custom(None),
                             condition: Condition::True,
                             histogram: Some(
-                                meter.f64_histogram("http.server.response.body.size").init(),
+                                meter
+                                    .f64_histogram("http.server.response.body.size")
+                                    .with_unit(Unit::new("By"))
+                                    .with_description("Size of HTTP server response bodies")
+                                    .init(),
                             ),
                             attributes: Vec::with_capacity(nb_attributes),
                             selector: Some(Arc::new(RouterSelector::ResponseHeader {
@@ -183,6 +197,8 @@ impl InstrumentsConfig {
                     counter: Some(
                         meter
                             .i64_up_down_counter("http.server.active_requests")
+                            .with_unit(Unit::new("request"))
+                            .with_description("Number of active HTTP server requests.")
                             .init(),
                     ),
                     attrs_config: match &self.router.attributes.http_server_active_requests {
@@ -213,34 +229,39 @@ impl InstrumentsConfig {
 
     pub(crate) fn new_subgraph_instruments(&self) -> SubgraphInstruments {
         let meter = metrics::meter_provider().meter(METER_NAME);
-        let http_client_request_duration = self
-            .subgraph
-            .attributes
-            .http_client_request_duration
-            .is_enabled()
-            .then(|| {
-                let mut nb_attributes = 0;
-                let selectors = match &self.subgraph.attributes.http_client_request_duration {
-                    DefaultedStandardInstrument::Bool(_) | DefaultedStandardInstrument::Unset => {
-                        None
+        let http_client_request_duration =
+            self.subgraph
+                .attributes
+                .http_client_request_duration
+                .is_enabled()
+                .then(|| {
+                    let mut nb_attributes = 0;
+                    let selectors = match &self.subgraph.attributes.http_client_request_duration {
+                        DefaultedStandardInstrument::Bool(_)
+                        | DefaultedStandardInstrument::Unset => None,
+                        DefaultedStandardInstrument::Extendable { attributes } => {
+                            nb_attributes = attributes.custom.len();
+                            Some(attributes.clone())
+                        }
+                    };
+                    CustomHistogram {
+                        inner: Mutex::new(CustomHistogramInner {
+                            increment: Increment::Duration(Instant::now()),
+                            condition: Condition::True,
+                            histogram: Some(
+                                meter
+                                    .f64_histogram("http.client.request.duration")
+                                    .with_unit(Unit::new("s"))
+                                    .with_description("Duration of HTTP client requests.")
+                                    .init(),
+                            ),
+                            attributes: Vec::with_capacity(nb_attributes),
+                            selector: None,
+                            selectors,
+                            updated: false,
+                        }),
                     }
-                    DefaultedStandardInstrument::Extendable { attributes } => {
-                        nb_attributes = attributes.custom.len();
-                        Some(attributes.clone())
-                    }
-                };
-                CustomHistogram {
-                    inner: Mutex::new(CustomHistogramInner {
-                        increment: Increment::Duration(Instant::now()),
-                        condition: Condition::True,
-                        histogram: Some(meter.f64_histogram("http.client.request.duration").init()),
-                        attributes: Vec::with_capacity(nb_attributes),
-                        selector: None,
-                        selectors,
-                        updated: false,
-                    }),
-                }
-            });
+                });
         let http_client_request_body_size =
             self.subgraph
                 .attributes
@@ -261,7 +282,11 @@ impl InstrumentsConfig {
                             increment: Increment::Custom(None),
                             condition: Condition::True,
                             histogram: Some(
-                                meter.f64_histogram("http.client.request.body.size").init(),
+                                meter
+                                    .f64_histogram("http.client.request.body.size")
+                                    .with_unit(Unit::new("By"))
+                                    .with_description("	Size of HTTP client request bodies.")
+                                    .init(),
                             ),
                             attributes: Vec::with_capacity(nb_attributes),
                             selector: Some(Arc::new(SubgraphSelector::SubgraphRequestHeader {
@@ -294,7 +319,11 @@ impl InstrumentsConfig {
                             increment: Increment::Custom(None),
                             condition: Condition::True,
                             histogram: Some(
-                                meter.f64_histogram("http.client.response.body.size").init(),
+                                meter
+                                    .f64_histogram("http.client.response.body.size")
+                                    .with_unit(Unit::new("By"))
+                                    .with_description("	Size of HTTP client response bodies.")
+                                    .init(),
                             ),
                             attributes: Vec::with_capacity(nb_attributes),
                             selector: Some(Arc::new(SubgraphSelector::SubgraphResponseHeader {

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -173,7 +173,7 @@ impl InstrumentsConfig {
                                 meter
                                     .f64_histogram("http.server.response.body.size")
                                     .with_unit(Unit::new("By"))
-                                    .with_description("Size of HTTP server response bodies")
+                                    .with_description("Size of HTTP server response bodies.")
                                     .init(),
                             ),
                             attributes: Vec::with_capacity(nb_attributes),

--- a/apollo-router/src/plugins/telemetry/config_new/instruments.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/instruments.rs
@@ -285,7 +285,7 @@ impl InstrumentsConfig {
                                 meter
                                     .f64_histogram("http.client.request.body.size")
                                     .with_unit(Unit::new("By"))
-                                    .with_description("	Size of HTTP client request bodies.")
+                                    .with_description("Size of HTTP client request bodies.")
                                     .init(),
                             ),
                             attributes: Vec::with_capacity(nb_attributes),
@@ -322,7 +322,7 @@ impl InstrumentsConfig {
                                 meter
                                     .f64_histogram("http.client.response.body.size")
                                     .with_unit(Unit::new("By"))
-                                    .with_description("	Size of HTTP client response bodies.")
+                                    .with_description("Size of HTTP client response bodies.")
                                     .init(),
                             ),
                             attributes: Vec::with_capacity(nb_attributes),


### PR DESCRIPTION
This PR adds description and units to standard instruments available in the router. These descriptions and units have been copy pasted directly from the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/) and are needed for better integrations with APMs.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
