### PR TITLE
Move validation imports out of models

### DIFF
--- a/apollo-federation/src/sources/connect/mod.rs
+++ b/apollo-federation/src/sources/connect/mod.rs
@@ -9,7 +9,7 @@ mod json_selection;
 mod models;
 pub(crate) mod spec;
 mod url_path_template;
-mod validation;
+pub mod validation;
 
 use apollo_compiler::name;
 pub use json_selection::ApplyTo;
@@ -18,11 +18,6 @@ pub use json_selection::JSONSelection;
 pub use json_selection::Key;
 pub use json_selection::PathSelection;
 pub use json_selection::SubSelection;
-pub use models::validate;
-pub use models::Location;
-pub use models::ValidationCode;
-pub use models::ValidationMessage;
-pub use models::ValidationSeverity;
 pub(crate) use spec::ConnectSpecDefinition;
 pub use url_path_template::URLPathTemplate;
 

--- a/apollo-federation/src/sources/connect/models.rs
+++ b/apollo-federation/src/sources/connect/models.rs
@@ -1,14 +1,8 @@
 use indexmap::IndexMap;
-pub use validation::validate;
-pub use validation::Code as ValidationCode;
-pub use validation::Location;
-pub use validation::Message as ValidationMessage;
-pub use validation::Severity as ValidationSeverity;
 
 use super::spec::ConnectHTTPArguments;
 use super::spec::HTTPHeaderOption;
 use super::spec::SourceHTTPArguments;
-use super::validation;
 use super::ConnectId;
 use super::JSONSelection;
 use super::URLPathTemplate;


### PR DESCRIPTION
This was vestigial from before the reorganization. Now exposing the module instead of items from within it to make changes easier in the future.