### PR TITLE
docs: use shared `HTTPConnection` component

### DIFF
--- a/docs/source/configuration/traffic-shaping.mdx
+++ b/docs/source/configuration/traffic-shaping.mdx
@@ -185,26 +185,7 @@ traffic_shaping:
 
 ### HTTP/2
 
-The router supports subgraph connections over:
-- HTTP/1.1
-- HTTP/1.1 with TLS
-- HTTP/2 with TLS
-- HTTP/2 Cleartext protocol (h2c). This uses HTTP/2 over plaintext connections.
-
-Use the table below to look up the resulting protocol of a subgraph connection, based on the subgraph URL and the `experimental_http2` option:
-
-|                           | URL with `http://` | URL with `https://`         |
-| ------------------------- | ------------------- | --------------------------- |
-| `experimental_http2: disable` | HTTP/1.1           | HTTP/1.1 with TLS           |
-| `experimental_http2: enable`  | HTTP/1.1           | Either HTTP/1.1 or HTTP/2 with TLS, as determined by the TLS handshake with a subgraph |
-| `experimental_http2: http2only` | h2c              | HTTP/2 with TLS              |
-| `experimental_http2` not set | HTTP/1.1 | Either HTTP/1.1 or HTTP/2 with TLS, as determined by the TLS handshake with a subgraph |
-
-<Note>
-
-Configuring `experimental_http2: http2only` for a subgraph that doesn't support HTTP/2 results in a failed subgraph connection.
-
-</Note>
+<HttpConnection type="subgraph" />
 
 ### Ordering
 


### PR DESCRIPTION
Uses shared `<HttpConnection />` component introduced in https://github.com/apollographql/docs/pull/889

See in deploy preview: https://deploy-preview-5536--apollo-router-docs.netlify.app/configuration/traffic-shaping#http2