### PR TITLE
Fix typo in batch processor default config docs

### DIFF
--- a/docs/shared/batch-processor-ref.mdx
+++ b/docs/shared/batch-processor-ref.mdx
@@ -1,7 +1,7 @@
-| Attribute                | Default | Description                                                                              |
-|--------------------------|---------|------------------------------------------------------------------------------------------|
-| `scheduled_delay`        | 5s      | The delay in seconds from receiving the first span to sending the batch.                        |
-| `max_concurrent_exports` | 1       | The maximum number of overlapping export requests.                                       |
+| Attribute                | Default | Description                                                                               |
+|--------------------------|---------|-------------------------------------------------------------------------------------------|
+| `scheduled_delay`        | 5s      | The delay in seconds from receiving the first span to sending the batch.                  |
+| `max_concurrent_exports` | 1       | The maximum number of overlapping export requests.                                        |
 | `max_export_batch_size`  | 512     | The number of spans to include in a batch. May be limited by maximum message size limits. |
-| `max_export_timeout`     | 30s     | The timeout in seconds for sending spans before dropping the data.                                  |
-| `max_queue_size`         | 5      | The maximum number of spans to be buffered before dropping span data.                    |
+| `max_export_timeout`     | 30s     | The timeout in seconds for sending spans before dropping the data.                        |
+| `max_queue_size`         | 2048    | The maximum number of spans to be buffered before dropping span data.                     |


### PR DESCRIPTION
Default for max_queue_size is 2048, not 5.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
