### PR TITLE
Fix bug in `advance_with_operation_element()` where type explosion should be avoided

### DIFF
--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -2511,7 +2511,7 @@ impl OpGraphPath {
                                 TypeDefinitionPosition::Scalar(_) | TypeDefinitionPosition::Enum(_)
                             );
                             if is_operation_field_type_leaf
-                                && self.has_an_entity_implementation_with_shareable_field(
+                                || !self.has_an_entity_implementation_with_shareable_field(
                                     &tail_weight.source,
                                     tail_type_pos.field(
                                         operation_field.data().field_position.field_name().clone(),


### PR DESCRIPTION
This PR fixes a bug in `OpGraphPath.advance_with_operation_element()` where, when dealing with a field on an interface type, type explosion was mistakenly performed when it shouldn't have been.