### PR TITLE
Propagate HTTP headers to connectors requests

### DIFF
--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_realistic_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_realistic_supergraph-2.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/sources/connect/expand/tests/mod.rs
-expression: connectors_by_service_name
+expression: connectors.by_service_name
 ---
 {
     "connectors_Query_user_0": Connector {
@@ -36,7 +36,7 @@ expression: connectors_by_service_name
                     query: {},
                 },
                 method: Get,
-                headers: {},
+                headers: [],
                 body: None,
             },
         ),

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_supergraph-2.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/sources/connect/expand/tests/mod.rs
-expression: connectors_by_service_name
+expression: connectors.by_service_name
 ---
 {
     "connectors_Query_users_0": Connector {
@@ -24,7 +24,7 @@ expression: connectors_by_service_name
                     query: {},
                 },
                 method: Get,
-                headers: {},
+                headers: [],
                 body: None,
             },
         ),
@@ -81,7 +81,7 @@ expression: connectors_by_service_name
                     query: {},
                 },
                 method: Get,
-                headers: {},
+                headers: [],
                 body: None,
             },
         ),
@@ -150,7 +150,7 @@ expression: connectors_by_service_name
                     query: {},
                 },
                 method: Get,
-                headers: {},
+                headers: [],
                 body: None,
             },
         ),

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_steelthread_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_steelthread_supergraph-2.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/sources/connect/expand/tests/mod.rs
-expression: connectors_by_service_name
+expression: connectors.by_service_name
 ---
 {
     "connectors_Query_users_0": Connector {
@@ -32,7 +32,7 @@ expression: connectors_by_service_name
                     query: {},
                 },
                 method: Get,
-                headers: {},
+                headers: [],
                 body: None,
             },
         ),
@@ -96,7 +96,7 @@ expression: connectors_by_service_name
                     query: {},
                 },
                 method: Get,
-                headers: {},
+                headers: [],
                 body: None,
             },
         ),
@@ -165,7 +165,7 @@ expression: connectors_by_service_name
                     query: {},
                 },
                 method: Get,
-                headers: {},
+                headers: [],
                 body: None,
             },
         ),

--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -25,6 +25,7 @@ pub(crate) use spec::ConnectSpecDefinition;
 pub use url_path_template::URLPathTemplate;
 
 pub use self::models::Connector;
+pub use self::models::HTTPHeader;
 pub use self::models::HTTPMethod;
 pub use self::models::HttpJsonTransport;
 pub use self::models::Transport;

--- a/apollo-federation/src/sources/connect/models/mod.rs
+++ b/apollo-federation/src/sources/connect/models/mod.rs
@@ -188,6 +188,19 @@ pub enum HTTPMethod {
     Delete,
 }
 
+impl HTTPMethod {
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        match self {
+            HTTPMethod::Get => "GET",
+            HTTPMethod::Post => "POST",
+            HTTPMethod::Patch => "PATCH",
+            HTTPMethod::Put => "PUT",
+            HTTPMethod::Delete => "DELETE",
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum HTTPHeader {
     Propagate {

--- a/apollo-router/src/plugins/connectors/http_json_transport.rs
+++ b/apollo-router/src/plugins/connectors/http_json_transport.rs
@@ -66,10 +66,8 @@ pub(crate) fn make_request(
 ) -> Result<http::Request<RouterBody>, HttpJsonTransportError> {
     let body = hyper::Body::empty();
 
-    // TODO: why is apollo_federation HTTPMethod Ucfirst?
-    let method = transport.method.to_string().to_uppercase();
     let mut request = http::Request::builder()
-        .method(method.as_bytes())
+        .method(transport.method.as_str())
         .uri(
             make_uri(transport, &inputs)
                 .map_err(HttpJsonTransportError::ConnectorDirectiveError)?

--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -133,14 +133,14 @@ pub(crate) fn make_requests(
 fn request_params_to_requests(
     connector: &Connector,
     request_params: Vec<(ResponseKey, RequestInputs)>,
-    _original_request: &connect::Request, // TODO headers
+    original_request: &connect::Request,
 ) -> Result<Vec<(http::Request<RouterBody>, ResponseKey)>, MakeRequestError> {
     request_params
         .into_iter()
         .map(|(response_key, inputs)| {
             let request = match connector.transport {
                 apollo_federation::sources::connect::Transport::HttpJson(ref transport) => {
-                    make_request(transport, inputs.merge())?
+                    make_request(transport, inputs.merge(), original_request)?
                 }
             };
 

--- a/apollo-router/src/plugins/connectors/testdata/steelthread.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/steelthread.graphql
@@ -2,7 +2,7 @@ schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
   @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
-  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "json", http: {baseURL: "https://jsonplaceholder.typicode.com/"}})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "json", http: {baseURL: "https://jsonplaceholder.typicode.com/", headers: [{name: "x-propagate"}, {name: "x-rename", as: "x-new-name"}, {name: "x-insert", value: "inserted"}]}})
 {
   query: Query
 }

--- a/apollo-router/src/plugins/connectors/testdata/steelthread.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/steelthread.yaml
@@ -16,7 +16,14 @@ subgraphs:
           )
           @source(
             name: "json"
-            http: { baseURL: "https://jsonplaceholder.typicode.com/" }
+            http: {
+              baseURL: "https://jsonplaceholder.typicode.com/"
+              headers: [
+                { name: "x-propagate" }
+                { name: "x-rename" as: "x-new-name" }
+                { name: "x-insert" value: "inserted" }
+              ]
+            }
           )
 
         type Query {

--- a/apollo-router/src/services/connect.rs
+++ b/apollo-router/src/services/connect.rs
@@ -19,7 +19,7 @@ pub(crate) struct Request {
     pub(crate) service_name: Arc<str>,
     pub(crate) context: Context,
     pub(crate) operation: Arc<Valid<ExecutableDocument>>,
-    pub(crate) _supergraph_request: Arc<http::Request<GraphQLRequest>>,
+    pub(crate) supergraph_request: Arc<http::Request<GraphQLRequest>>,
     pub(crate) variables: Variables,
 }
 
@@ -47,7 +47,7 @@ impl Request {
             service_name,
             context,
             operation,
-            _supergraph_request: supergraph_request,
+            supergraph_request,
             variables,
         }
     }


### PR DESCRIPTION

Propagate headers from the supergraph GraphQL query to Connectors REST HTTP requests, as specified by the `headers` attributes on the `@connect` and `@source` directives.

<!-- [CNN-235] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-235]: https://apollographql.atlassian.net/browse/CNN-235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ