### PR TITLE
connectors: expand input types

### DIFF
--- a/apollo-federation/src/sources/connect/expand/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/mod.rs
@@ -1,12 +1,9 @@
 use std::sync::Arc;
 
-use apollo_compiler::ast::Directive;
 use apollo_compiler::validation::Valid;
-use apollo_compiler::Name;
 use apollo_compiler::Schema;
 use carryover::carryover_directives;
 use indexmap::IndexMap;
-use indexmap::IndexSet;
 use itertools::Itertools;
 
 use crate::error::FederationError;
@@ -22,8 +19,8 @@ use crate::Supergraph;
 use crate::ValidFederationSubgraph;
 
 mod carryover;
-mod visitor;
-use visitor::ToSchemaVisitor;
+pub(crate) mod visitors;
+use visitors::filter_directives;
 
 pub struct Connectors {
     pub by_service_name: Arc<IndexMap<Arc<str>, Connector>>,
@@ -172,20 +169,6 @@ fn split_subgraph(
         .try_collect()
 }
 
-/// Filter out directives from a directive list
-fn filter_directives<'a, D, I, O>(deny_list: &IndexSet<Name>, directives: D) -> O
-where
-    D: IntoIterator<Item = &'a I>,
-    I: 'a + AsRef<Directive> + Clone,
-    O: FromIterator<I>,
-{
-    directives
-        .into_iter()
-        .filter(|d| !deny_list.contains(&d.as_ref().name))
-        .cloned()
-        .collect()
-}
-
 mod helpers {
     use apollo_compiler::ast;
     use apollo_compiler::ast::Argument;
@@ -198,27 +181,28 @@ mod helpers {
     use apollo_compiler::schema::ComponentName;
     use apollo_compiler::schema::ComponentOrigin;
     use apollo_compiler::schema::DirectiveList;
+    use apollo_compiler::schema::EnumType;
     use apollo_compiler::schema::ObjectType;
+    use apollo_compiler::schema::ScalarType;
     use apollo_compiler::Name;
     use apollo_compiler::Node;
     use indexmap::IndexMap;
     use indexmap::IndexSet;
 
     use super::filter_directives;
-    use super::ToSchemaVisitor;
+    use super::visitors::GroupVisitor;
+    use super::visitors::SchemaVisitor;
     use crate::error::FederationError;
     use crate::link::spec::Identity;
     use crate::link::Link;
     use crate::query_graph::extract_subgraphs_from_supergraph::new_empty_fed_2_subgraph_schema;
-    use crate::schema::position::ObjectFieldDefinitionPosition;
-    use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
+    use crate::schema::position::ObjectOrInterfaceTypeDefinitionPosition;
     use crate::schema::position::ObjectTypeDefinitionPosition;
     use crate::schema::position::SchemaRootDefinitionKind;
     use crate::schema::position::SchemaRootDefinitionPosition;
     use crate::schema::position::TypeDefinitionPosition;
     use crate::schema::FederationSchema;
     use crate::schema::ValidFederationSchema;
-    use crate::sources::connect::json_selection::JSONSelectionVisitor;
     use crate::sources::connect::url_template::Parameter;
     use crate::sources::connect::ConnectSpecDefinition;
     use crate::sources::connect::Connector;
@@ -301,20 +285,6 @@ mod helpers {
             connector: &Connector,
         ) -> Result<FederationSchema, FederationError> {
             let mut schema = new_empty_fed_2_subgraph_schema()?;
-
-            // Add the parent type for this connector
-            let field = &connector.id.directive.field;
-            match field {
-                ObjectOrInterfaceFieldDefinitionPosition::Object(o) => {
-                    self.expand_object(&mut schema, o, connector)?
-                }
-                ObjectOrInterfaceFieldDefinitionPosition::Interface(i) => {
-                    todo!("not yet done for interface {i}")
-                }
-            };
-
-            // Add a query root with dummy information if the connect directive is not on a query
-            // field.
             let query_alias = self
                 .original_schema
                 .schema()
@@ -323,11 +293,67 @@ mod helpers {
                 .as_ref()
                 .map(|m| m.name.clone())
                 .unwrap_or(name!("Query"));
-            if field.parent().type_name() != &query_alias {
-                self.insert_dummy_query(&mut schema, query_alias)?;
-            }
 
-            // Add the query root
+            let field = &connector.id.directive.field;
+            let field_def = field.get(self.original_schema.schema())?;
+            let field_type = self
+                .original_schema
+                .get_type(field_def.ty.inner_named_type().clone())?;
+
+            // We'll need to make sure that we always process the inputs first, since they need to be present
+            // before any dependent types
+            self.process_inputs(&mut schema, connector, &field_def.arguments)?;
+
+            // Actually process the type annotated with the connector, making sure to walk nested types
+            match field_type {
+                TypeDefinitionPosition::Object(object) => {
+                    SchemaVisitor::new(
+                        self.original_schema,
+                        &mut schema,
+                        &self.directive_deny_list,
+                    )
+                    .walk((
+                        object,
+                        connector.selection.next_subselection().cloned().unwrap(),
+                    ))?;
+                }
+
+                TypeDefinitionPosition::Scalar(_) | TypeDefinitionPosition::Enum(_) => {
+                    self.insert_custom_leaf(&mut schema, &field_type)?;
+                }
+
+                TypeDefinitionPosition::Interface(interface) => {
+                    return Err(FederationError::internal(format!(
+                        "connect directives not yet supported on interfaces: found on {}",
+                        interface.type_name
+                    )))
+                }
+                TypeDefinitionPosition::Union(union) => {
+                    return Err(FederationError::internal(format!(
+                        "connect directives not yet supported on union: found on {}",
+                        union.type_name
+                    )))
+                }
+                TypeDefinitionPosition::InputObject(input) => {
+                    return Err(FederationError::internal(format!(
+                        "connect directives not yet supported on inputs: found on {}",
+                        input.type_name
+                    )))
+                }
+            };
+
+            // Add the root type for this connector, optionally inserting a dummy query root
+            // if the connector is not defined within a field on a Query (since a subgraph is invalid
+            // without at least a root-level Query)
+            let ObjectOrInterfaceTypeDefinitionPosition::Object(parent_object) = field.parent()
+            else {
+                return Err(FederationError::internal(
+                    "connect directives on interfaces is not yet supported",
+                ));
+            };
+
+            self.insert_query_for_field(&mut schema, &query_alias, &parent_object, field_def)?;
+
             let root = SchemaRootDefinitionPosition {
                 root_kind: SchemaRootDefinitionKind::Query,
             };
@@ -335,74 +361,19 @@ mod helpers {
                 &mut schema,
                 ComponentName {
                     origin: ComponentOrigin::Definition,
-                    name: name!("Query"),
+                    name: query_alias,
                 },
             )?;
 
+            // Process any outputs needed by the connector
+            self.process_outputs(
+                &mut schema,
+                connector,
+                parent_object.type_name.clone(),
+                field_def.ty.inner_named_type().clone(),
+            )?;
+
             Ok(schema)
-        }
-
-        /// Expand an object into the schema, copying over fields / types specified by the
-        /// JSONSelection.
-        fn expand_object(
-            &self,
-            to_schema: &mut FederationSchema,
-            object_field: &ObjectFieldDefinitionPosition,
-            connector: &Connector,
-        ) -> Result<(), FederationError> {
-            // Prime the schema for our new output parent
-            let parent = object_field.parent();
-            let parent_type = parent.get(self.original_schema.schema())?;
-            parent.pre_insert(to_schema)?;
-
-            // Process the output type, making sure to carry over just the fields / types
-            // needed by the selection.
-            let field_def = object_field.get(self.original_schema.schema())?;
-            let output_name = field_def.ty.inner_named_type().clone();
-            let output_type = self.original_schema.get_type(output_name.clone())?;
-            let extended_output_type = output_type.get(self.original_schema.schema())?;
-
-            // If the type is built-in, then there isn't anything that we need to do for the output type
-            if !extended_output_type.is_built_in() {
-                let visitor = ToSchemaVisitor::new(
-                    self.original_schema,
-                    to_schema,
-                    output_type,
-                    extended_output_type,
-                    &self.directive_deny_list,
-                );
-
-                visitor.walk(&connector.selection)?;
-            }
-
-            // Add the object to our schema
-            let field_type = FieldDefinition {
-                description: field_def.description.clone(),
-                name: field_def.name.clone(),
-                arguments: field_def.arguments.clone(),
-                ty: field_def.ty.clone(),
-                directives: filter_directives(&self.directive_deny_list, &field_def.directives),
-            };
-            let connector_parent_type = ObjectType {
-                description: parent_type.description.clone(),
-                name: parent_type.name.clone(),
-                implements_interfaces: parent_type.implements_interfaces.clone(),
-                directives: filter_directives(&self.directive_deny_list, &parent_type.directives),
-                fields: IndexMap::from_iter([(
-                    field_type.ty.inner_named_type().clone(),
-                    Component::new(field_type),
-                )]),
-            };
-
-            // The input arguments are independent of the actual output type in which they are used, but
-            // require access to the field of the output in order to process the inputs. The output type
-            // needs to be present in order to modify its keys and other directives, so we split up
-            // the processing so that each has what it needs before and after adding the field.
-            self.process_inputs(to_schema, connector, &field_def.arguments)?;
-            parent.insert(to_schema, Node::new(connector_parent_type))?;
-            self.process_outputs(to_schema, connector, parent_type.name.clone(), output_name)?;
-
-            Ok(())
         }
 
         /// Process all input types
@@ -432,56 +403,31 @@ mod helpers {
                         let arg = arguments
                             .iter()
                             .find(|a| a.name.as_str() == argument)
-                            .ok_or(FederationError::internal("could not find argument"))?;
-                        let arg_type = self
-                            .original_schema
-                            .get_type(arg.ty.inner_named_type().clone())?;
-                        let extended_arg_type = arg_type.get(self.original_schema.schema())?;
+                            .ok_or(FederationError::internal(format!(
+                                "could not find argument: {argument}"
+                            )))?;
+                        let arg_type_name = arg.ty.inner_named_type();
+                        let arg_type = self.original_schema.get_type(arg_type_name.clone())?;
+                        let arg_extended_type = arg_type.get(self.original_schema.schema())?;
 
                         // If the input type isn't built in (and hasn't been copied over yet), then we
                         // need to carry it over.
-                        //
-                        // TODO: We need to drill down the input type and make sure that all of its field
-                        // types are also carried over.
-                        if !extended_arg_type.is_built_in()
-                            && arg_type.try_get(to_schema.schema()).is_none()
+                        if !arg_extended_type.is_built_in()
+                            && to_schema.try_get_type(arg_type_name.clone()).is_none()
                         {
-                            match (arg_type, extended_arg_type) {
-                                // Input objects are special because it would be invalid to not carry
-                                // over the entire input type since intersection merging rules dictate
-                                // that subgraphs with different views of the same input type would
-                                // not carry over the union of those types, but rather the intersection.
-                                //
-                                // So we just copy it blindly.
-                                (
-                                    TypeDefinitionPosition::InputObject(pos),
-                                    apollo_compiler::schema::ExtendedType::InputObject(def),
-                                ) => {
-                                    pos.pre_insert(to_schema)?;
-                                    pos.insert(to_schema, def.clone())?;
+                            let visitor = SchemaVisitor::new(
+                                self.original_schema,
+                                to_schema,
+                                &self.directive_deny_list,
+                            );
+
+                            // Only walk if we have an input, making sure to simply insert the type otherwise
+                            match arg_type {
+                                TypeDefinitionPosition::InputObject(input) => {
+                                    visitor.walk(input)?
                                 }
 
-                                // Leaf types are simple: just insert
-                                (
-                                    TypeDefinitionPosition::Scalar(pos),
-                                    apollo_compiler::schema::ExtendedType::Scalar(def),
-                                ) => {
-                                    pos.pre_insert(to_schema)?;
-                                    pos.insert(to_schema, def.clone())?;
-                                }
-                                (
-                                    TypeDefinitionPosition::Enum(pos),
-                                    apollo_compiler::schema::ExtendedType::Enum(def),
-                                ) => {
-                                    pos.pre_insert(to_schema)?;
-                                    pos.insert(to_schema, def.clone())?;
-                                }
-
-                                (pos, def) => {
-                                    return Err(FederationError::internal(format!(
-                                        "did not expect to process in input: {pos:?} {def:?}"
-                                    )));
-                                }
+                                other => self.insert_custom_leaf(to_schema, &other)?,
                             };
                         }
                     }
@@ -494,6 +440,11 @@ mod helpers {
             Ok(())
         }
 
+        // Process outputs needed by a connector
+        //
+        // By the time this method is called, all dependent types should exist for a connector,
+        // including its direct inputs. Since each connector could select only a subset of its output
+        // type, this method carries over each output type as seen by the selection defined on the connector.
         fn process_outputs(
             &self,
             to_schema: &mut FederationSchema,
@@ -573,18 +524,11 @@ mod helpers {
                                     // selection.
                                     let field_output = field_def.ty.inner_named_type();
                                     if to_schema.try_get_type(field_output.clone()).is_none() {
-                                        let field_output =
-                                            self.original_schema.get_type(field_output.clone())?;
-                                        let field_type =
-                                            field_output.get(self.original_schema.schema())?;
-
                                         // We use a fake JSONSelection here so that we can reuse the visitor
                                         // when generating the output types and their required memebers.
-                                        let visitor = ToSchemaVisitor::new(
+                                        let visitor = SchemaVisitor::new(
                                             self.original_schema,
                                             to_schema,
-                                            field_output,
-                                            field_type,
                                             &self.directive_deny_list,
                                         );
                                         let (_, parsed) =
@@ -592,7 +536,21 @@ mod helpers {
                                                 FederationError::internal(format!("could not parse fake selection for sibling field: {e}"))
                                             })?;
 
-                                        visitor.walk(&parsed)?;
+                                        let output_type = match self
+                                            .original_schema
+                                            .get_type(field_output.clone())?
+                                        {
+                                            TypeDefinitionPosition::Object(object) => object,
+
+                                            other => {
+                                                return Err(FederationError::internal(format!("connector output types currently only support object types: found {}", other.type_name())))
+                                            }
+                                        };
+
+                                        visitor.walk((
+                                            output_type,
+                                            parsed.next_subselection().cloned().unwrap(),
+                                        ))?;
                                     }
                                 }
 
@@ -621,7 +579,8 @@ mod helpers {
 
                             other => {
                                 return Err(FederationError::internal(format!(
-                                    "cannot select a sibling on a leaf type: {other:#?}"
+                                    "cannot select a sibling on a leaf type: {}",
+                                    other.type_name()
                                 )))
                             }
                         };
@@ -662,9 +621,51 @@ mod helpers {
             Ok(())
         }
 
-        /// Inserts a dummy root-level query to the schema to pass validation.
+        /// Inserts a custom leaf type into the schema
         ///
-        /// The inserted dummy query looks like the schema below:
+        /// This errors if called with a non-leaf type.
+        fn insert_custom_leaf(
+            &self,
+            to_schema: &mut FederationSchema,
+            r#type: &TypeDefinitionPosition,
+        ) -> Result<(), FederationError> {
+            match r#type {
+                TypeDefinitionPosition::Scalar(scalar) => {
+                    let def = scalar.get(self.original_schema.schema())?;
+                    let def = ScalarType {
+                        description: def.description.clone(),
+                        name: def.name.clone(),
+                        directives: filter_directives(&self.directive_deny_list, &def.directives),
+                    };
+
+                    scalar.pre_insert(to_schema)?;
+                    scalar.insert(to_schema, Node::new(def))
+                }
+                TypeDefinitionPosition::Enum(r#enum) => {
+                    let def = r#enum.get(self.original_schema.schema())?;
+                    let def = EnumType {
+                        description: def.description.clone(),
+                        name: def.name.clone(),
+                        directives: filter_directives(&self.directive_deny_list, &def.directives),
+                        values: def.values.clone(),
+                    };
+
+                    r#enum.pre_insert(to_schema)?;
+                    r#enum.insert(to_schema, Node::new(def))
+                }
+
+                other => Err(FederationError::internal(format!(
+                    "expected a leaf, found: {}",
+                    other.type_name(),
+                ))),
+            }
+        }
+
+        /// Insert a query root for a connect field
+        ///
+        /// This method will handle creating a dummy query root as shown below when the
+        /// parent type is _not_ a root-level Query to pass schema validation.
+        ///
         /// ```graphql
         /// type Query {
         ///   _: ID @shareable @inaccessible
@@ -673,46 +674,93 @@ mod helpers {
         ///
         /// Note: This would probably be better off expanding the query to have
         /// an __entries vs. adding an inaccessible field.
-        fn insert_dummy_query(
+        fn insert_query_for_field(
             &self,
             to_schema: &mut FederationSchema,
-            name: Name,
+            query_alias: &Name,
+            field_parent: &ObjectTypeDefinitionPosition,
+            field: impl AsRef<FieldDefinition>,
         ) -> Result<(), FederationError> {
-            let field_name = name!("_");
-
-            let dummy_query = ObjectTypeDefinitionPosition {
-                type_name: name.clone(),
+            // Prime the query type
+            let query = ObjectTypeDefinitionPosition {
+                type_name: query_alias.clone(),
             };
-            let dummy_field = Component::new(FieldDefinition {
-                description: None,
-                name: field_name.clone(),
-                arguments: Vec::new(),
-                ty: ast::Type::Named(ast::NamedType::new_unchecked("ID")),
-                directives: ast::DirectiveList(
-                    [
-                        name!("federation__shareable"),
-                        name!("federation__inaccessible"),
-                    ]
-                    .into_iter()
-                    .map(|name| {
-                        Node::new(ast::Directive {
-                            name,
-                            arguments: Vec::new(),
-                        })
-                    })
-                    .collect(),
-                ),
-            });
 
-            dummy_query.pre_insert(to_schema)?;
-            dummy_query.insert(
+            // Now we'll need to know what field to add to the query root. In the case
+            // where the parent of the field on the original schema was not the root
+            // Query object, the field added is a dummy inaccessible field and the actual
+            // parent root is created and upserted. Otherwise, the query will contain the field specified.
+            let original = field.as_ref();
+            let field = if field_parent.type_name != *query_alias {
+                // We'll need to upsert the actual type for the field's parent
+                let parent_type = field_parent.get(self.original_schema.schema())?;
+
+                field_parent.pre_insert(to_schema)?;
+                let field_def = FieldDefinition {
+                    description: original.description.clone(),
+                    name: original.name.clone(),
+                    arguments: original.arguments.clone(),
+                    ty: original.ty.clone(),
+                    directives: filter_directives(&self.directive_deny_list, &original.directives),
+                };
+                field_parent.insert(
+                    to_schema,
+                    Node::new(ObjectType {
+                        description: parent_type.description.clone(),
+                        name: parent_type.name.clone(),
+                        implements_interfaces: parent_type.implements_interfaces.clone(),
+                        directives: filter_directives(
+                            &self.directive_deny_list,
+                            &parent_type.directives,
+                        ),
+                        fields: IndexMap::from_iter([(
+                            field_def.name.clone(),
+                            Component::new(field_def.clone()),
+                        )]),
+                    }),
+                )?;
+
+                // Return the dummy field to add to the root Query
+                FieldDefinition {
+                    description: None,
+                    name: name!("_"),
+                    arguments: Vec::new(),
+                    ty: ast::Type::Named(ast::NamedType::new("ID")?),
+                    directives: ast::DirectiveList(
+                        [
+                            name!("federation__shareable"),
+                            name!("federation__inaccessible"),
+                        ]
+                        .into_iter()
+                        .map(|name| {
+                            Node::new(ast::Directive {
+                                name,
+                                arguments: Vec::new(),
+                            })
+                        })
+                        .collect(),
+                    ),
+                }
+            } else {
+                FieldDefinition {
+                    description: original.description.clone(),
+                    name: original.name.clone(),
+                    arguments: original.arguments.clone(),
+                    ty: original.ty.clone(),
+                    directives: filter_directives(&self.directive_deny_list, &original.directives),
+                }
+            };
+
+            // Insert the root Query
+            query.pre_insert(to_schema)?;
+            query.insert(
                 to_schema,
                 Node::new(ObjectType {
                     description: None,
-                    name,
+                    name: query_alias.clone(),
                     implements_interfaces: IndexSet::with_hasher(Default::default()),
                     directives: DirectiveList::new(),
-                    fields: IndexMap::from_iter([(field_name, dummy_field)]),
+                    fields: IndexMap::from_iter([(field.name.clone(), Component::new(field))]),
                 }),
             )?;
 

--- a/apollo-federation/src/sources/connect/expand/tests/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/tests/mod.rs
@@ -61,6 +61,7 @@ macro_rules! test_ignores {
 }
 
 test_expands! {
+    nested_inputs,
     realistic,
     simple,
     steelthread,

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/nested_inputs.graphql
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/nested_inputs.graphql
@@ -55,7 +55,7 @@ enum link__Purpose {
 type Query
   @join__type(graph: CONNECTORS)
 {
-  foo(bar: String, baz: BazInput): String @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "example", http: {GET: "/{$args.bar}/{$args.baz.buzz}/{$args.baz.quux.quaz}"}, selection: ""})
+  foo(bar: String, baz: BazInput, doubleBaz: BazInput): String @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "example", http: {GET: "/{$args.bar}/{$args.doubleBaz.buzz}/{$args.baz.quux.quaz}"}, selection: "$"})
 }
 
 input QuuxInput

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/nested_inputs.graphql
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/nested_inputs.graphql
@@ -23,40 +23,12 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-type Address
+input BazInput
   @join__type(graph: CONNECTORS)
 {
-  street: String
-  suite: String
-  city: String
-  zipcode: String
-  geo: AddressGeo
+  buzz: String
+  quux: QuuxInput
 }
-
-type AddressGeo
-  @join__type(graph: CONNECTORS)
-{
-  lat: Float
-  lng: Float
-}
-
-type CompanyInfo
-  @join__type(graph: CONNECTORS)
-{
-  name: String
-  catchPhrase: String
-  bs: String
-}
-
-input CompanyInput
-  @join__type(graph: CONNECTORS)
-{
-  name: String!
-  catchPhrase: String
-}
-
-scalar EmailAddress
-  @join__type(graph: CONNECTORS)
 
 scalar join__DirectiveArguments
 
@@ -83,19 +55,11 @@ enum link__Purpose {
 type Query
   @join__type(graph: CONNECTORS)
 {
-  usersByCompany(company: CompanyInput!): [User] @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "example", http: {GET: "/by-company/{$args.company.name}"}, selection: "id\nname\ncompany {\n  name\n  catchPhrase\n  bs\n}"})
-  user(id: ID!): User @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "example", http: {GET: "/{$args.id}"}, selection: "id\nname\nusername\nemail\naddress {\n  street\n  suite\n  city\n  zipcode\n  geo {\n    lat\n    lng\n  }\n}\nphone\nwebsite\ncompany {\n  name\n  catchPhrase\n  bs\n}", entity: true})
+  foo(bar: String, baz: BazInput): String @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "example", http: {GET: "/{$args.bar}/{$args.baz.buzz}/{$args.baz.quux.quaz}"}, selection: ""})
 }
 
-type User
-  @join__type(graph: CONNECTORS, key: "id")
+input QuuxInput
+  @join__type(graph: CONNECTORS)
 {
-  id: ID!
-  name: String
-  username: String
-  email: EmailAddress
-  address: Address
-  phone: String
-  website: String
-  company: CompanyInfo
+  quaz: String
 }

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/nested_inputs.yaml
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/nested_inputs.yaml
@@ -13,10 +13,10 @@ subgraphs:
           @source(name: "example", http: { baseURL: "http://example" })
 
         type Query {
-          foo(bar: String, baz: BazInput): String @connect(
+          foo(bar: String, baz: BazInput, doubleBaz: BazInput): String @connect(
             source: "example",
-            http: { GET: "/{$$args.bar}/{$$args.baz.buzz}/{$$args.baz.quux.quaz}" }
-            selection: ""
+            http: { GET: "/{$$args.bar}/{$$args.doubleBaz.buzz}/{$$args.baz.quux.quaz}" }
+            selection: "$"
           )
         }
 

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/nested_inputs.yaml
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/nested_inputs.yaml
@@ -1,0 +1,30 @@
+federation_version: =2.9.0-connectors.0
+subgraphs:
+  connectors:
+    routing_url: none
+    schema:
+      sdl: |
+        extend schema
+          @link(
+            url: "https://specs.apollo.dev/federation/v2.7"
+            import: ["@key"]
+          )
+          @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"])
+          @source(name: "example", http: { baseURL: "http://example" })
+
+        type Query {
+          foo(bar: String, baz: BazInput): String @connect(
+            source: "example",
+            http: { GET: "/{$$args.bar}/{$$args.baz.buzz}/{$$args.baz.quux.quaz}" }
+            selection: ""
+          )
+        }
+
+        input BazInput {
+          buzz: String
+          quux: QuuxInput
+        }
+
+        input QuuxInput {
+          quaz: String
+        }

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/realistic.graphql
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/realistic.graphql
@@ -46,6 +46,7 @@ type CompanyInfo
   name: String
   catchPhrase: String
   bs: String
+  email: EmailAddress
 }
 
 input CompanyInput
@@ -84,7 +85,7 @@ type Query
   @join__type(graph: CONNECTORS)
 {
   usersByCompany(company: CompanyInput!): [User] @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "example", http: {GET: "/by-company/{$args.company.name}"}, selection: "id\nname\ncompany {\n  name\n  catchPhrase\n  bs\n}"})
-  user(id: ID!): User @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "example", http: {GET: "/{$args.id}"}, selection: "id\nname\nusername\nemail\naddress {\n  street\n  suite\n  city\n  zipcode\n  geo {\n    lat\n    lng\n  }\n}\nphone\nwebsite\ncompany {\n  name\n  catchPhrase\n  bs\n}", entity: true})
+  user(id: ID!): User @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "example", http: {GET: "/{$args.id}"}, selection: "id\nname\nusername\nemail\naddress {\n  street\n  suite\n  city\n  zipcode\n  geo {\n    lat\n    lng\n  }\n}\nphone\nwebsite\ncompany {\n  name\n  catchPhrase\n  bs\n  email\n}", entity: true})
 }
 
 type User

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/realistic.yaml
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/realistic.yaml
@@ -45,6 +45,7 @@ subgraphs:
                 name
                 catchPhrase
                 bs
+                email
               }""", entity: true)
         }
 
@@ -76,6 +77,7 @@ subgraphs:
           name: String
           catchPhrase: String
           bs: String
+          email: EmailAddress
         }
 
         input CompanyInput {

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/realistic.yaml
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/realistic.yaml
@@ -52,7 +52,7 @@ subgraphs:
           id: ID!
           name: String
           username: String
-          email: String
+          email: EmailAddress
           address: Address
           phone: String
           website: String
@@ -82,3 +82,5 @@ subgraphs:
           name: String!
           catchPhrase: String
         }
+
+        scalar EmailAddress

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__nested_inputs__it_expands_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__nested_inputs__it_expands_supergraph-2.snap
@@ -1,0 +1,74 @@
+---
+source: apollo-federation/src/sources/connect/expand/tests/mod.rs
+expression: connectors.by_service_name
+---
+{
+    "connectors_Query_foo_0": Connector {
+        id: ConnectId {
+            label: "connectors.example http: GET /{$args.bar!}/{$args.baz.buzz!}/{$args.baz.quux.quaz!}",
+            subgraph_name: "connectors",
+            source_name: Some(
+                "example",
+            ),
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.foo),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJsonTransport {
+            source_url: Some(
+                "http://example",
+            ),
+            connect_template: URLTemplate {
+                base: None,
+                path: [
+                    ParameterValue {
+                        parts: [
+                            Var(
+                                VariableExpression {
+                                    var_path: "$args.bar",
+                                    batch_separator: None,
+                                    required: true,
+                                },
+                            ),
+                        ],
+                    },
+                    ParameterValue {
+                        parts: [
+                            Var(
+                                VariableExpression {
+                                    var_path: "$args.baz.buzz",
+                                    batch_separator: None,
+                                    required: true,
+                                },
+                            ),
+                        ],
+                    },
+                    ParameterValue {
+                        parts: [
+                            Var(
+                                VariableExpression {
+                                    var_path: "$args.baz.quux.quaz",
+                                    batch_separator: None,
+                                    required: true,
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                query: {},
+            },
+            method: Get,
+            headers: {},
+            body: None,
+        },
+        selection: Named(
+            SubSelection {
+                selections: [],
+                star: None,
+            },
+        ),
+        entity_resolver: None,
+    },
+}

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__nested_inputs__it_expands_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__nested_inputs__it_expands_supergraph-2.snap
@@ -5,7 +5,7 @@ expression: connectors.by_service_name
 {
     "connectors_Query_foo_0": Connector {
         id: ConnectId {
-            label: "connectors.example http: GET /{$args.bar!}/{$args.baz.buzz!}/{$args.baz.quux.quaz!}",
+            label: "connectors.example http: GET /{$args.bar!}/{$args.doubleBaz.buzz!}/{$args.baz.quux.quaz!}",
             subgraph_name: "connectors",
             source_name: Some(
                 "example",
@@ -38,7 +38,7 @@ expression: connectors.by_service_name
                         parts: [
                             Var(
                                 VariableExpression {
-                                    var_path: "$args.baz.buzz",
+                                    var_path: "$args.doubleBaz.buzz",
                                     batch_separator: None,
                                     required: true,
                                 },
@@ -63,11 +63,11 @@ expression: connectors.by_service_name
             headers: {},
             body: None,
         },
-        selection: Named(
-            SubSelection {
-                selections: [],
-                star: None,
-            },
+        selection: Path(
+            Var(
+                "$",
+                Empty,
+            ),
         ),
         entity_resolver: None,
     },

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__nested_inputs__it_expands_supergraph-3.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__nested_inputs__it_expands_supergraph-3.snap
@@ -47,5 +47,5 @@ input BazInput @join__type(graph: CONNECTORS_QUERY_FOO_0) {
 }
 
 type Query @join__type(graph: CONNECTORS_QUERY_FOO_0) {
-  foo(bar: String, baz: BazInput): String @join__field(graph: CONNECTORS_QUERY_FOO_0)
+  foo(bar: String, baz: BazInput, doubleBaz: BazInput): String @join__field(graph: CONNECTORS_QUERY_FOO_0)
 }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__nested_inputs__it_expands_supergraph-3.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__nested_inputs__it_expands_supergraph-3.snap
@@ -1,0 +1,51 @@
+---
+source: apollo-federation/src/sources/connect/expand/tests/mod.rs
+expression: raw_sdl
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on ENUM | INPUT_OBJECT | INTERFACE | OBJECT | SCALAR | UNION
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on INTERFACE | OBJECT
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+enum link__Purpose {
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """EXECUTION features provide metadata necessary for operation execution."""
+  EXECUTION
+}
+
+scalar link__Import
+
+scalar join__FieldSet
+
+enum join__Graph {
+  CONNECTORS_QUERY_FOO_0 @join__graph(name: "connectors_Query_foo_0", url: "none")
+}
+
+input QuuxInput @join__type(graph: CONNECTORS_QUERY_FOO_0) {
+  quaz: String
+}
+
+input BazInput @join__type(graph: CONNECTORS_QUERY_FOO_0) {
+  buzz: String
+  quux: QuuxInput
+}
+
+type Query @join__type(graph: CONNECTORS_QUERY_FOO_0) {
+  foo(bar: String, baz: BazInput): String @join__field(graph: CONNECTORS_QUERY_FOO_0)
+}

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__nested_inputs__it_expands_supergraph.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__nested_inputs__it_expands_supergraph.snap
@@ -10,7 +10,7 @@ input BazInput {
 }
 
 type Query {
-  foo(bar: String, baz: BazInput): String
+  foo(bar: String, baz: BazInput, doubleBaz: BazInput): String
 }
 
 input QuuxInput {

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__nested_inputs__it_expands_supergraph.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__nested_inputs__it_expands_supergraph.snap
@@ -1,0 +1,18 @@
+---
+source: apollo-federation/src/sources/connect/expand/tests/mod.rs
+expression: api_schema
+---
+directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+input BazInput {
+  buzz: String
+  quux: QuuxInput
+}
+
+type Query {
+  foo(bar: String, baz: BazInput): String
+}
+
+input QuuxInput {
+  quaz: String
+}

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__realistic__it_expands_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__realistic__it_expands_supergraph-2.snap
@@ -237,6 +237,11 @@ expression: connectors.by_service_name
                                         "bs",
                                         None,
                                     ),
+                                    Field(
+                                        None,
+                                        "email",
+                                        None,
+                                    ),
                                 ],
                                 star: None,
                             },

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__realistic__it_expands_supergraph-3.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__realistic__it_expands_supergraph-3.snap
@@ -57,10 +57,12 @@ type CompanyInfo @join__type(graph: CONNECTORS_QUERY_USER_0) @join__type(graph: 
   name: String @join__field(graph: CONNECTORS_QUERY_USER_0) @join__field(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0)
 }
 
+scalar EmailAddress @join__type(graph: CONNECTORS_QUERY_USER_0)
+
 type User @join__type(graph: CONNECTORS_QUERY_USER_0, key: "id") @join__type(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0) {
   address: Address @join__field(graph: CONNECTORS_QUERY_USER_0)
   company: CompanyInfo @join__field(graph: CONNECTORS_QUERY_USER_0) @join__field(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0)
-  email: String @join__field(graph: CONNECTORS_QUERY_USER_0)
+  email: EmailAddress @join__field(graph: CONNECTORS_QUERY_USER_0)
   id: ID! @join__field(graph: CONNECTORS_QUERY_USER_0) @join__field(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0)
   name: String @join__field(graph: CONNECTORS_QUERY_USER_0) @join__field(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0)
   phone: String @join__field(graph: CONNECTORS_QUERY_USER_0)

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__realistic__it_expands_supergraph-3.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__realistic__it_expands_supergraph-3.snap
@@ -51,13 +51,14 @@ type Address @join__type(graph: CONNECTORS_QUERY_USER_0) {
   zipcode: String @join__field(graph: CONNECTORS_QUERY_USER_0)
 }
 
+scalar EmailAddress @join__type(graph: CONNECTORS_QUERY_USER_0)
+
 type CompanyInfo @join__type(graph: CONNECTORS_QUERY_USER_0) @join__type(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0) {
   bs: String @join__field(graph: CONNECTORS_QUERY_USER_0) @join__field(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0)
   catchPhrase: String @join__field(graph: CONNECTORS_QUERY_USER_0) @join__field(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0)
+  email: EmailAddress @join__field(graph: CONNECTORS_QUERY_USER_0)
   name: String @join__field(graph: CONNECTORS_QUERY_USER_0) @join__field(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0)
 }
-
-scalar EmailAddress @join__type(graph: CONNECTORS_QUERY_USER_0)
 
 type User @join__type(graph: CONNECTORS_QUERY_USER_0, key: "id") @join__type(graph: CONNECTORS_QUERY_USERSBYCOMPANY_0) {
   address: Address @join__field(graph: CONNECTORS_QUERY_USER_0)

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__realistic__it_expands_supergraph.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__realistic__it_expands_supergraph.snap
@@ -28,6 +28,8 @@ input CompanyInput {
   catchPhrase: String
 }
 
+scalar EmailAddress
+
 type Query {
   usersByCompany(company: CompanyInput!): [User]
   user(id: ID!): User
@@ -37,7 +39,7 @@ type User {
   id: ID!
   name: String
   username: String
-  email: String
+  email: EmailAddress
   address: Address
   phone: String
   website: String

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__realistic__it_expands_supergraph.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__realistic__it_expands_supergraph.snap
@@ -21,6 +21,7 @@ type CompanyInfo {
   name: String
   catchPhrase: String
   bs: String
+  email: EmailAddress
 }
 
 input CompanyInput {

--- a/apollo-federation/src/sources/connect/expand/visitors/input.rs
+++ b/apollo-federation/src/sources/connect/expand/visitors/input.rs
@@ -1,0 +1,101 @@
+use apollo_compiler::ast::InputValueDefinition;
+use apollo_compiler::schema::Component;
+use apollo_compiler::schema::InputObjectType;
+use apollo_compiler::Node;
+use indexmap::IndexMap;
+
+use super::filter_directives;
+use super::FieldVisitor;
+use super::GroupVisitor;
+use super::SchemaVisitor;
+use crate::error::FederationError;
+use crate::schema::position::InputObjectFieldDefinitionPosition;
+use crate::schema::position::InputObjectTypeDefinitionPosition;
+use crate::schema::position::TypeDefinitionPosition;
+
+impl FieldVisitor<InputObjectFieldDefinitionPosition>
+    for SchemaVisitor<'_, InputObjectTypeDefinitionPosition, InputObjectType>
+{
+    type Error = FederationError;
+
+    fn visit<'a>(&mut self, field: InputObjectFieldDefinitionPosition) -> Result<(), Self::Error> {
+        let (_, type_) = self.type_stack.last_mut().unwrap();
+
+        // Extract the node info
+        let field_def = field.get(self.original_schema.schema())?;
+
+        // Add it to the currently processing object
+        type_.fields.insert(
+            field.field_name,
+            Component::new(InputValueDefinition {
+                description: field_def.description.clone(),
+                name: field_def.name.clone(),
+                default_value: field_def.default_value.clone(),
+                ty: field_def.ty.clone(),
+                directives: filter_directives(self.directive_deny_list, &field_def.directives),
+            }),
+        );
+
+        Ok(())
+    }
+}
+
+impl GroupVisitor<InputObjectTypeDefinitionPosition, InputObjectFieldDefinitionPosition>
+    for SchemaVisitor<'_, InputObjectTypeDefinitionPosition, InputObjectType>
+{
+    fn get_group_fields(
+        &self,
+        group: InputObjectTypeDefinitionPosition,
+    ) -> Result<
+        Vec<InputObjectFieldDefinitionPosition>,
+        <Self as FieldVisitor<InputObjectFieldDefinitionPosition>>::Error,
+    > {
+        let def = group.get(self.original_schema.schema())?;
+        Ok(def.fields.keys().cloned().map(|f| group.field(f)).collect())
+    }
+
+    fn try_get_group_for_field(
+        &self,
+        field: &InputObjectFieldDefinitionPosition,
+    ) -> Result<Option<InputObjectTypeDefinitionPosition>, FederationError> {
+        // Return the next group, if found
+        let field_type = field.get(self.original_schema.schema())?;
+        let inner_type = self
+            .original_schema
+            .get_type(field_type.ty.inner_named_type().clone())?;
+        match inner_type {
+            TypeDefinitionPosition::InputObject(input) => Ok(Some(input)),
+            TypeDefinitionPosition::Scalar(_) | TypeDefinitionPosition::Enum(_) => Ok(None),
+
+            other => Err(FederationError::internal(format!(
+                "input objects cannot include fields of type: {}",
+                other.type_name()
+            ))),
+        }
+    }
+
+    fn enter_group<'a>(
+        &mut self,
+        group: InputObjectTypeDefinitionPosition,
+    ) -> Result<Vec<InputObjectFieldDefinitionPosition>, FederationError> {
+        group.pre_insert(self.to_schema)?;
+
+        let group_def = group.get(self.original_schema.schema())?;
+        let output_type = InputObjectType {
+            description: group_def.description.clone(),
+            name: group_def.name.clone(),
+            directives: filter_directives(self.directive_deny_list, &group_def.directives),
+            fields: IndexMap::with_hasher(Default::default()), // Filled in by the rest of the visitor
+        };
+
+        self.type_stack.push((group.clone(), output_type));
+        self.get_group_fields(group)
+    }
+
+    fn exit_group(&mut self) -> Result<(), FederationError> {
+        let (definition, type_) = self.type_stack.pop().unwrap();
+
+        // Now actually consolidate the object into our schema
+        definition.insert(self.to_schema, Node::new(type_))
+    }
+}

--- a/apollo-federation/src/sources/connect/expand/visitors/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/visitors/mod.rs
@@ -1,0 +1,367 @@
+//! Expansion Visitors
+//!
+//! This module contains various helper visitors for traversing nested structures,
+//! adding needed types to a mutable schema.
+
+pub mod input;
+mod selection;
+
+use std::collections::VecDeque;
+
+use apollo_compiler::ast::Directive;
+use apollo_compiler::Name;
+use indexmap::IndexSet;
+
+use crate::schema::FederationSchema;
+use crate::schema::ValidFederationSchema;
+
+/// Filter out directives from a directive list
+pub(crate) fn filter_directives<'a, D, I, O>(deny_list: &IndexSet<Name>, directives: D) -> O
+where
+    D: IntoIterator<Item = &'a I>,
+    I: 'a + AsRef<Directive> + Clone,
+    O: FromIterator<I>,
+{
+    directives
+        .into_iter()
+        .filter(|d| !deny_list.contains(&d.as_ref().name))
+        .cloned()
+        .collect()
+}
+
+/// Visitor for arbitrary field types.
+///
+/// Any type of interest that should be viewed when traversing the tree-like structure
+/// defined by [GroupVisitor] should implement this trait.
+pub(crate) trait FieldVisitor<Field>: Sized {
+    type Error;
+
+    /// Visit a field
+    fn visit(&mut self, field: Field) -> Result<(), Self::Error>;
+}
+
+/// Visitor for arbitrary tree-like structures where nodes can also have children
+///
+/// This trait treats all nodes in the graph as Fields, checking if a Field is also
+/// a group for handling children.
+pub(crate) trait GroupVisitor<Group, Field>
+where
+    Self: FieldVisitor<Field>,
+    Field: Clone,
+{
+    /// Get all of the fields for a specified group
+    fn get_group_fields(
+        &self,
+        group: Group,
+    ) -> Result<Vec<Field>, <Self as FieldVisitor<Field>>::Error>;
+
+    fn try_get_group_for_field(
+        &self,
+        field: &Field,
+    ) -> Result<Option<Group>, <Self as FieldVisitor<Field>>::Error>;
+
+    /// Enter a subselection group
+    /// Note: You can assume that the named selection corresponding to this
+    /// group will be visited first.
+    fn enter_group(
+        &mut self,
+        group: Group,
+    ) -> Result<Vec<Field>, <Self as FieldVisitor<Field>>::Error>;
+
+    /// Exit a subselection group
+    /// Note: You can assume that the named selection corresponding to this
+    /// group will be visited and entered first.
+    fn exit_group(&mut self) -> Result<(), <Self as FieldVisitor<Field>>::Error>;
+
+    /// Walk through a [`JSONSelection`], visiting each output key. If at any point, one of the
+    /// visitor methods returns an error, then the walk will be stopped and the error will be
+    /// returned.
+    fn walk(mut self, entry: Group) -> Result<(), <Self as FieldVisitor<Field>>::Error> {
+        // Start visiting each of the fields
+        let mut to_visit =
+            VecDeque::from_iter(self.enter_group(entry)?.into_iter().map(|n| (0i32, n)));
+        let mut current_depth = 0;
+        while let Some((depth, next)) = to_visit.pop_front() {
+            for _ in depth..current_depth {
+                self.exit_group()?;
+            }
+            current_depth = depth;
+
+            self.visit(next.clone())?;
+
+            // If we have a named selection that has a subselection, then we want to
+            // make sure that we visit the children before all other siblings.
+            //
+            // Note: We reverse here since we always push to the front.
+            if let Some(group) = self.try_get_group_for_field(&next)? {
+                current_depth += 1;
+
+                let fields = self.enter_group(group)?;
+                fields
+                    .into_iter()
+                    .rev()
+                    .for_each(|s| to_visit.push_front((current_depth, s)));
+            }
+        }
+
+        // Make sure that we exit until we are no longer nested
+        for _ in 0..=current_depth {
+            self.exit_group()?;
+        }
+
+        Ok(())
+    }
+}
+
+/// A visitor for schema building.
+///
+/// This implementation of the JSONSelection visitor walks a JSONSelection,
+/// copying over all output types (and respective fields / sub types) as it goes
+/// from a reference schema.
+pub(crate) struct SchemaVisitor<'a, Group, GroupType> {
+    /// List of directives to not copy over into the target schema.
+    directive_deny_list: &'a IndexSet<Name>,
+
+    /// The original schema used for sourcing all types / fields / directives / etc.
+    original_schema: &'a ValidFederationSchema,
+
+    /// The target schema for adding all types.
+    to_schema: &'a mut FederationSchema,
+
+    /// A stack of parent types used for fetching subtypes
+    ///
+    /// Each entry corresponds to a nested subselect in the JSONSelection.
+    type_stack: Vec<(Group, GroupType)>,
+}
+
+impl<'a, Group, GroupType> SchemaVisitor<'a, Group, GroupType> {
+    pub fn new(
+        original_schema: &'a ValidFederationSchema,
+        to_schema: &'a mut FederationSchema,
+        directive_deny_list: &'a IndexSet<Name>,
+    ) -> SchemaVisitor<'a, Group, GroupType> {
+        SchemaVisitor {
+            directive_deny_list,
+            original_schema,
+            to_schema,
+            type_stack: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use insta::assert_snapshot;
+    use itertools::Itertools;
+
+    use crate::error::FederationError;
+    use crate::sources::connect::expand::visitors::FieldVisitor;
+    use crate::sources::connect::expand::visitors::GroupVisitor;
+    use crate::sources::connect::json_selection::NamedSelection;
+    use crate::sources::connect::JSONSelection;
+    use crate::sources::connect::SubSelection;
+
+    /// Visitor for tests.
+    ///
+    /// Each node visited is added, along with its depth. This is later printed
+    /// such that groups are indented based on depth.
+    struct TestVisitor<'a> {
+        depth_stack: Vec<usize>,
+        visited: &'a mut Vec<(usize, String)>,
+    }
+
+    impl<'a> TestVisitor<'a> {
+        fn new(visited: &'a mut Vec<(usize, String)>) -> Self {
+            Self {
+                depth_stack: Vec::new(),
+                visited,
+            }
+        }
+
+        fn last_depth(&self) -> Option<usize> {
+            self.depth_stack.last().copied()
+        }
+    }
+
+    fn print_visited(visited: Vec<(usize, String)>) -> String {
+        let mut result = String::new();
+        for (depth, visited) in visited {
+            result.push_str(&format!("{}{visited}\n", "|  ".repeat(depth)));
+        }
+
+        result
+    }
+
+    impl FieldVisitor<NamedSelection> for TestVisitor<'_> {
+        type Error = FederationError;
+
+        fn visit<'a>(&mut self, field: NamedSelection) -> Result<(), Self::Error> {
+            self.visited.push((
+                self.last_depth().unwrap_or_default(),
+                field.name().to_string(),
+            ));
+
+            Ok(())
+        }
+    }
+
+    impl GroupVisitor<SubSelection, NamedSelection> for TestVisitor<'_> {
+        fn try_get_group_for_field(
+            &self,
+            field: &NamedSelection,
+        ) -> Result<Option<SubSelection>, FederationError> {
+            Ok(field.next_subselection().cloned())
+        }
+
+        fn get_group_fields(
+            &self,
+            group: SubSelection,
+        ) -> Result<Vec<NamedSelection>, FederationError> {
+            Ok(group
+                .selections_iter()
+                .sorted_by_key(|s| s.name())
+                .cloned()
+                .collect())
+        }
+
+        fn enter_group(
+            &mut self,
+            group: SubSelection,
+        ) -> Result<Vec<NamedSelection>, FederationError> {
+            let next_depth = self.last_depth().map(|d| d + 1).unwrap_or(0);
+            self.depth_stack.push(next_depth);
+            self.get_group_fields(group)
+        }
+
+        fn exit_group(&mut self) -> Result<(), FederationError> {
+            self.depth_stack.pop().unwrap();
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn it_iterates_over_empty_path() {
+        let mut visited = Vec::new();
+        let visitor = TestVisitor::new(&mut visited);
+        let (unmatched, selection) = JSONSelection::parse("").unwrap();
+        assert!(unmatched.is_empty());
+
+        visitor
+            .walk(selection.next_subselection().cloned().unwrap())
+            .unwrap();
+        assert_snapshot!(print_visited(visited), @"");
+    }
+
+    #[test]
+    fn it_iterates_over_simple_selection() {
+        let mut visited = Vec::new();
+        let visitor = TestVisitor::new(&mut visited);
+        let (unmatched, selection) = JSONSelection::parse("a b c d").unwrap();
+        assert!(unmatched.is_empty());
+
+        visitor
+            .walk(selection.next_subselection().cloned().unwrap())
+            .unwrap();
+        assert_snapshot!(print_visited(visited), @r###"
+        a
+        b
+        c
+        d
+        "###);
+    }
+
+    #[test]
+    fn it_iterates_over_aliased_selection() {
+        let mut visited = Vec::new();
+        let visitor = TestVisitor::new(&mut visited);
+        let (unmatched, selection) =
+            JSONSelection::parse("a: one b: two c: three d: four").unwrap();
+        assert!(unmatched.is_empty());
+
+        visitor
+            .walk(selection.next_subselection().cloned().unwrap())
+            .unwrap();
+        assert_snapshot!(print_visited(visited), @r###"
+        a
+        b
+        c
+        d
+        "###);
+    }
+
+    #[test]
+    fn it_iterates_over_nested_selection() {
+        let mut visited = Vec::new();
+        let visitor = TestVisitor::new(&mut visited);
+        let (unmatched, selection) = JSONSelection::parse("a { b { c { d { e } } } }").unwrap();
+        assert!(unmatched.is_empty());
+
+        visitor
+            .walk(selection.next_subselection().cloned().unwrap())
+            .unwrap();
+        assert_snapshot!(print_visited(visited), @r###"
+        a
+        |  b
+        |  |  c
+        |  |  |  d
+        |  |  |  |  e
+        "###);
+    }
+
+    #[test]
+    fn it_iterates_over_complex_selection() {
+        let mut visited = Vec::new();
+        let visitor = TestVisitor::new(&mut visited);
+        let (unmatched, selection) = JSONSelection::parse(
+            "id
+            name
+            username
+            email
+            address {
+              street
+              suite
+              city
+              zipcode
+              geo {
+                lat
+                lng
+              }
+            }
+            phone
+            website
+            company {
+              name
+              catchPhrase
+              bs
+            }",
+        )
+        .unwrap();
+        assert!(unmatched.is_empty());
+
+        visitor
+            .walk(selection.next_subselection().cloned().unwrap())
+            .unwrap();
+        assert_snapshot!(print_visited(visited), @r###"
+        address
+        |  city
+        |  geo
+        |  |  lat
+        |  |  lng
+        |  street
+        |  suite
+        |  zipcode
+        company
+        |  bs
+        |  catchPhrase
+        |  name
+        email
+        id
+        name
+        phone
+        username
+        website
+        "###);
+        // let iter = selection.iter();
+        // assert_debug_snapshot!(iter.collect_vec());
+    }
+}

--- a/apollo-federation/src/sources/connect/expand/visitors/selection.rs
+++ b/apollo-federation/src/sources/connect/expand/visitors/selection.rs
@@ -1,0 +1,191 @@
+use apollo_compiler::ast::FieldDefinition;
+use apollo_compiler::schema::Component;
+use apollo_compiler::schema::EnumType;
+use apollo_compiler::schema::ObjectType;
+use apollo_compiler::schema::ScalarType;
+use apollo_compiler::Name;
+use apollo_compiler::Node;
+use indexmap::IndexMap;
+use itertools::Itertools;
+
+use super::filter_directives;
+use super::FieldVisitor;
+use super::GroupVisitor;
+use super::SchemaVisitor;
+use crate::error::FederationError;
+use crate::schema::position::ObjectTypeDefinitionPosition;
+use crate::schema::position::TypeDefinitionPosition;
+use crate::sources::connect::json_selection::NamedSelection;
+use crate::sources::connect::SubSelection;
+
+pub(crate) type JSONSelectionGroup = (ObjectTypeDefinitionPosition, SubSelection);
+
+impl FieldVisitor<NamedSelection> for SchemaVisitor<'_, ObjectTypeDefinitionPosition, ObjectType> {
+    type Error = FederationError;
+
+    fn visit<'a>(&mut self, field: NamedSelection) -> Result<(), Self::Error> {
+        let (definition, r#type) = self.type_stack.last_mut().unwrap();
+
+        // Get the type of the field so we know how to visit it
+        let field_name = Name::new(field.name())?;
+        let field = definition
+            .field(field_name.clone())
+            .get(self.original_schema.schema())?;
+        let field_type = self
+            .original_schema
+            .get_type(field.ty.inner_named_type().clone())?;
+        let extended_field_type = field_type.get(self.original_schema.schema())?;
+
+        // We only need to care about the type of the field if it isn't built-in
+        if !extended_field_type.is_built_in() {
+            match field_type {
+                TypeDefinitionPosition::Scalar(scalar) => {
+                    let def = scalar.get(self.original_schema.schema())?;
+                    let def = ScalarType {
+                        description: def.description.clone(),
+                        name: def.name.clone(),
+                        directives: filter_directives(self.directive_deny_list, &def.directives),
+                    };
+
+                    scalar.pre_insert(self.to_schema)?;
+                    scalar.insert(self.to_schema, Node::new(def))?;
+                }
+                TypeDefinitionPosition::Enum(r#enum) => {
+                    let def = r#enum.get(self.original_schema.schema())?;
+                    let def = EnumType {
+                        description: def.description.clone(),
+                        name: def.name.clone(),
+                        directives: filter_directives(self.directive_deny_list, &def.directives),
+                        values: def.values.clone(),
+                    };
+
+                    r#enum.pre_insert(self.to_schema)?;
+                    r#enum.insert(self.to_schema, Node::new(def))?;
+                }
+
+                // This will be handled by the rest of the visitor
+                TypeDefinitionPosition::Object(_) => {}
+
+                // These will be handled later
+                TypeDefinitionPosition::Union(_) => {
+                    return Err(FederationError::internal(
+                        "unions are not yet handled for expansion",
+                    ))
+                }
+
+                // Anything else is not supported
+                TypeDefinitionPosition::InputObject(input) => {
+                    return Err(FederationError::internal(format!(
+                        "expected field to be a leaf or object type, found: input {}",
+                        input.type_name,
+                    )))
+                }
+                TypeDefinitionPosition::Interface(interface) => {
+                    return Err(FederationError::internal(format!(
+                        "expected field to be a leaf or object type, found: interface {}",
+                        interface.type_name,
+                    )))
+                }
+            };
+        }
+
+        // Add the field to the currently processing object
+        r#type.fields.insert(
+            field_name,
+            Component::new(FieldDefinition {
+                description: field.description.clone(),
+                name: field.name.clone(),
+                arguments: field.arguments.clone(),
+                ty: field.ty.clone(),
+                directives: filter_directives(self.directive_deny_list, &field.directives),
+            }),
+        );
+
+        Ok(())
+    }
+}
+
+impl GroupVisitor<JSONSelectionGroup, NamedSelection>
+    for SchemaVisitor<'_, ObjectTypeDefinitionPosition, ObjectType>
+{
+    fn get_group_fields(
+        &self,
+        (_, group): JSONSelectionGroup,
+    ) -> Result<Vec<NamedSelection>, <Self as FieldVisitor<NamedSelection>>::Error> {
+        Ok(group
+            .selections_iter()
+            .sorted_by_key(|s| s.name())
+            .cloned()
+            .collect())
+    }
+
+    fn try_get_group_for_field(
+        &self,
+        field: &NamedSelection,
+    ) -> Result<Option<JSONSelectionGroup>, FederationError> {
+        let (definition, _) = self.type_stack.last().unwrap();
+        let field_name = Name::new(field.name())?;
+
+        let field_type_name = definition
+            .field(field_name)
+            .get(self.original_schema.schema())?
+            .ty
+            .inner_named_type();
+
+        let TypeDefinitionPosition::Object(field_type) =
+            self.original_schema.get_type(field_type_name.clone())?
+        else {
+            return Ok(None);
+        };
+
+        Ok(field.next_subselection().cloned().map(|s| (field_type, s)))
+    }
+
+    fn enter_group(
+        &mut self,
+        (group_type, group): JSONSelectionGroup,
+    ) -> Result<Vec<NamedSelection>, FederationError> {
+        // this is really an upsert — pre_insert/insert will error if the object already exists
+        if !self
+            .to_schema
+            .schema()
+            .types
+            .contains_key(&group_type.type_name)
+        {
+            group_type.pre_insert(self.to_schema)?;
+        }
+        let def = group_type.get(self.original_schema.schema())?;
+
+        let sub_type = ObjectType {
+            description: def.description.clone(),
+            name: def.name.clone(),
+            implements_interfaces: def.implements_interfaces.clone(),
+            directives: filter_directives(self.directive_deny_list, &def.directives),
+            fields: IndexMap::with_hasher(Default::default()), // Will be filled in by the `visit` method for each field
+        };
+
+        self.type_stack.push((group_type.clone(), sub_type));
+        self.get_group_fields((group_type, group))
+    }
+
+    fn exit_group(&mut self) -> Result<(), FederationError> {
+        let (definition, r#type) = self.type_stack.pop().unwrap();
+
+        // this is really an upsert — pre_insert/insert will error if the object already exists
+        if !self
+            .to_schema
+            .schema()
+            .types
+            .contains_key(&definition.type_name)
+        {
+            definition.insert(self.to_schema, Node::new(r#type))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO: Write these tests
+}


### PR DESCRIPTION
This PR adds input type support to the subgraph expansion code needed for processing connect directives.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.

<!-- CNN-232 -->