### PR TITLE
Add basic helm support for EC invalidation port exposure

### DIFF
--- a/helm/chart/router/templates/service.yaml
+++ b/helm/chart/router/templates/service.yaml
@@ -22,6 +22,12 @@ spec:
       targetPort: health
       protocol: TCP
       name: health
+    {{- if and (.Values.router.configuration.preview_entity_cache).enabled  (((.Values.router.configuration.preview_entity_cache).subgraph).all).enabled ((((.Values.router.configuration.preview_entity_cache).subgraph).all).invalidation).enabled}}
+    - port: {{ (splitList ":" .Values.router.configuration.preview_entity_cache.subgraph.all.invalidation.listen | last) }}
+      targetPort: 12345
+      protocol: TCP
+      name: invalidation
+    {{- end }}
     {{- if .Values.serviceMonitor.enabled }}
     {{/* NOTE: metrics configuration moved under telemetry.exporters in Router 1.35.0 */}}
     {{- if .Values.router.configuration.telemetry.exporters.metrics.prometheus.listen }}

--- a/helm/chart/router/templates/service.yaml
+++ b/helm/chart/router/templates/service.yaml
@@ -22,7 +22,7 @@ spec:
       targetPort: health
       protocol: TCP
       name: health
-    {{/* Should we expose an entity cache invalidation port? */}}
+    {{- /* Should we expose an entity cache invalidation port? */}}
     {{- if and (.Values.router.configuration.preview_entity_cache).enabled  (((.Values.router.configuration.preview_entity_cache).subgraph).all).enabled ((((.Values.router.configuration.preview_entity_cache).subgraph).all).invalidation).enabled}}
     - port: {{ (splitList ":" .Values.router.configuration.preview_entity_cache.subgraph.all.invalidation.listen | last) }}
       targetPort: invalidation

--- a/helm/chart/router/templates/service.yaml
+++ b/helm/chart/router/templates/service.yaml
@@ -22,9 +22,10 @@ spec:
       targetPort: health
       protocol: TCP
       name: health
+    {{/* Should we expose an entity cache invalidation port? */}}
     {{- if and (.Values.router.configuration.preview_entity_cache).enabled  (((.Values.router.configuration.preview_entity_cache).subgraph).all).enabled ((((.Values.router.configuration.preview_entity_cache).subgraph).all).invalidation).enabled}}
     - port: {{ (splitList ":" .Values.router.configuration.preview_entity_cache.subgraph.all.invalidation.listen | last) }}
-      targetPort: 12345
+      targetPort: invalidation
       protocol: TCP
       name: invalidation
     {{- end }}

--- a/helm/chart/router/templates/service.yaml
+++ b/helm/chart/router/templates/service.yaml
@@ -23,8 +23,8 @@ spec:
       protocol: TCP
       name: health
     {{- /* Should we expose an entity cache invalidation port? */}}
-    {{- if and (.Values.router.configuration.preview_entity_cache).enabled  (((.Values.router.configuration.preview_entity_cache).subgraph).all).enabled ((((.Values.router.configuration.preview_entity_cache).subgraph).all).invalidation).enabled}}
-    - port: {{ (splitList ":" .Values.router.configuration.preview_entity_cache.subgraph.all.invalidation.listen | last) }}
+    {{- if and (.Values.router.configuration.preview_entity_cache).enabled (.Values.router.configuration.preview_entity_cache).invalidation }}
+    - port: {{ (splitList ":" .Values.router.configuration.preview_entity_cache.invalidation.listen | last) }}
       targetPort: invalidation
       protocol: TCP
       name: invalidation


### PR DESCRIPTION
<!--ROUTER-422--->
A first stab at trying to expose EC invalidation port.

Some questions:
 - Do we want to expose more than one port?
   - We don't.
 - Do we want a default port or do we want to just expose the chosen port as the service port?
   - We don't, you must specify a port number in your `listen` configuration.
 - Do we want to call the port "invalidation". I just chose that arbitrarily.
   - Good enough choice for now, to be finalised at some point. 

Some thoughts. The check to see if `invalidation` is enabled is a relatively complex `and` of various configuration properties. Could this be simplified?

Anyway, it's basically working within the constraints established by these questions.

Here are some sample configurations that highlight why we need to resolve these question:

1. Defined two listen points, one that is for `all`, one just for `reviews`.
```
preview_entity_cache:
  enabled: true
  redis:
    urls:
      ["redis://localhost:6379",]
  subgraph:
    all:
      enabled: true
      invalidation:
        enabled: true
        # FIXME: right now we cannot configure it to use the same port used for the GraphQL endpoint if it is chosen at random
        listen: "127.0.0.1:12345"
        path: "/invalidation-sample-subgraph-type"
        shared_key: "1234"
    subgraphs:
      reviews:
      invalidation:
        enabled: true
        # FIXME: right now we cannot configure it to use the same port used for the GraphQL endpoint if it is chosen at random
        listen: "127.0.0.1:12346"
        path: "/invalidation-sample-review-type"
        shared_key: "1234"        ttl: 120s
        enabled: true
```
2. Defined two listen points, one that is for `all`, one just for `reviews`. All is disabled.
```
preview_entity_cache:
  enabled: true
  redis:
    urls:
      ["redis://localhost:6379",]
  subgraph:
    all:
      enabled: true
      invalidation:
        enabled: false
        # FIXME: right now we cannot configure it to use the same port used for the GraphQL endpoint if it is chosen at random
        listen: "127.0.0.1:12345"
        path: "/invalidation-sample-subgraph-type"
        shared_key: "1234"
    subgraphs:
      reviews:
      invalidation:
        enabled: true
        # FIXME: right now we cannot configure it to use the same port used for the GraphQL endpoint if it is chosen at random
        listen: "127.0.0.1:12346"
        path: "/invalidation-sample-review-type"
        shared_key: "1234"        ttl: 120s
        enabled: true
```
3. Defined one listen point, no port number.
```
preview_entity_cache:
  enabled: true
  redis:
    urls:
      ["redis://localhost:6379",]
  subgraph:
    all:
      enabled: true
      invalidation:
        enabled: false
        # FIXME: right now we cannot configure it to use the same port used for the GraphQL endpoint if it is chosen at random
        listen: "127.0.0.1"
        path: "/invalidation-sample-subgraph-type"
        shared_key: "1234"
```
===UPDATE===
Following discussion, the `listen` and `path` configuration details are hoisted out of individual subgraph configuration. This is what the configuration looks like now:

```
preview_entity_cache:
  enabled: true
  invalidation:
    # FIXME: right now we cannot configure it to use the same port used for the GraphQL endpoint if it is chosen at random
    listen: "127.0.0.1:12345"
    path: "/invalidation-sample-subgraph-type"
  redis:
    urls:
      ["redis://localhost:6379",]
  subgraph:
    all:
      enabled: true
      invalidation:
        enabled: false
        shared_key: "1234"
```