### PR TITLE
fix(federation): turn todos into SingleFederationError

### DIFF
--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -111,8 +111,7 @@ impl Supergraph {
     pub fn compose(subgraphs: Vec<&ValidSubgraph>) -> Result<Self, MergeFailure> {
         let schema = merge_subgraphs(subgraphs)?.schema;
         Ok(Self {
-            schema: ValidFederationSchema::new(schema)
-                .map_err(|err| Into::<MergeFailure>::into(err))?,
+            schema: ValidFederationSchema::new(schema).map_err(Into::<MergeFailure>::into)?,
         })
     }
 

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -112,7 +112,7 @@ impl Supergraph {
         let schema = merge_subgraphs(subgraphs)?.schema;
         Ok(Self {
             schema: ValidFederationSchema::new(schema)
-                .map_err(|err| todo!("missing error handling: {err}"))?,
+                .map_err(|err| Into::<MergeFailure>::into(err))?,
         })
     }
 

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -3123,7 +3123,10 @@ impl SelectionSet {
                     field: field.clone(),
                 }),
                 Selection::FragmentSpread(_fragment) => {
-                    debug_assert!(false, "unexpected fragment spreads in expanded fetch operation");
+                    debug_assert!(
+                        false,
+                        "unexpected fragment spreads in expanded fetch operation"
+                    );
                 }
                 Selection::InlineFragment(inline_fragment) => {
                     let condition = inline_fragment

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -3122,9 +3122,7 @@ impl SelectionSet {
                     path: Vec::new(),
                     field: field.clone(),
                 }),
-                Selection::FragmentSpread(_fragment) => {
-                    todo!()
-                }
+                Selection::FragmentSpread(_fragment) => return fields,
                 Selection::InlineFragment(inline_fragment) => {
                     let condition = inline_fragment
                         .inline_fragment

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -3122,7 +3122,9 @@ impl SelectionSet {
                     path: Vec::new(),
                     field: field.clone(),
                 }),
-                Selection::FragmentSpread(_fragment) => return fields,
+                Selection::FragmentSpread(_fragment) => {
+                    debug_assert!(false, "unexpected fragment spreads in expanded fetch operation");
+                }
                 Selection::InlineFragment(inline_fragment) => {
                     let condition = inline_fragment
                         .inline_fragment

--- a/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -97,8 +97,11 @@ pub(crate) fn extract_subgraphs_from_supergraph(
         }
     }
     if is_fed_1 {
-        // Handle Fed 1 supergraphs eventually, the extraction logic is gnarly
-        todo!()
+        let unsupported = 
+            SingleFederationError::UnsupportedFederationVersion {
+                message: String::from("Supergraphs composed with federation version 1 are not supported. Please recompose your supergraph with federation version 2 or greater")
+            };
+        return Err(unsupported.into());
     } else {
         extract_subgraphs_from_fed_2_supergraph(
             supergraph_schema,
@@ -132,8 +135,11 @@ pub(crate) fn extract_subgraphs_from_supergraph(
                 Err((schema, error)) => {
                     subgraph.schema = schema;
                     if is_fed_1 {
-                        // See message above about Fed 1 supergraphs
-                        todo!()
+                        let message = 
+                                String::from("Supergraphs composed with federation version 1 are not supported. Please recompose your supergraph with federation version 2 or greater");
+                        return Err(
+                            SingleFederationError::UnsupportedFederationVersion { message }.into()
+                        );
                     } else {
                         let mut message = format!(
                                     "Unexpected error extracting {} from the supergraph: this is either a bug, or the supergraph has been corrupted.\n\nDetails:\n{error}",

--- a/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -97,7 +97,7 @@ pub(crate) fn extract_subgraphs_from_supergraph(
         }
     }
     if is_fed_1 {
-        let unsupported = 
+        let unsupported =
             SingleFederationError::UnsupportedFederationVersion {
                 message: String::from("Supergraphs composed with federation version 1 are not supported. Please recompose your supergraph with federation version 2 or greater")
             };
@@ -135,11 +135,12 @@ pub(crate) fn extract_subgraphs_from_supergraph(
                 Err((schema, error)) => {
                     subgraph.schema = schema;
                     if is_fed_1 {
-                        let message = 
+                        let message =
                                 String::from("Supergraphs composed with federation version 1 are not supported. Please recompose your supergraph with federation version 2 or greater");
-                        return Err(
-                            SingleFederationError::UnsupportedFederationVersion { message }.into()
-                        );
+                        return Err(SingleFederationError::UnsupportedFederationVersion {
+                            message,
+                        }
+                        .into());
                     } else {
                         let mut message = format!(
                                     "Unexpected error extracting {} from the supergraph: this is either a bug, or the supergraph has been corrupted.\n\nDetails:\n{error}",

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -724,11 +724,15 @@ fn compute_plan_internal(
     }
 }
 
+// TODO: FED-95
 fn compute_plan_for_defer_conditionals(
     _parameters: &mut QueryPlanningParameters,
     _defer_conditions: IndexMap<String, IndexSet<String>>,
 ) -> Result<Option<PlanNode>, FederationError> {
-    todo!("FED-95")
+    Err(SingleFederationError::Internal {
+        message: String::from("@defer is currently not supported"),
+    }
+    .into())
 }
 
 #[cfg(test)]

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -277,7 +277,13 @@ impl ValidFederationSchema {
             return Ok(name);
         }
 
-        todo!()
+        // TODO: this otherwise needs to check for a type name in schema based
+        // on the latest federation version.
+        // FED-311
+        Err(SingleFederationError::Internal {
+            message: String::from("typename should have been looked in a federation feature"),
+        }
+        .into())
     }
 
     pub(crate) fn is_interface_object_type(


### PR DESCRIPTION
Instead of panicking with `todo!()`, return an error.

A lot of these were only coming from composition call sites as far as I could tell, but I'd rather not have the todos and have redundant errors in places than a panic. 

I added an explicit `UnsupportedFederationVersion` error kind to `SingleFederationError`. It's `ErrorCode` placement is the very last, so shouldn't mess up the numbering there. I prefer to be extra explicit here rather than returning `Internal`. 

The `MergeFailure` had to be turned to `Vec<String>`, I didn't really feel like dealing with `Vec<&str>` (which we shouldn't have had in the first place) when trying to do a `From`. That entire module's error handling will have to be reworked anyways, this just makes it more straightforward to convert for that todo.