### PR TITLE
fix(federation): handle shareable root operations

### DIFF
--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -416,7 +416,7 @@ impl ProcessingState {
         {
             // Remove any of the processed nodes from the unhandled edges of that node.
             // And if there is no remaining edge, that node can be handled.
-            edges.retain(|edge| processed.contains(&edge.parent_node_id));
+            edges.retain(|edge| !processed.contains(&edge.parent_node_id));
             if edges.is_empty() {
                 if !next.contains(&g) {
                     next.push(g);

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -3975,6 +3975,15 @@ fn handle_requires(
         let parent_type = new_node.parent_type.clone();
         for created_node_id in &new_created_nodes {
             let created_node = dependency_graph.node_weight(*created_node_id)?;
+            // Usually, computing the path of our new group into the created groups
+            // is not entirely trivial, but there is at least the relatively common
+            // case where the 2 groups we look at have:
+            // 1) the same `mergeAt`, and
+            // 2) the same parentType; in that case, we can basically infer those 2
+            //    groups apply at the same "place" and so the "path in parent" is
+            //    empty. TODO: it should probably be possible to generalize this by
+            //    checking the `mergeAt` plus analyzing the selection but that
+            //    warrants some reflection...
             let new_path =
                 if merge_at == created_node.merge_at && parent_type == created_node.parent_type {
                     Some(Arc::new(OpPath::default()))
@@ -3982,20 +3991,10 @@ fn handle_requires(
                     None
                 };
             let new_parent_relation = ParentRelation {
-                parent_node_id: new_node_id,
-                // Usually, computing the path of our new group into the created groups
-                // is not entirely trivial, but there is at least the relatively common
-                // case where the 2 groups we look at have:
-                // 1) the same `mergeAt`, and
-                // 2) the same parentType; in that case, we can basically infer those 2
-                //    groups apply at the same "place" and so the "path in parent" is
-                //    empty. TODO: it should probably be possible to generalize this by
-                //    checking the `mergeAt` plus analyzing the selection but that
-                //    warrants some reflection...
+                parent_node_id: *created_node_id,
                 path_in_parent: new_path,
             };
-            dependency_graph.add_parent(*created_node_id, new_parent_relation);
-            created_nodes.insert(*created_node_id);
+            dependency_graph.add_parent(new_node_id, new_parent_relation);
         }
 
         add_post_require_inputs(

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -377,7 +377,7 @@ impl ProcessingState {
             };
 
             // The uhandled are the one that are unhandled on both side.
-            in_edges.retain(|e| !other_node.unhandled_parents.contains(e));
+            in_edges.retain(|e| other_node.unhandled_parents.contains(e));
             other_nodes.remove(other_index);
             in_edges
         }

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/shareable_root_fields.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/shareable_root_fields.rs
@@ -56,9 +56,6 @@ fn can_use_same_root_operation_from_multiple_subgraphs_in_parallel() {
 }
 
 #[test]
-#[should_panic(
-    expected = "Root nodes should have no remaining nodes unhandled, but got: [1 (missing: [2])]"
-)]
 fn handles_root_operation_shareable_in_many_subgraphs() {
     let planner = planner!(
         Subgraph1: r#"


### PR DESCRIPTION
Fix state update logic for handling processed nodes. We were incorrectly retaining already processed nodes.

JS code `mergeRemaingsAndRemoveIfFound`
```javascript
return inEdges.filter(e => otherEdges.includes(e))
```

RS code `merge_remains_and_remove_if_found`
```rust
- in_edges.retain(|e| !other_node.unhandled_parents.contains(e));
+ in_edges.retain(|e| other_node.unhandled_parents.contains(e));
```


JS code `updateForProcessedGroups`
```javascript
const newEdges = edges.filter((edge) => !processed.includes(edge.group));
```

RS code `update_for_processed_nodes`
```rust
- edges.retain(|edge| processed.contains(&edge.parent_node_id));
+ edges.retain(|edge| !processed.contains(&edge.parent_node_id));
```

Also fixed incorrect parent<->child relationship in handle requires -> when creating new key fetch nodes we should make it a child of newly created nodes and NOT the opposite.

<!-- Fixes FED-306 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
