### PR TITLE
new versions of make_requests and handle_responses that use apollo-federation's Connector

### DIFF
--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -4,7 +4,6 @@ use std::hash::Hasher;
 use std::sync::Arc;
 
 use apollo_compiler::ast::Name;
-use apollo_compiler::name;
 use apollo_compiler::NodeStr;
 use indexmap::IndexMap;
 
@@ -13,6 +12,7 @@ mod models;
 pub(crate) mod spec;
 mod url_path_template;
 
+use apollo_compiler::name;
 pub use json_selection::ApplyTo;
 pub use json_selection::ApplyToError;
 pub use json_selection::JSONSelection;
@@ -32,6 +32,8 @@ pub use self::models::HttpJsonTransport;
 pub use self::models::Transport;
 use super::to_remove::SourceId;
 use crate::schema::position::ObjectOrInterfaceFieldDirectivePosition;
+use crate::schema::ObjectFieldDefinitionPosition;
+use crate::schema::ObjectOrInterfaceFieldDefinitionPosition;
 
 pub type Connectors = Arc<IndexMap<SourceId, Connector>>;
 
@@ -64,12 +66,16 @@ impl Display for ConnectId {
 }
 
 impl ConnectId {
-    pub fn new_for_test(subgraph_name: NodeStr, type_name: Name, field_name: Name) -> Self {
-        use crate::schema::ObjectFieldDefinitionPosition;
-        use crate::schema::ObjectOrInterfaceFieldDefinitionPosition;
-
+    /// Mostly intended for tests in apollo-router
+    pub fn new(
+        subgraph_name: NodeStr,
+        type_name: Name,
+        field_name: Name,
+        index: usize,
+        label: &str,
+    ) -> Self {
         Self {
-            label: "test label".to_string(),
+            label: label.to_string(),
             subgraph_name,
             directive: ObjectOrInterfaceFieldDirectivePosition {
                 field: ObjectOrInterfaceFieldDefinitionPosition::Object(
@@ -79,7 +85,7 @@ impl ConnectId {
                     },
                 ),
                 directive_name: name!(connect),
-                directive_index: 0,
+                directive_index: index,
             },
         }
     }

--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -3,6 +3,8 @@ use std::hash::Hash;
 use std::hash::Hasher;
 use std::sync::Arc;
 
+use apollo_compiler::ast::Name;
+use apollo_compiler::name;
 use apollo_compiler::NodeStr;
 use indexmap::IndexMap;
 
@@ -58,5 +60,27 @@ impl Hash for ConnectId {
 impl Display for ConnectId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.label)
+    }
+}
+
+impl ConnectId {
+    pub fn new_for_test(subgraph_name: NodeStr, type_name: Name, field_name: Name) -> Self {
+        use crate::schema::ObjectFieldDefinitionPosition;
+        use crate::schema::ObjectOrInterfaceFieldDefinitionPosition;
+
+        Self {
+            label: "test label".to_string(),
+            subgraph_name,
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: ObjectOrInterfaceFieldDefinitionPosition::Object(
+                    ObjectFieldDefinitionPosition {
+                        type_name,
+                        field_name,
+                    },
+                ),
+                directive_name: name!(connect),
+                directive_index: 0,
+            },
+        }
     }
 }

--- a/apollo-federation/src/sources/connect/models/mod.rs
+++ b/apollo-federation/src/sources/connect/models/mod.rs
@@ -26,6 +26,8 @@ pub struct Connector {
     pub id: ConnectId,
     pub transport: Transport,
     pub selection: JSONSelection,
+    pub entity: bool,
+    pub on_root_type: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -80,6 +82,18 @@ impl Connector {
                     source_http,
                 )?);
 
+                let parent_type_name = args.position.field.type_name().clone();
+                let schema_def = &schema.schema().schema_definition;
+                let on_root_type = schema_def
+                    .query
+                    .as_ref()
+                    .map(|ty| ty.name == parent_type_name)
+                    .or(schema_def
+                        .mutation
+                        .as_ref()
+                        .map(|ty| ty.name == parent_type_name))
+                    .unwrap_or(false);
+
                 let id = ConnectId {
                     label: make_label(&subgraph_name, source_name, &transport),
                     subgraph_name: subgraph_name.clone(),
@@ -90,6 +104,8 @@ impl Connector {
                     id: id.clone(),
                     transport,
                     selection: args.selection,
+                    entity: args.entity,
+                    on_root_type,
                 };
 
                 Ok((id, connector))

--- a/apollo-federation/src/sources/connect/models/mod.rs
+++ b/apollo-federation/src/sources/connect/models/mod.rs
@@ -281,6 +281,8 @@ mod tests {
                         star: None,
                     },
                 ),
+                entity: false,
+                on_root_type: true,
             },
             ConnectId {
                 label: "connectors.json http: Get /posts",
@@ -356,6 +358,8 @@ mod tests {
                         star: None,
                     },
                 ),
+                entity: false,
+                on_root_type: true,
             },
         }
         "###);

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -61,6 +61,7 @@ pub(super) async fn handle_responses(
 
             let mut res_data = {
                 let (res, _apply_to_errors) = connector.selection.apply_to(&json_data);
+                // TODO log apply_to_errors as diagnostics
                 res.unwrap_or_else(|| Value::Null)
             };
 
@@ -149,10 +150,7 @@ pub(super) async fn handle_responses(
         }
     }
 
-    let data = match data.is_empty() {
-        true => None,
-        false => Some(Value::Object(data)),
-    };
+    let data = (!data.is_empty()).then(|| Value::Object(data));
 
     let response = SubgraphResponse::builder()
         .and_data(data)
@@ -201,7 +199,13 @@ mod tests {
     #[tokio::test]
     async fn test_handle_responses_root_fields() {
         let connector = Connector {
-            id: ConnectId::new_for_test("subgraph_name".into(), name!(Query), name!(hello)),
+            id: ConnectId::new(
+                "subgraph_name".into(),
+                name!(Query),
+                name!(hello),
+                0,
+                "test label",
+            ),
             transport: Transport::HttpJson(HttpJsonTransport {
                 base_url: "http://localhost/api".into(),
                 path_template: URLPathTemplate::parse("/path").unwrap(),
@@ -269,7 +273,13 @@ mod tests {
     #[tokio::test]
     async fn test_handle_responses_entities() {
         let connector = Connector {
-            id: ConnectId::new_for_test("subgraph_name".into(), name!(Query), name!(user)),
+            id: ConnectId::new(
+                "subgraph_name".into(),
+                name!(Query),
+                name!(user),
+                0,
+                "test label",
+            ),
             transport: Transport::HttpJson(HttpJsonTransport {
                 base_url: "http://localhost/api".into(),
                 path_template: URLPathTemplate::parse("/path").unwrap(),
@@ -354,7 +364,13 @@ mod tests {
     #[tokio::test]
     async fn test_handle_responses_entity_field() {
         let connector = Connector {
-            id: ConnectId::new_for_test("subgraph_name".into(), name!(User), name!(field)),
+            id: ConnectId::new(
+                "subgraph_name".into(),
+                name!(User),
+                name!(field),
+                0,
+                "test label",
+            ),
             transport: Transport::HttpJson(HttpJsonTransport {
                 base_url: "http://localhost/api".into(),
                 path_template: URLPathTemplate::parse("/path").unwrap(),
@@ -441,7 +457,13 @@ mod tests {
     #[tokio::test]
     async fn test_handle_responses_errors() {
         let connector = Connector {
-            id: ConnectId::new_for_test("subgraph_name".into(), name!(Query), name!(user)),
+            id: ConnectId::new(
+                "subgraph_name".into(),
+                name!(Query),
+                name!(user),
+                0,
+                "test label",
+            ),
             transport: Transport::HttpJson(HttpJsonTransport {
                 base_url: "http://localhost/api".into(),
                 path_template: URLPathTemplate::parse("/path").unwrap(),

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -1,0 +1,558 @@
+use apollo_compiler::validation::Valid;
+use apollo_compiler::Schema;
+use apollo_federation::sources::connect::ApplyTo;
+use apollo_federation::sources::connect::Connector;
+use serde_json_bytes::ByteString;
+use serde_json_bytes::Value;
+
+use crate::json_ext::Object;
+use crate::plugins::connectors::make_requests::ResponseKey;
+use crate::plugins::connectors::make_requests::ResponseTypeName;
+use crate::services::SubgraphResponse;
+use crate::Context;
+
+const ENTITIES: &str = "_entities";
+const TYPENAME: &str = "__typename";
+
+// --- ERRORS ------------------------------------------------------------------
+
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
+pub(super) enum HandleResponseError {
+    /// Missing response key
+    MissingResponseKey,
+
+    /// Invalid response body: {0}
+    InvalidResponseBody(String),
+
+    /// Merge error: {0}
+    MergeError(String),
+}
+
+// --- RESPONSES ---------------------------------------------------------------
+
+pub(super) async fn handle_responses(
+    responses: Vec<http::Response<hyper::Body>>,
+    connector: &Connector,
+    context: Context,
+    _schema: &Valid<Schema>,   // TODO for future apply_with_selection
+    _document: Option<String>, // TODO pass in relevant selection set, not the whole operation
+) -> Result<SubgraphResponse, HandleResponseError> {
+    use HandleResponseError::*;
+
+    let mut data = serde_json_bytes::Map::new();
+    let mut errors = Vec::new();
+    let count = responses.len();
+
+    for response in responses {
+        let (parts, body) = response.into_parts();
+
+        let response_key = parts
+            .extensions
+            .get::<ResponseKey>()
+            .ok_or(MissingResponseKey)?;
+
+        let body = &hyper::body::to_bytes(body)
+            .await
+            .map_err(|_| InvalidResponseBody("couldn't retrieve http response body".into()))?;
+
+        if parts.status.is_success() {
+            let json_data: Value = serde_json::from_slice(body)
+                .map_err(|_| InvalidResponseBody("couldn't deserialize response body".into()))?;
+
+            let mut res_data = {
+                let (res, _apply_to_errors) = connector.selection.apply_to(&json_data);
+                res.unwrap_or_else(|| Value::Null)
+            };
+
+            match response_key {
+                // add the response to the "data" using the root field name or alias
+                ResponseKey::RootField {
+                    ref name,
+                    ref typename,
+                } => {
+                    if let ResponseTypeName::Concrete(typename) = typename {
+                        inject_typename(&mut res_data, typename);
+                    }
+
+                    data.insert(name.clone(), res_data);
+                }
+
+                // add the response to the "_entities" array at the right index
+                ResponseKey::Entity {
+                    index,
+                    ref typename,
+                } => {
+                    if let ResponseTypeName::Concrete(typename) = typename {
+                        inject_typename(&mut res_data, typename);
+                    }
+
+                    let entities = data
+                        .entry(ENTITIES)
+                        .or_insert(Value::Array(Vec::with_capacity(count)));
+                    entities
+                        .as_array_mut()
+                        .ok_or_else(|| MergeError("entities is not an array".into()))?
+                        .insert(*index, res_data);
+                }
+
+                // make an entity object and assign the response to the appropriate field or aliased field,
+                // then add the object to the _entities array at the right index (or add the field to an existing object)
+                ResponseKey::EntityField {
+                    index,
+                    ref field_name,
+                    ref typename,
+                } => {
+                    let entities = data
+                        .entry(ENTITIES)
+                        .or_insert(Value::Array(Vec::with_capacity(count)))
+                        .as_array_mut()
+                        .ok_or_else(|| MergeError("entities is not an array".into()))?;
+
+                    match entities.get_mut(*index) {
+                        Some(Value::Object(entity)) => {
+                            entity.insert(field_name.clone(), res_data);
+                        }
+                        _ => {
+                            let mut entity = serde_json_bytes::Map::new();
+                            if let ResponseTypeName::Concrete(typename) = typename {
+                                entity.insert(TYPENAME, Value::String(typename.clone().into()));
+                            }
+                            entity.insert(field_name.clone(), res_data);
+                            entities.insert(*index, Value::Object(entity));
+                        }
+                    };
+                }
+            }
+        } else {
+            match response_key {
+                // add a null to the "_entities" array at the right index
+                ResponseKey::Entity { index, .. } | ResponseKey::EntityField { index, .. } => {
+                    let entities = data
+                        .entry(ENTITIES)
+                        .or_insert(Value::Array(Vec::with_capacity(count)));
+                    entities
+                        .as_array_mut()
+                        .ok_or_else(|| MergeError("entities is not an array".into()))?
+                        .insert(*index, Value::Null);
+                }
+                _ => {}
+            };
+
+            errors.push(
+                crate::graphql::Error::builder()
+                    .message(format!("http error: {}", parts.status))
+                    // todo path: ["_entities", i, "???"]
+                    .extension_code(format!("{}", parts.status.as_u16()))
+                    .extension("connector", connector.id.label.clone())
+                    .build(),
+            );
+        }
+    }
+
+    let data = match data.is_empty() {
+        true => None,
+        false => Some(Value::Object(data)),
+    };
+
+    let response = SubgraphResponse::builder()
+        .and_data(data)
+        .errors(errors)
+        .context(context)
+        .extensions(Object::default())
+        .build();
+
+    Ok(response)
+}
+
+fn inject_typename(data: &mut Value, typename: &str) {
+    match data {
+        Value::Array(data) => {
+            for data in data {
+                inject_typename(data, typename);
+            }
+        }
+        Value::Object(data) => {
+            data.insert(
+                ByteString::from(TYPENAME),
+                Value::String(ByteString::from(typename)),
+            );
+        }
+        _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use apollo_compiler::name;
+    use apollo_compiler::Schema;
+    use apollo_federation::sources::connect::ConnectId;
+    use apollo_federation::sources::connect::Connector;
+    use apollo_federation::sources::connect::HTTPMethod;
+    use apollo_federation::sources::connect::HttpJsonTransport;
+    use apollo_federation::sources::connect::JSONSelection;
+    use apollo_federation::sources::connect::Transport;
+    use apollo_federation::sources::connect::URLPathTemplate;
+    use insta::assert_debug_snapshot;
+
+    use crate::plugins::connectors::make_requests::ResponseKey;
+    use crate::plugins::connectors::make_requests::ResponseTypeName;
+    use crate::Context;
+
+    #[tokio::test]
+    async fn test_handle_responses_root_fields() {
+        let connector = Connector {
+            id: ConnectId::new_for_test("subgraph_name".into(), name!(Query), name!(hello)),
+            transport: Transport::HttpJson(HttpJsonTransport {
+                base_url: "http://localhost/api".into(),
+                path_template: URLPathTemplate::parse("/path").unwrap(),
+                method: HTTPMethod::Get,
+                headers: Default::default(),
+                body: Default::default(),
+            }),
+            selection: JSONSelection::parse(".data").unwrap().1,
+            entity: false,
+            on_root_type: true,
+        };
+
+        let response1 = http::Response::builder()
+            .extension(ResponseKey::RootField {
+                name: "hello".to_string(),
+                typename: ResponseTypeName::Concrete("String".to_string()),
+            })
+            .body(hyper::Body::from(r#"{"data":"world"}"#))
+            .expect("response builder");
+
+        let response2 = http::Response::builder()
+            .extension(ResponseKey::RootField {
+                name: "hello2".to_string(),
+                typename: ResponseTypeName::Concrete("String".to_string()),
+            })
+            .body(hyper::Body::from(r#"{"data":"world"}"#))
+            .expect("response builder");
+
+        let schema = Schema::parse_and_validate("type Query { hello: String }", "./").unwrap();
+
+        let res = super::handle_responses(
+            vec![response1, response2],
+            &connector,
+            Context::default(),
+            &schema,
+            Some("{hello hello2: hello}".to_string()),
+        )
+        .await
+        .unwrap();
+
+        assert_debug_snapshot!(res.response.body(), @r###"
+        Response {
+            label: None,
+            data: Some(
+                Object({
+                    "hello": String(
+                        "world",
+                    ),
+                    "hello2": String(
+                        "world",
+                    ),
+                }),
+            ),
+            path: None,
+            errors: [],
+            extensions: {},
+            has_next: None,
+            subscribed: None,
+            created_at: None,
+            incremental: [],
+        }
+        "###);
+    }
+
+    #[tokio::test]
+    async fn test_handle_responses_entities() {
+        let connector = Connector {
+            id: ConnectId::new_for_test("subgraph_name".into(), name!(Query), name!(user)),
+            transport: Transport::HttpJson(HttpJsonTransport {
+                base_url: "http://localhost/api".into(),
+                path_template: URLPathTemplate::parse("/path").unwrap(),
+                method: HTTPMethod::Get,
+                headers: Default::default(),
+                body: Default::default(),
+            }),
+            selection: JSONSelection::parse(".data { id }").unwrap().1,
+            entity: true,
+            on_root_type: true,
+        };
+
+        let response1 = http::Response::builder()
+            .extension(ResponseKey::Entity {
+                index: 0,
+                typename: ResponseTypeName::Concrete("User".to_string()),
+            })
+            .body(hyper::Body::from(r#"{"data":{"id": "1"}}"#))
+            .expect("response builder");
+
+        let response2 = http::Response::builder()
+            .extension(ResponseKey::Entity {
+                index: 1,
+                typename: ResponseTypeName::Concrete("User".to_string()),
+            })
+            .body(hyper::Body::from(r#"{"data":{"id": "2"}}"#))
+            .expect("response builder");
+
+        let schema = Schema::parse_and_validate(
+            "type Query { user(id: ID!): User }
+            type User { id: ID! }",
+            "./",
+        )
+        .unwrap();
+
+        let res = super::handle_responses(
+            vec![response1, response2],
+            &connector,
+            Context::default(),
+            &schema,
+            Some("query ($representations: [_Any]) {_entities(representations: $representations) { ... on User { id }}}".to_string()),
+        )
+        .await
+        .unwrap();
+
+        assert_debug_snapshot!(res.response.body(), @r###"
+        Response {
+            label: None,
+            data: Some(
+                Object({
+                    "_entities": Array([
+                        Object({
+                            "id": String(
+                                "1",
+                            ),
+                            "__typename": String(
+                                "User",
+                            ),
+                        }),
+                        Object({
+                            "id": String(
+                                "2",
+                            ),
+                            "__typename": String(
+                                "User",
+                            ),
+                        }),
+                    ]),
+                }),
+            ),
+            path: None,
+            errors: [],
+            extensions: {},
+            has_next: None,
+            subscribed: None,
+            created_at: None,
+            incremental: [],
+        }
+        "###);
+    }
+
+    #[tokio::test]
+    async fn test_handle_responses_entity_field() {
+        let connector = Connector {
+            id: ConnectId::new_for_test("subgraph_name".into(), name!(User), name!(field)),
+            transport: Transport::HttpJson(HttpJsonTransport {
+                base_url: "http://localhost/api".into(),
+                path_template: URLPathTemplate::parse("/path").unwrap(),
+                method: HTTPMethod::Get,
+                headers: Default::default(),
+                body: Default::default(),
+            }),
+            selection: JSONSelection::parse(".data").unwrap().1,
+            entity: false,
+            on_root_type: false,
+        };
+
+        let response1 = http::Response::builder()
+            .extension(ResponseKey::EntityField {
+                index: 0,
+                field_name: "field".to_string(),
+                typename: ResponseTypeName::Concrete("User".to_string()),
+            })
+            .body(hyper::Body::from(r#"{"data":"value1"}"#))
+            .expect("response builder");
+
+        let response2 = http::Response::builder()
+            .extension(ResponseKey::EntityField {
+                index: 1,
+                field_name: "field".to_string(),
+                typename: ResponseTypeName::Concrete("User".to_string()),
+            })
+            .body(hyper::Body::from(r#"{"data":"value2"}"#))
+            .expect("response builder");
+
+        let schema = Schema::parse_and_validate(
+            "type Query { _: Int } # just to make it valid
+            type User { id: ID! field: String! }",
+            "./",
+        )
+        .unwrap();
+
+        let res = super::handle_responses(
+            vec![response1, response2],
+            &connector,
+            Context::default(),
+            &schema,
+            Some("query ($representations: [_Any]) {_entities(representations: $representations) { ... on User { field }}}".to_string()),
+        )
+        .await
+        .unwrap();
+
+        assert_debug_snapshot!(res.response.body(), @r###"
+        Response {
+            label: None,
+            data: Some(
+                Object({
+                    "_entities": Array([
+                        Object({
+                            "__typename": String(
+                                "User",
+                            ),
+                            "field": String(
+                                "value1",
+                            ),
+                        }),
+                        Object({
+                            "__typename": String(
+                                "User",
+                            ),
+                            "field": String(
+                                "value2",
+                            ),
+                        }),
+                    ]),
+                }),
+            ),
+            path: None,
+            errors: [],
+            extensions: {},
+            has_next: None,
+            subscribed: None,
+            created_at: None,
+            incremental: [],
+        }
+        "###);
+    }
+
+    #[tokio::test]
+    async fn test_handle_responses_errors() {
+        let connector = Connector {
+            id: ConnectId::new_for_test("subgraph_name".into(), name!(Query), name!(user)),
+            transport: Transport::HttpJson(HttpJsonTransport {
+                base_url: "http://localhost/api".into(),
+                path_template: URLPathTemplate::parse("/path").unwrap(),
+                method: HTTPMethod::Get,
+                headers: Default::default(),
+                body: Default::default(),
+            }),
+            selection: JSONSelection::parse(".data").unwrap().1,
+            entity: true,
+            on_root_type: true,
+        };
+
+        let response1 = http::Response::builder()
+            .extension(ResponseKey::Entity {
+                index: 0,
+
+                typename: ResponseTypeName::Concrete("User".to_string()),
+            })
+            .status(404)
+            .body(hyper::Body::from(r#"{"error":"not found"}"#))
+            .expect("response builder");
+
+        let response2 = http::Response::builder()
+            .extension(ResponseKey::Entity {
+                index: 1,
+
+                typename: ResponseTypeName::Concrete("User".to_string()),
+            })
+            .body(hyper::Body::from(r#"{"data":{"id":"2"}}"#))
+            .expect("response builder");
+
+        let response3 = http::Response::builder()
+            .extension(ResponseKey::Entity {
+                index: 2,
+                typename: ResponseTypeName::Concrete("User".to_string()),
+            })
+            .status(500)
+            .body(hyper::Body::from(r#"{"error":"whoops"}"#))
+            .expect("response builder");
+
+        let schema = Schema::parse_and_validate(
+            "type Query { user(id: ID): User }
+            type User { id: ID! }",
+            "./",
+        )
+        .unwrap();
+
+        let res = super::handle_responses(
+            vec![response1, response2, response3],
+            &connector,
+            Context::default(),
+            &schema,
+            Some("query ($representations: [_Any]) {_entities(representations: $representations) { ... on User { id }}}".to_string()),
+        )
+        .await
+        .unwrap();
+
+        assert_debug_snapshot!(res.response.body(), @r###"
+        Response {
+            label: None,
+            data: Some(
+                Object({
+                    "_entities": Array([
+                        Null,
+                        Object({
+                            "id": String(
+                                "2",
+                            ),
+                            "__typename": String(
+                                "User",
+                            ),
+                        }),
+                        Null,
+                    ]),
+                }),
+            ),
+            path: None,
+            errors: [
+                Error {
+                    message: "http error: 404 Not Found",
+                    locations: [],
+                    path: None,
+                    extensions: {
+                        "connector": String(
+                            "test label",
+                        ),
+                        "code": String(
+                            "404",
+                        ),
+                    },
+                },
+                Error {
+                    message: "http error: 500 Internal Server Error",
+                    locations: [],
+                    path: None,
+                    extensions: {
+                        "connector": String(
+                            "test label",
+                        ),
+                        "code": String(
+                            "500",
+                        ),
+                    },
+                },
+            ],
+            extensions: {},
+            has_next: None,
+            subscribed: None,
+            created_at: None,
+            incremental: [],
+        }
+        "###);
+    }
+}

--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -1,0 +1,1280 @@
+use std::sync::Arc;
+
+use apollo_compiler::executable::Selection;
+use apollo_compiler::validation::Valid;
+use apollo_compiler::ExecutableDocument;
+use apollo_compiler::Schema;
+use apollo_federation::sources::connect::Connector;
+use serde_json_bytes::json;
+use serde_json_bytes::ByteString;
+use serde_json_bytes::Map;
+use serde_json_bytes::Value;
+
+use super::http_json_transport::http_json_transport::make_request;
+use super::http_json_transport::HttpJsonTransportError;
+use crate::services::SubgraphRequest;
+
+const REPRESENTATIONS_VAR: &str = "representations";
+const ENTITIES: &str = "_entities";
+const TYPENAME: &str = "__typename";
+
+#[derive(Debug, Default)]
+struct RequestInputs {
+    args: Map<ByteString, Value>,
+    this: Map<ByteString, Value>,
+}
+
+impl RequestInputs {
+    fn merge(self) -> Value {
+        json!({
+            "$args": self.args,
+            "$this": self.this
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum ResponseKey {
+    RootField {
+        name: String,
+        typename: ResponseTypeName,
+    },
+    Entity {
+        index: usize,
+        typename: ResponseTypeName,
+    },
+    EntityField {
+        index: usize,
+        field_name: String,
+        typename: ResponseTypeName,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum ResponseTypeName {
+    Concrete(String),
+    /// For interfaceObject support. We don't want to include __typename in the
+    /// response because this subgraph doesn't know the concrete type
+    Omitted,
+}
+
+pub(crate) fn make_requests(
+    request: SubgraphRequest,
+    connector: &Connector,
+    schema: Arc<Valid<Schema>>,
+) -> Result<Vec<(http::Request<hyper::Body>, ResponseKey)>, MakeRequestError> {
+    let request_params = if connector.entity {
+        entities_from_request(&request, schema)
+    } else if connector.on_root_type {
+        root_fields(&request, schema)
+    } else {
+        entities_with_fields_from_request(&request, schema)
+    }?;
+
+    request_params_to_requests(connector, request_params, &request)
+}
+
+fn request_params_to_requests(
+    connector: &Connector,
+    request_params: Vec<(ResponseKey, RequestInputs)>,
+    _original_request: &SubgraphRequest, // TODO headers
+) -> Result<Vec<(http::Request<hyper::Body>, ResponseKey)>, MakeRequestError> {
+    request_params
+        .into_iter()
+        .map(|(response_key, inputs)| {
+            let request = match connector.transport {
+                apollo_federation::sources::connect::Transport::HttpJson(ref transport) => {
+                    make_request(transport, inputs.merge())?
+                }
+            };
+
+            Ok((request, response_key))
+        })
+        .collect::<Result<Vec<_>, _>>()
+}
+
+// --- ERRORS ------------------------------------------------------------------
+
+#[derive(Debug, thiserror::Error, displaydoc::Display)]
+pub(crate) enum MakeRequestError {
+    /// Invalid request operation: {0}
+    InvalidOperation(String),
+
+    /// Unsupported request operation: {0}
+    UnsupportedOperation(String),
+
+    /// Invalid request arguments: {0}
+    InvalidArguments(String),
+
+    /// Invalid entity representation: {0}
+    InvalidRepresentations(String),
+
+    /// Cannot create HTTP request: {0}
+    TransportError(#[from] HttpJsonTransportError),
+}
+
+// --- ROOT FIELDS -------------------------------------------------------------
+
+/// Given a query, find the root fields and return a list of requests.
+/// The connector subgraph must have only a single root field, but it could be
+/// used multiple times with aliases.
+///
+/// Root fields exist in the supergraph schema so we can parse the operation
+/// using the schema. (This isn't true for _entities oeprations.)
+///
+/// Example:
+/// ```graphql
+/// type Query {
+///   foo(bar: String): Foo @connect(...)
+/// }
+/// ```
+/// ```graphql
+/// {
+///   a: foo(bar: "a") # one request
+///   b: foo(bar: "b") # another request
+/// }
+/// ```
+fn root_fields(
+    request: &SubgraphRequest,
+    schema: Arc<Valid<Schema>>,
+) -> Result<Vec<(ResponseKey, RequestInputs)>, MakeRequestError> {
+    let query = request
+        .subgraph_request
+        .body()
+        .query
+        .clone()
+        .ok_or_else(|| MakeRequestError::InvalidOperation("missing query".into()))?;
+
+    let doc = ExecutableDocument::parse(&schema, query, "op.graphql").map_err(|_| {
+        MakeRequestError::InvalidOperation("cannot parse operation document".into())
+    })?;
+
+    let op = doc
+        .get_operation(request.subgraph_request.body().operation_name.as_deref())
+        .map_err(|_| MakeRequestError::InvalidOperation("no operation found".into()))?;
+
+    op.selection_set
+        .selections
+        .iter()
+        .map(|s| match s {
+            Selection::Field(field) => {
+                let response_key = ResponseKey::RootField {
+                    name: field.response_key().to_string(),
+                    typename: ResponseTypeName::Concrete(field.ty().inner_named_type().to_string()),
+                };
+
+                let args = graphql_utils::field_arguments_map(
+                    field,
+                    &request.subgraph_request.body().variables,
+                )
+                .map_err(|_| {
+                    MakeRequestError::InvalidArguments(
+                        "cannot get inputs from field arguments".into(),
+                    )
+                })?;
+
+                let request_inputs = RequestInputs {
+                    args,
+                    this: Default::default(),
+                };
+
+                Ok((response_key, request_inputs))
+            }
+
+            // The query planner removes fragments at the root so we don't have
+            // to worry these branches
+            Selection::FragmentSpread(_) | Selection::InlineFragment(_) => {
+                Err(MakeRequestError::UnsupportedOperation(
+                    "top-level fragments in query planner nodes should not happen".into(),
+                ))
+            }
+        })
+        .collect::<Result<Vec<_>, MakeRequestError>>()
+}
+
+// --- ENTITIES ----------------------------------------------------------------
+
+/// Connectors marked with `entity: true` can be used as entity resolvers,
+/// (resolving `_entities` queries) or regular root fields. For now we'll check
+/// the existence of the `representations` variable to determine which use case
+/// is relevant here.
+///
+/// If it's an entity resolver, we create separate requests for each item in the
+/// representations array.
+///
+/// ```json
+/// {
+///   "variables": {
+///      "representations": [{ "__typename": "User", "id": "1" }]
+///   }
+/// }
+/// ```
+///
+/// Returns a list of request inputs and the response key (index in the array).
+fn entities_from_request(
+    request: &SubgraphRequest,
+    schema: Arc<Valid<Schema>>,
+) -> Result<Vec<(ResponseKey, RequestInputs)>, MakeRequestError> {
+    use MakeRequestError::InvalidRepresentations;
+
+    let Some(representations) = request
+        .subgraph_request
+        .body()
+        .variables
+        .get(REPRESENTATIONS_VAR)
+    else {
+        return root_fields(request, schema);
+    };
+
+    let (_, typename_requested) = graphql_utils::get_entity_fields(
+        request
+            .subgraph_request
+            .body()
+            .query
+            .as_ref()
+            .ok_or_else(|| MakeRequestError::InvalidOperation("missing query".into()))?,
+    )?;
+
+    representations
+        .as_array()
+        .ok_or_else(|| InvalidRepresentations("representations is not an array".into()))?
+        .iter()
+        .enumerate()
+        .map(|(i, rep)| {
+            // TODO abstract types?
+            let typename = rep
+                .as_object()
+                .ok_or_else(|| InvalidRepresentations("representation is not an object".into()))?
+                .get(TYPENAME)
+                .ok_or_else(|| {
+                    InvalidRepresentations("representation is missing __typename".into())
+                })?
+                .as_str()
+                .ok_or_else(|| InvalidRepresentations("__typename is not a string".into()))?
+                .to_string();
+
+            // if the fetch node operation doesn't include __typename, then
+            // we're assuming this is for an interface object and we don't want
+            // to include a __typename in the response.
+            let typename = if typename_requested {
+                ResponseTypeName::Concrete(typename)
+            } else {
+                ResponseTypeName::Omitted
+            };
+
+            Ok((
+                ResponseKey::Entity { index: i, typename },
+                RequestInputs {
+                    args: rep
+                        .as_object()
+                        .ok_or_else(|| {
+                            InvalidRepresentations("representation is not an object".into())
+                        })?
+                        .clone(),
+                    // entity connectors are always on Query fields, so they cannot use
+                    // sibling fields with $this
+                    this: Default::default(),
+                },
+            ))
+        })
+        .collect::<Result<Vec<_>, _>>()
+}
+
+// --- ENTITY FIELDS -----------------------------------------------------------
+
+/// This is effectively the combination of the other two functions:
+///
+/// * It makes a request for each item in the `representations` array.
+/// * If the connector field is aliased, it makes a request for each alias.
+///
+/// So it can return N (representations) x M (aliases) requests.
+///
+/// ```json
+/// {
+///   "query": "{ _entities(representations: $representations) { ... on User { name } } }",
+///   "variables": { "representations": [{ "__typename": "User", "id": "1" }] }
+/// }
+/// ```
+///
+/// Return a list of request inputs with the response key (index in list and
+/// name/alias of field) for each.
+fn entities_with_fields_from_request(
+    request: &SubgraphRequest,
+    _schema: Arc<Valid<Schema>>,
+) -> Result<Vec<(ResponseKey, RequestInputs)>, MakeRequestError> {
+    use MakeRequestError::*;
+
+    let (entities_field, typename_requested) = graphql_utils::get_entity_fields(
+        request
+            .subgraph_request
+            .body()
+            .query
+            .as_ref()
+            .ok_or_else(|| InvalidOperation("missing query".into()))?,
+    )?;
+
+    let types_and_fields = entities_field
+        .selection_set
+        .iter()
+        .map(|selection| match selection {
+            apollo_compiler::ast::Selection::Field(_) => Ok(vec![]),
+
+            apollo_compiler::ast::Selection::FragmentSpread(_) => Err(InvalidOperation(
+                "_entities selection can't be a named fragment".into(),
+            )),
+
+            apollo_compiler::ast::Selection::InlineFragment(frag) => {
+                let typename = frag
+                    .type_condition
+                    .as_ref()
+                    .ok_or_else(|| InvalidOperation("missing type condition".into()))?;
+                Ok(frag
+                    .selection_set
+                    .iter()
+                    .map(|sel| {
+                        let field = match sel {
+                            apollo_compiler::ast::Selection::Field(f) => f,
+                            apollo_compiler::ast::Selection::FragmentSpread(_) => todo!(),
+                            apollo_compiler::ast::Selection::InlineFragment(_) => todo!(),
+                        };
+                        (typename.to_string(), field)
+                    })
+                    .collect::<Vec<_>>())
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let representations = request
+        .subgraph_request
+        .body()
+        .variables
+        .get(REPRESENTATIONS_VAR)
+        .ok_or_else(|| InvalidRepresentations("missing representations variable".into()))?
+        .as_array()
+        .ok_or_else(|| InvalidRepresentations("representations is not an array".into()))?
+        .iter()
+        .enumerate()
+        .collect::<Vec<_>>();
+
+    // if we have multiple fields (because of aliases, we'll flatten that list)
+    // and generate requests for each field/representation pair
+    types_and_fields
+        .into_iter()
+        .flatten()
+        .flat_map(|(typename, field)| {
+            representations.iter().map(move |(i, representation)| {
+                let args = graphql_utils::ast_field_arguments_map(
+                    field,
+                    &request.subgraph_request.body().variables,
+                )
+                .map_err(|_| InvalidArguments("cannot build inputs from field arguments".into()))?;
+
+                // if the fetch node operation doesn't include __typename, then
+                // we're assuming this is for an interface object and we don't want
+                // to include a __typename in the response.
+                let typename = if typename_requested {
+                    ResponseTypeName::Concrete(typename.to_string())
+                } else {
+                    ResponseTypeName::Omitted
+                };
+
+                Ok::<_, MakeRequestError>((
+                    ResponseKey::EntityField {
+                        index: *i,
+                        field_name: field.response_name().to_string(),
+                        typename,
+                    },
+                    RequestInputs {
+                        args,
+                        this: representation
+                            .as_object()
+                            .ok_or_else(|| {
+                                InvalidRepresentations("representation is not an object".into())
+                            })?
+                            .clone(),
+                    },
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use apollo_compiler::name;
+    use apollo_compiler::Schema;
+    use apollo_federation::sources::connect::ConnectId;
+    use apollo_federation::sources::connect::Connector;
+    use apollo_federation::sources::connect::HTTPMethod;
+    use apollo_federation::sources::connect::HttpJsonTransport;
+    use apollo_federation::sources::connect::JSONSelection;
+    use apollo_federation::sources::connect::URLPathTemplate;
+    use insta::assert_debug_snapshot;
+
+    #[test]
+    fn test_root_fields_simple() {
+        let schema =
+            Arc::new(Schema::parse_and_validate("type Query { a: String }", "./").unwrap());
+
+        let req = crate::services::SubgraphRequest::fake_builder()
+            .subgraph_request(
+                http::Request::builder()
+                    .body(
+                        crate::graphql::Request::builder()
+                            .query("query { a a2: a }")
+                            .build(),
+                    )
+                    .expect("request builder"),
+            )
+            .build();
+
+        assert_debug_snapshot!(super::root_fields(&req, schema.clone()), @r###"
+        Ok(
+            [
+                (
+                    RootField {
+                        name: "a",
+                        typename: Concrete(
+                            "String",
+                        ),
+                    },
+                    RequestInputs {
+                        args: {},
+                        this: {},
+                    },
+                ),
+                (
+                    RootField {
+                        name: "a2",
+                        typename: Concrete(
+                            "String",
+                        ),
+                    },
+                    RequestInputs {
+                        args: {},
+                        this: {},
+                    },
+                ),
+            ],
+        )
+        "###);
+    }
+
+    #[test]
+    fn test_root_fields_inputs() {
+        let schema = Arc::new(
+            Schema::parse_and_validate("type Query {b(var: String): String}", "./").unwrap(),
+        );
+
+        let req = crate::services::SubgraphRequest::fake_builder()
+            .subgraph_request(
+                http::Request::builder()
+                    .body(
+                        crate::graphql::Request::builder()
+                            .query("query($var: String) { b(var: \"inline\") b2: b(var: $var) }")
+                            .variables(
+                                serde_json_bytes::json!({ "var": "variable" })
+                                    .as_object()
+                                    .unwrap()
+                                    .clone(),
+                            )
+                            .build(),
+                    )
+                    .expect("request builder"),
+            )
+            .build();
+
+        assert_debug_snapshot!(super::root_fields(&req, schema.clone()), @r###"
+        Ok(
+            [
+                (
+                    RootField {
+                        name: "b",
+                        typename: Concrete(
+                            "String",
+                        ),
+                    },
+                    RequestInputs {
+                        args: {
+                            "var": String(
+                                "inline",
+                            ),
+                        },
+                        this: {},
+                    },
+                ),
+                (
+                    RootField {
+                        name: "b2",
+                        typename: Concrete(
+                            "String",
+                        ),
+                    },
+                    RequestInputs {
+                        args: {
+                            "var": String(
+                                "variable",
+                            ),
+                        },
+                        this: {},
+                    },
+                ),
+            ],
+        )
+        "###);
+    }
+
+    #[test]
+    fn test_root_fields_input_types() {
+        let schema = Arc::new(Schema::parse_and_validate(
+            r#"
+            scalar JSON
+            type Query {
+
+              c(var1: Int, var2: Boolean, var3: Float, var4: ID, var5: JSON, var6: [String], var7: String): String
+            }
+          "#,
+            "./",
+        ).unwrap());
+
+        let req = crate::services::SubgraphRequest::fake_builder()
+            .subgraph_request(
+                http::Request::builder()
+                    .body(
+                        crate::graphql::Request::builder()
+                            .query(r#"
+                              query(
+                                $var1: Int, $var2: Bool, $var3: Float, $var4: ID, $var5: JSON, $var6: [String], $var7: String
+                              ) {
+                                c(var1: $var1, var2: $var2, var3: $var3, var4: $var4, var5: $var5, var6: $var6, var7: $var7)
+                                c2: c(
+                                  var1: 1,
+                                  var2: true,
+                                  var3: 0.9,
+                                  var4: "123",
+                                  var5: { a: 42 },
+                                  var6: ["item"],
+                                  var7: null
+                                )
+                              }
+                            "#)
+                            .variables(
+                                serde_json_bytes::json!({
+                                  "var1": 1, "var2": true, "var3": 0.9,
+                                  "var4": "123", "var5": { "a": 42 }, "var6": ["item"],
+                                  "var7": null
+                                })
+                                .as_object()
+                                .unwrap()
+                                .clone(),
+                            )
+                            .build(),
+                    )
+                    .expect("request builder"),
+            )
+            .build();
+
+        assert_debug_snapshot!(super::root_fields(&req, schema.clone()), @r###"
+        Ok(
+            [
+                (
+                    RootField {
+                        name: "c",
+                        typename: Concrete(
+                            "String",
+                        ),
+                    },
+                    RequestInputs {
+                        args: {
+                            "var1": Number(1),
+                            "var2": Bool(
+                                true,
+                            ),
+                            "var3": Number(0.9),
+                            "var4": String(
+                                "123",
+                            ),
+                            "var5": Object({
+                                "a": Number(42),
+                            }),
+                            "var6": Array([
+                                String(
+                                    "item",
+                                ),
+                            ]),
+                            "var7": Null,
+                        },
+                        this: {},
+                    },
+                ),
+                (
+                    RootField {
+                        name: "c2",
+                        typename: Concrete(
+                            "String",
+                        ),
+                    },
+                    RequestInputs {
+                        args: {
+                            "var1": Number(1),
+                            "var2": Bool(
+                                true,
+                            ),
+                            "var3": Number(0.9),
+                            "var4": String(
+                                "123",
+                            ),
+                            "var5": Object({
+                                "a": Number(42),
+                            }),
+                            "var6": Array([
+                                String(
+                                    "item",
+                                ),
+                            ]),
+                            "var7": Null,
+                        },
+                        this: {},
+                    },
+                ),
+            ],
+        )
+        "###);
+    }
+
+    #[test]
+    fn entities_from_request_entity() {
+        let partial_sdl = r#"
+        type Query {
+          entity(id: ID!): Entity
+        }
+
+        type Entity {
+          field: String
+        }
+        "#;
+        let schema = Arc::new(Schema::parse_and_validate(partial_sdl, "./").unwrap());
+
+        let req = crate::services::SubgraphRequest::fake_builder()
+            .subgraph_request(
+                http::Request::builder()
+                    .body(
+                        crate::graphql::Request::builder()
+                            .query(
+                                r#"
+                              query($representations: [_Any!]!) {
+                                _entities(representations: $representations) {
+                                  __typename
+                                  ... on Entity {
+                                    field
+                                    alias: field
+                                  }
+                                }
+                              }
+                            "#,
+                            )
+                            .variables(
+                                serde_json_bytes::json!({
+                                  "representations": [
+                                      { "__typename": "Entity", "id": "1" },
+                                      { "__typename": "Entity", "id": "2" },
+                                  ]
+                                })
+                                .as_object()
+                                .unwrap()
+                                .clone(),
+                            )
+                            .build(),
+                    )
+                    .expect("request builder"),
+            )
+            .build();
+
+        assert_debug_snapshot!(super::entities_from_request(&req, schema.clone()).unwrap(), @r###"
+        [
+            (
+                Entity {
+                    index: 0,
+                    typename: Concrete(
+                        "Entity",
+                    ),
+                },
+                RequestInputs {
+                    args: {
+                        "__typename": String(
+                            "Entity",
+                        ),
+                        "id": String(
+                            "1",
+                        ),
+                    },
+                    this: {},
+                },
+            ),
+            (
+                Entity {
+                    index: 1,
+                    typename: Concrete(
+                        "Entity",
+                    ),
+                },
+                RequestInputs {
+                    args: {
+                        "__typename": String(
+                            "Entity",
+                        ),
+                        "id": String(
+                            "2",
+                        ),
+                    },
+                    this: {},
+                },
+            ),
+        ]
+        "###);
+    }
+
+    #[test]
+    fn entities_from_request_root_field() {
+        let partial_sdl = r#"
+        type Query {
+          entity(id: ID!): Entity
+        }
+
+        type Entity {
+          field: String
+        }
+        "#;
+        let schema = Arc::new(Schema::parse_and_validate(partial_sdl, "./").unwrap());
+
+        let req = crate::services::SubgraphRequest::fake_builder()
+            .subgraph_request(
+                http::Request::builder()
+                    .body(
+                        crate::graphql::Request::builder()
+                            .query(
+                                r#"
+                              query($a: ID!, $b: ID!) {
+                                a: entity(id: $a) { field }
+                                b: entity(id: $b) { field }
+                              }
+                            "#,
+                            )
+                            .variables(
+                                serde_json_bytes::json!({
+                                  "a": "1",
+                                  "b": "2"
+                                })
+                                .as_object()
+                                .unwrap()
+                                .clone(),
+                            )
+                            .build(),
+                    )
+                    .expect("request builder"),
+            )
+            .build();
+
+        assert_debug_snapshot!(super::entities_from_request(&req, schema.clone()).unwrap(), @r###"
+        [
+            (
+                RootField {
+                    name: "a",
+                    typename: Concrete(
+                        "Entity",
+                    ),
+                },
+                RequestInputs {
+                    args: {
+                        "id": String(
+                            "1",
+                        ),
+                    },
+                    this: {},
+                },
+            ),
+            (
+                RootField {
+                    name: "b",
+                    typename: Concrete(
+                        "Entity",
+                    ),
+                },
+                RequestInputs {
+                    args: {
+                        "id": String(
+                            "2",
+                        ),
+                    },
+                    this: {},
+                },
+            ),
+        ]
+        "###);
+    }
+
+    #[test]
+    fn entities_with_fields_from_request() {
+        let partial_sdl = r#"
+        type Query { _: String } # just to make it valid
+
+        type Entity { # @key(fields: "id")
+          id: ID!
+          field(foo: String): String
+        }
+        "#;
+        let schema = Arc::new(Schema::parse_and_validate(partial_sdl, "./").unwrap());
+
+        let req = crate::services::SubgraphRequest::fake_builder()
+            .subgraph_request(
+                http::Request::builder()
+                    .body(
+                        crate::graphql::Request::builder()
+                            .query(
+                                r#"
+                              query($representations: [_Any!]!, $bye: String) {
+                                _entities(representations: $representations) {
+                                  __typename
+                                  ... on Entity {
+                                    field(foo: "hi")
+                                    alias: field(foo: $bye)
+                                  }
+                                }
+                              }
+                            "#,
+                            )
+                            .variables(
+                                serde_json_bytes::json!({
+                                  "representations": [
+                                      { "__typename": "Entity", "id": "1" },
+                                      { "__typename": "Entity", "id": "2" },
+                                  ],
+                                  "bye": "bye"
+                                })
+                                .as_object()
+                                .unwrap()
+                                .clone(),
+                            )
+                            .build(),
+                    )
+                    .expect("request builder"),
+            )
+            .build();
+
+        assert_debug_snapshot!(super::entities_with_fields_from_request(&req, schema.clone()).unwrap(), @r###"
+        [
+            (
+                EntityField {
+                    index: 0,
+                    field_name: "field",
+                    typename: Concrete(
+                        "Entity",
+                    ),
+                },
+                RequestInputs {
+                    args: {
+                        "foo": String(
+                            "hi",
+                        ),
+                    },
+                    this: {
+                        "__typename": String(
+                            "Entity",
+                        ),
+                        "id": String(
+                            "1",
+                        ),
+                    },
+                },
+            ),
+            (
+                EntityField {
+                    index: 1,
+                    field_name: "field",
+                    typename: Concrete(
+                        "Entity",
+                    ),
+                },
+                RequestInputs {
+                    args: {
+                        "foo": String(
+                            "hi",
+                        ),
+                    },
+                    this: {
+                        "__typename": String(
+                            "Entity",
+                        ),
+                        "id": String(
+                            "2",
+                        ),
+                    },
+                },
+            ),
+            (
+                EntityField {
+                    index: 0,
+                    field_name: "alias",
+                    typename: Concrete(
+                        "Entity",
+                    ),
+                },
+                RequestInputs {
+                    args: {
+                        "foo": String(
+                            "bye",
+                        ),
+                    },
+                    this: {
+                        "__typename": String(
+                            "Entity",
+                        ),
+                        "id": String(
+                            "1",
+                        ),
+                    },
+                },
+            ),
+            (
+                EntityField {
+                    index: 1,
+                    field_name: "alias",
+                    typename: Concrete(
+                        "Entity",
+                    ),
+                },
+                RequestInputs {
+                    args: {
+                        "foo": String(
+                            "bye",
+                        ),
+                    },
+                    this: {
+                        "__typename": String(
+                            "Entity",
+                        ),
+                        "id": String(
+                            "2",
+                        ),
+                    },
+                },
+            ),
+        ]
+        "###);
+    }
+
+    #[test]
+    fn entities_with_fields_from_request_interface_object() {
+        let partial_sdl = r#"
+        type Query { _: String } # just to make it valid
+
+        type Entity { # @interfaceObject @key(fields: "id")
+          id: ID!
+          field(foo: String): String
+        }
+        "#;
+        let schema = Arc::new(Schema::parse_and_validate(partial_sdl, "./").unwrap());
+
+        let req = crate::services::SubgraphRequest::fake_builder()
+            .subgraph_request(
+                http::Request::builder()
+                    .body(
+                        crate::graphql::Request::builder()
+                            .query(
+                                r#"
+                              query($representations: [_Any!]!, $foo: String) {
+                                _entities(representations: $representations) {
+                                  ... on Entity {
+                                    field(foo: $foo)
+                                  }
+                                }
+                              }
+                            "#,
+                            )
+                            .variables(
+                                serde_json_bytes::json!({
+                                  "representations": [
+                                      { "__typename": "Entity", "id": "1" },
+                                      { "__typename": "Entity", "id": "2" },
+                                  ],
+                                  "foo": "bar"
+                                })
+                                .as_object()
+                                .unwrap()
+                                .clone(),
+                            )
+                            .build(),
+                    )
+                    .expect("request builder"),
+            )
+            .build();
+
+        assert_debug_snapshot!(super::entities_with_fields_from_request(&req, schema.clone()).unwrap(), @r###"
+        [
+            (
+                EntityField {
+                    index: 0,
+                    field_name: "field",
+                    typename: Omitted,
+                },
+                RequestInputs {
+                    args: {
+                        "foo": String(
+                            "bar",
+                        ),
+                    },
+                    this: {
+                        "__typename": String(
+                            "Entity",
+                        ),
+                        "id": String(
+                            "1",
+                        ),
+                    },
+                },
+            ),
+            (
+                EntityField {
+                    index: 1,
+                    field_name: "field",
+                    typename: Omitted,
+                },
+                RequestInputs {
+                    args: {
+                        "foo": String(
+                            "bar",
+                        ),
+                    },
+                    this: {
+                        "__typename": String(
+                            "Entity",
+                        ),
+                        "id": String(
+                            "2",
+                        ),
+                    },
+                },
+            ),
+        ]
+        "###);
+    }
+
+    #[test]
+    fn make_requests() {
+        let req = crate::services::SubgraphRequest::fake_builder()
+            .subgraph_name("CONNECTOR_0")
+            .subgraph_request(
+                http::Request::builder()
+                    .body(
+                        crate::graphql::Request::builder()
+                            .query("query { a: hello }")
+                            .build(),
+                    )
+                    .expect("request builder"),
+            )
+            .build();
+
+        let schema = Schema::parse_and_validate("type Query { hello: String }", "./").unwrap();
+
+        let connector = Connector {
+            id: ConnectId::new_for_test("subgraph_name".into(), name!(Query), name!(users)),
+            transport: apollo_federation::sources::connect::Transport::HttpJson(
+                HttpJsonTransport {
+                    base_url: "http://localhost/api".into(),
+                    path_template: URLPathTemplate::parse("/path").unwrap(),
+                    method: HTTPMethod::Get,
+                    headers: Default::default(),
+                    body: Default::default(),
+                },
+            ),
+            selection: JSONSelection::parse(".data").unwrap().1,
+            entity: false,
+            on_root_type: true,
+        };
+
+        let requests = super::make_requests(req, &connector, Arc::new(schema)).unwrap();
+
+        assert_debug_snapshot!(requests, @r###"
+        [
+            (
+                Request {
+                    method: GET,
+                    uri: http://localhost/api/path,
+                    version: HTTP/1.1,
+                    headers: {
+                        "content-type": "application/json",
+                    },
+                    body: Body(
+                        Empty,
+                    ),
+                },
+                RootField {
+                    name: "a",
+                    typename: Concrete(
+                        "String",
+                    ),
+                },
+            ),
+        ]
+        "###);
+    }
+}
+
+mod graphql_utils {
+    use apollo_compiler::ast;
+    use apollo_compiler::ast::Definition;
+    use apollo_compiler::executable::Field;
+    use apollo_compiler::schema::Value;
+    use apollo_compiler::Node;
+    use serde_json::Number;
+    use serde_json_bytes::ByteString;
+    use serde_json_bytes::Map;
+    use serde_json_bytes::Value as JSONValue;
+    use tower::BoxError;
+
+    use super::MakeRequestError;
+    use super::ENTITIES;
+
+    pub(super) fn field_arguments_map(
+        field: &Node<Field>,
+        variables: &Map<ByteString, JSONValue>,
+    ) -> Result<Map<ByteString, JSONValue>, BoxError> {
+        let mut arguments = Map::new();
+        for argument in field.arguments.iter() {
+            match &*argument.value {
+                apollo_compiler::schema::Value::Variable(name) => {
+                    if let Some(value) = variables.get(name.as_str()) {
+                        arguments.insert(argument.name.as_str(), value.clone());
+                    }
+                }
+                _ => {
+                    arguments.insert(
+                        argument.name.as_str(),
+                        argument_value_to_json(&argument.value)?,
+                    );
+                }
+            }
+        }
+        Ok(arguments)
+    }
+
+    pub(super) fn ast_field_arguments_map(
+        field: &apollo_compiler::Node<apollo_compiler::ast::Field>,
+        variables: &Map<ByteString, JSONValue>,
+    ) -> Result<Map<ByteString, JSONValue>, BoxError> {
+        let mut arguments = Map::new();
+        for argument in field.arguments.iter() {
+            match &*argument.value {
+                apollo_compiler::schema::Value::Variable(name) => {
+                    if let Some(value) = variables.get(name.as_str()) {
+                        arguments.insert(argument.name.as_str(), value.clone());
+                    }
+                }
+                _ => {
+                    arguments.insert(
+                        argument.name.as_str(),
+                        argument_value_to_json(&argument.value)?,
+                    );
+                }
+            }
+        }
+        Ok(arguments)
+    }
+
+    pub(super) fn argument_value_to_json(
+        value: &apollo_compiler::ast::Value,
+    ) -> Result<JSONValue, BoxError> {
+        match value {
+            Value::Null => Ok(JSONValue::Null),
+            Value::Enum(e) => Ok(JSONValue::String(e.as_str().into())),
+            Value::Variable(_) => Err(BoxError::from("variables not supported")),
+            Value::String(s) => Ok(JSONValue::String(s.as_str().into())),
+            Value::Float(f) => Ok(JSONValue::Number(
+                Number::from_f64(
+                    f.try_to_f64()
+                        .map_err(|_| BoxError::from("try_to_f64 failed"))?,
+                )
+                .ok_or_else(|| BoxError::from("Number::from_f64 failed"))?,
+            )),
+            Value::Int(i) => Ok(JSONValue::Number(Number::from(
+                i.try_to_i32().map_err(|_| "invalid int")?,
+            ))),
+            Value::Boolean(b) => Ok(JSONValue::Bool(*b)),
+            Value::List(l) => Ok(JSONValue::Array(
+                l.iter()
+                    .map(|v| argument_value_to_json(v))
+                    .collect::<Result<Vec<_>, _>>()?,
+            )),
+            Value::Object(o) => Ok(JSONValue::Object(
+                o.iter()
+                    .map(|(k, v)| argument_value_to_json(v).map(|v| (k.as_str().into(), v)))
+                    .collect::<Result<Map<_, _>, _>>()?,
+            )),
+        }
+    }
+
+    pub(super) fn get_entity_fields(
+        query: &str,
+    ) -> Result<(Node<ast::Field>, bool), MakeRequestError> {
+        use MakeRequestError::*;
+
+        // Use the AST because the `_entities` field is not actually present in the supergraph
+        let doc = apollo_compiler::ast::Document::parse(query, "op.graphql")
+            .map_err(|_| InvalidOperation("cannot parse operation document".into()))?;
+
+        // Assume a single operation (because this is from a query plan)
+        let op = doc
+            .definitions
+            .into_iter()
+            .find_map(|d| match d {
+                Definition::OperationDefinition(op) => Some(op),
+                _ => None,
+            })
+            .ok_or_else(|| InvalidOperation("missing operation".into()))?;
+
+        let root_field = op
+            .selection_set
+            .iter()
+            .find_map(|s| match s {
+                apollo_compiler::ast::Selection::Field(f) if f.name == ENTITIES => Some(f),
+                _ => None,
+            })
+            .ok_or_else(|| InvalidOperation("missing entities root field".into()))?;
+
+        let mut typename_requested = false;
+
+        for selection in root_field.selection_set.iter() {
+            match selection {
+                apollo_compiler::ast::Selection::Field(f) => {
+                    if f.name == "__typename" {
+                        typename_requested = true;
+                    }
+                }
+                apollo_compiler::ast::Selection::FragmentSpread(_) => {
+                    return Err(UnsupportedOperation("fragment spread not supported".into()))
+                }
+                apollo_compiler::ast::Selection::InlineFragment(f) => {
+                    for selection in f.selection_set.iter() {
+                        match selection {
+                            apollo_compiler::ast::Selection::Field(f) => {
+                                if f.name == "__typename" {
+                                    typename_requested = true;
+                                }
+                            }
+                            apollo_compiler::ast::Selection::FragmentSpread(_)
+                            | apollo_compiler::ast::Selection::InlineFragment(_) => {
+                                return Err(UnsupportedOperation(
+                                    "fragment spread not supported".into(),
+                                ))
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok((root_field.clone(), typename_requested))
+    }
+}

--- a/apollo-router/src/plugins/connectors/mod.rs
+++ b/apollo-router/src/plugins/connectors/mod.rs
@@ -12,6 +12,8 @@ pub(crate) use supergraph::ConnectorSupergraphError;
 pub(crate) use self::directives::Source;
 pub(crate) mod configuration;
 mod fetch;
+#[allow(dead_code)]
+mod handle_responses;
 pub(crate) mod http_json_transport;
 #[allow(dead_code)]
 pub(crate) mod make_requests;

--- a/apollo-router/src/plugins/connectors/mod.rs
+++ b/apollo-router/src/plugins/connectors/mod.rs
@@ -13,6 +13,8 @@ pub(crate) use self::directives::Source;
 pub(crate) mod configuration;
 mod fetch;
 pub(crate) mod http_json_transport;
+#[allow(dead_code)]
+pub(crate) mod make_requests;
 mod request_inputs;
 mod request_response;
 mod response_formatting;

--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -265,6 +265,8 @@ mod soure_node_tests {
                     body: Default::default(),
                 }),
                 selection: JSONSelection::parse(".data { id }").unwrap().1,
+                entity: false,
+                on_root_type: false,
             },
         );
 


### PR DESCRIPTION
After we switch the router services to use Connectors generated in expand_connectors(), we can start using these functions and delete:

* src/plugins/connectors/response_formatting/ — will be replaced with apply_with_selection
* src/plugins/connectors/finder_field.rs — not necessary in single-phase query planning!
* src/plugins/connectors/http_json_transport.rs — saving the part that use the new Transport
* src/plugins/connectors/request_inputs.rs — didn't need to be its own module
* src/plugins/connectors/request_response.rs

This version leaves out some functionality:

* instrumentation, logging, and json selection diagnostics
* alias and __typename handling (beyond the root output type)

we should address both of these when we add JSONSelection::apply_with_selection or whatever we're going to call it

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
