### PR TITLE
chore(federation): remove unnecessary Result from Selection::selection_set()

### DIFF
--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -194,7 +194,7 @@ impl Selection {
     /// empty). Otherwise, we have no diff.
     fn minus(&self, other: &Selection) -> Result<Option<Selection>, FederationError> {
         if let (Some(self_sub_selection), Some(other_sub_selection)) =
-            (self.selection_set()?, other.selection_set()?)
+            (self.selection_set(), other.selection_set())
         {
             let diff = self_sub_selection.minus(other_sub_selection)?;
             if !diff.is_empty() {
@@ -215,7 +215,7 @@ impl Selection {
     /// - Otherwise, the intersection is same as `self`.
     fn intersection(&self, other: &Selection) -> Result<Option<Selection>, FederationError> {
         if let (Some(self_sub_selection), Some(other_sub_selection)) =
-            (self.selection_set()?, other.selection_set()?)
+            (self.selection_set(), other.selection_set())
         {
             let common = self_sub_selection.intersection(other_sub_selection)?;
             if !common.is_empty() {
@@ -1394,7 +1394,7 @@ impl SelectionSet {
         self.iter().any(|selection| {
             matches!(selection, Selection::FragmentSpread(_))
                 || selection
-                    .try_selection_set()
+                    .selection_set()
                     .map(|subselection| subselection.contains_fragment_spread())
                     .unwrap_or(false)
         })

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -1149,7 +1149,7 @@ fn get_value_at_path<'a>(ss: &'a SelectionSet, path: &[Name]) -> Option<&'a Sele
         Some(value)
     } else {
         // Recursive case
-        match value.selection_set().unwrap() {
+        match value.selection_set() {
             None => None, // Error: Sub-selection expected, but not found.
             Some(ss) => get_value_at_path(ss, rest),
         }
@@ -1199,7 +1199,7 @@ mod make_selection_tests {
 
         // Create a new foo with a different selection order using `make_selection`.
         let clone_selection_at_path = |base: &Selection, path: &[Name]| {
-            let base_selection_set = base.selection_set().unwrap().unwrap();
+            let base_selection_set = base.selection_set().unwrap();
             let selection = get_value_at_path(base_selection_set, path).expect("path should exist");
             let subselections = SelectionSet::from_selection(
                 base_selection_set.type_position.clone(),
@@ -1237,7 +1237,7 @@ mod lazy_map_tests {
             if !pred(s) {
                 return Ok(SelectionMapperReturn::None);
             }
-            match s.selection_set()? {
+            match s.selection_set() {
                 // Base case: leaf field
                 None => Ok(s.clone().into()),
 

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -291,7 +291,7 @@ impl SchemaQueryGraphBuilder {
         if let Some(subgraph_metadata) = self.base.query_graph.schema()?.subgraph_metadata() {
             Ok(subgraph_metadata
                 .external_metadata()
-                .is_external(field_definition_position)?)
+                .is_external(field_definition_position))
         } else {
             Ok(false)
         }

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -630,7 +630,7 @@ impl QueryGraph {
                 composite_type_position.type_name().clone(),
                 key_value.fields,
             )?;
-            if !external_metadata.selects_any_external_field(&selection)? {
+            if !external_metadata.selects_any_external_field(&selection) {
                 return Ok(Some(selection));
             }
         }
@@ -857,7 +857,7 @@ impl QueryGraph {
             let selection = parse_field_set(schema, ty.name().clone(), value)?;
             let has_external = metadata
                 .external_metadata()
-                .selects_any_external_field(&selection)?;
+                .selects_any_external_field(&selection);
             if !has_external {
                 return Ok(Some(selection));
             }

--- a/apollo-federation/src/query_plan/conditions.rs
+++ b/apollo-federation/src/query_plan/conditions.rs
@@ -213,7 +213,7 @@ pub(crate) fn remove_conditions_from_selection_set(
                 // We remove any of the conditions on the element and recurse.
                 let updated_element =
                     remove_conditions_of_element(element.clone(), variable_conditions);
-                let new_selection = if let Ok(Some(selection_set)) = selection.selection_set() {
+                let new_selection = if let Some(selection_set) = selection.selection_set() {
                     let updated_selection_set =
                         remove_conditions_from_selection_set(selection_set, conditions)?;
                     if updated_element == element {

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -1296,7 +1296,7 @@ impl FetchDependencyGraph {
                     }
                 }
 
-                let Some(sub_selection_set) = selection.selection_set()? else {
+                let Some(sub_selection_set) = selection.selection_set() else {
                     // we're only here if `conditionInSupergraphIfInterfaceObject` returned something,
                     // we imply that selection is a fragment selection and so has a sub-selectionSet.
                     return Err(FederationError::internal(format!(
@@ -1311,14 +1311,14 @@ impl FetchDependencyGraph {
                 // case as a "safe" default).
                 if !interface_input_selections.is_empty() {
                     Ok(interface_input_selections.iter().any(|input| {
-                        let Ok(Some(input_selection_set)) = input.selection_set() else {
+                        let Some(input_selection_set) = input.selection_set() else {
                             return false;
                         };
                         input_selection_set.contains(sub_selection_set)
                     }))
                 } else if !implementation_input_selections.is_empty() {
                     Ok(interface_input_selections.iter().all(|input| {
-                        let Ok(Some(input_selection_set)) = input.selection_set() else {
+                        let Some(input_selection_set) = input.selection_set() else {
                             return false;
                         };
                         input_selection_set.contains(sub_selection_set)

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -432,7 +432,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             };
         }
 
-        if let Some(selection_set) = selection.selection_set()? {
+        if let Some(selection_set) = selection.selection_set() {
             let mut all_tail_nodes = IndexSet::default();
             for option in &new_options {
                 for path in &option.paths.0 {

--- a/apollo-federation/src/schema/subgraph_metadata.rs
+++ b/apollo-federation/src/schema/subgraph_metadata.rs
@@ -256,15 +256,12 @@ impl ExternalMetadata {
         Ok(fields_on_external_types)
     }
 
-    pub(crate) fn is_external(
-        &self,
-        field_definition_position: &FieldDefinitionPosition,
-    ) -> Result<bool, FederationError> {
-        Ok((self.external_fields.contains(field_definition_position)
+    pub(crate) fn is_external(&self, field_definition_position: &FieldDefinitionPosition) -> bool {
+        (self.external_fields.contains(field_definition_position)
             || self
                 .fields_on_external_types
                 .contains(field_definition_position))
-            && !self.is_fake_external(field_definition_position))
+            && !self.is_fake_external(field_definition_position)
     }
 
     pub(crate) fn is_fake_external(
@@ -275,38 +272,35 @@ impl ExternalMetadata {
             .contains(field_definition_position)
     }
 
-    pub(crate) fn selects_any_external_field(
-        &self,
-        selection_set: &SelectionSet,
-    ) -> Result<bool, FederationError> {
+    pub(crate) fn selects_any_external_field(&self, selection_set: &SelectionSet) -> bool {
         for selection in selection_set.selections.values() {
             if let Selection::Field(field_selection) = selection {
-                if self.is_external(&field_selection.field.field_position)? {
-                    return Ok(true);
+                if self.is_external(&field_selection.field.field_position) {
+                    return true;
                 }
             }
-            if let Some(selection_set) = selection.selection_set()? {
-                if self.selects_any_external_field(selection_set)? {
-                    return Ok(true);
+            if let Some(selection_set) = selection.selection_set() {
+                if self.selects_any_external_field(selection_set) {
+                    return true;
                 }
             }
         }
-        Ok(false)
+        false
     }
 
     pub(crate) fn is_partially_external(
         &self,
         field_definition_position: &FieldDefinitionPosition,
-    ) -> Result<bool, FederationError> {
-        Ok(self.is_external(field_definition_position)?
-            && self.provided_fields.contains(field_definition_position))
+    ) -> bool {
+        self.is_external(field_definition_position)
+            && self.provided_fields.contains(field_definition_position)
     }
 
     pub(crate) fn is_fully_external(
         &self,
         field_definition_position: &FieldDefinitionPosition,
-    ) -> Result<bool, FederationError> {
-        Ok(self.is_external(field_definition_position)?
-            && !self.provided_fields.contains(field_definition_position))
+    ) -> bool {
+        self.is_external(field_definition_position)
+            && !self.provided_fields.contains(field_definition_position)
     }
 }


### PR DESCRIPTION
A small cleanup. This function is infallible, so we should not return a `Result`.

Also allows removing Result wrapping from a few other functions, notably everything in `ExternalMetadata`.