### PR TITLE
adding validation for entity types with entity:true

### DIFF
--- a/apollo-federation/src/sources/connect/models/snapshots/validation_tests@invalid_entity_arg_on_field.graphql.snap
+++ b/apollo-federation/src/sources/connect/models/snapshots/validation_tests@invalid_entity_arg_on_field.graphql.snap
@@ -3,4 +3,4 @@ source: apollo-federation/src/sources/connect/models/validation.rs
 expression: "format!(\"{:?}\", errors)"
 input_file: apollo-federation/src/sources/connect/models/test_data/validation/invalid_entity_arg_on_field.graphql
 ---
-[Message { code: EntityNotOnRootQuery, message: "`@connect(entity: true)` on `User.bestFriend` is invalid. Entities can only be declared on root `Query` fields.", locations: [Location { line: 15, column: 61 }..Location { line: 15, column: 73 }] }]
+[Message { code: EntityNotOnRootQuery, message: "`@connect(entity: true)` on `User.bestFriend` is invalid. Entity resolvers can only be declared on root `Query` fields.", locations: [Location { line: 15, column: 61 }..Location { line: 15, column: 73 }] }]

--- a/apollo-federation/src/sources/connect/models/snapshots/validation_tests@invalid_entity_arg_on_field.graphql.snap
+++ b/apollo-federation/src/sources/connect/models/snapshots/validation_tests@invalid_entity_arg_on_field.graphql.snap
@@ -3,4 +3,4 @@ source: apollo-federation/src/sources/connect/models/validation.rs
 expression: "format!(\"{:?}\", errors)"
 input_file: apollo-federation/src/sources/connect/models/test_data/validation/invalid_entity_arg_on_field.graphql
 ---
-[Message { code: EntityNotOnRootQuery, message: "`@connect(entity:)` on `User.bestFriend` is invalid. Entities can only be declared on root `Query` fields.", locations: [Location { line: 15, column: 61 }..Location { line: 15, column: 73 }] }]
+[Message { code: EntityNotOnRootQuery, message: "`@connect(entity: true)` on `User.bestFriend` is invalid. Entities can only be declared on root `Query` fields.", locations: [Location { line: 15, column: 61 }..Location { line: 15, column: 73 }] }]

--- a/apollo-federation/src/sources/connect/models/snapshots/validation_tests@invalid_entity_arg_on_list_type.graphql.snap
+++ b/apollo-federation/src/sources/connect/models/snapshots/validation_tests@invalid_entity_arg_on_list_type.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-federation/src/sources/connect/models/validation.rs
+expression: "format!(\"{:?}\", errors)"
+input_file: apollo-federation/src/sources/connect/models/test_data/validation/invalid_entity_arg_on_list_type.graphql
+---
+[Message { code: EntityTypeInvalid, message: "`@connect(entity: true)` on `Query.users` is invalid. Entities can only be non-list, object types.", locations: [Location { line: 5, column: 63 }..Location { line: 5, column: 75 }] }]

--- a/apollo-federation/src/sources/connect/models/snapshots/validation_tests@invalid_entity_arg_on_non_entity_field.graphql.snap
+++ b/apollo-federation/src/sources/connect/models/snapshots/validation_tests@invalid_entity_arg_on_non_entity_field.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-federation/src/sources/connect/models/validation.rs
+expression: "format!(\"{:?}\", errors)"
+input_file: apollo-federation/src/sources/connect/models/test_data/validation/invalid_entity_arg_on_non_entity_field.graphql
+---
+[Message { code: EntityTypeInvalid, message: "`@connect(entity: true)` on `Query.name` is invalid. Entities can only be non-list, object types.", locations: [Location { line: 5, column: 63 }..Location { line: 5, column: 75 }] }]

--- a/apollo-federation/src/sources/connect/models/test_data/validation/invalid_entity_arg_on_list_type.graphql
+++ b/apollo-federation/src/sources/connect/models/test_data/validation/invalid_entity_arg_on_list_type.graphql
@@ -1,0 +1,12 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect"])
+
+type Query {
+  users: [User]
+    @connect(http: { GET: "http://127.0.0.1:8000/resources" }, entity: true)
+}
+
+type User {
+  id: ID!
+  name: String!
+}

--- a/apollo-federation/src/sources/connect/models/test_data/validation/invalid_entity_arg_on_non_entity_field.graphql
+++ b/apollo-federation/src/sources/connect/models/test_data/validation/invalid_entity_arg_on_non_entity_field.graphql
@@ -1,0 +1,7 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect"])
+
+type Query {
+  name: String
+    @connect(http: { GET: "http://127.0.0.1:8000/resources" }, entity: true)
+}

--- a/apollo-federation/src/sources/connect/models/validation.rs
+++ b/apollo-federation/src/sources/connect/models/validation.rs
@@ -385,15 +385,15 @@ fn validate_field(
                 errors.push(Message {
                     code: Code::EntityNotOnRootQuery,
                     message: format!(
-                        "{coordinate} is invalid. Entities can only be declared on root `Query` fields.", 
+                        "{coordinate} is invalid. Entity resolvers can only be declared on root `Query` fields.", 
                         coordinate = connect_directive_entity_argument_coordinate(connect_directive_name, entity_arg_value.as_ref(), object_name, &field.name)
                     ),
                     locations: Location::from_node(entity_arg.location(), source_map)
                         .into_iter()
                         .collect(),
                 })
+                // TODO: Allow interfaces
             } else if field.ty.is_list() || schema.get_object(field.ty.inner_named_type()).is_none()
-            /* taylor */
             {
                 errors.push(Message {
                     code: Code::EntityTypeInvalid,

--- a/apollo-federation/src/sources/connect/models/validation.rs
+++ b/apollo-federation/src/sources/connect/models/validation.rs
@@ -258,9 +258,9 @@ fn validate_object_fields(
                 object_category,
                 source_names,
                 &object.name,
-                source_map,
                 connect_directive_name,
                 source_directive_name,
+                schema,
             )
         })
         .collect()
@@ -271,11 +271,11 @@ fn validate_field(
     category: ObjectCategory,
     source_names: &[SourceName],
     object_name: &Name,
-    source_map: &SourceMap,
     connect_directive_name: &Name,
     source_directive_name: &Name,
+    schema: &Schema,
 ) -> Vec<Message> {
-    let _connect_directive_name = connect_directive_name.as_str();
+    let source_map = &schema.sources;
     let mut errors = Vec::new();
     let Some(connect_directive) = field
         .directives
@@ -376,19 +376,41 @@ fn validate_field(
         .iter()
         .find(|arg| arg.name == CONNECT_ENTITY_ARGUMENT_NAME)
     {
-        if entity_arg
-            .value
+        let entity_arg_value = &entity_arg.value;
+        if entity_arg_value
             .to_bool()
             .is_some_and(|entity_arg_value| entity_arg_value)
-            && category != ObjectCategory::Query
         {
-            errors.push(Message {
-                code: Code::EntityNotOnRootQuery,
-                message: format!("{coordinate} is invalid. Entities can only be declared on root `Query` fields.", coordinate = connect_directive_entity_argument_coordinate(connect_directive_name, object_name, &field.name)),
-                locations: Location::from_node(entity_arg.location(), source_map)
-                    .into_iter()
-                    .collect(),
-            })
+            if category != ObjectCategory::Query {
+                errors.push(Message {
+                    code: Code::EntityNotOnRootQuery,
+                    message: format!(
+                        "{coordinate} is invalid. Entities can only be declared on root `Query` fields.", 
+                        coordinate = connect_directive_entity_argument_coordinate(connect_directive_name, entity_arg_value.as_ref(), object_name, &field.name)
+                    ),
+                    locations: Location::from_node(entity_arg.location(), source_map)
+                        .into_iter()
+                        .collect(),
+                })
+            } else if field.ty.is_list() || schema.get_object(field.ty.inner_named_type()).is_none()
+            /* taylor */
+            {
+                errors.push(Message {
+                    code: Code::EntityTypeInvalid,
+                    message: format!(
+                        "{coordinate} is invalid. Entities can only be non-list, object types.",
+                        coordinate = connect_directive_entity_argument_coordinate(
+                            connect_directive_name,
+                            entity_arg_value.as_ref(),
+                            object_name,
+                            &field.name
+                        )
+                    ),
+                    locations: Location::from_node(entity_arg.location(), source_map)
+                        .into_iter()
+                        .collect(),
+                })
+            }
         }
     }
 
@@ -525,10 +547,11 @@ fn connect_directive_name_coordinate(
 
 fn connect_directive_entity_argument_coordinate(
     connect_directive_entity_argument: &Name,
+    value: &Value,
     object: &Name,
     field: &Name,
 ) -> String {
-    format!("`@{connect_directive_entity_argument}({CONNECT_ENTITY_ARGUMENT_NAME}:)` on `{object}.{field}`")
+    format!("`@{connect_directive_entity_argument}({CONNECT_ENTITY_ARGUMENT_NAME}: {value})` on `{object}.{field}`")
 }
 
 fn connect_directive_http_coordinate(
@@ -763,6 +786,8 @@ pub enum Code {
     MissingHttpMethod,
     /// The `entity` argument should only be used on the root `Query` field
     EntityNotOnRootQuery,
+    /// The `entity` argument should only be used with non-list, object types
+    EntityTypeInvalid,
 }
 
 impl Code {


### PR DESCRIPTION
Adding validation check to ensure `entity: true` is only set on fields that return valid entity types (non list & non scalar)

Fixes #**issue_number**

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.

<!-- [CNN-207] -->

[CNN-207]: https://apollographql.atlassian.net/browse/CNN-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ