### PR TITLE
docs: clarify enhanced signature generation might cause different operation ids

### DIFF
--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -602,7 +602,7 @@ telemetry:
     experimental_apollo_signature_normalization_algorithm: enhanced # Default is legacy
 ```
 
-Once you enable this configuration, operations with enhanced signatures may appear with different operation IDs than they did previously in GraphOS Studio.
+Once you enable this configuration, operations with enhanced signatures might appear with different operation IDs than they did previously in GraphOS Studio.
 
 #### Input types
 

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -602,7 +602,7 @@ telemetry:
     experimental_apollo_signature_normalization_algorithm: enhanced # Default is legacy
 ```
 
-Once you enable this configuration, operations with enhanced signatures appear with different operation IDs than they did previously in GraphOS Studio.
+Once you enable this configuration, operations with enhanced signatures may appear with different operation IDs than they did previously in GraphOS Studio.
 
 #### Input types
 


### PR DESCRIPTION
Clarify enhanced signature generation _may_ cause different operation ids