### PR TITLE
Datadog sampling priority not set

### DIFF
--- a/.changesets/fix_bryn_datadog_exporter_span_metrics.md
+++ b/.changesets/fix_bryn_datadog_exporter_span_metrics.md
@@ -29,4 +29,4 @@ telemetry:
           my_custom_span: true
 ```
 
-By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5609
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5609 and https://github.com/apollographql/router/pull/5703

--- a/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/model/v05.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/datadog_exporter/exporter/model/v05.rs
@@ -128,12 +128,8 @@ fn write_unified_tag<'a>(
     Ok(())
 }
 
-fn get_sampling_priority(span: &SpanData) -> f64 {
-    if span.span_context.trace_state().priority_sampling_enabled() {
-        1.0
-    } else {
-        0.0
-    }
+fn get_sampling_priority(_span: &SpanData) -> f64 {
+    1.0
 }
 
 fn get_measuring(span: &SpanData) -> f64 {

--- a/apollo-router/tests/integration/telemetry/datadog.rs
+++ b/apollo-router/tests/integration/telemetry/datadog.rs
@@ -427,6 +427,7 @@ impl TraceSpec {
         tracing::debug!("{}", serde_json::to_string_pretty(&trace)?);
         self.verify_trace_participants(&trace)?;
         self.verify_operation_name(&trace)?;
+        self.verify_priority_sampled(&trace)?;
         self.verify_version(&trace)?;
         self.verify_spans_present(&trace)?;
         self.validate_span_kinds(&trace)?;
@@ -574,6 +575,19 @@ impl TraceSpec {
                 expected_operation_name
             );
         }
+        Ok(())
+    }
+
+    fn verify_priority_sampled(&self, trace: &Value) -> Result<(), BoxError> {
+        let binding = trace.select_path("$.._sampling_priority_v1")?;
+        let sampling_priority = binding.first();
+        assert_eq!(
+            sampling_priority
+                .expect("sampling priority expected")
+                .as_f64()
+                .expect("sampling priority must be a number"),
+            1.0
+        );
         Ok(())
     }
 }


### PR DESCRIPTION
In #5609 The backported code from the datadog exporter used code from the feature `agent-sampling`.

This was an incorrect decision as this requires that the sampler is updated to support such functionality. The result is that traces are not being shown in the Datadog UI even though they were exported.

This PR switches the code with `not(agent-samping)` code which will delegate sampling to the sampler in the router yaml config.

Relates to #5609

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
