### PR TITLE
fix(federation): fixed unnecessary sibling typename aliasing

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -209,7 +209,6 @@ mod selection_map {
     use std::ops::Deref;
     use std::sync::Arc;
 
-    use apollo_compiler::ast::Name;
     use apollo_compiler::executable;
     use indexmap::IndexMap;
 
@@ -222,6 +221,7 @@ mod selection_map {
     use crate::operation::Selection;
     use crate::operation::SelectionKey;
     use crate::operation::SelectionSet;
+    use crate::operation::SiblingTypename;
 
     /// A "normalized" selection map is an optimized representation of a selection set which does
     /// not contain selections with the same selection "key". Selections that do have the same key
@@ -457,7 +457,7 @@ mod selection_map {
             self.0
         }
 
-        pub(crate) fn get_sibling_typename_mut(&mut self) -> &mut Option<Name> {
+        pub(crate) fn get_sibling_typename_mut(&mut self) -> &mut Option<SiblingTypename> {
             Arc::make_mut(self.0).field.sibling_typename_mut()
         }
 
@@ -1272,11 +1272,11 @@ mod field_selection {
             &mut self.data.directives
         }
 
-        pub(crate) fn sibling_typename(&self) -> Option<&Name> {
+        pub(crate) fn sibling_typename(&self) -> Option<&SiblingTypename> {
             self.data.sibling_typename.as_ref()
         }
 
-        pub(crate) fn sibling_typename_mut(&mut self) -> &mut Option<Name> {
+        pub(crate) fn sibling_typename_mut(&mut self) -> &mut Option<SiblingTypename> {
             &mut self.data.sibling_typename
         }
 
@@ -1330,6 +1330,24 @@ mod field_selection {
         }
     }
 
+    // SiblingTypename indicates how the sibling __typename field should be restored.
+    // PORT_NOTE: The JS version used the empty string to indicate unaliased sibling typenames.
+    // Here we use an enum to make the distinction explicit.
+    #[derive(Debug, Clone)]
+    pub(crate) enum SiblingTypename {
+        Unaliased,
+        Aliased(Name), // the sibling __typename has been aliased
+    }
+
+    impl SiblingTypename {
+        pub(crate) fn alias(&self) -> Option<&Name> {
+            match self {
+                SiblingTypename::Unaliased => None,
+                SiblingTypename::Aliased(alias) => Some(alias),
+            }
+        }
+    }
+
     #[derive(Debug, Clone)]
     pub(crate) struct FieldData {
         pub(crate) schema: ValidFederationSchema,
@@ -1337,7 +1355,7 @@ mod field_selection {
         pub(crate) alias: Option<Name>,
         pub(crate) arguments: Arc<Vec<Node<executable::Argument>>>,
         pub(crate) directives: Arc<executable::DirectiveList>,
-        pub(crate) sibling_typename: Option<Name>,
+        pub(crate) sibling_typename: Option<SiblingTypename>,
     }
 
     impl FieldData {
@@ -1398,6 +1416,7 @@ mod field_selection {
 pub(crate) use field_selection::Field;
 pub(crate) use field_selection::FieldData;
 pub(crate) use field_selection::FieldSelection;
+pub(crate) use field_selection::SiblingTypename;
 
 mod fragment_spread_selection {
     use std::sync::Arc;
@@ -2451,8 +2470,13 @@ impl SelectionSet {
                 mutable_selection_map.remove(&typename_key),
                 mutable_selection_map.get_mut(&sibling_field_key),
             ) {
-                *sibling_field.get_sibling_typename_mut() =
-                    Some(typename_field.field.data().response_name());
+                // Note that as we tag the element, we also record the alias used if any since that
+                // needs to be preserved.
+                let sibling_typename = match &typename_field.field.data().alias {
+                    None => SiblingTypename::Unaliased,
+                    Some(alias) => SiblingTypename::Aliased(alias.clone()),
+                };
+                *sibling_field.get_sibling_typename_mut() = Some(sibling_typename);
             } else {
                 unreachable!("typename and sibling fields must both exist at this point")
             }
@@ -2683,16 +2707,11 @@ impl SelectionSet {
                 return Ok(updated.into());
             };
             // We need to add the query __typename for the current type in the current group.
-            // Note that the value of the sibling_typename is the alias or "" if there is no alias
-            let alias = if sibling_typename.is_empty() {
-                None
-            } else {
-                Some(sibling_typename.clone())
-            };
+            let alias = sibling_typename.alias();
             let field_element = Field::new_introspection_typename(
                 &self.schema,
                 &selection.element()?.parent_type_position(),
-                alias,
+                alias.cloned(),
             );
             let typename_selection =
                 Selection::from_element(field_element.into(), /*subselection*/ None)?;

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -2707,11 +2707,10 @@ impl SelectionSet {
                 return Ok(updated.into());
             };
             // We need to add the query __typename for the current type in the current group.
-            let alias = sibling_typename.alias();
             let field_element = Field::new_introspection_typename(
                 &self.schema,
                 &selection.element()?.parent_type_position(),
-                alias.cloned(),
+                sibling_typename.alias().cloned(),
             );
             let typename_selection =
                 Selection::from_element(field_element.into(), /*subselection*/ None)?;

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 
 use apollo_compiler::ast::Value;
 use apollo_compiler::executable::DirectiveList;
-use apollo_compiler::schema::Name;
 use apollo_compiler::NodeStr;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
@@ -36,6 +35,7 @@ use crate::operation::RebaseErrorHandlingOption;
 use crate::operation::SelectionId;
 use crate::operation::SelectionKey;
 use crate::operation::SelectionSet;
+use crate::operation::SiblingTypename;
 use crate::query_graph::condition_resolver::ConditionResolution;
 use crate::query_graph::condition_resolver::ConditionResolver;
 use crate::query_graph::condition_resolver::UnsatisfiedConditionReason;
@@ -318,7 +318,7 @@ impl OpPathElement {
         }
     }
 
-    pub(crate) fn sibling_typename(&self) -> Option<&Name> {
+    pub(crate) fn sibling_typename(&self) -> Option<&SiblingTypename> {
         match self {
             OpPathElement::Field(field) => field.sibling_typename(),
             OpPathElement::InlineFragment(_) => None,

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -3325,18 +3325,13 @@ fn compute_nodes_for_op_path_element<'a>(
     // We have a operation element, field or inline fragment.
     // We first check if it's been "tagged" to remember that __typename must be queried.
     // See the comment on the `optimize_sibling_typenames()` method to see why this exists.
-    if let Some(name) = operation.sibling_typename() {
+    if let Some(sibling_typename) = operation.sibling_typename() {
         // We need to add the query __typename for the current type in the current node.
-        // Note that `name` is the alias or '' if there is no alias
-        let alias = if name.is_empty() {
-            None
-        } else {
-            Some(name.clone())
-        };
+        let alias = sibling_typename.alias();
         let typename_field = Arc::new(OpPathElement::Field(Field::new_introspection_typename(
             &dependency_graph.supergraph_schema,
             &operation.parent_type_position(),
-            alias,
+            alias.cloned(),
         )));
         let typename_path = stack_item
             .node_path

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -3327,11 +3327,10 @@ fn compute_nodes_for_op_path_element<'a>(
     // See the comment on the `optimize_sibling_typenames()` method to see why this exists.
     if let Some(sibling_typename) = operation.sibling_typename() {
         // We need to add the query __typename for the current type in the current node.
-        let alias = sibling_typename.alias();
         let typename_field = Arc::new(OpPathElement::Field(Field::new_introspection_typename(
             &dependency_graph.supergraph_schema,
             &operation.parent_type_position(),
-            alias.cloned(),
+            sibling_typename.alias().cloned(),
         )));
         let typename_path = stack_item
             .node_path

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/introspection_typename_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/introspection_typename_handling.rs
@@ -64,8 +64,6 @@ fn it_preservers_aliased_typename() {
 }
 
 #[test]
-#[should_panic(expected = r#"snapshot assertion"#)]
-// TODO: investigate this failure (`__typename: __typename` is not expected)
 fn it_does_not_needlessly_consider_options_for_typename() {
     let planner = planner!(
         Subgraph1: r#"


### PR DESCRIPTION
In JS version, Field's `siblingTypename` field can be either undefined, empty string or an alias name.
In Rust, the `Name` type can't hold empty string and the empty string case wasn't implemented before. This PR fixed that by adding a new enum type to distinguish the unaliased/aliased cases.

One previously failing snapshot test is now fixed.
Many mismatches from corpus data are fixed.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests
