### PR TITLE
Apply selection set to JSONSelection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,7 @@ dependencies = [
  "multimap 0.10.0",
  "nom",
  "petgraph",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "serde_json_bytes",
@@ -732,7 +733,7 @@ checksum = "44055e597c674aef7cb903b2b9f6e4cba1277ed0d2d61dae7cd52d7ffa81f8e2"
 dependencies = [
  "concolor",
  "unicode-width",
- "yansi",
+ "yansi 1.0.1",
 ]
 
 [[package]]
@@ -5475,6 +5476,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi 0.5.1",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8529,6 +8540,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "yansi"

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -31,6 +31,7 @@ strum_macros = "0.26.0"
 thiserror = "1.0"
 url = "2"
 either = "1.12"
+pretty_assertions = "1.4.0"
 
 [dev-dependencies]
 hex.workspace = true

--- a/apollo-federation/src/sources/connect/json_selection/mod.rs
+++ b/apollo-federation/src/sources/connect/json_selection/mod.rs
@@ -3,6 +3,7 @@ mod graphql;
 mod helpers;
 mod parser;
 mod pretty;
+mod selection_set;
 mod visitor;
 
 pub use apply_to::*;

--- a/apollo-federation/src/sources/connect/json_selection/mod.rs
+++ b/apollo-federation/src/sources/connect/json_selection/mod.rs
@@ -13,4 +13,5 @@ pub use parser::*;
 // remove the `#[cfg(test)]`.
 #[cfg(test)]
 pub use pretty::*;
+pub use selection_set::ApplySelectionSet;
 pub use visitor::*;

--- a/apollo-federation/src/sources/connect/json_selection/mod.rs
+++ b/apollo-federation/src/sources/connect/json_selection/mod.rs
@@ -13,5 +13,4 @@ pub use parser::*;
 // remove the `#[cfg(test)]`.
 #[cfg(test)]
 pub use pretty::*;
-pub use selection_set::ApplySelectionSet;
 pub use visitor::*;

--- a/apollo-federation/src/sources/connect/json_selection/selection_set.rs
+++ b/apollo-federation/src/sources/connect/json_selection/selection_set.rs
@@ -1,12 +1,16 @@
 //! Functions for applying a [`SelectionSet`] to a [`JSONSelection`]. This creates a new
-//! `JSONSelection` mapping to the fields on the selection set, and excluding any parts of the
+//! `JSONSelection` mapping to the fields on the selection set, and excluding parts of the
 //! original `JSONSelection` that are not needed by the selection set.
+
+use std::collections::HashSet;
+
 use apollo_compiler::executable::Selection;
 use apollo_compiler::executable::SelectionSet;
 
 use crate::sources::connect::json_selection::Alias;
 use crate::sources::connect::json_selection::NamedSelection;
 use crate::sources::connect::JSONSelection;
+use crate::sources::connect::Key;
 use crate::sources::connect::PathSelection;
 use crate::sources::connect::SubSelection;
 
@@ -16,18 +20,14 @@ fn find_fields_in_selection_set<'a>(set: &'a SelectionSet, name: &str) -> Vec<&'
     for selection in &set.selections {
         match selection {
             Selection::Field(field) => {
-                // TODO: handle include/skip directives, but will affect cache-ability
                 if field.name == name {
                     fields.push(selection);
                 }
             }
             Selection::FragmentSpread(_) => {
-                // TODO: are these always expanded to inline fragments?
-                todo!("Handle fragment spread?")
+                // Ignore - these are always expanded into inline fragments
             }
             Selection::InlineFragment(fragment) => {
-                // TODO: take directives like skip or include into account?
-                // TODO: take type condition into account? or is this out of scope for preview?
                 fields.extend(find_fields_in_selection_set(&fragment.selection_set, name));
             }
         }
@@ -35,28 +35,20 @@ fn find_fields_in_selection_set<'a>(set: &'a SelectionSet, name: &str) -> Vec<&'
     fields
 }
 
-// TODO: are there any ways this can fail that need to be exposed?
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub struct ApplySelectionSetError;
-
 impl JSONSelection {
-    pub fn apply_selection_set(
-        &self,
-        selection_set: &SelectionSet,
-    ) -> Result<Self, ApplySelectionSetError> {
+    pub fn apply_selection_set(&self, selection_set: &SelectionSet) -> Self {
         match self {
-            Self::Named(sub) => Ok(Self::Named(sub.apply_selection_set(selection_set)?)),
-            Self::Path(path) => Ok(Self::Path(path.apply_selection_set(selection_set)?)),
+            Self::Named(sub) => Self::Named(sub.apply_selection_set(selection_set)),
+            Self::Path(path) => Self::Path(path.apply_selection_set(selection_set)),
         }
     }
 }
 
 impl SubSelection {
-    fn apply_selection_set(
-        &self,
-        selection_set: &SelectionSet,
-    ) -> Result<Self, ApplySelectionSetError> {
+    fn apply_selection_set(&self, selection_set: &SelectionSet) -> Self {
         let mut new_selections = Vec::new();
+        let mut dropped_fields = HashSet::new();
+        let mut referenced_fields = HashSet::new();
         for selection in &self.selections {
             match selection {
                 NamedSelection::Field(alias, name, sub) => {
@@ -64,29 +56,47 @@ impl SubSelection {
                         .as_ref()
                         .map(|a| a.name.to_string())
                         .unwrap_or(name.to_string());
-                    for field in find_fields_in_selection_set(selection_set, &key) {
-                        new_selections.push(NamedSelection::Field(
+                    let fields = find_fields_in_selection_set(selection_set, &key);
+                    if self.star.is_some() {
+                        if fields.is_empty() {
+                            dropped_fields.insert(key.clone());
+                        } else {
+                            referenced_fields.insert(key.clone());
+                        }
+                    }
+                    for field in fields {
+                        let field_response_key = field
+                            .as_field()
+                            .map(|s| s.response_key())
+                            .unwrap()
+                            .to_string();
+                        let alias = if field_response_key == *name {
+                            None
+                        } else {
                             Some(Alias {
-                                name: field
-                                    .as_field()
-                                    .map(|s| s.response_key())
-                                    .unwrap()
-                                    .to_string(),
-                            }),
+                                name: field_response_key.clone(),
+                            })
+                        };
+                        new_selections.push(NamedSelection::Field(
+                            alias,
                             name.clone(),
-                            sub.as_ref()
-                                .map(|sub| {
-                                    sub.apply_selection_set(
-                                        &field.as_field().unwrap().selection_set,
-                                    )
-                                })
-                                .transpose()?,
+                            sub.as_ref().map(|sub| {
+                                sub.apply_selection_set(&field.as_field().unwrap().selection_set)
+                            }),
                         ));
                     }
                 }
                 NamedSelection::Quoted(alias, name, sub) => {
                     let key = alias.name.to_string();
-                    for field in find_fields_in_selection_set(selection_set, &key) {
+                    let fields = find_fields_in_selection_set(selection_set, &key);
+                    if self.star.is_some() {
+                        if fields.is_empty() {
+                            dropped_fields.insert(key.clone());
+                        } else {
+                            referenced_fields.insert(key.clone());
+                        }
+                    }
+                    for field in fields {
                         new_selections.push(NamedSelection::Quoted(
                             Alias {
                                 name: field
@@ -96,19 +106,27 @@ impl SubSelection {
                                     .to_string(),
                             },
                             name.clone(),
-                            sub.as_ref()
-                                .map(|sub| {
-                                    sub.apply_selection_set(
-                                        &field.as_field().unwrap().selection_set,
-                                    )
-                                })
-                                .transpose()?,
+                            sub.as_ref().map(|sub| {
+                                sub.apply_selection_set(&field.as_field().unwrap().selection_set)
+                            }),
                         ));
                     }
                 }
-                NamedSelection::Path(alias, sub) => {
+                NamedSelection::Path(alias, path_selection) => {
                     let key = alias.name.to_string();
-                    for field in find_fields_in_selection_set(selection_set, &key) {
+                    let fields = find_fields_in_selection_set(selection_set, &key);
+                    if self.star.is_some() {
+                        if let PathSelection::Key(key, _) = path_selection {
+                            if let Key::Field(name) | Key::Quoted(name) = key {
+                                if fields.is_empty() {
+                                    dropped_fields.insert(name.clone());
+                                } else {
+                                    referenced_fields.insert(name.clone());
+                                }
+                            }
+                        }
+                    }
+                    for field in fields {
                         new_selections.push(NamedSelection::Path(
                             Alias {
                                 name: field
@@ -117,7 +135,8 @@ impl SubSelection {
                                     .unwrap()
                                     .to_string(),
                             },
-                            sub.apply_selection_set(&field.as_field().unwrap().selection_set)?,
+                            path_selection
+                                .apply_selection_set(&field.as_field().unwrap().selection_set),
                         ));
                     }
                 }
@@ -132,45 +151,74 @@ impl SubSelection {
                                     .unwrap()
                                     .to_string(),
                             },
-                            sub.apply_selection_set(&field.as_field().unwrap().selection_set)?,
+                            sub.apply_selection_set(&field.as_field().unwrap().selection_set),
                         ));
                     }
                 }
             }
         }
-        // TODO: handle star selections
         let new_star = self.star.as_ref().cloned();
+        if new_star.is_some() {
+            // Alias fields that were dropped from the original selection to prevent them from
+            // being picked up by the star.
+            dropped_fields.retain(|key| !referenced_fields.contains(key));
+            for dropped in dropped_fields {
+                let mut unused = "__unused__".to_owned();
+                unused.push_str(dropped.as_str());
+                new_selections.push(NamedSelection::Field(
+                    Some(Alias { name: unused }),
+                    dropped.clone(),
+                    None,
+                ));
+            }
+        }
 
-        Ok(Self {
+        Self {
             selections: new_selections,
             star: new_star,
-        })
+        }
     }
 }
 
 impl PathSelection {
-    fn apply_selection_set(
-        &self,
-        selection_set: &SelectionSet,
-    ) -> Result<Self, ApplySelectionSetError> {
+    fn apply_selection_set(&self, selection_set: &SelectionSet) -> Self {
         match self {
-            Self::Var(str, path) => Ok(Self::Var(
+            Self::Var(str, path) => Self::Var(
                 str.clone(),
-                Box::new(path.apply_selection_set(selection_set)?),
-            )),
-            Self::Key(key, path) => Ok(Self::Key(
+                Box::new(path.apply_selection_set(selection_set)),
+            ),
+            Self::Key(key, path) => Self::Key(
                 key.clone(),
-                Box::new(path.apply_selection_set(selection_set)?),
-            )),
-            Self::Selection(sub) => Ok(Self::Selection(sub.apply_selection_set(selection_set)?)),
-            Self::Empty => Ok(Self::Empty),
+                Box::new(path.apply_selection_set(selection_set)),
+            ),
+            Self::Selection(sub) => Self::Selection(sub.apply_selection_set(selection_set)),
+            Self::Empty => Self::Empty,
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use apollo_compiler::executable::SelectionSet;
+    use apollo_compiler::validation::Valid;
+    use apollo_compiler::Schema;
     use pretty_assertions::assert_eq;
+
+    use crate::sources::connect::ApplyTo;
+
+    fn selection_set(schema: &Valid<Schema>, s: &str) -> SelectionSet {
+        apollo_compiler::ExecutableDocument::parse_and_validate(schema, s, "./")
+            .unwrap()
+            .anonymous_operation
+            .as_ref()
+            .unwrap()
+            .selection_set
+            .fields()
+            .next()
+            .unwrap()
+            .selection_set
+            .clone()
+    }
 
     #[test]
     fn test() {
@@ -188,9 +236,8 @@ mod tests {
         )
         .unwrap()
         .1;
-        println!("{json}");
 
-        let schema = apollo_compiler::Schema::parse_and_validate(
+        let schema = Schema::parse_and_validate(
             r###"
             type Query {
                 t: T
@@ -214,24 +261,12 @@ mod tests {
         )
         .unwrap();
 
-        let op = apollo_compiler::ExecutableDocument::parse_and_validate(
+        let selection_set = selection_set(
             &schema,
             "{ t { z: a, y: b, x: d, w: h v: k { u: l t: m } } }",
-            "./",
-        )
-        .unwrap();
-        let graphql = &op
-            .anonymous_operation
-            .as_ref()
-            .unwrap()
-            .selection_set
-            .fields()
-            .next()
-            .unwrap()
-            .selection_set;
+        );
 
-        let transformed = json.apply_selection_set(graphql).unwrap();
-        println!("{transformed}");
+        let transformed = json.apply_selection_set(&selection_set);
         assert_eq!(
             transformed.to_string(),
             r###".result {
@@ -244,6 +279,143 @@ mod tests {
     t: n
   }
 }"###
+        );
+    }
+
+    #[test]
+    fn test_star() {
+        let json_selection = super::JSONSelection::parse(
+            r###"
+        .result {
+          a
+          b
+          c
+          rest: *
+        }
+        "###,
+        )
+        .unwrap()
+        .1;
+
+        let schema = Schema::parse_and_validate(
+            r###"
+            type Query {
+                t: T
+            }
+
+            type T {
+                a: String
+                b: String
+                c: String
+                d: String
+            }
+            "###,
+            "./",
+        )
+        .unwrap();
+
+        let selection_set = selection_set(&schema, "{ t { a b } }");
+
+        let transformed = json_selection.apply_selection_set(&selection_set);
+        assert_eq!(
+            transformed.to_string(),
+            r###".result {
+  a
+  b
+  __unused__c: c
+  rest: *
+}"###
+        );
+
+        let data = serde_json_bytes::json!({
+            "result": {
+                "a": "a",
+                "b": "b",
+                "c": "c",
+                "d": "d",
+            }
+        });
+        let result = transformed.apply_to(&data);
+        assert_eq!(
+            result,
+            (
+                Some(
+                    serde_json_bytes::json!({"a": "a", "b": "b", "__unused__c": "c", "rest": { "d": "d" }})
+                ),
+                vec![]
+            )
+        );
+    }
+
+    #[test]
+    fn test_depth() {
+        let json = super::JSONSelection::parse(
+            r###"
+        .result {
+          a {
+            b {
+              renamed: c
+            }
+          }
+        }
+        "###,
+        )
+        .unwrap()
+        .1;
+
+        let schema = Schema::parse_and_validate(
+            r###"
+            type Query {
+                t: T
+            }
+
+            type T {
+              a: A
+            }
+
+            type A {
+              b: B
+            }
+
+            type B {
+              renamed: String
+            }
+            "###,
+            "./",
+        )
+        .unwrap();
+
+        let selection_set = selection_set(&schema, "{ t { a { b { renamed } } } }");
+
+        let transformed = json.apply_selection_set(&selection_set);
+        assert_eq!(
+            transformed.to_string(),
+            r###".result {
+  a {
+    b {
+      renamed: c
+    }
+  }
+}"###
+        );
+
+        let data = serde_json_bytes::json!({
+            "result": {
+              "a": {
+                "b": {
+                  "c": "c",
+                }
+              }
+            }
+          }
+        );
+        let result = transformed.apply_to(&data);
+        assert_eq!(
+            result,
+            (
+                Some(serde_json_bytes::json!({"a": { "b": { "renamed": "c" } } } )),
+                vec![]
+            )
         );
     }
 }

--- a/apollo-federation/src/sources/connect/json_selection/selection_set.rs
+++ b/apollo-federation/src/sources/connect/json_selection/selection_set.rs
@@ -1,0 +1,249 @@
+//! Functions for applying a [`SelectionSet`] to a [`JSONSelection`]. This creates a new
+//! `JSONSelection` mapping to the fields on the selection set, and excluding any parts of the
+//! original `JSONSelection` that are not needed by the selection set.
+use apollo_compiler::executable::Selection;
+use apollo_compiler::executable::SelectionSet;
+
+use crate::sources::connect::json_selection::Alias;
+use crate::sources::connect::json_selection::NamedSelection;
+use crate::sources::connect::JSONSelection;
+use crate::sources::connect::PathSelection;
+use crate::sources::connect::SubSelection;
+
+/// Find all fields in a selection set with a given name.
+fn find_fields_in_selection_set<'a>(set: &'a SelectionSet, name: &str) -> Vec<&'a Selection> {
+    let mut fields = vec![];
+    for selection in &set.selections {
+        match selection {
+            Selection::Field(field) => {
+                // TODO: handle include/skip directives, but will affect cache-ability
+                if field.name == name {
+                    fields.push(selection);
+                }
+            }
+            Selection::FragmentSpread(_) => {
+                // TODO: are these always expanded to inline fragments?
+                todo!("Handle fragment spread?")
+            }
+            Selection::InlineFragment(fragment) => {
+                // TODO: take directives like skip or include into account?
+                // TODO: take type condition into account? or is this out of scope for preview?
+                fields.extend(find_fields_in_selection_set(&fragment.selection_set, name));
+            }
+        }
+    }
+    fields
+}
+
+// TODO: are there any ways this can fail that need to be exposed?
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct ApplySelectionSetError;
+
+impl JSONSelection {
+    pub fn apply_selection_set(
+        &self,
+        selection_set: &SelectionSet,
+    ) -> Result<Self, ApplySelectionSetError> {
+        match self {
+            Self::Named(sub) => Ok(Self::Named(sub.apply_selection_set(selection_set)?)),
+            Self::Path(path) => Ok(Self::Path(path.apply_selection_set(selection_set)?)),
+        }
+    }
+}
+
+impl SubSelection {
+    fn apply_selection_set(
+        &self,
+        selection_set: &SelectionSet,
+    ) -> Result<Self, ApplySelectionSetError> {
+        let mut new_selections = Vec::new();
+        for selection in &self.selections {
+            match selection {
+                NamedSelection::Field(alias, name, sub) => {
+                    let key = alias
+                        .as_ref()
+                        .map(|a| a.name.to_string())
+                        .unwrap_or(name.to_string());
+                    for field in find_fields_in_selection_set(selection_set, &key) {
+                        new_selections.push(NamedSelection::Field(
+                            Some(Alias {
+                                name: field
+                                    .as_field()
+                                    .map(|s| s.response_key())
+                                    .unwrap()
+                                    .to_string(),
+                            }),
+                            name.clone(),
+                            sub.as_ref()
+                                .map(|sub| {
+                                    sub.apply_selection_set(
+                                        &field.as_field().unwrap().selection_set,
+                                    )
+                                })
+                                .transpose()?,
+                        ));
+                    }
+                }
+                NamedSelection::Quoted(alias, name, sub) => {
+                    let key = alias.name.to_string();
+                    for field in find_fields_in_selection_set(selection_set, &key) {
+                        new_selections.push(NamedSelection::Quoted(
+                            Alias {
+                                name: field
+                                    .as_field()
+                                    .map(|s| s.response_key())
+                                    .unwrap()
+                                    .to_string(),
+                            },
+                            name.clone(),
+                            sub.as_ref()
+                                .map(|sub| {
+                                    sub.apply_selection_set(
+                                        &field.as_field().unwrap().selection_set,
+                                    )
+                                })
+                                .transpose()?,
+                        ));
+                    }
+                }
+                NamedSelection::Path(alias, sub) => {
+                    let key = alias.name.to_string();
+                    for field in find_fields_in_selection_set(selection_set, &key) {
+                        new_selections.push(NamedSelection::Path(
+                            Alias {
+                                name: field
+                                    .as_field()
+                                    .map(|s| s.response_key())
+                                    .unwrap()
+                                    .to_string(),
+                            },
+                            sub.apply_selection_set(&field.as_field().unwrap().selection_set)?,
+                        ));
+                    }
+                }
+                NamedSelection::Group(alias, sub) => {
+                    let key = alias.name.to_string();
+                    for field in find_fields_in_selection_set(selection_set, &key) {
+                        new_selections.push(NamedSelection::Group(
+                            Alias {
+                                name: field
+                                    .as_field()
+                                    .map(|s| s.response_key())
+                                    .unwrap()
+                                    .to_string(),
+                            },
+                            sub.apply_selection_set(&field.as_field().unwrap().selection_set)?,
+                        ));
+                    }
+                }
+            }
+        }
+        // TODO: handle star selections
+        let new_star = self.star.as_ref().cloned();
+
+        Ok(Self {
+            selections: new_selections,
+            star: new_star,
+        })
+    }
+}
+
+impl PathSelection {
+    fn apply_selection_set(
+        &self,
+        selection_set: &SelectionSet,
+    ) -> Result<Self, ApplySelectionSetError> {
+        match self {
+            Self::Var(str, path) => Ok(Self::Var(
+                str.clone(),
+                Box::new(path.apply_selection_set(selection_set)?),
+            )),
+            Self::Key(key, path) => Ok(Self::Key(
+                key.clone(),
+                Box::new(path.apply_selection_set(selection_set)?),
+            )),
+            Self::Selection(sub) => Ok(Self::Selection(sub.apply_selection_set(selection_set)?)),
+            Self::Empty => Ok(Self::Empty),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn test() {
+        let json = super::JSONSelection::parse(
+            r###"
+        .result {
+          a
+          b: c
+          d: .e.f
+          g
+          h: 'i-j'
+          k: { l m: n }
+        }
+        "###,
+        )
+        .unwrap()
+        .1;
+        println!("{json}");
+
+        let schema = apollo_compiler::Schema::parse_and_validate(
+            r###"
+            type Query {
+                t: T
+            }
+
+            type T {
+                a: String
+                b: String
+                d: String
+                g: String
+                h: String
+                k: K
+            }
+
+            type K {
+              l: String
+              m: String
+            }
+            "###,
+            "./",
+        )
+        .unwrap();
+
+        let op = apollo_compiler::ExecutableDocument::parse_and_validate(
+            &schema,
+            "{ t { z: a, y: b, x: d, w: h v: k { u: l t: m } } }",
+            "./",
+        )
+        .unwrap();
+        let graphql = &op
+            .anonymous_operation
+            .as_ref()
+            .unwrap()
+            .selection_set
+            .fields()
+            .next()
+            .unwrap()
+            .selection_set;
+
+        let transformed = json.apply_selection_set(graphql).unwrap();
+        println!("{transformed}");
+        assert_eq!(
+            transformed.to_string(),
+            r###".result {
+  z: a
+  y: c
+  x: .e.f
+  w: "i-j"
+  v: {
+    u: l
+    t: n
+  }
+}"###
+        );
+    }
+}

--- a/apollo-federation/src/sources/connect/json_selection/selection_set.rs
+++ b/apollo-federation/src/sources/connect/json_selection/selection_set.rs
@@ -32,14 +32,9 @@ use crate::sources::connect::Key;
 use crate::sources::connect::PathSelection;
 use crate::sources::connect::SubSelection;
 
-/// Create a new version of `Self` by applying a selection set.
-pub trait ApplySelectionSet {
-    /// Apply a selection set to create a new version of `Self`
-    fn apply_selection_set(&self, selection_set: &SelectionSet) -> Self;
-}
-
-impl ApplySelectionSet for JSONSelection {
-    fn apply_selection_set(&self, selection_set: &SelectionSet) -> Self {
+impl JSONSelection {
+    /// Apply a selection set to create a new [`JSONSelection`]
+    pub fn apply_selection_set(&self, selection_set: &SelectionSet) -> Self {
         match self {
             Self::Named(sub) => Self::Named(sub.apply_selection_set(selection_set)),
             Self::Path(path) => Self::Path(path.apply_selection_set(selection_set)),
@@ -47,8 +42,9 @@ impl ApplySelectionSet for JSONSelection {
     }
 }
 
-impl ApplySelectionSet for SubSelection {
-    fn apply_selection_set(&self, selection_set: &SelectionSet) -> Self {
+impl SubSelection {
+    /// Apply a selection set to create a new [`SubSelection`]
+    pub fn apply_selection_set(&self, selection_set: &SelectionSet) -> Self {
         let mut new_selections = Vec::new();
         let mut dropped_fields = IndexMap::new();
         let mut referenced_fields = HashSet::new();
@@ -164,8 +160,9 @@ impl ApplySelectionSet for SubSelection {
     }
 }
 
-impl ApplySelectionSet for PathSelection {
-    fn apply_selection_set(&self, selection_set: &SelectionSet) -> Self {
+impl PathSelection {
+    /// Apply a selection set to create a new [`PathSelection`]
+    pub fn apply_selection_set(&self, selection_set: &SelectionSet) -> Self {
         match self {
             Self::Var(str, path) => Self::Var(
                 str.clone(),
@@ -219,7 +216,6 @@ mod tests {
     use apollo_compiler::Schema;
     use pretty_assertions::assert_eq;
 
-    use crate::sources::connect::json_selection::selection_set::ApplySelectionSet;
     use crate::sources::connect::ApplyTo;
 
     fn selection_set(schema: &Valid<Schema>, s: &str) -> SelectionSet {

--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -12,6 +12,7 @@ mod url_path_template;
 mod validation;
 
 use apollo_compiler::name;
+pub use json_selection::ApplySelectionSet;
 pub use json_selection::ApplyTo;
 pub use json_selection::ApplyToError;
 pub use json_selection::JSONSelection;

--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -12,7 +12,6 @@ mod url_path_template;
 mod validation;
 
 use apollo_compiler::name;
-pub use json_selection::ApplySelectionSet;
 pub use json_selection::ApplyTo;
 pub use json_selection::ApplyToError;
 pub use json_selection::JSONSelection;

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -1,6 +1,5 @@
 use apollo_compiler::validation::Valid;
 use apollo_compiler::Schema;
-use apollo_federation::sources::connect::ApplySelectionSet;
 use apollo_federation::sources::connect::ApplyTo;
 use apollo_federation::sources::connect::Connector;
 use serde_json_bytes::ByteString;

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -1,5 +1,6 @@
 use apollo_compiler::validation::Valid;
 use apollo_compiler::Schema;
+use apollo_federation::sources::connect::ApplySelectionSet;
 use apollo_federation::sources::connect::ApplyTo;
 use apollo_federation::sources::connect::Connector;
 use serde_json_bytes::ByteString;

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -67,9 +67,14 @@ pub(crate) async fn handle_responses(
             };
 
             let mut res_data = {
-                // TODO use response_key.selection_set() to use the operation selection set for alias/typename/field selection
-                // TODO use apply_with_args after passing the inputs to this function
-                let (res, apply_to_errors) = connector.selection.apply_to(&json_data);
+                // TODO: caching of the transformed JSONSelection with the selection set applied?
+                let transformed_selection = connector
+                    .selection
+                    .apply_selection_set(response_key.selection_set())
+                    .unwrap(); // TODO: error handling
+
+                let (res, apply_to_errors) =
+                    transformed_selection.apply_with_vars(&json_data, &response_key.inputs());
 
                 if let Some(ref mut debug) = debug {
                     debug.push_response(
@@ -77,6 +82,7 @@ pub(crate) async fn handle_responses(
                         &json_data,
                         Some(SelectionData {
                             source: connector.selection.to_string(),
+                            transformed: transformed_selection.to_string(),
                             result: res.clone(),
                             errors: apply_to_errors,
                         }),
@@ -218,8 +224,14 @@ fn inject_typename(data: &mut Value, typename: &str) {
 
 #[cfg(test)]
 mod tests {
+    use apollo_compiler::ast::FieldDefinition;
+    use apollo_compiler::ast::Type;
+    use apollo_compiler::executable::Field;
+    use apollo_compiler::executable::Selection;
     use apollo_compiler::executable::SelectionSet;
     use apollo_compiler::name;
+    use apollo_compiler::Name;
+    use apollo_compiler::Node;
     use apollo_compiler::Schema;
     use apollo_federation::sources::connect::ConnectId;
     use apollo_federation::sources::connect::Connector;
@@ -230,6 +242,7 @@ mod tests {
     use apollo_federation::sources::connect::Transport;
     use apollo_federation::sources::connect::URLPathTemplate;
     use insta::assert_debug_snapshot;
+    use serde_json_bytes::json;
 
     use crate::plugins::connectors::make_requests::ResponseKey;
     use crate::plugins::connectors::make_requests::ResponseTypeName;
@@ -259,6 +272,7 @@ mod tests {
         let response1 = http::Response::builder()
             .extension(ResponseKey::RootField {
                 name: "hello".to_string(),
+                inputs: json!({}),
                 typename: ResponseTypeName::Concrete("String".to_string()),
                 selection_set: SelectionSet {
                     ty: name!(Todo), // TODO
@@ -271,6 +285,7 @@ mod tests {
         let response2 = http::Response::builder()
             .extension(ResponseKey::RootField {
                 name: "hello2".to_string(),
+                inputs: json!({}),
                 typename: ResponseTypeName::Concrete("String".to_string()),
                 selection_set: SelectionSet {
                     ty: name!(Todo), // TODO
@@ -340,13 +355,22 @@ mod tests {
             entity_resolver: Some(EntityResolver::Explicit),
         };
 
+        let id_field_definition = FieldDefinition {
+            description: None,
+            name: Name::new("id").unwrap(),
+            arguments: Default::default(),
+            ty: Type::Named(Name::new("String").unwrap()),
+            directives: Default::default(),
+        };
+        let id_field = Field::new(Name::new("id").unwrap(), Node::from(id_field_definition));
         let response1 = http::Response::builder()
             .extension(ResponseKey::Entity {
                 index: 0,
+                inputs: json!({}),
                 typename: ResponseTypeName::Concrete("User".to_string()),
                 selection_set: SelectionSet {
                     ty: name!(Todo), // TODO
-                    selections: Default::default(),
+                    selections: vec![Selection::Field(Node::new(id_field.clone()))],
                 },
             })
             .body(hyper::Body::from(r#"{"data":{"id": "1"}}"#).into())
@@ -355,10 +379,11 @@ mod tests {
         let response2 = http::Response::builder()
             .extension(ResponseKey::Entity {
                 index: 1,
+                inputs: json!({}),
                 typename: ResponseTypeName::Concrete("User".to_string()),
                 selection_set: SelectionSet {
                     ty: name!(Todo), // TODO
-                    selections: Default::default(),
+                    selections: vec![Selection::Field(Node::new(id_field.clone()))],
                 },
             })
             .body(hyper::Body::from(r#"{"data":{"id": "2"}}"#).into())
@@ -444,6 +469,7 @@ mod tests {
         let response1 = http::Response::builder()
             .extension(ResponseKey::EntityField {
                 index: 0,
+                inputs: json!({}),
                 field_name: "field".to_string(),
                 typename: ResponseTypeName::Concrete("User".to_string()),
                 selection_set: SelectionSet {
@@ -457,6 +483,7 @@ mod tests {
         let response2 = http::Response::builder()
             .extension(ResponseKey::EntityField {
                 index: 1,
+                inputs: json!({}),
                 field_name: "field".to_string(),
                 typename: ResponseTypeName::Concrete("User".to_string()),
                 selection_set: SelectionSet {
@@ -547,6 +574,7 @@ mod tests {
         let response1 = http::Response::builder()
             .extension(ResponseKey::Entity {
                 index: 0,
+                inputs: json!({}),
                 typename: ResponseTypeName::Concrete("User".to_string()),
                 selection_set: SelectionSet {
                     ty: name!(Todo), // TODO
@@ -560,6 +588,7 @@ mod tests {
         let response2 = http::Response::builder()
             .extension(ResponseKey::Entity {
                 index: 1,
+                inputs: json!({}),
                 typename: ResponseTypeName::Concrete("User".to_string()),
                 selection_set: SelectionSet {
                     ty: name!(Todo), // TODO
@@ -572,6 +601,7 @@ mod tests {
         let response3 = http::Response::builder()
             .extension(ResponseKey::Entity {
                 index: 2,
+                inputs: json!({}),
                 typename: ResponseTypeName::Concrete("User".to_string()),
                 selection_set: SelectionSet {
                     ty: name!(Todo), // TODO

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -70,8 +70,7 @@ pub(crate) async fn handle_responses(
                 // TODO: caching of the transformed JSONSelection with the selection set applied?
                 let transformed_selection = connector
                     .selection
-                    .apply_selection_set(response_key.selection_set())
-                    .unwrap(); // TODO: error handling
+                    .apply_selection_set(response_key.selection_set());
 
                 let (res, apply_to_errors) =
                     transformed_selection.apply_with_vars(&json_data, &response_key.inputs());

--- a/apollo-router/src/plugins/connectors/http_json_transport.rs
+++ b/apollo-router/src/plugins/connectors/http_json_transport.rs
@@ -114,6 +114,7 @@ pub(crate) fn make_request(
             json_body.as_ref(),
             transport.body.as_ref().map(|body| SelectionData {
                 source: body.to_string(),
+                transformed: body.to_string(),
                 result: json_body.clone(),
                 errors: apply_to_errors,
             }),

--- a/apollo-router/src/plugins/connectors/plugin.rs
+++ b/apollo-router/src/plugins/connectors/plugin.rs
@@ -184,6 +184,7 @@ impl ConnectorContext {
 
 pub(crate) struct SelectionData {
     pub(crate) source: String,
+    pub(crate) transformed: String,
     pub(crate) result: Option<serde_json_bytes::Value>,
     pub(crate) errors: Vec<ApplyToError>,
 }
@@ -206,6 +207,7 @@ struct ConnectorDebugHttpRequest {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ConnectorDebugSelection {
     source: String,
+    transformed: String,
     result: Option<serde_json_bytes::Value>,
     errors: Vec<serde_json_bytes::Value>,
 }
@@ -233,6 +235,7 @@ fn serialize_request(
             content: body.clone(),
             selection: selection_data.map(|selection| ConnectorDebugSelection {
                 source: selection.source,
+                transformed: selection.transformed,
                 result: selection.result,
                 errors: aggregate_apply_to_errors(&selection.errors),
             }),
@@ -269,6 +272,7 @@ fn serialize_response(
             content: json_body.clone(),
             selection: selection_data.map(|selection| ConnectorDebugSelection {
                 source: selection.source,
+                transformed: selection.transformed,
                 result: selection.result,
                 errors: aggregate_apply_to_errors(&selection.errors),
             }),

--- a/apollo-router/src/plugins/connectors/testdata/mutation.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/mutation.yaml
@@ -1,5 +1,5 @@
 # rover supergraph compose --config apollo-router/src/plugins/connectors/testdata/mutation.yaml > apollo-router/src/plugins/connectors/testdata/mutation.graphql
-federation_version: =2.9.0-connectors.0
+federation_version: =2.9.0-connectors.8
 subgraphs:
   connectors:
     routing_url: none

--- a/apollo-router/src/plugins/connectors/testdata/selection.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/selection.graphql
@@ -23,16 +23,9 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-type Author
-  @join__type(graph: CONNECTORS)
-{
-  login: String
-}
-
 type Commit
   @join__type(graph: CONNECTORS)
 {
-  author: Author!
   commit: CommitDetail
 }
 
@@ -48,7 +41,7 @@ type CommitDetail
   @join__type(graph: CONNECTORS)
 {
   name_from_path: String
-  author: CommitAuthor
+  by: CommitAuthor
 }
 
 input join__ContextArgument {
@@ -85,5 +78,5 @@ enum link__Purpose {
 type Query
   @join__type(graph: CONNECTORS)
 {
-  commits(owner: String!, repo: String!): [Commit] @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/repos/{$args.owner}/{$args.repo}/commits"}, selection: "commit {\n  name_from_path: .author.name\n  author {\n    name\n    email\n    owner: $args.owner\n  }\n}"})
+  commits(owner: String!, repo: String!): [Commit] @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/repos/{$args.owner}/{$args.repo}/commits"}, selection: "commit {\n  name_from_path: .author.name\n  by: {\n    name: .author.name\n    email: .author.email\n    owner: $args.owner\n  }\n}"})
 }

--- a/apollo-router/src/plugins/connectors/testdata/selection.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/selection.graphql
@@ -5,7 +5,6 @@ schema
   @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "json", http: {baseURL: "https://jsonplaceholder.typicode.com/"}})
 {
   query: Query
-  mutation: Mutation
 }
 
 directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
@@ -23,6 +22,34 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Author
+  @join__type(graph: CONNECTORS)
+{
+  login: String
+}
+
+type Commit
+  @join__type(graph: CONNECTORS)
+{
+  author: Author!
+  commit: CommitDetail
+}
+
+type CommitAuthor
+  @join__type(graph: CONNECTORS)
+{
+  name: String
+  email: String
+  owner: String
+}
+
+type CommitDetail
+  @join__type(graph: CONNECTORS)
+{
+  name_from_path: String
+  author: CommitAuthor
+}
 
 input join__ContextArgument {
   name: String!
@@ -55,21 +82,8 @@ enum link__Purpose {
   EXECUTION
 }
 
-type Mutation
-  @join__type(graph: CONNECTORS)
-{
-  createUser(name: String!): User @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {POST: "/user", body: "username: $args.name"}, selection: "id\nname: username"})
-}
-
 type Query
   @join__type(graph: CONNECTORS)
 {
-  users: [User] @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users"}, selection: "id name"})
-}
-
-type User
-  @join__type(graph: CONNECTORS)
-{
-  id: ID!
-  name: String
+  commits(owner: String!, repo: String!): [Commit] @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/repos/{$args.owner}/{$args.repo}/commits"}, selection: "commit {\n  name_from_path: .author.name\n  author {\n    name\n    email\n    owner: $args.owner\n  }\n}"})
 }

--- a/apollo-router/src/plugins/connectors/testdata/selection.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/selection.yaml
@@ -1,0 +1,52 @@
+# rover supergraph compose --config apollo-router/src/plugins/connectors/testdata/selection.yaml > apollo-router/src/plugins/connectors/testdata/selection.graphql
+federation_version: =2.9.0-connectors.8
+subgraphs:
+  connectors:
+    routing_url: none
+    schema:
+      sdl: |
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.7")
+          @link(
+            url: "https://specs.apollo.dev/connect/v0.1"
+            import: ["@connect", "@source"]
+          )
+          @source(
+            name: "json"
+            http: {
+              baseURL: "https://jsonplaceholder.typicode.com/"
+            }
+          )
+
+        type Commit {
+          commit: CommitDetail
+        }
+        
+        type CommitDetail {
+          name_from_path: String
+          author: CommitAuthor
+        }
+          
+        type CommitAuthor {
+          name: String
+          email: String
+          owner: String
+        }
+          
+        type Query {
+          commits(owner: String!, repo: String!): [Commit]
+            @connect(
+              source: "json"
+                http: { GET: "/repos/{$$args.owner}/{$$args.repo}/commits" }
+                selection: """
+                commit {
+                  name_from_path: .author.name
+                  author {
+                    name
+                    email
+                    owner: $$args.owner
+                  }
+                }
+            """
+          )
+        }

--- a/apollo-router/src/plugins/connectors/testdata/selection.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/selection.yaml
@@ -24,7 +24,7 @@ subgraphs:
         
         type CommitDetail {
           name_from_path: String
-          author: CommitAuthor
+          by: CommitAuthor
         }
           
         type CommitAuthor {
@@ -41,9 +41,9 @@ subgraphs:
                 selection: """
                 commit {
                   name_from_path: .author.name
-                  author {
-                    name
-                    email
+                  by: {
+                    name: .author.name
+                    email: .author.email
                     owner: $$args.owner
                   }
                 }

--- a/apollo-router/src/plugins/connectors/testdata/steelthread.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/steelthread.graphql
@@ -1,6 +1,6 @@
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
   @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
   @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "json", http: {baseURL: "https://jsonplaceholder.typicode.com/", headers: [{name: "x-propagate"}, {name: "x-rename", as: "x-new-name"}, {name: "x-insert", value: "inserted"}]}})
 {
@@ -11,7 +11,7 @@ directive @join__directive(graphs: [join__Graph!], name: String!, args: join__Di
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -23,9 +23,18 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
 scalar join__DirectiveArguments
 
 scalar join__FieldSet
+
+scalar join__FieldValue
 
 enum join__Graph {
   CONNECTORS @join__graph(name: "connectors", url: "none")

--- a/apollo-router/src/plugins/connectors/testdata/steelthread.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/steelthread.yaml
@@ -1,5 +1,5 @@
 # rover supergraph compose --config apollo-router/src/plugins/connectors/testdata/steelthread.yaml > apollo-router/src/plugins/connectors/testdata/steelthread.graphql
-federation_version: =2.9.0-connectors.0
+federation_version: =2.9.0-connectors.8
 subgraphs:
   connectors:
     routing_url: none

--- a/apollo-router/src/plugins/connectors/tests.rs
+++ b/apollo-router/src/plugins/connectors/tests.rs
@@ -449,7 +449,7 @@ async fn test_selection_set() {
             }
 
             fragment CommitDetails on CommitDetail {
-              author {
+              by {
                 user: name @skip(if: $skipField)
                 name
                 ...on CommitAuthor @skip(if: $skipInlineFragment) {
@@ -481,7 +481,7 @@ async fn test_selection_set() {
           {
             "commit": {
               "from_path_alias": "Foo Bar",
-              "author": {
+              "by": {
                 "user": "Foo Bar",
                 "name": "Foo Bar",
                 "address": "noone@nowhere",

--- a/apollo-router/src/plugins/connectors/tests.rs
+++ b/apollo-router/src/plugins/connectors/tests.rs
@@ -121,6 +121,25 @@ pub(crate) mod mock_api {
               }
             })))
     }
+
+    pub(crate) fn commits() -> Mock {
+        Mock::given(method("GET"))
+            .and(path("/repos/foo/bar/commits"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!(
+              [
+                {
+                  "sha": "abcdef",
+                  "commit": {
+                    "author": {
+                      "name": "Foo Bar",
+                      "email": "noone@nowhere",
+                      "date": "2024-07-09T01:22:33Z"
+                    },
+                    "message": "commit message",
+                  },
+                }]
+            )))
+    }
 }
 
 pub(crate) mod mock_subgraph {
@@ -412,6 +431,80 @@ async fn test_mutation() {
 }
 
 #[tokio::test]
+async fn test_selection_set() {
+    let mock_server = MockServer::start().await;
+    mock_api::commits().mount(&mock_server).await;
+
+    let response = execute(
+        SELECTION_SCHEMA,
+        &mock_server.uri(),
+        "query Commits($owner: String!, $repo: String!, $skipInlineFragment: Boolean!,
+                             $skipNamedFragment: Boolean!, $skipField: Boolean!) {
+              commits(owner: $owner, repo: $repo) {
+                commit {
+                  from_path_alias: name_from_path
+                  ...CommitDetails @skip(if: $skipNamedFragment)
+                }
+              }
+            }
+
+            fragment CommitDetails on CommitDetail {
+              author {
+                user: name @skip(if: $skipField)
+                name
+                ...on CommitAuthor @skip(if: $skipInlineFragment) {
+                  address: email
+                  owner
+                }
+                owner_not_fragment: owner
+              }
+            }",
+        serde_json_bytes::json!({
+        "owner": "foo",
+        "repo": "bar",
+        "skipField": false,
+        "skipInlineFragment": false,
+        "skipNamedFragment": false
+        })
+        .as_object()
+        .unwrap()
+        .clone(),
+        None,
+        |_| {},
+    )
+    .await;
+
+    insta::assert_json_snapshot!(response, @r###"
+    {
+      "data": {
+        "commits": [
+          {
+            "commit": {
+              "from_path_alias": "Foo Bar",
+              "author": {
+                "user": "Foo Bar",
+                "name": "Foo Bar",
+                "address": "noone@nowhere",
+                "owner": "foo",
+                "owner_not_fragment": "foo"
+              }
+            }
+          }
+        ]
+      }
+    }
+    "###);
+
+    req_asserts::matches(
+        &mock_server.received_requests().await.unwrap(),
+        vec![Matcher::new()
+            .method("GET")
+            .path("/repos/foo/bar/commits")
+            .build()],
+    );
+}
+
+#[tokio::test]
 async fn test_nullability() {
     let mock_server = MockServer::start().await;
     mock_api::user_1_with_pet().mount(&mock_server).await;
@@ -451,6 +544,7 @@ async fn test_nullability() {
 const STEEL_THREAD_SCHEMA: &str = include_str!("./testdata/steelthread.graphql");
 const MUTATION_SCHEMA: &str = include_str!("./testdata/mutation.graphql");
 const NULLABILITY_SCHEMA: &str = include_str!("./testdata/nullability.graphql");
+const SELECTION_SCHEMA: &str = include_str!("./testdata/selection.graphql");
 
 async fn execute(
     schema: &str,


### PR DESCRIPTION
Implement a mechanism to apply a selection set to a `JSONSelection` to create a new `JSONSelection`. This selects only things that are in the selection set, and maps fields to aliases in the selection set. The transformed `JSONSelection` is then applied to the result of the connectors REST API call to create the response. The transformed `JSONSelection` is also included in the debug extension data.

This also adds support for variables when applying the `JSONSelection`.

<!-- [CNN-187] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-187]: https://apollographql.atlassian.net/browse/CNN-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ