### PR TITLE
chore(qp): add a diff_plan function to display differences between js & rust qps

### DIFF
--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -114,7 +114,6 @@ pub mod _private {
     pub use crate::plugin::PluginFactory;
     pub use crate::plugin::PLUGINS;
     // For comparison/fuzzing
-    pub use crate::query_planner::bridge_query_planner::render_diff;
     pub use crate::query_planner::bridge_query_planner::QueryPlanResult;
     pub use crate::query_planner::dual_query_planner::diff_plan;
     pub use crate::query_planner::dual_query_planner::plan_matches;

--- a/apollo-router/src/lib.rs
+++ b/apollo-router/src/lib.rs
@@ -114,7 +114,9 @@ pub mod _private {
     pub use crate::plugin::PluginFactory;
     pub use crate::plugin::PLUGINS;
     // For comparison/fuzzing
+    pub use crate::query_planner::bridge_query_planner::render_diff;
     pub use crate::query_planner::bridge_query_planner::QueryPlanResult;
+    pub use crate::query_planner::dual_query_planner::diff_plan;
     pub use crate::query_planner::dual_query_planner::plan_matches;
     // For tests
     pub use crate::router_factory::create_test_service_factory_from_yaml;

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -882,7 +882,7 @@ impl BridgeQueryPlanner {
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryPlanResult {
-    pub(super) formatted_query_plan: Option<Arc<String>>,
+    pub formatted_query_plan: Option<Arc<String>>,
     pub(super) query_plan: QueryPlan,
 }
 
@@ -894,7 +894,7 @@ pub(super) struct QueryPlan {
     pub(super) node: Option<Arc<PlanNode>>,
 }
 
-pub(crate) fn render_diff(differences: &[diff::Result<&str>]) -> String {
+pub fn render_diff(differences: &[diff::Result<&str>]) -> String {
     let mut output = String::new();
     for diff_line in differences {
         match diff_line {

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -894,7 +894,7 @@ pub(super) struct QueryPlan {
     pub(super) node: Option<Arc<PlanNode>>,
 }
 
-pub fn render_diff(differences: &[diff::Result<&str>]) -> String {
+pub(crate) fn render_diff(differences: &[diff::Result<&str>]) -> String {
     let mut output = String::new();
     for diff_line in differences {
         match diff_line {

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -882,7 +882,7 @@ impl BridgeQueryPlanner {
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryPlanResult {
-    pub formatted_query_plan: Option<Arc<String>>,
+    pub(super) formatted_query_plan: Option<Arc<String>>,
     pub(super) query_plan: QueryPlan,
 }
 

--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -145,7 +145,7 @@ impl BothModeComparisonJob {
                     tracing::debug!("JS v.s. Rust query plan mismatch{operation_desc}");
                     tracing::debug!(
                         "Diff of formatted plans:\n{}",
-                        diff_plan(&js_plan, &rust_plan)
+                        diff_plan(js_plan, rust_plan)
                     );
                     tracing::trace!("JS query plan Debug: {js_root_node:#?}");
                     tracing::trace!("Rust query plan Debug: {rust_root_node:#?}");

--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -249,18 +249,18 @@ pub fn diff_plan(js_plan: &QueryPlanResult, rust_plan: &QueryPlan) -> String {
     match (js_root_node, rust_root_node) {
         (None, None) => String::from(""),
         (None, Some(rust)) => {
-            let rust = &format!("{rust:?}");
+            let rust = &format!("{rust:#?}");
             let differences = diff::lines("", rust);
             render_diff(&differences)
         }
         (Some(js), None) => {
-            let js = &format!("{js:?}");
+            let js = &format!("{js:#?}");
             let differences = diff::lines(js, "");
             render_diff(&differences)
         }
         (Some(js), Some(rust)) => {
-            let rust = &format!("{rust:?}");
-            let js = &format!("{js:?}");
+            let rust = &format!("{rust:#?}");
+            let js = &format!("{js:#?}");
             let differences = diff::lines(js, rust);
             render_diff(&differences)
         }

--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -242,6 +242,31 @@ pub fn plan_matches(js_plan: &QueryPlanResult, rust_plan: &QueryPlan) -> bool {
     opt_plan_node_matches(js_root_node, &rust_root_node)
 }
 
+pub fn diff_plan(js_plan: &QueryPlanResult, rust_plan: &QueryPlan) -> String {
+    let js_root_node = &js_plan.query_plan.node;
+    let rust_root_node = convert_root_query_plan_node(rust_plan);
+
+    match (js_root_node, rust_root_node) {
+        (None, None) => String::from(""),
+        (None, Some(rust)) => {
+            let rust = &format!("{rust:?}");
+            let differences = diff::lines("", rust);
+            render_diff(&differences)
+        }
+        (Some(js), None) => {
+            let js = &format!("{js:?}");
+            let differences = diff::lines(js, "");
+            render_diff(&differences)
+        }
+        (Some(js), Some(rust)) => {
+            let rust = &format!("{rust:?}");
+            let js = &format!("{js:?}");
+            let differences = diff::lines(js, rust);
+            render_diff(&differences)
+        }
+    }
+}
+
 fn opt_plan_node_matches(
     this: &Option<impl Borrow<PlanNode>>,
     other: &Option<impl Borrow<PlanNode>>,

--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -143,12 +143,10 @@ impl BothModeComparisonJob {
                     tracing::debug!("JS and Rust query plans match{operation_desc}! 🎉");
                 } else {
                     tracing::debug!("JS v.s. Rust query plan mismatch{operation_desc}");
-                    if let Some(formatted) = &js_plan.formatted_query_plan {
-                        tracing::debug!(
-                            "Diff of formatted plans:\n{}",
-                            render_diff(&diff::lines(formatted, &rust_plan.to_string()))
-                        );
-                    }
+                    tracing::debug!(
+                        "Diff of formatted plans:\n{}",
+                        diff_plan(&js_plan, &rust_plan)
+                    );
                     tracing::trace!("JS query plan Debug: {js_root_node:#?}");
                     tracing::trace!("Rust query plan Debug: {rust_root_node:#?}");
                 }


### PR DESCRIPTION
This specifically compares JS' `QueryPlanResult` and Rust's `QueryPlan` structs, i.e. the ones we use to semantic diff when looking for mismatches. The rendered diff uses `diff::lines` under the hood. 