### PR TITLE
Add ability to override base URL on a connector source

### DIFF
--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_realistic_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_realistic_supergraph-2.snap
@@ -7,6 +7,9 @@ expression: connectors_by_service_name
         id: ConnectId {
             label: "connectors.example http: Get /{$args.id!}",
             subgraph_name: "connectors",
+            source_name: Some(
+                "example",
+            ),
             directive: ObjectOrInterfaceFieldDirectivePosition {
                 field: Object(Query.user),
                 directive_name: "connect",

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_supergraph-2.snap
@@ -7,6 +7,9 @@ expression: connectors_by_service_name
         id: ConnectId {
             label: "connectors.example http: Get ",
             subgraph_name: "connectors",
+            source_name: Some(
+                "example",
+            ),
             directive: ObjectOrInterfaceFieldDirectivePosition {
                 field: Object(Query.users),
                 directive_name: "connect",
@@ -49,6 +52,9 @@ expression: connectors_by_service_name
         id: ConnectId {
             label: "connectors.example http: Get /{$args.id!}",
             subgraph_name: "connectors",
+            source_name: Some(
+                "example",
+            ),
             directive: ObjectOrInterfaceFieldDirectivePosition {
                 field: Object(Query.user),
                 directive_name: "connect",
@@ -108,6 +114,9 @@ expression: connectors_by_service_name
         id: ConnectId {
             label: "connectors.example http: Get /{$this.c!}/d",
             subgraph_name: "connectors",
+            source_name: Some(
+                "example",
+            ),
             directive: ObjectOrInterfaceFieldDirectivePosition {
                 field: Object(User.d),
                 directive_name: "connect",

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_steelthread_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_steelthread_supergraph-2.snap
@@ -7,6 +7,9 @@ expression: connectors_by_service_name
         id: ConnectId {
             label: "connectors.json http: Get /users",
             subgraph_name: "connectors",
+            source_name: Some(
+                "json",
+            ),
             directive: ObjectOrInterfaceFieldDirectivePosition {
                 field: Object(Query.users),
                 directive_name: "connect",
@@ -57,6 +60,9 @@ expression: connectors_by_service_name
         id: ConnectId {
             label: "connectors.json http: Get /users/{$args.id!}",
             subgraph_name: "connectors",
+            source_name: Some(
+                "json",
+            ),
             directive: ObjectOrInterfaceFieldDirectivePosition {
                 field: Object(Query.user),
                 directive_name: "connect",
@@ -123,6 +129,9 @@ expression: connectors_by_service_name
         id: ConnectId {
             label: "connectors.json http: Get /users/{$this.c!}",
             subgraph_name: "connectors",
+            source_name: Some(
+                "json",
+            ),
             directive: ObjectOrInterfaceFieldDirectivePosition {
                 field: Object(User.d),
                 directive_name: "connect",

--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -37,6 +37,7 @@ use crate::schema::ObjectOrInterfaceFieldDefinitionPosition;
 pub struct ConnectId {
     pub label: String,
     pub subgraph_name: NodeStr,
+    pub source_name: Option<NodeStr>,
     pub directive: ObjectOrInterfaceFieldDirectivePosition,
 }
 
@@ -82,6 +83,7 @@ impl ConnectId {
     /// Mostly intended for tests in apollo-router
     pub fn new(
         subgraph_name: NodeStr,
+        source_name: Option<NodeStr>,
         type_name: Name,
         field_name: Name,
         index: usize,
@@ -90,6 +92,7 @@ impl ConnectId {
         Self {
             label: label.to_string(),
             subgraph_name,
+            source_name,
             directive: ObjectOrInterfaceFieldDirectivePosition {
                 field: ObjectOrInterfaceFieldDefinitionPosition::Object(
                     ObjectFieldDefinitionPosition {

--- a/apollo-federation/src/sources/connect/models/mod.rs
+++ b/apollo-federation/src/sources/connect/models/mod.rs
@@ -95,8 +95,9 @@ impl Connector {
                     .unwrap_or(false);
 
                 let id = ConnectId {
-                    label: make_label(&subgraph_name, source_name, &transport),
+                    label: make_label(&subgraph_name, source_name.clone(), &transport),
                     subgraph_name: subgraph_name.clone(),
+                    source_name: source_name.clone(),
                     directive: args.position,
                 };
 
@@ -217,6 +218,9 @@ mod tests {
             ConnectId {
                 label: "connectors.json http: Get /users",
                 subgraph_name: "connectors",
+                source_name: Some(
+                    "json",
+                ),
                 directive: ObjectOrInterfaceFieldDirectivePosition {
                     field: Object(Query.users),
                     directive_name: "connect",
@@ -226,6 +230,9 @@ mod tests {
                 id: ConnectId {
                     label: "connectors.json http: Get /users",
                     subgraph_name: "connectors",
+                    source_name: Some(
+                        "json",
+                    ),
                     directive: ObjectOrInterfaceFieldDirectivePosition {
                         field: Object(Query.users),
                         directive_name: "connect",
@@ -289,6 +296,9 @@ mod tests {
             ConnectId {
                 label: "connectors.json http: Get /posts",
                 subgraph_name: "connectors",
+                source_name: Some(
+                    "json",
+                ),
                 directive: ObjectOrInterfaceFieldDirectivePosition {
                     field: Object(Query.posts),
                     directive_name: "connect",
@@ -298,6 +308,9 @@ mod tests {
                 id: ConnectId {
                     label: "connectors.json http: Get /posts",
                     subgraph_name: "connectors",
+                    source_name: Some(
+                        "json",
+                    ),
                     directive: ObjectOrInterfaceFieldDirectivePosition {
                         field: Object(Query.posts),
                         directive_name: "connect",

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -199,6 +199,7 @@ mod tests {
         let connector = Connector {
             id: ConnectId::new(
                 "subgraph_name".into(),
+                None,
                 name!(Query),
                 name!(hello),
                 0,
@@ -271,6 +272,7 @@ mod tests {
         let connector = Connector {
             id: ConnectId::new(
                 "subgraph_name".into(),
+                None,
                 name!(Query),
                 name!(user),
                 0,
@@ -360,6 +362,7 @@ mod tests {
         let connector = Connector {
             id: ConnectId::new(
                 "subgraph_name".into(),
+                None,
                 name!(User),
                 name!(field),
                 0,
@@ -451,6 +454,7 @@ mod tests {
         let connector = Connector {
             id: ConnectId::new(
                 "subgraph_name".into(),
+                None,
                 name!(Query),
                 name!(user),
                 0,

--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -1301,6 +1301,7 @@ mod tests {
         let connector = Connector {
             id: ConnectId::new(
                 "subgraph_name".into(),
+                None,
                 name!(Query),
                 name!(users),
                 0,

--- a/apollo-router/src/plugins/connectors/tests.rs
+++ b/apollo-router/src/plugins/connectors/tests.rs
@@ -242,7 +242,6 @@ async fn execute(uri: &str, query: &str, config: Option<serde_json::Value>) -> s
       "include_subgraph_errors": { "all": true },
     }));
 
-    // TODO: implement override_url handling
     let config_object = config.as_object_mut().unwrap();
     config_object.insert(
         "preview_connectors".to_string(),
@@ -268,9 +267,7 @@ async fn execute(uri: &str, query: &str, config: Option<serde_json::Value>) -> s
         .create(
             false,
             Arc::new(serde_json::from_value(config).unwrap()),
-            SCHEMA
-                .to_string()
-                .replace("https://jsonplaceholder.typicode.com/", uri),
+            SCHEMA.to_string(),
             None,
             None,
         )

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -12,7 +12,6 @@ use apollo_compiler::NodeStr;
 use apollo_federation::sources::connect::expand::expand_connectors;
 use apollo_federation::sources::connect::expand::ExpansionResult;
 use apollo_federation::sources::connect::Connector;
-use apollo_federation::sources::connect::Transport;
 use http::Uri;
 use indexmap::IndexMap;
 use semver::Version;
@@ -24,6 +23,7 @@ use crate::configuration::ApiSchemaMode;
 use crate::configuration::QueryPlannerMode;
 use crate::error::ParseErrors;
 use crate::error::SchemaError;
+use crate::plugins::connectors::configuration::override_connector_base_urls;
 use crate::query_planner::OperationKind;
 use crate::Configuration;
 
@@ -92,7 +92,7 @@ impl Schema {
                 api_schema: api,
                 connectors_by_service_name: mut connectors,
             } => {
-                Self::override_connector_base_urls(config, &mut connectors);
+                override_connector_base_urls(config, connectors.values_mut());
                 api_schema = Some(ApiSchema(api));
                 connectors_by_service_name = Some(connectors);
                 raw_sdl
@@ -179,29 +179,6 @@ impl Schema {
             schema_id,
             connectors_by_service_name,
         })
-    }
-
-    /// If a base URL override is specified for a source API, apply it to the connectors using
-    /// that source.
-    fn override_connector_base_urls(
-        config: &Configuration,
-        connectors: &mut IndexMap<NodeStr, Connector>,
-    ) {
-        for connector in connectors.values_mut() {
-            if let Some(url) = config
-                .preview_connectors
-                .subgraphs
-                .get(&connector.id.subgraph_name.to_string())
-                .and_then(|map| map.get(&connector.id.source_name.clone()?.to_string()))
-                .and_then(|api_config| api_config.override_url.as_ref())
-            {
-                match &mut connector.transport {
-                    Transport::HttpJson(transport) => {
-                        transport.base_url = NodeStr::from(url.as_str())
-                    }
-                }
-            }
-        }
     }
 
     pub(crate) fn federation_supergraph(&self) -> &apollo_federation::Supergraph {


### PR DESCRIPTION
Add the ability override the base URL of a `@source` directive in the supergraph configuration YAML. Any connector referencing that source will use the overridden base URL.

This required adding the source name to the `ConnectId` of the connector, to allow looking up the associated source configuration. This field is optional, since a connector can directly specify the full URL of the REST API, rather than referring to a source directive. In that case, the base URL cannot be overridden.

<!-- [CNN-229] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**


**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-229]: https://apollographql.atlassian.net/browse/CNN-229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ