### PR TITLE
chore(federation): remove `FederationSchema::schema_mut`

### DIFF
--- a/apollo-federation/src/api_schema.rs
+++ b/apollo-federation/src/api_schema.rs
@@ -146,7 +146,7 @@ pub fn to_api_schema(
 
     remove_core_feature_elements(&mut api_schema)?;
 
-    let schema = api_schema.schema_mut();
+    let mut schema = api_schema.into_inner();
 
     if options.include_defer {
         schema
@@ -160,9 +160,9 @@ pub fn to_api_schema(
             .insert(name!("stream"), stream_definition());
     }
 
-    crate::compat::make_print_schema_compatible(schema);
+    crate::compat::make_print_schema_compatible(&mut schema);
 
-    api_schema.validate()
+    ValidFederationSchema::new(schema.validate()?)
 }
 
 fn defer_definition() -> Node<DirectiveDefinition> {

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -63,10 +63,6 @@ impl FederationSchema {
         &self.schema
     }
 
-    pub(crate) fn schema_mut(&mut self) -> &mut Schema {
-        &mut self.schema
-    }
-
     /// Discard the Federation metadata and return the apollo-compiler schema.
     pub fn into_inner(self) -> Schema {
         self.schema


### PR DESCRIPTION
`FederationSchema` requires that the schema isn't modified behind its back. Otherwise the referencers may get out of sync. With `schema_mut()`, you could modify types directly and cause bugs.

Only API schema was using this function. It doesn't use it in a way that would affect referencers, but the method should still not exist. Here I replaced it by unwrapping the schema and then re-wrapping it after API schema has done its thing. It means referencers will be re-computed, but all in all that's not the biggest issue in the world.