### PR TITLE
`possible_runtime_types` causing perf issues on large complex schemas

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -47,6 +47,7 @@ use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::FieldDefinitionPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::position::SchemaRootDefinitionKind;
+use crate::schema::PossibleRuntimeTypes;
 use crate::schema::ValidFederationSchema;
 
 mod contains;
@@ -4878,10 +4879,22 @@ fn runtime_types_intersect(
     }
 
     if let (Ok(runtimes_1), Ok(runtimes_2)) = (
-        schema.possible_runtime_types(type1.clone()),
-        schema.possible_runtime_types(type2.clone()),
+        schema.possible_runtime_types_ref(type1.clone()),
+        schema.possible_runtime_types_ref(type2.clone()),
     ) {
-        return runtimes_1.intersection(&runtimes_2).next().is_some();
+        // println!("type1 {:#?}", type1);
+        // println!("type1 {:#?}", type2);
+        // println!("runtimes_1 {:#?}", runtimes_1);
+        // println!("runtimes_2 {:#?}", runtimes_2);
+        // let works = schema.possible_runtime_types(type1.clone());
+        // println!("runtimes_1 works {:#?}", works);
+
+        return match (runtimes_1, runtimes_2) {
+            (PossibleRuntimeTypes::Owned(a), PossibleRuntimeTypes::Owned(b)) => a.intersection(&b).next().is_some(),
+            (PossibleRuntimeTypes::Owned(a), PossibleRuntimeTypes::Ref(b)) => a.intersection(b).next().is_some(),
+            (PossibleRuntimeTypes::Ref(a), PossibleRuntimeTypes::Owned(b)) => a.intersection(&b).next().is_some(),
+            (PossibleRuntimeTypes::Ref(a), PossibleRuntimeTypes::Ref(b)) => a.intersection(b).next().is_some(),
+        }
     }
 
     false

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -4882,18 +4882,11 @@ fn runtime_types_intersect(
         schema.possible_runtime_types_ref(type1.clone()),
         schema.possible_runtime_types_ref(type2.clone()),
     ) {
-        // println!("type1 {:#?}", type1);
-        // println!("type1 {:#?}", type2);
-        // println!("runtimes_1 {:#?}", runtimes_1);
-        // println!("runtimes_2 {:#?}", runtimes_2);
-        // let works = schema.possible_runtime_types(type1.clone());
-        // println!("runtimes_1 works {:#?}", works);
-
         return match (runtimes_1, runtimes_2) {
-            (PossibleRuntimeTypes::Owned(a), PossibleRuntimeTypes::Owned(b)) => a.intersection(&b).next().is_some(),
-            (PossibleRuntimeTypes::Owned(a), PossibleRuntimeTypes::Ref(b)) => a.intersection(b).next().is_some(),
-            (PossibleRuntimeTypes::Ref(a), PossibleRuntimeTypes::Owned(b)) => a.intersection(&b).next().is_some(),
-            (PossibleRuntimeTypes::Ref(a), PossibleRuntimeTypes::Ref(b)) => a.intersection(b).next().is_some(),
+            (PossibleRuntimeTypes::Single(_), PossibleRuntimeTypes::Single(_)) => false,
+            (PossibleRuntimeTypes::Single(a), PossibleRuntimeTypes::Many(b)) => b.contains(&a),
+            (PossibleRuntimeTypes::Many(a), PossibleRuntimeTypes::Single(b)) => a.contains(&b),
+            (PossibleRuntimeTypes::Many(a), PossibleRuntimeTypes::Many(b)) => a.intersection(b).next().is_some(),
         }
     }
 


### PR DESCRIPTION
`possible_runtime_types` allocates  an `IndexSet` and inserts all possible types on every call which can be quite expensive for complex query plans combined with large schemas.

This PR shows an example fix where I was able to get 4x improvements on complex plans by removing all allocations. I'm happy to discuss a proper fix here, or treat this PR as an issue if you have a fix in mind.