### PR TITLE
fix: misc graph_path display fixes

### DIFF
--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -3015,10 +3015,11 @@ impl Display for OpGraphPath {
         // If the path is length is 0 return "[]"
         // Traverse the path, getting the of the edge.
         let head = &self.graph.graph()[self.head];
-        if head.is_root_node() && self.edges.is_empty() {
+        let head_is_root_node = head.is_root_node();
+        if head_is_root_node && self.edges.is_empty() {
             return write!(f, "_");
         }
-        if !head.is_root_node() {
+        if !head_is_root_node {
             write!(f, "{head}")?;
         }
         self.edges
@@ -3029,7 +3030,7 @@ impl Display for OpGraphPath {
                 Some(e) => {
                     let tail = self.graph.graph().edge_endpoints(e).unwrap().1;
                     let node = &self.graph.graph()[tail];
-                    if i == 0 && head.is_root_node() {
+                    if i == 0 && head_is_root_node {
                         write!(f, "{node}")
                     } else {
                         let edge = &self.graph.graph()[e];

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -3033,7 +3033,10 @@ impl Display for OpGraphPath {
                     let label = edge.transition.to_string();
                     if let Some(conditions) = &edge.conditions {
                         write!(f, " --[{conditions} ⊢ {label}]--> {node}")
-                    } else if !matches!(edge.transition, QueryGraphEdgeTransition::SubgraphEnteringTransition) {
+                    } else if !matches!(
+                        edge.transition,
+                        QueryGraphEdgeTransition::SubgraphEnteringTransition
+                    ) {
                         write!(f, " --[{label}]--> {node}")
                     } else {
                         core::fmt::Result::Ok(())

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -544,7 +544,7 @@ impl SimultaneousPaths {
         match self.0.as_slice() {
             [] => f.write("<no path>"),
 
-            [first] => f.write_fmt(format_args!("{{ {first} }}")),
+            [first] => f.write_fmt(format_args!("{first}")),
 
             _ => {
                 f.write("{")?;
@@ -3031,7 +3031,13 @@ impl Display for OpGraphPath {
                     let node = &self.graph.graph()[tail];
                     let edge = &self.graph.graph()[e];
                     let label = edge.transition.to_string();
-                    write!(f, " --[{label}]--> {node}")
+                    if let Some(conditions) = &edge.conditions {
+                        write!(f, " --[{conditions} ⊢ {label}]--> {node}")
+                    } else if !matches!(edge.transition, QueryGraphEdgeTransition::SubgraphEnteringTransition) {
+                        write!(f, " --[{label}]--> {node}")
+                    } else {
+                        core::fmt::Result::Ok(())
+                    }
                 }
                 None => write!(f, " ({}) ", self.edge_triggers[i].as_ref()),
             })?;

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -3018,12 +3018,7 @@ impl Display for OpGraphPath {
         if head.root_kind.is_some() && self.edges.is_empty() {
             return write!(f, "_");
         }
-        if head.root_kind.is_some() {
-            // TODO it appears that we are missing this extra edge?
-            // if (isRoot && idx == 0) {
-            //   return edge.tail.toString();
-            // }
-        } else {
+        if head.root_kind.is_none() {
             write!(f, "{head}")?;
         }
         self.edges
@@ -3034,17 +3029,22 @@ impl Display for OpGraphPath {
                 Some(e) => {
                     let tail = self.graph.graph().edge_endpoints(e).unwrap().1;
                     let node = &self.graph.graph()[tail];
-                    let edge = &self.graph.graph()[e];
-                    let label = edge.transition.to_string();
-                    if let Some(conditions) = &edge.conditions {
-                        write!(f, " --[{conditions} ⊢ {label}]--> {node}")
-                    } else if !matches!(
-                        edge.transition,
-                        QueryGraphEdgeTransition::SubgraphEnteringTransition
-                    ) {
-                        write!(f, " --[{label}]--> {node}")
+                    if i == 0 && head.root_kind.is_some() {
+                        write!(f, "{node}")
                     } else {
-                        core::fmt::Result::Ok(())
+                        let edge = &self.graph.graph()[e];
+                        let label = edge.transition.to_string();
+
+                        if let Some(conditions) = &edge.conditions {
+                            write!(f, " --[{conditions} ⊢ {label}]--> {node}")
+                        } else if !matches!(
+                            edge.transition,
+                            QueryGraphEdgeTransition::SubgraphEnteringTransition
+                        ) {
+                            write!(f, " --[{label}]--> {node}")
+                        } else {
+                            core::fmt::Result::Ok(())
+                        }
                     }
                 }
                 None => write!(f, " ({}) ", self.edge_triggers[i].as_ref()),

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -3019,6 +3019,11 @@ impl Display for OpGraphPath {
             return write!(f, "_");
         }
         if head.root_kind.is_some() {
+            // TODO it appears that we are missing this extra edge?
+            // if (isRoot && idx == 0) {
+            //   return edge.tail.toString();
+            // }
+        } else {
             write!(f, "{head}")?;
         }
         self.edges

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -80,7 +80,7 @@ impl Display for QueryGraphNode {
         if let Some(provide_id) = self.provide_id {
             write!(f, "-{}", provide_id)?;
         }
-        if self.root_kind.is_some() {
+        if self.is_root_node() {
             write!(f, "*")?;
         }
         Ok(())

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -513,7 +513,7 @@ mod tests {
             build_graph_path(&query_graph, SchemaRootDefinitionKind::Query, &["t", "id"]).unwrap();
         assert_eq!(
             path1.to_string(),
-            "Query(Test)* --[t]--> T(Test) --[id]--> ID(Test)"
+            "Query(Test) --[t]--> T(Test) --[id]--> ID(Test)"
         );
 
         let path2 = build_graph_path(
@@ -524,7 +524,7 @@ mod tests {
         .unwrap();
         assert_eq!(
             path2.to_string(),
-            "Query(Test)* --[t]--> T(Test) --[otherId]--> ID(Test)"
+            "Query(Test) --[t]--> T(Test) --[otherId]--> ID(Test)"
         );
 
         let normalized_operation =
@@ -539,7 +539,7 @@ mod tests {
         let path_tree =
             OpPathTree::from_op_paths(query_graph.to_owned(), NodeIndex::new(0), &paths).unwrap();
         let computed = path_tree.to_string();
-        let expected = r#"Query(Test)*:
+        let expected = r#"Query(Test):
  -> [3] t = T(Test):
    -> [1] id = ID(Test)
    -> [0] otherId = ID(Test)"#;


### PR DESCRIPTION
Fixes
* `SimultaneousPaths` should not wrap single element in redundant brackets `{ }`
* `OpGraphPath` added missing conditions to the edges
* `OpGraphPath` added missing root nodes

Before
```
{ --[key()]--> I(S1) --[__typename]--> String(S1) }
```

After
```
I(S2) --[{ id } ⊢ key()]--> I(S1) --[__typename]--> String(S1)
```

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
