### PR TITLE
(fix) Prevent Datadog timeout errors in logs

### DIFF
--- a/.changesets/fix_bryn_datadog_timeout.md
+++ b/.changesets/fix_bryn_datadog_timeout.md
@@ -1,0 +1,12 @@
+### Prevent Datadog timeout errors in logs ([Issue #2058](https://github.com/apollographql/router/issue/2058))
+
+The telemetry Datadog exporter uses connection pooling by default. However, these pools connections are frequently closed leading to errors in the router logs.
+
+For example:
+```
+2024-07-19T15:28:22.970360Z ERROR  OpenTelemetry trace error occurred: error sending request for url (http://127.0.0.1:8126/v0.5/traces): connection error: Connection reset by peer (os error 54)
+```
+
+The pool timeout for the Datadog exporter is now set to 1 millisecond, which will greatly reduce the frequency that this occurs.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5692

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -198,6 +198,8 @@ impl TracingConfigurator for Config {
             )
             .with_http_client(
                 reqwest::Client::builder()
+                    // https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/7
+                    // Set the idle timeout to something low to prevent termination of connections.
                     .pool_idle_timeout(Duration::from_millis(1))
                     .build()?,
             )

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -1,5 +1,9 @@
 //! Configuration for datadog tracing.
 
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::time::Duration;
+
 use ahash::HashMap;
 use ahash::HashMapExt;
 use futures::future::BoxFuture;
@@ -19,9 +23,6 @@ use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
 use opentelemetry_semantic_conventions::resource::SERVICE_VERSION;
 use schemars::JsonSchema;
 use serde::Deserialize;
-use std::fmt::Debug;
-use std::fmt::Formatter;
-use std::time::Duration;
 use tower::BoxError;
 
 use crate::plugins::telemetry::config::GenericWith;

--- a/apollo-router/src/plugins/telemetry/tracing/datadog.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog.rs
@@ -1,8 +1,5 @@
 //! Configuration for datadog tracing.
 
-use std::fmt::Debug;
-use std::fmt::Formatter;
-
 use ahash::HashMap;
 use ahash::HashMapExt;
 use futures::future::BoxFuture;
@@ -22,6 +19,9 @@ use opentelemetry_semantic_conventions::resource::SERVICE_NAME;
 use opentelemetry_semantic_conventions::resource::SERVICE_VERSION;
 use schemars::JsonSchema;
 use serde::Deserialize;
+use std::fmt::Debug;
+use std::fmt::Formatter;
+use std::time::Duration;
 use tower::BoxError;
 
 use crate::plugins::telemetry::config::GenericWith;
@@ -196,7 +196,11 @@ impl TracingConfigurator for Config {
                     .expect("cargo version is set as a resource default;qed")
                     .to_string(),
             )
-            .with_http_client(reqwest::Client::builder().build()?)
+            .with_http_client(
+                reqwest::Client::builder()
+                    .pool_idle_timeout(Duration::from_millis(1))
+                    .build()?,
+            )
             .with_trace_config(common)
             .build_exporter()?;
 


### PR DESCRIPTION
This is caused by connection pooling.
Setting the pool value to something very low causes the errors to disappear.

Improves #2058

This is impossible to automatically test as the Datadog agent test image does not behave in the same way as the real agent.

Related issue:
https://github.com/open-telemetry/opentelemetry-rust-contrib/issues/7

I did some manual testing.

<!-- start metadata -->
---
#ROUTER-456
**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
