### PR TITLE
Fixed serialization panic in snapshot macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,7 @@ dependencies = [
  "multimap 0.10.0",
  "nom",
  "petgraph",
+ "ron",
  "serde",
  "serde_json",
  "serde_json_bytes",
@@ -1615,6 +1616,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block-buffer"
@@ -6091,6 +6095,18 @@ dependencies = [
  "byteorder",
  "num-traits",
  "paste",
+]
+
+[[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags 2.6.0",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -14,7 +14,7 @@ autotests = false                                      # Integration tests are m
 # logging statements that capture serialized versions of key data structures.
 # This logging is gated behind a feature to avoid any unnecessary (even if
 # small) runtime costs where this data will not be desired.
-snapshot_tracing = []
+snapshot_tracing = ["ron"]
 
 [dependencies]
 apollo-compiler.workspace = true
@@ -36,6 +36,7 @@ strum_macros = "0.26.0"
 thiserror = "1.0"
 url = "2"
 tracing = "0.1.40"
+ron = { version = "0.8.1", optional = true }
 
 [dev-dependencies]
 hex.workspace = true

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -67,7 +67,10 @@ static NEXT_ID: atomic::AtomicUsize = atomic::AtomicUsize::new(1);
 ///
 /// Note that we shouldn't add `derive(Serialize, Deserialize)` to this without changing the types
 /// to be something like UUIDs.
-#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+// NOTE(@TylerBloom): This feature gate can be removed once the condition in the comment above is
+// met.
+#[cfg_attr(feature = "snapshot_tracing", derive(Serialize))]
 pub(crate) struct SelectionId(usize);
 
 impl SelectionId {

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -69,7 +69,7 @@ static NEXT_ID: atomic::AtomicUsize = atomic::AtomicUsize::new(1);
 /// to be something like UUIDs.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 // NOTE(@TylerBloom): This feature gate can be removed once the condition in the comment above is
-// met.
+// met. Note that there are `serde(skip)` statements that should be removed once this is removed.
 #[cfg_attr(feature = "snapshot_tracing", derive(Serialize))]
 pub(crate) struct SelectionId(usize);
 
@@ -634,6 +634,7 @@ pub(crate) enum SelectionKey {
     },
     Defer {
         /// Unique selection ID used to distinguish deferred fragment spreads that cannot be merged.
+        #[cfg_attr(not(feature = "snapshot_tracing"), serde(skip))]
         deferred_id: SelectionId,
     },
 }
@@ -1470,6 +1471,7 @@ mod fragment_spread_selection {
         // on different locations. While we now keep track of those references, they are currently ignored.
         #[serde(serialize_with = "crate::display_helpers::serialize_as_string")]
         pub(crate) fragment_directives: Arc<executable::DirectiveList>,
+        #[cfg_attr(not(feature = "snapshot_tracing"), serde(skip))]
         pub(crate) selection_id: SelectionId,
     }
 
@@ -1762,6 +1764,7 @@ mod inline_fragment_selection {
         pub(crate) type_condition_position: Option<CompositeTypeDefinitionPosition>,
         #[serde(serialize_with = "crate::display_helpers::serialize_as_string")]
         pub(crate) directives: Arc<executable::DirectiveList>,
+        #[cfg_attr(not(feature = "snapshot_tracing"), serde(skip))]
         pub(crate) selection_id: SelectionId,
     }
 

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -227,6 +227,9 @@ pub(crate) struct SubgraphEnteringEdgeInfo {
 /// Note that we shouldn't add `derive(Serialize, Deserialize)` to this without changing the types
 /// to be something like UUIDs.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+// NOTE(@TylerBloom): This feature gate can be removed once the condition in the comment above is
+// met.
+#[cfg_attr(feature = "snapshot_tracing", derive(serde::Serialize))]
 pub(crate) struct OverrideId(usize);
 
 /// Global storage for the counter used to allocate `OverrideId`s.

--- a/apollo-federation/src/utils/logging.rs
+++ b/apollo-federation/src/utils/logging.rs
@@ -25,7 +25,7 @@ macro_rules! snapshot {
         #[cfg(feature = "snapshot_tracing")]
         tracing::trace!(
             snapshot = std::any::type_name_of_val(&$value),
-            data = serde_json::to_string(&$value).expect(concat!(
+            data = ron::ser::to_string(&$value).expect(concat!(
                 "Could not serialize value for a snapshot with message: ",
                 $msg
             )),
@@ -36,7 +36,7 @@ macro_rules! snapshot {
         #[cfg(feature = "snapshot_tracing")]
         tracing::trace!(
             snapshot = std::any::type_name_of_val(&$value),
-            data = serde_json::to_string(&$value).expect(concat!(
+            data = ron::ser::to_string(&$value).expect(concat!(
                 "Could not serialize value for a snapshot with message: ",
                 $msg
             )),


### PR DESCRIPTION
The `snapshot!` macro was serializing values to JSON. This caused issues for graphs and maps with nodes and keys (respectively) that could not be readily serialized into strings. The `derive` impl of `Serialize` was also feature gated for a few types that we do not yet to generally be serializable.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
