### PR TITLE
feat(telemetry): add the ability to drop metrics using otel views

### DIFF
--- a/.changesets/feat_bnjjj_implement_drop_aggregation_view.md
+++ b/.changesets/feat_bnjjj_implement_drop_aggregation_view.md
@@ -1,0 +1,17 @@
+### Add the ability to drop metrics using otel views ([PR #5531](https://github.com/apollographql/router/pull/5531))
+
+You can drop specific metrics if you don't want these metrics to be sent to your APM using [otel views](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view).
+
+```yaml title="router.yaml"
+telemetry:
+  exporters:
+    metrics:
+      common:
+        service_name: apollo-router
+        views:
+          - name: apollo_router_http_request_duration_seconds # Instrument name you want to edit. You can use wildcard in names. If you want to target all instruments just use '*'
+            aggregation: drop
+
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/5531

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -3641,6 +3641,13 @@ expression: "&schema"
             "histogram"
           ],
           "type": "object"
+        },
+        {
+          "description": "Simply drop the metrics matching this view",
+          "enum": [
+            "drop"
+          ],
+          "type": "string"
         }
       ]
     },

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -2992,6 +2992,22 @@ mod tests {
         .await;
     }
 
+    #[tokio::test(flavor = "multi_thread")]
+    async fn it_test_prometheus_metrics_custom_view_drop() {
+        async {
+            let plugin = create_plugin_with_config(include_str!(
+                "testdata/prometheus_custom_view_drop.router.yaml"
+            ))
+            .await;
+            make_supergraph_request(plugin.as_ref()).await;
+            let prometheus_metrics = get_prometheus_metrics(plugin.as_ref()).await;
+
+            assert!(prometheus_metrics.is_empty());
+        }
+        .with_metrics()
+        .await;
+    }
+
     #[test]
     fn it_test_send_headers_to_studio() {
         let fw_headers = ForwardHeaders::Only(vec![

--- a/apollo-router/src/plugins/telemetry/testdata/prometheus_custom_view_drop.router.yaml
+++ b/apollo-router/src/plugins/telemetry/testdata/prometheus_custom_view_drop.router.yaml
@@ -1,0 +1,13 @@
+telemetry:
+  apollo:
+    client_name_header: name_header
+    client_version_header: version_header
+  exporters:
+    metrics:
+      common:
+        service_name: apollo-router
+        views:
+          - name: apollo_router_http_request_duration_seconds
+            aggregation: drop
+      prometheus:
+        enabled: true

--- a/docs/source/configuration/telemetry/exporters/metrics/overview.mdx
+++ b/docs/source/configuration/telemetry/exporters/metrics/overview.mdx
@@ -217,6 +217,20 @@ telemetry:
 
 ```
 
+You can drop specific metrics if you don't want these metrics to be sent to your APM.
+
+```yaml title="router.yaml"
+telemetry:
+  exporters:
+    metrics:
+      common:
+        service_name: apollo-router
+        views:
+          - name: apollo_router_http_request_duration_seconds # Instrument name you want to edit. You can use wildcard in names. If you want to target all instruments just use '*'
+            aggregation: drop
+
+```
+
 ## Metrics common reference
 
 | Attribute           | Default                  | Description                                                   |
@@ -225,6 +239,7 @@ telemetry:
 | `service_namespace` |                          | The OpenTelemetry namespace.                                  |
 | `resource`          |                          | The OpenTelemetry resource to attach to metrics.              |
 | `attributes`        |                          | Customization for the apollo_router_http_requests instrument. |
+| `views`             |                          | Override default buckets or configuration for metrics (including dropping the metric itself) |
 
 
 ## Related topics


### PR DESCRIPTION
You can drop specific metrics if you don't want these metrics to be sent to your APM using [otel views](https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view).

```yaml title="router.yaml"
telemetry:
  exporters:
    metrics:
      common:
        service_name: apollo-router
        views:
          - name: apollo_router_http_request_duration_seconds # Instrument name you want to edit. You can use wildcard in names. If you want to target all instruments just use '*'
            aggregation: drop

```

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
