### PR TITLE
Add connect tracing span

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,7 @@ dependencies = [
  "tower-test",
  "tracing",
  "tracing-core",
+ "tracing-fluent-assertions",
  "tracing-futures",
  "tracing-opentelemetry",
  "tracing-serde",
@@ -7597,6 +7598,17 @@ checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-fluent-assertions"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12de1a8c6bcfee614305e836308b596bbac831137a04c61f7e5b0b0bf2cfeaf6"
+dependencies = [
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -330,6 +330,7 @@ tower-test = "0.4.0"
 
 # See note above in this file about `^tracing` packages which also applies to
 # these dev dependencies.
+tracing-fluent-assertions = "0.3.0"
 tracing-subscriber = { version = "0.3", default-features = false, features = [
     "env-filter",
     "fmt",

--- a/apollo-router/src/plugins/connectors/mod.rs
+++ b/apollo-router/src/plugins/connectors/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod http_json_transport;
 pub(crate) mod make_requests;
 pub(crate) mod plugin;
 pub(crate) mod query_plans;
+pub(crate) mod tracing;
 
 #[cfg(test)]
 pub(crate) mod tests;

--- a/apollo-router/src/plugins/connectors/tracing.rs
+++ b/apollo-router/src/plugins/connectors/tracing.rs
@@ -1,0 +1,2 @@
+pub(crate) const CONNECT_SPAN_NAME: &str = "connect";
+pub(crate) const CONNECTOR_TYPE_HTTP: &str = "http";

--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -5,10 +5,12 @@ use std::task::Poll;
 
 use apollo_compiler::validation::Valid;
 use apollo_federation::sources::connect::Connector;
+use apollo_federation::sources::connect::Transport;
 use futures::future::BoxFuture;
 use indexmap::IndexMap;
 use tower::BoxError;
 use tower::ServiceExt;
+use tracing::Instrument;
 
 use super::connect::BoxService;
 use super::http::HttpClientServiceFactory;
@@ -17,6 +19,8 @@ use super::new_service::ServiceFactory;
 use crate::plugins::connectors::handle_responses::handle_responses;
 use crate::plugins::connectors::make_requests::make_requests;
 use crate::plugins::connectors::plugin::ConnectorContext;
+use crate::plugins::connectors::tracing::CONNECTOR_TYPE_HTTP;
+use crate::plugins::connectors::tracing::CONNECT_SPAN_NAME;
 use crate::plugins::subscription::SubscriptionConfig;
 use crate::services::ConnectRequest;
 use crate::services::ConnectResponse;
@@ -62,7 +66,39 @@ impl tower::Service<ConnectRequest> for ConnectorService {
                 return Err("no http client found".into());
             };
 
-            execute(&http_client_factory, request, &connector, &schema).await
+            let fetch_time_offset = request.context.created_at.elapsed().as_nanos() as i64;
+            let span = tracing::info_span!(
+                CONNECT_SPAN_NAME,
+                "otel.kind" = "INTERNAL",
+                "apollo.connector.type" = CONNECTOR_TYPE_HTTP,
+                "apollo.connector.detail" = tracing::field::Empty,
+                "apollo.connector.field.name" = connector.id.directive.field.to_string(),
+                "apollo.connector.selection" = connector.selection.to_string(),
+                "apollo.connector.source.name" = tracing::field::Empty,
+                "apollo.connector.source.detail" = tracing::field::Empty,
+                "apollo_private.sent_time_offset" = fetch_time_offset,
+            );
+            // TODO: apollo.connector.field.alias
+            // TODO: apollo.connector.field.return_type
+            // TODO: apollo.connector.field.selection_set
+            let Transport::HttpJson(ref http_json) = connector.transport;
+            if let Ok(detail) = serde_json::to_string(
+                &serde_json::json!({ http_json.method.as_str(): http_json.path_template.to_string() }),
+            ) {
+                span.record("apollo.connector.detail", detail);
+            }
+            if let Some(source_name) = connector.id.source_name.as_ref() {
+                span.record("apollo.connector.source.name", source_name);
+                if let Ok(detail) =
+                    serde_json::to_string(&serde_json::json!({ "baseURL": http_json.base_url }))
+                {
+                    span.record("apollo.connector.source.detail", detail);
+                }
+            }
+
+            execute(&http_client_factory, request, &connector, &schema)
+                .instrument(span)
+                .await
         })
     }
 }

--- a/apollo-router/src/services/fetch_service.rs
+++ b/apollo-router/src/services/fetch_service.rs
@@ -5,7 +5,6 @@ use std::sync::Arc;
 use std::task::Poll;
 
 use apollo_compiler::validation::Valid;
-use apollo_federation::sources::connect::Transport;
 use futures::future::BoxFuture;
 use tower::BoxError;
 use tower::ServiceExt;
@@ -19,8 +18,6 @@ use super::ConnectRequest;
 use super::SubgraphRequest;
 use crate::graphql::Request as GraphQLRequest;
 use crate::http_ext;
-use crate::plugins::connectors::tracing::CONNECTOR_TYPE_HTTP;
-use crate::plugins::connectors::tracing::CONNECT_SPAN_NAME;
 use crate::plugins::subscription::SubscriptionConfig;
 use crate::query_planner::build_operation_with_aliasing;
 use crate::query_planner::fetch::FetchNode;
@@ -64,40 +61,17 @@ impl tower::Service<FetchRequest> for FetchService {
             .connectors_by_service_name
             .get(service_name.as_ref())
         {
-            let span = tracing::info_span!(
-                CONNECT_SPAN_NAME,
-                "otel.kind" = "INTERNAL",
-                "apollo.connector.type" = CONNECTOR_TYPE_HTTP,
-                "apollo.connector.detail" = tracing::field::Empty,
-                "apollo.connector.field.name" = connector.id.directive.field.to_string(),
-                "apollo.connector.selection" = connector.selection.to_string(),
-                "apollo.connector.source.name" = tracing::field::Empty,
-                "apollo.connector.source.detail" = tracing::field::Empty,
-                "apollo_private.sent_time_offset" = fetch_time_offset,
-            );
-            // TODO: apollo.connector.field.alias
-            // TODO: apollo.connector.field.return_type
-            // TODO: apollo.connector.field.selection_set
-            let Transport::HttpJson(ref http_json) = connector.transport;
-            if let Ok(detail) = serde_json::to_string(
-                &serde_json::json!({ http_json.method.as_str(): http_json.path_template.to_string() }),
-            ) {
-                span.record("apollo.connector.detail", detail);
-            }
-            if let Some(source_name) = connector.id.source_name.as_ref() {
-                span.record("apollo.connector.source.name", source_name);
-                if let Ok(detail) =
-                    serde_json::to_string(&serde_json::json!({ "baseURL": http_json.base_url }))
-                {
-                    span.record("apollo.connector.source.detail", detail);
-                }
-            }
             Self::fetch_with_connector_service(
                 self.schema.clone(),
                 self.connector_service_factory.clone(),
                 request,
             )
-            .instrument(span)
+            .instrument(tracing::info_span!(
+                FETCH_SPAN_NAME,
+                "otel.kind" = "INTERNAL",
+                "apollo.subgraph.name" = connector.id.subgraph_name,
+                "apollo_private.sent_time_offset" = fetch_time_offset
+            ))
         } else {
             Self::fetch_with_subgraph_service(
                 self.schema.clone(),


### PR DESCRIPTION
* Add a `connect` tracing span
* Refactor the `fetch` tracing span into the `FetchService`
* Set the name of the fetch span to the original subgraph name for a connectors subgraph

<!-- [CNN-189] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

**Notes**

In Jaeger, you can now see a fetch span on the original subgraph name, a connect span for the connector, and a request span for the REST HTTP request:

<img width="1591" alt="Screenshot 2024-07-05 at 12 31 48 PM" src="https://github.com/apollographql/router/assets/169163228/79c788df-216d-4e66-8ce8-0b4eb7146824">


There is remaining work to add additional field attributes.

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-189]: https://apollographql.atlassian.net/browse/CNN-189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ