### PR TITLE
Fix bug in interface object type collection during query planner construction

### DIFF
--- a/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
@@ -174,11 +174,6 @@ fn only_uses_an_interface_object_if_it_can() {
 }
 
 #[test]
-#[should_panic(
-    expected = "Cannot add selection of field \"I.__typename\" to selection set of parent type \"I\" that is potentially an interface object type at runtime"
-)]
-// TODO: investigate this failure
-// - Fails to rebase on an interface object type in a subgraph.
 fn does_not_rely_on_an_interface_object_directly_for_typename() {
     let planner = planner!(
         S1: SUBGRAPH1,


### PR DESCRIPTION
This PR fixes a bug where, during query planner construction, the interface types that are interface objects (in at least one subgraph schema) are computed incorrectly. This ends up fixing one particular snapshot test.