### PR TITLE
docs(telemetry): add docs about standard instruments for subgraph

### DIFF
--- a/.changesets/docs_bnjjj_docs_standard_instr.md
+++ b/.changesets/docs_bnjjj_docs_standard_instr.md
@@ -1,6 +1,6 @@
 ### Standard instrument configuration documentation for subgraphs ([PR #5422](https://github.com/apollographql/router/pull/5422))
 
-Added documentations about standard instruments available at the subgraph service:
+Added documentation about standard instruments available at the subgraph service level:
 
   * `http.client.request.body.size` - A histogram of request body sizes for requests handled by subgraphs.
   * `http.client.request.duration` - A histogram of request durations for requests handled by subgraphs.

--- a/.changesets/docs_bnjjj_docs_standard_instr.md
+++ b/.changesets/docs_bnjjj_docs_standard_instr.md
@@ -1,4 +1,4 @@
-### docs(telemetry): add docs about standard instruments for subgraph ([PR #5422](https://github.com/apollographql/router/pull/5422))
+### Standard instrument configuration documentation for subgraphs ([PR #5422](https://github.com/apollographql/router/pull/5422))
 
 Added documentations about standard instruments available at the subgraph service:
 

--- a/.changesets/docs_bnjjj_docs_standard_instr.md
+++ b/.changesets/docs_bnjjj_docs_standard_instr.md
@@ -1,0 +1,22 @@
+### docs(telemetry): add docs about standard instruments for subgraph ([PR #5422](https://github.com/apollographql/router/pull/5422))
+
+Added documentations about standard instruments available at the subgraph service:
+
+  * `http.client.request.body.size` - A histogram of request body sizes for requests handled by subgraphs.
+  * `http.client.request.duration` - A histogram of request durations for requests handled by subgraphs.
+  * `http.client.response.body.size` - A histogram of response body sizes for requests handled by subgraphs.
+
+
+These instruments are configurable in `router.yaml`:
+
+```yaml title="router.yaml"
+telemetry:
+  instrumentation:
+    instruments:
+      subgraph:
+        http.client.request.body.size: true # (default false)
+        http.client.request.duration: true # (default false)
+        http.client.response.body.size: true # (default false)
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/5422

--- a/docs/source/configuration/telemetry/instrumentation/instruments.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/instruments.mdx
@@ -17,10 +17,19 @@ You can configure instruments in `router.yaml` with `telemetry.instrumentation.i
 
 OpenTelemetry specifies multiple [standard metric instruments](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/) that are available in the router:
 
-* `http.server.active_requests` - The number of active requests in flight.
-* `http.server.request.body.size` - A histogram of request body sizes for requests handled by the router.
-* `http.server.request.duration` - A histogram of request durations for requests handled by the router.
-* `http.server.response.body.size` - A histogram of response body sizes for requests handled by the router.
++ At the router service:
+
+  * `http.server.active_requests` - The number of active requests in flight.
+  * `http.server.request.body.size` - A histogram of request body sizes for requests handled by the router.
+  * `http.server.request.duration` - A histogram of request durations for requests handled by the router.
+  * `http.server.response.body.size` - A histogram of response body sizes for requests handled by the router.
+
++ At the subgraph service:
+
+  * `http.client.request.body.size` - A histogram of request body sizes for requests handled by subgraphs.
+  * `http.client.request.duration` - A histogram of request durations for requests handled by subgraphs.
+  * `http.client.response.body.size` - A histogram of response body sizes for requests handled by subgraphs.
+
 
 These instruments are configurable in `router.yaml`:
 
@@ -33,6 +42,10 @@ telemetry:
         http.server.request.body.size: true # (default false)
         http.server.request.duration: true # (default false)
         http.server.response.body.size: true # (default false)
+      subgraph:
+        http.client.request.body.size: true # (default false)
+        http.client.request.duration: true # (default false)
+        http.client.response.body.size: true # (default false)
 ```
 
 They can be customized by attaching or removing attributes. See [attributes](#attributes) to learn more about configuring attributes.
@@ -46,6 +59,10 @@ telemetry:
         http.server.active_requests: 
           attributes:
             http.request.method: true
+      subgraph:
+        http.client.request.duration:
+          attributes:
+            subgraph.name: true
 ```
 
 ### Apollo standard instruments

--- a/docs/source/configuration/telemetry/instrumentation/instruments.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/instruments.mdx
@@ -22,7 +22,6 @@ OpenTelemetry specifies multiple [standard metric instruments](https://opentelem
   * `http.server.active_requests` - The number of active requests in flight.
   * `http.server.request.body.size` - A histogram of request body sizes for requests handled by the router.
   * `http.server.request.duration` - A histogram of request durations for requests handled by the router.
-  * `http.server.response.body.size` - A histogram of response body sizes for requests handled by the router.
 
 + In the [subgraph service](#router-request-lifecycle-services):
 
@@ -41,7 +40,6 @@ telemetry:
         http.server.active_requests: true # (default false)
         http.server.request.body.size: true # (default false)
         http.server.request.duration: true # (default false)
-        http.server.response.body.size: true # (default false)
       subgraph:
         http.client.request.body.size: true # (default false)
         http.client.request.duration: true # (default false)

--- a/docs/source/configuration/telemetry/instrumentation/instruments.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/instruments.mdx
@@ -17,14 +17,14 @@ You can configure instruments in `router.yaml` with `telemetry.instrumentation.i
 
 OpenTelemetry specifies multiple [standard metric instruments](https://opentelemetry.io/docs/specs/semconv/http/http-metrics/) that are available in the router:
 
-+ At the router service:
++ In the [router service](#router-request-lifecycle-services):
 
   * `http.server.active_requests` - The number of active requests in flight.
   * `http.server.request.body.size` - A histogram of request body sizes for requests handled by the router.
   * `http.server.request.duration` - A histogram of request durations for requests handled by the router.
   * `http.server.response.body.size` - A histogram of response body sizes for requests handled by the router.
 
-+ At the subgraph service:
++ In the [subgraph service](#router-request-lifecycle-services):
 
   * `http.client.request.body.size` - A histogram of request body sizes for requests handled by subgraphs.
   * `http.client.request.duration` - A histogram of request durations for requests handled by subgraphs.


### PR DESCRIPTION
Added documentations about standard instruments available at the subgraph service:

  * `http.client.request.body.size` - A histogram of request body sizes for requests handled by subgraphs.
  * `http.client.request.duration` - A histogram of request durations for requests handled by subgraphs.
  * `http.client.response.body.size` - A histogram of response body sizes for requests handled by subgraphs.


These instruments are configurable in `router.yaml`:

```yaml title="router.yaml"
telemetry:
  instrumentation:
    instruments:
      subgraph:
        http.client.request.body.size: true # (default false)
        http.client.request.duration: true # (default false)
        http.client.response.body.size: true # (default false)
```


---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
