### PR TITLE
Lrlna/patch to 5428

### DIFF
--- a/.changesets/fix_planning_plan_duration_metric.md
+++ b/.changesets/fix_planning_plan_duration_metric.md
@@ -1,0 +1,8 @@
+### fix(metrics) make query_planning.plan.duration more accurate ([PR #5428](https://github.com/apollographql/router/pull/5428))
+
+`apollo.router.query_planning.plan.duration` was previously recording identical
+data to `apollo.router.query_planning.total.duration` metric, incuding queue and
+pool time. This was an inaccurate representation of the actual query planning
+time, and is now fixed.
+
+By [@xuorig](https://github.com/xuorig) in https://github.com/apollographql/router/pull/5428

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Write;
 use std::sync::Arc;
+use std::time::Instant;
 
 use apollo_compiler::ast;
 use apollo_compiler::ast::Name;
@@ -197,12 +198,24 @@ impl PlannerMode {
     ) -> Result<PlanSuccess<QueryPlanResult>, QueryPlannerError> {
         match self {
             PlannerMode::Js(js) => {
-                let mut success = js
+                let start = Instant::now();
+
+                let result = js
                     .plan(filtered_query, operation, plan_options)
-                    .await
+                    .await;
+
+                f64_histogram!(
+                    "apollo.router.query_planning.plan.duration",
+                    "Duration of the query planning.",
+                    start.elapsed().as_secs_f64(),
+                    "planner" = "js" 
+                );
+
+                let mut success = result
                     .map_err(QueryPlannerError::RouterBridgeError)?
                     .into_result()
                     .map_err(PlanErrors::from)?;
+
                 if let Some(root_node) = &mut success.data.query_plan.node {
                     // Arc freshly deserialized from Deno should be unique, so this doesn’t clone:
                     let root_node = Arc::make_mut(root_node);
@@ -211,12 +224,23 @@ impl PlannerMode {
                 Ok(success)
             }
             PlannerMode::Rust { rust, .. } => {
-                let plan = operation
+                let start = Instant::now();
+
+                let result = operation
                     .as_deref()
                     .map(|n| Name::new(n).map_err(FederationError::from))
                     .transpose()
                     .and_then(|operation| rust.build_query_plan(&doc.executable, operation))
-                    .map_err(|e| QueryPlannerError::FederationError(e.to_string()))?;
+                    .map_err(|e| QueryPlannerError::FederationError(e.to_string()));
+
+                f64_histogram!(
+                    "apollo.router.query_planning.plan.duration",
+                    "Duration of the query planning.",
+                    start.elapsed().as_secs_f64(),
+                    "planner" = "rust" 
+                );
+
+                let plan = result?;
 
                 // Dummy value overwritten below in `BrigeQueryPlanner::plan`
                 // `Configuration::validate` ensures that we only take this path
@@ -242,10 +266,21 @@ impl PlannerMode {
             }
             PlannerMode::Both { js, rust } => {
                 let operation_name = operation.as_deref().map(NodeStr::from);
-                let mut js_result = js
+
+                let start = Instant::now();
+
+                let result = js
                     .plan(filtered_query, operation, plan_options)
-                    .await
-                    .map_err(QueryPlannerError::RouterBridgeError)?
+                    .await;
+
+                f64_histogram!(
+                    "apollo.router.query_planning.plan.duration",
+                    "Duration of the query planning.",
+                    start.elapsed().as_secs_f64(),
+                    "planner" = "js" 
+                );
+
+                let mut js_result = result.map_err(QueryPlannerError::RouterBridgeError)?
                     .into_result()
                     .map_err(PlanErrors::from);
 

--- a/apollo-router/src/query_planner/bridge_query_planner_pool.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner_pool.rs
@@ -103,7 +103,7 @@ impl BridgeQueryPlannerPool {
             .map(|p| p.planner().clone())
             .collect();
 
-        for (worker_id, mut planner) in bridge_query_planners.into_iter().enumerate() {
+        for (_, mut planner) in bridge_query_planners.into_iter().enumerate() {
             let receiver = receiver.clone();
 
             tokio::spawn(async move {

--- a/apollo-router/src/query_planner/bridge_query_planner_pool.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner_pool.rs
@@ -119,13 +119,6 @@ impl BridgeQueryPlannerPool {
 
                     let res = svc.call(request).await;
 
-                    f64_histogram!(
-                        "apollo.router.query_planning.pooled_planner.duration",
-                        "Duration of the query planning.",
-                        start.elapsed().as_secs_f64(),
-                        "workerId" = worker_id.to_string()
-                    );
-
                     let _ = res_sender.send(res);
                 }
             });

--- a/apollo-router/src/query_planner/bridge_query_planner_pool.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner_pool.rs
@@ -116,12 +116,11 @@ impl BridgeQueryPlannerPool {
                             continue;
                         }
                     };
-                    let start = Instant::now();
 
                     let res = svc.call(request).await;
 
                     f64_histogram!(
-                        "apollo.router.query_planning.plan.duration",
+                        "apollo.router.query_planning.pooled_planner.duration",
                         "Duration of the query planning.",
                         start.elapsed().as_secs_f64(),
                         "workerId" = worker_id.to_string()

--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -17,8 +17,9 @@ use super::subscription::SubscriptionNode;
 use super::FlattenNode;
 use crate::error::format_bridge_errors;
 use crate::executable::USING_CATCH_UNWIND;
+use crate::query_planner::bridge_query_planner::metric_query_planning_plan_duration;
+use crate::query_planner::bridge_query_planner::RUST_QP_MODE;
 use crate::query_planner::convert::convert_root_query_plan_node;
-use crate::query_planner::plan::metric_query_planning_plan_duration;
 use crate::query_planner::render_diff;
 use crate::query_planner::DeferredNode;
 use crate::query_planner::PlanNode;
@@ -78,7 +79,7 @@ impl BothModeComparisonJob {
             // No question mark operator or macro from here …
             let result = self.rust_planner.build_query_plan(&self.document, name);
 
-            metric_query_planning_plan_duration("rust", start);
+            metric_query_planning_plan_duration(RUST_QP_MODE, start);
 
             // … to here, so the thread can only eiher reach here or panic.
             // We unset USING_CATCH_UNWIND in both cases.

--- a/apollo-router/src/query_planner/plan.rs
+++ b/apollo-router/src/query_planner/plan.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Instant;
 
 use apollo_compiler::validation::Valid;
 use apollo_compiler::NodeStr;
@@ -604,4 +605,13 @@ pub(crate) struct DeferredNode {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Depends {
     pub(crate) id: NodeStr,
+}
+
+pub(crate) fn metric_query_planning_plan_duration(planner: &str, start: Instant) {
+    f64_histogram!(
+        "apollo.router.query_planning.plan.duration",
+        "Duration of the query planning.",
+        start.elapsed().as_secs_f64(),
+        "planner" = planner
+    );
 }

--- a/apollo-router/src/query_planner/plan.rs
+++ b/apollo-router/src/query_planner/plan.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use std::time::Instant;
 
 use apollo_compiler::validation::Valid;
 use apollo_compiler::NodeStr;
@@ -605,13 +604,4 @@ pub(crate) struct DeferredNode {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Depends {
     pub(crate) id: NodeStr,
-}
-
-pub(crate) fn metric_query_planning_plan_duration(planner: &str, start: Instant) {
-    f64_histogram!(
-        "apollo.router.query_planning.plan.duration",
-        "Duration of the query planning.",
-        start.elapsed().as_secs_f64(),
-        "planner" = planner
-    );
 }


### PR DESCRIPTION
Continues work started in #5428.

This PR fixes the representation of `apollo.router.query_planning.plan.duration`, which previously included pool time + extra processing time of functionality of the `labeler.rs` and other functions in `BridgeQueryPlanner`. All this additional data processing duration is already included in an existing metric `apollo.router.query_planning.total.duration`

This PR is also adding an additional breakdown of duration specifically for `rust` and `js` query planners to help spot the difference when running the router with  `experimental_query_planner_mode: both`.

Here is an example of what `apollo.router.query_planning.plan.duration` and `apollo.router.query_planning.total.duration` would be reporting before this change:
```bash
2024-06-21T13:37:27.744592Z WARN  apollo.router.query_planning.plan.duration 0.002475708
2024-06-21T13:37:27.744651Z WARN  apollo.router.query_planning.total.duration 0.002553958

2024-06-21T13:37:27.748831Z WARN  apollo.router.query_planning.plan.duration 0.001635833
2024-06-21T13:37:27.748860Z WARN  apollo.router.query_planning.total.duration 0.001677167

2024-06-21T13:37:27.754119Z WARN  apollo.router.query_planning.plan.duration 0.00186375
2024-06-21T13:37:27.754157Z WARN  apollo.router.query_planning.total.duration 0.001916667
```
And here is what this is reporting after this change:
```bash
2024-06-21T13:37:27.743465Z WARN  apollo.router.query_planning.plan.duration 0.00107725
2024-06-21T13:37:27.744651Z WARN  apollo.router.query_planning.total.duration 0.002553958

2024-06-21T13:37:27.748299Z WARN  apollo.router.query_planning.plan.duration 0.000827
2024-06-21T13:37:27.748860Z WARN  apollo.router.query_planning.total.duration 0.001677167

2024-06-21T13:37:27.753427Z WARN  apollo.router.query_planning.plan.duration 0.00088525
2024-06-21T13:37:27.754157Z WARN  apollo.router.query_planning.total.duration 0.001916667
```