### PR TITLE
FED-251: fixed `inputs_for_require` to use the entity_type/schema

### DIFF
--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -3856,6 +3856,7 @@ fn handle_requires(
             let inputs = inputs_for_require(
                 dependency_graph,
                 entity_type_position.clone(),
+                entity_type_schema,
                 query_graph_edge_id,
                 context,
                 false,
@@ -4028,6 +4029,7 @@ fn defer_context_for_conditions(base_context: &DeferContext) -> DeferContext {
 fn inputs_for_require(
     fetch_dependency_graph: &mut FetchDependencyGraph,
     entity_type_position: ObjectTypeDefinitionPosition,
+    entity_type_schema: ValidFederationSchema,
     query_graph_edge_id: EdgeIndex,
     context: &OpGraphPathContext,
     include_key_inputs: bool,
@@ -4112,7 +4114,7 @@ fn inputs_for_require(
         // should just use `entity_type` (that @interfaceObject type), not input type which will be an implementation the
         // subgraph does not know in that particular case.
         let mut key_inputs =
-            SelectionSet::for_composite_type(edge_conditions.schema.clone(), input_type.clone());
+            SelectionSet::for_composite_type(entity_type_schema, entity_type_position.into());
         key_inputs.add_selection_set(&key_condition)?;
 
         Ok((
@@ -4152,6 +4154,7 @@ fn add_post_require_inputs(
     let (inputs, key_inputs) = inputs_for_require(
         dependency_graph,
         entity_type_position.clone(),
+        entity_type_schema.clone(),
         query_graph_edge_id,
         context,
         true,

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
@@ -224,11 +224,8 @@ fn does_not_rely_on_an_interface_object_directly_for_typename() {
 }
 
 #[test]
-#[should_panic(
-    expected = r#"Cannot add selection of field "I.id" to selection set of parent type "A""#
-)]
-// TODO: investigate this failure
-// - Fails to rebase on an interface object type in a subgraph.
+#[should_panic(expected = r#"snapshot assertion"#)]
+// TODO: investigate this failure (missing fetch node for `iFromS2 { ... on I { y } }`)
 fn does_not_rely_on_an_interface_object_directly_if_a_specific_implementation_is_requested() {
     let planner = planner!(
         S1: SUBGRAPH1,
@@ -426,11 +423,8 @@ fn handles_query_of_an_interface_field_for_a_specific_implementation_when_query_
 }
 
 #[test]
-#[should_panic(
-    expected = r#"Cannot add selection of field "I.id" to selection set of parent type "A""#
-)]
-// TODO: investigate this failure
-// - Fails to rebase on an interface object type in a subgraph.
+#[should_panic(expected = r#"snapshot assertion"#)]
+// TODO: investigate this failure (missing fetch node for "everything.@ { ... on I { expansiveField } }")
 fn it_avoids_buffering_interface_object_results_that_may_have_to_be_filtered_with_lists() {
     let planner = planner!(
         S1: r#"


### PR DESCRIPTION
The `inputs_for_require` looked different from JS counterpart ([permalink](https://github.com/duckki/federation/blob/bbf83946800d0e6f83307e1941cd7052f8a3c38d/query-planner-js/src/buildPlan.ts#L4762)). I fixed that.

That eliminates the remaining FED-251 test failures. They turned into snapshot assertion failures, but they looked like a condition fetch issue (the final entity fetch wasn't added to the plan).

Fixes https://apollographql.atlassian.net/browse/FED-251

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
