### PR TITLE
Use OpTree concatenation in serial query planning 

### DIFF
--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -283,6 +283,40 @@ where
             })
     }
 
+    pub(crate) fn concat(self: &Arc<Self>, other: &Arc<Self>) -> Arc<Self> {
+        if Arc::ptr_eq(self, other) {
+            return self.clone();
+        }
+        assert!(
+            Arc::ptr_eq(&self.graph, &other.graph),
+            "Cannot merge path tree build on another graph"
+        );
+        assert_eq!(
+            self.node, other.node,
+            "Cannot merge path trees rooted different nodes"
+        );
+        if other.childs.is_empty() {
+            return self.clone();
+        }
+        if self.childs.is_empty() {
+            return other.clone();
+        }
+        let mut childs = Vec::with_capacity(self.childs.len() + other.childs.len());
+        childs.extend_from_slice(&self.childs);
+        childs.extend_from_slice(&other.childs);
+        Arc::new(Self {
+            graph: self.graph.clone(),
+            node: self.node,
+            local_selection_sets: self
+                .local_selection_sets
+                .iter()
+                .chain(&other.local_selection_sets)
+                .cloned()
+                .collect(),
+            childs,
+        })
+    }
+
     pub(crate) fn merge(self: &Arc<Self>, other: &Arc<Self>) -> Arc<Self> {
         if Arc::ptr_eq(self, other) {
             return self.clone();

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -329,7 +329,7 @@ where
     /// Like `Self::merge`, this method will panic if the graphs of the two `OpTree`s below to
     /// different allocations (i.e. they don't below to the same graph) or if they below to
     /// different root nodes.
-    pub(crate) fn concat(&mut self, other: &Self) {
+    pub(crate) fn extend(&mut self, other: &Self) {
         assert!(
             Arc::ptr_eq(&self.graph, &other.graph),
             "Cannot merge path tree build on another graph"

--- a/apollo-federation/src/query_graph/path_tree.rs
+++ b/apollo-federation/src/query_graph/path_tree.rs
@@ -23,7 +23,6 @@ use crate::query_graph::QueryGraphNode;
 // Typescript doesn't have a native way of associating equality/hash functions with types, so they
 // were passed around manually. This isn't the case with Rust, where we instead implement trigger
 // equality via `PartialEq` and `Hash`.
-#[derive(Clone)]
 pub(crate) struct PathTree<TTrigger, TEdge>
 where
     TTrigger: Eq + Hash,
@@ -45,6 +44,34 @@ where
     pub(crate) childs: Vec<Arc<PathTreeChild<TTrigger, TEdge>>>,
 }
 
+impl<TTrigger, TEdge> Clone for PathTree<TTrigger, TEdge>
+where
+    TTrigger: Eq + Hash,
+    TEdge: Copy + Into<Option<EdgeIndex>>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            graph: self.graph.clone(),
+            node: self.node,
+            local_selection_sets: self.local_selection_sets.clone(),
+            childs: self.childs.clone(),
+        }
+    }
+}
+
+impl<TTrigger, TEdge> PartialEq for PathTree<TTrigger, TEdge>
+where
+    TTrigger: Eq + Hash,
+    TEdge: Copy + PartialEq + Into<Option<EdgeIndex>>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.graph, &other.graph)
+            && self.node == other.node
+            && self.local_selection_sets == other.local_selection_sets
+            && self.childs == other.childs
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct PathTreeChild<TTrigger, TEdge>
 where
@@ -59,6 +86,19 @@ where
     pub(crate) conditions: Option<Arc<OpPathTree>>,
     /// The child `PathTree` reached by taking the edge.
     pub(crate) tree: Arc<PathTree<TTrigger, TEdge>>,
+}
+
+impl<TTrigger, TEdge> PartialEq for PathTreeChild<TTrigger, TEdge>
+where
+    TTrigger: Eq + Hash,
+    TEdge: Copy + PartialEq + Into<Option<EdgeIndex>>,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.edge == other.edge
+            && self.trigger == other.trigger
+            && self.conditions == other.conditions
+            && self.tree == other.tree
+    }
 }
 
 /// A `PathTree` whose triggers are operation elements (essentially meaning that the constituent
@@ -283,10 +323,13 @@ where
             })
     }
 
-    pub(crate) fn concat(self: &Arc<Self>, other: &Arc<Self>) -> Arc<Self> {
-        if Arc::ptr_eq(self, other) {
-            return self.clone();
-        }
+    /// Appends the children of the other `OpTree` onto the children of this tree.
+    ///
+    /// ## Panics
+    /// Like `Self::merge`, this method will panic if the graphs of the two `OpTree`s below to
+    /// different allocations (i.e. they don't below to the same graph) or if they below to
+    /// different root nodes.
+    pub(crate) fn concat(&mut self, other: &Self) {
         assert!(
             Arc::ptr_eq(&self.graph, &other.graph),
             "Cannot merge path tree build on another graph"
@@ -295,28 +338,24 @@ where
             self.node, other.node,
             "Cannot merge path trees rooted different nodes"
         );
+        if self == other {
+            return;
+        }
         if other.childs.is_empty() {
-            return self.clone();
+            return;
         }
         if self.childs.is_empty() {
-            return other.clone();
+            self.clone_from(other);
+            return;
         }
-        let mut childs = Vec::with_capacity(self.childs.len() + other.childs.len());
-        childs.extend_from_slice(&self.childs);
-        childs.extend_from_slice(&other.childs);
-        Arc::new(Self {
-            graph: self.graph.clone(),
-            node: self.node,
-            local_selection_sets: self
-                .local_selection_sets
-                .iter()
-                .chain(&other.local_selection_sets)
-                .cloned()
-                .collect(),
-            childs,
-        })
+        self.childs.extend_from_slice(&other.childs);
+        self.local_selection_sets
+            .extend_from_slice(&other.local_selection_sets);
     }
 
+    /// ## Panics
+    /// This method will panic if the graphs of the two `OpTree`s below to different allocations
+    /// (i.e. they don't below to the same graph) or if they below to different root nodes.
     pub(crate) fn merge(self: &Arc<Self>, other: &Arc<Self>) -> Arc<Self> {
         if Arc::ptr_eq(self, other) {
             return self.clone();

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -8,8 +8,6 @@ use apollo_compiler::Name;
 use indexmap::IndexMap;
 use indexmap::IndexSet;
 use itertools::Itertools;
-use petgraph::csr::NodeIndex;
-use petgraph::stable_graph::IndexType;
 
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
@@ -590,14 +588,14 @@ fn compute_root_serial_dependency_graph(
     Ok(digest)
 }
 
-fn only_root_subgraph(graph: &FetchDependencyGraph) -> Result<NodeIndex, FederationError> {
+fn only_root_subgraph(graph: &FetchDependencyGraph) -> Result<Arc<str>, FederationError> {
     let mut iter = graph.root_node_by_subgraph_iter();
-    let (Some((_, index)), None) = (iter.next(), iter.next()) else {
+    let (Some((name, _)), None) = (iter.next(), iter.next()) else {
         return Err(FederationError::internal(format!(
             "{graph} should have only one root."
         )));
     };
-    Ok(index.index() as u32)
+    Ok(name.clone())
 }
 
 pub(crate) fn compute_root_fetch_groups(

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -558,7 +558,7 @@ fn compute_root_serial_dependency_graph(
             // }
             // then we should _not_ merge the 2 `mut1` fields (contrarily to what happens on queried fields).
 
-            prev_path = OpPathTree::concat(&prev_path, &new_path);
+            Arc::make_mut(&mut prev_path).concat(&new_path);
             fetch_dependency_graph = FetchDependencyGraph::new(
                 supergraph_schema.clone(),
                 federated_query_graph.clone(),

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -558,7 +558,7 @@ fn compute_root_serial_dependency_graph(
             // }
             // then we should _not_ merge the 2 `mut1` fields (contrarily to what happens on queried fields).
 
-            Arc::make_mut(&mut prev_path).concat(&new_path);
+            Arc::make_mut(&mut prev_path).extend(&new_path);
             fetch_dependency_graph = FetchDependencyGraph::new(
                 supergraph_schema.clone(),
                 federated_query_graph.clone(),

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -560,7 +560,7 @@ fn compute_root_serial_dependency_graph(
             // }
             // then we should _not_ merge the 2 `mut1` fields (contrarily to what happens on queried fields).
 
-            prev_path = OpPathTree::merge(&prev_path, &new_path);
+            prev_path = OpPathTree::concat(&prev_path, &new_path);
             fetch_dependency_graph = FetchDependencyGraph::new(
                 supergraph_schema.clone(),
                 federated_query_graph.clone(),

--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -41,6 +41,7 @@ mod interface_object;
 mod interface_type_explosion;
 mod introspection_typename_handling;
 mod merged_abstract_types_handling;
+mod mutations;
 mod named_fragments;
 mod named_fragments_preservation;
 mod provides;

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/mutations.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/mutations.rs
@@ -38,6 +38,59 @@ fn adjacent_mutations_get_merged() {
             id
             bar
           }
+          updateInATwo: updateFooInA {
+            id
+            bar
+          }
+          updateInBOne: updateFooInB {
+            id
+            baz
+          }
+        }
+        "#,
+        @r###"
+        QueryPlan {
+          Sequence {
+            Fetch(service: "SubgraphA") {
+              {
+                updateInAOne: updateFooInA {
+                  id
+                  bar
+                }
+                updateInATwo: updateFooInA {
+                  id
+                  bar
+                }
+              }
+            },
+            Fetch(service: "SubgraphB") {
+              {
+                updateInBOne: updateFooInB {
+                  id
+                  baz
+                }
+              }
+            },
+          },
+        }
+        "###
+    );
+}
+
+#[test]
+fn non_adjacent_mutations_do_not_get_merged() {
+    let planner = planner!(
+        SubgraphA: SUBGRAPH_A,
+        SubgraphB: SUBGRAPH_B,
+    );
+    assert_plan!(
+        &planner,
+        r#"
+        mutation TestMutation {
+          updateInAOne: updateFooInA {
+            id
+            bar
+          }
           updateInBOne: updateFooInB {
             id
             baz

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/mutations.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/mutations.rs
@@ -1,0 +1,78 @@
+const SUBGRAPH_A: &str = r#"
+      type Foo @key(fields: "id") {
+        id: ID!
+        bar: String
+      }
+
+      type Query {
+        foo: Foo
+      }
+
+      type Mutation {
+        updateFooInA: Foo
+      }
+"#;
+
+const SUBGRAPH_B: &str = r#"
+      type Mutation {
+        updateFooInB: Foo
+      }
+
+      type Foo @key(fields: "id") {
+        id: ID!
+        baz: Int
+      }
+"#;
+
+#[test]
+fn adjacent_mutations_get_merged() {
+    let planner = planner!(
+        SubgraphA: SUBGRAPH_A,
+        SubgraphB: SUBGRAPH_B,
+    );
+    assert_plan!(
+        &planner,
+        r#"
+        mutation TestMutation {
+          updateInAOne: updateFooInA {
+            id
+            bar
+          }
+          updateInBOne: updateFooInB {
+            id
+            baz
+          }
+          updateInATwo: updateFooInA {
+            id
+            baz
+          }
+        }
+        "#,
+        @r###"
+        QueryPlan {
+          Sequence {
+            Fetch(service: "SubgraphA") {
+              {
+                updateInAOne: updateFooInA {
+                  id
+                  bar
+                }
+                updateInATwo: updateFooInA {
+                  id
+                  bar
+                }
+              }
+            },
+            Fetch(service: "SubgraphB") {
+              {
+                updateInBOne: updateFooInB {
+                  id
+                  baz
+                }
+              }
+            },
+          },
+        }
+        "###
+    );
+}

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/mutations.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/mutations.rs
@@ -44,7 +44,7 @@ fn adjacent_mutations_get_merged() {
           }
           updateInATwo: updateFooInA {
             id
-            baz
+            bar
           }
         }
         "#,
@@ -57,10 +57,6 @@ fn adjacent_mutations_get_merged() {
                   id
                   bar
                 }
-                updateInATwo: updateFooInA {
-                  id
-                  bar
-                }
               }
             },
             Fetch(service: "SubgraphB") {
@@ -68,6 +64,14 @@ fn adjacent_mutations_get_merged() {
                 updateInBOne: updateFooInB {
                   id
                   baz
+                }
+              }
+            },
+            Fetch(service: "SubgraphA") {
+              {
+                updateInATwo: updateFooInA {
+                  id
+                  bar
                 }
               }
             },

--- a/apollo-federation/tests/query_plan/supergraphs/adjacent_mutations_get_merged.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/adjacent_mutations_get_merged.graphql
@@ -1,0 +1,67 @@
+# Composed from subgraphs with hash: 2655e7da6754e73955fece01d7cbb5f21085bdbb
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+  mutation: Mutation
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Foo
+  @join__type(graph: SUBGRAPHA, key: "id")
+  @join__type(graph: SUBGRAPHB, key: "id")
+{
+  id: ID!
+  bar: String @join__field(graph: SUBGRAPHA)
+  baz: Int @join__field(graph: SUBGRAPHB)
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPHA @join__graph(name: "SubgraphA", url: "none")
+  SUBGRAPHB @join__graph(name: "SubgraphB", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Mutation
+  @join__type(graph: SUBGRAPHA)
+  @join__type(graph: SUBGRAPHB)
+{
+  updateFooInA: Foo @join__field(graph: SUBGRAPHA)
+  updateFooInB: Foo @join__field(graph: SUBGRAPHB)
+}
+
+type Query
+  @join__type(graph: SUBGRAPHA)
+  @join__type(graph: SUBGRAPHB)
+{
+  foo: Foo @join__field(graph: SUBGRAPHA)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/non_adjacent_mutations_do_not_get_merged.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/non_adjacent_mutations_do_not_get_merged.graphql
@@ -1,0 +1,67 @@
+# Composed from subgraphs with hash: 2655e7da6754e73955fece01d7cbb5f21085bdbb
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+  mutation: Mutation
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Foo
+  @join__type(graph: SUBGRAPHA, key: "id")
+  @join__type(graph: SUBGRAPHB, key: "id")
+{
+  id: ID!
+  bar: String @join__field(graph: SUBGRAPHA)
+  baz: Int @join__field(graph: SUBGRAPHB)
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPHA @join__graph(name: "SubgraphA", url: "none")
+  SUBGRAPHB @join__graph(name: "SubgraphB", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Mutation
+  @join__type(graph: SUBGRAPHA)
+  @join__type(graph: SUBGRAPHB)
+{
+  updateFooInA: Foo @join__field(graph: SUBGRAPHA)
+  updateFooInB: Foo @join__field(graph: SUBGRAPHB)
+}
+
+type Query
+  @join__type(graph: SUBGRAPHA)
+  @join__type(graph: SUBGRAPHB)
+{
+  foo: Foo @join__field(graph: SUBGRAPHA)
+}


### PR DESCRIPTION
This PR addresses an issue in the `compute_root_serial_dependency_graph` function. While iterating through the top-level fields, sucessive `OpTree`s from the same subgraph were being merged instead of concatenated. This can cause mutations to be merged together and effective forgotten.

Fixes FED-336.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
