### PR TITLE
connectors: separate input type and output key processing

### DIFF
--- a/apollo-federation/src/sources/connect/expand/tests/schemas/realistic.graphql
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/realistic.graphql
@@ -48,6 +48,13 @@ type CompanyInfo
   bs: String
 }
 
+input CompanyInput
+  @join__type(graph: CONNECTORS)
+{
+  name: String!
+  catchPhrase: String
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
@@ -73,6 +80,7 @@ enum link__Purpose {
 type Query
   @join__type(graph: CONNECTORS)
 {
+  usersByCompany(company: CompanyInput!): [User] @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "example", http: {GET: "/by-company/{$args.company.name}"}, selection: "id\nname\ncompany {\n  name\n  catchPhrase\n  bs\n}"})
   user(id: ID!): User @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "example", http: {GET: "/{$args.id}"}, selection: "id\nname\nusername\nemail\naddress {\n  street\n  suite\n  city\n  zipcode\n  geo {\n    lat\n    lng\n  }\n}\nphone\nwebsite\ncompany {\n  name\n  catchPhrase\n  bs\n}", entity: true})
 }
 

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/realistic.yaml
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/realistic.yaml
@@ -13,6 +13,16 @@ subgraphs:
           @source(name: "example", http: { baseURL: "http://example" })
 
         type Query {
+          usersByCompany(company: CompanyInput!): [User]
+            @connect(source: "example", http: { GET: "/by-company/{$$args.company.name}" }, selection: """
+              id
+              name
+              company {
+                name
+                catchPhrase
+                bs
+              }""")
+
           user(id: ID!): User
             @connect(source: "example", http: { GET: "/{$$args.id}" }, selection: """
               id
@@ -66,4 +76,9 @@ subgraphs:
           name: String
           catchPhrase: String
           bs: String
+        }
+
+        input CompanyInput {
+          name: String!
+          catchPhrase: String
         }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_realistic_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_realistic_supergraph-2.snap
@@ -3,6 +3,95 @@ source: apollo-federation/src/sources/connect/expand/tests/mod.rs
 expression: connectors.by_service_name
 ---
 {
+    "connectors_Query_usersByCompany_0": Connector {
+        id: ConnectId {
+            label: "connectors.example http: Get /by-company/{$args.company.name!}",
+            subgraph_name: "connectors",
+            source_name: Some(
+                "example",
+            ),
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.usersByCompany),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJson(
+            HttpJsonTransport {
+                base_url: "http://example",
+                path_template: URLPathTemplate {
+                    path: [
+                        ParameterValue {
+                            parts: [
+                                Text(
+                                    "by-company",
+                                ),
+                            ],
+                        },
+                        ParameterValue {
+                            parts: [
+                                Var(
+                                    VariableExpression {
+                                        var_path: "$args.company.name",
+                                        batch_separator: None,
+                                        required: true,
+                                    },
+                                ),
+                            ],
+                        },
+                    ],
+                    query: {},
+                },
+                method: Get,
+                headers: [],
+                body: None,
+            },
+        ),
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "name",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "company",
+                        Some(
+                            SubSelection {
+                                selections: [
+                                    Field(
+                                        None,
+                                        "name",
+                                        None,
+                                    ),
+                                    Field(
+                                        None,
+                                        "catchPhrase",
+                                        None,
+                                    ),
+                                    Field(
+                                        None,
+                                        "bs",
+                                        None,
+                                    ),
+                                ],
+                                star: None,
+                            },
+                        ),
+                    ),
+                ],
+                star: None,
+            },
+        ),
+        entity_resolver: None,
+    },
     "connectors_Query_user_0": Connector {
         id: ConnectId {
             label: "connectors.example http: Get /{$args.id!}",

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_realistic_supergraph-3.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_realistic_supergraph-3.snap
@@ -35,6 +35,7 @@ scalar join__FieldSet
 
 enum join__Graph {
   CONNECTORS_QUERY_USER_0 @join__graph(name: "connectors_Query_user_0", url: "none")
+  CONNECTORS_QUERY_USERSBYCOMPANY_0 @join__graph(name: "connectors_Query_usersByCompany_0", url: "none")
 }
 
 type AddressGeo @join__type(graph: CONNECTORS_QUERY_USER_0) {
@@ -50,23 +51,29 @@ type Address @join__type(graph: CONNECTORS_QUERY_USER_0) {
   zipcode: String @join__field(graph: CONNECTORS_QUERY_USER_0)
 }
 
-type CompanyInfo @join__type(graph: CONNECTORS_QUERY_USER_0) {
-  bs: String @join__field(graph: CONNECTORS_QUERY_USER_0)
-  catchPhrase: String @join__field(graph: CONNECTORS_QUERY_USER_0)
-  name: String @join__field(graph: CONNECTORS_QUERY_USER_0)
+type CompanyInfo @join__type(graph: CONNECTORS_QUERY_USER_0) @join__type(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0) {
+  bs: String @join__field(graph: CONNECTORS_QUERY_USER_0) @join__field(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0)
+  catchPhrase: String @join__field(graph: CONNECTORS_QUERY_USER_0) @join__field(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0)
+  name: String @join__field(graph: CONNECTORS_QUERY_USER_0) @join__field(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0)
 }
 
-type User @join__type(graph: CONNECTORS_QUERY_USER_0, key: "id") {
+type User @join__type(graph: CONNECTORS_QUERY_USER_0, key: "id") @join__type(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0) {
   address: Address @join__field(graph: CONNECTORS_QUERY_USER_0)
-  company: CompanyInfo @join__field(graph: CONNECTORS_QUERY_USER_0)
+  company: CompanyInfo @join__field(graph: CONNECTORS_QUERY_USER_0) @join__field(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0)
   email: String @join__field(graph: CONNECTORS_QUERY_USER_0)
-  id: ID! @join__field(graph: CONNECTORS_QUERY_USER_0)
-  name: String @join__field(graph: CONNECTORS_QUERY_USER_0)
+  id: ID! @join__field(graph: CONNECTORS_QUERY_USER_0) @join__field(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0)
+  name: String @join__field(graph: CONNECTORS_QUERY_USER_0) @join__field(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0)
   phone: String @join__field(graph: CONNECTORS_QUERY_USER_0)
   username: String @join__field(graph: CONNECTORS_QUERY_USER_0)
   website: String @join__field(graph: CONNECTORS_QUERY_USER_0)
 }
 
-type Query @join__type(graph: CONNECTORS_QUERY_USER_0) {
+type Query @join__type(graph: CONNECTORS_QUERY_USER_0) @join__type(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0) {
   user(id: ID!): User @join__field(graph: CONNECTORS_QUERY_USER_0)
+  usersByCompany: [User] @join__field(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0)
+}
+
+input CompanyInput @join__type(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0) {
+  name: String!
+  catchPhrase: String
 }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_realistic_supergraph.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_realistic_supergraph.snap
@@ -23,7 +23,13 @@ type CompanyInfo {
   bs: String
 }
 
+input CompanyInput {
+  name: String!
+  catchPhrase: String
+}
+
 type Query {
+  usersByCompany(company: CompanyInput!): [User]
   user(id: ID!): User
 }
 


### PR DESCRIPTION
This commit separates out processing of input types and output directives into two separate stages. This addresses issues when populating output fields since input types need to exist before creating the field with arguments and output keys need to reference the output field before appending key directives.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.

<!-- [CNN-231] -->

[CNN-231]: https://apollographql.atlassian.net/browse/CNN-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ