### PR TITLE
fix(subscription): make coprocessors work better with subscriptions

### DIFF
--- a/.changesets/fix_bnjjj_fix_coprocessor_with_subs.md
+++ b/.changesets/fix_bnjjj_fix_coprocessor_with_subs.md
@@ -1,0 +1,5 @@
+### make coprocessors work with subscriptions ([PR #5542](https://github.com/apollographql/router/pull/5542))
+
+Do not override skipped data from serde when you returns a body from a coprocessor response stage.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/5542

--- a/apollo-router/src/plugins/coprocessor/execution.rs
+++ b/apollo-router/src/plugins/coprocessor/execution.rs
@@ -397,10 +397,7 @@ where
     // that we replace "bits" of our incoming response with the updated bits if they
     // are present in our co_processor_output. If they aren't present, just use the
     // bits that we sent to the co_processor.
-    let new_body: graphql::Response = match co_processor_output.body {
-        Some(value) => serde_json::from_value(value)?,
-        None => first,
-    };
+    let new_body: graphql::Response = handle_graphql_response(first, co_processor_output.body)?;
 
     if let Some(control) = co_processor_output.control {
         parts.status = control.get_http_status()?
@@ -467,10 +464,8 @@ where
                 // that we replace "bits" of our incoming response with the updated bits if they
                 // are present in our co_processor_output. If they aren't present, just use the
                 // bits that we sent to the co_processor.
-                let new_deferred_response: graphql::Response = match co_processor_output.body {
-                    Some(value) => serde_json::from_value(value)?,
-                    None => deferred_response,
-                };
+                let new_deferred_response: graphql::Response =
+                    handle_graphql_response(deferred_response, co_processor_output.body)?;
 
                 if let Some(context) = co_processor_output.context {
                     for (key, value) in context.try_into_iter()? {

--- a/apollo-router/src/plugins/coprocessor/supergraph.rs
+++ b/apollo-router/src/plugins/coprocessor/supergraph.rs
@@ -389,10 +389,7 @@ where
     // that we replace "bits" of our incoming response with the updated bits if they
     // are present in our co_processor_output. If they aren't present, just use the
     // bits that we sent to the co_processor.
-    let new_body: graphql::Response = match co_processor_output.body {
-        Some(value) => serde_json::from_value(value)?,
-        None => first,
-    };
+    let new_body: graphql::Response = handle_graphql_response(first, co_processor_output.body)?;
 
     if let Some(control) = co_processor_output.control {
         parts.status = control.get_http_status()?
@@ -462,10 +459,8 @@ where
                 // that we replace "bits" of our incoming response with the updated bits if they
                 // are present in our co_processor_output. If they aren't present, just use the
                 // bits that we sent to the co_processor.
-                let new_deferred_response: graphql::Response = match co_processor_output.body {
-                    Some(value) => serde_json::from_value(value)?,
-                    None => deferred_response,
-                };
+                let new_deferred_response: graphql::Response =
+                    handle_graphql_response(deferred_response, co_processor_output.body)?;
 
                 if let Some(context) = co_processor_output.context {
                     for (key, value) in context.try_into_iter()? {

--- a/apollo-router/src/protocols/multipart.rs
+++ b/apollo-router/src/protocols/multipart.rs
@@ -37,6 +37,7 @@ struct SubscriptionPayload {
     errors: Vec<graphql::Error>,
 }
 
+#[derive(Debug)]
 enum MessageKind {
     Heartbeat,
     Message(graphql::Response),


### PR DESCRIPTION
Do not override skipped data from serde when you returns a body from a coprocessor response stage.

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
