### PR TITLE
fix(federation): collect variables nested inside lists and input objects

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -640,6 +640,18 @@ impl SelectionKey {
     pub(crate) fn is_typename_field(&self) -> bool {
         matches!(self, SelectionKey::Field { response_name, directives } if *response_name == TYPENAME_FIELD && directives.is_empty())
     }
+
+    /// Create a selection key for a specific field name.
+    ///
+    /// This is available for tests only as selection keys should not normally be created outside of
+    /// `HasSelectionKey::key`.
+    #[cfg(test)]
+    pub(crate) fn field_name(name: &str) -> Self {
+        SelectionKey::Field {
+            response_name: Name::new(name).unwrap(),
+            directives: Default::default(),
+        }
+    }
 }
 
 pub(crate) trait HasSelectionKey {
@@ -4001,12 +4013,25 @@ impl RebasedFragments {
 
 // Collect used variables from operation types.
 
-fn collect_variables_from_argument<'selection>(
-    argument: &'selection executable::Argument,
+fn collect_variables_from_value<'selection>(
+    value: &'selection executable::Value,
     variables: &mut HashSet<&'selection Name>,
 ) {
-    if let Some(v) = argument.value.as_variable() {
-        variables.insert(v);
+    match value {
+        executable::Value::Variable(v) => {
+            variables.insert(v);
+        }
+        executable::Value::List(list) => {
+            for value in list {
+                collect_variables_from_value(value, variables);
+            }
+        }
+        executable::Value::Object(object) => {
+            for (_key, value) in object {
+                collect_variables_from_value(value, variables);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -4015,14 +4040,14 @@ fn collect_variables_from_directive<'selection>(
     variables: &mut HashSet<&'selection Name>,
 ) {
     for arg in directive.arguments.iter() {
-        collect_variables_from_argument(arg, variables)
+        collect_variables_from_value(&arg.value, variables)
     }
 }
 
 impl Field {
     fn collect_variables<'selection>(&'selection self, variables: &mut HashSet<&'selection Name>) {
         for arg in self.arguments.iter() {
-            collect_variables_from_argument(arg, variables)
+            collect_variables_from_value(&arg.value, variables)
         }
         for dir in self.directives.iter() {
             collect_variables_from_directive(dir, variables)


### PR DESCRIPTION
When variables are inserted inside a list or an input object, we were not propagating the variable definition onto subgraph queries, so we'd generate invalid output. The variable reference would still exist inside the list or input object but the definition was missing.

This patch recurses into lists and input objects when collecting variable usages.