### PR TITLE
Improves semantic comparison of query plans

### DIFF
--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -511,24 +511,19 @@ fn hash_selection_key(selection: &ast::Selection) -> u64 {
 }
 
 fn same_ast_selection_set_sorted(x: &[ast::Selection], y: &[ast::Selection]) -> bool {
-    fn sorted_by_selection_key(s: &[ast::Selection]) -> Vec<ast::Selection> {
-        let mut sorted = s.to_owned();
-        sorted.sort_by_key(hash_selection_key);
+    fn sorted_by_selection_key(s: &[ast::Selection]) -> Vec<&ast::Selection> {
+        let mut sorted: Vec<&ast::Selection> = s.iter().collect();
+        sorted.sort_by_key(|x| hash_selection_key(x));
         sorted
     }
 
     if x.len() != y.len() {
         return false;
     }
-
-    let x_sorted = sorted_by_selection_key(x);
-    let y_sorted = sorted_by_selection_key(y);
-    for (x, y) in x_sorted.iter().zip(y_sorted.iter()) {
-        if !same_ast_selection(x, y) {
-            return false;
-        }
-    }
-    true
+    sorted_by_selection_key(x)
+        .into_iter()
+        .zip(sorted_by_selection_key(y))
+        .all(|(x, y)| same_ast_selection(x, y))
 }
 
 #[cfg(test)]

--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -372,8 +372,13 @@ fn flatten_node_matches(this: &FlattenNode, other: &FlattenNode) -> bool {
 // AST comparison functions
 
 fn same_ast_document(x: &ast::Document, y: &ast::Document) -> bool {
-    fn split_definitions(doc: &ast::Document
-    ) -> (Vec<&ast::OperationDefinition>, Vec<&ast::FragmentDefinition>, Vec<&ast::Definition>) {
+    fn split_definitions(
+        doc: &ast::Document,
+    ) -> (
+        Vec<&ast::OperationDefinition>,
+        Vec<&ast::FragmentDefinition>,
+        Vec<&ast::Definition>,
+    ) {
         let mut operations: Vec<&ast::OperationDefinition> = Vec::new();
         let mut fragments: Vec<&ast::FragmentDefinition> = Vec::new();
         let mut others: Vec<&ast::Definition> = Vec::new();
@@ -393,14 +398,17 @@ fn same_ast_document(x: &ast::Document, y: &ast::Document) -> bool {
 
     assert!(x_others.is_empty(), "Unexpected definition types");
     assert!(y_others.is_empty(), "Unexpected definition types");
-    assert!(x_ops.len() == y_ops.len(), "Different number of operation definitions");
+    assert!(
+        x_ops.len() == y_ops.len(),
+        "Different number of operation definitions"
+    );
 
     x_ops
         .iter()
         .zip(y_ops.iter())
         .all(|(x_op, y_op)| same_ast_operation_definition(x_op, y_op))
-    && x_frags.len() == y_frags.len()
-    && x_frags
+        && x_frags.len() == y_frags.len()
+        && x_frags
             .iter()
             .zip(y_frags.iter())
             .all(|(x_frag, y_frag)| same_ast_fragment_definition(x_frag, y_frag))
@@ -417,10 +425,7 @@ fn same_ast_operation_definition(
         && same_ast_selection_set_sorted(&x.selection_set, &y.selection_set)
 }
 
-fn same_ast_fragment_definition(
-    x: &ast::FragmentDefinition,
-    y: &ast::FragmentDefinition,
-) -> bool {
+fn same_ast_fragment_definition(x: &ast::FragmentDefinition, y: &ast::FragmentDefinition) -> bool {
     x.name == y.name
         && x.type_condition == y.type_condition
         && x.directives == y.directives
@@ -460,7 +465,7 @@ fn get_selection_key(selection: &ast::Selection) -> SelectionKey {
         ast::Selection::InlineFragment(fragment) => SelectionKey::InlineFragment {
             type_condition: fragment.type_condition.clone(),
             directives: fragment.directives.clone(),
-        }
+        },
     }
 }
 
@@ -469,7 +474,11 @@ use std::ops::Not;
 /// Get the sub-selections of a selection.
 fn get_selection_set(selection: &ast::Selection) -> Option<&Vec<ast::Selection>> {
     match selection {
-        ast::Selection::Field(field) => field.selection_set.is_empty().not().then(|| &field.selection_set),
+        ast::Selection::Field(field) => field
+            .selection_set
+            .is_empty()
+            .not()
+            .then(|| &field.selection_set),
         ast::Selection::FragmentSpread(_) => None,
         ast::Selection::InlineFragment(fragment) => Some(&fragment.selection_set),
     }

--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -396,17 +396,18 @@ fn same_ast_document(x: &ast::Document, y: &ast::Document) -> bool {
     let (x_ops, x_frags, x_others) = split_definitions(x);
     let (y_ops, y_frags, y_others) = split_definitions(y);
 
-    assert!(x_others.is_empty(), "Unexpected definition types");
-    assert!(y_others.is_empty(), "Unexpected definition types");
-    assert!(
+    debug_assert!(x_others.is_empty(), "Unexpected definition types");
+    debug_assert!(y_others.is_empty(), "Unexpected definition types");
+    debug_assert!(
         x_ops.len() == y_ops.len(),
         "Different number of operation definitions"
     );
 
-    x_ops
-        .iter()
-        .zip(y_ops.iter())
-        .all(|(x_op, y_op)| same_ast_operation_definition(x_op, y_op))
+    x_ops.len() == y_ops.len()
+        && x_ops
+            .iter()
+            .zip(y_ops.iter())
+            .all(|(x_op, y_op)| same_ast_operation_definition(x_op, y_op))
         && x_frags.len() == y_frags.len()
         && x_frags
             .iter()


### PR DESCRIPTION
This PR improves semantic comparison of query plans as following:

- Selection sets are no longer order-sensitive. Selections are sorted by the selection key before comparison.
- Fragment definitions are no longer order-sensitive. Fragment definitions are sorted by the name before comparison.


<!-- [FED-318] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests


[FED-318]: https://apollographql.atlassian.net/browse/FED-318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ