### PR TITLE
connector: initial expand subgraphs

### DIFF
--- a/apollo-federation/src/sources/connect/expand/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/mod.rs
@@ -1,0 +1,385 @@
+use apollo_compiler::validation::Valid;
+use apollo_compiler::NodeStr;
+use apollo_compiler::Schema;
+use indexmap::IndexMap;
+use itertools::Itertools;
+
+use crate::error::FederationError;
+use crate::link::Link;
+use crate::merge::merge_subgraphs;
+use crate::sources::connect::ConnectSpecDefinition;
+use crate::sources::connect::Connector;
+use crate::subgraph::Subgraph;
+use crate::subgraph::ValidSubgraph;
+use crate::ApiSchemaOptions;
+use crate::Supergraph;
+use crate::ValidFederationSubgraph;
+
+/// The result of a supergraph expansion of connect-aware subgraphs
+pub enum ExpansionResult {
+    /// The supergraph had some subgraphs that were expanded
+    Expanded {
+        raw_sdl: String,
+        api_schema: Valid<Schema>,
+        connectors_by_service_name: IndexMap<NodeStr, Connector>,
+    },
+
+    /// The supergraph contained no connect directives and was unchanged.
+    Unchanged,
+}
+
+/// Expand a schema with connector directives into unique subgraphs per directive
+///
+/// Until we have a source-aware query planner, work with connectors will need to interface
+/// with standard query planning concepts while still enforcing connector-specific rules. To do so,
+/// each connector is separated into its own unique subgraph with relevant GraphQL directives to enforce
+/// field dependencies and response structures. This allows for satisfiability and validation to piggy-back
+/// off of existing functionality in a reproducable way.
+pub fn expand_connectors(supergraph_str: &str) -> Result<ExpansionResult, FederationError> {
+    // TODO: Don't rely on finding the URL manually to short out
+    let connect_url = ConnectSpecDefinition::identity();
+    let connect_url = format!("{}/{}/v", connect_url.domain, connect_url.name);
+    if !supergraph_str.contains(&connect_url) {
+        return Ok(ExpansionResult::Unchanged);
+    }
+
+    let supergraph = Supergraph::new(supergraph_str)?;
+    let api_schema = supergraph.to_api_schema(ApiSchemaOptions {
+        include_defer: true,
+        include_stream: true,
+    })?;
+
+    let (connect_subgraphs, graphql_subgraphs): (Vec<_>, Vec<_>) = supergraph
+        .extract_subgraphs()?
+        .into_iter()
+        .partition_map(|(_, sub)| {
+            match ConnectSpecDefinition::get_from_schema(&sub.schema.schema()) {
+                Ok(Some((_, link))) if contains_connectors(&link, &sub) => {
+                    either::Either::Left((link, sub))
+                }
+                _ => either::Either::Right(ValidSubgraph::from(sub)),
+            }
+        });
+
+    // Expand just the connector subgraphs
+    let connect_subgraphs = connect_subgraphs
+        .into_iter()
+        .map(|(link, sub)| split_subgraph(&link, sub))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .flatten()
+        .collect_vec();
+
+    // Merge the subgraphs into one supergraph
+    let all_subgraphs = graphql_subgraphs
+        .iter()
+        .chain(connect_subgraphs.iter().map(|(_, sub)| sub))
+        .collect();
+    let supergraph = merge_subgraphs(all_subgraphs).map_err(|e| {
+        FederationError::internal(format!("could not merge expanded subgraphs: {e:?}"))
+    })?;
+
+    let connectors_by_service_name: IndexMap<NodeStr, Connector> = connect_subgraphs
+        .into_iter()
+        .map(|(connector, sub)| (NodeStr::new(&sub.name), connector))
+        .collect();
+
+    Ok(ExpansionResult::Expanded {
+        raw_sdl: supergraph.schema.serialize().to_string(),
+        api_schema: api_schema.schema().clone(),
+        connectors_by_service_name,
+    })
+}
+
+fn contains_connectors(link: &Link, subgraph: &ValidFederationSubgraph) -> bool {
+    let connect_name = ConnectSpecDefinition::connect_directive_name(link);
+    let source_name = ConnectSpecDefinition::source_directive_name(link);
+
+    subgraph
+        .schema
+        .get_directive_definitions()
+        .any(|directive| {
+            directive.directive_name == connect_name || directive.directive_name == source_name
+        })
+}
+
+/// Split up a subgraph so that each connector directive becomes its own subgraph.
+///
+/// Subgraphs passed to this function should contain connector directives.
+fn split_subgraph(
+    link: &Link,
+    subgraph: ValidFederationSubgraph,
+) -> Result<Vec<(Connector, ValidSubgraph)>, FederationError> {
+    let connector_map =
+        Connector::from_valid_schema(&subgraph.schema, NodeStr::new(&subgraph.name))?;
+
+    let expander = helpers::Expander::new(&link, &subgraph);
+    connector_map
+        .into_iter()
+        .map(|(id, connector)| {
+            // Build a subgraph using only the necessary fields from the directive
+            let schema = expander.expand(&connector)?;
+            let subgraph = Subgraph::new(
+                id.synthetic_name().as_str(),
+                &subgraph.url,
+                &schema.schema().serialize().to_string(),
+            )?;
+
+            // We only validate during debug builds since we should realistically only generate valid schemas
+            // for these subgraphs.
+            #[cfg(debug_assertions)]
+            let schema = subgraph.schema.validate()?;
+            #[cfg(not(debug_assertions))]
+            let schema = Valid::assume_valid(subgraph.schema);
+
+            Ok((
+                connector,
+                ValidSubgraph {
+                    name: subgraph.name,
+                    url: subgraph.url,
+                    schema,
+                },
+            ))
+        })
+        .try_collect()
+}
+
+mod helpers {
+    use apollo_compiler::ast;
+    use apollo_compiler::ast::FieldDefinition;
+    use apollo_compiler::ast::Name;
+    use apollo_compiler::name;
+    use apollo_compiler::schema::Component;
+    use apollo_compiler::schema::ComponentName;
+    use apollo_compiler::schema::ComponentOrigin;
+    use apollo_compiler::schema::DirectiveList;
+    use apollo_compiler::schema::ObjectType;
+    use apollo_compiler::Node;
+    use apollo_compiler::NodeStr;
+    use indexmap::IndexMap;
+    use indexmap::IndexSet;
+
+    use crate::error::FederationError;
+    use crate::link::Link;
+    use crate::query_graph::extract_subgraphs_from_supergraph::new_empty_fed_2_subgraph_schema;
+    use crate::schema::position::ObjectTypeDefinitionPosition;
+    use crate::schema::position::SchemaRootDefinitionKind;
+    use crate::schema::position::SchemaRootDefinitionPosition;
+    use crate::schema::position::TypeDefinitionPosition;
+    use crate::schema::FederationSchema;
+    use crate::schema::ObjectFieldDefinitionPosition;
+    use crate::schema::ObjectOrInterfaceFieldDefinitionPosition;
+    use crate::schema::ValidFederationSchema;
+    use crate::sources::connect::ConnectSpecDefinition;
+    use crate::sources::connect::Connector;
+    use crate::sources::connect::JSONSelection;
+    use crate::ValidFederationSubgraph;
+
+    /// A helper struct for expanding a subgraph into one per connect directive.
+    pub(super) struct Expander<'a> {
+        /// The name of the connect directive, possibly aliased.
+        connect_name: Name,
+
+        /// The name of the connect directive, possibly aliased.
+        source_name: Name,
+
+        /// The original schema that contains connect directives
+        original_schema: &'a ValidFederationSchema,
+    }
+
+    impl<'a> Expander<'a> {
+        pub(super) fn new(link: &Link, subgraph: &'a ValidFederationSubgraph) -> Expander<'a> {
+            let connect_name = ConnectSpecDefinition::connect_directive_name(link);
+            let source_name = ConnectSpecDefinition::source_directive_name(link);
+
+            Self {
+                connect_name,
+                source_name,
+                original_schema: &subgraph.schema,
+            }
+        }
+
+        /// Build an expanded subgraph for the supplied connector
+        pub(super) fn expand(
+            &self,
+            connector: &Connector,
+        ) -> Result<FederationSchema, FederationError> {
+            let mut schema = new_empty_fed_2_subgraph_schema()?;
+
+            // Add the parent type for this connector
+            let ref field = connector.id.directive.field;
+            match field {
+                ObjectOrInterfaceFieldDefinitionPosition::Object(o) => {
+                    self.expand_object(&mut schema, o, &connector)?
+                }
+                ObjectOrInterfaceFieldDefinitionPosition::Interface(i) => {
+                    todo!("not yet done for interface {i}")
+                }
+            };
+
+            // Add a query root with dummy information if the connect directive is not on a query
+            // field.
+            let query_alias = self
+                .original_schema
+                .schema()
+                .schema_definition
+                .query
+                .as_ref()
+                .map(|m| m.name.clone())
+                .unwrap_or(name!("Query"));
+            if field.parent().type_name() != &query_alias {
+                self.insert_dummy_query(&mut schema, query_alias)?;
+            }
+
+            // Add the query root
+            let root = SchemaRootDefinitionPosition {
+                root_kind: SchemaRootDefinitionKind::Query,
+            };
+            root.insert(
+                &mut schema,
+                ComponentName {
+                    origin: ComponentOrigin::Definition,
+                    name: name!("Query"),
+                },
+            )?;
+
+            Ok(schema)
+        }
+
+        fn expand_object(
+            &self,
+            to_schema: &mut FederationSchema,
+            object: &ObjectFieldDefinitionPosition,
+            connector: &Connector,
+        ) -> Result<(), FederationError> {
+            let field_type = object.get(self.original_schema.schema())?;
+
+            // We first need to create the type pointed at by the current field
+            let output_name = field_type.ty.inner_named_type().clone();
+            let output_type = self.original_schema.get_type(output_name)?;
+            let extended_output_type = output_type.get(self.original_schema.schema())?;
+
+            // If the type is built-in, then there isn't anything that we need to do for the output type
+            if !extended_output_type.is_built_in() {
+                match output_type {
+                    TypeDefinitionPosition::Object(out) => {
+                        // Extract the needed fields from the selection
+                        let JSONSelection::Named(ref selections) = connector.selection else {
+                            unimplemented!()
+                        };
+                        let mut field_selections = IndexMap::new();
+                        for selection in selections.selections_iter() {
+                            let as_name = Name::new(selection.name())?;
+                            let field = out
+                                .field(as_name.clone())
+                                .get(self.original_schema.schema())?;
+                            let field = FieldDefinition {
+                                description: field.description.clone(),
+                                name: field.name.clone(),
+                                arguments: field.arguments.clone(),
+                                ty: field.ty.clone(),
+                                directives: ast::DirectiveList::new(),
+                            };
+
+                            field_selections.insert(as_name, Component::new(field));
+                        }
+
+                        let out_def = out.get(self.original_schema.schema())?;
+                        let out_type = ObjectType {
+                            description: out_def.description.clone(),
+                            name: out_def.name.clone(),
+                            implements_interfaces: out_def.implements_interfaces.clone(),
+                            directives: DirectiveList::new(),
+                            fields: field_selections,
+                        };
+
+                        out.pre_insert(to_schema)?;
+                        out.insert(to_schema, Node::new(out_type))?
+                    }
+                    o => todo!("not yet done for {o:?}"),
+                };
+            }
+
+            let parent = object.parent();
+            let parent_type = parent.get(self.original_schema.schema())?;
+            // let parent_directives = parent_type
+            //     .directives
+            //     .into_iter()
+            //     .filter(|d| d.name != source_name && d.name != connect_name)
+            //     .collect();
+
+            let field_type = FieldDefinition {
+                description: field_type.description.clone(),
+                name: field_type.name.clone(),
+                arguments: field_type.arguments.clone(),
+                ty: field_type.ty.clone(),
+                directives: ast::DirectiveList::new(),
+            };
+            let connector_parent_type = ObjectType {
+                description: parent_type.description.clone(),
+                name: parent_type.name.clone(),
+                implements_interfaces: parent_type.implements_interfaces.clone(),
+                directives: DirectiveList::new(),
+                fields: IndexMap::from([(
+                    field_type.ty.inner_named_type().clone(),
+                    Component::new(field_type),
+                )]),
+            };
+
+            parent.pre_insert(to_schema)?;
+            parent.insert(to_schema, Node::new(connector_parent_type))?;
+
+            Ok(())
+        }
+
+        /// Inserts a dummy root-level query to the schema to pass validation.
+        fn insert_dummy_query(
+            &self,
+            to_schema: &mut FederationSchema,
+            name: Name,
+        ) -> Result<(), FederationError> {
+            let field_name = name!("_");
+
+            let dummy_query = ObjectTypeDefinitionPosition {
+                type_name: name.clone(),
+            };
+            let dummy_field = Component::new(FieldDefinition {
+                description: None,
+                name: field_name.clone(),
+                arguments: Vec::new(),
+                ty: ast::Type::Named(ast::NamedType::new_unchecked(NodeStr::from_static(&"ID"))),
+                directives: ast::DirectiveList(
+                    [
+                        name!("federation__shareable"),
+                        name!("federation__inaccessible"),
+                    ]
+                    .into_iter()
+                    .map(|name| {
+                        Node::new(ast::Directive {
+                            name,
+                            arguments: Vec::new(),
+                        })
+                    })
+                    .collect(),
+                ),
+            });
+
+            dummy_query.pre_insert(to_schema)?;
+            dummy_query.insert(
+                to_schema,
+                Node::new(ObjectType {
+                    description: None,
+                    name,
+                    implements_interfaces: IndexSet::new(),
+                    directives: DirectiveList::new(),
+                    fields: IndexMap::from([(field_name, dummy_field)]),
+                }),
+            )?;
+
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/apollo-federation/src/sources/connect/expand/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/mod.rs
@@ -53,7 +53,7 @@ pub fn expand_connectors(supergraph_str: &str) -> Result<ExpansionResult, Federa
         .extract_subgraphs()?
         .into_iter()
         .partition_map(|(_, sub)| {
-            match ConnectSpecDefinition::get_from_schema(&sub.schema.schema()) {
+            match ConnectSpecDefinition::get_from_schema(sub.schema.schema()) {
                 Ok(Some((_, link))) if contains_connectors(&link, &sub) => {
                     either::Either::Left((link, sub))
                 }
@@ -113,7 +113,7 @@ fn split_subgraph(
     let connector_map =
         Connector::from_valid_schema(&subgraph.schema, NodeStr::new(&subgraph.name))?;
 
-    let expander = helpers::Expander::new(&link, &subgraph);
+    let expander = helpers::Expander::new(link, &subgraph);
     connector_map
         .into_iter()
         .map(|(id, connector)| {
@@ -207,10 +207,10 @@ mod helpers {
             let mut schema = new_empty_fed_2_subgraph_schema()?;
 
             // Add the parent type for this connector
-            let ref field = connector.id.directive.field;
+            let field = &connector.id.directive.field;
             match field {
                 ObjectOrInterfaceFieldDefinitionPosition::Object(o) => {
-                    self.expand_object(&mut schema, o, &connector)?
+                    self.expand_object(&mut schema, o, connector)?
                 }
                 ObjectOrInterfaceFieldDefinitionPosition::Interface(i) => {
                     todo!("not yet done for interface {i}")

--- a/apollo-federation/src/sources/connect/expand/tests/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/tests/mod.rs
@@ -1,0 +1,243 @@
+use insta::{assert_debug_snapshot, assert_snapshot};
+
+use crate::sources::connect::expand::{expand_connectors, ExpansionResult};
+
+#[test]
+fn it_expands_a_supergraph() {
+    let to_expand = include_str!("./schemas/simple.graphql");
+    let ExpansionResult::Expanded {
+        raw_sdl,
+        api_schema,
+        connectors_by_service_name,
+    } = expand_connectors(to_expand).unwrap()
+    else {
+        panic!("expected expansion to actually expand subgraphs");
+    };
+
+    assert_snapshot!(api_schema, @r###"
+    directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+    directive @stream(label: String, if: Boolean! = true, initialCount: Int = 0) on FIELD
+
+    type Query {
+      users: [User]
+      user(id: ID!): User
+    }
+
+    type User {
+      id: ID!
+      a: String
+      b: String
+      c: String
+      d: String
+    }
+    "###);
+    assert_debug_snapshot!(connectors_by_service_name, @r###"
+    {
+        "connectors_Query_users_0": Connector {
+            id: ConnectId {
+                label: "connectors.example http: Get ",
+                subgraph_name: "connectors",
+                directive: ObjectOrInterfaceFieldDirectivePosition {
+                    field: Object(Query.users),
+                    directive_name: "connect",
+                    directive_index: 0,
+                },
+            },
+            transport: HttpJson(
+                HttpJsonTransport {
+                    base_url: "http://example",
+                    path_template: URLPathTemplate {
+                        path: [],
+                        query: {},
+                    },
+                    method: Get,
+                    headers: {},
+                    body: None,
+                },
+            ),
+            selection: Named(
+                SubSelection {
+                    selections: [
+                        Field(
+                            None,
+                            "id",
+                            None,
+                        ),
+                        Field(
+                            None,
+                            "a",
+                            None,
+                        ),
+                    ],
+                    star: None,
+                },
+            ),
+            entity: false,
+            on_root_type: true,
+        },
+        "connectors_Query_user_0": Connector {
+            id: ConnectId {
+                label: "connectors.example http: Get /{$args.id!}",
+                subgraph_name: "connectors",
+                directive: ObjectOrInterfaceFieldDirectivePosition {
+                    field: Object(Query.user),
+                    directive_name: "connect",
+                    directive_index: 0,
+                },
+            },
+            transport: HttpJson(
+                HttpJsonTransport {
+                    base_url: "http://example",
+                    path_template: URLPathTemplate {
+                        path: [
+                            ParameterValue {
+                                parts: [
+                                    Var(
+                                        VariableExpression {
+                                            var_path: "$args.id",
+                                            batch_separator: None,
+                                            required: true,
+                                        },
+                                    ),
+                                ],
+                            },
+                        ],
+                        query: {},
+                    },
+                    method: Get,
+                    headers: {},
+                    body: None,
+                },
+            ),
+            selection: Named(
+                SubSelection {
+                    selections: [
+                        Field(
+                            None,
+                            "id",
+                            None,
+                        ),
+                        Field(
+                            None,
+                            "a",
+                            None,
+                        ),
+                        Field(
+                            None,
+                            "b",
+                            None,
+                        ),
+                    ],
+                    star: None,
+                },
+            ),
+            entity: false,
+            on_root_type: true,
+        },
+        "connectors_User_d_1": Connector {
+            id: ConnectId {
+                label: "connectors.example http: Get /{$this.c!}/d",
+                subgraph_name: "connectors",
+                directive: ObjectOrInterfaceFieldDirectivePosition {
+                    field: Object(User.d),
+                    directive_name: "connect",
+                    directive_index: 1,
+                },
+            },
+            transport: HttpJson(
+                HttpJsonTransport {
+                    base_url: "http://example",
+                    path_template: URLPathTemplate {
+                        path: [
+                            ParameterValue {
+                                parts: [
+                                    Var(
+                                        VariableExpression {
+                                            var_path: "$this.c",
+                                            batch_separator: None,
+                                            required: true,
+                                        },
+                                    ),
+                                ],
+                            },
+                            ParameterValue {
+                                parts: [
+                                    Text(
+                                        "d",
+                                    ),
+                                ],
+                            },
+                        ],
+                        query: {},
+                    },
+                    method: Get,
+                    headers: {},
+                    body: None,
+                },
+            ),
+            selection: Path(
+                Var(
+                    "$",
+                    Empty,
+                ),
+            ),
+            entity: false,
+            on_root_type: false,
+        },
+    }
+    "###);
+    assert_snapshot!(raw_sdl, @r###"
+    schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+      query: Query
+    }
+
+    directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+    directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+    directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on ENUM | INPUT_OBJECT | INTERFACE | OBJECT | SCALAR | UNION
+
+    directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+    directive @join__implements(graph: join__Graph!, interface: String!) repeatable on INTERFACE | OBJECT
+
+    directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+    directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+    enum link__Purpose {
+      """
+      SECURITY features provide metadata necessary to securely resolve fields.
+      """
+      SECURITY
+      """EXECUTION features provide metadata necessary for operation execution."""
+      EXECUTION
+    }
+
+    scalar link__Import
+
+    scalar join__FieldSet
+
+    enum join__Graph {
+      CONNECTORS_QUERY_USER_0 @join__graph(name: "connectors_Query_user_0", url: "none")
+      CONNECTORS_QUERY_USERS_0 @join__graph(name: "connectors_Query_users_0", url: "none")
+      CONNECTORS_USER_D_1 @join__graph(name: "connectors_User_d_1", url: "none")
+      GRAPHQL @join__graph(name: "graphql", url: "https://graphql")
+    }
+
+    type User @join__type(graph: CONNECTORS_QUERY_USER_0) @join__type(graph: CONNECTORS_QUERY_USERS_0) @join__type(graph: CONNECTORS_USER_D_1) @join__type(graph: GRAPHQL) {
+      id: ID!
+      a: String
+      b: String
+      d: String
+      c: String
+    }
+
+    type Query @join__type(graph: CONNECTORS_QUERY_USER_0) @join__type(graph: CONNECTORS_QUERY_USERS_0) @join__type(graph: CONNECTORS_USER_D_1) @join__type(graph: GRAPHQL) {
+      user(id: ID!): User @join__field(graph: CONNECTORS_QUERY_USER_0)
+      users: [User] @join__field(graph: CONNECTORS_QUERY_USERS_0)
+      _: ID @join__field(graph: CONNECTORS_USER_D_1)
+    }
+    "###);
+}

--- a/apollo-federation/src/sources/connect/expand/tests/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/tests/mod.rs
@@ -1,6 +1,8 @@
-use insta::{assert_debug_snapshot, assert_snapshot};
+use insta::assert_debug_snapshot;
+use insta::assert_snapshot;
 
-use crate::sources::connect::expand::{expand_connectors, ExpansionResult};
+use crate::sources::connect::expand::expand_connectors;
+use crate::sources::connect::expand::ExpansionResult;
 
 #[test]
 fn it_expands_a_supergraph() {

--- a/apollo-federation/src/sources/connect/expand/tests/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/tests/mod.rs
@@ -19,8 +19,6 @@ fn it_expands_a_supergraph() {
     assert_snapshot!(api_schema, @r###"
     directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
 
-    directive @stream(label: String, if: Boolean! = true, initialCount: Int = 0) on FIELD
-
     type Query {
       users: [User]
       user(id: ID!): User

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/simple.graphql
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/simple.graphql
@@ -1,0 +1,66 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "example", http: {baseURL: "http://example"}})
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+enum join__Graph {
+  CONNECTORS @join__graph(name: "connectors", url: "none")
+  GRAPHQL @join__graph(name: "graphql", url: "https://graphql")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: CONNECTORS)
+  @join__type(graph: GRAPHQL)
+{
+  users: [User] @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "example", http: {GET: "/"}, selection: "id a"})
+  user(id: ID!): User @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "example", http: {GET: "/{$args.id}"}, selection: "id a b"})
+}
+
+type User
+  @join__type(graph: CONNECTORS, key: "id")
+  @join__type(graph: GRAPHQL, key: "id")
+{
+  id: ID!
+  a: String @join__field(graph: CONNECTORS)
+  b: String @join__field(graph: CONNECTORS)
+  c: String @join__field(graph: CONNECTORS, external: true) @join__field(graph: GRAPHQL)
+  d: String @join__field(graph: CONNECTORS, requires: "c") @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "example", http: {GET: "/{$this.c}/d"}, selection: "$"})
+}

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/simple.yaml
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/simple.yaml
@@ -1,0 +1,42 @@
+federation_version: =2.8.0-connectors.5
+subgraphs:
+  connectors:
+    routing_url: none
+    schema:
+      sdl: |
+        extend schema
+          @link(
+            url: "https://specs.apollo.dev/federation/v2.7"
+            import: ["@key", "@external", "@requires"]
+          )
+          @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"])
+          @source(name: "example", http: { baseURL: "http://example" })
+
+        type Query {
+          users: [User] @connect(source: "example", http: { GET: "/" }, selection: "id a")
+
+          user(id: ID!): User
+            @connect(source: "example", http: { GET: "/{$$args.id}" }, selection: "id a b") # entity: true
+        }
+
+        type User @key(fields: "id") {
+          id: ID!
+          a: String
+          b: String
+          c: String @external
+          d: String
+            @requires(fields: "c")
+            @connect(source: "example", http: { GET: "/{$$this.c}/d" }, selection: "$")
+        }
+
+  graphql:
+    routing_url: https://graphql
+    schema:
+      sdl: |
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.7", import: ["@key"])
+
+        type User @key(fields: "id") {
+          id: ID!
+          c: String
+        }

--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -7,6 +7,7 @@ use apollo_compiler::ast::Name;
 use apollo_compiler::NodeStr;
 use indexmap::IndexMap;
 
+pub mod expand;
 mod json_selection;
 mod models;
 pub(crate) mod spec;
@@ -42,6 +43,23 @@ pub struct ConnectId {
     pub label: String,
     pub subgraph_name: NodeStr,
     pub directive: ObjectOrInterfaceFieldDirectivePosition,
+}
+
+impl ConnectId {
+    /// Create a synthetic name for this connect ID
+    ///
+    /// Until we have a source-aware query planner, we'll need to split up connectors into
+    /// their own subgraphs when doing planning. Each subgraph will need a name, so we
+    /// synthesize one using metadata present on the directive.
+    pub(crate) fn synthetic_name(&self) -> String {
+        format!(
+            "{}_{}_{}_{}",
+            self.subgraph_name,
+            self.directive.field.type_name(),
+            self.directive.field.field_name(),
+            self.directive.directive_index
+        )
+    }
 }
 
 impl PartialEq for ConnectId {

--- a/apollo-federation/src/sources/connect/models/mod.rs
+++ b/apollo-federation/src/sources/connect/models/mod.rs
@@ -156,6 +156,9 @@ impl HttpJsonTransport {
         headers.extend(http.headers.0.clone());
 
         Ok(Self {
+            // TODO: We'll need to eventually support @connect directives without
+            // a corresponding @source...
+            // See: https://apollographql.atlassian.net/browse/CNN-201
             base_url: source
                 .map(|s| s.base_url.clone())
                 .ok_or(FederationError::internal(

--- a/apollo-federation/src/sources/connect/spec/directives.rs
+++ b/apollo-federation/src/sources/connect/spec/directives.rs
@@ -40,7 +40,10 @@ pub(crate) fn extract_source_directive_arguments(
         return Ok(vec![]);
     };
 
-    let schema_directive_pos = directive_refs.schema.as_ref().unwrap();
+    // If we don't have any sources, then just short out
+    let Some(schema_directive_pos) = directive_refs.schema.as_ref() else {
+        return Ok(Vec::new());
+    };
 
     let schema_def = schema_directive_pos.get(schema.schema());
 

--- a/apollo-federation/src/sources/connect/url_path_template.rs
+++ b/apollo-federation/src/sources/connect/url_path_template.rs
@@ -548,7 +548,7 @@ impl Display for VariableExpression {
 }
 
 fn nom_parse_identifier_possible_namespace(input: &str) -> IResult<&str, &str> {
-    recognize(alt((tag("$this"), nom_parse_identifier)))(input)
+    recognize(alt((tag("$args"), tag("$this"), nom_parse_identifier)))(input)
 }
 
 fn nom_parse_identifier(input: &str) -> IResult<&str, &str> {
@@ -1804,6 +1804,13 @@ mod tests {
                 .unwrap()
                 .required_parameters(),
             vec!["$this.bar", "$this.id"],
+        );
+
+        assert_eq!(
+            URLPathTemplate::parse("/users/{$args.id}?foo={$args.bar!}")
+                .unwrap()
+                .required_parameters(),
+            vec!["$args.bar", "$args.id"],
         );
     }
 }

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -28,6 +28,7 @@ use crate::subgraph::spec::FEDERATION_V2_DIRECTIVE_NAMES;
 use crate::subgraph::spec::KEY_DIRECTIVE_NAME;
 use crate::subgraph::spec::SERVICE_SDL_QUERY;
 use crate::subgraph::spec::SERVICE_TYPE;
+use crate::ValidFederationSubgraph;
 
 mod database;
 pub mod spec;
@@ -324,6 +325,16 @@ pub struct ValidSubgraph {
 impl std::fmt::Debug for ValidSubgraph {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, r#"name: {}, url: {}"#, self.name, self.url)
+    }
+}
+
+impl From<ValidFederationSubgraph> for ValidSubgraph {
+    fn from(value: ValidFederationSubgraph) -> Self {
+        Self {
+            name: value.name,
+            url: value.url,
+            schema: value.schema.schema().clone(),
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds the ability to expand connect-aware subgraphs into their own atomic subgraphs each containing a single connector. Each subgraph only contains the needed types and fields as described by the connector's selection set, inputs, and body.

This PR is only the initial implementation. More PRs are needed to have it fully working.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
