### PR TITLE
fix(federation): remove temporary string allocations from position `try_from()` errors

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -3436,8 +3436,10 @@ impl FieldSelection {
         // Operation creation and the creation of the ValidFederationSchema, it's safer to just
         // confirm it exists in this schema.
         field_position.get(schema.schema())?;
-        let field_composite_type_result: Result<CompositeTypeDefinitionPosition, FederationError> =
-            schema.get_type(field.selection_set.ty.clone())?.try_into();
+        let is_composite = CompositeTypeDefinitionPosition::try_from(
+            schema.get_type(field.selection_set.ty.clone())?,
+        )
+        .is_ok();
 
         Ok(Some(FieldSelection {
             field: Field::new(FieldData {
@@ -3448,7 +3450,7 @@ impl FieldSelection {
                 directives: Arc::new(field.directives.clone()),
                 sibling_typename: None,
             }),
-            selection_set: if field_composite_type_result.is_ok() {
+            selection_set: if is_composite {
                 Some(SelectionSet::from_selection_set(
                     &field.selection_set,
                     fragments,

--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -546,9 +546,10 @@ impl InlineFragmentData {
         };
         match schema
             .get_type(ty.type_name().clone())
-            .and_then(CompositeTypeDefinitionPosition::try_from)
+            .ok()
+            .and_then(|ty| CompositeTypeDefinitionPosition::try_from(ty).ok())
         {
-            Ok(ty) if runtime_types_intersect(parent_type, &ty, schema) => (true, Some(ty)),
+            Some(ty) if runtime_types_intersect(parent_type, &ty, schema) => (true, Some(ty)),
             _ => (false, None),
         }
     }
@@ -798,9 +799,10 @@ impl NamedFragments {
     ) -> Result<NamedFragments, FederationError> {
         let mut rebased_fragments = NamedFragments::default();
         for fragment in self.fragments.values() {
-            if let Ok(rebased_type) = schema
+            if let Some(rebased_type) = schema
                 .get_type(fragment.type_condition_position.type_name().clone())
-                .and_then(CompositeTypeDefinitionPosition::try_from)
+                .ok()
+                .and_then(|ty| CompositeTypeDefinitionPosition::try_from(ty).ok())
             {
                 if let Ok(mut rebased_selection) = fragment.selection_set.rebase_inner(
                     &rebased_type,

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -108,7 +108,7 @@ impl TryFrom<QueryGraphNodeType> for CompositeTypeDefinitionPosition {
 
     fn try_from(value: QueryGraphNodeType) -> Result<Self, Self::Error> {
         match value {
-            QueryGraphNodeType::SchemaType(ty) => ty.try_into(),
+            QueryGraphNodeType::SchemaType(ty) => Ok(ty.try_into()?),
             QueryGraphNodeType::FederatedRootType(_) => Err(FederationError::internal(format!(
                 r#"Type "{value}" was unexpectedly not a composite type"#
             ))),
@@ -121,7 +121,7 @@ impl TryFrom<QueryGraphNodeType> for ObjectTypeDefinitionPosition {
 
     fn try_from(value: QueryGraphNodeType) -> Result<Self, Self::Error> {
         match value {
-            QueryGraphNodeType::SchemaType(ty) => ty.try_into(),
+            QueryGraphNodeType::SchemaType(ty) => Ok(ty.try_into()?),
             QueryGraphNodeType::FederatedRootType(_) => Err(FederationError::internal(format!(
                 r#"Type "{value}" was unexpectedly not an object type"#
             ))),

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -886,9 +886,10 @@ impl FetchDependencyGraph {
         &self,
         type_name: &Name,
     ) -> Result<CompositeTypeDefinitionPosition, FederationError> {
-        self.supergraph_schema
+        Ok(self
+            .supergraph_schema
             .get_type(type_name.clone())?
-            .try_into()
+            .try_into()?)
     }
 
     /// Find redundant edges coming out of a node. See `remove_redundant_edges`.
@@ -3564,8 +3565,8 @@ fn create_fetch_initial_path(
     // supergraph). Doing this make sure we can rely on things like checking subtyping between
     // the types of a given path.
     let rebased_type: CompositeTypeDefinitionPosition = supergraph_schema
-        .get_type(dest_type.type_name().clone())
-        .and_then(|res| res.try_into())?;
+        .get_type(dest_type.type_name().clone())?
+        .try_into()?;
     Ok(Arc::new(wrap_selection_with_type_and_conditions(
         supergraph_schema,
         &rebased_type,

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -78,6 +78,79 @@ impl From<PositionLookupError> for FederationError {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+#[error("Type {actual:?} was unexpectedly not {expected}")]
+pub(crate) struct PositionConvertError<T: Debug + Display> {
+    actual: T,
+    expected: &'static str,
+}
+
+impl<T: Debug + Display> From<PositionConvertError<T>> for FederationError {
+    fn from(value: PositionConvertError<T>) -> Self {
+        FederationError::internal(value.to_string())
+    }
+}
+
+/// fallible_conversions!(TypeDefinition::Scalar -> ScalarTypeDefinition);
+/// fallible_conversions!(TypeDefinition::{Scalar, Enum, InputObject} -> InputObjectTypeDefinition)
+macro_rules! fallible_conversions {
+    ( $from:ident :: $branch:ident -> $to:ident ) => {
+        impl TryFrom<$from> for $to {
+            type Error = PositionConvertError<$from>;
+
+            fn try_from(value: $from) -> Result<Self, Self::Error> {
+                match value {
+                    $from::$branch(value) => Ok(value),
+                    _ => Err(PositionConvertError {
+                        actual: value,
+                        expected: $to::EXPECTED,
+                    }),
+                }
+            }
+        }
+    };
+    ( $from:ident :: { $($branch:ident),+ } -> $to:ident ) => {
+        impl TryFrom<$from> for $to {
+            type Error = PositionConvertError<$from>;
+
+            fn try_from(value: $from) -> Result<Self, Self::Error> {
+                match value {
+                    $(
+                        $from::$branch(value) => Ok($to::$branch(value)),
+                    )+
+                    _ => Err(PositionConvertError {
+                        actual: value,
+                        expected: $to::EXPECTED,
+                    }),
+                }
+            }
+        }
+    }
+}
+
+/// infallible_conversions!(ScalarTypeDefinition -> TypeDefinition::Scalar);
+/// infallible_conversions!(InputObjectTypeDefinition::{Scalar, Enum, InputObject} -> TypeDefinition)
+macro_rules! infallible_conversions {
+    ( $from:ident -> $to:ident :: $branch:ident ) => {
+        impl From<$from> for $to {
+            fn from(value: $from) -> Self {
+                $to::$branch(value)
+            }
+        }
+    };
+    ( $from:ident :: { $($branch:ident),+ } -> $to:ident ) => {
+        impl From<$from> for $to {
+            fn from(value: $from) -> Self {
+                match value {
+                    $(
+                        $from::$branch(value) => $to::$branch(value)
+                    ),+
+                }
+            }
+        }
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Display)]
 pub(crate) enum TypeDefinitionPosition {
     Scalar(ScalarTypeDefinitionPosition),
@@ -155,123 +228,17 @@ impl TypeDefinitionPosition {
     }
 }
 
-impl TryFrom<TypeDefinitionPosition> for ScalarTypeDefinitionPosition {
-    type Error = FederationError;
+fallible_conversions!(TypeDefinitionPosition::Scalar -> ScalarTypeDefinitionPosition);
+fallible_conversions!(TypeDefinitionPosition::Object -> ObjectTypeDefinitionPosition);
+fallible_conversions!(TypeDefinitionPosition::Interface -> InterfaceTypeDefinitionPosition);
+fallible_conversions!(TypeDefinitionPosition::Union -> UnionTypeDefinitionPosition);
+fallible_conversions!(TypeDefinitionPosition::Enum -> EnumTypeDefinitionPosition);
+fallible_conversions!(TypeDefinitionPosition::InputObject -> InputObjectTypeDefinitionPosition);
 
-    fn try_from(value: TypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            TypeDefinitionPosition::Scalar(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not a scalar type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<TypeDefinitionPosition> for ObjectTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: TypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            TypeDefinitionPosition::Object(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an object type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<TypeDefinitionPosition> for InterfaceTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: TypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            TypeDefinitionPosition::Interface(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an interface type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<TypeDefinitionPosition> for UnionTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: TypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            TypeDefinitionPosition::Union(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not a union type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<TypeDefinitionPosition> for EnumTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: TypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            TypeDefinitionPosition::Enum(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an enum type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<TypeDefinitionPosition> for InputObjectTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: TypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            TypeDefinitionPosition::InputObject(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an input object type"#
-            ))),
-        }
-    }
-}
-
-impl From<OutputTypeDefinitionPosition> for TypeDefinitionPosition {
-    fn from(value: OutputTypeDefinitionPosition) -> Self {
-        match value {
-            OutputTypeDefinitionPosition::Scalar(value) => value.into(),
-            OutputTypeDefinitionPosition::Object(value) => value.into(),
-            OutputTypeDefinitionPosition::Interface(value) => value.into(),
-            OutputTypeDefinitionPosition::Union(value) => value.into(),
-            OutputTypeDefinitionPosition::Enum(value) => value.into(),
-        }
-    }
-}
-
-impl From<CompositeTypeDefinitionPosition> for TypeDefinitionPosition {
-    fn from(value: CompositeTypeDefinitionPosition) -> Self {
-        match value {
-            CompositeTypeDefinitionPosition::Object(value) => value.into(),
-            CompositeTypeDefinitionPosition::Interface(value) => value.into(),
-            CompositeTypeDefinitionPosition::Union(value) => value.into(),
-        }
-    }
-}
-
-impl From<AbstractTypeDefinitionPosition> for TypeDefinitionPosition {
-    fn from(value: AbstractTypeDefinitionPosition) -> Self {
-        match value {
-            AbstractTypeDefinitionPosition::Interface(value) => value.into(),
-            AbstractTypeDefinitionPosition::Union(value) => value.into(),
-        }
-    }
-}
-
-impl From<ObjectOrInterfaceTypeDefinitionPosition> for TypeDefinitionPosition {
-    fn from(value: ObjectOrInterfaceTypeDefinitionPosition) -> Self {
-        match value {
-            ObjectOrInterfaceTypeDefinitionPosition::Object(value) => value.into(),
-            ObjectOrInterfaceTypeDefinitionPosition::Interface(value) => value.into(),
-        }
-    }
-}
+infallible_conversions!(OutputTypeDefinitionPosition::{Scalar, Object, Interface, Union, Enum} -> TypeDefinitionPosition);
+infallible_conversions!(CompositeTypeDefinitionPosition::{Object, Interface, Union} -> TypeDefinitionPosition);
+infallible_conversions!(AbstractTypeDefinitionPosition::{Interface, Union} -> TypeDefinitionPosition);
+infallible_conversions!(ObjectOrInterfaceTypeDefinitionPosition::{Object, Interface} -> TypeDefinitionPosition);
 
 #[derive(Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Display)]
 pub(crate) enum OutputTypeDefinitionPosition {
@@ -295,6 +262,8 @@ impl Debug for OutputTypeDefinitionPosition {
 }
 
 impl OutputTypeDefinitionPosition {
+    const EXPECTED: &'static str = "an output type";
+
     pub(crate) fn type_name(&self) -> &Name {
         match self {
             OutputTypeDefinitionPosition::Scalar(type_) => &type_.type_name,
@@ -345,115 +314,16 @@ impl OutputTypeDefinitionPosition {
     }
 }
 
-impl TryFrom<OutputTypeDefinitionPosition> for ScalarTypeDefinitionPosition {
-    type Error = FederationError;
+fallible_conversions!(OutputTypeDefinitionPosition::Scalar -> ScalarTypeDefinitionPosition);
+fallible_conversions!(OutputTypeDefinitionPosition::Object -> ObjectTypeDefinitionPosition);
+fallible_conversions!(OutputTypeDefinitionPosition::Interface -> InterfaceTypeDefinitionPosition);
+fallible_conversions!(OutputTypeDefinitionPosition::Union -> UnionTypeDefinitionPosition);
+fallible_conversions!(OutputTypeDefinitionPosition::Enum -> EnumTypeDefinitionPosition);
+fallible_conversions!(TypeDefinitionPosition::{Scalar, Object, Interface, Enum, Union} -> OutputTypeDefinitionPosition);
 
-    fn try_from(value: OutputTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            OutputTypeDefinitionPosition::Scalar(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not a scalar type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<OutputTypeDefinitionPosition> for ObjectTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: OutputTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            OutputTypeDefinitionPosition::Object(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an object type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<OutputTypeDefinitionPosition> for InterfaceTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: OutputTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            OutputTypeDefinitionPosition::Interface(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an interface type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<OutputTypeDefinitionPosition> for UnionTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: OutputTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            OutputTypeDefinitionPosition::Union(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not a union type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<OutputTypeDefinitionPosition> for EnumTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: OutputTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            OutputTypeDefinitionPosition::Enum(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an enum type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<TypeDefinitionPosition> for OutputTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: TypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            TypeDefinitionPosition::Scalar(value) => Ok(value.into()),
-            TypeDefinitionPosition::Object(value) => Ok(value.into()),
-            TypeDefinitionPosition::Interface(value) => Ok(value.into()),
-            TypeDefinitionPosition::Enum(value) => Ok(value.into()),
-            TypeDefinitionPosition::Union(value) => Ok(value.into()),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an output type"#
-            ))),
-        }
-    }
-}
-
-impl From<CompositeTypeDefinitionPosition> for OutputTypeDefinitionPosition {
-    fn from(value: CompositeTypeDefinitionPosition) -> Self {
-        match value {
-            CompositeTypeDefinitionPosition::Object(value) => value.into(),
-            CompositeTypeDefinitionPosition::Interface(value) => value.into(),
-            CompositeTypeDefinitionPosition::Union(value) => value.into(),
-        }
-    }
-}
-
-impl From<AbstractTypeDefinitionPosition> for OutputTypeDefinitionPosition {
-    fn from(value: AbstractTypeDefinitionPosition) -> Self {
-        match value {
-            AbstractTypeDefinitionPosition::Interface(value) => value.into(),
-            AbstractTypeDefinitionPosition::Union(value) => value.into(),
-        }
-    }
-}
-
-impl From<ObjectOrInterfaceTypeDefinitionPosition> for OutputTypeDefinitionPosition {
-    fn from(value: ObjectOrInterfaceTypeDefinitionPosition) -> Self {
-        match value {
-            ObjectOrInterfaceTypeDefinitionPosition::Object(value) => value.into(),
-            ObjectOrInterfaceTypeDefinitionPosition::Interface(value) => value.into(),
-        }
-    }
-}
+infallible_conversions!(CompositeTypeDefinitionPosition::{Object, Interface, Union} -> OutputTypeDefinitionPosition);
+infallible_conversions!(AbstractTypeDefinitionPosition::{Interface, Union} -> OutputTypeDefinitionPosition);
+infallible_conversions!(ObjectOrInterfaceTypeDefinitionPosition::{Object, Interface} -> OutputTypeDefinitionPosition);
 
 #[derive(Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Display)]
 pub(crate) enum CompositeTypeDefinitionPosition {
@@ -473,6 +343,8 @@ impl Debug for CompositeTypeDefinitionPosition {
 }
 
 impl CompositeTypeDefinitionPosition {
+    const EXPECTED: &'static str = "a composite type";
+
     pub(crate) fn is_object_type(&self) -> bool {
         matches!(self, CompositeTypeDefinitionPosition::Object(_))
     }
@@ -569,92 +441,14 @@ impl CompositeTypeDefinitionPosition {
     }
 }
 
-impl TryFrom<CompositeTypeDefinitionPosition> for ObjectTypeDefinitionPosition {
-    type Error = FederationError;
+fallible_conversions!(CompositeTypeDefinitionPosition::Object -> ObjectTypeDefinitionPosition);
+fallible_conversions!(CompositeTypeDefinitionPosition::Interface -> InterfaceTypeDefinitionPosition);
+fallible_conversions!(CompositeTypeDefinitionPosition::Union -> UnionTypeDefinitionPosition);
 
-    fn try_from(value: CompositeTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            CompositeTypeDefinitionPosition::Object(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an object type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<CompositeTypeDefinitionPosition> for InterfaceTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: CompositeTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            CompositeTypeDefinitionPosition::Interface(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an interface type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<CompositeTypeDefinitionPosition> for UnionTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: CompositeTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            CompositeTypeDefinitionPosition::Union(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not a union type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<TypeDefinitionPosition> for CompositeTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: TypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            TypeDefinitionPosition::Object(value) => Ok(value.into()),
-            TypeDefinitionPosition::Interface(value) => Ok(value.into()),
-            TypeDefinitionPosition::Union(value) => Ok(value.into()),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not a composite type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<OutputTypeDefinitionPosition> for CompositeTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: OutputTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            OutputTypeDefinitionPosition::Object(value) => Ok(value.into()),
-            OutputTypeDefinitionPosition::Interface(value) => Ok(value.into()),
-            OutputTypeDefinitionPosition::Union(value) => Ok(value.into()),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not a composite type"#
-            ))),
-        }
-    }
-}
-
-impl From<AbstractTypeDefinitionPosition> for CompositeTypeDefinitionPosition {
-    fn from(value: AbstractTypeDefinitionPosition) -> Self {
-        match value {
-            AbstractTypeDefinitionPosition::Interface(value) => value.into(),
-            AbstractTypeDefinitionPosition::Union(value) => value.into(),
-        }
-    }
-}
-
-impl From<ObjectOrInterfaceTypeDefinitionPosition> for CompositeTypeDefinitionPosition {
-    fn from(value: ObjectOrInterfaceTypeDefinitionPosition) -> Self {
-        match value {
-            ObjectOrInterfaceTypeDefinitionPosition::Object(value) => value.into(),
-            ObjectOrInterfaceTypeDefinitionPosition::Interface(value) => value.into(),
-        }
-    }
-}
+fallible_conversions!(TypeDefinitionPosition::{Object, Interface, Union} -> CompositeTypeDefinitionPosition);
+fallible_conversions!(OutputTypeDefinitionPosition::{Object, Interface, Union} -> CompositeTypeDefinitionPosition);
+infallible_conversions!(AbstractTypeDefinitionPosition::{Interface, Union} -> CompositeTypeDefinitionPosition);
+infallible_conversions!(ObjectOrInterfaceTypeDefinitionPosition::{Object, Interface} -> CompositeTypeDefinitionPosition);
 
 #[derive(Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Display)]
 pub(crate) enum AbstractTypeDefinitionPosition {
@@ -672,6 +466,8 @@ impl Debug for AbstractTypeDefinitionPosition {
 }
 
 impl AbstractTypeDefinitionPosition {
+    const EXPECTED: &'static str = "an abstract type";
+
     pub(crate) fn type_name(&self) -> &Name {
         match self {
             AbstractTypeDefinitionPosition::Interface(type_) => &type_.type_name,
@@ -745,86 +541,12 @@ impl AbstractTypeDefinitionPosition {
     }
 }
 
-impl TryFrom<AbstractTypeDefinitionPosition> for InterfaceTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: AbstractTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            AbstractTypeDefinitionPosition::Interface(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an interface type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<AbstractTypeDefinitionPosition> for UnionTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: AbstractTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            AbstractTypeDefinitionPosition::Union(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not a union type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<TypeDefinitionPosition> for AbstractTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: TypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            TypeDefinitionPosition::Interface(value) => Ok(value.into()),
-            TypeDefinitionPosition::Union(value) => Ok(value.into()),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an abstract type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<OutputTypeDefinitionPosition> for AbstractTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: OutputTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            OutputTypeDefinitionPosition::Interface(value) => Ok(value.into()),
-            OutputTypeDefinitionPosition::Union(value) => Ok(value.into()),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an abstract type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<CompositeTypeDefinitionPosition> for AbstractTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: CompositeTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            CompositeTypeDefinitionPosition::Interface(value) => Ok(value.into()),
-            CompositeTypeDefinitionPosition::Union(value) => Ok(value.into()),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an abstract type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<ObjectOrInterfaceTypeDefinitionPosition> for AbstractTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: ObjectOrInterfaceTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            ObjectOrInterfaceTypeDefinitionPosition::Interface(value) => Ok(value.into()),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an abstract type"#
-            ))),
-        }
-    }
-}
+fallible_conversions!(AbstractTypeDefinitionPosition::Interface -> InterfaceTypeDefinitionPosition);
+fallible_conversions!(AbstractTypeDefinitionPosition::Union -> UnionTypeDefinitionPosition);
+fallible_conversions!(TypeDefinitionPosition::{Interface, Union} -> AbstractTypeDefinitionPosition);
+fallible_conversions!(OutputTypeDefinitionPosition::{Interface, Union} -> AbstractTypeDefinitionPosition);
+fallible_conversions!(CompositeTypeDefinitionPosition::{Interface, Union} -> AbstractTypeDefinitionPosition);
+fallible_conversions!(ObjectOrInterfaceTypeDefinitionPosition::{Interface} -> AbstractTypeDefinitionPosition);
 
 #[derive(Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Display)]
 pub(crate) enum ObjectOrInterfaceTypeDefinitionPosition {
@@ -842,6 +564,8 @@ impl Debug for ObjectOrInterfaceTypeDefinitionPosition {
 }
 
 impl ObjectOrInterfaceTypeDefinitionPosition {
+    const EXPECTED: &'static str = "an object/interface type";
+
     pub(crate) fn type_name(&self) -> &Name {
         match self {
             ObjectOrInterfaceTypeDefinitionPosition::Object(type_) => &type_.type_name,
@@ -924,86 +648,12 @@ impl ObjectOrInterfaceTypeDefinitionPosition {
     }
 }
 
-impl TryFrom<ObjectOrInterfaceTypeDefinitionPosition> for ObjectTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: ObjectOrInterfaceTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            ObjectOrInterfaceTypeDefinitionPosition::Object(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an object type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<ObjectOrInterfaceTypeDefinitionPosition> for InterfaceTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: ObjectOrInterfaceTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            ObjectOrInterfaceTypeDefinitionPosition::Interface(value) => Ok(value),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an interface type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<TypeDefinitionPosition> for ObjectOrInterfaceTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: TypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            TypeDefinitionPosition::Object(value) => Ok(value.into()),
-            TypeDefinitionPosition::Interface(value) => Ok(value.into()),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an object/interface type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<OutputTypeDefinitionPosition> for ObjectOrInterfaceTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: OutputTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            OutputTypeDefinitionPosition::Object(value) => Ok(value.into()),
-            OutputTypeDefinitionPosition::Interface(value) => Ok(value.into()),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an object/interface type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<CompositeTypeDefinitionPosition> for ObjectOrInterfaceTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: CompositeTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            CompositeTypeDefinitionPosition::Object(value) => Ok(value.into()),
-            CompositeTypeDefinitionPosition::Interface(value) => Ok(value.into()),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an object/interface type"#
-            ))),
-        }
-    }
-}
-
-impl TryFrom<AbstractTypeDefinitionPosition> for ObjectOrInterfaceTypeDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: AbstractTypeDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            AbstractTypeDefinitionPosition::Interface(value) => Ok(value.into()),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an object/interface type"#
-            ))),
-        }
-    }
-}
+fallible_conversions!(ObjectOrInterfaceTypeDefinitionPosition::Object -> ObjectTypeDefinitionPosition);
+fallible_conversions!(ObjectOrInterfaceTypeDefinitionPosition::Interface -> InterfaceTypeDefinitionPosition);
+fallible_conversions!(TypeDefinitionPosition::{Object, Interface} -> ObjectOrInterfaceTypeDefinitionPosition);
+fallible_conversions!(OutputTypeDefinitionPosition::{Object, Interface} -> ObjectOrInterfaceTypeDefinitionPosition);
+fallible_conversions!(CompositeTypeDefinitionPosition::{Object, Interface} -> ObjectOrInterfaceTypeDefinitionPosition);
+fallible_conversions!(AbstractTypeDefinitionPosition::{Interface} -> ObjectOrInterfaceTypeDefinitionPosition);
 
 #[derive(Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Display)]
 pub(crate) enum FieldDefinitionPosition {
@@ -1070,14 +720,7 @@ impl FieldDefinitionPosition {
     }
 }
 
-impl From<ObjectOrInterfaceFieldDefinitionPosition> for FieldDefinitionPosition {
-    fn from(value: ObjectOrInterfaceFieldDefinitionPosition) -> Self {
-        match value {
-            ObjectOrInterfaceFieldDefinitionPosition::Object(value) => value.into(),
-            ObjectOrInterfaceFieldDefinitionPosition::Interface(value) => value.into(),
-        }
-    }
-}
+infallible_conversions!(ObjectOrInterfaceFieldDefinitionPosition::{Object, Interface} -> FieldDefinitionPosition);
 
 #[derive(Clone, PartialEq, Eq, Hash, derive_more::From, derive_more::Display)]
 pub(crate) enum ObjectOrInterfaceFieldDefinitionPosition {
@@ -1095,6 +738,8 @@ impl Debug for ObjectOrInterfaceFieldDefinitionPosition {
 }
 
 impl ObjectOrInterfaceFieldDefinitionPosition {
+    const EXPECTED: &'static str = "an object/interface field";
+
     pub(crate) fn type_name(&self) -> &Name {
         match self {
             ObjectOrInterfaceFieldDefinitionPosition::Object(field) => &field.type_name,
@@ -1169,19 +814,7 @@ impl ObjectOrInterfaceFieldDefinitionPosition {
     }
 }
 
-impl TryFrom<FieldDefinitionPosition> for ObjectOrInterfaceFieldDefinitionPosition {
-    type Error = FederationError;
-
-    fn try_from(value: FieldDefinitionPosition) -> Result<Self, Self::Error> {
-        match value {
-            FieldDefinitionPosition::Object(value) => Ok(value.into()),
-            FieldDefinitionPosition::Interface(value) => Ok(value.into()),
-            _ => Err(FederationError::internal(format!(
-                r#"Type "{value}" was unexpectedly not an object/interface field"#
-            ))),
-        }
-    }
-}
+fallible_conversions!(FieldDefinitionPosition::{Object, Interface} -> ObjectOrInterfaceFieldDefinitionPosition);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct SchemaDefinitionPosition;
@@ -1572,6 +1205,8 @@ pub(crate) struct ScalarTypeDefinitionPosition {
 }
 
 impl ScalarTypeDefinitionPosition {
+    const EXPECTED: &'static str = "a scalar type";
+
     pub(crate) fn get<'schema>(
         &self,
         schema: &'schema Schema,
@@ -1883,6 +1518,8 @@ pub(crate) struct ObjectTypeDefinitionPosition {
 }
 
 impl ObjectTypeDefinitionPosition {
+    const EXPECTED: &'static str = "an object type";
+
     pub(crate) fn new(type_name: Name) -> Self {
         Self { type_name }
     }
@@ -3062,6 +2699,8 @@ pub(crate) struct InterfaceTypeDefinitionPosition {
 }
 
 impl InterfaceTypeDefinitionPosition {
+    const EXPECTED: &'static str = "an interface type";
+
     pub(crate) fn new(type_name: Name) -> Self {
         Self { type_name }
     }
@@ -4166,6 +3805,8 @@ pub(crate) struct UnionTypeDefinitionPosition {
 }
 
 impl UnionTypeDefinitionPosition {
+    const EXPECTED: &'static str = "a union type";
+
     pub(crate) fn new(type_name: Name) -> Self {
         Self { type_name }
     }
@@ -4608,6 +4249,8 @@ pub(crate) struct EnumTypeDefinitionPosition {
 }
 
 impl EnumTypeDefinitionPosition {
+    const EXPECTED: &'static str = "an enum type";
+
     pub(crate) fn value(&self, value_name: Name) -> EnumValueDefinitionPosition {
         EnumValueDefinitionPosition {
             type_name: self.type_name.clone(),
@@ -5173,6 +4816,8 @@ pub(crate) struct InputObjectTypeDefinitionPosition {
 }
 
 impl InputObjectTypeDefinitionPosition {
+    const EXPECTED: &'static str = "an input object type";
+
     pub(crate) fn field(&self, field_name: Name) -> InputObjectFieldDefinitionPosition {
         InputObjectFieldDefinitionPosition {
             type_name: self.type_name.clone(),

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -78,8 +78,9 @@ impl From<PositionLookupError> for FederationError {
     }
 }
 
+/// The error type returned when a position conversion fails.
 #[derive(Debug, thiserror::Error)]
-#[error("Type {actual:?} was unexpectedly not {expected}")]
+#[error("Type `{actual}` was unexpectedly not {expected}")]
 pub(crate) struct PositionConvertError<T: Debug + Display> {
     actual: T,
     expected: &'static str,
@@ -91,8 +92,15 @@ impl<T: Debug + Display> From<PositionConvertError<T>> for FederationError {
     }
 }
 
+/// To declare a conversion for a `Position::Branch(T) -> T`:
+/// ```no_compile
 /// fallible_conversions!(TypeDefinition::Scalar -> ScalarTypeDefinition);
+/// ```
+///
+/// To declare a conversion from one enum to another, with a different set of branches:
+/// ```no_compile
 /// fallible_conversions!(TypeDefinition::{Scalar, Enum, InputObject} -> InputObjectTypeDefinition)
+/// ```
 macro_rules! fallible_conversions {
     ( $from:ident :: $branch:ident -> $to:ident ) => {
         impl TryFrom<$from> for $to {
@@ -128,16 +136,11 @@ macro_rules! fallible_conversions {
     }
 }
 
-/// infallible_conversions!(ScalarTypeDefinition -> TypeDefinition::Scalar);
+/// To declare a conversion from a type to a superset type:
+/// ```no_compile
 /// infallible_conversions!(InputObjectTypeDefinition::{Scalar, Enum, InputObject} -> TypeDefinition)
+/// ```
 macro_rules! infallible_conversions {
-    ( $from:ident -> $to:ident :: $branch:ident ) => {
-        impl From<$from> for $to {
-            fn from(value: $from) -> Self {
-                $to::$branch(value)
-            }
-        }
-    };
     ( $from:ident :: { $($branch:ident),+ } -> $to:ident ) => {
         impl From<$from> for $to {
             fn from(value: $from) -> Self {

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -1232,7 +1232,7 @@ impl ScalarTypeDefinitionPosition {
                 } else {
                     Err(PositionLookupError::TypeWrongKind(
                         self.type_name.clone(),
-                        "scalar",
+                        Self::EXPECTED,
                     ))
                 }
             })
@@ -1259,7 +1259,7 @@ impl ScalarTypeDefinitionPosition {
                 } else {
                     Err(PositionLookupError::TypeWrongKind(
                         self.type_name.clone(),
-                        "scalar",
+                        Self::EXPECTED,
                     ))
                 }
             })
@@ -1585,7 +1585,7 @@ impl ObjectTypeDefinitionPosition {
                 } else {
                     Err(PositionLookupError::TypeWrongKind(
                         self.type_name.clone(),
-                        "object",
+                        Self::EXPECTED,
                     ))
                 }
             })
@@ -1612,7 +1612,7 @@ impl ObjectTypeDefinitionPosition {
                 } else {
                     Err(PositionLookupError::TypeWrongKind(
                         self.type_name.clone(),
-                        "object",
+                        Self::EXPECTED,
                     ))
                 }
             })
@@ -2758,7 +2758,7 @@ impl InterfaceTypeDefinitionPosition {
                 } else {
                     Err(PositionLookupError::TypeWrongKind(
                         self.type_name.clone(),
-                        "interface",
+                        Self::EXPECTED,
                     ))
                 }
             })
@@ -2785,7 +2785,7 @@ impl InterfaceTypeDefinitionPosition {
                 } else {
                     Err(PositionLookupError::TypeWrongKind(
                         self.type_name.clone(),
-                        "interface",
+                        Self::EXPECTED,
                     ))
                 }
             })
@@ -3842,7 +3842,7 @@ impl UnionTypeDefinitionPosition {
                 } else {
                     Err(PositionLookupError::TypeWrongKind(
                         self.type_name.clone(),
-                        "union",
+                        Self::EXPECTED,
                     ))
                 }
             })
@@ -3869,7 +3869,7 @@ impl UnionTypeDefinitionPosition {
                 } else {
                     Err(PositionLookupError::TypeWrongKind(
                         self.type_name.clone(),
-                        "union",
+                        Self::EXPECTED,
                     ))
                 }
             })
@@ -4283,7 +4283,7 @@ impl EnumTypeDefinitionPosition {
                 } else {
                     Err(PositionLookupError::TypeWrongKind(
                         self.type_name.clone(),
-                        "enum",
+                        Self::EXPECTED,
                     ))
                 }
             })
@@ -4310,7 +4310,7 @@ impl EnumTypeDefinitionPosition {
                 } else {
                     Err(PositionLookupError::TypeWrongKind(
                         self.type_name.clone(),
-                        "enum",
+                        Self::EXPECTED,
                     ))
                 }
             })
@@ -4850,7 +4850,7 @@ impl InputObjectTypeDefinitionPosition {
                 } else {
                     Err(PositionLookupError::TypeWrongKind(
                         self.type_name.clone(),
-                        "input object",
+                        Self::EXPECTED,
                     ))
                 }
             })
@@ -4877,7 +4877,7 @@ impl InputObjectTypeDefinitionPosition {
                 } else {
                     Err(PositionLookupError::TypeWrongKind(
                         self.type_name.clone(),
-                        "input object",
+                        Self::EXPECTED,
                     ))
                 }
             })

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -58,7 +58,7 @@ pub(crate) enum PositionLookupError {
     DirectiveMissing(DirectiveDefinitionPosition),
     #[error("Schema has no type `{0}`")]
     TypeMissing(Name),
-    #[error("Schema type `{0}` is not a(n) {1}")]
+    #[error("Schema type `{0}` is not {1}")]
     TypeWrongKind(Name, &'static str),
     #[error("{0} type `{1}` has no field `{2}`")]
     MissingField(&'static str, Name, Name),
@@ -191,12 +191,12 @@ impl TypeDefinitionPosition {
 
     fn describe(&self) -> &'static str {
         match self {
-            TypeDefinitionPosition::Scalar(_) => "scalar",
-            TypeDefinitionPosition::Object(_) => "object",
-            TypeDefinitionPosition::Interface(_) => "interface",
-            TypeDefinitionPosition::Union(_) => "union",
-            TypeDefinitionPosition::Enum(_) => "enum",
-            TypeDefinitionPosition::InputObject(_) => "input object",
+            TypeDefinitionPosition::Scalar(_) => ScalarTypeDefinitionPosition::EXPECTED,
+            TypeDefinitionPosition::Object(_) => ObjectTypeDefinitionPosition::EXPECTED,
+            TypeDefinitionPosition::Interface(_) => InterfaceTypeDefinitionPosition::EXPECTED,
+            TypeDefinitionPosition::Union(_) => UnionTypeDefinitionPosition::EXPECTED,
+            TypeDefinitionPosition::Enum(_) => EnumTypeDefinitionPosition::EXPECTED,
+            TypeDefinitionPosition::InputObject(_) => InputObjectTypeDefinitionPosition::EXPECTED,
         }
     }
 
@@ -279,11 +279,11 @@ impl OutputTypeDefinitionPosition {
 
     fn describe(&self) -> &'static str {
         match self {
-            OutputTypeDefinitionPosition::Scalar(_) => "scalar",
-            OutputTypeDefinitionPosition::Object(_) => "object",
-            OutputTypeDefinitionPosition::Interface(_) => "interface",
-            OutputTypeDefinitionPosition::Union(_) => "union",
-            OutputTypeDefinitionPosition::Enum(_) => "enum",
+            OutputTypeDefinitionPosition::Scalar(_) => ScalarTypeDefinitionPosition::EXPECTED,
+            OutputTypeDefinitionPosition::Object(_) => ObjectTypeDefinitionPosition::EXPECTED,
+            OutputTypeDefinitionPosition::Interface(_) => InterfaceTypeDefinitionPosition::EXPECTED,
+            OutputTypeDefinitionPosition::Union(_) => UnionTypeDefinitionPosition::EXPECTED,
+            OutputTypeDefinitionPosition::Enum(_) => EnumTypeDefinitionPosition::EXPECTED,
         }
     }
 
@@ -374,9 +374,11 @@ impl CompositeTypeDefinitionPosition {
 
     fn describe(&self) -> &'static str {
         match self {
-            CompositeTypeDefinitionPosition::Object(_) => "object",
-            CompositeTypeDefinitionPosition::Interface(_) => "interface",
-            CompositeTypeDefinitionPosition::Union(_) => "union",
+            CompositeTypeDefinitionPosition::Object(_) => ObjectTypeDefinitionPosition::EXPECTED,
+            CompositeTypeDefinitionPosition::Interface(_) => {
+                InterfaceTypeDefinitionPosition::EXPECTED
+            }
+            CompositeTypeDefinitionPosition::Union(_) => UnionTypeDefinitionPosition::EXPECTED,
         }
     }
 
@@ -480,8 +482,10 @@ impl AbstractTypeDefinitionPosition {
 
     fn describe(&self) -> &'static str {
         match self {
-            AbstractTypeDefinitionPosition::Interface(_) => "interface",
-            AbstractTypeDefinitionPosition::Union(_) => "union",
+            AbstractTypeDefinitionPosition::Interface(_) => {
+                InterfaceTypeDefinitionPosition::EXPECTED
+            }
+            AbstractTypeDefinitionPosition::Union(_) => UnionTypeDefinitionPosition::EXPECTED,
         }
     }
 
@@ -578,8 +582,12 @@ impl ObjectOrInterfaceTypeDefinitionPosition {
 
     fn describe(&self) -> &'static str {
         match self {
-            ObjectOrInterfaceTypeDefinitionPosition::Object(_) => "object",
-            ObjectOrInterfaceTypeDefinitionPosition::Interface(_) => "interface",
+            ObjectOrInterfaceTypeDefinitionPosition::Object(_) => {
+                ObjectTypeDefinitionPosition::EXPECTED
+            }
+            ObjectOrInterfaceTypeDefinitionPosition::Interface(_) => {
+                InterfaceTypeDefinitionPosition::EXPECTED
+            }
         }
     }
 


### PR DESCRIPTION
Much like `try_get()` in #5605, we regularly use `try_from()` on positions just to check if we *can* convert, or to conditionally do something with a converted type. In some hot paths like rebasing or optimize(), we do not actually use the error. So creating a full error with an allocated string is excessive in those cases.

This adds a cheap internal error type for `Position::try_from()` conversion failures. I also added macros to declare the conversions because they're all the same.