### PR TITLE
fix(federation): optimize `runtime_types_intersect`

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -4949,12 +4949,14 @@ fn runtime_types_intersect(
             .referencers()
             .get_interface_type(&interface.type_name)
             .is_ok_and(|referencers| referencers.object_types.contains(object)),
+        (Union(left), Union(right)) if left == right => true,
         (Union(left), Union(right)) => {
             match (left.get(schema.schema()), right.get(schema.schema())) {
                 (Ok(left), Ok(right)) => left.members.intersection(&right.members).next().is_some(),
                 _ => false,
             }
         }
+        (Interface(left), Interface(right)) if left == right => true,
         (Interface(left), Interface(right)) => {
             let r = schema.referencers();
             match (

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -4931,21 +4931,55 @@ fn remove_introspection(selection_set: &mut SelectionSet) {
     });
 }
 
+/// Check if the runtime types of two composite types intersect.
+///
+/// This avoids using `possible_runtime_types` and instead implements fast paths.
 fn runtime_types_intersect(
     type1: &CompositeTypeDefinitionPosition,
     type2: &CompositeTypeDefinitionPosition,
     schema: &ValidFederationSchema,
 ) -> bool {
-    if type1 == type2 {
-        return true;
+    use CompositeTypeDefinitionPosition::*;
+    match (type1, type2) {
+        (Object(left), Object(right)) => left == right,
+        (Object(object), Union(union_)) | (Union(union_), Object(object)) => union_
+            .get(schema.schema())
+            .is_ok_and(|union_| union_.members.contains(&object.type_name)),
+        (Object(object), Interface(interface)) | (Interface(interface), Object(object)) => schema
+            .referencers()
+            .get_interface_type(&interface.type_name)
+            .is_ok_and(|referencers| referencers.object_types.contains(object)),
+        (Union(left), Union(right)) => {
+            match (left.get(schema.schema()), right.get(schema.schema())) {
+                (Ok(left), Ok(right)) => left.members.intersection(&right.members).next().is_some(),
+                _ => false,
+            }
+        }
+        (Interface(left), Interface(right)) => {
+            let r = schema.referencers();
+            match (
+                r.get_interface_type(&left.type_name),
+                r.get_interface_type(&right.type_name),
+            ) {
+                (Ok(left), Ok(right)) => left
+                    .object_types
+                    .intersection(&right.object_types)
+                    .next()
+                    .is_some(),
+                _ => false,
+            }
+        }
+        (Union(union_), Interface(interface)) | (Interface(interface), Union(union_)) => match (
+            union_.get(schema.schema()),
+            schema
+                .referencers()
+                .get_interface_type(&interface.type_name),
+        ) {
+            (Ok(union_), Ok(referencers)) => referencers
+                .object_types
+                .iter()
+                .any(|implementer| union_.members.contains(&implementer.type_name)),
+            _ => false,
+        },
     }
-
-    if let (Ok(runtimes_1), Ok(runtimes_2)) = (
-        schema.possible_runtime_types(type1.clone()),
-        schema.possible_runtime_types(type2.clone()),
-    ) {
-        return runtimes_1.intersection(&runtimes_2).next().is_some();
-    }
-
-    false
 }

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -135,6 +135,12 @@ impl FederationSchema {
         self.get_type(type_name).ok()
     }
 
+    /// Return the possible runtime types for a definition.
+    ///
+    /// For a union, the possible runtime types are its members.
+    /// For an interface, the possible runtime types are its implementers.
+    ///
+    /// Note this always allocates a set for the result. Avoid calling it frequently.
     pub(crate) fn possible_runtime_types(
         &self,
         composite_type_definition_position: CompositeTypeDefinitionPosition,


### PR DESCRIPTION
This is an alternative to #5534 that does not add a new cache. I think this approach is preferable
as it has the same effect (optimizing the one very hot path) but with a much more limited "blast radius"
(less code affected overall).

It does the intersection check with just the information that's readily available on the schema.

`possible_runtime_types` is still slow, but it's no longer called in this very hot path. If it turns up in profiling later we can still consider optimizing `possible_runtime_types` with a cache or with wrapper types.

Closes #5534.