### PR TITLE
fix: don't double up inaccessible link

### DIFF
--- a/apollo-federation/src/sources/connect/expand/carryover.rs
+++ b/apollo-federation/src/sources/connect/expand/carryover.rs
@@ -48,7 +48,14 @@ pub(super) fn carryover_directives(
         from.referencers()
             .get_directive(&directive_name)
             .and_then(|referencers| {
-                if referencers.len() > 0 {
+                // because the merge code handles inaccessible, we have to check if the
+                // @link and directive definition are already present in the schema
+                if referencers.len() > 0
+                    && to
+                        .metadata()
+                        .and_then(|m| m.by_identity.get(&Identity::inaccessible_identity()))
+                        .is_none()
+                {
                     SchemaDefinitionPosition
                         .insert_directive(to, link.to_directive_application().into())?;
                     copy_directive_definition(from, to, directive_name.clone())?;
@@ -245,7 +252,7 @@ impl Link {
         if !self.imports.is_empty() {
             arguments.push(
                 Argument {
-                    name: name!(imports),
+                    name: name!(import),
                     value: Value::List(
                         self.imports
                             .iter()

--- a/apollo-federation/src/sources/connect/expand/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/mod.rs
@@ -96,8 +96,9 @@ pub fn expand_connectors(supergraph_str: &str) -> Result<ExpansionResult, Federa
     })?;
 
     let mut new_supergraph = FederationSchema::new(new_supergraph.schema.into_inner())?;
-    carryover_directives(&supergraph.schema, &mut new_supergraph)
-        .map_err(|_e| FederationError::internal("could not carry over directives"))?;
+    carryover_directives(&supergraph.schema, &mut new_supergraph).map_err(|e| {
+        FederationError::internal(format!("could not carry over directives: {e:?}"))
+    })?;
 
     let connectors_by_service_name: IndexMap<Arc<str>, Connector> = connect_subgraphs
         .into_iter()

--- a/apollo-federation/src/sources/connect/expand/snapshots/apollo_federation__sources__connect__expand__carryover__tests__carryover.snap
+++ b/apollo-federation/src/sources/connect/expand/snapshots/apollo_federation__sources__connect__expand__carryover__tests__carryover.snap
@@ -2,7 +2,7 @@
 source: apollo-federation/src/sources/connect/expand/carryover.rs
 expression: schema.schema().serialize().to_string()
 ---
-schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY) @link(url: "https://specs.apollo.dev/tag/v0.3") @link(url: "https://specs.apollo.dev/authenticated/v0.1", for: SECURITY) @link(url: "https://specs.apollo.dev/requiresScopes/v0.1", for: SECURITY) @link(url: "https://specs.apollo.dev/policy/v0.1", for: SECURITY) @link(url: "http://specs.example.org/custom/v0.1", imports: ["@custom"]) {
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY) @link(url: "https://specs.apollo.dev/tag/v0.3") @link(url: "https://specs.apollo.dev/authenticated/v0.1", for: SECURITY) @link(url: "https://specs.apollo.dev/requiresScopes/v0.1", for: SECURITY) @link(url: "https://specs.apollo.dev/policy/v0.1", for: SECURITY) @link(url: "http://specs.example.org/custom/v0.1", import: ["@custom"]) {
   query: Query
 }
 

--- a/apollo-federation/src/sources/connect/expand/tests/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/tests/mod.rs
@@ -65,6 +65,7 @@ test_expands! {
     simple,
     steelthread,
     types_used_twice,
+    carryover
 }
 
 test_ignores! {

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/carryover.graphql
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/carryover.graphql
@@ -1,0 +1,87 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/tag/v0.3")
+  @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
+  @join__directive(graphs: [ONE], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
+  @join__directive(graphs: [ONE], name: "source", args: {name: "json", http: {baseURL: "http://example/"}})
+{
+  query: Query
+}
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  ONE @join__graph(name: "one", url: "none")
+  TWO @join__graph(name: "two", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: ONE)
+  @join__type(graph: TWO)
+{
+  ts: [T] @join__field(graph: ONE) @join__directive(graphs: [ONE], name: "connect", args: {source: "json", http: {GET: "/t"}, selection: "id\ntagged\nhidden\n# custom\n# authenticated\n# requiresScopes\n# policy\noverridden"})
+  t(id: ID): T @join__field(graph: ONE) @join__directive(graphs: [ONE], name: "connect", args: {source: "json", http: {GET: "/t/{$args.id}"}, selection: "id\ntagged\nhidden\n# custom\n# authenticated\n# requiresScopes\n# policy\noverridden", entity: true})
+}
+
+type R
+  @join__type(graph: ONE)
+{
+  id: ID!
+}
+
+type T
+  @join__type(graph: ONE, key: "id")
+  @join__type(graph: TWO, key: "id")
+{
+  id: ID!
+  tagged: String @join__field(graph: ONE) @tag(name: "tag")
+  hidden: String @inaccessible @join__field(graph: ONE)
+  overridden: String @join__field(graph: ONE, override: "two", overrideLabel: "label") @join__field(graph: TWO, overrideLabel: "label")
+  r: R @join__field(graph: ONE) @join__directive(graphs: [ONE], name: "connect", args: {source: "json", http: {GET: "/t/{$this.id}/r"}, selection: "id"})
+}

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/carryover.yaml
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/carryover.yaml
@@ -1,0 +1,81 @@
+# rover supergraph compose --config apollo-federation/src/sources/connect/expand/tests/schemas/carryover.yaml > apollo-federation/src/sources/connect/expand/tests/schemas/carryover.graphql
+federation_version: =2.9.0-connectors.9
+subgraphs:
+  one:
+    routing_url: none
+    schema:
+      sdl: |
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.8", import: [
+              "@key",
+              "@inaccessible", "@tag", "@override",
+              "@authenticated", "@requiresScopes", "@policy",
+              "@composeDirective"
+            ]
+          )
+          @link(url: "http://specs.example.org/custom/v0.1", import: ["@custom"])
+          @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"])
+          # @composeDirective(name: "@custom")
+          @source(name: "json" http: { baseURL: "http://example/" })
+        # directive @custom on OBJECT | FIELD_DEFINITION
+        type Query {
+          ts: [T] @connect(
+            source: "json"
+            http: { GET: "/t" }
+            selection: """
+              id
+              tagged
+              hidden
+              # custom
+              # authenticated
+              # requiresScopes
+              # policy
+              overridden
+            """
+          )
+          t(id: ID): T @connect(
+            source: "json"
+            http: { GET: "/t/{$$args.id}" }
+            selection: """
+              id
+              tagged
+              hidden
+              # custom
+              # authenticated
+              # requiresScopes
+              # policy
+              overridden
+            """
+            entity: true
+          )
+        }
+
+        type T @key(fields: "id") {
+          id: ID!
+          tagged: String @tag(name: "tag")
+          hidden: String @inaccessible
+          # custom: String @custom
+          # authenticated: String @authenticated
+          # requiresScopes: String @requiresScopes(scopes: ["scope"])
+          # policy: String @policy(policies: [["admin"]])
+          overridden: String @override(from: "two", label: "label")
+          r: R @connect(
+            source: "json"
+            http: { GET: "/t/{$$this.id}/r" }
+            selection: "id"
+          )
+        }
+
+        type R {
+          id: ID!
+        }
+  two:
+    routing_url: none
+    schema:
+      sdl: |
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@key"])
+        type T @key(fields: "id") {
+          id: ID!
+          overridden: String
+        }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__carryover__it_expands_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__carryover__it_expands_supergraph-2.snap
@@ -1,0 +1,210 @@
+---
+source: apollo-federation/src/sources/connect/expand/tests/mod.rs
+expression: connectors.by_service_name
+---
+{
+    "one_Query_ts_0": Connector {
+        id: ConnectId {
+            label: "one.json http: GET /t",
+            subgraph_name: "one",
+            source_name: Some(
+                "json",
+            ),
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.ts),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJson(
+            HttpJsonTransport {
+                base_url: "http://example/",
+                path_template: URLPathTemplate {
+                    path: [
+                        ParameterValue {
+                            parts: [
+                                Text(
+                                    "t",
+                                ),
+                            ],
+                        },
+                    ],
+                    query: {},
+                },
+                method: Get,
+                headers: {},
+                body: None,
+            },
+        ),
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "tagged",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "hidden",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "overridden",
+                        None,
+                    ),
+                ],
+                star: None,
+            },
+        ),
+        entity_resolver: None,
+    },
+    "one_Query_t_0": Connector {
+        id: ConnectId {
+            label: "one.json http: GET /t/{$args.id!}",
+            subgraph_name: "one",
+            source_name: Some(
+                "json",
+            ),
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.t),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJson(
+            HttpJsonTransport {
+                base_url: "http://example/",
+                path_template: URLPathTemplate {
+                    path: [
+                        ParameterValue {
+                            parts: [
+                                Text(
+                                    "t",
+                                ),
+                            ],
+                        },
+                        ParameterValue {
+                            parts: [
+                                Var(
+                                    VariableExpression {
+                                        var_path: "$args.id",
+                                        batch_separator: None,
+                                        required: true,
+                                    },
+                                ),
+                            ],
+                        },
+                    ],
+                    query: {},
+                },
+                method: Get,
+                headers: {},
+                body: None,
+            },
+        ),
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "tagged",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "hidden",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "overridden",
+                        None,
+                    ),
+                ],
+                star: None,
+            },
+        ),
+        entity_resolver: Some(
+            Explicit,
+        ),
+    },
+    "one_T_r_0": Connector {
+        id: ConnectId {
+            label: "one.json http: GET /t/{$this.id!}/r",
+            subgraph_name: "one",
+            source_name: Some(
+                "json",
+            ),
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(T.r),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJson(
+            HttpJsonTransport {
+                base_url: "http://example/",
+                path_template: URLPathTemplate {
+                    path: [
+                        ParameterValue {
+                            parts: [
+                                Text(
+                                    "t",
+                                ),
+                            ],
+                        },
+                        ParameterValue {
+                            parts: [
+                                Var(
+                                    VariableExpression {
+                                        var_path: "$this.id",
+                                        batch_separator: None,
+                                        required: true,
+                                    },
+                                ),
+                            ],
+                        },
+                        ParameterValue {
+                            parts: [
+                                Text(
+                                    "r",
+                                ),
+                            ],
+                        },
+                    ],
+                    query: {},
+                },
+                method: Get,
+                headers: {},
+                body: None,
+            },
+        ),
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                ],
+                star: None,
+            },
+        ),
+        entity_resolver: Some(
+            Implicit,
+        ),
+    },
+}

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__carryover__it_expands_supergraph-3.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__carryover__it_expands_supergraph-3.snap
@@ -1,0 +1,63 @@
+---
+source: apollo-federation/src/sources/connect/expand/tests/mod.rs
+expression: raw_sdl
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY) @link(url: "https://specs.apollo.dev/tag/v0.3") {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on ENUM | INPUT_OBJECT | INTERFACE | OBJECT | SCALAR | UNION
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on INTERFACE | OBJECT
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+enum link__Purpose {
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """EXECUTION features provide metadata necessary for operation execution."""
+  EXECUTION
+}
+
+scalar link__Import
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ONE_QUERY_T_0 @join__graph(name: "one_Query_t_0", url: "none")
+  ONE_QUERY_TS_0 @join__graph(name: "one_Query_ts_0", url: "none")
+  ONE_T_R_0 @join__graph(name: "one_T_r_0", url: "none")
+  TWO @join__graph(name: "two", url: "none")
+}
+
+type T @join__type(graph: ONE_QUERY_T_0, key: "id") @join__type(graph: ONE_QUERY_TS_0) @join__type(graph: ONE_T_R_0, key: "id") @join__type(graph: TWO, key: "id") {
+  hidden: String @join__field(graph: ONE_QUERY_T_0) @join__field(graph: ONE_QUERY_TS_0) @inaccessible
+  id: ID! @join__field(graph: ONE_QUERY_T_0) @join__field(graph: ONE_QUERY_TS_0) @join__field(graph: ONE_T_R_0) @join__field(graph: TWO)
+  overridden: String @join__field(graph: ONE_QUERY_T_0, override: "two", overrideLabel: "label") @join__field(graph: ONE_QUERY_TS_0, override: "two", overrideLabel: "label") @join__field(graph: TWO)
+  tagged: String @join__field(graph: ONE_QUERY_T_0) @join__field(graph: ONE_QUERY_TS_0) @tag(name: "tag")
+  r: R @join__field(graph: ONE_T_R_0)
+}
+
+type Query @join__type(graph: ONE_QUERY_T_0) @join__type(graph: ONE_QUERY_TS_0) @join__type(graph: ONE_T_R_0) @join__type(graph: TWO) {
+  t(id: ID): T @join__field(graph: ONE_QUERY_T_0)
+  ts: [T] @join__field(graph: ONE_QUERY_TS_0)
+  _: ID @inaccessible @join__field(graph: ONE_T_R_0)
+}
+
+type R @join__type(graph: ONE_T_R_0) {
+  id: ID! @join__field(graph: ONE_T_R_0)
+}

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__carryover__it_expands_supergraph.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__carryover__it_expands_supergraph.snap
@@ -1,0 +1,21 @@
+---
+source: apollo-federation/src/sources/connect/expand/tests/mod.rs
+expression: api_schema
+---
+directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+type Query {
+  ts: [T]
+  t(id: ID): T
+}
+
+type R {
+  id: ID!
+}
+
+type T {
+  id: ID!
+  tagged: String
+  overridden: String
+  r: R
+}


### PR DESCRIPTION
merge code now handles inaccessible, but we still need the carryover code because expansion doesn't copy over inaccessibles yet. this change avoids adding the link twice and adds a test to capture this behavior.

the test does not cover other carried-over directives (authenticated, etc) because composition doesn't support them yet

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
