### PR TITLE
Evaluate selectors in response stage when possible

### DIFF
--- a/.changesets/fix_bnjjj_fix_subgraph_selector_for_event.md
+++ b/.changesets/fix_bnjjj_fix_subgraph_selector_for_event.md
@@ -1,0 +1,20 @@
+### Evaluate selectors in response stage when possible ([PR #5725](https://github.com/apollographql/router/pull/5725))
+
+As `events` are triggered at a specific stage (`request`|`response`|`error`) we can only have condition for the related stage and so sometimes you can also have selectors that can be applied at several stages (like `subgraph_name` to get the subgraph name). This change adds more possibilities when creating conditions on events.
+
+Example of an event to log the raw subgraph response only on a subgraph named `products`, this was not working before.
+
+```yaml
+telemetry:
+  instrumentation:
+    events:
+      subgraph:
+        response:
+          level: info
+          condition:
+            eq:
+            - subgraph_name: true
+            - "products"
+```
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/5725

--- a/apollo-router/src/plugins/telemetry/config_new/events.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/events.rs
@@ -1006,6 +1006,7 @@ mod tests {
                         subgraph::Response::fake2_builder()
                             .header("custom-header", "val1")
                             .header("x-log-response", HeaderValue::from_static("log"))
+                            .subgraph_name("subgraph")
                             .data(serde_json::json!({"data": "res"}).to_string())
                             .build()
                             .expect("expecting valid response")

--- a/apollo-router/src/plugins/telemetry/config_new/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/selectors.rs
@@ -2592,6 +2592,14 @@ mod test {
         assert_eq!(
             selector.on_request(
                 &crate::services::SubgraphRequest::fake_builder()
+                    .context(context.clone())
+                    .build(),
+            ),
+            Some("query".into())
+        );
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
                     .context(context)
                     .build(),
             ),
@@ -2608,6 +2616,15 @@ mod test {
         assert_eq!(
             selector.on_request(
                 &crate::services::SubgraphRequest::fake_builder()
+                    .context(context.clone())
+                    .subgraph_name("test".to_string())
+                    .build(),
+            ),
+            Some("test".into())
+        );
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
                     .context(context)
                     .subgraph_name("test".to_string())
                     .build(),
@@ -2743,6 +2760,14 @@ mod test {
         assert_eq!(
             selector.on_request(
                 &crate::services::SubgraphRequest::fake_builder()
+                    .context(context.clone())
+                    .build(),
+            ),
+            Some("topProducts".into())
+        );
+        assert_eq!(
+            selector.on_response(
+                &crate::services::SubgraphResponse::fake_builder()
                     .context(context)
                     .build(),
             ),

--- a/apollo-router/src/plugins/telemetry/config_new/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/selectors.rs
@@ -1357,6 +1357,39 @@ impl Selector for SubgraphSelector {
                     .canonical_reason()
                     .map(|reason| reason.into()),
             },
+            SubgraphSelector::SubgraphOperationKind { .. } => response
+                .context
+                .get::<_, String>(OPERATION_KIND)
+                .ok()
+                .flatten()
+                .map(opentelemetry::Value::from),
+            SubgraphSelector::SupergraphOperationKind { .. } => response
+                .context
+                .get::<_, String>(OPERATION_KIND)
+                .ok()
+                .flatten()
+                .map(opentelemetry::Value::from),
+            SubgraphSelector::SupergraphOperationName {
+                supergraph_operation_name,
+                default,
+                ..
+            } => {
+                let op_name = response.context.get(OPERATION_NAME).ok().flatten();
+                match supergraph_operation_name {
+                    OperationName::String => op_name.or_else(|| default.clone()),
+                    OperationName::Hash => op_name.or_else(|| default.clone()).map(|op_name| {
+                        let mut hasher = sha2::Sha256::new();
+                        hasher.update(op_name.as_bytes());
+                        let result = hasher.finalize();
+                        hex::encode(result)
+                    }),
+                }
+                .map(opentelemetry::Value::from)
+            }
+            SubgraphSelector::SubgraphName { subgraph_name } if *subgraph_name => response
+                .subgraph_name
+                .clone()
+                .map(opentelemetry::Value::from),
             SubgraphSelector::SubgraphResponseBody {
                 subgraph_response_body,
                 default,
@@ -1452,6 +1485,33 @@ impl Selector for SubgraphSelector {
 
     fn on_error(&self, error: &tower::BoxError, ctx: &Context) -> Option<opentelemetry::Value> {
         match self {
+            SubgraphSelector::SubgraphOperationKind { .. } => ctx
+                .get::<_, String>(OPERATION_KIND)
+                .ok()
+                .flatten()
+                .map(opentelemetry::Value::from),
+            SubgraphSelector::SupergraphOperationKind { .. } => ctx
+                .get::<_, String>(OPERATION_KIND)
+                .ok()
+                .flatten()
+                .map(opentelemetry::Value::from),
+            SubgraphSelector::SupergraphOperationName {
+                supergraph_operation_name,
+                default,
+                ..
+            } => {
+                let op_name = ctx.get(OPERATION_NAME).ok().flatten();
+                match supergraph_operation_name {
+                    OperationName::String => op_name.or_else(|| default.clone()),
+                    OperationName::Hash => op_name.or_else(|| default.clone()).map(|op_name| {
+                        let mut hasher = sha2::Sha256::new();
+                        hasher.update(op_name.as_bytes());
+                        let result = hasher.finalize();
+                        hex::encode(result)
+                    }),
+                }
+                .map(opentelemetry::Value::from)
+            }
             SubgraphSelector::Error { .. } => Some(error.to_string().into()),
             SubgraphSelector::Static(val) => Some(val.clone().into()),
             SubgraphSelector::StaticField { r#static } => Some(r#static.clone().into()),

--- a/apollo-router/src/plugins/telemetry/testdata/custom_events.router.yaml
+++ b/apollo-router/src/plugins/telemetry/testdata/custom_events.router.yaml
@@ -116,9 +116,13 @@ telemetry:
         response:
           level: warn
           condition:
-            eq:
-            - subgraph_response_header: x-log-response
-            - "log"
+            all:
+            - eq:
+              - subgraph_response_header: x-log-response
+              - "log"
+            - eq:
+              - subgraph_name: true
+              - "subgraph"
         error: error
 
         # Custom events


### PR DESCRIPTION
As `events` are triggered at a specific stage (`request`|`response`|`error`) we can only have condition for the related stage and so sometimes you can also have selectors that can be applied at several stages (like `subgraph_name` to get the subgraph name). This change adds more possibilities when creating conditions on events.

Example of an event to log the raw subgraph response only on a subgraph named `products`, this was not working before.

```yaml
telemetry:
  instrumentation:
    events:
      subgraph:
        response:
          level: info
          condition:
            eq:
            - subgraph_name: true
            - "products"
```

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
