### PR TITLE
connector debugging on response extensions

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/pretty.rs
+++ b/apollo-federation/src/sources/connect/json_selection/pretty.rs
@@ -11,6 +11,12 @@ use crate::sources::connect::json_selection::PathSelection;
 use crate::sources::connect::json_selection::StarSelection;
 use crate::sources::connect::json_selection::SubSelection;
 
+impl std::fmt::Display for JSONSelection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.pretty_print())
+    }
+}
+
 /// Pretty print trait
 ///
 /// This trait marks a type as supporting pretty printing itself outside of a

--- a/apollo-router/src/configuration/expansion.rs
+++ b/apollo-router/src/configuration/expansion.rs
@@ -168,6 +168,11 @@ fn dev_mode_defaults() -> Vec<Override> {
             .value(false)
             .value_type(ValueType::Bool)
             .build(),
+        Override::builder()
+            .config_path("preview_connectors.debug_extensions")
+            .value(true)
+            .value_type(ValueType::Bool)
+            .build(),
     ]
 }
 

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -47,7 +47,6 @@ use crate::configuration::schema::Mode;
 use crate::graphql;
 use crate::notification::Notify;
 use crate::plugin::plugins;
-use crate::plugins::connectors::configuration::Connectors;
 use crate::plugins::subscription::SubscriptionConfig;
 use crate::plugins::subscription::APOLLO_SUBSCRIPTION_PLUGIN;
 use crate::plugins::subscription::APOLLO_SUBSCRIPTION_PLUGIN_NAME;
@@ -197,10 +196,6 @@ pub struct Configuration {
     /// Type conditioned fetching configuration.
     #[serde(default)]
     pub(crate) experimental_type_conditioned_fetching: bool,
-
-    /// Connectors configuration
-    #[serde(default)]
-    pub(crate) preview_connectors: Connectors,
 }
 
 impl PartialEq for Configuration {
@@ -282,7 +277,6 @@ impl<'de> serde::Deserialize<'de> for Configuration {
             experimental_apollo_metrics_generation_mode: ApolloMetricsGenerationMode,
             experimental_api_schema_generation_mode: ApiSchemaMode,
             experimental_query_planner_mode: QueryPlannerMode,
-            preview_connectors: Connectors,
         }
         let ad_hoc: AdHocConfiguration = serde::Deserialize::deserialize(deserializer)?;
 
@@ -309,7 +303,6 @@ impl<'de> serde::Deserialize<'de> for Configuration {
             plugins: ad_hoc.plugins,
             apollo_plugins: ad_hoc.apollo_plugins,
             batching: ad_hoc.batching,
-            preview_connectors: ad_hoc.preview_connectors,
 
             // serde(skip)
             notify,
@@ -355,7 +348,6 @@ impl Configuration {
         batching: Option<Batching>,
         experimental_apollo_metrics_generation_mode: Option<ApolloMetricsGenerationMode>,
         experimental_query_planner_mode: Option<QueryPlannerMode>,
-        preview_connectors: Option<Connectors>,
     ) -> Result<Self, ConfigurationError> {
         let notify = Self::notify(&apollo_plugins)?;
 
@@ -387,7 +379,6 @@ impl Configuration {
             experimental_type_conditioned_fetching: experimental_type_conditioned_fetching
                 .unwrap_or_default(),
             notify,
-            preview_connectors: preview_connectors.unwrap_or_default(),
         };
 
         conf.validate()
@@ -480,7 +471,6 @@ impl Configuration {
         experimental_type_conditioned_fetching: Option<bool>,
         experimental_apollo_metrics_generation_mode: Option<ApolloMetricsGenerationMode>,
         experimental_query_planner_mode: Option<QueryPlannerMode>,
-        preview_connectors: Option<Connectors>,
     ) -> Result<Self, ConfigurationError> {
         let configuration = Self {
             validated_yaml: Default::default(),
@@ -510,7 +500,6 @@ impl Configuration {
             experimental_type_conditioned_fetching: experimental_type_conditioned_fetching
                 .unwrap_or_default(),
             batching: batching.unwrap_or_default(),
-            preview_connectors: preview_connectors.unwrap_or_default(),
         };
 
         configuration.validate()

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__expansion__test__dev_mode.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__expansion__test__dev_mode.snap
@@ -9,6 +9,8 @@ include_subgraph_errors:
   all: true
 plugins:
   experimental.expose_query_plan: true
+preview_connectors:
+  debug_extensions: true
 sandbox:
   enabled: true
 supergraph:
@@ -18,4 +20,3 @@ telemetry:
     tracing:
       experimental_response_trace_id:
         enabled: true
-

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -1715,10 +1715,14 @@ expression: "&schema"
       ],
       "type": "object"
     },
-    "Connectors": {
+    "ConnectorsConfig": {
       "additionalProperties": false,
-      "description": "Connectors configuration",
       "properties": {
+        "debug_extensions": {
+          "default": false,
+          "description": "Enables connector debugging information on response extensions if the feature is enabled",
+          "type": "boolean"
+        },
         "subgraphs": {
           "additionalProperties": {
             "additionalProperties": {
@@ -8106,8 +8110,8 @@ expression: "&schema"
       "description": "#/definitions/Plugins"
     },
     "preview_connectors": {
-      "$ref": "#/definitions/Connectors",
-      "description": "#/definitions/Connectors"
+      "$ref": "#/definitions/ConnectorsConfig",
+      "description": "#/definitions/ConnectorsConfig"
     },
     "preview_demand_control": {
       "$ref": "#/definitions/DemandControlConfig",

--- a/apollo-router/src/plugins/connectors/http_json_transport.rs
+++ b/apollo-router/src/plugins/connectors/http_json_transport.rs
@@ -64,6 +64,7 @@ pub(crate) fn make_request(
     inputs: Value,
     original_request: &connect::Request,
 ) -> Result<http::Request<RouterBody>, HttpJsonTransportError> {
+    // TODO build body using transport.body and inputs
     let body = hyper::Body::empty();
 
     let mut request = http::Request::builder()

--- a/apollo-router/src/plugins/connectors/mod.rs
+++ b/apollo-router/src/plugins/connectors/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod configuration;
 pub(crate) mod handle_responses;
 pub(crate) mod http_json_transport;
 pub(crate) mod make_requests;
+pub(crate) mod plugin;
 pub(crate) mod query_plans;
 
 #[cfg(test)]

--- a/apollo-router/src/plugins/connectors/plugin.rs
+++ b/apollo-router/src/plugins/connectors/plugin.rs
@@ -72,7 +72,7 @@ impl Plugin for Connectors {
                             == Some(&HeaderValue::from_static("true"));
                     if is_enabled {
                         req.context.extensions().with_lock(|mut lock| {
-                            lock.insert::<ConnectorContext>(ConnectorContext::new());
+                            lock.insert::<ConnectorContext>(ConnectorContext::default());
                         });
                     }
 
@@ -121,7 +121,7 @@ register_plugin!("apollo", "preview_connectors", Connectors);
 
 // === Structs for collecting debugging information ============================
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub(crate) struct ConnectorContext {
     requests: Vec<ConnectorDebugHttpRequest>,
     responses: Vec<ConnectorDebugHttpResponse>,
@@ -129,13 +129,6 @@ pub(crate) struct ConnectorContext {
 }
 
 impl ConnectorContext {
-    fn new() -> Self {
-        Self {
-            requests: Default::default(),
-            responses: Default::default(),
-            selections: Default::default(),
-        }
-    }
     pub(crate) fn push_request(&mut self, req: &http::Request<RouterBody>) {
         self.requests.push(req.into());
     }

--- a/apollo-router/src/plugins/connectors/plugin.rs
+++ b/apollo-router/src/plugins/connectors/plugin.rs
@@ -1,0 +1,263 @@
+use std::collections::HashMap;
+
+use apollo_federation::sources::connect::ApplyToError;
+use futures::future::ready;
+use futures::stream::once;
+use futures::StreamExt;
+use http::HeaderValue;
+use itertools::Itertools;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json_bytes::json;
+use serde_json_bytes::Value;
+use tower::BoxError;
+use tower::ServiceExt as TowerServiceExt;
+
+use super::configuration::SourceApiConfiguration;
+use crate::layers::ServiceExt;
+use crate::plugin::Plugin;
+use crate::plugin::PluginInit;
+use crate::register_plugin;
+use crate::services::router::body::RouterBody;
+use crate::services::supergraph;
+
+const CONNECTORS_DEBUG_HEADER_NAME: &str = "Apollo-Connectors-Debugging";
+const CONNECTORS_DEBUG_ENV: &str = "APOLLO_CONNECTORS_DEBUGGING";
+
+#[derive(Debug, Clone)]
+struct Connectors {
+    debug_extensions: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ConnectorsConfig {
+    /// Per subgraph configuration
+    #[serde(default)]
+    pub(crate) subgraphs: HashMap<String, HashMap<String, SourceApiConfiguration>>,
+
+    /// Enables connector debugging information on response extensions if the feature is enabled
+    #[serde(default)]
+    pub(crate) debug_extensions: bool,
+}
+
+#[async_trait::async_trait]
+impl Plugin for Connectors {
+    type Config = ConnectorsConfig;
+
+    async fn new(init: PluginInit<Self::Config>) -> Result<Self, BoxError> {
+        let debug_extensions = init.config.debug_extensions
+            || std::env::var(CONNECTORS_DEBUG_ENV).as_deref() == Ok("true");
+
+        if debug_extensions {
+            tracing::warn!(
+                "Connector debugging is enabled, this may expose sensitive information."
+            );
+        }
+
+        Ok(Connectors { debug_extensions })
+    }
+
+    fn supergraph_service(&self, service: supergraph::BoxService) -> supergraph::BoxService {
+        let conf_enabled = self.debug_extensions;
+        service
+            .map_future_with_request_data(
+                move |req: &supergraph::Request| {
+                    let is_enabled = conf_enabled
+                        && req
+                            .supergraph_request
+                            .headers()
+                            .get(CONNECTORS_DEBUG_HEADER_NAME)
+                            == Some(&HeaderValue::from_static("true"));
+                    if is_enabled {
+                        req.context.extensions().with_lock(|mut lock| {
+                            lock.insert::<ConnectorContext>(ConnectorContext::new());
+                        });
+                    }
+
+                    is_enabled
+                },
+                move |is_enabled: bool, f| async move {
+                    let mut res: supergraph::ServiceResult = f.await;
+
+                    res = match res {
+                        Ok(mut res) => {
+                            if is_enabled {
+                                if let Some(debug) = res
+                                    .context
+                                    .extensions()
+                                    .with_lock(|mut lock| lock.remove::<ConnectorContext>())
+                                {
+                                    let (parts, stream) = res.response.into_parts();
+                                    let (mut first, rest) = stream.into_future().await;
+
+                                    if let Some(first) = &mut first {
+                                        first.extensions.insert(
+                                            "apolloConnectorsDebugging",
+                                            json!({"version": "1", "data": debug.serialize() }),
+                                        );
+                                    }
+                                    res.response = http::Response::from_parts(
+                                        parts,
+                                        once(ready(first.unwrap_or_default())).chain(rest).boxed(),
+                                    );
+                                }
+                            }
+
+                            Ok(res)
+                        }
+                        Err(err) => Err(err),
+                    };
+
+                    res
+                },
+            )
+            .boxed()
+    }
+}
+
+register_plugin!("apollo", "preview_connectors", Connectors);
+
+// === Structs for collecting debugging information ============================
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ConnectorContext {
+    requests: Vec<ConnectorDebugHttpRequest>,
+    responses: Vec<ConnectorDebugHttpResponse>,
+    selections: Vec<ConnectorDebugSelection>,
+}
+
+impl ConnectorContext {
+    fn new() -> Self {
+        Self {
+            requests: Default::default(),
+            responses: Default::default(),
+            selections: Default::default(),
+        }
+    }
+    pub(crate) fn push_request(&mut self, req: &http::Request<RouterBody>) {
+        self.requests.push(req.into());
+    }
+
+    pub(crate) fn push_response(
+        &mut self,
+        parts: &http::response::Parts,
+        json_body: &serde_json_bytes::Value,
+    ) {
+        self.responses.push(serialize_response(parts, json_body));
+    }
+
+    pub(crate) fn push_mapping(
+        &mut self,
+        source: String,
+        result: Option<serde_json_bytes::Value>,
+        errors: Vec<ApplyToError>,
+    ) {
+        self.selections.push(ConnectorDebugSelection {
+            source,
+            result,
+            errors: aggregate_apply_to_errors(&errors),
+        });
+    }
+
+    fn serialize(self) -> Value {
+        json!(self
+            .requests
+            .into_iter()
+            .zip(self.responses.into_iter())
+            .zip(self.selections.into_iter())
+            .map(|((req, res), sel)| json!({
+                "request": req,
+                "response": res,
+                "selection": sel,
+            }))
+            .collect::<Vec<_>>())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ConnectorDebugBody {
+    kind: String,
+    content: serde_json_bytes::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ConnectorDebugHttpRequest {
+    url: String,
+    method: String,
+    headers: Vec<(String, String)>,
+    body: Option<ConnectorDebugBody>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ConnectorDebugSelection {
+    source: String,
+    result: Option<serde_json_bytes::Value>,
+    errors: Vec<serde_json_bytes::Value>,
+}
+
+impl From<&http::Request<RouterBody>> for ConnectorDebugHttpRequest {
+    fn from(value: &http::Request<RouterBody>) -> Self {
+        Self {
+            url: value.uri().to_string(),
+            method: value.method().to_string(),
+            headers: value
+                .headers()
+                .iter()
+                .map(|(name, value)| {
+                    (
+                        name.as_str().to_string(),
+                        value.to_str().unwrap().to_string(),
+                    )
+                })
+                .collect(),
+            body: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ConnectorDebugHttpResponse {
+    status: u16,
+    headers: Vec<(String, String)>,
+    body: ConnectorDebugBody,
+}
+
+fn serialize_response(
+    parts: &http::response::Parts,
+    json_body: &serde_json_bytes::Value,
+) -> ConnectorDebugHttpResponse {
+    ConnectorDebugHttpResponse {
+        status: parts.status.as_u16(),
+        headers: parts
+            .headers
+            .iter()
+            .map(|(name, value)| {
+                (
+                    name.as_str().to_string(),
+                    value.to_str().unwrap().to_string(),
+                )
+            })
+            .collect(),
+        body: ConnectorDebugBody {
+            kind: "json".to_string(),
+            content: json_body.clone(),
+        },
+    }
+}
+
+fn aggregate_apply_to_errors(errors: &[ApplyToError]) -> Vec<serde_json_bytes::Value> {
+    let mut aggregated = vec![];
+
+    for (key, group) in &errors.iter().group_by(|e| (e.message(), e.path())) {
+        let group = group.collect_vec();
+        aggregated.push(json!({
+            "message": key.0,
+            "path": key.1,
+            "count": group.len(),
+        }));
+    }
+
+    aggregated
+}

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -717,6 +717,7 @@ pub(crate) async fn create_plugins(
     add_optional_apollo_plugin!("rhai");
     add_optional_apollo_plugin!("coprocessor");
     add_optional_apollo_plugin!("preview_demand_control");
+    add_optional_apollo_plugin!("preview_connectors");
     add_user_plugins!();
 
     // Macros above remove from `apollo_plugin_factories`, so anything left at the end

--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -93,7 +93,7 @@ async fn execute(
             let client = http_client_factory.create(&original_subgraph_name);
             let req = HttpRequest {
                 http_request: req,
-                context: context.clone(),
+                context,
             };
             let res = client.oneshot(req).await?;
             let mut res = res.http_response;

--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -16,6 +16,7 @@ use super::http::HttpRequest;
 use super::new_service::ServiceFactory;
 use crate::plugins::connectors::handle_responses::handle_responses;
 use crate::plugins::connectors::make_requests::make_requests;
+use crate::plugins::connectors::plugin::ConnectorContext;
 use crate::plugins::subscription::SubscriptionConfig;
 use crate::services::ConnectRequest;
 use crate::services::ConnectResponse;
@@ -73,24 +74,32 @@ async fn execute(
     schema: &Valid<apollo_compiler::Schema>,
 ) -> Result<ConnectResponse, BoxError> {
     let context = request.context.clone();
+    let context2 = context.clone();
     let original_subgraph_name = connector.id.subgraph_name.to_string();
 
+    let mut debug = context
+        .extensions()
+        .with_lock(|mut lock| lock.remove::<ConnectorContext>());
+
     let requests =
-        make_requests(request, connector, schema).map_err(|_e| BoxError::from("TODO"))?;
+        make_requests(request, connector, &mut debug).map_err(|_e| BoxError::from("TODO"))?;
 
     let tasks = requests.into_iter().map(move |(req, key)| {
         let context = context.clone();
         let original_subgraph_name = original_subgraph_name.clone();
         async move {
+            let context = context.clone();
+
             let client = http_client_factory.create(&original_subgraph_name);
             let req = HttpRequest {
                 http_request: req,
-                context,
+                context: context.clone(),
             };
             let res = client.oneshot(req).await?;
             let mut res = res.http_response;
             let extensions = res.extensions_mut();
             extensions.insert(key);
+
             Ok::<_, BoxError>(res)
         }
     });
@@ -99,9 +108,17 @@ async fn execute(
         .await
         .map_err(BoxError::from)?;
 
-    handle_responses(responses, connector, schema, Some("TODO".to_string()))
+    let result = handle_responses(responses, connector, &mut debug, schema)
         .await
-        .map_err(|_e| BoxError::from("todo"))
+        .map_err(|_e| BoxError::from("todo"));
+
+    if let Some(debug) = debug {
+        context2
+            .extensions()
+            .with_lock(|mut lock| lock.insert::<ConnectorContext>(debug));
+    }
+
+    result
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
in `--dev` mode or with preview_connectors.debug_extensions set to true, and the client includes a `Apollo-Connectors-Debugging: true` request header, responses will include connector request/response data like this:

```json
{
  "extensions": {
    "apolloConnectorsDebugging": {
      "version": "1",
      "data": [
        {
          "request": {
            "url": "https://jsonplaceholder.typicode.com/users",
            "method": "GET",
            "headers": [["content-type","application/json"]],
            "body": "TODO"
          },
          "response": {
            "status": 200,
            "headers": [["content-type","application/json"]],
            "body": {"kind":"json","content":{...}}
          },
          "selection": {
            "source":".results { id name }",
            "result": {...},
            "errors":[{"message":"...","path":"...","count":10}]
          }
        }
      ]
    }
  }
}
```

<!-- CNN-239 -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
