### PR TITLE
remove BAS reference

### DIFF
--- a/docs/source/containerization/kubernetes.mdx
+++ b/docs/source/containerization/kubernetes.mdx
@@ -101,7 +101,7 @@ helm show values oci://ghcr.io/apollographql/helm-charts/router
 
 Install the tools and provision the infrastructure for your Kubernetes cluster.
 
-For an example, see the [Setup from Apollo's Build a Supergraph tutorial](https://github.com/apollosolutions/build-a-supergraph/tree/main/01-setup#01---setup). It provides steps you can reference for gathering accounts and credentials for your cloud platform (GCP or AWS), provisioning resources, and deploying your subgraphs.
+For an example, see the [Setup from Apollo's Reference Architecture](https://github.com/apollosolutions/reference-architecture/blob/main/docs/setup.md). It provides steps you can reference for gathering accounts and credentials for your cloud platform (GCP or AWS), provisioning resources, and deploying your subgraphs.
 
 <Tip>
 


### PR DESCRIPTION
Fixes a doc reference to an archived Build a Supergraph (BAS) repository in favor of the replacement reference architecture. 
