### PR TITLE
deprecate hyper::Body usage

### DIFF
--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -19,6 +19,7 @@
 #![cfg_attr(feature = "failfast", allow(unreachable_code))]
 #![warn(unreachable_pub)]
 #![warn(missing_docs)]
+#![allow(deprecated)]
 
 macro_rules! failfast_debug {
     ($($tokens:tt)+) => {{

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -31,7 +31,7 @@ use crate::Context;
 pub type BoxService = tower::util::BoxService<Request, Response, BoxError>;
 pub type BoxCloneService = tower::util::BoxCloneService<Request, Response, BoxError>;
 pub type ServiceResult = Result<Response, BoxError>;
-//#[deprecated]
+#[deprecated]
 pub type Body = hyper::Body;
 pub type Error = hyper::Error;
 

--- a/apollo-router/src/services/router.rs
+++ b/apollo-router/src/services/router.rs
@@ -47,6 +47,10 @@ assert_impl_all!(Request: Send);
 #[non_exhaustive]
 pub struct Request {
     /// Original request to the Router.
+    #[deprecated(
+        since = "1.50.0",
+        note = "the request body type will move from hyper::Body to a new type in Router 2.0"
+    )]
     pub router_request: http::Request<Body>,
 
     /// Context for extension
@@ -183,6 +187,10 @@ assert_impl_all!(Response: Send);
 #[non_exhaustive]
 #[derive(Debug)]
 pub struct Response {
+    #[deprecated(
+        since = "1.50.0",
+        note = "the response body type will move from hyper::Body to a new type in Router 2.0"
+    )]
     pub response: http::Response<Body>,
     pub context: Context,
 }

--- a/examples/async-auth/rust/src/allow_client_id_from_file.rs
+++ b/examples/async-auth/rust/src/allow_client_id_from_file.rs
@@ -6,6 +6,7 @@ use apollo_router::layers::ServiceBuilderExt;
 use apollo_router::plugin::Plugin;
 use apollo_router::plugin::PluginInit;
 use apollo_router::register_plugin;
+use apollo_router::services::router;
 use apollo_router::services::supergraph;
 use http::StatusCode;
 use schemars::JsonSchema;
@@ -38,6 +39,18 @@ impl Plugin for AllowClientIdFromFile {
             allowed_ids_path,
             header,
         })
+    }
+
+    fn router_service(&self, service: router::BoxService) -> router::BoxService {
+        // or ControlFlow::Break(response) with a crafted response if we don't want the request to go through.
+        ServiceBuilder::new()
+            .map_request(|req: router::Request| {
+                let body = req.router_request.body();
+
+                req
+            })
+            .service(service)
+            .boxed()
     }
 
     // On each request, this plugin will extract a x-client-id header, and check against a file


### PR DESCRIPTION
Follow up to https://github.com/apollographql/router/pull/5175

We cannot just mark the `Body` type as deprecated, because it is just an alias to an external type. Instead, we can add the deprecation notice on the router request and response types. We can also allow deprecated elements inside the router code, to avoid warnings internally

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
