### PR TITLE
Add 'subgraph_on_graphql_error' selector for subgraph

### DIFF
--- a/.changesets/feat_bnjjj_feat_284.md
+++ b/.changesets/feat_bnjjj_feat_284.md
@@ -1,0 +1,16 @@
+### Add 'subgraph_on_graphql_error' selector for subgraph ([PR #5622](https://github.com/apollographql/router/pull/5622))
+
+`on_graphql_error` exists for router and supergraph, but not for subgraph. This adds support for `subgraph_on_graphql_error` selector for symmetry and to also allow easy detection of which subgraphs requests contain graphql errors in response body. 
+
+```yaml
+telemetry:
+  instrumentation:
+    instruments:
+      subgraph:
+        http.client.request.duration:
+          attributes:
+            subgraph.graphql.errors: # attribute containing a boolean set to true if response.errors is not empty
+              subgraph_on_graphql_error: true
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/5622

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -6085,6 +6085,19 @@ expression: "&schema"
         {
           "additionalProperties": false,
           "properties": {
+            "subgraph_on_graphql_error": {
+              "description": "Boolean set to true if the response body contains graphql error",
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "subgraph_on_graphql_error"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
             "baggage": {
               "description": "The name of the baggage item.",
               "type": "string"

--- a/docs/source/configuration/telemetry/instrumentation/selectors.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/selectors.mdx
@@ -82,6 +82,7 @@ The subgraph service executes multiple times during query execution, with each e
 | `subgraph_request_header`   | Yes         |                  | The name of a subgraph request header                                          |
 | `subgraph_response_header`  | Yes         |                  | The name of a subgraph response header                                         |
 | `subgraph_response_status`  | Yes         | `code`\|`reason` | The status of a subgraph response                                              |
+| `subgraph_on_graphql_error` | No          | `true`\|`false`  | Boolean set to true if the subgrapoh response payload contains a graphql error |
 | `supergraph_operation_name` | Yes         | `string`\|`hash` | The operation name from the supergraph query                                   |
 | `supergraph_operation_kind` | Yes         | `string`         | The operation kind from the supergraph query                                   |
 | `supergraph_query`          | Yes         | `string`         | The graphql query to the supergraph                                            |


### PR DESCRIPTION
`on_graphql_error` exists for router and supergraph, but not for subgraph. This adds support for `subgraph_on_graphql_error` selector for symmetry and to also allow easy detection of which subgraphs requests contain graphql errors in response body. 

```yaml
telemetry:
  instrumentation:
    instruments:
      subgraph:
        http.client.request.duration:
          attributes:
            subgraph.graphql.errors: # attribute containing a boolean set to true if response.errors is not empty
              subgraph_on_graphql_error: true
```

<!-- [ROUTER-284] -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-284]: https://apollographql.atlassian.net/browse/ROUTER-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ