### PR TITLE
More `@connect` validations

### DIFF
--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -19,8 +19,8 @@ pub use json_selection::PathSelection;
 pub use json_selection::SubSelection;
 pub use models::validate;
 pub use models::Location;
-pub use models::ValidationError;
-pub use models::ValidationErrorCode;
+pub use models::ValidationCode;
+pub use models::ValidationMessage;
 pub(crate) use spec::ConnectSpecDefinition;
 pub use url_path_template::URLPathTemplate;
 

--- a/apollo-federation/src/sources/connect/models/mod.rs
+++ b/apollo-federation/src/sources/connect/models/mod.rs
@@ -3,9 +3,9 @@ mod validation;
 use apollo_compiler::NodeStr;
 use indexmap::IndexMap;
 pub use validation::validate;
-pub use validation::Error as ValidationError;
-pub use validation::ErrorCode as ValidationErrorCode;
+pub use validation::Code as ValidationCode;
 pub use validation::Location;
+pub use validation::Message as ValidationMessage;
 
 use super::spec::ConnectHTTPArguments;
 use super::spec::HTTPHeaderOption;

--- a/apollo-federation/src/sources/connect/models/test_data/absolute_connect_url_with_source.graphql
+++ b/apollo-federation/src/sources/connect/models/test_data/absolute_connect_url_with_source.graphql
@@ -1,0 +1,11 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect", "@source"]
+)
+@source(name: "v2", http: {baseURL: "http://127.0.0.1"})
+
+type Query {
+    resources: [String!]!
+    @connect(source: "v2", http: {GET: "http://127.0.0.1/resources"})
+}

--- a/apollo-federation/src/sources/connect/models/test_data/invalid_connect_url.graphql
+++ b/apollo-federation/src/sources/connect/models/test_data/invalid_connect_url.graphql
@@ -1,0 +1,10 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    resources: [String!]!
+    @connect(http: {GET: "127.0.0.1"})
+}

--- a/apollo-federation/src/sources/connect/models/test_data/invalid_connect_url_scheme.graphql
+++ b/apollo-federation/src/sources/connect/models/test_data/invalid_connect_url_scheme.graphql
@@ -1,0 +1,10 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    resources: [String!]!
+    @connect(http: {GET: "file://data.json"})
+}

--- a/apollo-federation/src/sources/connect/models/test_data/missing_connect_on_query_field.graphql
+++ b/apollo-federation/src/sources/connect/models/test_data/missing_connect_on_query_field.graphql
@@ -1,0 +1,10 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect", "@source"]
+)
+@source(name: "v2", http: {baseURL: "http://127.0.0.1"})
+
+type Query {
+    resources: [String!]!
+}

--- a/apollo-federation/src/sources/connect/models/test_data/missing_source_import.graphql
+++ b/apollo-federation/src/sources/connect/models/test_data/missing_source_import.graphql
@@ -1,0 +1,11 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+@source(name: "v2", http: {baseURL: "http://127.0.0.1"})
+
+type Query {
+    resources: [String!]!
+    @connect(source: "v2", http: {GET: "/resources"})
+}

--- a/apollo-federation/src/sources/connect/models/test_data/relative_connect_url_without_source.graphql
+++ b/apollo-federation/src/sources/connect/models/test_data/relative_connect_url_without_source.graphql
@@ -1,0 +1,10 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    resources: [String!]!
+    @connect(http: {GET: "/resources"})
+}

--- a/apollo-federation/src/sources/connect/models/test_data/renamed_connect_directive.graphql
+++ b/apollo-federation/src/sources/connect/models/test_data/renamed_connect_directive.graphql
@@ -1,0 +1,10 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: [{name: "@connect", as: "@data"}, "@source"]
+)
+@source(name: "v2", http: {baseURL: "http://127.0.0.1"})
+
+type Query {
+    resources: [String!]!
+}

--- a/apollo-federation/src/sources/connect/models/test_data/valid_connect_absolute_url.graphql
+++ b/apollo-federation/src/sources/connect/models/test_data/valid_connect_absolute_url.graphql
@@ -1,0 +1,10 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    resources: [String!]!
+    @connect(http: {GET: "http://127.0.0.1:8000/resources"})
+}

--- a/apollo-federation/src/sources/connect/models/validation.rs
+++ b/apollo-federation/src/sources/connect/models/validation.rs
@@ -18,16 +18,12 @@
 
 ## @connect
 
-- Disallowed on Subscription fields
 - http:
   - Has one path (GET, POST, etc)
   - URL path template valid syntax
   - body is valid syntax
 - selection
   - Valid syntax
-- If no source:
-  - http:
-    - Path is a fully qualified URL (plus a URL path template)
 - If entity: true
   - Must be on Query type
   - Field arguments must match fields in type (and @key if present)
@@ -51,16 +47,13 @@
 - Missing $args
 - Missing $this
 
-## @link
-
-- Rename @connect import
-
 */
 
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::ops::Range;
 
+use apollo_compiler::ast::FieldDefinition;
 use apollo_compiler::ast::Name;
 use apollo_compiler::ast::Value;
 use apollo_compiler::schema::Component;
@@ -75,8 +68,10 @@ use itertools::Itertools;
 use url::Url;
 
 use crate::link::Link;
+use crate::sources::connect::spec::schema::CONNECT_HTTP_ARGUMENT_NAME;
 use crate::sources::connect::spec::schema::CONNECT_SOURCE_ARGUMENT_NAME;
 use crate::sources::connect::spec::schema::SOURCE_BASE_URL_ARGUMENT_NAME;
+use crate::sources::connect::spec::schema::SOURCE_DIRECTIVE_NAME_IN_SPEC;
 use crate::sources::connect::spec::schema::SOURCE_HTTP_ARGUMENT_NAME;
 use crate::sources::connect::spec::schema::SOURCE_NAME_ARGUMENT_NAME;
 use crate::sources::connect::ConnectSpecDefinition;
@@ -85,21 +80,22 @@ use crate::sources::connect::ConnectSpecDefinition;
 ///
 /// This function attempts to collect as many validation errors as possible, so it does not bail
 /// out as soon as it encounters one.
-pub fn validate(schema: Schema) -> Vec<Error> {
+pub fn validate(schema: Schema) -> Vec<Message> {
     let connect_identity = ConnectSpecDefinition::identity();
-    let link = schema
-        .schema_definition
-        .directives
-        .iter()
-        .find_map(|directive| {
-            let link = Link::from_directive_application(directive).ok()?;
-            if link.url.identity == connect_identity {
-                Some(link)
-            } else {
-                None
-            }
-        });
-    let Some(link) = link else {
+    let Some((link, link_directive)) =
+        schema
+            .schema_definition
+            .directives
+            .iter()
+            .find_map(|directive| {
+                let link = Link::from_directive_application(directive).ok()?;
+                if link.url.identity == connect_identity {
+                    Some((link, directive))
+                } else {
+                    None
+                }
+            })
+    else {
         return vec![]; // There are no connectors-related directives to validate
     };
     let source_map = &schema.sources;
@@ -113,16 +109,16 @@ pub fn validate(schema: Schema) -> Vec<Error> {
         .map(|directive| validate_source(directive, source_map))
         .collect();
 
-    let mut errors = Vec::new();
+    let mut messages = Vec::new();
     let mut valid_source_names = HashMap::new();
     let all_source_names = source_directives
         .iter()
         .map(|directive| directive.name.clone())
         .collect_vec();
     for directive in source_directives {
-        errors.extend(directive.errors);
+        messages.extend(directive.errors);
         match directive.name.into_value_or_error(source_map) {
-            Err(error) => errors.push(error),
+            Err(error) => messages.push(error),
             Ok(name) => valid_source_names
                 .entry(name)
                 .or_insert_with(Vec::new)
@@ -134,9 +130,9 @@ pub fn validate(schema: Schema) -> Vec<Error> {
     }
     for (name, locations) in valid_source_names {
         if locations.len() > 1 {
-            errors.push(Error {
+            messages.push(Message {
                 message: format!("Every `@{source_directive_name}({SOURCE_NAME_ARGUMENT_NAME}:)` must be unique. Found duplicate name {name}."),
-                code: ErrorCode::DuplicateSourceName,
+                code: Code::DuplicateSourceName,
                 locations,
             });
         }
@@ -157,9 +153,25 @@ pub fn validate(schema: Schema) -> Vec<Error> {
                 &all_source_names,
             )
         });
-    errors.extend(connect_errors);
-    errors
+    messages.extend(connect_errors);
+    if source_directive_name == DEFAULT_SOURCE_DIRECTIVE_NAME
+        && messages
+            .iter()
+            .any(|error| error.code == Code::NoSourcesDefined)
+    {
+        messages.push(Message {
+            code: Code::NoSourceImport,
+            message: format!("The `@{SOURCE_DIRECTIVE_NAME_IN_SPEC}` directive is not imported. Try adding `@{SOURCE_DIRECTIVE_NAME_IN_SPEC}` to `import` for `@{link_name}(url: \"{connect_identity}\")`", link_name=link_directive.name),
+            locations: Location::from_node(link_directive.location(), source_map)
+                .into_iter()
+                .collect(),
+        });
+    }
+    messages
 }
+
+const DEFAULT_SOURCE_DIRECTIVE_NAME: &str = "connect__source";
+const DEFAULT_CONNECT_DIRECTIVE_NAME: &str = "connect__connect";
 
 fn validate_source(directive: &Component<Directive>, sources: &SourceMap) -> SourceDirective {
     let name = SourceName::from_directive(directive);
@@ -168,43 +180,15 @@ fn validate_source(directive: &Component<Directive>, sources: &SourceMap) -> Sou
         .iter()
         .find(|arg| arg.name == SOURCE_HTTP_ARGUMENT_NAME)
         .and_then(|arg| {
-            let value = arg
-                .value
-                .as_object()?
-                .iter()
-                .find_map(|(name, value)| {
-                    (*name == SOURCE_BASE_URL_ARGUMENT_NAME).then_some(value)
-                })?
-                .as_str()?;
-            let url = match Url::parse(value) {
-                Err(inner) => {
-                    return Some(Error {
-                        code: ErrorCode::SourceUrl,
-                        message: format!(
-                            "The value \"{value}\" for {coordinate} is not a valid URL: {inner}.",
-                            coordinate = source_base_url_argument_coordinate(&directive.name),
-                        ),
-                        locations: Location::from_node(arg.location(), sources)
-                            .into_iter()
-                            .collect(),
-                    })
-                }
-                Ok(url) => url,
-            };
-            let scheme = url.scheme();
-            if scheme != "http" && scheme != "https" {
-                return Some(Error {
-                    code: ErrorCode::SourceScheme,
-                    message: format!(
-                        "The value \"{value}\" for {coordinate} must be http or https, got {scheme}.",
-                        coordinate = source_base_url_argument_coordinate(&directive.name),
-                    ),
-                    locations: Location::from_node(arg.value.location(), sources)
-                        .into_iter()
-                        .collect(),
-                });
-            }
-            None
+            let value = arg.value.as_object()?.iter().find_map(|(name, value)| {
+                (*name == SOURCE_BASE_URL_ARGUMENT_NAME).then_some(value)
+            })?;
+            parse_url(
+                value,
+                &source_base_url_argument_coordinate(&directive.name),
+                sources,
+            )
+            .err()
         });
     let mut errors = Vec::new();
     if let Some(url_error) = url_error {
@@ -220,7 +204,7 @@ fn validate_source(directive: &Component<Directive>, sources: &SourceMap) -> Sou
 /// A `@source` directive along with any errors related to it.
 struct SourceDirective {
     name: SourceName,
-    errors: Vec<Error>,
+    errors: Vec<Message>,
     directive: Component<Directive>,
 }
 
@@ -232,7 +216,7 @@ fn validate_object_fields(
     connect_directive_name: &Name,
     source_directive_name: &Name,
     source_names: &[SourceName],
-) -> Vec<Error> {
+) -> Vec<Message> {
     let source_map = &schema.sources;
     let is_subscription = schema
         .schema_definition
@@ -240,8 +224,8 @@ fn validate_object_fields(
         .as_ref()
         .is_some_and(|sub| sub.name == object.name);
     if is_subscription {
-        return vec![Error {
-            code: ErrorCode::SubscriptionInConnectors,
+        return vec![Message {
+            code: Code::SubscriptionInConnectors,
             message: format!(
                 "A subscription root type is not supported when using `@{connect_directive_name}`."
             ),
@@ -250,81 +234,223 @@ fn validate_object_fields(
                 .collect(),
         }];
     }
-    let is_query = schema
+    let object_category = if schema
         .schema_definition
         .query
         .as_ref()
-        .is_some_and(|query| query.name == object.name);
-    let fields = object.fields.values();
+        .is_some_and(|query| query.name == object.name)
+    {
+        ObjectCategory::Query
+    } else {
+        ObjectCategory::Other
+    };
+    object
+        .fields
+        .values()
+        .flat_map(|field| {
+            validate_field(
+                field,
+                object_category,
+                source_names,
+                &object.name,
+                source_map,
+                connect_directive_name,
+                source_directive_name,
+            )
+        })
+        .collect()
+}
+
+fn validate_field(
+    field: &Component<FieldDefinition>,
+    category: ObjectCategory,
+    source_names: &[SourceName],
+    object_name: &Name,
+    source_map: &SourceMap,
+    connect_directive_name: &Name,
+    source_directive_name: &Name,
+) -> Vec<Message> {
+    let _connect_directive_name = connect_directive_name.as_str();
     let mut errors = Vec::new();
-    for field in fields {
-        let Some(connect_directive) = field
-            .directives
-            .iter()
-            .find(|directive| directive.name == *connect_directive_name)
-        else {
-            if is_query {
-                errors.push(Error {
-                    code: ErrorCode::QueryFieldMissingConnect,
+    let Some(connect_directive) = field
+        .directives
+        .iter()
+        .find(|directive| directive.name == *connect_directive_name)
+    else {
+        if category == ObjectCategory::Query {
+            errors.push(Message {
+                code: Code::QueryFieldMissingConnect,
+                message: format!(
+                    "The field `{object_name}.{field}` has no `@{connect_directive_name}` directive.",
+                    field = field.name,
+                ),
+                locations: Location::from_node(field.location(), source_map)
+                    .into_iter()
+                    .collect(),
+            });
+        }
+        // TODO: return errors when a field is not resolvable by some combination of `@connect`
+        return errors;
+    };
+    let Some((http_verb, url)) = connect_directive
+        .argument_by_name(&CONNECT_HTTP_ARGUMENT_NAME)
+        .and_then(
+            |http_arg| http_arg.as_object()?.first(), // TODO: Error if more than one verb is defined
+        )
+    else {
+        errors.push(Message {
+            code: Code::GraphQLError,
+            message: format!(
+                "{coordinate} must have a `{CONNECT_HTTP_ARGUMENT_NAME}` argument.",
+                coordinate =
+                    connect_directive_coordinate(connect_directive_name, object_name, &field.name),
+            ),
+            locations: Location::from_node(connect_directive.location(), source_map)
+                .into_iter()
+                .collect(),
+        });
+        return errors;
+    };
+    let url_coordinate = connect_directive_url_coordinate(
+        connect_directive_name,
+        http_verb,
+        object_name,
+        &field.name,
+    );
+    if let Some(source_name) = connect_directive
+        .arguments
+        .iter()
+        .find(|arg| arg.name == CONNECT_SOURCE_ARGUMENT_NAME)
+    {
+        if source_names.iter().all(|name| name != &source_name.value) {
+            // TODO: Pick a suggestion that's not just the first defined source
+            let qualified_directive = connect_directive_name_coordinate(
+                connect_directive_name,
+                &source_name.value,
+                object_name,
+                &field.name,
+            );
+            if let Some(first_source_name) = source_names.first() {
+                errors.push(Message {
+                    code: Code::SourceNameMismatch,
                     message: format!(
-                        "The field `{object}.{field}` has no `@{connect_directive_name}` directive.",
-                        object = object.name,
-                        field = field.name,
+                        "{qualified_directive} does not match any defined sources. Did you mean {first_source_name}?",
                     ),
-                    locations: Location::from_node(field.location(), source_map)
+                    locations: Location::from_node(source_name.location(), source_map)
+                        .into_iter()
+                        .collect(),
+                });
+            } else {
+                errors.push(Message {
+                    code: Code::NoSourcesDefined,
+                    message: format!(
+                        "{qualified_directive} specifies a source, but none are defined. Try adding {coordinate} to the schema.",
+                        coordinate = source_name_value_coordinate(source_directive_name, &source_name.value),
+                    ),
+                    locations: Location::from_node(source_name.location(), source_map)
                         .into_iter()
                         .collect(),
                 });
             }
-            // TODO: return errors when a field is not resolvable by some combination of `@connect`
-            continue;
-        };
-        let Some(source_name) = connect_directive
-            .arguments
-            .iter()
-            .find(|arg| arg.name == CONNECT_SOURCE_ARGUMENT_NAME)
-        else {
-            // TODO: handle direct http connects, not just named sources
-            continue;
-        };
-
-        if source_names.iter().all(|name| name != &source_name.value) {
-            // TODO: Pick a suggestion that's not just the first defined source
-            let qualified_directive = connect_directive_coordinate(
-                connect_directive_name,
-                &source_name.value,
-                &object.name,
-                &field.name,
-            );
-            let message = if let Some(first_source_name) = source_names.first() {
-                format!(
-                        "{qualified_directive} does not match any defined sources. Did you mean {first_source_name}?",
-                    )
-            } else {
-                format!(
-                        "{qualified_directive} specifies a source, but none are defined. Try adding {coordinate} to the schema.",
-                        coordinate = source_name_value_coordinate(source_directive_name, &source_name.value),
-                    )
-            };
-            errors.push(Error {
-                code: ErrorCode::SourceNameMismatch,
-                message,
-                locations: Location::from_node(source_name.location(), source_map)
+        }
+        if parse_url(url, &url_coordinate, source_map).is_ok() {
+            errors.push(Message {
+                code: Code::AbsoluteConnectUrlWithSource,
+                message: format!(
+                    "{url_coordinate} contains the absolute URL {url} while also specifying a `{CONNECT_SOURCE_ARGUMENT_NAME}`. Either remove the `{CONNECT_SOURCE_ARGUMENT_NAME}` argument or change the URL to a path.",
+                ),
+                locations: Location::from_node(url.location(), source_map)
                     .into_iter()
                     .collect(),
             });
+        }
+    } else if let Some(err) = parse_url(url, &url_coordinate, source_map).err() {
+        // Attempt to detect if they were using a relative path without a source, no way to be perfect with this
+        if url
+            .as_str()
+            .is_some_and(|url| url.starts_with('/') || url.ends_with('/'))
+        {
+            errors.push(Message {
+                code: Code::RelativeConnectUrlWithoutSource,
+                message: format!(
+                    "{url_coordinate} specifies the relative URL {url}, but no `{CONNECT_SOURCE_ARGUMENT_NAME}` is defined. Either use an absolute URL, or add a `@{source_directive_name}`."),
+                locations: Location::from_node(url.location(), source_map).into_iter().collect()
+            });
+        } else {
+            errors.push(err);
         }
     }
     errors
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ObjectCategory {
+    Query,
+    Other,
+}
+
+fn parse_url(value: &Node<Value>, coordinate: &str, sources: &SourceMap) -> Result<Url, Message> {
+    let str_value = require_value_is_str(value, coordinate, sources)?;
+    let url = Url::parse(str_value).map_err(|inner| Message {
+        code: Code::InvalidUrl,
+        message: format!("The value {value} for {coordinate} is not a valid URL: {inner}.",),
+        locations: Location::from_node(value.location(), sources)
+            .into_iter()
+            .collect(),
+    })?;
+    let scheme = url.scheme();
+    if scheme != "http" && scheme != "https" {
+        return Err(Message {
+            code: Code::SourceScheme,
+            message: format!(
+                "The value {value} for {coordinate} must be http or https, got {scheme}.",
+            ),
+            locations: Location::from_node(value.location(), sources)
+                .into_iter()
+                .collect(),
+        });
+    }
+    Ok(url)
+}
+
+fn require_value_is_str<'a>(
+    value: &'a Node<Value>,
+    coordinate: &str,
+    sources: &SourceMap,
+) -> Result<&'a str, Message> {
+    value.as_str().ok_or_else(|| Message {
+        code: Code::GraphQLError,
+        message: format!("The value for {coordinate} must be a string.",),
+        locations: Location::from_node(value.location(), sources)
+            .into_iter()
+            .collect(),
+    })
+}
+
 fn connect_directive_coordinate(
+    connect_directive_name: &Name,
+    object: &Name,
+    field: &Name,
+) -> String {
+    format!("`@{connect_directive_name}` on `{object}.{field}`")
+}
+
+fn connect_directive_name_coordinate(
     connect_directive_name: &Name,
     source: &Node<Value>,
     object: &Name,
     field: &Name,
 ) -> String {
     format!("`@{connect_directive_name}({CONNECT_SOURCE_ARGUMENT_NAME}: {source})` on `{object}.{field}`")
+}
+
+fn connect_directive_url_coordinate(
+    connect_directive_name: &Name,
+    http_verb: &Name,
+    object: &Name,
+    field: &Name,
+) -> String {
+    format!("`{http_verb}` in `@{connect_directive_name}({CONNECT_HTTP_ARGUMENT_NAME}:)` on `{object}.{field}`")
 }
 
 fn source_name_argument_coordinate(source_directive_name: &DirectiveName) -> String {
@@ -408,26 +534,26 @@ impl SourceName {
         }
     }
 
-    pub fn into_value_or_error(self, sources: &SourceMap) -> Result<Node<Value>, Error> {
+    pub fn into_value_or_error(self, sources: &SourceMap) -> Result<Node<Value>, Message> {
         match self {
             Self::Valid { value, ..} => Ok(value),
             Self::Invalid {
                 value,
                 directive_name,
-            } => Err(Error {
+            } => Err(Message {
                 message: format!("There are invalid characters in {coordinate}. Only alphanumeric and underscores are allowed.", coordinate = source_name_value_coordinate(&directive_name, &value)),
-                code: ErrorCode::InvalidSourceName,
+                code: Code::InvalidSourceName,
                 locations: Location::from_node(value.location(), sources).into_iter().collect(),
             }),
             Self::Empty { directive_name, value } => {
-                Err(Error {
-                    code: ErrorCode::EmptySourceName,
+                Err(Message {
+                    code: Code::EmptySourceName,
                     message: format!("The value for {coordinate} can't be empty.", coordinate = source_name_argument_coordinate(&directive_name))   ,
                     locations: Location::from_node(value.location(), sources).into_iter().collect(),
                 })
             }
-            Self::Missing { directive_name, ast_node } => Err(Error {
-                code: ErrorCode::GraphQLError,
+            Self::Missing { directive_name, ast_node } => Err(Message {
+                code: Code::GraphQLError,
                 message: format!("The {coordinate} argument is required.", coordinate = source_name_argument_coordinate(&directive_name)),
                 locations: Location::from_node(ast_node.location(), sources).into_iter().collect()
             }),
@@ -469,10 +595,10 @@ impl PartialEq<Node<Value>> for SourceName {
 
 /// A problem was found when validating the connectors directives.
 #[derive(Debug)]
-pub struct Error {
+pub struct Message {
     /// A unique, per-error code to allow consuming tools to take specific actions. These codes
     /// should not change once stabilized.
-    pub code: ErrorCode,
+    pub code: Code,
     /// A human-readable message describing the error. These messages are not stable, tools should
     /// not rely on them remaining the same.
     ///
@@ -510,25 +636,50 @@ impl Location {
     }
 }
 
-impl Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message)
-    }
-}
-
-impl std::error::Error for Error {}
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ErrorCode {
+pub enum Code {
+    /// A problem with GraphQL syntax or semantics was found. These will usually be caught before
+    /// this validation process.
     GraphQLError,
     DuplicateSourceName,
     InvalidSourceName,
     EmptySourceName,
-    SourceUrl,
+    InvalidUrl,
     SourceScheme,
     SourceNameMismatch,
     SubscriptionInConnectors,
     QueryFieldMissingConnect,
+    /// The `@connect` is using a `source`, but the URL is absolute. This is trouble because
+    /// the `@source` URL will be joined with the `@connect` URL, so the `@connect` URL should
+    /// actually be a path only.
+    AbsoluteConnectUrlWithSource,
+    /// The `@connect` directive is using a relative URL (path only) but does not define a `source`.
+    /// This is just a specialization of [`Self::InvalidUrl`] that provides a better suggestion for
+    /// the user.
+    RelativeConnectUrlWithoutSource,
+    /// This is a specialization of [`Self::SourceNameMismatch`] that provides a better suggestion.
+    NoSourcesDefined,
+    /// The subgraph doesn't import the `@source` directive. This isn't necessarily a problem, but
+    /// is likely a mistake.
+    NoSourceImport,
+}
+
+impl Code {
+    pub const fn severity(&self) -> Severity {
+        match self {
+            Self::NoSourceImport => Severity::Warning,
+            _ => Severity::Error,
+        }
+    }
+}
+
+/// Given the [`Code`] of a [`Message`], how important is that message?
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Severity {
+    /// This is an error, validation as failed.
+    Error,
+    /// The user probably wants to know about this, but it doesn't halt composition.
+    Warning,
 }
 
 #[cfg(test)]
@@ -543,7 +694,7 @@ mod test_validate_source {
         let schema = Schema::parse(schema, "test.graphql").unwrap();
         let errors = validate(schema);
         assert_eq!(errors.len(), 1);
-        assert_snapshot!(errors[0].to_string(), @r###"The value "127.0.0.1" for `@source(baseURL:)` is not a valid URL: relative URL without a base."###);
+        assert_snapshot!(errors[0].message, @r###"The value "127.0.0.1" for `@source(baseURL:)` is not a valid URL: relative URL without a base."###);
     }
 
     #[test]
@@ -552,7 +703,7 @@ mod test_validate_source {
         let schema = Schema::parse(schema, "test.graphql").unwrap();
         let errors = validate(schema);
         assert_eq!(errors.len(), 1);
-        assert_snapshot!(errors[0].to_string(), @r###"The value "file://data.json" for `@source(baseURL:)` must be http or https, got file."###);
+        assert_snapshot!(errors[0].message, @r###"The value "file://data.json" for `@source(baseURL:)` must be http or https, got file."###);
     }
 
     #[test]
@@ -561,7 +712,7 @@ mod test_validate_source {
         let schema = Schema::parse(schema, "test.graphql").unwrap();
         let errors = validate(schema);
         assert_eq!(errors.len(), 1);
-        assert_snapshot!(errors[0].to_string(), @r###"There are invalid characters in `@source(name: "u$ers")`. Only alphanumeric and underscores are allowed."###);
+        assert_snapshot!(errors[0].message, @r###"There are invalid characters in `@source(name: "u$ers")`. Only alphanumeric and underscores are allowed."###);
     }
 
     #[test]
@@ -570,7 +721,7 @@ mod test_validate_source {
         let schema = Schema::parse(schema, "test.graphql").unwrap();
         let errors = validate(schema);
         assert_eq!(errors.len(), 1);
-        assert_snapshot!(errors[0].to_string(), @"The value for `@source(name:)` can't be empty.");
+        assert_snapshot!(errors[0].message, @"The value for `@source(name:)` can't be empty.");
     }
 
     #[test]
@@ -579,7 +730,7 @@ mod test_validate_source {
         let schema = Schema::parse(schema, "test.graphql").unwrap();
         let errors = validate(schema);
         assert_eq!(errors.len(), 1);
-        assert_snapshot!(errors[0].to_string(), @r###"Every `@source(name:)` must be unique. Found duplicate name "v1"."###);
+        assert_snapshot!(errors[0].message, @r###"Every `@source(name:)` must be unique. Found duplicate name "v1"."###);
     }
 
     #[test]
@@ -588,8 +739,8 @@ mod test_validate_source {
         let schema = Schema::parse(schema, "test.graphql").unwrap();
         let errors = validate(schema);
         assert_eq!(errors.len(), 2);
-        assert_snapshot!(errors[0].to_string(), @r###"The value "ftp://127.0.0.1" for `@source(baseURL:)` must be http or https, got ftp."###);
-        assert_snapshot!(errors[1].to_string(), @r###"There are invalid characters in `@source(name: "u$ers")`. Only alphanumeric and underscores are allowed."###);
+        assert_snapshot!(errors[0].message, @r###"The value "ftp://127.0.0.1" for `@source(baseURL:)` must be http or https, got ftp."###);
+        assert_snapshot!(errors[1].message, @r###"There are invalid characters in `@source(name: "u$ers")`. Only alphanumeric and underscores are allowed."###);
     }
 
     #[test]
@@ -598,7 +749,7 @@ mod test_validate_source {
         let schema = Schema::parse(schema, "test.graphql").unwrap();
         let errors = validate(schema);
         assert_eq!(errors.len(), 1);
-        assert_snapshot!(errors[0].to_string(), @r###"The value "blahblahblah" for `@api(baseURL:)` is not a valid URL: relative URL without a base."###);
+        assert_snapshot!(errors[0].message, @r###"The value "blahblahblah" for `@api(baseURL:)` is not a valid URL: relative URL without a base."###);
     }
 
     #[test]
@@ -607,7 +758,7 @@ mod test_validate_source {
         let schema = Schema::parse(schema, "test.graphql").unwrap();
         let errors = validate(schema);
         assert_eq!(errors.len(), 1);
-        assert_snapshot!(errors[0].to_string(), @r###"`@connect(source: "v1")` on `Query.resources` does not match any defined sources. Did you mean `@source(name: "v2")`?"###);
+        assert_snapshot!(errors[0].message, @r###"`@connect(source: "v1")` on `Query.resources` does not match any defined sources. Did you mean `@source(name: "v2")`?"###);
     }
 
     #[test]
@@ -616,7 +767,7 @@ mod test_validate_source {
         let schema = Schema::parse(schema, "test.graphql").unwrap();
         let errors = validate(schema);
         assert_eq!(errors.len(), 1);
-        assert_snapshot!(errors[0].to_string(), @r###"`@connect(source: "v1")` on `Query.resources` specifies a source, but none are defined. Try adding `@source(name: "v1")` to the schema."###);
+        assert_snapshot!(errors[0].message, @r###"`@connect(source: "v1")` on `Query.resources` specifies a source, but none are defined. Try adding `@source(name: "v1")` to the schema."###);
     }
 
     #[test]
@@ -625,7 +776,7 @@ mod test_validate_source {
         let schema = Schema::parse(schema, "test.graphql").unwrap();
         let errors = validate(schema);
         assert_eq!(errors.len(), 1);
-        assert_snapshot!(errors[0].to_string(), @"A subscription root type is not supported when using `@connect`.");
+        assert_snapshot!(errors[0].message, @"A subscription root type is not supported when using `@connect`.");
     }
 
     #[test]
@@ -634,8 +785,8 @@ mod test_validate_source {
         let schema = Schema::parse(schema, "test.graphql").unwrap();
         let errors = validate(schema);
         assert_eq!(errors.len(), 1);
-        assert_eq!(errors[0].code, ErrorCode::QueryFieldMissingConnect);
-        assert_snapshot!(errors[0], @r###"The field `Query.resources` has no `@connect` directive."###);
+        assert_eq!(errors[0].code, Code::QueryFieldMissingConnect);
+        assert_snapshot!(errors[0].message, @r###"The field `Query.resources` has no `@connect` directive."###);
     }
 
     #[test]
@@ -644,7 +795,65 @@ mod test_validate_source {
         let schema = Schema::parse(schema, "test.graphql").unwrap();
         let errors = validate(schema);
         assert_eq!(errors.len(), 1);
-        assert_eq!(errors[0].code, ErrorCode::QueryFieldMissingConnect);
-        assert_snapshot!(errors[0], @r###"The field `Query.resources` has no `@data` directive."###);
+        assert_eq!(errors[0].code, Code::QueryFieldMissingConnect);
+        assert_snapshot!(errors[0].message, @r###"The field `Query.resources` has no `@data` directive."###);
+    }
+
+    #[test]
+    fn absolute_connect_url_with_source() {
+        let schema = include_str!("test_data/absolute_connect_url_with_source.graphql");
+        let schema = Schema::parse(schema, "test.graphql").unwrap();
+        let errors = validate(schema);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, Code::AbsoluteConnectUrlWithSource);
+        assert_snapshot!(errors[0].message, @r###"`GET` in `@connect(http:)` on `Query.resources` contains the absolute URL "http://127.0.0.1/resources" while also specifying a `source`. Either remove the `source` argument or change the URL to a path."###);
+    }
+
+    #[test]
+    fn invalid_connect_url() {
+        let schema = include_str!("test_data/invalid_connect_url.graphql");
+        let schema = Schema::parse(schema, "test.graphql").unwrap();
+        let errors = validate(schema);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, Code::InvalidUrl);
+        assert_snapshot!(errors[0].message, @r###"The value "127.0.0.1" for `GET` in `@connect(http:)` on `Query.resources` is not a valid URL: relative URL without a base."###);
+    }
+
+    #[test]
+    fn invalid_connect_url_scheme() {
+        let schema = include_str!("test_data/invalid_connect_url_scheme.graphql");
+        let schema = Schema::parse(schema, "test.graphql").unwrap();
+        let errors = validate(schema);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, Code::SourceScheme);
+        assert_snapshot!(errors[0].message, @r###"The value "file://data.json" for `GET` in `@connect(http:)` on `Query.resources` must be http or https, got file."###);
+    }
+
+    #[test]
+    fn relative_connect_url_without_source() {
+        let schema = include_str!("test_data/relative_connect_url_without_source.graphql");
+        let schema = Schema::parse(schema, "test.graphql").unwrap();
+        let errors = validate(schema);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, Code::RelativeConnectUrlWithoutSource);
+        assert_snapshot!(errors[0].message, @r###"`GET` in `@connect(http:)` on `Query.resources` specifies the relative URL "/resources", but no `source` is defined. Either use an absolute URL, or add a `@connect__source`."###);
+    }
+
+    #[test]
+    fn valid_connect_absolute_url() {
+        let schema = include_str!("test_data/valid_connect_absolute_url.graphql");
+        let schema = Schema::parse(schema, "test.graphql").unwrap();
+        let errors = validate(schema);
+        assert_eq!(errors.len(), 0);
+    }
+
+    #[test]
+    fn missing_source_import() {
+        let schema = include_str!("test_data/missing_source_import.graphql");
+        let schema = Schema::parse(schema, "test.graphql").unwrap();
+        let errors = validate(schema);
+        assert_eq!(errors.len(), 2);
+        assert_eq!(errors[1].code, Code::NoSourceImport);
+        assert_snapshot!(errors[1].message, @r###"The `@source` directive is not imported. Try adding `@source` to `import` for `@link(url: "https://specs.apollo.dev/connect")`"###);
     }
 }


### PR DESCRIPTION
Includes:

* Require that all fields on `Query` have a `@connect`
* Check for relative vs absolute URLs in `@connect` are applied correctly, depending on whether a `source` is set
* Provide a warning if it looks like users are trying to use a source, but didn't import the directive (since this is usually a mistake)

Because there is now a warning, there's also refactoring to make this a little closer to fbp-style build messages with severity (instead of only errors).

(recreation of #5355)