### PR TITLE
Add test for nullability with connectors

### DIFF
--- a/apollo-router/src/plugins/connectors/testdata/nullability.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/nullability.graphql
@@ -1,0 +1,85 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "json", http: {baseURL: "https://jsonplaceholder.typicode.com/"}})
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Address
+  @join__type(graph: CONNECTORS)
+{
+  street: String
+  zip: String
+}
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  CONNECTORS @join__graph(name: "connectors", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Pet
+  @join__type(graph: CONNECTORS)
+{
+  name: String
+  species: String
+}
+
+type Query
+  @join__type(graph: CONNECTORS)
+{
+  user(id: ID!): User @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users/{$args.id}"}, selection: "id\nname\noccupation: job\naddress {\n  street\n  zip\n}\npet {\n  name\n  species\n}", entity: true})
+}
+
+type User
+  @join__type(graph: CONNECTORS)
+{
+  id: ID!
+  name: String
+  occupation: String
+  address: Address
+  pet: Pet
+}

--- a/apollo-router/src/plugins/connectors/testdata/nullability.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/nullability.yaml
@@ -1,0 +1,59 @@
+# rover supergraph compose --config apollo-router/src/plugins/connectors/testdata/nullability.yaml > apollo-router/src/plugins/connectors/testdata/nullability.graphql
+federation_version: =2.9.0-connectors.8
+subgraphs:
+  connectors:
+    routing_url: none
+    schema:
+      sdl: |
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.7")
+          @link(
+            url: "https://specs.apollo.dev/connect/v0.1"
+            import: ["@connect", "@source"]
+          )
+          @source(
+            name: "json"
+            http: {
+              baseURL: "https://jsonplaceholder.typicode.com/"
+            }
+          )
+
+        type User {
+          id: ID!
+          name: String
+          occupation: String
+          address: Address
+          pet: Pet
+        }
+
+        type Address {
+          street: String
+          zip: String
+        }
+
+        type Pet {
+          name: String
+          species: String
+        }
+
+        type Query {
+          user(id: ID!): User
+            @connect(
+              source: "json"
+              http: { GET: "/users/{$$args.id}" }
+              selection: """
+              id
+              name
+              occupation: job
+              address {
+                street
+                zip
+              }
+              pet {
+                name
+                species
+              }
+              """
+              entity: true
+            )
+        }


### PR DESCRIPTION
Add a test that nullable fields are correctly set to `null` when not included in the REST response.

<!-- [CNN-251] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-251]: https://apollographql.atlassian.net/browse/CNN-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ