### PR TITLE
FED-251: fixed a (type-position, schema) inconsistency in `compute_nodes_for_key_resolution`

### DIFF
--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -3062,6 +3062,10 @@ fn compute_nodes_for_key_resolution<'a>(
     let dest = stack_item.tree.graph.node_weight(dest_id)?;
     // We shouldn't have a key on a non-composite type
     let source_type: CompositeTypeDefinitionPosition = source.type_.clone().try_into()?;
+    let source_schema: ValidFederationSchema = dependency_graph
+        .federated_query_graph
+        .schema_by_source(&source.source)?
+        .clone();
     let dest_type: CompositeTypeDefinitionPosition = dest.type_.clone().try_into()?;
     let dest_schema: ValidFederationSchema = dependency_graph
         .federated_query_graph
@@ -3153,7 +3157,7 @@ fn compute_nodes_for_key_resolution<'a>(
     let node =
         FetchDependencyGraph::node_weight_mut(&mut dependency_graph.graph, stack_item.node_id)?;
     let typename_field = Arc::new(OpPathElement::Field(Field::new_introspection_typename(
-        &dependency_graph.supergraph_schema,
+        &source_schema,
         &source_type,
         None,
     )));

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
@@ -93,10 +93,6 @@ fn can_use_a_key_on_an_interface_object_type() {
 }
 
 #[test]
-#[should_panic(
-    expected = r#"Cannot add selection of field "I.__typename" to selection set of parent type "I" that is potentially an interface object type at runtime"#
-)]
-// TODO: investigate this failure
 fn can_use_a_key_on_an_interface_object_from_an_interface_object_type() {
     let planner = planner!(
         S1: SUBGRAPH1,
@@ -181,6 +177,8 @@ fn only_uses_an_interface_object_if_it_can() {
 #[should_panic(
     expected = "Cannot add selection of field \"I.__typename\" to selection set of parent type \"I\" that is potentially an interface object type at runtime"
 )]
+// TODO: investigate this failure
+// - Fails to rebase on an interface object type in a subgraph.
 fn does_not_rely_on_an_interface_object_directly_for_typename() {
     let planner = planner!(
         S1: SUBGRAPH1,
@@ -232,9 +230,10 @@ fn does_not_rely_on_an_interface_object_directly_for_typename() {
 
 #[test]
 #[should_panic(
-    expected = r#"Cannot add selection of field "I.__typename" to selection set of parent type "I" that is potentially an interface object type at runtime"#
+    expected = r#"Cannot add selection of field "I.id" to selection set of parent type "A""#
 )]
 // TODO: investigate this failure
+// - Fails to rebase on an interface object type in a subgraph.
 fn does_not_rely_on_an_interface_object_directly_if_a_specific_implementation_is_requested() {
     let planner = planner!(
         S1: SUBGRAPH1,
@@ -377,10 +376,6 @@ fn can_use_a_key_on_an_interface_object_type_even_for_a_concrete_implementation(
 }
 
 #[test]
-#[should_panic(
-    expected = r#"Cannot add selection of field "I.__typename" to selection set of parent type "I" that is potentially an interface object type at runtime"#
-)]
-// TODO: investigate this failure
 fn handles_query_of_an_interface_field_for_a_specific_implementation_when_query_starts_with_interface_object(
 ) {
     let planner = planner!(
@@ -437,9 +432,10 @@ fn handles_query_of_an_interface_field_for_a_specific_implementation_when_query_
 
 #[test]
 #[should_panic(
-    expected = r#"Cannot add selection of field "I.__typename" to selection set of parent type "I" that is potentially an interface object type at runtime"#
+    expected = r#"Cannot add selection of field "I.id" to selection set of parent type "A""#
 )]
 // TODO: investigate this failure
+// - Fails to rebase on an interface object type in a subgraph.
 fn it_avoids_buffering_interface_object_results_that_may_have_to_be_filtered_with_lists() {
     let planner = planner!(
         S1: r#"


### PR DESCRIPTION
FED-251 is actually a symptom of several different root causes.
This PR is relatively clear-cut case, but others need a more closer look.

Partially fixes https://apollographql.atlassian.net/browse/FED-251

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
