### PR TITLE
fix(rhai): provide a valid trace id even if the trace isn't sampled

### DIFF
--- a/.changesets/fix_bnjjj_fix_rhai_traceid.md
+++ b/.changesets/fix_bnjjj_fix_rhai_traceid.md
@@ -1,0 +1,5 @@
+### Provide a valid trace id in rhai scripts even if the trace isn't sampled ([PR #5606](https://github.com/apollographql/router/pull/5606))
+
+Before, when calling `traceid()` in a rhai script, if the trace wasn't sampled you won't get the traceid. It's now fixed and you'll get trace id even if the trace is not sampled.
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/5606

--- a/apollo-router/src/plugins/rhai/engine.rs
+++ b/apollo-router/src/plugins/rhai/engine.rs
@@ -1200,7 +1200,9 @@ mod router_plugin {
     // TraceId support
     #[rhai_fn(return_raw)]
     pub(crate) fn traceid() -> Result<TraceId, Box<EvalAltResult>> {
-        TraceId::maybe_new().ok_or_else(|| "trace unavailable".into())
+        TraceId::maybe_new()
+            .or_else(TraceId::current)
+            .ok_or_else(|| "trace unavailable".into())
     }
 
     #[rhai_fn(name = "to_string")]


### PR DESCRIPTION
Before, when calling `traceid()` in a rhai script, if the trace wasn't sampled you won't get the traceid. It's now fixed and you'll get trace id even if the trace is not sampled.

<!-- [ROUTER-412] -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-412]: https://apollographql.atlassian.net/browse/ROUTER-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ