### PR TITLE
feat(qp): enable running both query planners by default

### DIFF
--- a/.changesets/feat_lrlna_enable_both_query_planners_by_default.md
+++ b/.changesets/feat_lrlna_enable_both_query_planners_by_default.md
@@ -1,8 +1,7 @@
 ### Enable running both query planners by default ([PR #5709](https://github.com/apollographql/router/pull/5709))
 
-<!-- [ROUTER-458] -->
 
-This change is enabling running the Native query planner in a background thread
+This change enables running the Native query planner in a background thread
 in order to compare output and performance differences to the existing JS query
 planner. Execution continues to be based on query plans produced by the JS query
 planner, as Native query planner results are discarded after the comparison.

--- a/.changesets/feat_lrlna_enable_both_query_planners_by_default.md
+++ b/.changesets/feat_lrlna_enable_both_query_planners_by_default.md
@@ -1,0 +1,19 @@
+### Enable running both query planners by default ([PR #5709](https://github.com/apollographql/router/pull/5709))
+
+<!-- [ROUTER-458] -->
+
+This change is enabling running the Native query planner in a background thread
+in order to compare output and performance differences to the existing JS query
+planner. Execution continues to be based on query plans produced by the JS query
+planner, as Native query planner results are discarded after the comparison.
+
+This option has been run in various different environments without an impact to
+memory or CPU utilisation.
+
+You can go back to the previous behaviour of running only the JS query planner with the following config in your router yaml:
+
+```yml
+experimental_query_planner_mode: legacy
+```
+
+By [lrlna](https://github.com/lrlna) in https://github.com/apollographql/router/pull/5709

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -223,10 +223,10 @@ pub(crate) enum QueryPlannerMode {
     /// Use the new Rust-based implementation.
     New,
     /// Use the old JavaScript-based implementation.
-    #[default]
     Legacy,
     /// Use Rust-based and Javascript-based implementations side by side, logging warnings if the
     /// implementations disagree.
+    #[default]
     Both,
 }
 


### PR DESCRIPTION
<!-- [ROUTER-458] -->

This change is enabling running the Native query planner in a background thread in order to compare output and performance differences to the existing JS query planner. Execution continues to be based on query plans produced by the JS query planner, as Native query planner results are discarded after the comparison.

This option has been run in various different environments without an impact to memory or CPU utilisation.

You can go back to the previous behaviour of running only the JS query planner with the following config in your router yaml:

```yml
experimental_query_planner_mode: legacy
```

[ROUTER-458]: https://apollographql.atlassian.net/browse/ROUTER-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ