### PR TITLE
Add cost information to protobuf traces

### DIFF
--- a/.changesets/maint_bryn_demand_control_studio_traces.md
+++ b/.changesets/maint_bryn_demand_control_studio_traces.md
@@ -1,0 +1,5 @@
+### Add cost information to protobuf traces ([PR #5430](https://github.com/apollographql/router/pull/5430))
+
+If `experimental_demand_control` is enabled, cost information for queries is now exported on Apollo protobuf traces for display in studio.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5430

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -43,6 +43,7 @@ pub(crate) struct CostContext {
     pub(crate) estimated: f64,
     pub(crate) actual: f64,
     pub(crate) result: &'static str,
+    pub(crate) strategy: &'static str,
 }
 
 impl Default for CostContext {
@@ -51,6 +52,7 @@ impl Default for CostContext {
             estimated: 0.0,
             actual: 0.0,
             result: "COST_OK",
+            strategy: "COST_STRATEGY_UNKNOWN",
         }
     }
 }

--- a/apollo-router/src/plugins/demand_control/strategy/static_estimated.rs
+++ b/apollo-router/src/plugins/demand_control/strategy/static_estimated.rs
@@ -22,6 +22,7 @@ impl StrategyImpl for StaticEstimated {
             .and_then(|cost| {
                 request.context.extensions().with_lock(|mut lock| {
                     let cost_result = lock.get_or_default_mut::<CostContext>();
+                    cost_result.strategy = "static_estimated";
                     cost_result.estimated = cost;
                     if cost > self.max {
                         Err(

--- a/apollo-router/src/plugins/telemetry/config_new/cost/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/cost/mod.rs
@@ -287,11 +287,11 @@ pub(crate) fn add_cost_attributes(context: &Context, custom_attributes: &mut Vec
         if let Some(cost) = c.get::<CostContext>().cloned() {
             custom_attributes.push(KeyValue::new(
                 APOLLO_PRIVATE_COST_ESTIMATED.clone(),
-                AttributeValue::I64(cost.estimated as i64),
+                AttributeValue::F64(cost.estimated),
             ));
             custom_attributes.push(KeyValue::new(
                 APOLLO_PRIVATE_COST_ACTUAL.clone(),
-                AttributeValue::I64(cost.actual as i64),
+                AttributeValue::F64(cost.actual),
             ));
             custom_attributes.push(KeyValue::new(
                 APOLLO_PRIVATE_COST_RESULT.clone(),

--- a/apollo-router/src/plugins/telemetry/config_new/cost/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/cost/mod.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use opentelemetry::metrics::MeterProvider;
-use opentelemetry_api::{Key, KeyValue};
+use opentelemetry_api::Key;
+use opentelemetry_api::KeyValue;
 use parking_lot::Mutex;
 use schemars::JsonSchema;
 use serde::Deserialize;

--- a/apollo-router/src/plugins/telemetry/config_new/cost/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/cost/mod.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use opentelemetry::metrics::MeterProvider;
-use opentelemetry_api::KeyValue;
+use opentelemetry_api::{Key, KeyValue};
 use parking_lot::Mutex;
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -23,6 +23,15 @@ use crate::services::supergraph;
 use crate::services::supergraph::Request;
 use crate::services::supergraph::Response;
 use crate::Context;
+
+pub(crate) const APOLLO_PRIVATE_COST_ESTIMATED: Key =
+    Key::from_static_str("apollo_private.cost.estimated");
+pub(crate) const APOLLO_PRIVATE_COST_ACTUAL: Key =
+    Key::from_static_str("apollo_private.cost.actual");
+pub(crate) const APOLLO_PRIVATE_COST_STRATEGY: Key =
+    Key::from_static_str("apollo_private.cost.strategy");
+pub(crate) const APOLLO_PRIVATE_COST_RESULT: Key =
+    Key::from_static_str("apollo_private.cost.result");
 
 static COST_ESTIMATED: &str = "cost.estimated";
 static COST_ACTUAL: &str = "cost.actual";

--- a/apollo-router/src/plugins/telemetry/config_new/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/mod.rs
@@ -18,7 +18,7 @@ pub(crate) mod attributes;
 pub(crate) mod conditions;
 
 mod conditional;
-mod cost;
+pub(crate) mod cost;
 pub(crate) mod events;
 mod experimental_when_header;
 pub(crate) mod extendable;

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -86,17 +86,13 @@ use crate::metrics::filter::FilterMeterProvider;
 use crate::metrics::meter_provider;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
-use crate::plugins::demand_control::CostContext;
 use crate::plugins::telemetry::apollo::ForwardHeaders;
 use crate::plugins::telemetry::apollo_exporter::proto::reports::trace::node::Id::ResponseName;
 use crate::plugins::telemetry::apollo_exporter::proto::reports::StatsContext;
 use crate::plugins::telemetry::config::AttributeValue;
 use crate::plugins::telemetry::config::MetricsCommon;
 use crate::plugins::telemetry::config::TracingCommon;
-use crate::plugins::telemetry::config_new::cost::{
-    APOLLO_PRIVATE_COST_ACTUAL, APOLLO_PRIVATE_COST_ESTIMATED, APOLLO_PRIVATE_COST_RESULT,
-    APOLLO_PRIVATE_COST_STRATEGY,
-};
+use crate::plugins::telemetry::config_new::cost::add_cost_attributes;
 use crate::plugins::telemetry::config_new::graphql::GraphQLInstruments;
 use crate::plugins::telemetry::config_new::instruments::SupergraphInstruments;
 use crate::plugins::telemetry::dynamic_attribute::SpanDynAttribute;
@@ -778,29 +774,6 @@ impl Plugin for Telemetry {
     fn web_endpoints(&self) -> MultiMap<ListenAddr, Endpoint> {
         self.custom_endpoints.clone()
     }
-}
-
-fn add_cost_attributes(context: &Context, custom_attributes: &mut Vec<KeyValue>) {
-    context.extensions().with_lock(|c| {
-        if let Some(cost) = c.get::<CostContext>().cloned() {
-            custom_attributes.push(KeyValue::new(
-                APOLLO_PRIVATE_COST_ESTIMATED.clone(),
-                AttributeValue::I64(cost.estimated as i64),
-            ));
-            custom_attributes.push(KeyValue::new(
-                APOLLO_PRIVATE_COST_ACTUAL.clone(),
-                AttributeValue::I64(cost.actual as i64),
-            ));
-            custom_attributes.push(KeyValue::new(
-                APOLLO_PRIVATE_COST_RESULT.clone(),
-                AttributeValue::String(cost.result.into()),
-            ));
-            custom_attributes.push(KeyValue::new(
-                APOLLO_PRIVATE_COST_STRATEGY.clone(),
-                AttributeValue::String(cost.strategy.into()),
-            ));
-        }
-    });
 }
 
 impl Telemetry {

--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -53,9 +53,10 @@ use crate::plugins::telemetry::apollo_exporter::proto::reports::trace::query_pla
 use crate::plugins::telemetry::apollo_exporter::proto::reports::trace::query_plan_node::ParallelNode;
 use crate::plugins::telemetry::apollo_exporter::proto::reports::trace::query_plan_node::ResponsePathElement;
 use crate::plugins::telemetry::apollo_exporter::proto::reports::trace::query_plan_node::SequenceNode;
+use crate::plugins::telemetry::apollo_exporter::proto::reports::trace::Details;
 use crate::plugins::telemetry::apollo_exporter::proto::reports::trace::Http;
+use crate::plugins::telemetry::apollo_exporter::proto::reports::trace::Limits;
 use crate::plugins::telemetry::apollo_exporter::proto::reports::trace::QueryPlanNode;
-use crate::plugins::telemetry::apollo_exporter::proto::reports::trace::{Details, Limits};
 use crate::plugins::telemetry::apollo_exporter::ApolloExporter;
 use crate::plugins::telemetry::apollo_otlp_exporter::ApolloOtlpExporter;
 use crate::plugins::telemetry::config::Sampler;

--- a/apollo-router/tests/apollo_reports.rs
+++ b/apollo-router/tests/apollo_reports.rs
@@ -675,7 +675,7 @@ async fn test_demand_control_trace_batched() {
                 result.push(b']');
                 hyper::Body::from(result)
             });
-        let req: router::Request = request.try_into().expect("could not convert request");
+        let req: router::Request = request.into();
         let reports = Arc::new(Mutex::new(vec![]));
         let report = get_batch_trace_report(reports, req, use_legacy_request_span, true).await;
         assert_report!(report);

--- a/apollo-router/tests/fixtures/apollo_reports.router.yaml
+++ b/apollo-router/tests/fixtures/apollo_reports.router.yaml
@@ -3,6 +3,13 @@ include_subgraph_errors:
 rhai:
   scripts: tests/fixtures
   main: test_callbacks.rhai
+preview_demand_control:
+  mode: measure
+  enabled: false
+  strategy:
+    static_estimated:
+      max: 1500
+      list_size: 10
 telemetry:
   instrumentation:
     spans:

--- a/apollo-router/tests/fixtures/apollo_reports_batch.router.yaml
+++ b/apollo-router/tests/fixtures/apollo_reports_batch.router.yaml
@@ -6,6 +6,13 @@ rhai:
   main: test_callbacks.rhai
 include_subgraph_errors:
   all: true
+preview_demand_control:
+  mode: measure
+  enabled: false
+  strategy:
+    static_estimated:
+      max: 1500
+      list_size: 10
 telemetry:
   exporters:
     tracing:

--- a/apollo-router/tests/snapshots/apollo_reports__batch_send_header-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__batch_send_header-2.snap
@@ -552,7 +552,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
       - start_time:
           seconds: "[seconds]"
           nanos: "[nanos]"
@@ -1092,7 +1100,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__batch_send_header.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__batch_send_header.snap
@@ -552,7 +552,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
       - start_time:
           seconds: "[seconds]"
           nanos: "[nanos]"
@@ -1092,7 +1100,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__batch_trace_id-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__batch_trace_id-2.snap
@@ -549,7 +549,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
       - start_time:
           seconds: "[seconds]"
           nanos: "[nanos]"
@@ -1086,7 +1094,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__batch_trace_id.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__batch_trace_id.snap
@@ -549,7 +549,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
       - start_time:
           seconds: "[seconds]"
           nanos: "[nanos]"
@@ -1086,7 +1094,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__client_name-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__client_name-2.snap
@@ -549,7 +549,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__client_name.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__client_name.snap
@@ -549,7 +549,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__client_version-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__client_version-2.snap
@@ -549,7 +549,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__client_version.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__client_version.snap
@@ -549,7 +549,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__condition_else-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__condition_else-2.snap
@@ -555,7 +555,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__condition_else.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__condition_else.snap
@@ -555,7 +555,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__condition_if-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__condition_if-2.snap
@@ -568,7 +568,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__condition_if.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__condition_if.snap
@@ -568,7 +568,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__demand_control_trace-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__demand_control_trace-2.snap
@@ -1,0 +1,568 @@
+---
+source: apollo-router/tests/apollo_reports.rs
+expression: report
+---
+header:
+  graph_ref: test
+  hostname: "[hostname]"
+  agent_version: "[agent_version]"
+  service_version: ""
+  runtime_version: rust
+  uname: "[uname]"
+  executable_schema_id: "[executable_schema_id]"
+traces_per_query:
+  "# -\n{topProducts{name reviews{author{name}}reviews{author{name}}}}":
+    trace:
+      - start_time:
+          seconds: "[seconds]"
+          nanos: "[nanos]"
+        end_time:
+          seconds: "[seconds]"
+          nanos: "[nanos]"
+        duration_ns: "[duration_ns]"
+        root: ~
+        is_incomplete: false
+        signature: ""
+        unexecuted_operation_body: ""
+        unexecuted_operation_name: ""
+        details:
+          variables_json: {}
+          operation_name: ""
+        client_name: ""
+        client_version: ""
+        operation_type: query
+        operation_subtype: ""
+        http:
+          method: 4
+          request_headers: {}
+          response_headers:
+            my_trace_id: "[my_trace_id]"
+          status_code: 0
+        cache_policy: ~
+        query_plan:
+          node:
+            Sequence:
+              nodes:
+                - node:
+                    Fetch:
+                      service_name: products
+                      trace_parsing_failed: false
+                      trace:
+                        start_time:
+                          seconds: "[seconds]"
+                          nanos: "[nanos]"
+                        end_time:
+                          seconds: "[seconds]"
+                          nanos: "[nanos]"
+                        duration_ns: "[duration_ns]"
+                        root:
+                          original_field_name: ""
+                          type: ""
+                          parent_type: ""
+                          cache_policy: ~
+                          start_time: 0
+                          end_time: 0
+                          error: []
+                          child:
+                            - original_field_name: ""
+                              type: "[Product]"
+                              parent_type: Query
+                              cache_policy: ~
+                              start_time: "[start_time]"
+                              end_time: "[end_time]"
+                              error: []
+                              child:
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 0
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 1
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 2
+                              id:
+                                ResponseName: topProducts
+                          id: ~
+                        is_incomplete: false
+                        signature: ""
+                        unexecuted_operation_body: ""
+                        unexecuted_operation_name: ""
+                        details: ~
+                        client_name: ""
+                        client_version: ""
+                        operation_type: ""
+                        operation_subtype: ""
+                        http: ~
+                        cache_policy: ~
+                        query_plan: ~
+                        full_query_cache_hit: false
+                        persisted_query_hit: false
+                        persisted_query_register: false
+                        registered_operation: false
+                        forbidden_operation: false
+                        field_execution_weight: 1
+                        limits: ~
+                      sent_time_offset: "[sent_time_offset]"
+                      sent_time:
+                        seconds: "[seconds]"
+                        nanos: "[nanos]"
+                      received_time:
+                        seconds: "[seconds]"
+                        nanos: "[nanos]"
+                - node:
+                    Flatten:
+                      response_path:
+                        - id:
+                            FieldName: topProducts
+                      node:
+                        node:
+                          Fetch:
+                            service_name: reviews
+                            trace_parsing_failed: false
+                            trace:
+                              start_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              end_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              duration_ns: "[duration_ns]"
+                              root:
+                                original_field_name: ""
+                                type: ""
+                                parent_type: ""
+                                cache_policy: ~
+                                start_time: 0
+                                end_time: 0
+                                error: []
+                                child:
+                                  - original_field_name: ""
+                                    type: "[_Entity]!"
+                                    parent_type: Query
+                                    cache_policy: ~
+                                    start_time: "[start_time]"
+                                    end_time: "[end_time]"
+                                    error: []
+                                    child:
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 1
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 0
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 1
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 2
+                                    id:
+                                      ResponseName: _entities
+                                id: ~
+                              is_incomplete: false
+                              signature: ""
+                              unexecuted_operation_body: ""
+                              unexecuted_operation_name: ""
+                              details: ~
+                              client_name: ""
+                              client_version: ""
+                              operation_type: ""
+                              operation_subtype: ""
+                              http: ~
+                              cache_policy: ~
+                              query_plan: ~
+                              full_query_cache_hit: false
+                              persisted_query_hit: false
+                              persisted_query_register: false
+                              registered_operation: false
+                              forbidden_operation: false
+                              field_execution_weight: 1
+                              limits: ~
+                            sent_time_offset: "[sent_time_offset]"
+                            sent_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                            received_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                - node:
+                    Flatten:
+                      response_path:
+                        - id:
+                            FieldName: topProducts
+                        - id:
+                            FieldName: reviews
+                        - id:
+                            FieldName: author
+                      node:
+                        node:
+                          Fetch:
+                            service_name: accounts
+                            trace_parsing_failed: false
+                            trace:
+                              start_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              end_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              duration_ns: "[duration_ns]"
+                              root:
+                                original_field_name: ""
+                                type: ""
+                                parent_type: ""
+                                cache_policy: ~
+                                start_time: 0
+                                end_time: 0
+                                error: []
+                                child:
+                                  - original_field_name: ""
+                                    type: "[_Entity]!"
+                                    parent_type: Query
+                                    cache_policy: ~
+                                    start_time: "[start_time]"
+                                    end_time: "[end_time]"
+                                    error: []
+                                    child:
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: User
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                        id:
+                                          Index: 0
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: User
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                        id:
+                                          Index: 1
+                                    id:
+                                      ResponseName: _entities
+                                id: ~
+                              is_incomplete: false
+                              signature: ""
+                              unexecuted_operation_body: ""
+                              unexecuted_operation_name: ""
+                              details: ~
+                              client_name: ""
+                              client_version: ""
+                              operation_type: ""
+                              operation_subtype: ""
+                              http: ~
+                              cache_policy: ~
+                              query_plan: ~
+                              full_query_cache_hit: false
+                              persisted_query_hit: false
+                              persisted_query_register: false
+                              registered_operation: false
+                              forbidden_operation: false
+                              field_execution_weight: 1
+                              limits: ~
+                            sent_time_offset: "[sent_time_offset]"
+                            sent_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                            received_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+        full_query_cache_hit: false
+        persisted_query_hit: false
+        persisted_query_register: false
+        registered_operation: false
+        forbidden_operation: false
+        field_execution_weight: 1
+        limits:
+          result: COST_OK
+          strategy: static_estimated
+          cost_estimated: 230
+          cost_actual: 19
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
+    stats_with_context: []
+    referenced_fields_by_type: {}
+    query_metadata: ~
+end_time: "[end_time]"
+operation_count: 0
+operation_count_by_type: []
+traces_pre_aggregated: true
+extended_references_enabled: false

--- a/apollo-router/tests/snapshots/apollo_reports__demand_control_trace.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__demand_control_trace.snap
@@ -1,0 +1,568 @@
+---
+source: apollo-router/tests/apollo_reports.rs
+expression: report
+---
+header:
+  graph_ref: test
+  hostname: "[hostname]"
+  agent_version: "[agent_version]"
+  service_version: ""
+  runtime_version: rust
+  uname: "[uname]"
+  executable_schema_id: "[executable_schema_id]"
+traces_per_query:
+  "# -\n{topProducts{name reviews{author{name}}reviews{author{name}}}}":
+    trace:
+      - start_time:
+          seconds: "[seconds]"
+          nanos: "[nanos]"
+        end_time:
+          seconds: "[seconds]"
+          nanos: "[nanos]"
+        duration_ns: "[duration_ns]"
+        root: ~
+        is_incomplete: false
+        signature: ""
+        unexecuted_operation_body: ""
+        unexecuted_operation_name: ""
+        details:
+          variables_json: {}
+          operation_name: ""
+        client_name: ""
+        client_version: ""
+        operation_type: query
+        operation_subtype: ""
+        http:
+          method: 4
+          request_headers: {}
+          response_headers:
+            my_trace_id: "[my_trace_id]"
+          status_code: 0
+        cache_policy: ~
+        query_plan:
+          node:
+            Sequence:
+              nodes:
+                - node:
+                    Fetch:
+                      service_name: products
+                      trace_parsing_failed: false
+                      trace:
+                        start_time:
+                          seconds: "[seconds]"
+                          nanos: "[nanos]"
+                        end_time:
+                          seconds: "[seconds]"
+                          nanos: "[nanos]"
+                        duration_ns: "[duration_ns]"
+                        root:
+                          original_field_name: ""
+                          type: ""
+                          parent_type: ""
+                          cache_policy: ~
+                          start_time: 0
+                          end_time: 0
+                          error: []
+                          child:
+                            - original_field_name: ""
+                              type: "[Product]"
+                              parent_type: Query
+                              cache_policy: ~
+                              start_time: "[start_time]"
+                              end_time: "[end_time]"
+                              error: []
+                              child:
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 0
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 1
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 2
+                              id:
+                                ResponseName: topProducts
+                          id: ~
+                        is_incomplete: false
+                        signature: ""
+                        unexecuted_operation_body: ""
+                        unexecuted_operation_name: ""
+                        details: ~
+                        client_name: ""
+                        client_version: ""
+                        operation_type: ""
+                        operation_subtype: ""
+                        http: ~
+                        cache_policy: ~
+                        query_plan: ~
+                        full_query_cache_hit: false
+                        persisted_query_hit: false
+                        persisted_query_register: false
+                        registered_operation: false
+                        forbidden_operation: false
+                        field_execution_weight: 1
+                        limits: ~
+                      sent_time_offset: "[sent_time_offset]"
+                      sent_time:
+                        seconds: "[seconds]"
+                        nanos: "[nanos]"
+                      received_time:
+                        seconds: "[seconds]"
+                        nanos: "[nanos]"
+                - node:
+                    Flatten:
+                      response_path:
+                        - id:
+                            FieldName: topProducts
+                      node:
+                        node:
+                          Fetch:
+                            service_name: reviews
+                            trace_parsing_failed: false
+                            trace:
+                              start_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              end_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              duration_ns: "[duration_ns]"
+                              root:
+                                original_field_name: ""
+                                type: ""
+                                parent_type: ""
+                                cache_policy: ~
+                                start_time: 0
+                                end_time: 0
+                                error: []
+                                child:
+                                  - original_field_name: ""
+                                    type: "[_Entity]!"
+                                    parent_type: Query
+                                    cache_policy: ~
+                                    start_time: "[start_time]"
+                                    end_time: "[end_time]"
+                                    error: []
+                                    child:
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 1
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 0
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 1
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 2
+                                    id:
+                                      ResponseName: _entities
+                                id: ~
+                              is_incomplete: false
+                              signature: ""
+                              unexecuted_operation_body: ""
+                              unexecuted_operation_name: ""
+                              details: ~
+                              client_name: ""
+                              client_version: ""
+                              operation_type: ""
+                              operation_subtype: ""
+                              http: ~
+                              cache_policy: ~
+                              query_plan: ~
+                              full_query_cache_hit: false
+                              persisted_query_hit: false
+                              persisted_query_register: false
+                              registered_operation: false
+                              forbidden_operation: false
+                              field_execution_weight: 1
+                              limits: ~
+                            sent_time_offset: "[sent_time_offset]"
+                            sent_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                            received_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                - node:
+                    Flatten:
+                      response_path:
+                        - id:
+                            FieldName: topProducts
+                        - id:
+                            FieldName: reviews
+                        - id:
+                            FieldName: author
+                      node:
+                        node:
+                          Fetch:
+                            service_name: accounts
+                            trace_parsing_failed: false
+                            trace:
+                              start_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              end_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              duration_ns: "[duration_ns]"
+                              root:
+                                original_field_name: ""
+                                type: ""
+                                parent_type: ""
+                                cache_policy: ~
+                                start_time: 0
+                                end_time: 0
+                                error: []
+                                child:
+                                  - original_field_name: ""
+                                    type: "[_Entity]!"
+                                    parent_type: Query
+                                    cache_policy: ~
+                                    start_time: "[start_time]"
+                                    end_time: "[end_time]"
+                                    error: []
+                                    child:
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: User
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                        id:
+                                          Index: 0
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: User
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                        id:
+                                          Index: 1
+                                    id:
+                                      ResponseName: _entities
+                                id: ~
+                              is_incomplete: false
+                              signature: ""
+                              unexecuted_operation_body: ""
+                              unexecuted_operation_name: ""
+                              details: ~
+                              client_name: ""
+                              client_version: ""
+                              operation_type: ""
+                              operation_subtype: ""
+                              http: ~
+                              cache_policy: ~
+                              query_plan: ~
+                              full_query_cache_hit: false
+                              persisted_query_hit: false
+                              persisted_query_register: false
+                              registered_operation: false
+                              forbidden_operation: false
+                              field_execution_weight: 1
+                              limits: ~
+                            sent_time_offset: "[sent_time_offset]"
+                            sent_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                            received_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+        full_query_cache_hit: false
+        persisted_query_hit: false
+        persisted_query_register: false
+        registered_operation: false
+        forbidden_operation: false
+        field_execution_weight: 1
+        limits:
+          result: COST_OK
+          strategy: static_estimated
+          cost_estimated: 230
+          cost_actual: 19
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
+    stats_with_context: []
+    referenced_fields_by_type: {}
+    query_metadata: ~
+end_time: "[end_time]"
+operation_count: 0
+operation_count_by_type: []
+traces_pre_aggregated: true
+extended_references_enabled: false

--- a/apollo-router/tests/snapshots/apollo_reports__demand_control_trace_batched-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__demand_control_trace_batched-2.snap
@@ -1,0 +1,1113 @@
+---
+source: apollo-router/tests/apollo_reports.rs
+expression: report
+---
+header:
+  graph_ref: test
+  hostname: "[hostname]"
+  agent_version: "[agent_version]"
+  service_version: ""
+  runtime_version: rust
+  uname: "[uname]"
+  executable_schema_id: "[executable_schema_id]"
+traces_per_query:
+  "# -\n{topProducts{name reviews{author{name}}reviews{author{name}}}}":
+    trace:
+      - start_time:
+          seconds: "[seconds]"
+          nanos: "[nanos]"
+        end_time:
+          seconds: "[seconds]"
+          nanos: "[nanos]"
+        duration_ns: "[duration_ns]"
+        root: ~
+        is_incomplete: false
+        signature: ""
+        unexecuted_operation_body: ""
+        unexecuted_operation_name: ""
+        details:
+          variables_json: {}
+          operation_name: ""
+        client_name: ""
+        client_version: ""
+        operation_type: query
+        operation_subtype: ""
+        http:
+          method: 4
+          request_headers: {}
+          response_headers:
+            my_trace_id: "[my_trace_id]"
+          status_code: 0
+        cache_policy: ~
+        query_plan:
+          node:
+            Sequence:
+              nodes:
+                - node:
+                    Fetch:
+                      service_name: products
+                      trace_parsing_failed: false
+                      trace:
+                        start_time:
+                          seconds: "[seconds]"
+                          nanos: "[nanos]"
+                        end_time:
+                          seconds: "[seconds]"
+                          nanos: "[nanos]"
+                        duration_ns: "[duration_ns]"
+                        root:
+                          original_field_name: ""
+                          type: ""
+                          parent_type: ""
+                          cache_policy: ~
+                          start_time: 0
+                          end_time: 0
+                          error: []
+                          child:
+                            - original_field_name: ""
+                              type: "[Product]"
+                              parent_type: Query
+                              cache_policy: ~
+                              start_time: "[start_time]"
+                              end_time: "[end_time]"
+                              error: []
+                              child:
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 0
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 1
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 2
+                              id:
+                                ResponseName: topProducts
+                          id: ~
+                        is_incomplete: false
+                        signature: ""
+                        unexecuted_operation_body: ""
+                        unexecuted_operation_name: ""
+                        details: ~
+                        client_name: ""
+                        client_version: ""
+                        operation_type: ""
+                        operation_subtype: ""
+                        http: ~
+                        cache_policy: ~
+                        query_plan: ~
+                        full_query_cache_hit: false
+                        persisted_query_hit: false
+                        persisted_query_register: false
+                        registered_operation: false
+                        forbidden_operation: false
+                        field_execution_weight: 1
+                        limits: ~
+                      sent_time_offset: "[sent_time_offset]"
+                      sent_time:
+                        seconds: "[seconds]"
+                        nanos: "[nanos]"
+                      received_time:
+                        seconds: "[seconds]"
+                        nanos: "[nanos]"
+                - node:
+                    Flatten:
+                      response_path:
+                        - id:
+                            FieldName: topProducts
+                      node:
+                        node:
+                          Fetch:
+                            service_name: reviews
+                            trace_parsing_failed: false
+                            trace:
+                              start_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              end_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              duration_ns: "[duration_ns]"
+                              root:
+                                original_field_name: ""
+                                type: ""
+                                parent_type: ""
+                                cache_policy: ~
+                                start_time: 0
+                                end_time: 0
+                                error: []
+                                child:
+                                  - original_field_name: ""
+                                    type: "[_Entity]!"
+                                    parent_type: Query
+                                    cache_policy: ~
+                                    start_time: "[start_time]"
+                                    end_time: "[end_time]"
+                                    error: []
+                                    child:
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 1
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 0
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 1
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 2
+                                    id:
+                                      ResponseName: _entities
+                                id: ~
+                              is_incomplete: false
+                              signature: ""
+                              unexecuted_operation_body: ""
+                              unexecuted_operation_name: ""
+                              details: ~
+                              client_name: ""
+                              client_version: ""
+                              operation_type: ""
+                              operation_subtype: ""
+                              http: ~
+                              cache_policy: ~
+                              query_plan: ~
+                              full_query_cache_hit: false
+                              persisted_query_hit: false
+                              persisted_query_register: false
+                              registered_operation: false
+                              forbidden_operation: false
+                              field_execution_weight: 1
+                              limits: ~
+                            sent_time_offset: "[sent_time_offset]"
+                            sent_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                            received_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                - node:
+                    Flatten:
+                      response_path:
+                        - id:
+                            FieldName: topProducts
+                        - id:
+                            FieldName: reviews
+                        - id:
+                            FieldName: author
+                      node:
+                        node:
+                          Fetch:
+                            service_name: accounts
+                            trace_parsing_failed: false
+                            trace:
+                              start_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              end_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              duration_ns: "[duration_ns]"
+                              root:
+                                original_field_name: ""
+                                type: ""
+                                parent_type: ""
+                                cache_policy: ~
+                                start_time: 0
+                                end_time: 0
+                                error: []
+                                child:
+                                  - original_field_name: ""
+                                    type: "[_Entity]!"
+                                    parent_type: Query
+                                    cache_policy: ~
+                                    start_time: "[start_time]"
+                                    end_time: "[end_time]"
+                                    error: []
+                                    child:
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: User
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                        id:
+                                          Index: 0
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: User
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                        id:
+                                          Index: 1
+                                    id:
+                                      ResponseName: _entities
+                                id: ~
+                              is_incomplete: false
+                              signature: ""
+                              unexecuted_operation_body: ""
+                              unexecuted_operation_name: ""
+                              details: ~
+                              client_name: ""
+                              client_version: ""
+                              operation_type: ""
+                              operation_subtype: ""
+                              http: ~
+                              cache_policy: ~
+                              query_plan: ~
+                              full_query_cache_hit: false
+                              persisted_query_hit: false
+                              persisted_query_register: false
+                              registered_operation: false
+                              forbidden_operation: false
+                              field_execution_weight: 1
+                              limits: ~
+                            sent_time_offset: "[sent_time_offset]"
+                            sent_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                            received_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+        full_query_cache_hit: false
+        persisted_query_hit: false
+        persisted_query_register: false
+        registered_operation: false
+        forbidden_operation: false
+        field_execution_weight: 1
+        limits:
+          result: COST_OK
+          strategy: static_estimated
+          cost_estimated: 230
+          cost_actual: 19
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
+      - start_time:
+          seconds: "[seconds]"
+          nanos: "[nanos]"
+        end_time:
+          seconds: "[seconds]"
+          nanos: "[nanos]"
+        duration_ns: "[duration_ns]"
+        root: ~
+        is_incomplete: false
+        signature: ""
+        unexecuted_operation_body: ""
+        unexecuted_operation_name: ""
+        details:
+          variables_json: {}
+          operation_name: ""
+        client_name: ""
+        client_version: ""
+        operation_type: query
+        operation_subtype: ""
+        http:
+          method: 4
+          request_headers: {}
+          response_headers:
+            my_trace_id: "[my_trace_id]"
+          status_code: 0
+        cache_policy: ~
+        query_plan:
+          node:
+            Sequence:
+              nodes:
+                - node:
+                    Fetch:
+                      service_name: products
+                      trace_parsing_failed: false
+                      trace:
+                        start_time:
+                          seconds: "[seconds]"
+                          nanos: "[nanos]"
+                        end_time:
+                          seconds: "[seconds]"
+                          nanos: "[nanos]"
+                        duration_ns: "[duration_ns]"
+                        root:
+                          original_field_name: ""
+                          type: ""
+                          parent_type: ""
+                          cache_policy: ~
+                          start_time: 0
+                          end_time: 0
+                          error: []
+                          child:
+                            - original_field_name: ""
+                              type: "[Product]"
+                              parent_type: Query
+                              cache_policy: ~
+                              start_time: "[start_time]"
+                              end_time: "[end_time]"
+                              error: []
+                              child:
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 0
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 1
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 2
+                              id:
+                                ResponseName: topProducts
+                          id: ~
+                        is_incomplete: false
+                        signature: ""
+                        unexecuted_operation_body: ""
+                        unexecuted_operation_name: ""
+                        details: ~
+                        client_name: ""
+                        client_version: ""
+                        operation_type: ""
+                        operation_subtype: ""
+                        http: ~
+                        cache_policy: ~
+                        query_plan: ~
+                        full_query_cache_hit: false
+                        persisted_query_hit: false
+                        persisted_query_register: false
+                        registered_operation: false
+                        forbidden_operation: false
+                        field_execution_weight: 1
+                        limits: ~
+                      sent_time_offset: "[sent_time_offset]"
+                      sent_time:
+                        seconds: "[seconds]"
+                        nanos: "[nanos]"
+                      received_time:
+                        seconds: "[seconds]"
+                        nanos: "[nanos]"
+                - node:
+                    Flatten:
+                      response_path:
+                        - id:
+                            FieldName: topProducts
+                      node:
+                        node:
+                          Fetch:
+                            service_name: reviews
+                            trace_parsing_failed: false
+                            trace:
+                              start_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              end_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              duration_ns: "[duration_ns]"
+                              root:
+                                original_field_name: ""
+                                type: ""
+                                parent_type: ""
+                                cache_policy: ~
+                                start_time: 0
+                                end_time: 0
+                                error: []
+                                child:
+                                  - original_field_name: ""
+                                    type: "[_Entity]!"
+                                    parent_type: Query
+                                    cache_policy: ~
+                                    start_time: "[start_time]"
+                                    end_time: "[end_time]"
+                                    error: []
+                                    child:
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 1
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 0
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 1
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 2
+                                    id:
+                                      ResponseName: _entities
+                                id: ~
+                              is_incomplete: false
+                              signature: ""
+                              unexecuted_operation_body: ""
+                              unexecuted_operation_name: ""
+                              details: ~
+                              client_name: ""
+                              client_version: ""
+                              operation_type: ""
+                              operation_subtype: ""
+                              http: ~
+                              cache_policy: ~
+                              query_plan: ~
+                              full_query_cache_hit: false
+                              persisted_query_hit: false
+                              persisted_query_register: false
+                              registered_operation: false
+                              forbidden_operation: false
+                              field_execution_weight: 1
+                              limits: ~
+                            sent_time_offset: "[sent_time_offset]"
+                            sent_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                            received_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                - node:
+                    Flatten:
+                      response_path:
+                        - id:
+                            FieldName: topProducts
+                        - id:
+                            FieldName: reviews
+                        - id:
+                            FieldName: author
+                      node:
+                        node:
+                          Fetch:
+                            service_name: accounts
+                            trace_parsing_failed: false
+                            trace:
+                              start_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              end_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              duration_ns: "[duration_ns]"
+                              root:
+                                original_field_name: ""
+                                type: ""
+                                parent_type: ""
+                                cache_policy: ~
+                                start_time: 0
+                                end_time: 0
+                                error: []
+                                child:
+                                  - original_field_name: ""
+                                    type: "[_Entity]!"
+                                    parent_type: Query
+                                    cache_policy: ~
+                                    start_time: "[start_time]"
+                                    end_time: "[end_time]"
+                                    error: []
+                                    child:
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: User
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                        id:
+                                          Index: 0
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: User
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                        id:
+                                          Index: 1
+                                    id:
+                                      ResponseName: _entities
+                                id: ~
+                              is_incomplete: false
+                              signature: ""
+                              unexecuted_operation_body: ""
+                              unexecuted_operation_name: ""
+                              details: ~
+                              client_name: ""
+                              client_version: ""
+                              operation_type: ""
+                              operation_subtype: ""
+                              http: ~
+                              cache_policy: ~
+                              query_plan: ~
+                              full_query_cache_hit: false
+                              persisted_query_hit: false
+                              persisted_query_register: false
+                              registered_operation: false
+                              forbidden_operation: false
+                              field_execution_weight: 1
+                              limits: ~
+                            sent_time_offset: "[sent_time_offset]"
+                            sent_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                            received_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+        full_query_cache_hit: false
+        persisted_query_hit: false
+        persisted_query_register: false
+        registered_operation: false
+        forbidden_operation: false
+        field_execution_weight: 1
+        limits:
+          result: COST_OK
+          strategy: static_estimated
+          cost_estimated: 230
+          cost_actual: 19
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
+    stats_with_context: []
+    referenced_fields_by_type: {}
+    query_metadata: ~
+end_time: "[end_time]"
+operation_count: 0
+operation_count_by_type: []
+traces_pre_aggregated: true
+extended_references_enabled: false

--- a/apollo-router/tests/snapshots/apollo_reports__demand_control_trace_batched.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__demand_control_trace_batched.snap
@@ -1,0 +1,1113 @@
+---
+source: apollo-router/tests/apollo_reports.rs
+expression: report
+---
+header:
+  graph_ref: test
+  hostname: "[hostname]"
+  agent_version: "[agent_version]"
+  service_version: ""
+  runtime_version: rust
+  uname: "[uname]"
+  executable_schema_id: "[executable_schema_id]"
+traces_per_query:
+  "# -\n{topProducts{name reviews{author{name}}reviews{author{name}}}}":
+    trace:
+      - start_time:
+          seconds: "[seconds]"
+          nanos: "[nanos]"
+        end_time:
+          seconds: "[seconds]"
+          nanos: "[nanos]"
+        duration_ns: "[duration_ns]"
+        root: ~
+        is_incomplete: false
+        signature: ""
+        unexecuted_operation_body: ""
+        unexecuted_operation_name: ""
+        details:
+          variables_json: {}
+          operation_name: ""
+        client_name: ""
+        client_version: ""
+        operation_type: query
+        operation_subtype: ""
+        http:
+          method: 4
+          request_headers: {}
+          response_headers:
+            my_trace_id: "[my_trace_id]"
+          status_code: 0
+        cache_policy: ~
+        query_plan:
+          node:
+            Sequence:
+              nodes:
+                - node:
+                    Fetch:
+                      service_name: products
+                      trace_parsing_failed: false
+                      trace:
+                        start_time:
+                          seconds: "[seconds]"
+                          nanos: "[nanos]"
+                        end_time:
+                          seconds: "[seconds]"
+                          nanos: "[nanos]"
+                        duration_ns: "[duration_ns]"
+                        root:
+                          original_field_name: ""
+                          type: ""
+                          parent_type: ""
+                          cache_policy: ~
+                          start_time: 0
+                          end_time: 0
+                          error: []
+                          child:
+                            - original_field_name: ""
+                              type: "[Product]"
+                              parent_type: Query
+                              cache_policy: ~
+                              start_time: "[start_time]"
+                              end_time: "[end_time]"
+                              error: []
+                              child:
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 0
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 1
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 2
+                              id:
+                                ResponseName: topProducts
+                          id: ~
+                        is_incomplete: false
+                        signature: ""
+                        unexecuted_operation_body: ""
+                        unexecuted_operation_name: ""
+                        details: ~
+                        client_name: ""
+                        client_version: ""
+                        operation_type: ""
+                        operation_subtype: ""
+                        http: ~
+                        cache_policy: ~
+                        query_plan: ~
+                        full_query_cache_hit: false
+                        persisted_query_hit: false
+                        persisted_query_register: false
+                        registered_operation: false
+                        forbidden_operation: false
+                        field_execution_weight: 1
+                        limits: ~
+                      sent_time_offset: "[sent_time_offset]"
+                      sent_time:
+                        seconds: "[seconds]"
+                        nanos: "[nanos]"
+                      received_time:
+                        seconds: "[seconds]"
+                        nanos: "[nanos]"
+                - node:
+                    Flatten:
+                      response_path:
+                        - id:
+                            FieldName: topProducts
+                      node:
+                        node:
+                          Fetch:
+                            service_name: reviews
+                            trace_parsing_failed: false
+                            trace:
+                              start_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              end_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              duration_ns: "[duration_ns]"
+                              root:
+                                original_field_name: ""
+                                type: ""
+                                parent_type: ""
+                                cache_policy: ~
+                                start_time: 0
+                                end_time: 0
+                                error: []
+                                child:
+                                  - original_field_name: ""
+                                    type: "[_Entity]!"
+                                    parent_type: Query
+                                    cache_policy: ~
+                                    start_time: "[start_time]"
+                                    end_time: "[end_time]"
+                                    error: []
+                                    child:
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 1
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 0
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 1
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 2
+                                    id:
+                                      ResponseName: _entities
+                                id: ~
+                              is_incomplete: false
+                              signature: ""
+                              unexecuted_operation_body: ""
+                              unexecuted_operation_name: ""
+                              details: ~
+                              client_name: ""
+                              client_version: ""
+                              operation_type: ""
+                              operation_subtype: ""
+                              http: ~
+                              cache_policy: ~
+                              query_plan: ~
+                              full_query_cache_hit: false
+                              persisted_query_hit: false
+                              persisted_query_register: false
+                              registered_operation: false
+                              forbidden_operation: false
+                              field_execution_weight: 1
+                              limits: ~
+                            sent_time_offset: "[sent_time_offset]"
+                            sent_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                            received_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                - node:
+                    Flatten:
+                      response_path:
+                        - id:
+                            FieldName: topProducts
+                        - id:
+                            FieldName: reviews
+                        - id:
+                            FieldName: author
+                      node:
+                        node:
+                          Fetch:
+                            service_name: accounts
+                            trace_parsing_failed: false
+                            trace:
+                              start_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              end_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              duration_ns: "[duration_ns]"
+                              root:
+                                original_field_name: ""
+                                type: ""
+                                parent_type: ""
+                                cache_policy: ~
+                                start_time: 0
+                                end_time: 0
+                                error: []
+                                child:
+                                  - original_field_name: ""
+                                    type: "[_Entity]!"
+                                    parent_type: Query
+                                    cache_policy: ~
+                                    start_time: "[start_time]"
+                                    end_time: "[end_time]"
+                                    error: []
+                                    child:
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: User
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                        id:
+                                          Index: 0
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: User
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                        id:
+                                          Index: 1
+                                    id:
+                                      ResponseName: _entities
+                                id: ~
+                              is_incomplete: false
+                              signature: ""
+                              unexecuted_operation_body: ""
+                              unexecuted_operation_name: ""
+                              details: ~
+                              client_name: ""
+                              client_version: ""
+                              operation_type: ""
+                              operation_subtype: ""
+                              http: ~
+                              cache_policy: ~
+                              query_plan: ~
+                              full_query_cache_hit: false
+                              persisted_query_hit: false
+                              persisted_query_register: false
+                              registered_operation: false
+                              forbidden_operation: false
+                              field_execution_weight: 1
+                              limits: ~
+                            sent_time_offset: "[sent_time_offset]"
+                            sent_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                            received_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+        full_query_cache_hit: false
+        persisted_query_hit: false
+        persisted_query_register: false
+        registered_operation: false
+        forbidden_operation: false
+        field_execution_weight: 1
+        limits:
+          result: COST_OK
+          strategy: static_estimated
+          cost_estimated: 230
+          cost_actual: 19
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
+      - start_time:
+          seconds: "[seconds]"
+          nanos: "[nanos]"
+        end_time:
+          seconds: "[seconds]"
+          nanos: "[nanos]"
+        duration_ns: "[duration_ns]"
+        root: ~
+        is_incomplete: false
+        signature: ""
+        unexecuted_operation_body: ""
+        unexecuted_operation_name: ""
+        details:
+          variables_json: {}
+          operation_name: ""
+        client_name: ""
+        client_version: ""
+        operation_type: query
+        operation_subtype: ""
+        http:
+          method: 4
+          request_headers: {}
+          response_headers:
+            my_trace_id: "[my_trace_id]"
+          status_code: 0
+        cache_policy: ~
+        query_plan:
+          node:
+            Sequence:
+              nodes:
+                - node:
+                    Fetch:
+                      service_name: products
+                      trace_parsing_failed: false
+                      trace:
+                        start_time:
+                          seconds: "[seconds]"
+                          nanos: "[nanos]"
+                        end_time:
+                          seconds: "[seconds]"
+                          nanos: "[nanos]"
+                        duration_ns: "[duration_ns]"
+                        root:
+                          original_field_name: ""
+                          type: ""
+                          parent_type: ""
+                          cache_policy: ~
+                          start_time: 0
+                          end_time: 0
+                          error: []
+                          child:
+                            - original_field_name: ""
+                              type: "[Product]"
+                              parent_type: Query
+                              cache_policy: ~
+                              start_time: "[start_time]"
+                              end_time: "[end_time]"
+                              error: []
+                              child:
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 0
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 1
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 2
+                              id:
+                                ResponseName: topProducts
+                          id: ~
+                        is_incomplete: false
+                        signature: ""
+                        unexecuted_operation_body: ""
+                        unexecuted_operation_name: ""
+                        details: ~
+                        client_name: ""
+                        client_version: ""
+                        operation_type: ""
+                        operation_subtype: ""
+                        http: ~
+                        cache_policy: ~
+                        query_plan: ~
+                        full_query_cache_hit: false
+                        persisted_query_hit: false
+                        persisted_query_register: false
+                        registered_operation: false
+                        forbidden_operation: false
+                        field_execution_weight: 1
+                        limits: ~
+                      sent_time_offset: "[sent_time_offset]"
+                      sent_time:
+                        seconds: "[seconds]"
+                        nanos: "[nanos]"
+                      received_time:
+                        seconds: "[seconds]"
+                        nanos: "[nanos]"
+                - node:
+                    Flatten:
+                      response_path:
+                        - id:
+                            FieldName: topProducts
+                      node:
+                        node:
+                          Fetch:
+                            service_name: reviews
+                            trace_parsing_failed: false
+                            trace:
+                              start_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              end_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              duration_ns: "[duration_ns]"
+                              root:
+                                original_field_name: ""
+                                type: ""
+                                parent_type: ""
+                                cache_policy: ~
+                                start_time: 0
+                                end_time: 0
+                                error: []
+                                child:
+                                  - original_field_name: ""
+                                    type: "[_Entity]!"
+                                    parent_type: Query
+                                    cache_policy: ~
+                                    start_time: "[start_time]"
+                                    end_time: "[end_time]"
+                                    error: []
+                                    child:
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 1
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 0
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 1
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child:
+                                              - original_field_name: ""
+                                                type: ""
+                                                parent_type: ""
+                                                cache_policy: ~
+                                                start_time: "[start_time]"
+                                                end_time: "[end_time]"
+                                                error: []
+                                                child:
+                                                  - original_field_name: ""
+                                                    type: User
+                                                    parent_type: Review
+                                                    cache_policy: ~
+                                                    start_time: "[start_time]"
+                                                    end_time: "[end_time]"
+                                                    error: []
+                                                    child:
+                                                      - original_field_name: ""
+                                                        type: ID!
+                                                        parent_type: User
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child: []
+                                                        id:
+                                                          ResponseName: id
+                                                    id:
+                                                      ResponseName: author
+                                                id:
+                                                  Index: 0
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 2
+                                    id:
+                                      ResponseName: _entities
+                                id: ~
+                              is_incomplete: false
+                              signature: ""
+                              unexecuted_operation_body: ""
+                              unexecuted_operation_name: ""
+                              details: ~
+                              client_name: ""
+                              client_version: ""
+                              operation_type: ""
+                              operation_subtype: ""
+                              http: ~
+                              cache_policy: ~
+                              query_plan: ~
+                              full_query_cache_hit: false
+                              persisted_query_hit: false
+                              persisted_query_register: false
+                              registered_operation: false
+                              forbidden_operation: false
+                              field_execution_weight: 1
+                              limits: ~
+                            sent_time_offset: "[sent_time_offset]"
+                            sent_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                            received_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                - node:
+                    Flatten:
+                      response_path:
+                        - id:
+                            FieldName: topProducts
+                        - id:
+                            FieldName: reviews
+                        - id:
+                            FieldName: author
+                      node:
+                        node:
+                          Fetch:
+                            service_name: accounts
+                            trace_parsing_failed: false
+                            trace:
+                              start_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              end_time:
+                                seconds: "[seconds]"
+                                nanos: "[nanos]"
+                              duration_ns: "[duration_ns]"
+                              root:
+                                original_field_name: ""
+                                type: ""
+                                parent_type: ""
+                                cache_policy: ~
+                                start_time: 0
+                                end_time: 0
+                                error: []
+                                child:
+                                  - original_field_name: ""
+                                    type: "[_Entity]!"
+                                    parent_type: Query
+                                    cache_policy: ~
+                                    start_time: "[start_time]"
+                                    end_time: "[end_time]"
+                                    error: []
+                                    child:
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: User
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                        id:
+                                          Index: 0
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: User
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                        id:
+                                          Index: 1
+                                    id:
+                                      ResponseName: _entities
+                                id: ~
+                              is_incomplete: false
+                              signature: ""
+                              unexecuted_operation_body: ""
+                              unexecuted_operation_name: ""
+                              details: ~
+                              client_name: ""
+                              client_version: ""
+                              operation_type: ""
+                              operation_subtype: ""
+                              http: ~
+                              cache_policy: ~
+                              query_plan: ~
+                              full_query_cache_hit: false
+                              persisted_query_hit: false
+                              persisted_query_register: false
+                              registered_operation: false
+                              forbidden_operation: false
+                              field_execution_weight: 1
+                              limits: ~
+                            sent_time_offset: "[sent_time_offset]"
+                            sent_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+                            received_time:
+                              seconds: "[seconds]"
+                              nanos: "[nanos]"
+        full_query_cache_hit: false
+        persisted_query_hit: false
+        persisted_query_register: false
+        registered_operation: false
+        forbidden_operation: false
+        field_execution_weight: 1
+        limits:
+          result: COST_OK
+          strategy: static_estimated
+          cost_estimated: 230
+          cost_actual: 19
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
+    stats_with_context: []
+    referenced_fields_by_type: {}
+    query_metadata: ~
+end_time: "[end_time]"
+operation_count: 0
+operation_count_by_type: []
+traces_pre_aggregated: true
+extended_references_enabled: false

--- a/apollo-router/tests/snapshots/apollo_reports__non_defer-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__non_defer-2.snap
@@ -549,7 +549,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__non_defer.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__non_defer.snap
@@ -549,7 +549,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__send_header-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__send_header-2.snap
@@ -552,7 +552,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__send_header.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__send_header.snap
@@ -552,7 +552,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__send_variable_value-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__send_variable_value-2.snap
@@ -551,7 +551,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__send_variable_value.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__send_variable_value.snap
@@ -551,7 +551,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__trace_id-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__trace_id-2.snap
@@ -549,7 +549,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~

--- a/apollo-router/tests/snapshots/apollo_reports__trace_id.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__trace_id.snap
@@ -549,7 +549,15 @@ traces_per_query:
         registered_operation: false
         forbidden_operation: false
         field_execution_weight: 1
-        limits: ~
+        limits:
+          result: ""
+          strategy: ""
+          cost_estimated: 0
+          cost_actual: 0
+          depth: 0
+          height: 0
+          alias_count: 0
+          root_field_count: 0
     stats_with_context: []
     referenced_fields_by_type: {}
     query_metadata: ~


### PR DESCRIPTION
Cost information for queries is now exported on Apollo protobuf traces:
If available the calculations are attached to the supergraph span and then later picked up by the ApolloExporter.


The new keys on the supergraph span are:
```
pub(crate) const APOLLO_PRIVATE_COST_ESTIMATED: Key =
    Key::from_static_str("apollo_private.cost.estimated");
pub(crate) const APOLLO_PRIVATE_COST_ACTUAL: Key =
    Key::from_static_str("apollo_private.cost.actual");
pub(crate) const APOLLO_PRIVATE_COST_STRATEGY: Key =
    Key::from_static_str("apollo_private.cost.strategy");
pub(crate) const APOLLO_PRIVATE_COST_RESULT: Key =
    Key::from_static_str("apollo_private.cost.result");
```

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
