### PR TITLE
docs: clarify offline license options

### DIFF
--- a/apollo-router/tests/snapshots/apollo_reports__batch_send_header-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__batch_send_header-2.snap
@@ -165,6 +165,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -409,6 +439,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~
@@ -705,6 +755,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -949,6 +1029,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__batch_send_header.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__batch_send_header.snap
@@ -165,6 +165,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -409,6 +439,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~
@@ -705,6 +755,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -949,6 +1029,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__batch_trace_id-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__batch_trace_id-2.snap
@@ -162,6 +162,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -406,6 +436,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~
@@ -699,6 +749,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -943,6 +1023,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__batch_trace_id.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__batch_trace_id.snap
@@ -162,6 +162,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -406,6 +436,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~
@@ -699,6 +749,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -943,6 +1023,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__client_name-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__client_name-2.snap
@@ -162,6 +162,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -406,6 +436,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__client_name.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__client_name.snap
@@ -162,6 +162,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -406,6 +436,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__client_version-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__client_version-2.snap
@@ -162,6 +162,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -406,6 +436,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__client_version.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__client_version.snap
@@ -162,6 +162,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -406,6 +436,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__condition_else-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__condition_else-2.snap
@@ -168,6 +168,36 @@ traces_per_query:
                                               ResponseName: name
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String!
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: upc
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: topProducts
                                 id: ~
@@ -412,6 +442,26 @@ traces_per_query:
                                                     ResponseName: reviews
                                               id:
                                                 Index: 2
+                                            - original_field_name: ""
+                                              type: ""
+                                              parent_type: ""
+                                              cache_policy: ~
+                                              start_time: "[start_time]"
+                                              end_time: "[end_time]"
+                                              error: []
+                                              child:
+                                                - original_field_name: ""
+                                                  type: "[Review]"
+                                                  parent_type: Product
+                                                  cache_policy: ~
+                                                  start_time: "[start_time]"
+                                                  end_time: "[end_time]"
+                                                  error: []
+                                                  child: []
+                                                  id:
+                                                    ResponseName: reviews
+                                              id:
+                                                Index: 3
                                           id:
                                             ResponseName: _entities
                                       id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__condition_else.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__condition_else.snap
@@ -168,6 +168,36 @@ traces_per_query:
                                               ResponseName: name
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String!
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: upc
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: topProducts
                                 id: ~
@@ -412,6 +442,26 @@ traces_per_query:
                                                     ResponseName: reviews
                                               id:
                                                 Index: 2
+                                            - original_field_name: ""
+                                              type: ""
+                                              parent_type: ""
+                                              cache_policy: ~
+                                              start_time: "[start_time]"
+                                              end_time: "[end_time]"
+                                              error: []
+                                              child:
+                                                - original_field_name: ""
+                                                  type: "[Review]"
+                                                  parent_type: Product
+                                                  cache_policy: ~
+                                                  start_time: "[start_time]"
+                                                  end_time: "[end_time]"
+                                                  error: []
+                                                  child: []
+                                                  id:
+                                                    ResponseName: reviews
+                                              id:
+                                                Index: 3
                                           id:
                                             ResponseName: _entities
                                       id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__condition_if-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__condition_if-2.snap
@@ -168,6 +168,36 @@ traces_per_query:
                                               ResponseName: upc
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                          - original_field_name: ""
+                                            type: String!
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: upc
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: topProducts
                                 id: ~
@@ -424,6 +454,26 @@ traces_per_query:
                                                               ResponseName: reviews
                                                         id:
                                                           Index: 2
+                                                      - original_field_name: ""
+                                                        type: ""
+                                                        parent_type: ""
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child:
+                                                          - original_field_name: ""
+                                                            type: "[Review]"
+                                                            parent_type: Product
+                                                            cache_policy: ~
+                                                            start_time: "[start_time]"
+                                                            end_time: "[end_time]"
+                                                            error: []
+                                                            child: []
+                                                            id:
+                                                              ResponseName: reviews
+                                                        id:
+                                                          Index: 3
                                                     id:
                                                       ResponseName: _entities
                                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__condition_if.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__condition_if.snap
@@ -168,6 +168,36 @@ traces_per_query:
                                               ResponseName: upc
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: String
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: name
+                                          - original_field_name: ""
+                                            type: String!
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: upc
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: topProducts
                                 id: ~
@@ -424,6 +454,26 @@ traces_per_query:
                                                               ResponseName: reviews
                                                         id:
                                                           Index: 2
+                                                      - original_field_name: ""
+                                                        type: ""
+                                                        parent_type: ""
+                                                        cache_policy: ~
+                                                        start_time: "[start_time]"
+                                                        end_time: "[end_time]"
+                                                        error: []
+                                                        child:
+                                                          - original_field_name: ""
+                                                            type: "[Review]"
+                                                            parent_type: Product
+                                                            cache_policy: ~
+                                                            start_time: "[start_time]"
+                                                            end_time: "[end_time]"
+                                                            error: []
+                                                            child: []
+                                                            id:
+                                                              ResponseName: reviews
+                                                        id:
+                                                          Index: 3
                                                     id:
                                                       ResponseName: _entities
                                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__non_defer-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__non_defer-2.snap
@@ -162,6 +162,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -406,6 +436,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__non_defer.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__non_defer.snap
@@ -162,6 +162,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -406,6 +436,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__send_header-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__send_header-2.snap
@@ -165,6 +165,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -409,6 +439,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__send_header.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__send_header.snap
@@ -165,6 +165,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -409,6 +439,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__send_variable_value-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__send_variable_value-2.snap
@@ -164,6 +164,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -408,6 +438,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__send_variable_value.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__send_variable_value.snap
@@ -164,6 +164,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -408,6 +438,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__stats.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__stats.snap
@@ -43,22 +43,22 @@ traces_per_query:
               name:
                 return_type: String
                 errors_count: 0
-                observed_execution_count: 3
-                estimated_execution_count: 3
+                observed_execution_count: 4
+                estimated_execution_count: 4
                 requests_with_errors_count: 0
                 latency_count: "[latency_count]"
               reviews:
                 return_type: "[Review]"
                 errors_count: 0
-                observed_execution_count: 3
-                estimated_execution_count: 3
+                observed_execution_count: 4
+                estimated_execution_count: 4
                 requests_with_errors_count: 0
                 latency_count: "[latency_count]"
               upc:
                 return_type: String!
                 errors_count: 0
-                observed_execution_count: 3
-                estimated_execution_count: 3
+                observed_execution_count: 4
+                estimated_execution_count: 4
                 requests_with_errors_count: 0
                 latency_count: "[latency_count]"
           Query:

--- a/apollo-router/tests/snapshots/apollo_reports__trace_id-2.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__trace_id-2.snap
@@ -162,6 +162,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -406,6 +436,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/apollo-router/tests/snapshots/apollo_reports__trace_id.snap
+++ b/apollo-router/tests/snapshots/apollo_reports__trace_id.snap
@@ -162,6 +162,36 @@ traces_per_query:
                                         ResponseName: name
                                   id:
                                     Index: 2
+                                - original_field_name: ""
+                                  type: ""
+                                  parent_type: ""
+                                  cache_policy: ~
+                                  start_time: "[start_time]"
+                                  end_time: "[end_time]"
+                                  error: []
+                                  child:
+                                    - original_field_name: ""
+                                      type: String!
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: upc
+                                    - original_field_name: ""
+                                      type: String
+                                      parent_type: Product
+                                      cache_policy: ~
+                                      start_time: "[start_time]"
+                                      end_time: "[end_time]"
+                                      error: []
+                                      child: []
+                                      id:
+                                        ResponseName: name
+                                  id:
+                                    Index: 3
                               id:
                                 ResponseName: topProducts
                           id: ~
@@ -406,6 +436,26 @@ traces_per_query:
                                               ResponseName: reviews
                                         id:
                                           Index: 2
+                                      - original_field_name: ""
+                                        type: ""
+                                        parent_type: ""
+                                        cache_policy: ~
+                                        start_time: "[start_time]"
+                                        end_time: "[end_time]"
+                                        error: []
+                                        child:
+                                          - original_field_name: ""
+                                            type: "[Review]"
+                                            parent_type: Product
+                                            cache_policy: ~
+                                            start_time: "[start_time]"
+                                            end_time: "[end_time]"
+                                            error: []
+                                            child: []
+                                            id:
+                                              ResponseName: reviews
+                                        id:
+                                          Index: 3
                                     id:
                                       ResponseName: _entities
                                 id: ~

--- a/docs/source/enterprise-features.mdx
+++ b/docs/source/enterprise-features.mdx
@@ -104,7 +104,12 @@ Follow these steps to configure an Apollo Router to use an offline Enterprise li
     1. [`APOLLO_ROUTER_LICENSE_PATH`](./configuration/overview/#--license) environment variable, containing an absolute or relative path to an offline license file 
     1. [`APOLLO_ROUTER_LICENSE`](./configuration/overview/#--license) environment variable, containing the stringified contents of an offline license file
 
-    The router checks the CLI option and environment variables in the listed order, then it uses the value of the first option or variable that is set.
+    <Note>
+
+    - The router checks the CLI option and environment variables in the listed order, then it uses the value of the first option or variable that is set.
+    - The `--license <license_path>` option is only available when running the router binary. When running a router with `rover dev`, you must use environment variables to provide your offline license.
+    
+    </Note>
 
 1. Configure the router to use a local supergraph schema by setting one of the following:
 


### PR DESCRIPTION
Clarify that the `--license <license_path>` option is only available when running the router binary, not for use with `rover dev`