### PR TITLE
Fetch parity between connector service and subgraph service

### DIFF
--- a/apollo-router/src/plugins/connectors/tests.rs
+++ b/apollo-router/src/plugins/connectors/tests.rs
@@ -116,11 +116,18 @@ pub(crate) mod mock_subgraph {
 }
 
 #[tokio::test]
-async fn test_root_field() {
+async fn test_root_field_plus_entity() {
     let mock_server = MockServer::start().await;
     mock_api::users().mount(&mock_server).await;
+    mock_api::user_1().mount(&mock_server).await;
+    mock_api::user_2().mount(&mock_server).await;
 
-    let response = execute(&mock_server.uri(), "query { users { id name } }", None).await;
+    let response = execute(
+        &mock_server.uri(),
+        "query { users { id name username } }",
+        None,
+    )
+    .await;
 
     insta::assert_json_snapshot!(response, @r###"
     {
@@ -128,11 +135,13 @@ async fn test_root_field() {
         "users": [
           {
             "id": 1,
-            "name": "Leanne Graham"
+            "name": "Leanne Graham",
+            "username": "Bret"
           },
           {
             "id": 2,
-            "name": "Ervin Howell"
+            "name": "Ervin Howell",
+            "username": "Antonette"
           }
         ]
       }
@@ -141,7 +150,11 @@ async fn test_root_field() {
 
     req_asserts::matches(
         &mock_server.received_requests().await.unwrap(),
-        vec![Matcher::new().method("GET").path("/users").build()],
+        vec![
+            Matcher::new().method("GET").path("/users").build(),
+            Matcher::new().method("GET").path("/users/1").build(),
+            Matcher::new().method("GET").path("/users/2").build(),
+        ],
     );
 }
 

--- a/apollo-router/src/services/connect.rs
+++ b/apollo-router/src/services/connect.rs
@@ -5,10 +5,10 @@ use std::sync::Arc;
 use apollo_compiler::validation::Valid;
 use apollo_compiler::ExecutableDocument;
 use apollo_compiler::NodeStr;
-use serde_json_bytes::Value;
+use static_assertions::assert_impl_all;
 use tower::BoxError;
 
-use crate::error::Error;
+use crate::graphql;
 use crate::graphql::Request as GraphQLRequest;
 use crate::query_planner::fetch::Variables;
 use crate::Context;
@@ -24,7 +24,12 @@ pub(crate) struct Request {
     pub(crate) variables: Variables,
 }
 
-pub(crate) type Response = (Value, Vec<Error>);
+assert_impl_all!(Response: Send);
+#[derive(Debug)]
+#[non_exhaustive]
+pub(crate) struct Response {
+    pub(crate) response: http::Response<graphql::Response>,
+}
 
 #[buildstructor::buildstructor]
 impl Request {

--- a/apollo-router/src/services/fetch_service.rs
+++ b/apollo-router/src/services/fetch_service.rs
@@ -14,6 +14,7 @@ use super::fetch::BoxService;
 use super::new_service::ServiceFactory;
 use super::ConnectRequest;
 use super::SubgraphRequest;
+use crate::graphql;
 use crate::graphql::Request as GraphQLRequest;
 use crate::http_ext;
 use crate::plugins::subscription::SubscriptionConfig;
@@ -54,7 +55,11 @@ impl tower::Service<FetchRequest> for FetchService {
             .connectors_by_service_name
             .contains_key(service_name.to_string().as_str())
         {
-            Self::fetch_with_connector_service(self.connector_service_factory.clone(), request)
+            Self::fetch_with_connector_service(
+                self.schema.clone(),
+                self.connector_service_factory.clone(),
+                request,
+            )
         } else {
             Self::fetch_with_subgraph_service(
                 self.schema.clone(),
@@ -68,6 +73,7 @@ impl tower::Service<FetchRequest> for FetchService {
 
 impl FetchService {
     fn fetch_with_connector_service(
+        schema: Arc<Schema>,
         connector_service_factory: Arc<ConnectorServiceFactory>,
         request: FetchRequest,
     ) -> BoxFuture<'static, Result<FetchResponse, BoxError>> {
@@ -76,30 +82,49 @@ impl FetchService {
             supergraph_request,
             variables,
             context,
+            current_dir,
             ..
         } = request;
 
         let FetchNode {
             operation,
             service_name,
+            requires,
+            output_rewrites,
             ..
         } = fetch_node;
 
+        let paths = variables.inverted_paths.clone();
         let operation = operation.as_parsed().cloned();
 
         Box::pin(async move {
-            connector_service_factory
+            let (data, errors) = connector_service_factory
                 .create()
                 .oneshot(
                     ConnectRequest::builder()
-                        .service_name(service_name)
+                        .service_name(service_name.clone())
                         .context(context)
                         .operation(operation?.clone())
                         .supergraph_request(supergraph_request)
                         .variables(variables)
                         .build(),
                 )
-                .await
+                .await?;
+
+            let response = graphql::Response::builder()
+                .data(data)
+                .errors(errors)
+                .build();
+
+            Ok(FetchNode::response_at_path(
+                &schema,
+                &current_dir,
+                paths,
+                response,
+                &requires,
+                &output_rewrites,
+                &service_name,
+            ))
         })
     }
 


### PR DESCRIPTION
* Change return type of the connector service to `graphql::Response` to match subgraph service. This allows the fetch service to treat responses the same as subgraph service responses
* Add `response_at_path` call after connector service responses
* Add deferred fetch handling after connector service responses
* The unit test is updated to include an entity, which now passes

The goal here is to achieve parity between connector service and subgraph service response processing, while minimizing changes from the `dev` branch.

<!-- [CNN-255[ -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
