### PR TITLE
fix(telemetry): add response_context handling in event selector when using an event_* instrument

### DIFF
--- a/.changesets/fix_bnjjj_fix_event_instr_response_context_sel.md
+++ b/.changesets/fix_bnjjj_fix_event_instr_response_context_sel.md
@@ -1,0 +1,26 @@
+### fix(telemetry): add response_context handling in event selector when using an event_* instrument ([PR #5565](https://github.com/apollographql/router/pull/5565))
+
+This will fix cases when you want to create a custom instruments having a value set to `event_*` with a condition executed on event and using the `response_context` selector in attributes.
+
+Example:
+
+```yaml
+telemetry:
+  instrumentation:
+    instruments:
+      supergraph:
+        sf.graphql_router.errors:
+          value: event_unit
+          type: counter
+          unit: count
+          description: "graphql errors handled by the apollo router"
+          condition:
+            eq:
+            - true
+            - on_graphql_error: true
+          attributes:
+            "operation":
+              response_context: "operation_name" # This was not working before
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/5565

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/supergraph/event.attributes.on_graphql_error/metrics.snap
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/supergraph/event.attributes.on_graphql_error/metrics.snap
@@ -16,6 +16,8 @@ info:
             attributes:
               on.graphql.error:
                 on_graphql_error: true
+              operation:
+                response_context: operation_name
 ---
 - name: custom_counter
   description: count of requests
@@ -25,3 +27,4 @@ info:
       - value: 1
         attributes:
           on.graphql.error: true
+          operation: Test

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/supergraph/event.attributes.on_graphql_error/router.yaml
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/supergraph/event.attributes.on_graphql_error/router.yaml
@@ -11,3 +11,5 @@ telemetry:
           attributes:
             on.graphql.error:
               on_graphql_error: true
+            operation:
+              response_context: "operation_name"

--- a/apollo-router/src/plugins/telemetry/config_new/fixtures/supergraph/event.attributes.on_graphql_error/test.yaml
+++ b/apollo-router/src/plugins/telemetry/config_new/fixtures/supergraph/event.attributes.on_graphql_error/test.yaml
@@ -8,7 +8,10 @@ events:
     - supergraph_request:
         uri: "/hello"
         method: GET
-        query: "query { hello }"
+        query: "query Test { hello }"
+    - context:
+        map:
+          "operation_name": "Test"
     - context:
         map:
           "apollo::telemetry::contains_graphql_error": true

--- a/apollo-router/src/plugins/telemetry/config_new/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/selectors.rs
@@ -987,6 +987,15 @@ impl Selector for SupergraphSelector {
                     None
                 }
             }
+            SupergraphSelector::ResponseContext {
+                response_context,
+                default,
+                ..
+            } => ctx
+                .get_json_value(response_context)
+                .as_ref()
+                .and_then(|v| v.maybe_to_otel_value())
+                .or_else(|| default.maybe_to_otel_value()),
             SupergraphSelector::Static(val) => Some(val.clone().into()),
             SupergraphSelector::StaticField { r#static } => Some(r#static.clone().into()),
             _ => None,


### PR DESCRIPTION
This will fix cases when you want to create a custom instruments having a value set to `event_*` with a condition executed on event and using the `response_context` selector in attributes.

Example:

```yaml
telemetry:
  instrumentation:
    instruments:
      supergraph:
        sf.graphql_router.errors:
          value: event_unit
          type: counter
          unit: count
          description: "graphql errors handled by the apollo router"
          condition:
            eq:
            - true
            - on_graphql_error: true
          attributes:
            "operation":
              response_context: "operation_name" # This was not working before
```

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
