### PR TITLE
Implemented `Operation::without_defer`

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -143,6 +143,15 @@ impl Operation {
     // PORT_NOTE(@goto-bus-stop): It might make sense for the returned data structure to *be* the
     // `DeferNormalizer` from the JS side
     pub(crate) fn with_normalized_defer(self) -> NormalizedDefer {
+        NormalizedDefer {
+            operation: self,
+            has_defers: false,
+            assigned_defer_labels: HashSet::new(),
+            defer_conditions: IndexMap::new(),
+        }
+        // TODO(@TylerBloom): Once defer is implement, the above statement needs to be replaced
+        // with the commented-out one below.
+        /*
         if self.has_defer() {
             todo!("@defer not implemented");
         } else {
@@ -153,6 +162,7 @@ impl Operation {
                 defer_conditions: IndexMap::new(),
             }
         }
+        */
     }
 
     fn has_defer(&self) -> bool {
@@ -2977,14 +2987,8 @@ impl SelectionSet {
 
     /// Removes the @defer directive from all selections without removing that selection.
     fn without_defer(&mut self) {
-        // TODO: This doesn't seem like the correct way to get the directive name...
-        let Some(defer_name) = self.schema.get_directive_definition(&name!("defer")) else {
-            // TODO: Return an error? Continue? Dunno...
-            return;
-        };
         for (_key, mut selection) in Arc::make_mut(&mut self.selections).iter_mut() {
-            Arc::make_mut(selection.get_directives_mut())
-                .retain(|dir| dir.name != defer_name.directive_name);
+            Arc::make_mut(selection.get_directives_mut()).retain(|dir| dir.name != name!("defer"));
             if let Some(set) = selection.get_selection_set_mut() {
                 set.without_defer();
             }

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -150,7 +150,7 @@ impl Operation {
             defer_conditions: IndexMap::new(),
         }
         // TODO(@TylerBloom): Once defer is implement, the above statement needs to be replaced
-        // with the commented-out one below.
+        // with the commented-out one below. This is part of FED-95
         /*
         if self.has_defer() {
             todo!("@defer not implemented");

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -165,9 +165,6 @@ impl Operation {
     }
 
     /// Removes the @defer directive from all selections without removing that selection.
-    // PORT_NOTE: This behavior differs from the JS code, which removes anything with @defer.
-    // TODO(@TylerBloom): After the private preview and @defer being impl-ed, check if this logic
-    // should be changed to mirror the JS code.
     pub(crate) fn without_defer(mut self) -> Self {
         if self.has_defer() {
             self.selection_set.without_defer();
@@ -413,7 +410,7 @@ mod selection_map {
             }
         }
 
-        pub(crate) fn get_directives_mut(&mut self) -> &mut Arc<executable::DirectiveList> {
+        pub(super) fn get_directives_mut(&mut self) -> &mut Arc<executable::DirectiveList> {
             match self {
                 Self::Field(field) => field.get_directives_mut(),
                 Self::FragmentSpread(spread) => spread.get_directives_mut(),
@@ -421,7 +418,7 @@ mod selection_map {
             }
         }
 
-        pub(crate) fn get_selection_set_mut(&mut self) -> Option<&mut SelectionSet> {
+        pub(super) fn get_selection_set_mut(&mut self) -> Option<&mut SelectionSet> {
             match self {
                 Self::Field(field) => field.get_selection_set_mut().as_mut(),
                 Self::FragmentSpread(spread) => Some(spread.get_selection_set_mut()),
@@ -446,7 +443,7 @@ mod selection_map {
             Arc::make_mut(self.0).field.sibling_typename_mut()
         }
 
-        pub(crate) fn get_directives_mut(&mut self) -> &mut Arc<executable::DirectiveList> {
+        pub(super) fn get_directives_mut(&mut self) -> &mut Arc<executable::DirectiveList> {
             Arc::make_mut(self.0).field.directives_mut()
         }
 
@@ -463,7 +460,7 @@ mod selection_map {
             Self(fragment_spread_selection)
         }
 
-        pub(crate) fn get_directives_mut(&mut self) -> &mut Arc<executable::DirectiveList> {
+        pub(super) fn get_directives_mut(&mut self) -> &mut Arc<executable::DirectiveList> {
             Arc::make_mut(self.0).spread.directives_mut()
         }
 
@@ -488,7 +485,7 @@ mod selection_map {
             self.0
         }
 
-        pub(crate) fn get_directives_mut(&mut self) -> &mut Arc<executable::DirectiveList> {
+        pub(super) fn get_directives_mut(&mut self) -> &mut Arc<executable::DirectiveList> {
             Arc::make_mut(self.0).inline_fragment.directives_mut()
         }
 
@@ -1237,7 +1234,7 @@ mod field_selection {
             &self.data
         }
 
-        pub(crate) fn directives_mut(&mut self) -> &mut Arc<executable::DirectiveList> {
+        pub(super) fn directives_mut(&mut self) -> &mut Arc<executable::DirectiveList> {
             &mut self.data.directives
         }
 
@@ -1426,7 +1423,7 @@ mod fragment_spread_selection {
             }
         }
 
-        pub(crate) fn directives_mut(&mut self) -> &mut Arc<executable::DirectiveList> {
+        pub(super) fn directives_mut(&mut self) -> &mut Arc<executable::DirectiveList> {
             &mut self.data.directives
         }
 
@@ -1724,7 +1721,7 @@ mod inline_fragment_selection {
             &self.data
         }
 
-        pub(crate) fn directives_mut(&mut self) -> &mut Arc<executable::DirectiveList> {
+        pub(super) fn directives_mut(&mut self) -> &mut Arc<executable::DirectiveList> {
             &mut self.data.directives
         }
 
@@ -2979,9 +2976,6 @@ impl SelectionSet {
     }
 
     /// Removes the @defer directive from all selections without removing that selection.
-    // PORT_NOTE: This behavior differs from the JS code, which removes anything with @defer.
-    // TODO(@TylerBloom): After the private preview and @defer being impl-ed, check if this logic
-    // should be changed to mirror the JS code.
     fn without_defer(&mut self) {
         // TODO: This doesn't seem like the correct way to get the directive name...
         let Some(defer_name) = self.schema.get_directive_definition(&name!("defer")) else {

--- a/apollo-federation/src/query_plan/mod.rs
+++ b/apollo-federation/src/query_plan/mod.rs
@@ -18,13 +18,13 @@ pub(crate) mod query_planning_traversal;
 
 pub type QueryPlanCost = f64;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq)]
 pub struct QueryPlan {
     pub node: Option<TopLevelPlanNode>,
     pub statistics: QueryPlanningStatistics,
 }
 
-#[derive(Debug, derive_more::From)]
+#[derive(Debug, PartialEq, derive_more::From)]
 pub enum TopLevelPlanNode {
     Subscription(SubscriptionNode),
     #[from(types(FetchNode))]
@@ -37,14 +37,14 @@ pub enum TopLevelPlanNode {
     Condition(Box<ConditionNode>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SubscriptionNode {
     pub primary: Box<FetchNode>,
     // XXX(@goto-bus-stop) Is this not just always a SequenceNode?
     pub rest: Option<Box<PlanNode>>,
 }
 
-#[derive(Debug, Clone, derive_more::From)]
+#[derive(Debug, Clone, PartialEq, derive_more::From)]
 pub enum PlanNode {
     #[from(types(FetchNode))]
     Fetch(Box<FetchNode>),
@@ -56,7 +56,7 @@ pub enum PlanNode {
     Condition(Box<ConditionNode>),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FetchNode {
     pub subgraph_name: NodeStr,
     /// Optional identifier for the fetch for defer support. All fetches of a given plan will be
@@ -89,17 +89,17 @@ pub struct FetchNode {
     pub context_rewrites: Vec<Arc<FetchDataRewrite>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SequenceNode {
     pub nodes: Vec<PlanNode>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ParallelNode {
     pub nodes: Vec<PlanNode>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FlattenNode {
     pub path: Vec<FetchDataPathElement>,
     pub node: Box<PlanNode>,
@@ -121,7 +121,7 @@ pub struct FlattenNode {
 /// we implement more advanced server-side heuristics to decide if deferring is judicious or not.
 /// This allows the executor of the plan to consistently send a defer-abiding multipart response to
 /// the client.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DeferNode {
     /// The "primary" part of a defer, that is the non-deferred part (though could be deferred
     /// itself for a nested defer).
@@ -133,7 +133,7 @@ pub struct DeferNode {
 }
 
 /// The primary block of a `DeferNode`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PrimaryDeferBlock {
     /// The part of the original query that "selects" the data to send in that primary response
     /// once the plan in `node` completes). Note that if the parent `DeferNode` is nested, then it
@@ -149,7 +149,7 @@ pub struct PrimaryDeferBlock {
 }
 
 /// A deferred block of a `DeferNode`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DeferredDeferBlock {
     /// References one or more fetch node(s) (by `id`) within `DeferNode.primary.node`. The plan of
     /// this deferred part should not be started until all such fetches return.
@@ -171,13 +171,13 @@ pub struct DeferredDeferBlock {
     pub node: Option<Box<PlanNode>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct DeferredDependency {
     /// A `FetchNode` ID.
     pub id: NodeStr,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ConditionNode {
     pub condition_variable: Name,
     pub if_clause: Option<Box<PlanNode>>,
@@ -188,14 +188,14 @@ pub struct ConditionNode {
 ///
 /// A rewrite usually identifies some sub-part of the data and some action to perform on that
 /// sub-part.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum FetchDataRewrite {
     ValueSetter(FetchDataValueSetter),
     KeyRenamer(FetchDataKeyRenamer),
 }
 
 /// A rewrite that sets a value at the provided path of the data it is applied to.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FetchDataValueSetter {
     /// Path to the value that is set by this "rewrite".
     pub path: Vec<FetchDataPathElement>,
@@ -205,7 +205,7 @@ pub struct FetchDataValueSetter {
 }
 
 /// A rewrite that renames the key at the provided path of the data it is applied to.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FetchDataKeyRenamer {
     /// Path to the key that is renamed by this "rewrite".
     pub path: Vec<FetchDataPathElement>,
@@ -237,7 +237,7 @@ pub enum FetchDataPathElement {
 
 /// Vectors of this element match a path in a query. Each element is (1) a field in a query, or (2)
 /// an inline fragment in a query.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum QueryPathElement {
     Field(executable::Field),
     InlineFragment(executable::InlineFragment),

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -19,7 +19,6 @@ use crate::link::federation_spec_definition::FEDERATION_INTERFACEOBJECT_DIRECTIV
 use crate::link::spec::Identity;
 use crate::operation::normalize_operation;
 use crate::operation::NamedFragments;
-use crate::operation::NormalizedDefer;
 use crate::operation::RebasedFragments;
 use crate::operation::SelectionSet;
 use crate::query_graph::build_federated_query_graph;
@@ -369,29 +368,37 @@ impl QueryPlanner {
             &self.interface_types_with_interface_objects,
         )?;
 
-        let (normalized_operation, assigned_defer_labels, defer_conditions, has_defers) =
-            if self.config.incremental_delivery.enable_defer {
-                let NormalizedDefer {
-                    operation,
-                    assigned_defer_labels,
-                    defer_conditions,
-                    has_defers,
-                } = normalized_operation.with_normalized_defer();
-                if has_defers && is_subscription {
-                    return Err(SingleFederationError::DeferredSubscriptionUnsupported.into());
-                }
-                (
-                    operation,
-                    Some(assigned_defer_labels),
-                    Some(defer_conditions),
-                    has_defers,
-                )
-            } else {
-                // If defer is not enabled, we remove all @defer from the query. This feels cleaner do this once here than
-                // having to guard all the code dealing with defer later, and is probably less error prone too (less likely
-                // to end up passing through a @defer to a subgraph by mistake).
-                (normalized_operation.without_defer(), None, None, false)
-            };
+        let (normalized_operation, assigned_defer_labels, defer_conditions, has_defers) = (
+            normalized_operation.without_defer(),
+            None,
+            None::<IndexMap<String, IndexSet<String>>>,
+            false,
+        );
+        /* TODO(TylerBloom): After defer is impl-ed and after the private preview, the call
+         * above needs to be replaced with this if-else expression.
+        if self.config.incremental_delivery.enable_defer {
+            let NormalizedDefer {
+                operation,
+                assigned_defer_labels,
+                defer_conditions,
+                has_defers,
+            } = normalized_operation.with_normalized_defer();
+            if has_defers && is_subscription {
+                return Err(SingleFederationError::DeferredSubscriptionUnsupported.into());
+            }
+            (
+                operation,
+                Some(assigned_defer_labels),
+                Some(defer_conditions),
+                has_defers,
+            )
+        } else {
+            // If defer is not enabled, we remove all @defer from the query. This feels cleaner do this once here than
+            // having to guard all the code dealing with defer later, and is probably less error prone too (less likely
+            // to end up passing through a @defer to a subgraph by mistake).
+            (normalized_operation.without_defer(), None, None, false)
+        };
+        */
 
         if normalized_operation.selection_set.selections.is_empty() {
             return Ok(QueryPlan::default());

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -170,7 +170,7 @@ impl Default for QueryPlannerDebugConfig {
 }
 
 // PORT_NOTE: renamed from PlanningStatistics in the JS codebase.
-#[derive(Debug, Default)]
+#[derive(Debug, PartialEq, Default)]
 pub struct QueryPlanningStatistics {
     pub evaluated_plan_count: Cell<usize>,
 }

--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -612,3 +612,110 @@ fn key_where_at_external_is_not_at_top_level_of_selection_of_requires() {
       "###
     );
 }
+
+// TODO(@TylerBloom): As part of the private preview, we strip out all uses of the @defer
+// directive. Once handling that feature is implemented, this test will start failing and should be
+// updated to use a config for the planner to strip out the defer directive.
+#[test]
+fn defer_gets_stripped_out() {
+    let planner = planner!(
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+          }
+          "#,
+        Subgraph2: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            data: String
+          }
+          "#,
+    );
+    let plan_one = assert_plan!(
+        &planner,
+        r#"
+          {
+              t {
+                  id
+                  data
+              }
+          }
+        "#,
+        @r###"
+          QueryPlan {
+            Sequence {
+              Fetch(service: "Subgraph1") {
+                {
+                  t {
+                    __typename
+                    id
+                  }
+                }
+              },
+              Flatten(path: "t") {
+                Fetch(service: "Subgraph2") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      data
+                    }
+                  }
+                },
+              },
+            },
+          }
+        "###
+    );
+    let plan_two = assert_plan!(
+        &planner,
+        r#"
+          {
+              t {
+                  id
+                  ... @defer {
+                    data
+                  }
+              }
+          }
+        "#,
+        @r###"
+          QueryPlan {
+            Sequence {
+              Fetch(service: "Subgraph1") {
+                {
+                  t {
+                    __typename
+                    id
+                  }
+                }
+              },
+              Flatten(path: "t") {
+                Fetch(service: "Subgraph2") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      data
+                    }
+                  }
+                },
+              },
+            },
+          }
+        "###
+    );
+    assert_eq!(plan_one, plan_two)
+}

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/subscriptions.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/subscriptions.rs
@@ -135,10 +135,12 @@ fn basic_subscription_with_single_subgraph() {
     );
 }
 
+// TODO(@TylerBloom): Currently, all defer directives are stripped out, so this does not panic
+// quite as expected. Instead, it panics because the snapshots doesn't match. Once this behavior is
+// changed, this should panic with an error along the lines of "@defer can't be used with
+// subscriptions".
 #[test]
-// TODO: This panic should say something along the line os "@defer is not supported on subscriptions" but
-// defer is currently `todo!`. Change this error message once defer is implemented.
-#[should_panic(expected = "not yet implemented: @defer not implemented")]
+#[should_panic(expected = "snapshot assertion")]
 fn trying_to_use_defer_with_a_subcription_results_in_an_error() {
     let config = QueryPlannerConfig {
         incremental_delivery: QueryPlanIncrementalDeliveryConfig { enable_defer: true },

--- a/apollo-federation/tests/query_plan/supergraphs/defer_gets_stripped_out.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_gets_stripped_out.graphql
@@ -1,0 +1,57 @@
+# Composed from subgraphs with hash: 468d7f03b0a1c21793bcfc5e41d6ddeea4e94ed1
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  data: String @join__field(graph: SUBGRAPH2)
+}


### PR DESCRIPTION
Currently, the Rust QP does not handle `@defer`. Because of this, the private preview needs to strip out the use of this directive. This is requires implementing `Operation::without_defer` and ensuring that, while building the query plan, this method is called regardless of config.

Fixes FED-293

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
