### PR TITLE
Add request bodies to Connectors HTTP requests

### DIFF
--- a/apollo-federation/src/sources/connect/models/mod.rs
+++ b/apollo-federation/src/sources/connect/models/mod.rs
@@ -98,15 +98,17 @@ impl Connector {
 
                 let parent_type_name = args.position.field.type_name().clone();
                 let schema_def = &schema.schema().schema_definition;
-                let on_root_type = schema_def
+                let on_query = schema_def
                     .query
                     .as_ref()
                     .map(|ty| ty.name == parent_type_name)
-                    .or(schema_def
-                        .mutation
-                        .as_ref()
-                        .map(|ty| ty.name == parent_type_name))
                     .unwrap_or(false);
+                let on_mutation = schema_def
+                    .mutation
+                    .as_ref()
+                    .map(|ty| ty.name == parent_type_name)
+                    .unwrap_or(false);
+                let on_root_type = on_query || on_mutation;
 
                 let id = ConnectId {
                     label: make_label(subgraph_name, &source_name, &transport),

--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -139,13 +139,9 @@ fn request_params_to_requests(
     for (response_key, inputs) in request_params {
         let request = match connector.transport {
             apollo_federation::sources::connect::Transport::HttpJson(ref transport) => {
-                make_request(transport, inputs.merge(), original_request)?
+                make_request(transport, inputs.merge(), original_request, debug)?
             }
         };
-
-        if let Some(ref mut debug) = debug {
-            debug.push_request(&request);
-        }
 
         results.push((request, response_key));
     }

--- a/apollo-router/src/plugins/connectors/testdata/mutation.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/mutation.graphql
@@ -1,0 +1,66 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "json", http: {baseURL: "https://jsonplaceholder.typicode.com/"}})
+{
+  query: Query
+  mutation: Mutation
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+enum join__Graph {
+  CONNECTORS @join__graph(name: "connectors", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Mutation
+  @join__type(graph: CONNECTORS)
+{
+  createUser(name: String!): User @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {POST: "/user", body: "username: $args.name"}, selection: "id\nname: username"})
+}
+
+type Query
+  @join__type(graph: CONNECTORS)
+{
+  users: [User] @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users"}, selection: "id name"})
+}
+
+type User
+  @join__type(graph: CONNECTORS)
+{
+  id: ID!
+  name: String
+}

--- a/apollo-router/src/plugins/connectors/testdata/mutation.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/mutation.yaml
@@ -1,0 +1,46 @@
+# rover supergraph compose --config apollo-router/src/plugins/connectors/testdata/mutation.yaml > apollo-router/src/plugins/connectors/testdata/mutation.graphql
+federation_version: =2.9.0-connectors.0
+subgraphs:
+  connectors:
+    routing_url: none
+    schema:
+      sdl: |
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.7")
+          @link(
+            url: "https://specs.apollo.dev/connect/v0.1"
+            import: ["@connect", "@source"]
+          )
+          @source(
+            name: "json"
+            http: {
+              baseURL: "https://jsonplaceholder.typicode.com/"
+            }
+          )
+
+        type User {
+          id: ID!
+          name: String
+        }
+
+        type Query {
+          users: [User]
+            @connect(source: "json", http: { GET: "/users" }, selection: "id name")
+        }
+
+        type Mutation {
+          createUser(name: String!): User
+            @connect(
+              source: "json"
+              http: {
+                POST: "/user"
+                body: """
+                  username: $$args.name
+                """
+              }
+              selection: """
+                id
+                name: username
+              """
+            )
+        }


### PR DESCRIPTION

* Add request bodies to Connectors HTTP requests
* Add request body to debug extension data
* Refactor Connectors debug extension data so selection is part of associated request or response data
* Add test for mutation using a Connector
* Fix a bug in boolean logic to determine if a Connector is on a root type, which caused it to fail for mutation operations

<!-- [CNN-296] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

**Notes**

With these changes, it's now possible to execute mutations against REST APIs using Connectors, and to see the request body and selection in the debug output:

```json
"body": {
  "kind": "json",
  "content": {
    "title": "test issue 12"
  },
  "selection": {
    "source": "{\n  title: $args.title\n}",
    "result": {
      "title": "test issue 12"
   },
  "errors": []
  }
}
```

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
