### PR TITLE
FED-318: Semantic comparison of query plans

### DIFF
--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -110,9 +110,9 @@ pub mod _private {
 
     pub use crate::plugin::PluginFactory;
     pub use crate::plugin::PLUGINS;
-    // For tests
-    pub use crate::router_factory::create_test_service_factory_from_yaml;
     // For comparison/fuzzing
     pub use crate::query_planner::bridge_query_planner::QueryPlanResult;
     pub use crate::query_planner::dual_query_planner::plan_matches;
+    // For tests
+    pub use crate::router_factory::create_test_service_factory_from_yaml;
 }

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -112,4 +112,7 @@ pub mod _private {
     pub use crate::plugin::PLUGINS;
     // For tests
     pub use crate::router_factory::create_test_service_factory_from_yaml;
+    // For comparison/fuzzing
+    pub use crate::query_planner::bridge_query_planner::QueryPlanResult;
+    pub use crate::query_planner::dual_query_planner::plan_matches;
 }

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -952,9 +952,10 @@ impl BridgeQueryPlanner {
 }
 
 /// Data coming from the `plan` method on the router_bridge
+// Note: Reexported under `apollo_compiler::_private`
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(crate) struct QueryPlanResult {
+pub struct QueryPlanResult {
     pub(super) formatted_query_plan: Option<Arc<String>>,
     pub(super) query_plan: QueryPlan,
 }

--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Instant;
 
+use apollo_compiler::ast;
 use apollo_compiler::ast::Name;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::ExecutableDocument;
@@ -209,11 +210,19 @@ fn subscription_primary_matches(this: &SubscriptionNode, other: &SubscriptionNod
 }
 
 fn operation_matches(this: &SubgraphOperation, other: &SubgraphOperation) -> bool {
-    operation_without_whitespace(this) == operation_without_whitespace(other)
-}
-
-fn operation_without_whitespace(op: &SubgraphOperation) -> String {
-    op.as_serialized().replace([' ', '\n'], "")
+    let this_ast = match ast::Document::parse(this.as_serialized(), "this_operation.graphql") {
+        Ok(document) => {
+            document
+        },
+        Err(e) => panic!("Parse error in operation: {:?}", e),
+    };
+    let other_ast = match ast::Document::parse(other.as_serialized(), "other_operation.graphql") {
+        Ok(document) => {
+            document
+        },
+        Err(e) => panic!("Parse error in operation: {:?}", e),
+    };
+    this_ast == other_ast
 }
 
 // The rest is calling the comparison functions above instead of `PartialEq`,

--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -9,6 +9,7 @@ use apollo_compiler::ast::Name;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::ExecutableDocument;
 use apollo_compiler::NodeStr;
+use apollo_federation::query_plan::QueryPlan;
 use apollo_federation::query_plan::query_planner::QueryPlanner;
 
 use super::fetch::FetchNode;
@@ -217,6 +218,13 @@ fn operation_without_whitespace(op: &SubgraphOperation) -> String {
 
 // The rest is calling the comparison functions above instead of `PartialEq`,
 // but otherwise behave just like `PartialEq`:
+
+// Note: Reexported under `apollo_compiler::_private`
+pub fn plan_matches(js_plan: &QueryPlanResult, rust_plan: &QueryPlan) -> bool {
+    let js_root_node = &js_plan.query_plan.node;
+    let rust_root_node = convert_root_query_plan_node(rust_plan);
+    opt_plan_node_matches(js_root_node, &rust_root_node)
+}
 
 fn opt_plan_node_matches(
     this: &Option<impl Borrow<PlanNode>>,

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -10,11 +10,11 @@ pub(crate) use plan::*;
 
 pub use self::fetch::OperationKind;
 
-mod bridge_query_planner;
+pub(crate) mod bridge_query_planner;
 mod bridge_query_planner_pool;
 mod caching_query_planner;
 mod convert;
-mod dual_query_planner;
+pub(crate) mod dual_query_planner;
 mod execution;
 pub(crate) mod fetch;
 mod labeler;


### PR DESCRIPTION
Summary
* Expose `plan_matches` function via `_private` module, so performance-harness can use it without duplicating comparison code.
* `operation_matches` compares operations via their ASTs.
* Some parts of AST are ordering-tolerant like query variable declaration, parallel fetches.

Known issues:
* There are still false positive patterns that are not handled, yet. (Need more investigation)
* Comparison of parallel fetches could be more optimized.

<!-- [FED-318] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

[FED-318]: https://apollographql.atlassian.net/browse/FED-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ