### PR TITLE
Avoid cloning FetchDependencyGraphToQueryPlanProcessor

### DIFF
--- a/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
@@ -43,7 +43,6 @@ const FETCH_COST: QueryPlanCost = 1000.0;
 /// The exact number is a tad  arbitrary however.
 const PIPELINING_COST: QueryPlanCost = 100.0;
 
-#[derive(Clone)]
 pub(crate) struct FetchDependencyGraphToQueryPlanProcessor {
     variable_definitions: Vec<Node<VariableDefinition>>,
     fragments: Option<RebasedFragments>,

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -32,7 +32,6 @@ use crate::query_plan::fetch_dependency_graph::compute_nodes_for_tree;
 use crate::query_plan::fetch_dependency_graph::FetchDependencyGraph;
 use crate::query_plan::fetch_dependency_graph_processor::FetchDependencyGraphProcessor;
 use crate::query_plan::fetch_dependency_graph_processor::FetchDependencyGraphToCostProcessor;
-use crate::query_plan::fetch_dependency_graph_processor::FetchDependencyGraphToQueryPlanProcessor;
 use crate::query_plan::generate::generate_all_plans_and_find_best;
 use crate::query_plan::generate::PlanBuilder;
 use crate::query_plan::query_planner::compute_root_fetch_groups;
@@ -59,8 +58,6 @@ pub(crate) struct QueryPlanningParameters<'a> {
     pub(crate) federated_query_graph: Arc<QueryGraph>,
     /// The operation to be query planned.
     pub(crate) operation: Arc<Operation>,
-    /// A processor for converting fetch dependency graphs to query plans.
-    pub(crate) processor: FetchDependencyGraphToQueryPlanProcessor,
     /// The query graph node at which query planning begins.
     pub(crate) head: NodeIndex,
     /// Whether the head must be a root node for query planning.
@@ -1036,7 +1033,6 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             supergraph_schema: self.parameters.supergraph_schema.clone(),
             federated_query_graph: graph.clone(),
             operation: self.parameters.operation.clone(),
-            processor: self.parameters.processor.clone(),
             abstract_types_with_inconsistent_runtime_types: self
                 .parameters
                 .abstract_types_with_inconsistent_runtime_types


### PR DESCRIPTION
Remove the `Clone` impl and pass a `&mut` reference around instead.

Fixes FED-282, together with https://github.com/apollographql/router/pull/5391 which removed the `Clone` impl of `QueryPlanningParameters`

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
