### PR TITLE
Validation error when importing conflicting directives

### DIFF
--- a/apollo-federation/src/link/mod.rs
+++ b/apollo-federation/src/link/mod.rs
@@ -6,9 +6,11 @@ use std::sync::Arc;
 use apollo_compiler::ast::Directive;
 use apollo_compiler::ast::Value;
 use apollo_compiler::name;
+use apollo_compiler::schema::Component;
 use apollo_compiler::InvalidNameError;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
+use apollo_compiler::Schema;
 use thiserror::Error;
 
 use crate::error::FederationError;
@@ -328,6 +330,24 @@ impl Link {
             imports,
             purpose,
         })
+    }
+
+    pub fn for_identity<'schema>(
+        schema: &'schema Schema,
+        identity: &Identity,
+    ) -> Option<(Self, &'schema Component<Directive>)> {
+        schema
+            .schema_definition
+            .directives
+            .iter()
+            .find_map(|directive| {
+                let link = Link::from_directive_application(directive).ok()?;
+                if link.url.identity == *identity {
+                    Some((link, directive))
+                } else {
+                    None
+                }
+            })
     }
 }
 

--- a/apollo-federation/src/sources/connect/expand/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/mod.rs
@@ -70,7 +70,7 @@ pub fn expand_connectors(supergraph_str: &str) -> Result<ExpansionResult, Federa
         .into_iter()
         .partition_map(|(_, sub)| {
             match ConnectSpecDefinition::get_from_schema(sub.schema.schema()) {
-                Ok(Some((_, link))) if contains_connectors(&link, &sub) => {
+                Some((_, link)) if contains_connectors(&link, &sub) => {
                     either::Either::Left((link, sub))
                 }
                 _ => either::Either::Right(ValidSubgraph::from(sub)),

--- a/apollo-federation/src/sources/connect/models/snapshots/validation_tests@disallowed_federation_imports.graphql.snap
+++ b/apollo-federation/src/sources/connect/models/snapshots/validation_tests@disallowed_federation_imports.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-federation/src/sources/connect/models/validation.rs
+expression: "format!(\"{:?}\", errors)"
+input_file: apollo-federation/src/sources/connect/models/test_data/validation/disallowed_federation_imports.graphql
+---
+[Message { code: UnsupportedFederationDirective, message: "The directive `@context` is not supported when using connectors.", locations: [Location { line: 3, column: 21 }..Location { line: 3, column: 31 }] }, Message { code: UnsupportedFederationDirective, message: "The directive `@fromContext` is not supported when using connectors.", locations: [Location { line: 3, column: 33 }..Location { line: 3, column: 47 }] }, Message { code: UnsupportedFederationDirective, message: "The directive `@interfaceObject` is not supported when using connectors.", locations: [Location { line: 3, column: 49 }..Location { line: 3, column: 67 }] }]

--- a/apollo-federation/src/sources/connect/models/test_data/validation/disallowed_federation_imports.graphql
+++ b/apollo-federation/src/sources/connect/models/test_data/validation/disallowed_federation_imports.graphql
@@ -1,0 +1,14 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/federation/v2.8"
+    import: ["@key", "@context", "@fromContext", "@interfaceObject", "@external", "@requires", "@provides"]
+)
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect", "@source"]
+)
+
+type Query {
+    resources: [String!]!
+    @connect(http: {GET: "http://127.0.0.1"}, selection: "")
+}

--- a/apollo-federation/src/subgraph/database.rs
+++ b/apollo-federation/src/subgraph/database.rs
@@ -19,7 +19,6 @@ use apollo_compiler::name;
 use apollo_compiler::Name;
 use apollo_compiler::Schema;
 
-use crate::link::database::links_metadata;
 use crate::link::spec::Identity;
 use crate::link::spec::APOLLO_SPEC_DOMAIN;
 use crate::link::Link;
@@ -66,13 +65,10 @@ impl Key {
     }
 }
 
-pub fn federation_link(schema: &Schema) -> Arc<Link> {
-    links_metadata(schema)
-        // TODO: error handling?
-        .unwrap_or_default()
-        .unwrap_or_default()
-        .for_identity(&federation_link_identity())
+pub fn federation_link(schema: &Schema) -> Link {
+    Link::for_identity(schema, &federation_link_identity())
         .expect("The presence of the federation link should have been validated on construction")
+        .0
 }
 
 /// The name of the @key directive in this subgraph.

--- a/apollo-federation/src/subgraph/mod.rs
+++ b/apollo-federation/src/subgraph/mod.rs
@@ -30,7 +30,7 @@ use crate::subgraph::spec::SERVICE_SDL_QUERY;
 use crate::subgraph::spec::SERVICE_TYPE;
 use crate::ValidFederationSubgraph;
 
-mod database;
+pub(crate) mod database;
 pub mod spec;
 
 pub struct Subgraph {

--- a/apollo-federation/src/subgraph/spec.rs
+++ b/apollo-federation/src/subgraph/spec.rs
@@ -48,6 +48,8 @@ pub const PROVIDES_DIRECTIVE_NAME: Name = name!("provides");
 pub const REQUIRES_DIRECTIVE_NAME: Name = name!("requires");
 pub const SHAREABLE_DIRECTIVE_NAME: Name = name!("shareable");
 pub const TAG_DIRECTIVE_NAME: Name = name!("tag");
+pub const CONTEXT_DIRECTIVE_NAME: Name = name!("context");
+pub const FROM_CONTEXT_DIRECTIVE_NAME: Name = name!("fromContext");
 pub const FIELDSET_SCALAR_NAME: Name = name!("FieldSet");
 
 // federated types


### PR DESCRIPTION
<!-- [CNN-168] -->

Prevents `@context`, `@fromContext`, and `@interfaceObject` from being used with connectors.

We _might_ want `Link` and `Import` to retain location info (`Node`s) directly, but doing so will require carrying around lifetimes, so I didn't go mess with that yet.


[CNN-168]: https://apollographql.atlassian.net/browse/CNN-168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ