### PR TITLE
Fix bugs in interface object checking

### DIFF
--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -20,6 +20,7 @@ use apollo_compiler::Node;
 use apollo_compiler::NodeStr;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
+use itertools::Itertools;
 use multimap::MultiMap;
 use petgraph::stable_graph::EdgeIndex;
 use petgraph::stable_graph::NodeIndex;
@@ -1206,21 +1207,20 @@ impl FetchDependencyGraph {
             if condition.is_interface_type() {
                 // Lastly, we just need to check that we're coming from a subgraph
                 // that has the type as an interface object in its schema.
-                Ok(self.parents_of(node_index).any(|p| {
-                    let Ok(p_node) = self.node_weight(p) else {
-                        return false;
-                    };
-                    let p_subgraph_name = &p_node.subgraph_name;
-                    let Ok(p_subgraph_schema) = get_subgraph_schema(p_subgraph_name) else {
-                        return false;
-                    };
-                    let Ok(type_in_parent) =
-                        p_subgraph_schema.get_type(condition.type_name().clone())
-                    else {
-                        return false;
-                    };
-                    type_in_parent.is_interface_object_type(&p_subgraph_schema)
-                }))
+                Ok(self
+                    .parents_of(node_index)
+                    .map(|p| {
+                        let p_node = self.node_weight(p)?;
+                        let p_subgraph_name = &p_node.subgraph_name;
+                        let p_subgraph_schema = get_subgraph_schema(p_subgraph_name)?;
+                        let Ok(type_in_parent) =
+                            p_subgraph_schema.get_type(condition.type_name().clone())
+                        else {
+                            return Ok(false);
+                        };
+                        p_subgraph_schema.is_interface_object_type(type_in_parent)
+                    })
+                    .process_results(|mut iter| iter.any(|b| b))?)
             } else {
                 Ok(false)
             }
@@ -3063,6 +3063,10 @@ fn compute_nodes_for_key_resolution<'a>(
     // We shouldn't have a key on a non-composite type
     let source_type: CompositeTypeDefinitionPosition = source.type_.clone().try_into()?;
     let dest_type: CompositeTypeDefinitionPosition = dest.type_.clone().try_into()?;
+    let dest_schema: ValidFederationSchema = dependency_graph
+        .federated_query_graph
+        .schema_by_source(&dest.source)?
+        .clone();
     let path_in_parent = &stack_item.node_path.path_in_node;
     let updated_defer_context = stack_item.defer_context.after_subgraph_jump();
     // Note that we use the name of `dest_type` for the inputs parent type, which can seem strange,
@@ -3140,13 +3144,9 @@ fn compute_nodes_for_key_resolution<'a>(
             input_selections,
             new_context,
         ),
-        compute_input_rewrites_on_key_fetch(
-            &dependency_graph.supergraph_schema,
-            input_type.type_name(),
-            &dest_type,
-        )
-        .into_iter()
-        .flatten(),
+        compute_input_rewrites_on_key_fetch(input_type.type_name(), &dest_type, &dest_schema)?
+            .into_iter()
+            .flatten(),
     )?;
 
     // We also ensure to get the __typename of the current type in the "original" node.
@@ -3563,17 +3563,19 @@ fn create_fetch_initial_path(
 }
 
 fn compute_input_rewrites_on_key_fetch(
-    supergraph_schema: &ValidFederationSchema,
     input_type_name: &NodeStr,
     dest_type: &CompositeTypeDefinitionPosition,
-) -> Option<Vec<Arc<FetchDataRewrite>>> {
+    dest_schema: &ValidFederationSchema,
+) -> Result<Option<Vec<Arc<FetchDataRewrite>>>, FederationError> {
     // When we send a fetch to a subgraph, the inputs __typename must essentially match `dest_type`
     // so the proper __resolveReference is called. If `dest_type` is a "normal" object type, that's
     // going to be fine by default, but if `dest_type` is an interface in the supergraph (meaning
     // that it is either an interface or an interface object), then the underlying object might
     // have a __typename that is the concrete implementation type of the object, and we need to
     // rewrite it.
-    if dest_type.is_interface_type() || dest_type.is_interface_object_type(supergraph_schema) {
+    if dest_type.is_interface_type()
+        || dest_schema.is_interface_object_type(dest_type.clone().into())?
+    {
         // rewrite path: [ ... on <input_type_name>, __typename ]
         let type_cond = FetchDataPathElement::TypenameEquals(input_type_name.clone());
         let typename_field_elem = FetchDataPathElement::Key(TYPENAME_FIELD.into());
@@ -3581,9 +3583,9 @@ fn compute_input_rewrites_on_key_fetch(
             path: vec![type_cond, typename_field_elem],
             set_value_to: dest_type.type_name().to_string().into(),
         });
-        Some(vec![Arc::new(rewrite)])
+        Ok(Some(vec![Arc::new(rewrite)]))
     } else {
-        None
+        Ok(None)
     }
 }
 
@@ -3657,6 +3659,15 @@ fn handle_requires(
         return Err(FederationError::internal(
             "@requires applied on non-entity object type",
         ));
+    };
+    let entity_type_schema = dependency_graph
+        .federated_query_graph
+        .schema_by_source(&head.source)?
+        .clone();
+    let post_require_inputs_edge_info = PostRequireInputsEdgeInfo {
+        entity_type_position: entity_type_position.clone(),
+        entity_type_schema: &entity_type_schema,
+        query_graph_edge_id,
     };
 
     // In many cases, we can optimize @requires by merging the requirement to previously existing nodes. However,
@@ -3912,8 +3923,7 @@ fn handle_requires(
         add_post_require_inputs(
             dependency_graph,
             &path_for_parent,
-            entity_type_position.clone(),
-            query_graph_edge_id,
+            post_require_inputs_edge_info,
             context,
             parent.parent_node_id,
             post_require_node_id,
@@ -3988,8 +3998,7 @@ fn handle_requires(
         add_post_require_inputs(
             dependency_graph,
             fetch_node_path,
-            entity_type_position.clone(),
-            query_graph_edge_id,
+            post_require_inputs_edge_info,
             context,
             fetch_node_id,
             new_node_id,
@@ -4125,29 +4134,34 @@ fn inputs_for_require(
     }
 }
 
+struct PostRequireInputsEdgeInfo<'a> {
+    entity_type_position: ObjectTypeDefinitionPosition,
+    entity_type_schema: &'a ValidFederationSchema,
+    query_graph_edge_id: EdgeIndex,
+}
+
 fn add_post_require_inputs(
     dependency_graph: &mut FetchDependencyGraph,
     require_node_path: &FetchDependencyGraphNodePath,
-    entity_type_position: ObjectTypeDefinitionPosition,
-    query_graph_edge_id: EdgeIndex,
+    edge_info: PostRequireInputsEdgeInfo,
     context: &OpGraphPathContext,
     pre_require_node_id: NodeIndex,
     post_require_node_id: NodeIndex,
 ) -> Result<(), FederationError> {
     let (inputs, key_inputs) = inputs_for_require(
         dependency_graph,
-        entity_type_position.clone(),
-        query_graph_edge_id,
+        edge_info.entity_type_position.clone(),
+        edge_info.query_graph_edge_id,
         context,
         true,
     )?;
     // Note that `compute_input_rewrites_on_key_fetch` will return `None` in general, but if `entity_type_position` is an interface/interface object,
     // then we need those rewrites to ensure the underlying fetch is valid.
     let input_rewrites = compute_input_rewrites_on_key_fetch(
-        &dependency_graph.supergraph_schema,
-        &entity_type_position.type_name.clone(),
-        &entity_type_position.into(),
-    );
+        &edge_info.entity_type_position.type_name.clone(),
+        &edge_info.entity_type_position.into(),
+        edge_info.entity_type_schema,
+    )?;
     let post_require_node =
         FetchDependencyGraph::node_weight_mut(&mut dependency_graph.graph, post_require_node_id)?;
     post_require_node.add_inputs(&inputs, input_rewrites.into_iter().flatten())?;

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -279,6 +279,28 @@ impl ValidFederationSchema {
 
         todo!()
     }
+
+    pub(crate) fn is_interface_object_type(
+        &self,
+        type_definition_position: TypeDefinitionPosition,
+    ) -> Result<bool, FederationError> {
+        let Some(subgraph_metadata) = &self.subgraph_metadata else {
+            return Ok(false);
+        };
+        let Some(interface_object_directive_definition) = subgraph_metadata
+            .federation_spec_definition()
+            .interface_object_directive_definition(self)?
+        else {
+            return Ok(false);
+        };
+        match type_definition_position {
+            TypeDefinitionPosition::Object(type_) => Ok(type_
+                .get(self.schema())?
+                .directives
+                .has(&interface_object_directive_definition.name)),
+            _ => Ok(false),
+        }
+    }
 }
 
 impl Deref for ValidFederationSchema {

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -30,7 +30,6 @@ use strum::IntoEnumIterator;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
 use crate::link::database::links_metadata;
-use crate::link::federation_spec_definition::get_federation_spec_definition_from_subgraph;
 use crate::link::spec_definition::SpecDefinition;
 use crate::schema::referencer::DirectiveReferencers;
 use crate::schema::referencer::EnumTypeReferencers;
@@ -108,14 +107,6 @@ impl TypeDefinitionPosition {
         schema: &'schema Schema,
     ) -> Option<&'schema ExtendedType> {
         self.get(schema).ok()
-    }
-
-    pub(crate) fn is_interface_object_type(&self, schema: &FederationSchema) -> bool {
-        match self {
-            TypeDefinitionPosition::Object(obj) => obj.is_interface_object_type(schema),
-
-            _ => false,
-        }
     }
 }
 
@@ -508,14 +499,6 @@ impl CompositeTypeDefinitionPosition {
         schema: &'schema Schema,
     ) -> Option<&'schema ExtendedType> {
         self.get(schema).ok()
-    }
-
-    pub(crate) fn is_interface_object_type(&self, schema: &FederationSchema) -> bool {
-        match self {
-            CompositeTypeDefinitionPosition::Object(obj) => obj.is_interface_object_type(schema),
-
-            _ => false,
-        }
     }
 }
 
@@ -1887,17 +1870,6 @@ impl ObjectTypeDefinitionPosition {
         schema: &'schema Schema,
     ) -> Option<&'schema Node<ObjectType>> {
         self.get(schema).ok()
-    }
-
-    pub(crate) fn is_interface_object_type(&self, schema: &FederationSchema) -> bool {
-        if let Ok(interface_obj_directive) = get_federation_spec_definition_from_subgraph(schema)
-            .and_then(|spec| spec.interface_object_directive(schema))
-        {
-            self.try_get(schema.schema())
-                .is_some_and(|o| o.directives.has(&interface_obj_directive.name))
-        } else {
-            false
-        }
     }
 
     fn make_mut<'schema>(


### PR DESCRIPTION
While reviewing #5401, I noticed we had some bugs when checking for interface objects. This PR:
- Fixes a bug in `compute_input_rewrites_on_key_fetch()` where it was passing the wrong schema in when checking whether a type was an interface object.
  - Note that this required adding an argument to `add_post_require_inputs()`, which then caused Clippy to complain about there being too many arguments. I've accordingly split some of the arguments out into a separate struct.
- Fixes a bug in `is_interface_object_type()` where it silently ignores if the type doesn't exist, or if the `@interfaceObject` directive definition is missing. 
  - This requires changing it and some upstream callers to return `Result`s.
- Fixes a bug in `is_useless_node()` where it silently ignores if a node or its subgraph schema doesn't exist. 
- Changes `is_interface_object_type()` to be on `ValidFederationSchema` instead of on schema positions.
  - The JS codebase placed this function on `FederationMetadata` (renamed to `SubgraphMetadata` in Rust). We can't put it on `SubgraphMetadata` since it doesn't have access to the schema (to avoid circular references), but I've hoisted the method up to `ValidFederationSchema` instead.
  - I'm hesitant about adding subgraph-specific logic to schema positions, as it goes against the current separation of concerns (it's also a bit repetitive at the moment, and `position.rs` is already quite large).