### PR TITLE
(Fix) telemetry: allow overriding of service.version

### DIFF
--- a/.changesets/fix_bryn_service_version.md
+++ b/.changesets/fix_bryn_service_version.md
@@ -1,0 +1,17 @@
+### Allow overriding of service version ([PR #5689](https://github.com/apollographql/router/pull/5689))
+
+This PR allows yaml configured service.version to override the built in version that is baked into the router.
+
+For example:
+```yaml
+telemetry:
+  exporters:
+    tracing:
+      common:
+        resource:
+          service.version: 1.0
+```
+
+Overrides the version to `1.0`.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5689

--- a/.changesets/fix_bryn_service_version.md
+++ b/.changesets/fix_bryn_service_version.md
@@ -1,6 +1,6 @@
 ### Allow overriding of service version ([PR #5689](https://github.com/apollographql/router/pull/5689))
 
-This PR allows yaml configured service.version to override the built in version that is baked into the router.
+Previously `service.version` was not overridable via yaml and was ignored. It is now possible to set this explicitly which can be useful for users producing custom builds of the Router.
 
 For example:
 ```yaml

--- a/apollo-router/src/plugins/telemetry/resource.rs
+++ b/apollo-router/src/plugins/telemetry/resource.rs
@@ -11,8 +11,10 @@ use crate::plugins::telemetry::config::AttributeValue;
 const UNKNOWN_SERVICE: &str = "unknown_service";
 const OTEL_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
 
-struct StaticServiceNameDetector;
-impl ResourceDetector for StaticServiceNameDetector {
+/// This resource detector fills out things like the default service version and executable name.
+/// Users can always override them via config.
+struct StaticResourceDetector;
+impl ResourceDetector for StaticResourceDetector {
     fn detect(&self, _timeout: Duration) -> Resource {
         let mut config_resources = vec![];
         config_resources.push(KeyValue::new(
@@ -62,7 +64,7 @@ pub(crate) trait ConfigResource {
         let resource = Resource::from_detectors(
             Duration::from_secs(0),
             vec![
-                Box::new(StaticServiceNameDetector),
+                Box::new(StaticResourceDetector),
                 Box::new(config_resource_detector),
                 Box::new(EnvResourceDetector::new()),
                 Box::new(EnvServiceNameDetector),

--- a/apollo-router/src/plugins/telemetry/resource.rs
+++ b/apollo-router/src/plugins/telemetry/resource.rs
@@ -11,6 +11,26 @@ use crate::plugins::telemetry::config::AttributeValue;
 const UNKNOWN_SERVICE: &str = "unknown_service";
 const OTEL_SERVICE_NAME: &str = "OTEL_SERVICE_NAME";
 
+struct StaticServiceNameDetector;
+impl ResourceDetector for StaticServiceNameDetector {
+    fn detect(&self, _timeout: Duration) -> Resource {
+        let mut config_resources = vec![];
+        config_resources.push(KeyValue::new(
+            opentelemetry_semantic_conventions::resource::SERVICE_VERSION,
+            std::env!("CARGO_PKG_VERSION"),
+        ));
+
+        // Some other basic resources
+        if let Some(executable_name) = executable_name() {
+            config_resources.push(KeyValue::new(
+                opentelemetry_semantic_conventions::resource::PROCESS_EXECUTABLE_NAME,
+                executable_name,
+            ));
+        }
+        Resource::new(config_resources)
+    }
+}
+
 struct EnvServiceNameDetector;
 // Used instead of SdkProvidedResourceDetector
 impl ResourceDetector for EnvServiceNameDetector {
@@ -42,6 +62,7 @@ pub(crate) trait ConfigResource {
         let resource = Resource::from_detectors(
             Duration::from_secs(0),
             vec![
+                Box::new(StaticServiceNameDetector),
                 Box::new(config_resource_detector),
                 Box::new(EnvResourceDetector::new()),
                 Box::new(EnvServiceNameDetector),
@@ -84,22 +105,8 @@ impl ResourceDetector for ConfigResourceDetector {
         let mut config_resources = vec![];
 
         // For config resources last entry wins
-
-        // Add any other resources from config
         for (key, value) in self.resources.iter() {
             config_resources.push(KeyValue::new(key.clone(), value.clone()));
-        }
-
-        // Some other basic resources
-        config_resources.push(KeyValue::new(
-            opentelemetry_semantic_conventions::resource::SERVICE_VERSION,
-            std::env!("CARGO_PKG_VERSION"),
-        ));
-        if let Some(executable_name) = executable_name() {
-            config_resources.push(KeyValue::new(
-                opentelemetry_semantic_conventions::resource::PROCESS_EXECUTABLE_NAME,
-                executable_name,
-            ));
         }
 
         // Service namespace

--- a/apollo-router/tests/integration/telemetry/datadog.rs
+++ b/apollo-router/tests/integration/telemetry/datadog.rs
@@ -11,7 +11,8 @@ use tower::BoxError;
 
 use crate::integration::common::graph_os_enabled;
 use crate::integration::common::Telemetry;
-use crate::integration::{IntegrationTest, ValueExt};
+use crate::integration::IntegrationTest;
+use crate::integration::ValueExt;
 
 #[derive(buildstructor::Builder)]
 struct TraceSpec {

--- a/apollo-router/tests/integration/telemetry/datadog.rs
+++ b/apollo-router/tests/integration/telemetry/datadog.rs
@@ -521,7 +521,7 @@ impl TraceSpec {
             .collect();
         let mut span_names: HashSet<&str> = self.span_names.clone();
         if self.services.contains("client") {
-            span_names.insert("client_request".into());
+            span_names.insert("client_request");
         }
         tracing::debug!("found spans {:?}", operation_names);
         let missing_operation_names: Vec<_> = span_names

--- a/apollo-router/tests/integration/telemetry/datadog.rs
+++ b/apollo-router/tests/integration/telemetry/datadog.rs
@@ -11,8 +11,17 @@ use tower::BoxError;
 
 use crate::integration::common::graph_os_enabled;
 use crate::integration::common::Telemetry;
-use crate::integration::IntegrationTest;
-use crate::integration::ValueExt;
+use crate::integration::{IntegrationTest, ValueExt};
+
+#[derive(buildstructor::Builder)]
+struct TraceSpec {
+    operation_name: Option<String>,
+    version: Option<String>,
+    services: HashSet<&'static str>,
+    span_names: HashSet<&'static str>,
+    measured_spans: HashSet<&'static str>,
+    unmeasured_spans: HashSet<&'static str>,
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_default_span_names() -> Result<(), BoxError> {
@@ -41,29 +50,27 @@ async fn test_default_span_names() -> Result<(), BoxError> {
             .unwrap(),
         id.to_datadog()
     );
-    validate_trace(
-        id,
-        &query,
-        Some("ExampleQuery"),
-        &["client", "router", "subgraph"],
-        false,
-        &[
-            "query_planning",
-            "client_request",
-            "subgraph_request",
-            "subgraph",
-            "fetch",
-            "supergraph",
-            "execution",
-            "query ExampleQuery",
-            "subgraph server",
-            "http_request",
-            "parse_query",
-        ],
-        &[],
-        &[],
-    )
-    .await?;
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .span_names(
+            [
+                "query_planning",
+                "client_request",
+                "subgraph_request",
+                "subgraph",
+                "fetch",
+                "supergraph",
+                "execution",
+                "query ExampleQuery",
+                "subgraph server",
+                "http_request",
+                "parse_query",
+            ]
+            .into(),
+        )
+        .build()
+        .validate_trace(id)
+        .await?;
     router.graceful_shutdown().await;
     Ok(())
 }
@@ -95,29 +102,27 @@ async fn test_override_span_names() -> Result<(), BoxError> {
             .unwrap(),
         id.to_datadog()
     );
-    validate_trace(
-        id,
-        &query,
-        Some("ExampleQuery"),
-        &["client", "router", "subgraph"],
-        false,
-        &[
-            "query_planning",
-            "client_request",
-            "subgraph_request",
-            "subgraph",
-            "fetch",
-            "supergraph",
-            "execution",
-            "overridden",
-            "subgraph server",
-            "http_request",
-            "parse_query",
-        ],
-        &[],
-        &[],
-    )
-    .await?;
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .span_names(
+            [
+                "query_planning",
+                "client_request",
+                "subgraph_request",
+                "subgraph",
+                "fetch",
+                "supergraph",
+                "execution",
+                "overridden",
+                "subgraph server",
+                "http_request",
+                "parse_query",
+            ]
+            .into(),
+        )
+        .build()
+        .validate_trace(id)
+        .await?;
     router.graceful_shutdown().await;
     Ok(())
 }
@@ -149,29 +154,27 @@ async fn test_override_span_names_late() -> Result<(), BoxError> {
             .unwrap(),
         id.to_datadog()
     );
-    validate_trace(
-        id,
-        &query,
-        Some("ExampleQuery"),
-        &["client", "router", "subgraph"],
-        false,
-        &[
-            "query_planning",
-            "client_request",
-            "subgraph_request",
-            "subgraph",
-            "fetch",
-            "supergraph",
-            "execution",
-            "ExampleQuery",
-            "subgraph server",
-            "http_request",
-            "parse_query",
-        ],
-        &[],
-        &[],
-    )
-    .await?;
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .span_names(
+            [
+                "query_planning",
+                "client_request",
+                "subgraph_request",
+                "subgraph",
+                "fetch",
+                "supergraph",
+                "execution",
+                "ExampleQuery",
+                "subgraph server",
+                "http_request",
+                "parse_query",
+            ]
+            .into(),
+        )
+        .build()
+        .validate_trace(id)
+        .await?;
     router.graceful_shutdown().await;
     Ok(())
 }
@@ -201,37 +204,40 @@ async fn test_basic() -> Result<(), BoxError> {
             .unwrap(),
         id.to_datadog()
     );
-    validate_trace(
-        id,
-        &query,
-        Some("ExampleQuery"),
-        &["client", "router", "subgraph"],
-        false,
-        &[
-            "query_planning",
-            "client_request",
-            "ExampleQuery__products__0",
-            "products",
-            "fetch",
-            "/",
-            "execution",
-            "ExampleQuery",
-            "subgraph server",
-            "parse_query",
-        ],
-        &[
-            "query_planning",
-            "subgraph",
-            "http_request",
-            "subgraph_request",
-            "router",
-            "execution",
-            "supergraph",
-            "parse_query",
-        ],
-        &[],
-    )
-    .await?;
+    TraceSpec::builder()
+        .operation_name("ExampleQuery")
+        .services(["client", "router", "subgraph"].into())
+        .span_names(
+            [
+                "query_planning",
+                "client_request",
+                "ExampleQuery__products__0",
+                "products",
+                "fetch",
+                "/",
+                "execution",
+                "ExampleQuery",
+                "subgraph server",
+                "parse_query",
+            ]
+            .into(),
+        )
+        .measured_spans(
+            [
+                "query_planning",
+                "subgraph",
+                "http_request",
+                "subgraph_request",
+                "router",
+                "execution",
+                "supergraph",
+                "parse_query",
+            ]
+            .into(),
+        )
+        .build()
+        .validate_trace(id)
+        .await?;
     router.graceful_shutdown().await;
     Ok(())
 }
@@ -259,28 +265,27 @@ async fn test_resource_mapping_default() -> Result<(), BoxError> {
         .get("apollo-custom-trace-id")
         .unwrap()
         .is_empty());
-    validate_trace(
-        id,
-        &query,
-        Some("ExampleQuery"),
-        &["client", "router", "subgraph"],
-        false,
-        &[
-            "parse_query",
-            "/",
-            "ExampleQuery",
-            "client_request",
-            "execution",
-            "query_planning",
-            "products",
-            "fetch",
-            "subgraph server",
-            "ExampleQuery__products__0",
-        ],
-        &[],
-        &[],
-    )
-    .await?;
+    TraceSpec::builder()
+        .operation_name("ExampleQuery")
+        .services(["client", "router", "subgraph"].into())
+        .span_names(
+            [
+                "parse_query",
+                "/",
+                "ExampleQuery",
+                "client_request",
+                "execution",
+                "query_planning",
+                "products",
+                "fetch",
+                "subgraph server",
+                "ExampleQuery__products__0",
+            ]
+            .into(),
+        )
+        .build()
+        .validate_trace(id)
+        .await?;
     router.graceful_shutdown().await;
     Ok(())
 }
@@ -308,28 +313,26 @@ async fn test_resource_mapping_override() -> Result<(), BoxError> {
         .get("apollo-custom-trace-id")
         .unwrap()
         .is_empty());
-    validate_trace(
-        id,
-        &query,
-        Some("ExampleQuery"),
-        &["client", "router", "subgraph"],
-        false,
-        &[
-            "parse_query",
-            "ExampleQuery",
-            "client_request",
-            "execution",
-            "query_planning",
-            "products",
-            "fetch",
-            "subgraph server",
-            "overridden",
-            "ExampleQuery__products__0",
-        ],
-        &[],
-        &[],
-    )
-    .await?;
+    TraceSpec::builder()
+        .services(["client", "router", "subgraph"].into())
+        .span_names(
+            [
+                "parse_query",
+                "ExampleQuery",
+                "client_request",
+                "execution",
+                "query_planning",
+                "products",
+                "fetch",
+                "subgraph server",
+                "overridden",
+                "ExampleQuery__products__0",
+            ]
+            .into(),
+        )
+        .build()
+        .validate_trace(id)
+        .await?;
     router.graceful_shutdown().await;
     Ok(())
 }
@@ -355,225 +358,29 @@ async fn test_span_metrics() -> Result<(), BoxError> {
         .get("apollo-custom-trace-id")
         .unwrap()
         .is_empty());
-    validate_trace(
-        id,
-        &query,
-        Some("ExampleQuery"),
-        &["client", "router", "subgraph"],
-        false,
-        &[
-            "parse_query",
-            "ExampleQuery",
-            "client_request",
-            "execution",
-            "query_planning",
-            "products",
-            "fetch",
-            "subgraph server",
-            "ExampleQuery__products__0",
-        ],
-        &["subgraph"],
-        &["supergraph"],
-    )
-    .await?;
-    router.graceful_shutdown().await;
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn validate_trace(
-    id: TraceId,
-    query: &Value,
-    operation_name: Option<&str>,
-    services: &[&'static str],
-    custom_span_instrumentation: bool,
-    expected_span_names: &[&'static str],
-    expected_measured: &[&'static str],
-    unexpected_measured: &[&'static str],
-) -> Result<(), BoxError> {
-    let datadog_id = id.to_datadog();
-    let url = format!("http://localhost:8126/test/traces?trace_ids={datadog_id}");
-    for _ in 0..10 {
-        if find_valid_trace(
-            &url,
-            query,
-            operation_name,
-            services,
-            custom_span_instrumentation,
-            expected_span_names,
-            expected_measured,
-            unexpected_measured,
+    TraceSpec::builder()
+        .operation_name("ExampleQuery")
+        .services(["client", "router", "subgraph"].into())
+        .span_names(
+            [
+                "parse_query",
+                "ExampleQuery",
+                "client_request",
+                "execution",
+                "query_planning",
+                "products",
+                "fetch",
+                "subgraph server",
+                "ExampleQuery__products__0",
+            ]
+            .into(),
         )
-        .await
-        .is_ok()
-        {
-            return Ok(());
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    find_valid_trace(
-        &url,
-        query,
-        operation_name,
-        services,
-        custom_span_instrumentation,
-        expected_span_names,
-        expected_measured,
-        unexpected_measured,
-    )
-    .await?;
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-async fn find_valid_trace(
-    url: &str,
-    _query: &Value,
-    operation_name: Option<&str>,
-    services: &[&'static str],
-    _custom_span_instrumentation: bool,
-    expected_span_names: &[&'static str],
-    expected_measured: &[&'static str],
-    unexpected_measured: &[&'static str],
-) -> Result<(), BoxError> {
-    // A valid trace has:
-    // * All three services
-    // * The correct spans
-    // * All spans are parented
-    // * Required attributes of 'router' span has been set
-
-    // For now just validate service name.
-    let trace: Value = reqwest::get(url)
-        .await
-        .map_err(|e| anyhow!("failed to contact datadog; {}", e))?
-        .json()
+        .measured_span("subgraph")
+        .unmeasured_span("supergraph")
+        .build()
+        .validate_trace(id)
         .await?;
-    tracing::debug!("{}", serde_json::to_string_pretty(&trace)?);
-    verify_trace_participants(&trace, services)?;
-    verify_spans_present(&trace, operation_name, services, expected_span_names)?;
-    validate_span_kinds(&trace)?;
-    validate_measured_spans(&trace, expected_measured, unexpected_measured)?;
-    Ok(())
-}
-
-fn validate_measured_spans(
-    trace: &Value,
-    expected: &[&'static str],
-    unexpected: &[&'static str],
-) -> Result<(), BoxError> {
-    for expected in expected {
-        assert!(
-            measured_span(trace, expected)?,
-            "missing measured span {}",
-            expected
-        );
-    }
-    for unexpected in unexpected {
-        assert!(
-            !measured_span(trace, unexpected)?,
-            "unexpected measured span {}",
-            unexpected
-        );
-    }
-    Ok(())
-}
-
-fn measured_span(trace: &Value, name: &&str) -> Result<bool, BoxError> {
-    let binding1 = trace.select_path(&format!(
-        "$..[?(@.meta.['otel.original_name'] == '{}')].metrics.['_dd.measured']",
-        name
-    ))?;
-    let binding2 = trace.select_path(&format!(
-        "$..[?(@.name == '{}')].metrics.['_dd.measured']",
-        name
-    ))?;
-    Ok(binding1
-        .first()
-        .or(binding2.first())
-        .and_then(|v| v.as_f64())
-        .map(|v| v == 1.0)
-        .unwrap_or_default())
-}
-
-fn validate_span_kinds(trace: &Value) -> Result<(), BoxError> {
-    // Validate that the span.kind has been propagated. We can just do this for a selection of spans.
-    validate_span_kind(trace, "router", "server")?;
-    validate_span_kind(trace, "supergraph", "internal")?;
-    validate_span_kind(trace, "http_request", "client")?;
-    Ok(())
-}
-
-fn verify_trace_participants(trace: &Value, services: &[&'static str]) -> Result<(), BoxError> {
-    let actual_services: HashSet<String> = trace
-        .select_path("$..service")?
-        .into_iter()
-        .filter_map(|service| service.as_string())
-        .collect();
-    tracing::debug!("found services {:?}", actual_services);
-
-    let expected_services = services
-        .iter()
-        .map(|s| s.to_string())
-        .collect::<HashSet<_>>();
-    if actual_services != expected_services {
-        return Err(BoxError::from(format!(
-            "incomplete traces, got {actual_services:?} expected {expected_services:?}"
-        )));
-    }
-    Ok(())
-}
-
-fn verify_spans_present(
-    trace: &Value,
-    _operation_name: Option<&str>,
-    services: &[&'static str],
-    expected_span_names: &[&'static str],
-) -> Result<(), BoxError> {
-    let operation_names: HashSet<String> = trace
-        .select_path("$..resource")?
-        .into_iter()
-        .filter_map(|span_name| span_name.as_string())
-        .collect();
-    let mut expected_span_names: HashSet<String> =
-        expected_span_names.iter().map(|s| s.to_string()).collect();
-    if services.contains(&"client") {
-        expected_span_names.insert("client_request".into());
-    }
-    tracing::debug!("found spans {:?}", operation_names);
-    let missing_operation_names: Vec<_> = expected_span_names
-        .iter()
-        .filter(|o| !operation_names.contains(*o))
-        .collect();
-    if !missing_operation_names.is_empty() {
-        return Err(BoxError::from(format!(
-            "spans did not match, got {operation_names:?}, missing {missing_operation_names:?}"
-        )));
-    }
-    Ok(())
-}
-
-fn validate_span_kind(trace: &Value, name: &str, kind: &str) -> Result<(), BoxError> {
-    let binding1 = trace.select_path(&format!(
-        "$..[?(@.meta.['otel.original_name'] == '{}')].meta.['span.kind']",
-        name
-    ))?;
-    let binding2 =
-        trace.select_path(&format!("$..[?(@.name == '{}')].meta.['span.kind']", name))?;
-    let binding = binding1.first().or(binding2.first());
-
-    assert!(
-        binding.is_some(),
-        "span.kind missing or incorrect {}, {}",
-        name,
-        trace
-    );
-    assert_eq!(
-        binding
-            .expect("expected binding")
-            .as_str()
-            .expect("expected string"),
-        kind
-    );
+    router.graceful_shutdown().await;
     Ok(())
 }
 
@@ -584,5 +391,188 @@ impl DatadogId for TraceId {
     fn to_datadog(&self) -> String {
         let bytes = &self.to_bytes()[std::mem::size_of::<u64>()..std::mem::size_of::<u128>()];
         u64::from_be_bytes(bytes.try_into().unwrap()).to_string()
+    }
+}
+
+impl TraceSpec {
+    #[allow(clippy::too_many_arguments)]
+    async fn validate_trace(&self, id: TraceId) -> Result<(), BoxError> {
+        let datadog_id = id.to_datadog();
+        let url = format!("http://localhost:8126/test/traces?trace_ids={datadog_id}");
+        for _ in 0..10 {
+            if self.find_valid_trace(&url).await.is_ok() {
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        self.find_valid_trace(&url).await?;
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn find_valid_trace(&self, url: &str) -> Result<(), BoxError> {
+        // A valid trace has:
+        // * All three services
+        // * The correct spans
+        // * All spans are parented
+        // * Required attributes of 'router' span has been set
+
+        // For now just validate service name.
+        let trace: Value = reqwest::get(url)
+            .await
+            .map_err(|e| anyhow!("failed to contact datadog; {}", e))?
+            .json()
+            .await?;
+        tracing::debug!("{}", serde_json::to_string_pretty(&trace)?);
+        self.verify_trace_participants(&trace)?;
+        self.verify_operation_name(&trace)?;
+        self.verify_version(&trace)?;
+        self.verify_spans_present(&trace)?;
+        self.validate_span_kinds(&trace)?;
+        self.validate_measured_spans(&trace)?;
+        Ok(())
+    }
+
+    fn verify_version(&self, trace: &Value) -> Result<(), BoxError> {
+        if let Some(expected_version) = &self.version {
+            let binding = trace.select_path("$..version")?;
+            let version = binding.first();
+            assert_eq!(
+                version
+                    .expect("version expected")
+                    .as_str()
+                    .expect("version must be a string"),
+                expected_version
+            );
+        }
+        Ok(())
+    }
+
+    fn validate_measured_spans(&self, trace: &Value) -> Result<(), BoxError> {
+        for expected in &self.measured_spans {
+            assert!(
+                self.measured_span(trace, expected)?,
+                "missing measured span {}",
+                expected
+            );
+        }
+        for unexpected in &self.unmeasured_spans {
+            assert!(
+                !self.measured_span(trace, unexpected)?,
+                "unexpected measured span {}",
+                unexpected
+            );
+        }
+        Ok(())
+    }
+
+    fn measured_span(&self, trace: &Value, name: &str) -> Result<bool, BoxError> {
+        let binding1 = trace.select_path(&format!(
+            "$..[?(@.meta.['otel.original_name'] == '{}')].metrics.['_dd.measured']",
+            name
+        ))?;
+        let binding2 = trace.select_path(&format!(
+            "$..[?(@.name == '{}')].metrics.['_dd.measured']",
+            name
+        ))?;
+        Ok(binding1
+            .first()
+            .or(binding2.first())
+            .and_then(|v| v.as_f64())
+            .map(|v| v == 1.0)
+            .unwrap_or_default())
+    }
+
+    fn validate_span_kinds(&self, trace: &Value) -> Result<(), BoxError> {
+        // Validate that the span.kind has been propagated. We can just do this for a selection of spans.
+        self.validate_span_kind(trace, "router", "server")?;
+        self.validate_span_kind(trace, "supergraph", "internal")?;
+        self.validate_span_kind(trace, "http_request", "client")?;
+        Ok(())
+    }
+
+    fn verify_trace_participants(&self, trace: &Value) -> Result<(), BoxError> {
+        let actual_services: HashSet<String> = trace
+            .select_path("$..service")?
+            .into_iter()
+            .filter_map(|service| service.as_string())
+            .collect();
+        tracing::debug!("found services {:?}", actual_services);
+
+        let expected_services = self
+            .services
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<HashSet<_>>();
+        if actual_services != expected_services {
+            return Err(BoxError::from(format!(
+                "incomplete traces, got {actual_services:?} expected {expected_services:?}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn verify_spans_present(&self, trace: &Value) -> Result<(), BoxError> {
+        let operation_names: HashSet<String> = trace
+            .select_path("$..resource")?
+            .into_iter()
+            .filter_map(|span_name| span_name.as_string())
+            .collect();
+        let mut span_names: HashSet<&str> = self.span_names.clone();
+        if self.services.contains("client") {
+            span_names.insert("client_request".into());
+        }
+        tracing::debug!("found spans {:?}", operation_names);
+        let missing_operation_names: Vec<_> = span_names
+            .iter()
+            .filter(|o| !operation_names.contains(**o))
+            .collect();
+        if !missing_operation_names.is_empty() {
+            return Err(BoxError::from(format!(
+                "spans did not match, got {operation_names:?}, missing {missing_operation_names:?}"
+            )));
+        }
+        Ok(())
+    }
+
+    fn validate_span_kind(&self, trace: &Value, name: &str, kind: &str) -> Result<(), BoxError> {
+        let binding1 = trace.select_path(&format!(
+            "$..[?(@.meta.['otel.original_name'] == '{}')].meta.['span.kind']",
+            name
+        ))?;
+        let binding2 =
+            trace.select_path(&format!("$..[?(@.name == '{}')].meta.['span.kind']", name))?;
+        let binding = binding1.first().or(binding2.first());
+
+        assert!(
+            binding.is_some(),
+            "span.kind missing or incorrect {}, {}",
+            name,
+            trace
+        );
+        assert_eq!(
+            binding
+                .expect("expected binding")
+                .as_str()
+                .expect("expected string"),
+            kind
+        );
+        Ok(())
+    }
+
+    fn verify_operation_name(&self, trace: &Value) -> Result<(), BoxError> {
+        if let Some(expected_operation_name) = &self.operation_name {
+            let binding =
+                trace.select_path("$..[?(@.name == 'supergraph')]..['graphql.operation.name']")?;
+            let operation_name = binding.first();
+            assert_eq!(
+                operation_name
+                    .expect("graphql.operation.name expected")
+                    .as_str()
+                    .expect("graphql.operation.name must be a string"),
+                expected_operation_name
+            );
+        }
+        Ok(())
     }
 }

--- a/apollo-router/tests/integration/telemetry/fixtures/datadog.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/datadog.router.yaml
@@ -7,6 +7,9 @@ telemetry:
         format: datadog
       common:
         service_name: router
+        resource:
+          env: local1
+          service.version: router_version_override
       datadog:
         enabled: true
         batch_processor:


### PR DESCRIPTION
This PR allows yaml configured service.version to override the built in version that is baked into the router.

For example:
```yaml
telemetry:
  exporters:
    tracing:
      common:
        resource:
          service.version: 1.0
```

Overrides the version to `1.0`.

Here is an example where I have overridden the version in datadog:
<img width="513" alt="image" src="https://github.com/user-attachments/assets/89d8d98d-46fa-4f88-adda-8fb8b2c91866">


Existing docs are OK, this is a bugfix.


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
