### PR TITLE
Planner duration metric with "planner mode" attribute

### DIFF
--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Write;
 use std::sync::Arc;
+use std::time::Instant;
 
 use apollo_compiler::ast;
 use apollo_compiler::ast::Name;
@@ -197,12 +198,24 @@ impl PlannerMode {
     ) -> Result<PlanSuccess<QueryPlanResult>, QueryPlannerError> {
         match self {
             PlannerMode::Js(js) => {
-                let mut success = js
+                let start = Instant::now();
+
+                let result = js
                     .plan(filtered_query, operation, plan_options)
-                    .await
+                    .await;
+
+                f64_histogram!(
+                    "apollo.router.query_planning.plan.duration",
+                    "Duration of the query planning.",
+                    start.elapsed().as_secs_f64(),
+                    "planner" = "js" 
+                );
+
+                let mut success = result
                     .map_err(QueryPlannerError::RouterBridgeError)?
                     .into_result()
                     .map_err(PlanErrors::from)?;
+
                 if let Some(root_node) = &mut success.data.query_plan.node {
                     // Arc freshly deserialized from Deno should be unique, so this doesn’t clone:
                     let root_node = Arc::make_mut(root_node);
@@ -211,12 +224,23 @@ impl PlannerMode {
                 Ok(success)
             }
             PlannerMode::Rust { rust, .. } => {
-                let plan = operation
+                let start = Instant::now();
+
+                let result = operation
                     .as_deref()
                     .map(|n| Name::new(n).map_err(FederationError::from))
                     .transpose()
                     .and_then(|operation| rust.build_query_plan(&doc.executable, operation))
-                    .map_err(|e| QueryPlannerError::FederationError(e.to_string()))?;
+                    .map_err(|e| QueryPlannerError::FederationError(e.to_string()));
+
+                f64_histogram!(
+                    "apollo.router.query_planning.plan.duration",
+                    "Duration of the query planning.",
+                    start.elapsed().as_secs_f64(),
+                    "planner" = "rust" 
+                );
+
+                let plan = result?;
 
                 // Dummy value overwritten below in `BrigeQueryPlanner::plan`
                 // `Configuration::validate` ensures that we only take this path
@@ -242,10 +266,21 @@ impl PlannerMode {
             }
             PlannerMode::Both { js, rust } => {
                 let operation_name = operation.as_deref().map(NodeStr::from);
-                let mut js_result = js
+
+                let start = Instant::now();
+
+                let result = js
                     .plan(filtered_query, operation, plan_options)
-                    .await
-                    .map_err(QueryPlannerError::RouterBridgeError)?
+                    .await;
+
+                f64_histogram!(
+                    "apollo.router.query_planning.plan.duration",
+                    "Duration of the query planning.",
+                    start.elapsed().as_secs_f64(),
+                    "planner" = "js" 
+                );
+
+                let mut js_result = result.map_err(QueryPlannerError::RouterBridgeError)?
                     .into_result()
                     .map_err(PlanErrors::from);
 

--- a/apollo-router/src/query_planner/bridge_query_planner_pool.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner_pool.rs
@@ -116,12 +116,11 @@ impl BridgeQueryPlannerPool {
                             continue;
                         }
                     };
-                    let start = Instant::now();
 
                     let res = svc.call(request).await;
 
                     f64_histogram!(
-                        "apollo.router.query_planning.plan.duration",
+                        "apollo.router.query_planning.pooled_planner.duration",
                         "Duration of the query planning.",
                         start.elapsed().as_secs_f64(),
                         "workerId" = worker_id.to_string()


### PR DESCRIPTION
Mostly to discuss, not sure about the changes.

It would be nice to get metrics about the planning duration with a tag with the actual planner used under the hood. This requires moving the metric closer to the actual planner call.

Problem is we currently tag the `workerId` in the pool, where the metric is actually emitted. In this PR I've currently opted for a new metric for the pool. But alternatives with a bit of a higher effort could be:

  - Passing `workerId` down, which feels a bit odd leaking that concept.
  - Returning the time taken and planner in the response, and then emitting the metric with worker ID. (feels better)
  
  Let me know what you think.