### PR TITLE
fix(federation): pass fragments when normalizing selections

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -2799,7 +2799,7 @@ impl SelectionSet {
         &mut self,
         selection_set: &SelectionSet,
     ) -> Result<(), FederationError> {
-        self.add_selection_set_with_fragments(&selection_set, &NamedFragments::default())
+        self.add_selection_set_with_fragments(selection_set, &NamedFragments::default())
     }
 
     /// Rebase given `SelectionSet` on self with the specified fragments and then inserts it into the


### PR DESCRIPTION
When normalizing the selection sets they might contain references to named fragments. We need to pass valid named fragments in order to normalize.

Note that in the JS codebase, fragments kept reference to named fragments hence when rebasing it would work without explicitly passing the fragments. In RS we don't store those references so when we rebase/normalize we have to explicitly pass them in.

<!-- FED-324 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
