### PR TITLE
Fix casing on HTTP method in connectors label

### DIFF
--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_realistic_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_realistic_supergraph-2.snap
@@ -5,7 +5,7 @@ expression: connectors.by_service_name
 {
     "connectors_Query_usersByCompany_0": Connector {
         id: ConnectId {
-            label: "connectors.example http: Get /by-company/{$args.company.name!}",
+            label: "connectors.example http: GET /by-company/{$args.company.name!}",
             subgraph_name: "connectors",
             source_name: Some(
                 "example",
@@ -94,7 +94,7 @@ expression: connectors.by_service_name
     },
     "connectors_Query_user_0": Connector {
         id: ConnectId {
-            label: "connectors.example http: Get /{$args.id!}",
+            label: "connectors.example http: GET /{$args.id!}",
             subgraph_name: "connectors",
             source_name: Some(
                 "example",

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_a_supergraph-2.snap
@@ -5,7 +5,7 @@ expression: connectors.by_service_name
 {
     "connectors_Query_users_0": Connector {
         id: ConnectId {
-            label: "connectors.example http: Get ",
+            label: "connectors.example http: GET ",
             subgraph_name: "connectors",
             source_name: Some(
                 "example",
@@ -49,7 +49,7 @@ expression: connectors.by_service_name
     },
     "connectors_Query_user_0": Connector {
         id: ConnectId {
-            label: "connectors.example http: Get /{$args.id!}",
+            label: "connectors.example http: GET /{$args.id!}",
             subgraph_name: "connectors",
             source_name: Some(
                 "example",
@@ -112,7 +112,7 @@ expression: connectors.by_service_name
     },
     "connectors_User_d_1": Connector {
         id: ConnectId {
-            label: "connectors.example http: Get /{$this.c!}/d",
+            label: "connectors.example http: GET /{$this.c!}/d",
             subgraph_name: "connectors",
             source_name: Some(
                 "example",

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_steelthread_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__it_expands_steelthread_supergraph-2.snap
@@ -5,7 +5,7 @@ expression: connectors.by_service_name
 {
     "connectors_Query_users_0": Connector {
         id: ConnectId {
-            label: "connectors.json http: Get /users",
+            label: "connectors.json http: GET /users",
             subgraph_name: "connectors",
             source_name: Some(
                 "json",
@@ -57,7 +57,7 @@ expression: connectors.by_service_name
     },
     "connectors_Query_user_0": Connector {
         id: ConnectId {
-            label: "connectors.json http: Get /users/{$args.id!}",
+            label: "connectors.json http: GET /users/{$args.id!}",
             subgraph_name: "connectors",
             source_name: Some(
                 "json",
@@ -127,7 +127,7 @@ expression: connectors.by_service_name
     },
     "connectors_User_d_1": Connector {
         id: ConnectId {
-            label: "connectors.json http: Get /users/{$this.c!}",
+            label: "connectors.json http: GET /users/{$this.c!}",
             subgraph_name: "connectors",
             source_name: Some(
                 "json",

--- a/apollo-federation/src/sources/connect/models/mod.rs
+++ b/apollo-federation/src/sources/connect/models/mod.rs
@@ -198,7 +198,7 @@ impl HttpJsonTransport {
     }
 
     fn label(&self) -> String {
-        format!("http: {} {}", self.method, self.path_template)
+        format!("http: {} {}", self.method.as_str(), self.path_template)
     }
 }
 
@@ -288,7 +288,7 @@ mod tests {
         assert_debug_snapshot!(&connectors, @r###"
         {
             ConnectId {
-                label: "connectors.json http: Get /users",
+                label: "connectors.json http: GET /users",
                 subgraph_name: "connectors",
                 source_name: Some(
                     "json",
@@ -300,7 +300,7 @@ mod tests {
                 },
             }: Connector {
                 id: ConnectId {
-                    label: "connectors.json http: Get /users",
+                    label: "connectors.json http: GET /users",
                     subgraph_name: "connectors",
                     source_name: Some(
                         "json",
@@ -363,7 +363,7 @@ mod tests {
                 entity_resolver: None,
             },
             ConnectId {
-                label: "connectors.json http: Get /posts",
+                label: "connectors.json http: GET /posts",
                 subgraph_name: "connectors",
                 source_name: Some(
                     "json",
@@ -375,7 +375,7 @@ mod tests {
                 },
             }: Connector {
                 id: ConnectId {
-                    label: "connectors.json http: Get /posts",
+                    label: "connectors.json http: GET /posts",
                     subgraph_name: "connectors",
                     source_name: Some(
                         "json",

--- a/apollo-router/src/plugins/connectors/tests.rs
+++ b/apollo-router/src/plugins/connectors/tests.rs
@@ -270,7 +270,7 @@ async fn basic_errors() {
         {
           "message": "http error: 404 Not Found",
           "extensions": {
-            "connector": "connectors.json http: Get /users",
+            "connector": "connectors.json http: GET /users",
             "code": "404"
           }
         }


### PR DESCRIPTION

Quick fix for HTTP method case on connectors label. This label shows up in the query plan, for example.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**


**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
