### PR TITLE
Fix test snapshot misalignment between Rust and JS code

### DIFF
--- a/apollo-federation/tests/query_plan/build_query_plan_tests/provides.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/provides.rs
@@ -246,8 +246,6 @@ fn it_works_on_interfaces() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure (missing parallel fetches)
 fn it_works_on_unions() {
     let planner = planner!(
         Subgraph1: r#"
@@ -319,36 +317,26 @@ fn it_works_on_unions() {
             }
           }
         },
-        Parallel {
-          Flatten(path: "noProvides") {
-            Fetch(service: "Subgraph2") {
-              {
-                ... on T2 {
-                  __typename
-                  id
-                }
-              } =>
-              {
-                ... on T2 {
-                  b
-                }
+        Flatten(path: "noProvides") {
+          Fetch(service: "Subgraph2") {
+            {
+              ... on T1 {
+                __typename
+                id
               }
-            },
-          },
-          Flatten(path: "noProvides") {
-            Fetch(service: "Subgraph2") {
-              {
-                ... on T1 {
-                  __typename
-                  id
-                }
-              } =>
-              {
-                ... on T1 {
-                  a
-                }
+              ... on T2 {
+                __typename
+                id
               }
-            },
+            } =>
+            {
+              ... on T1 {
+                a
+              }
+              ... on T2 {
+                b
+              }
+            }
           },
         },
       },
@@ -412,6 +400,7 @@ fn it_works_on_unions() {
         Fetch(service: "Subgraph1") {
           {
             withProvidesForT1 {
+              __typename
               ... on T1 {
                 a
               }


### PR DESCRIPTION
For the `it_works_on_unions()` test in `provides.rs`, it turns out that the [Rust query plan snapshots](https://github.com/apollographql/router/blob/544f8f619f5541d37ed79176d463c8e0fc713b3b/apollo-federation/tests/query_plan/build_query_plan_tests/provides.rs#L251) have diverged from the [JS code's snapshots](https://github.com/apollographql/federation/blob/b2e5ab66f84688ec304cfcf2c6f749c86aded549/query-planner-js/src/__tests__/buildPlan.test.ts#L646). I'm not sure how it happened, but I copy/pasted the query plan snapshots from the JS tests back into the Rust tests, and they pass now.