### PR TITLE
fix(federation): fix "$var is not defined" in subgraph entity query

### DIFF
--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -170,7 +170,7 @@ fn plan(query_path: &Path, schema_paths: &[PathBuf]) -> Result<(), FederationErr
     // TODO: add CLI parameters for config as needed
     let config = QueryPlannerConfig::default();
     let planner = QueryPlanner::new(&supergraph, config)?;
-    print!("{}", planner.build_query_plan(&query_doc, None).unwrap());
+    print!("{}", planner.build_query_plan(&query_doc, None)?);
     Ok(())
 }
 

--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -170,7 +170,7 @@ fn plan(query_path: &Path, schema_paths: &[PathBuf]) -> Result<(), FederationErr
     // TODO: add CLI parameters for config as needed
     let config = QueryPlannerConfig::default();
     let planner = QueryPlanner::new(&supergraph, config)?;
-    print!("{}", planner.build_query_plan(&query_doc, None)?);
+    print!("{}", planner.build_query_plan(&query_doc, None).unwrap());
     Ok(())
 }
 

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -207,7 +207,8 @@ impl SingleFederationError {
         match self {
             SingleFederationError::Internal { .. } => ErrorCode::Internal,
             SingleFederationError::InternalRebaseError { .. } => ErrorCode::Internal,
-            SingleFederationError::InvalidGraphQL{..} | SingleFederationError::InvalidGraphQLName(_) => ErrorCode::InvalidGraphQL,
+            SingleFederationError::InvalidGraphQL { .. }
+            | SingleFederationError::InvalidGraphQLName(_) => ErrorCode::InvalidGraphQL,
             SingleFederationError::InvalidSubgraph { .. } => ErrorCode::InvalidGraphQL,
             SingleFederationError::DirectiveDefinitionInvalid { .. } => {
                 ErrorCode::DirectiveDefinitionInvalid
@@ -402,9 +403,7 @@ impl From<FederationSpecError> for FederationError {
             FederationSpecError::UnsupportedFederationDirective { .. } => {
                 SingleFederationError::UnsupportedFederationDirective { message }.into()
             }
-            FederationSpecError::InvalidGraphQLName(message) => {
-                message.into()
-            }
+            FederationSpecError::InvalidGraphQLName(message) => message.into(),
         }
     }
 }

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -636,8 +636,9 @@ pub(crate) enum SelectionKey {
 }
 
 impl SelectionKey {
+    /// Returns true if the selection key is `__typename` *without directives*.
     pub(crate) fn is_typename_field(&self) -> bool {
-        matches!(self, SelectionKey::Field { response_name, .. } if *response_name == TYPENAME_FIELD)
+        matches!(self, SelectionKey::Field { response_name, directives } if *response_name == TYPENAME_FIELD && directives.is_empty())
     }
 }
 

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -4019,10 +4019,7 @@ fn collect_variables_from_directive<'selection>(
 }
 
 impl Field {
-    fn collect_variables<'selection>(
-        &'selection self,
-        variables: &mut HashSet<&'selection Name>,
-    ) {
+    fn collect_variables<'selection>(&'selection self, variables: &mut HashSet<&'selection Name>) {
         for arg in self.arguments.iter() {
             collect_variables_from_argument(arg, variables)
         }
@@ -4048,10 +4045,7 @@ impl FieldSelection {
 }
 
 impl InlineFragment {
-    fn collect_variables<'selection>(
-        &'selection self,
-        variables: &mut HashSet<&'selection Name>,
-    ) {
+    fn collect_variables<'selection>(&'selection self, variables: &mut HashSet<&'selection Name>) {
         for dir in self.directives.iter() {
             collect_variables_from_directive(dir, variables)
         }
@@ -4082,29 +4076,27 @@ impl Selection {
             Selection::InlineFragment(inline_fragment) => {
                 inline_fragment.collect_variables(variables)
             }
-            Selection::FragmentSpread(_) => {
-                Err(FederationError::internal("collect_variables(): unexpected fragment spread"))
-            }
+            Selection::FragmentSpread(_) => Err(FederationError::internal(
+                "collect_variables(): unexpected fragment spread",
+            )),
         }
     }
 }
 
 impl SelectionSet {
-    /// erm
+    /// Returns the variable names that are used by this selection set.
     ///
     /// # Errors
     /// Returns an error if the selection set contains a named fragment spread.
-    pub(crate) fn used_variables(&self) -> Result<Vec<Name>, FederationError> {
+    pub(crate) fn used_variables(&self) -> Result<HashSet<&'_ Name>, FederationError> {
         let mut variables = HashSet::new();
         self.collect_variables(&mut variables)?;
-        let mut res: Vec<Name> = variables.into_iter().cloned().collect();
-        res.sort();
-        Ok(res)
+        Ok(variables)
     }
 
     /// # Errors
     /// Returns an error if the selection set contains a named fragment spread.
-    pub(crate) fn collect_variables<'selection>(
+    fn collect_variables<'selection>(
         &'selection self,
         variables: &mut HashSet<&'selection Name>,
     ) -> Result<(), FederationError> {

--- a/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -1416,12 +1416,7 @@ fn add_subgraph_input_field(
 
 /// Parse a string encoding a type reference.
 fn decode_type(type_: &str) -> Result<Type, FederationError> {
-    Type::parse(type_, "").map_err(|_| {
-        SingleFederationError::InvalidGraphQL {
-            message: format!("Cannot parse type \"{}\"", type_),
-        }
-        .into()
-    })
+    Ok(Type::parse(type_, "")?)
 }
 
 fn get_subgraph<'subgraph>(

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2544,14 +2544,14 @@ fn operation_for_entities_fetch(
     );
 
     let query_type_name = subgraph_schema.schema().root_operation(OperationType::Query).ok_or_else(||
-    SingleFederationError::InvalidGraphQL {
+    SingleFederationError::InvalidSubgraph {
         message: "Subgraphs should always have a query root (they should at least provides _entities)".to_string()
     })?;
 
     let query_type = match subgraph_schema.get_type(query_type_name.clone())? {
         crate::schema::position::TypeDefinitionPosition::Object(o) => o,
         _ => {
-            return Err(SingleFederationError::InvalidGraphQL {
+            return Err(SingleFederationError::InvalidSubgraph {
                 message: "the root query type must be an object".to_string(),
             }
             .into())
@@ -2563,7 +2563,7 @@ fn operation_for_entities_fetch(
         .fields
         .contains_key(&ENTITIES_QUERY)
     {
-        return Err(SingleFederationError::InvalidGraphQL {
+        return Err(SingleFederationError::InvalidSubgraph {
             message: "Subgraphs should always have the _entities field".to_string(),
         }
         .into());

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -332,7 +332,9 @@ impl QueryPlanner {
         if operation.selection_set.selections.is_empty() {
             // This should never happen because `operation` comes from a known-valid document.
             // TODO(@goto-bus-stop) it's probably fair to panic here :)
-            return Err(FederationError::internal("Invalid operation: empty selection set"));
+            return Err(FederationError::internal(
+                "Invalid operation: empty selection set",
+            ));
         }
 
         let is_subscription = operation.is_subscription();

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -331,10 +331,8 @@ impl QueryPlanner {
 
         if operation.selection_set.selections.is_empty() {
             // This should never happen because `operation` comes from a known-valid document.
-            return Err(SingleFederationError::InvalidGraphQL {
-                message: "Invalid operation: empty selection set".to_string(),
-            }
-            .into());
+            // TODO(@goto-bus-stop) it's probably fair to panic here :)
+            return Err(FederationError::internal("Invalid operation: empty selection set"));
         }
 
         let is_subscription = operation.is_subscription();

--- a/apollo-federation/src/subgraph/spec.rs
+++ b/apollo-federation/src/subgraph/spec.rs
@@ -135,13 +135,13 @@ pub enum FederationSpecError {
     },
     #[error("Unsupported federation directive import {0}")]
     UnsupportedFederationDirective(String),
-    #[error("Invalid GraphQL name {0}")]
-    InvalidGraphQLName(String),
+    #[error(transparent)]
+    InvalidGraphQLName(InvalidNameError),
 }
 
 impl From<InvalidNameError> for FederationSpecError {
     fn from(err: InvalidNameError) -> Self {
-        FederationSpecError::InvalidGraphQLName(format!("Invalid GraphQL name \"{}\"", err.name))
+        FederationSpecError::InvalidGraphQLName(err)
     }
 }
 

--- a/apollo-federation/tests/api_schema.rs
+++ b/apollo-federation/tests/api_schema.rs
@@ -2038,8 +2038,13 @@ fn inaccessible_on_builtins() {
 
     // Note this is different from the JS implementation
     insta::assert_snapshot!(errors, @r###"
-    The following errors occurred:
-      - built-in scalar definitions must be omitted
+    Error: built-in scalar definitions must be omitted
+        ╭─[schema.graphql:26:7]
+        │
+     26 │       scalar String @inaccessible
+        │       ─────────────┬─────────────  
+        │                    ╰─────────────── remove this scalar definition
+    ────╯
     "###);
 }
 


### PR DESCRIPTION
We had a bug where an input like this:
```graphql
fragment x on T {
  __typename @include(if: $var)
  field
}
query ($var: Boolean!) {
  returnsT {
    ...x
  }
  someEntity {
    .. on T { field }
  }
}
```

Could produce a subgraph entity query like this. Note this isn't a precise reproduction, since the exact reproduction involving entities is more difficult, but it is an accurate presentation of the problem:
```graphql
query Example($representations: [_Any!]!) {
  _entities(representations: $representations) {
    ... on T {
      __typename @include(if: $var)
      field
    }
  }
}
```

The entity query references a `$var` that does not exist.

This is because when the final subgraph operation is produced, we first determine what variables the operation needs, and *then* try to reuse fragments from the input. Inline fragments may be replaced by an equivalent fragment spread. Whether a `__typename` field is present does not matter for equivalence. So fragment reuse considers that `... on T { field }` may be reduced to `...x`. Then, it considers that `x` is only used once in the final operation, so using `x` actually requires more code, and re-expands it. We get:
```graphql
... on T {
  __typename @include(if: $var)
  field
}
```
And we're referencing `$var` even though the `someEntity` part of the query never referenced a variable originally.

So. The bug is that `.contains()` has to ignore `__typename`, but *only* if it does not have directives. It's possible that there are other issues when you have a `__typename` with directives. But the JS only considers `__typename` *without directives* specially, and Rust was considering *any* `__typename` specially. This patch aligns JS and Rust.

An alternative solution might have been to collect the used variables *after* reusing fragments. But I think fragment reuse should never introduce new requirements on the operation, so this is a better fix.

The first 3 commits are for debugging help and cleanup (see commit messages). The remaning commits are part of the fix.