### PR TITLE
fix(bridge_query_planner): change log level for mismatches

### DIFF
--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -125,7 +125,7 @@ impl BothModeComparisonJob {
                 if is_matched {
                     tracing::debug!("JS and Rust query plans match{operation_desc}! 🎉");
                 } else {
-                    tracing::warn!("JS v.s. Rust query plan mismatch{operation_desc}");
+                    tracing::debug!("JS v.s. Rust query plan mismatch{operation_desc}");
                     if let Some(formatted) = &js_plan.formatted_query_plan {
                         tracing::debug!(
                             "Diff of formatted plans:\n{}",


### PR DESCRIPTION
When using `experimental_query_planner_mode:both`, emit mismatch metrics as `debug` rather than `warn` as there are still a fair few mismatches.