### PR TITLE
chore(deps): collection of minor and patch version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,7 +487,7 @@ dependencies = [
  "base64 0.21.7",
  "basic-toml",
  "bloomfilter",
- "brotli 3.4.0",
+ "brotli 3.5.0",
  "buildstructor",
  "bytes",
  "bytesize",
@@ -562,8 +562,8 @@ dependencies = [
  "paste",
  "pin-project-lite",
  "prometheus",
- "prost 0.12.3",
- "prost-types 0.12.3",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "proteus",
  "rand 0.8.5",
  "rand_core 0.6.4",
@@ -577,7 +577,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pemfile",
  "schemars",
- "semver 1.0.22",
+ "semver 1.0.23",
  "serde",
  "serde_derive_default",
  "serde_json",
@@ -833,7 +833,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c"
 dependencies = [
- "brotli 3.4.0",
+ "brotli 3.5.0",
  "flate2",
  "futures-core",
  "memchr",
@@ -1557,9 +1557,9 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "basic-toml"
-version = "0.1.4"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bfc506e7a2370ec239e1d072507b2a80c833083699d3c6fa176fbb4de8448c6"
+checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
 dependencies = [
  "serde",
 ]
@@ -1629,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516074a47ef4bce09577a3b379392300159ce5b1ba2e501ff1c819950066100f"
+checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1809,7 +1809,7 @@ checksum = "4acbb09d9ee8e23699b9634375c72795d095bf268439da88562cf9b501f181fa"
 dependencies = [
  "camino",
  "cargo-platform",
- "semver 1.0.22",
+ "semver 1.0.23",
  "serde",
  "serde_json",
 ]
@@ -1997,8 +1997,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd326812b3fd01da5bb1af7d340d0d555fd3d4b641e7f1dfcf5962a902952787"
 dependencies = [
  "futures-core",
- "prost 0.12.3",
- "prost-types 0.12.3",
+ "prost 0.12.6",
+ "prost-types 0.12.6",
  "tonic 0.10.2",
  "tracing-core",
 ]
@@ -2015,7 +2015,7 @@ dependencies = [
  "futures-task",
  "hdrhistogram",
  "humantime",
- "prost-types 0.12.3",
+ "prost-types 0.12.6",
  "serde",
  "serde_json",
  "thread_local",
@@ -3005,9 +3005,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "libz-ng-sys",
@@ -3127,7 +3127,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-webpki",
- "semver 1.0.22",
+ "semver 1.0.23",
  "socket2 0.5.5",
  "tokio",
  "tokio-rustls",
@@ -4018,15 +4018,6 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -4212,9 +4203,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -4263,9 +4254,9 @@ dependencies = [
 
 [[package]]
 name = "libtest-mimic"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fefdf21230d6143476a28adbee3d930e2b68a3d56443c777cae3fe9340eebff9"
+checksum = "cc0bda45ed5b3a2904262c1bb91e526127aa70e7ef3758aba2ef93cf896b9b58"
 dependencies = [
  "clap",
  "escape8259",
@@ -4306,18 +4297,18 @@ dependencies = [
 
 [[package]]
 name = "linkme"
-version = "0.3.23"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a78816ac097580aa7fd9d2e9cc7395dda34367c07267a8657516d4ad5e2e3d3"
+checksum = "ccb76662d78edc9f9bf56360d6919bdacc8b7761227727e5082f128eeb90bbf5"
 dependencies = [
  "linkme-impl",
 ]
 
 [[package]]
 name = "linkme-impl"
-version = "0.3.23"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee9023a564f8bf7fe3da285a50c3e70de0df3e2bf277ff7c4e76d66008ef93b0"
+checksum = "f8dccda732e04fa3baf2e17cf835bfe2601c7c2edafd64417c627dabae3a8cda"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
@@ -4375,9 +4366,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2c024b41519440580066ba82aab04092b333e09066a5eb86c7c4890df31f22"
+checksum = "d3262e75e648fce39813cb56ac41f3c3e3f65217ebf3844d818d1f9398cfb0dc"
 dependencies = [
  "hashbrown 0.14.5",
 ]
@@ -4447,9 +4438,9 @@ checksum = "8878cd8d1b3c8c8ae4b2ba0a36652b7cf192f618a599a7fbdfa25cffd4ea72dd"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
@@ -5004,7 +4995,7 @@ dependencies = [
  "hex",
  "opentelemetry 0.22.0",
  "opentelemetry_sdk 0.22.1",
- "prost 0.12.3",
+ "prost 0.12.6",
  "serde",
  "tonic 0.11.0",
 ]
@@ -5200,9 +5191,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
@@ -5307,9 +5298,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -5550,12 +5541,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive 0.12.3",
+ "prost-derive 0.12.6",
 ]
 
 [[package]]
@@ -5595,12 +5586,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.12.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.11.0",
+ "itertools 0.12.1",
  "proc-macro2 1.0.76",
  "quote 1.0.35",
  "syn 2.0.48",
@@ -5617,11 +5608,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.12.3"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
 dependencies = [
- "prost 0.12.3",
+ "prost 0.12.6",
 ]
 
 [[package]]
@@ -5842,9 +5833,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5892,9 +5883,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "async-compression",
  "base64 0.21.7",
@@ -6227,7 +6218,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.22",
+ "semver 1.0.23",
 ]
 
 [[package]]
@@ -6259,9 +6250,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.11"
+version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
  "log",
  "ring 0.17.5",
@@ -6319,6 +6310,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "scc"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ad2bbb0ae5100a07b7a6f2ed7ab5fd0045551a4c507989b7a620046ea3efdc"
+dependencies = [
+ "sdd",
 ]
 
 [[package]]
@@ -6381,6 +6381,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sdd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6428,9 +6434,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 dependencies = [
  "serde",
 ]
@@ -6592,23 +6598,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ad9342b3aaca7cb43c45c097dd008d4907070394bd0751a0aa8817e5a018d"
+checksum = "4b4b487fe2acf240a021cf57c6b2b4903b1e78ca0ecd862a71b71d2a51fed77d"
 dependencies = [
- "dashmap",
  "futures",
- "lazy_static",
  "log",
+ "once_cell",
  "parking_lot",
+ "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.0.0"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93fb4adc70021ac1b47f7d45e8cc4169baaa7ea58483bc5b721d19a26202212"
+checksum = "82fe9db325bcef1fbcde82e078a5cc4efdf787e96b3b9cf45b50b529f2083d67"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
@@ -7015,9 +7021,9 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "test-log"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6159ab4116165c99fc88cce31f99fa2c9dbe08d3691cb38da02fc3b45f357d2b"
+checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
 dependencies = [
  "test-log-macros",
  "tracing-subscriber",
@@ -7025,9 +7031,9 @@ dependencies = [
 
 [[package]]
 name = "test-log-macros"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba277e77219e9eea169e8508942db1bf5d8a41ff2db9b20aab5a5aadc9fa25d"
+checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
@@ -7174,9 +7180,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -7197,9 +7203,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7292,9 +7298,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+checksum = "267ac89e0bec6e691e5813911606935d77c476ff49024f98abcea3e7b15e37af"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -7332,9 +7338,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
@@ -7342,7 +7348,6 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -7441,7 +7446,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost 0.12.3",
+ "prost 0.12.6",
  "tokio",
  "tokio-stream",
  "tower",
@@ -7463,7 +7468,7 @@ dependencies = [
  "http-body",
  "percent-encoding",
  "pin-project",
- "prost 0.12.3",
+ "prost 0.12.6",
  "tokio",
  "tokio-stream",
  "tower-layer",
@@ -7555,11 +7560,10 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -7568,9 +7572,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2 1.0.76",
  "quote 1.0.35",
@@ -7579,9 +7583,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -7959,9 +7963,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna 0.5.0",
@@ -8002,9 +8006,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 dependencies = [
  "getrandom 0.2.10",
  "serde",
@@ -8540,29 +8544,28 @@ checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
 
 [[package]]
 name = "zstd"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.8+zstd.1.5.5"
+version = "2.0.11+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
+checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -103,7 +103,7 @@ dhat = { version = "0.3.3", optional = true }
 diff = "0.1.13"
 directories = "5.0.1"
 displaydoc = "0.2"
-flate2 = "1.0.28"
+flate2 = "1.0.30"
 fred = { version = "7.1.2", features = ["enable-rustls"] }
 futures = { version = "0.3.30", features = ["thread-pool"] }
 graphql_client = "0.13.0"
@@ -122,9 +122,9 @@ jsonpath-rust = "0.3.5"
 jsonschema = { version = "0.17.1", default-features = false }
 jsonwebtoken = "9.3.0"
 lazy_static = "1.4.0"
-libc = "0.2.153"
-linkme = "0.3.23"
-lru = "0.12.2"
+libc = "0.2.155"
+linkme = "0.3.27"
+lru = "0.12.3"
 maplit = "1.0.2"
 mediatype = "0.19.18"
 mockall = "0.11.4"
@@ -179,28 +179,28 @@ opentelemetry-zipkin = { version = "0.18.0", default-features = false, features 
     "reqwest-rustls",
 ] }
 opentelemetry-prometheus = "0.13.0"
-paste = "1.0.14"
-pin-project-lite = "0.2.13"
+paste = "1.0.15"
+pin-project-lite = "0.2.14"
 prometheus = "0.13"
-prost = "0.12.3"
-prost-types = "0.12.3"
+prost = "0.12.6"
+prost-types = "0.12.6"
 proteus = "0.5.0"
 rand = "0.8.5"
 rhai = { version = "=1.17.1", features = ["sync", "serde", "internals"] }
-regex = "1.10.3"
+regex = "1.10.5"
 reqwest.workspace = true
 
 # note: this dependency should _always_ be pinned, prefix the version with an `=`
 router-bridge = "=0.5.27+v2.8.1"
 
 rust-embed = { version = "8.4.0", features = ["include-exclude"] }
-rustls = "0.21.11"
+rustls = "0.21.12"
 rustls-native-certs = "0.6.3"
 rustls-pemfile = "1.0.4"
 schemars.workspace = true
 shellexpand = "3.1.0"
 sha2 = "0.10.8"
-semver = "1.0.22"
+semver = "1.0.23"
 serde.workspace = true
 serde_derive_default = "0.1"
 serde_json_bytes.workspace = true
@@ -212,8 +212,8 @@ strum_macros = "0.25.3"
 sys-info = "0.9.1"
 thiserror = "1.0.61"
 tokio.workspace = true
-tokio-stream = { version = "0.1.14", features = ["sync", "net"] }
-tokio-util = { version = "0.7.10", features = ["net", "codec", "time"] }
+tokio-stream = { version = "0.1.15", features = ["sync", "net"] }
+tokio-util = { version = "0.7.11", features = ["net", "codec", "time"] }
 tonic = { version = "0.9.2", features = [
     "transport",
     "tls",
@@ -234,14 +234,14 @@ tower-http = { version = "0.4.4", features = [
     "timeout",
 ] }
 tower-service = "0.3.2"
-tracing = "0.1.37"
-tracing-core = "0.1.31"
+tracing = "0.1.40"
+tracing-core = "0.1.32"
 tracing-futures = { version = "0.2.5", features = ["futures-03"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 trust-dns-resolver = "0.23.2"
-url = { version = "2.5.0", features = ["serde"] }
+url = { version = "2.5.2", features = ["serde"] }
 urlencoding = "2.1.3"
-uuid = { version = "1.7.0", features = ["serde", "v4"] }
+uuid = { version = "1.9.1", features = ["serde", "v4"] }
 yaml-rust = "0.4.5"
 wiremock = "0.5.22"
 wsl = "0.1.0"
@@ -251,11 +251,11 @@ tokio-tungstenite = { version = "0.20.1", features = [
 tokio-rustls = "0.24.1"
 http-serde = "1.1.3"
 hmac = "0.12.1"
-parking_lot = { version = "0.12.1", features = ["serde"] }
-memchr = "2.7.1"
-brotli = "3.4.0"
-zstd = "0.13.0"
-zstd-safe = "7.0.0"
+parking_lot = { version = "0.12.3", features = ["serde"] }
+memchr = "2.7.4"
+brotli = "3.5.0"
+zstd = "0.13.1"
+zstd-safe = "7.1.0"
 # note: AWS dependencies should always use the same version
 aws-sigv4 = "1.1.6"
 aws-credential-types = "1.1.6"
@@ -264,8 +264,8 @@ aws-types = "1.1.6"
 aws-smithy-runtime-api = { version = "1.1.6", features = ["client"] }
 sha1.workspace = true
 tracing-serde = "0.1.3"
-time = { version = "0.3.34", features = ["serde"] }
-similar = { version = "2.4.0", features = ["inline"] }
+time = { version = "0.3.36", features = ["serde"] }
+similar = { version = "2.5.0", features = ["inline"] }
 console = "0.15.8"
 bytesize = { version = "1.3.0", features = ["serde"] }
 
@@ -279,7 +279,7 @@ hyperlocal = { version = "0.8.0", default-features = false, features = [
 ] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-tikv-jemallocator = "0.5"
+tikv-jemallocator = "0.5.4"
 
 [dev-dependencies]
 axum = { version = "0.6.20", features = [
@@ -293,9 +293,9 @@ fred = { version = "7.1.2", features = ["enable-rustls", "mocks"] }
 futures-test = "0.3.30"
 insta.workspace = true
 maplit = "1.0.2"
-memchr = { version = "2.7.1", default-features = false }
+memchr = { version = "2.7.4", default-features = false }
 mockall = "0.11.4"
-num-traits = "0.2.18"
+num-traits = "0.2.19"
 once_cell.workspace = true
 opentelemetry-stdout = { version = "0.1.0", features = ["trace"] }
 opentelemetry = { version = "0.20.0", features = ["testing"] }
@@ -307,7 +307,7 @@ opentelemetry-proto = { version = "0.5.0", features = [
 ] }
 p256 = "0.13.2"
 rand_core = "0.6.4"
-reqwest = { version = "0.11.24", default-features = false, features = [
+reqwest = { version = "0.11.27", default-features = false, features = [
     "json",
     "multipart",
     "stream",
@@ -318,26 +318,26 @@ rhai = { version = "1.17.1", features = [
     "internals",
     "testing-environ",
 ] }
-serial_test = { version = "3.0.0" }
+serial_test = { version = "3.1.1" }
 tempfile.workspace = true
-test-log = { version = "0.2.14", default-features = false, features = [
+test-log = { version = "0.2.16", default-features = false, features = [
     "trace",
 ] }
-test-span = "0.7"
-basic-toml = "0.1"
+test-span = "0.7.0"
+basic-toml = "0.1.9"
 tower-test = "0.4.0"
 
 # See note above in this file about `^tracing` packages which also applies to
 # these dev dependencies.
-tracing-subscriber = { version = "0.3", default-features = false, features = [
+tracing-subscriber = { version = "0.3.18", default-features = false, features = [
     "env-filter",
     "fmt",
 ] }
 tracing-opentelemetry = "0.21.0"
 tracing-test = "0.2.5"
-walkdir = "2.4.0"
+walkdir = "2.5.0"
 wiremock = "0.5.22"
-libtest-mimic = "0.7.2"
+libtest-mimic = "0.7.3"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 rstack = { version = "0.3.3", features = ["dw"], default-features = false }
@@ -350,7 +350,7 @@ hyperlocal = { version = "0.8.0", default-features = false, features = [
 
 [build-dependencies]
 tonic-build = "0.9.2"
-basic-toml = "0.1"
+basic-toml = "0.1.9"
 serde_json.workspace = true
 
 [[test]]


### PR DESCRIPTION
Changelogs are accessible within, but interdispersed between:

- https://github.com/apollographql/router/pull/3628
- https://github.com/apollographql/router/pull/4786

basic-toml = "0.1.9"
brotli = "3.5.0"
flate2 = "1.0.30"
libc = "0.2.155"
libtest-mimic = "0.7.3"
linkme = "0.3.27"
lru = "0.12.3"
memchr = "2.7.4"
num-traits = "0.2.19"
parking_lot = "0.12.3"
paste = "1.0.15"
pin-project-lite = "0.2.14"
prost = "0.12.6"
prost-types = "0.12.6"
regex = "1.10.5"
reqwest = "0.11.27"
rustls = "0.21.12"
semver = "1.0.23"
serial_test = "3.1.1"
similar = "2.5.0"
test-log = "0.2.16"
test-span = "0.7.0"
tikv-jemallocator = "0.5.4"
time = "0.3.36"
tokio-stream = "0.1.15"
tokio-util = "0.7.11"
tracing = "0.1.40"
tracing-core = "0.1.32"
tracing-subscriber = "0.3.18"
url = "2.5.2"
uuid = "1.9.1"
walkdir = "2.5.0"
zstd = "0.13.1"
zstd-safe = "7.1.0"

| Package | Change | Age | Adoption | Passing | Confidence | Type | Update |
|---|---|---|---|---|---|---|---|
| [brotli](https://togithub.com/dropbox/rust-brotli) | `3.4.0` -> `3.5.0` | [![age](https://developer.mend.io/api/mc/badges/age/crate/brotli/3.5.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/brotli/3.5.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/brotli/3.4.0/3.5.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/brotli/3.4.0/3.5.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dependencies | minor |
| [flate2](https://togithub.com/rust-lang/flate2-rs) | `1.0.28` -> `1.0.30` | [![age](https://developer.mend.io/api/mc/badges/age/crate/flate2/1.0.30?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/flate2/1.0.30?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/flate2/1.0.28/1.0.30?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/flate2/1.0.28/1.0.30?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dependencies | patch |
| [memchr](https://togithub.com/BurntSushi/memchr) | `2.7.1` -> `2.7.4` | [![age](https://developer.mend.io/api/mc/badges/age/crate/memchr/2.7.4?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/memchr/2.7.4?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/memchr/2.7.1/2.7.4?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/memchr/2.7.1/2.7.4?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dependencies | patch |
| [paste](https://togithub.com/dtolnay/paste) | `1.0.14` -> `1.0.15` | [![age](https://developer.mend.io/api/mc/badges/age/crate/paste/1.0.15?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/paste/1.0.15?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/paste/1.0.14/1.0.15?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/paste/1.0.14/1.0.15?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dependencies | patch |
| [regex](https://togithub.com/rust-lang/regex) | `1.10.3` -> `1.10.5` | [![age](https://developer.mend.io/api/mc/badges/age/crate/regex/1.10.5?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/regex/1.10.5?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/regex/1.10.3/1.10.5?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/regex/1.10.3/1.10.5?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dependencies | patch |
| [semver](https://togithub.com/dtolnay/semver) | `1.0.22` -> `1.0.23` | [![age](https://developer.mend.io/api/mc/badges/age/crate/semver/1.0.23?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/semver/1.0.23?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/semver/1.0.22/1.0.23?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/semver/1.0.22/1.0.23?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dependencies | patch |
| [serial_test](https://togithub.com/palfrey/serial_test) | `3.0.0` -> `3.1.1` | [![age](https://developer.mend.io/api/mc/badges/age/crate/serial_test/3.1.1?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/serial_test/3.1.1?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/serial_test/3.0.0/3.1.1?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/serial_test/3.0.0/3.1.1?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dev-dependencies | minor |
| [url](https://togithub.com/servo/rust-url) | `2.5.0` -> `2.5.2` | [![age](https://developer.mend.io/api/mc/badges/age/crate/url/2.5.2?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/url/2.5.2?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/url/2.5.0/2.5.2?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/url/2.5.0/2.5.2?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dependencies | patch |
| [uuid](https://togithub.com/uuid-rs/uuid) | `1.7.0` -> `1.9.1` | [![age](https://developer.mend.io/api/mc/badges/age/crate/uuid/1.9.1?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/uuid/1.9.1?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/uuid/1.7.0/1.9.1?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/uuid/1.7.0/1.9.1?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dependencies | minor |
| [walkdir](https://togithub.com/BurntSushi/walkdir) | `2.4.0` -> `2.5.0` | [![age](https://developer.mend.io/api/mc/badges/age/crate/walkdir/2.5.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/walkdir/2.5.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/walkdir/2.4.0/2.5.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/walkdir/2.4.0/2.5.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dependencies | minor |
| [zstd-safe](https://togithub.com/gyscos/zstd-rs) | `7.0.0` -> `7.1.0` | [![age](https://developer.mend.io/api/mc/badges/age/crate/zstd-safe/7.1.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![adoption](https://developer.mend.io/api/mc/badges/adoption/crate/zstd-safe/7.1.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![passing](https://developer.mend.io/api/mc/badges/compatibility/crate/zstd-safe/7.0.0/7.1.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | [![confidence](https://developer.mend.io/api/mc/badges/confidence/crate/zstd-safe/7.0.0/7.1.0?slim=true)](https://docs.renovatebot.com/merge-confidence/) | dependencies | minor |

Plus...

| Package | Type | Update | Change |
|---|---|---|---|
| [reqwest](https://togithub.com/seanmonstar/reqwest) | dev-dependencies | minor | `0.11.24` -> `0.11.27` |
| [rustls](https://togithub.com/rustls/rustls) | dependencies | minor | `0.21.11` -> `0.21.12` |
