### PR TITLE
Changed parent type when a fragement is rebased

### DIFF
--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -579,6 +579,7 @@ impl InlineFragment {
             .into())
         } else {
             let mut rebased_fragment_data = self.data().clone();
+            rebased_fragment_data.parent_type_position = parent_type.clone();
             rebased_fragment_data.type_condition_position = rebased_condition;
             rebased_fragment_data.schema = schema.clone();
             Ok(InlineFragment::new(rebased_fragment_data))


### PR DESCRIPTION
The PR ensures that the parent type of a fragment is changed when it is rebased.

Fixes FED-352

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
