### PR TITLE
chore(deps): anyhow, clap, tempfile, thiserror, rust-embed, jsonwebtoken

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "apollo-compiler"
@@ -400,7 +400,7 @@ checksum = "16a61580d9ee85ec35b892efb1f3eec193c520fc957b612989dc823551e2639d"
 dependencies = [
  "apollo-parser",
  "ariadne",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "rowan",
  "serde",
  "serde_json_bytes",
@@ -426,7 +426,7 @@ dependencies = [
  "apollo-compiler",
  "derive_more",
  "hex",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "insta",
  "itertools 0.13.0",
  "lazy_static",
@@ -510,7 +510,7 @@ dependencies = [
  "futures",
  "futures-test",
  "graphql_client",
- "heck",
+ "heck 0.4.1",
  "hex",
  "hmac",
  "http 0.2.11",
@@ -521,7 +521,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyperlocal",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "insta",
  "itertools 0.12.1",
  "jsonpath-rust",
@@ -699,7 +699,7 @@ dependencies = [
  "apollo-compiler",
  "apollo-parser",
  "arbitrary",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "once_cell",
  "thiserror",
 ]
@@ -1882,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.1"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1892,9 +1892,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.1"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1904,11 +1904,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
  "syn 2.0.48",
@@ -2782,7 +2782,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ffccbb6966c05b32ef8fbac435df276c4ae4d3dc55a8cd0eb9745e6c12f546a"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
  "syn 2.0.48",
@@ -3435,7 +3435,7 @@ checksum = "a40f793251171991c4eb75bd84bc640afa8b68ff6907bc89d3b712a22f700506"
 dependencies = [
  "graphql-introspection-query",
  "graphql-parser",
- "heck",
+ "heck 0.4.1",
  "lazy_static",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
@@ -3478,7 +3478,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.11",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -3578,6 +3578,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-world"
@@ -3864,9 +3870,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
@@ -4115,9 +4121,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.2.0"
+version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ea04a7c5c055c175f189b6dc6ba036fd62306b58c66c9f6389036c503a3f4"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
 dependencies = [
  "base64 0.21.7",
  "js-sys",
@@ -5274,7 +5280,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "serde",
  "serde_derive",
 ]
@@ -5559,7 +5565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.1",
  "itertools 0.10.5",
  "lazy_static",
  "log",
@@ -6161,9 +6167,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.2.0"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82c0bbc10308ed323529fd3c1dce8badda635aa319a5ff0e6466f33b8101e3f"
+checksum = "19549741604902eb99a7ed0ee177a0663ee1eda51a29f71401f166e47e77806a"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -6172,9 +6178,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.2.0"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6227c01b1783cdfee1bcf844eb44594cd16ec71c35305bf1c9fb5aade2735e16"
+checksum = "cb9f96e283ec64401f30d3df8ee2aaeb2561f34c824381efa24a35f79bf40ee4"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
@@ -6185,9 +6191,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.2.0"
+version = "8.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cb0a25bfbb2d4b4402179c2cf030387d9990857ce08a32592c6238db9fa8665"
+checksum = "38c74a686185620830701348de757fd36bef4aa9680fd23c49fc539ddcc1af32"
 dependencies = [
  "globset",
  "sha2",
@@ -6493,7 +6499,7 @@ version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -6507,7 +6513,7 @@ checksum = "0ecd92a088fb2500b2f146c9ddc5da9950bb7264d3f00932cd2a6fb369c26c46"
 dependencies = [
  "ahash",
  "bytes",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "jsonpath-rust",
  "regex",
  "serde",
@@ -6856,7 +6862,7 @@ version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
  "rustversion",
@@ -6869,7 +6875,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a3417fc93d76740d974a01654a09777cb500428cc874ca9f45edfe0c4d4cd18"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
  "rustversion",
@@ -6972,9 +6978,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand 2.0.1",
@@ -7077,18 +7083,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
@@ -7366,7 +7372,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow",
 ]
@@ -7377,7 +7383,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,6 @@ serde_json = { version = "1.0.114", features = [
 ] }
 serde_json_bytes = { version = "0.2.4", features = ["preserve_order"] }
 sha1 = "0.10.6"
-tempfile = "3.10.0"
+tempfile = "3.10.1"
 tokio = { version = "1.36.0", features = ["full"] }
 tower = { version = "0.4.13", features = ["full"] }

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -15,7 +15,7 @@ time = { version = "0.3.34", default-features = false, features = [
     "local-offset",
 ] }
 derive_more = "0.99.17"
-indexmap = "2.2.3"
+indexmap = "2.2.6"
 itertools = "0.13.0"
 lazy_static = "1.4.0"
 multimap = "0.10.0"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -66,7 +66,7 @@ features = ["docs_rs"]
 [dependencies]
 askama = "0.12.1"
 access-json = "0.1.0"
-anyhow = "1.0.80"
+anyhow = "1.0.86"
 apollo-compiler.workspace = true
 apollo-federation = { path = "../apollo-federation", version = "=1.50.0" }
 arc-swap = "1.6.0"
@@ -83,7 +83,7 @@ base64 = "0.21.7"
 bloomfilter = "1.0.13"
 buildstructor = "0.5.4"
 bytes = "1.6.0"
-clap = { version = "4.5.1", default-features = false, features = [
+clap = { version = "4.5.8", default-features = false, features = [
     "env",
     "derive",
     "std",
@@ -115,12 +115,12 @@ humantime = "2.1.0"
 humantime-serde = "1.1.1"
 hyper = { version = "0.14.28", features = ["server", "client", "stream"] }
 hyper-rustls = { version = "0.24.2", features = ["http1", "http2"] }
-indexmap = { version = "2.2.3", features = ["serde"] }
+indexmap = { version = "2.2.6", features = ["serde"] }
 itertools = "0.12.1"
 jsonpath_lib = "0.3.0"
 jsonpath-rust = "0.3.5"
 jsonschema = { version = "0.17.1", default-features = false }
-jsonwebtoken = "9.2.0"
+jsonwebtoken = "9.3.0"
 lazy_static = "1.4.0"
 libc = "0.2.153"
 linkme = "0.3.23"
@@ -193,7 +193,7 @@ reqwest.workspace = true
 # note: this dependency should _always_ be pinned, prefix the version with an `=`
 router-bridge = "=0.5.27+v2.8.1"
 
-rust-embed = { version = "8.2.0", features = ["include-exclude"] }
+rust-embed = { version = "8.4.0", features = ["include-exclude"] }
 rustls = "0.21.11"
 rustls-native-certs = "0.6.3"
 rustls-pemfile = "1.0.4"
@@ -210,7 +210,7 @@ serde_yaml = "0.8.26"
 static_assertions = "1.1.0"
 strum_macros = "0.25.3"
 sys-info = "0.9.1"
-thiserror = "1.0.57"
+thiserror = "1.0.61"
 tokio.workspace = true
 tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
 tokio-util = { version = "0.7.10", features = ["net", "codec", "time"] }


### PR DESCRIPTION
This bumps the versions of some minor and patch versions of packages which
are currently queued up in the (now) monolithic https://github.com/apollographql/router/pull/4786.

Chipping away at these is still important week to week.

This PR contains the following updates (largely copied from the other PR):

| Package | Change | Age | Adoption | Passing | Confidence | Type | Update |
|---|---|---|---|---|---|---|---|
| [anyhow](https://togithub.com/dtolnay/anyhow) | `1.0.80` -> `1.0.86` | [![age](https://developer.mend.io/api/mc/badges/age/crate/anyhow/1.0.81?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/anyhow/1.0.86?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/anyhow/1.0.80/1.0.86?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/anyhow/1.0.80/1.0.86?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dependencies | patch |
| [clap](https://togithub.com/clap-rs/clap) | `4.5.1` -> `4.5.8` | [![age](https://developer.mend.io/api/mc/badges/age/crate/clap/4.5.8?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/clap/4.5.3?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/clap/4.5.1/4.5.8?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/clap/4.5.1/4.5.8?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dependencies | patch |
| [jsonwebtoken](https://togithub.com/Keats/jsonwebtoken) | `9.2.0` -> `9.3.0` | [![age](https://developer.mend.io/api/mc/badges/age/crate/jsonwebtoken/9.3.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/jsonwebtoken/9.3.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/jsonwebtoken/9.2.0/9.3.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/jsonwebtoken/9.2.0/9.3.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dependencies | minor |
| [rust-embed](https://togithub.com/pyros2097/rust-embed) | `8.2.0` -> `8.4.0` | [![age](https://developer.mend.io/api/mc/badges/age/crate/rust-embed/8.4.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/rust-embed/8.4.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/rust-embed/8.2.0/8.4.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/rust-embed/8.2.0/8.4.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dependencies | minor |
| [tempfile](https://stebalien.com/projects/tempfile-rs/) ([source](https://togithub.com/Stebalien/tempfile)) | `3.10.0` -> `3.10.1` | [![age](https://developer.mend.io/api/mc/badges/age/crate/tempfile/3.10.1?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/tempfile/3.10.1?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/tempfile/3.10.0/3.10.1?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/tempfile/3.10.0/3.10.1?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dev-dependencies | patch |
| [thiserror](https://togithub.com/dtolnay/thiserror) | `1.0.57` -> `1.0.58` | [![age](https://developer.mend.io/api/mc/badges/age/crate/thiserror/1.0.58?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/thiserror/1.0.58?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/thiserror/1.0.57/1.0.58?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/thiserror/1.0.57/1.0.58?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dependencies | patch |

---

### Release Notes

<details>
<summary>dtolnay/anyhow (anyhow)</summary>

### [`v1.0.81`](https://togithub.com/dtolnay/anyhow/releases/tag/1.0.81)

[Compare Source](https://togithub.com/dtolnay/anyhow/compare/1.0.80...1.0.81)

-   Make backtrace support available when using -Dwarnings ([#&#8203;354](https://togithub.com/dtolnay/anyhow/issues/354))

</details>

<details>
<summary>clap-rs/clap (clap)</summary>

### [`v4.5.3`](https://togithub.com/clap-rs/clap/blob/HEAD/CHANGELOG.md#453---2024-03-15)

[Compare Source](https://togithub.com/clap-rs/clap/compare/v4.5.2...v4.5.3)

##### Internal

-   *(derive)* Update `heck`

### [`v4.5.2`](https://togithub.com/clap-rs/clap/blob/HEAD/CHANGELOG.md#452---2024-03-06)

[Compare Source](https://togithub.com/clap-rs/clap/compare/v4.5.1...v4.5.2)

##### Fixes

-   *(macros)* Silence a warning

</details>

<details>
<summary>Keats/jsonwebtoken (jsonwebtoken)</summary>

### [`v9.3.0`](https://togithub.com/Keats/jsonwebtoken/blob/HEAD/CHANGELOG.md#930-2024-03-12)

[Compare Source](https://togithub.com/Keats/jsonwebtoken/compare/v9.2.0...v9.3.0)

-   Add `Validation.reject_tokens_expiring_in_less_than`, the opposite of leeway

</details>

<details>
<summary>pyros2097/rust-embed (rust-embed)</summary>

### [`v8.3.0`](https://togithub.com/pyros2097/rust-embed/blob/HEAD/changelog.md#830---2024-02-26)

-   Fix symbolic links in debug builds [#&#8203;235](https://togithub.com/pyrossh/rust-embed/pull/235/files). Thanks to [Buckram123](https://togithub.com/Buckram123)

</details>

<details>
<summary>Stebalien/tempfile (tempfile)</summary>

### [`v3.10.1`](https://togithub.com/Stebalien/tempfile/blob/HEAD/CHANGELOG.md#3101)

[Compare Source](https://togithub.com/Stebalien/tempfile/compare/v3.10.0...v3.10.1)

-   Handle potential integer overflows in 32-bit systems when seeking/truncating "spooled" temporary files past 4GiB (2³²).
-   Handle a theoretical 32-bit overflow when generating a temporary file name larger than 4GiB. Now it'll panic (on allocation failure) rather than silently succeeding due to wraparound.

Thanks to [@&#8203;stoeckmann](https://togithub.com/stoeckmann) for finding and fixing both of these issues.

</details>

<details>
<summary>dtolnay/thiserror (thiserror)</summary>

### [`v1.0.58`](https://togithub.com/dtolnay/thiserror/releases/tag/1.0.58)

[Compare Source](https://togithub.com/dtolnay/thiserror/compare/1.0.57...1.0.58)

-   Make backtrace support available when using -Dwarnings ([#&#8203;292](https://togithub.com/dtolnay/thiserror/issues/292))

</details>
