### PR TITLE
fix(record plugin): record plugin should use a Schema with api_schema

### DIFF
--- a/apollo-router/src/plugins/record_replay/record.rs
+++ b/apollo-router/src/plugins/record_replay/record.rs
@@ -63,14 +63,16 @@ impl Plugin for Record {
             .storage_path
             .unwrap_or_else(default_storage_path);
 
+        let schema_config = Default::default();
+        let schema = Schema::parse(init.supergraph_sdl.clone().as_str(), &schema_config)?;
+        let api_schema = Schema::parse_compiler_schema(&schema.create_api_schema(&schema_config)?)?;
+        let schema = schema.with_api_schema(api_schema);
+
         let plugin = Self {
             enabled: init.config.enabled,
             supergraph_sdl: init.supergraph_sdl.clone(),
             storage_path: storage_path.clone().into(),
-            schema: Arc::new(Schema::parse(
-                init.supergraph_sdl.clone().as_str(),
-                &Default::default(),
-            )?),
+            schema: Arc::new(schema),
         };
 
         if init.config.enabled {


### PR DESCRIPTION
Currently the `Schema` struct created in Record/Replay plugin is missing api_schema (it's `None`!) information that's necessary when parsing an executable document. This means that any incoming operation with Record/Replay plugin enabled, will panic with `missing API schema`.

This change adds an additional `schema.with_api_schema()` call before instantiating this plugin. The fix does reparse the schema, but this is also a debugging plugin. The expectation is that this change will be superseded by #5623 in the 1.52.0 release. 