### PR TITLE
fix(federation): update the parallel fetch order for requires test

### DIFF
--- a/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
@@ -179,8 +179,6 @@ fn it_handles_multiple_requires_within_the_same_entity_fetch() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure after optimize is merged (reverse order of parallel fetches)
 fn handles_multiple_requires_involving_different_nestedness() {
     let planner = planner!(
         Subgraph1: r#"
@@ -248,6 +246,22 @@ fn handles_multiple_requires_involving_different_nestedness() {
               }
             },
             Parallel {
+              Flatten(path: "list.@.user") {
+                Fetch(service: "Subgraph2") {
+                  {
+                    ... on User {
+                      __typename
+                      id
+                      value
+                    }
+                  } =>
+                  {
+                    ... on User {
+                      computed
+                    }
+                  }
+                },
+              },
               Flatten(path: "list.@") {
                 Fetch(service: "Subgraph2") {
                   {
@@ -264,22 +278,6 @@ fn handles_multiple_requires_involving_different_nestedness() {
                     ... on Item {
                       computed
                       computed2
-                    }
-                  }
-                },
-              },
-              Flatten(path: "list.@.user") {
-                Fetch(service: "Subgraph2") {
-                  {
-                    ... on User {
-                      __typename
-                      id
-                      value
-                    }
-                  } =>
-                  {
-                    ... on User {
-                      computed
                     }
                   }
                 },

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
@@ -1161,8 +1161,6 @@ fn it_handles_complex_require_chain() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure after optimize is merged
 fn it_handes_diamond_shape_depedencies() {
     // The idea of this test is that to be able to fulfill the @require in subgraph D, we need
     // both values from C for the @require and values from B for the key itself, but both
@@ -1235,6 +1233,21 @@ fn it_handes_diamond_shape_depedencies() {
             },
             Parallel {
               Flatten(path: "t") {
+                Fetch(service: "C") {
+                  {
+                    ... on T {
+                      __typename
+                      id1
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      v3
+                    }
+                  }
+                },
+              },
+              Flatten(path: "t") {
                 Fetch(service: "B") {
                   {
                     ... on T {
@@ -1249,21 +1262,6 @@ fn it_handes_diamond_shape_depedencies() {
                       v1
                       v2
                       id1
-                    }
-                  }
-                },
-              },
-              Flatten(path: "t") {
-                Fetch(service: "C") {
-                  {
-                    ... on T {
-                      __typename
-                      id1
-                    }
-                  } =>
-                  {
-                    ... on T {
-                      v3
                     }
                   }
                 },


### PR DESCRIPTION
Updates the parallel fetch order for the `handles_multiple_requires_involving_different_nestedness` and `it_handes_diamond_shape_depedencies` tests.

<!-- FED-265 -->
<!-- FED-268 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
