### PR TITLE
FED-332: added the `remove_introspection` step in `normalize_operation`

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -4920,13 +4920,13 @@ pub(crate) fn normalize_operation(
 fn remove_introspection(selection_set: &mut SelectionSet) {
     // Note that, because we only apply this to the top-level selections, we skip all
     // introspection, including __typename. In general, we don't want to ignore __typename during
-    // query plans, but at top-level, we can let the gateway execution deal with it rather than
+    // query plans, but at top-level, we can let the router execution deal with it rather than
     // querying some service for that.
 
     Arc::make_mut(&mut selection_set.selections).retain(|_, selection| {
         !matches!(selection,
             Selection::Field(field_selection) if
-                field_selection.field.data().field_position.is_introspection_typename_field()
+                field_selection.field.field_position.is_introspection_typename_field()
         )
     });
 }


### PR DESCRIPTION
Summary
- ported `withoutIntrospection` JS function

<!-- [FED-332] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[FED-332]: https://apollographql.atlassian.net/browse/FED-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ