### PR TITLE
Handle subgraph response with -1 values inside error locations

### DIFF
--- a/.changesets/fix_error_locations.md
+++ b/.changesets/fix_error_locations.md
@@ -1,0 +1,33 @@
+### Gracefully handle subgraph response with `-1` values inside error locations ([PR #5633](https://github.com/apollographql/router/pull/5633))
+
+[GraphQL specification requires](https://spec.graphql.org/draft/#sel-GAPHRPFCCaCGX5zM) that both "line" and "column" are positive numbers. 
+However GraphQL Java and GraphQL Kotlin use `{ "line": -1, "column": -1 }` value if they can't determine error location inside query. 
+
+This change makes Router to gracefully handle such responses by ignoring such invalid locations.
+
+As an example, if subgraph respond with:
+```json
+{
+    "data": { "topProducts": null },
+    "errors": [{
+        "message":"Some error on subgraph",
+        "locations": [
+            { "line": -1, "column": -1 },
+        ],
+        "path":["topProducts"]
+    }]
+}
+```
+
+Router will return following to a client:
+```json
+{
+    "data": { "topProducts": null },
+    "errors": [{
+        "message":"Some error on subgraph",
+        "path":["topProducts"]
+    }]
+}
+```
+
+By [@IvanGoncharov](https://github.com/IvanGoncharov) in https://github.com/apollographql/router/pull/5633

--- a/apollo-router/src/graphql/mod.rs
+++ b/apollo-router/src/graphql/mod.rs
@@ -123,29 +123,30 @@ impl Error {
         let mut object =
             ensure_object!(value).map_err(|error| FetchError::SubrequestMalformedResponse {
                 service: service_name.to_string(),
-                reason: error.to_string(),
+                reason: format!("invalid error within `errors`: {}", error),
             })?;
 
         let extensions =
             extract_key_value_from_object!(object, "extensions", Value::Object(o) => o)
                 .map_err(|err| FetchError::SubrequestMalformedResponse {
                     service: service_name.to_string(),
-                    reason: err.to_string(),
+                    reason: format!("invalid `extensions` within error: {}", err),
                 })?
                 .unwrap_or_default();
         let message = extract_key_value_from_object!(object, "message", Value::String(s) => s)
             .map_err(|err| FetchError::SubrequestMalformedResponse {
                 service: service_name.to_string(),
-                reason: err.to_string(),
+                reason: format!("invalid `message` within error: {}", err),
             })?
             .map(|s| s.as_str().to_string())
             .unwrap_or_default();
         let locations = extract_key_value_from_object!(object, "locations")
+            .map(skip_invalid_locations)
             .map(serde_json_bytes::from_value)
             .transpose()
             .map_err(|err| FetchError::SubrequestMalformedResponse {
                 service: service_name.to_string(),
-                reason: err.to_string(),
+                reason: format!("invalid `locations` within error: {}", err),
             })?
             .unwrap_or_default();
         let path = extract_key_value_from_object!(object, "path")
@@ -153,7 +154,7 @@ impl Error {
             .transpose()
             .map_err(|err| FetchError::SubrequestMalformedResponse {
                 service: service_name.to_string(),
-                reason: err.to_string(),
+                reason: format!("invalid `path` within error: {}", err),
             })?;
 
         Ok(Error {
@@ -163,6 +164,19 @@ impl Error {
             extensions,
         })
     }
+}
+
+// GraphQL spec require that both "line" and "column" are positive numbers.
+// However GraphQL Java and GraphQL Kotlin return `{ "line": -1, "column": -1 }`
+// if they can't determine error location inside query.
+// This function removes such locations from suplied value.
+fn skip_invalid_locations(mut value: Value) -> Value {
+    value.as_array_mut().map(|array| {
+        array.retain(|location| {
+            location.get("line") != Some(&json!(-1)) || location.get("column") != Some(&json!(-1))
+        })
+    });
+    value
 }
 
 /// Displays (only) the error message.

--- a/apollo-router/src/graphql/mod.rs
+++ b/apollo-router/src/graphql/mod.rs
@@ -171,11 +171,11 @@ impl Error {
 // if they can't determine error location inside query.
 // This function removes such locations from suplied value.
 fn skip_invalid_locations(mut value: Value) -> Value {
-    value.as_array_mut().map(|array| {
+    if let Some(array) = value.as_array_mut() {
         array.retain(|location| {
             location.get("line") != Some(&json!(-1)) || location.get("column") != Some(&json!(-1))
         })
-    });
+    }
     value
 }
 

--- a/apollo-router/src/graphql/mod.rs
+++ b/apollo-router/src/graphql/mod.rs
@@ -166,14 +166,15 @@ impl Error {
     }
 }
 
-// GraphQL spec require that both "line" and "column" are positive numbers.
-// However GraphQL Java and GraphQL Kotlin return `{ "line": -1, "column": -1 }`
-// if they can't determine error location inside query.
-// This function removes such locations from suplied value.
+/// GraphQL spec require that both "line" and "column" are positive numbers.
+/// However GraphQL Java and GraphQL Kotlin return `{ "line": -1, "column": -1 }`
+/// if they can't determine error location inside query.
+/// This function removes such locations from suplied value.
 fn skip_invalid_locations(mut value: Value) -> Value {
     if let Some(array) = value.as_array_mut() {
         array.retain(|location| {
-            location.get("line") != Some(&json!(-1)) || location.get("column") != Some(&json!(-1))
+            location.get("line") != Some(&Value::from(-1))
+                || location.get("column") != Some(&Value::from(-1))
         })
     }
     value

--- a/apollo-router/tests/integration/mod.rs
+++ b/apollo-router/tests/integration/mod.rs
@@ -8,8 +8,8 @@ mod docs;
 mod file_upload;
 mod lifecycle;
 mod operation_limits;
-mod traffic_shaping;
 mod subgraph_response;
+mod traffic_shaping;
 
 #[cfg(any(not(feature = "ci"), all(target_arch = "x86_64", target_os = "linux")))]
 mod redis;

--- a/apollo-router/tests/integration/mod.rs
+++ b/apollo-router/tests/integration/mod.rs
@@ -9,6 +9,7 @@ mod file_upload;
 mod lifecycle;
 mod operation_limits;
 mod traffic_shaping;
+mod subgraph_response;
 
 #[cfg(any(not(feature = "ci"), all(target_arch = "x86_64", target_os = "linux")))]
 mod redis;

--- a/apollo-router/tests/integration/subgraph_response.rs
+++ b/apollo-router/tests/integration/subgraph_response.rs
@@ -139,11 +139,7 @@ async fn test_invalid_error_locations_with_single_negative_one_location() -> Res
             "data": { "me": null },
             "errors": [{
                 "message": "Some error on subgraph",
-                "locations": [
-                    { "line": 0, "column": 1 },
-                    { "line": -1, "column": -1 },
-                    { "line": 2, "column": 3 },
-                ],
+                "locations": [{ "line": -1, "column": -1 }],
                 "path": ["topProducts"]
             }]
         })))
@@ -163,10 +159,6 @@ async fn test_invalid_error_locations_with_single_negative_one_location() -> Res
             "data": { "topProducts": null },
             "errors": [{
                 "message":"Some error on subgraph",
-                "locations": [
-                    { "line": 0, "column": 1 },
-                    { "line": 2, "column": 3 },
-                ],
                 "path":["topProducts"]
             }]
         })

--- a/apollo-router/tests/integration/subgraph_response.rs
+++ b/apollo-router/tests/integration/subgraph_response.rs
@@ -14,7 +14,7 @@ async fn test_valid_error_locations() -> Result<(), BoxError> {
     let mut router = IntegrationTest::builder()
         .config(CONFIG)
         .responder(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "me": null },
+            "data": { "topProducts": null },
             "errors": [{
                 "message": "Some error on subgraph",
                 "locations": [
@@ -58,7 +58,7 @@ async fn test_empty_error_locations() -> Result<(), BoxError> {
     let mut router = IntegrationTest::builder()
         .config(CONFIG)
         .responder(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "me": null },
+            "data": { "topProducts": null },
             "errors": [{
                 "message": "Some error on subgraph",
                 "locations": [],
@@ -95,7 +95,7 @@ async fn test_invalid_error_locations() -> Result<(), BoxError> {
     let mut router = IntegrationTest::builder()
         .config(CONFIG)
         .responder(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "me": null },
+            "data": { "topProducts": null },
             "errors": [{
                 "message": "Some error on subgraph",
                 "locations": [{ "line": true }],
@@ -136,7 +136,7 @@ async fn test_invalid_error_locations_with_single_negative_one_location() -> Res
     let mut router = IntegrationTest::builder()
         .config(CONFIG)
         .responder(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "me": null },
+            "data": { "topProducts": null },
             "errors": [{
                 "message": "Some error on subgraph",
                 "locations": [{ "line": -1, "column": -1 }],
@@ -173,7 +173,7 @@ async fn test_invalid_error_locations_contains_negative_one_location() -> Result
     let mut router = IntegrationTest::builder()
         .config(CONFIG)
         .responder(ResponseTemplate::new(200).set_body_json(json!({
-            "data": { "me": null },
+            "data": { "topProducts": null },
             "errors": [{
                 "message": "Some error on subgraph",
                 "locations": [

--- a/apollo-router/tests/integration/subgraph_response.rs
+++ b/apollo-router/tests/integration/subgraph_response.rs
@@ -18,8 +18,8 @@ async fn test_valid_error_locations() -> Result<(), BoxError> {
             "errors": [{
                 "message": "Some error on subgraph",
                 "locations": [
-                    { "line": 0, "column": 1 },
-                    { "line": 2, "column": 3 },
+                    { "line": 1, "column": 2 },
+                    { "line": 3, "column": 4 },
                 ],
                 "path": ["topProducts"]
             }]
@@ -41,8 +41,8 @@ async fn test_valid_error_locations() -> Result<(), BoxError> {
             "errors": [{
                 "message":"Some error on subgraph",
                 "locations": [
-                    { "line": 0, "column": 1 },
-                    { "line": 2, "column": 3 },
+                    { "line": 1, "column": 2 },
+                    { "line": 3, "column": 4 },
                 ],
                 "path":["topProducts"]
             }]
@@ -177,9 +177,9 @@ async fn test_invalid_error_locations_contains_negative_one_location() -> Result
             "errors": [{
                 "message": "Some error on subgraph",
                 "locations": [
-                    { "line": 0, "column": 1 },
+                    { "line": 1, "column": 2 },
                     { "line": -1, "column": -1 },
-                    { "line": 2, "column": 3 },
+                    { "line": 3, "column": 4 },
                 ],
                 "path": ["topProducts"]
             }]
@@ -201,8 +201,8 @@ async fn test_invalid_error_locations_contains_negative_one_location() -> Result
             "errors": [{
                 "message":"Some error on subgraph",
                 "locations": [
-                    { "line": 0, "column": 1 },
-                    { "line": 2, "column": 3 },
+                    { "line": 1, "column": 2 },
+                    { "line": 3, "column": 4 },
                 ],
                 "path":["topProducts"]
             }]

--- a/apollo-router/tests/integration/subgraph_response.rs
+++ b/apollo-router/tests/integration/subgraph_response.rs
@@ -90,7 +90,6 @@ async fn test_empty_error_locations() -> Result<(), BoxError> {
     Ok(())
 }
 
-
 #[tokio::test(flavor = "multi_thread")]
 async fn test_invalid_error_locations() -> Result<(), BoxError> {
     let mut router = IntegrationTest::builder()

--- a/apollo-router/tests/integration/subgraph_response.rs
+++ b/apollo-router/tests/integration/subgraph_response.rs
@@ -1,0 +1,223 @@
+use serde_json::json;
+use tower::BoxError;
+use wiremock::ResponseTemplate;
+
+use crate::integration::IntegrationTest;
+
+const CONFIG: &str = r#"
+include_subgraph_errors:
+  all: true
+"#;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_valid_error_locations() -> Result<(), BoxError> {
+    let mut router = IntegrationTest::builder()
+        .config(CONFIG)
+        .responder(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "me": null },
+            "errors": [{
+                "message": "Some error on subgraph",
+                "locations": [
+                    { "line": 0, "column": 1 },
+                    { "line": 2, "column": 3 },
+                ],
+                "path": ["topProducts"]
+            }]
+        })))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    let (_trace_id, response) = router
+        .execute_query(&json!({ "query": "{ topProducts { name } }" }))
+        .await;
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&response.text().await?)?,
+        json!({
+            "data": { "topProducts": null },
+            "errors": [{
+                "message":"Some error on subgraph",
+                "locations": [
+                    { "line": 0, "column": 1 },
+                    { "line": 2, "column": 3 },
+                ],
+                "path":["topProducts"]
+            }]
+        })
+    );
+
+    router.graceful_shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_empty_error_locations() -> Result<(), BoxError> {
+    let mut router = IntegrationTest::builder()
+        .config(CONFIG)
+        .responder(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "me": null },
+            "errors": [{
+                "message": "Some error on subgraph",
+                "locations": [],
+                "path": ["topProducts"]
+            }]
+        })))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    let (_trace_id, response) = router
+        .execute_query(&json!({ "query": "{ topProducts { name } }" }))
+        .await;
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&response.text().await?)?,
+        json!({
+            "data": { "topProducts": null },
+            "errors": [{
+                "message":"Some error on subgraph",
+                "path":["topProducts"]
+            }]
+        })
+    );
+
+    router.graceful_shutdown().await;
+    Ok(())
+}
+
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invalid_error_locations() -> Result<(), BoxError> {
+    let mut router = IntegrationTest::builder()
+        .config(CONFIG)
+        .responder(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "me": null },
+            "errors": [{
+                "message": "Some error on subgraph",
+                "locations": [{ "line": true }],
+                "path": ["topProducts"]
+            }]
+        })))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    let (_trace_id, response) = router
+        .execute_query(&json!({ "query": "{ topProducts { name } }" }))
+        .await;
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&response.text().await?)?,
+        json!({
+            "data": null,
+            "errors": [{
+                "message":"service 'products' response was malformed: invalid `locations` within error: invalid type: boolean `true`, expected u32",
+                "extensions": {
+                    "service": "products",
+                    "reason": "invalid `locations` within error: invalid type: boolean `true`, expected u32",
+                    "code": "SUBREQUEST_MALFORMED_RESPONSE",
+                }
+            }]
+        })
+    );
+
+    router.graceful_shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invalid_error_locations_with_single_negative_one_location() -> Result<(), BoxError> {
+    let mut router = IntegrationTest::builder()
+        .config(CONFIG)
+        .responder(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "me": null },
+            "errors": [{
+                "message": "Some error on subgraph",
+                "locations": [
+                    { "line": 0, "column": 1 },
+                    { "line": -1, "column": -1 },
+                    { "line": 2, "column": 3 },
+                ],
+                "path": ["topProducts"]
+            }]
+        })))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    let (_trace_id, response) = router
+        .execute_query(&json!({ "query": "{ topProducts { name } }" }))
+        .await;
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&response.text().await?)?,
+        json!({
+            "data": { "topProducts": null },
+            "errors": [{
+                "message":"Some error on subgraph",
+                "locations": [
+                    { "line": 0, "column": 1 },
+                    { "line": 2, "column": 3 },
+                ],
+                "path":["topProducts"]
+            }]
+        })
+    );
+
+    router.graceful_shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_invalid_error_locations_contains_negative_one_location() -> Result<(), BoxError> {
+    let mut router = IntegrationTest::builder()
+        .config(CONFIG)
+        .responder(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "me": null },
+            "errors": [{
+                "message": "Some error on subgraph",
+                "locations": [
+                    { "line": 0, "column": 1 },
+                    { "line": -1, "column": -1 },
+                    { "line": 2, "column": 3 },
+                ],
+                "path": ["topProducts"]
+            }]
+        })))
+        .build()
+        .await;
+
+    router.start().await;
+    router.assert_started().await;
+
+    let (_trace_id, response) = router
+        .execute_query(&json!({ "query": "{ topProducts { name } }" }))
+        .await;
+    assert_eq!(response.status(), 200);
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&response.text().await?)?,
+        json!({
+            "data": { "topProducts": null },
+            "errors": [{
+                "message":"Some error on subgraph",
+                "locations": [
+                    { "line": 0, "column": 1 },
+                    { "line": 2, "column": 3 },
+                ],
+                "path":["topProducts"]
+            }]
+        })
+    );
+
+    router.graceful_shutdown().await;
+    Ok(())
+}


### PR DESCRIPTION
GraphQL spec require that both "line" and "column" are positive numbers. 
However GraphQL Java and GraphQL Kotlin return `{ "line": -1, "column": -1 }` if they can't determine error location inside query. 
So instead of failing we now just remove such locations.

<!-- start metadata -->
<!-- [ROUTER-393] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-393]: https://apollographql.atlassian.net/browse/ROUTER-393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ