### PR TITLE
Fix bug in selection set equality checking

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -188,12 +188,20 @@ impl Operation {
 /// - For the type, stores the schema and the position in that schema instead of just the
 ///   `NamedType`.
 /// - Stores selections in a map so they can be normalized efficiently.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub(crate) struct SelectionSet {
     pub(crate) schema: ValidFederationSchema,
     pub(crate) type_position: CompositeTypeDefinitionPosition,
     pub(crate) selections: Arc<SelectionMap>,
 }
+
+impl PartialEq for SelectionSet {
+    fn eq(&self, other: &Self) -> bool {
+        self.selections == other.selections
+    }
+}
+
+impl Eq for SelectionSet {}
 
 mod selection_map {
     use std::borrow::Cow;


### PR DESCRIPTION
Paired on this with @dariuszkuc 

This PR fixes a bug in selection set equality checking where it compares the schema and selection set's type when it shouldn't.

Note that we encountered this bug when discovering that condition exclusion wasn't working as expected. With this bugfix, computing how to jump to each subgraph should be much faster when there are many subgraphs.