### PR TITLE
fix(federation): prevent reuse_fragments() from introducing new variable references

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -4044,8 +4044,6 @@ impl Field {
 }
 
 impl FieldSelection {
-    /// # Errors
-    /// Returns an error if the selection contains a named fragment spread.
     fn collect_variables<'selection>(
         &'selection self,
         variables: &mut HashSet<&'selection Name>,
@@ -4066,8 +4064,6 @@ impl InlineFragment {
 }
 
 impl InlineFragmentSelection {
-    /// # Errors
-    /// Returns an error if the selection contains a named fragment spread.
     fn collect_variables<'selection>(
         &'selection self,
         variables: &mut HashSet<&'selection Name>,
@@ -4120,8 +4116,6 @@ impl SelectionSet {
         variables
     }
 
-    /// # Errors
-    /// Returns an error if the selection set contains a named fragment spread.
     fn collect_variables<'selection>(
         &'selection self,
         variables: &mut HashSet<&'selection Name>,

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -4044,10 +4044,7 @@ impl Field {
 }
 
 impl FieldSelection {
-    fn collect_variables<'selection>(
-        &'selection self,
-        variables: &mut HashSet<&'selection Name>,
-    ) {
+    fn collect_variables<'selection>(&'selection self, variables: &mut HashSet<&'selection Name>) {
         self.field.collect_variables(variables);
         if let Some(set) = &self.selection_set {
             set.collect_variables(variables);
@@ -4064,10 +4061,7 @@ impl InlineFragment {
 }
 
 impl InlineFragmentSelection {
-    fn collect_variables<'selection>(
-        &'selection self,
-        variables: &mut HashSet<&'selection Name>,
-    ) {
+    fn collect_variables<'selection>(&'selection self, variables: &mut HashSet<&'selection Name>) {
         self.inline_fragment.collect_variables(variables);
         self.selection_set.collect_variables(variables);
     }
@@ -4085,20 +4079,14 @@ impl FragmentSpread {
 }
 
 impl FragmentSpreadSelection {
-    fn collect_variables<'selection>(
-        &'selection self,
-        variables: &mut HashSet<&'selection Name>,
-    ) {
+    fn collect_variables<'selection>(&'selection self, variables: &mut HashSet<&'selection Name>) {
         self.spread.collect_variables(variables);
         self.selection_set.collect_variables(variables);
     }
 }
 
 impl Selection {
-    fn collect_variables<'selection>(
-        &'selection self,
-        variables: &mut HashSet<&'selection Name>,
-    ) {
+    fn collect_variables<'selection>(&'selection self, variables: &mut HashSet<&'selection Name>) {
         match self {
             Selection::Field(field) => field.collect_variables(variables),
             Selection::InlineFragment(frag) => frag.collect_variables(variables),
@@ -4116,10 +4104,7 @@ impl SelectionSet {
         variables
     }
 
-    fn collect_variables<'selection>(
-        &'selection self,
-        variables: &mut HashSet<&'selection Name>,
-    ) {
+    fn collect_variables<'selection>(&'selection self, variables: &mut HashSet<&'selection Name>) {
         for selection in self.selections.values() {
             selection.collect_variables(variables);
         }

--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -918,10 +918,11 @@ impl SelectionSet {
             // over fragment reuse, and so we do not want to invest a lot of time into improving
             // fragment reuse. We do the simple, less-than-ideal thing.
             if let Some(variable_definitions) = &context.operation_variables {
-                let fragment_variables = candidate.selection_set.used_variables()?;
-                if let Some(missing) = fragment_variables
+                let fragment_variables = candidate.selection_set.used_variables();
+                if fragment_variables
                     .difference(variable_definitions)
                     .next()
+                    .is_some()
                 {
                     continue;
                 }
@@ -1511,7 +1512,7 @@ impl Operation {
 
         // Optimize the operation's selection set by re-using existing fragments.
         let before_optimization = self.selection_set.clone();
-        self.selection_set.reuse_fragments(&ReuseContext::for_operation(&self.named_fragments, &self.variables))?;
+        self.selection_set.reuse_fragments(&ReuseContext::for_operation(fragments, &self.variables))?;
         if before_optimization == self.selection_set {
             return Ok(());
         }

--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -779,7 +779,8 @@ enum SelectionSetOrFragment {
 }
 
 impl SelectionSet {
-    /// Reduce the list of applicable fragments by eliminating ones that are subsumed by another.
+    /// Reduce the list of applicable fragments by eliminating fragments that directly include
+    /// another fragment.
     //
     // We have found the list of fragments that applies to some subset of sub-selection. In
     // general, we want to now produce the selection set with spread for those fragments plus
@@ -1405,10 +1406,10 @@ impl SelectionSet {
         }
 
         if self.contains_fragment_spread() {
-            return Err(FederationError::internal("optimize() must only be used on selection sets that do not contain named fragment spreads"));
+            return Err(FederationError::internal("reuse_fragments() must only be used on selection sets that do not contain named fragment spreads"));
         }
 
-        // Calling optimize() will not match a fragment that would have expanded at
+        // Calling reuse_fragments() will not match a fragment that would have expanded at
         // top-level. That is, say we have the selection set `{ x y }` for a top-level `Query`, and
         // we have a fragment
         // ```
@@ -1417,12 +1418,12 @@ impl SelectionSet {
         //   y
         // }
         // ```
-        // then calling `self.optimize(fragments)` would only apply check if F apply to
+        // then calling `self.reuse_fragments(fragments)` would only apply check if F apply to
         // `x` and then `y`.
         //
         // To ensure the fragment match in this case, we "wrap" the selection into a trivial
         // fragment of the selection parent, so in the example above, we create selection `... on
-        // Query { x y}`. With that, `optimize` will correctly match on the `on Query`
+        // Query { x y }`. With that, `reuse_fragments` will correctly match on the `on Query`
         // fragment; after which we can unpack the final result.
         let wrapped = InlineFragmentSelection::from_selection_set(
             self.type_position.clone(), // parent type
@@ -1453,7 +1454,7 @@ impl SelectionSet {
 }
 
 impl Operation {
-    // PORT_NOTE: The JS version of `optimize` takes an optional `minUsagesToOptimize` argument.
+    // PORT_NOTE: The JS version of `reuse_fragments` takes an optional `minUsagesToOptimize` argument.
     //            However, it's only used in tests. So, it's removed in the Rust version.
     const DEFAULT_MIN_USAGES_TO_OPTIMIZE: u32 = 2;
 

--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -78,7 +78,7 @@ impl<'a> ReuseContext<'a> {
     // Taking two separate parameters so the caller can still mutate the operation's selection set.
     fn for_operation(
         fragments: &'a NamedFragments,
-        operation_variables: &'a Vec<Node<VariableDefinition>>,
+        operation_variables: &'a [Node<VariableDefinition>],
     ) -> Self {
         Self {
             fragments,

--- a/apollo-federation/src/operation/simplify.rs
+++ b/apollo-federation/src/operation/simplify.rs
@@ -158,12 +158,12 @@ impl InlineFragmentSelection {
         named_fragments: &NamedFragments,
         schema: &ValidFederationSchema,
     ) -> Result<Option<SelectionOrSet>, FederationError> {
-        let this_condition = self.inline_fragment.type_condition_position.clone();
+        let this_condition = self.inline_fragment.type_condition_position.as_ref();
         // This method assumes by contract that `parent_type` runtimes intersects `self.inline_fragment.parent_type_position`'s,
         // but `parent_type` runtimes may be a subset. So first check if the selection should not be discarded on that account (that
         // is, we should not keep the selection if its condition runtimes don't intersect at all with those of
         // `parent_type` as that would ultimately make an invalid selection set).
-        if let Some(ref type_condition) = this_condition {
+        if let Some(type_condition) = this_condition {
             if (self.inline_fragment.schema != *schema
                 || self.inline_fragment.parent_type_position != *parent_type)
                 && !runtime_types_intersect(type_condition, parent_type, schema)
@@ -182,7 +182,7 @@ impl InlineFragmentSelection {
             //   cannot be restricting things further (it's typically a less precise interface/union).
             let useless_fragment = match this_condition {
                 None => true,
-                Some(ref c) => self.inline_fragment.schema == *schema && c == parent_type,
+                Some(c) => self.inline_fragment.schema == *schema && c == parent_type,
             };
             if useless_fragment || parent_type.is_object_type() {
                 // Try to skip this fragment and flatten_unnecessary_fragments self.selection_set with `parent_type`,

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -1614,7 +1614,6 @@ fn used_variables() {
     let mut variables = operation
         .selection_set
         .used_variables()
-        .unwrap()
         .into_iter()
         .collect::<Vec<_>>();
     variables.sort();
@@ -1633,7 +1632,6 @@ fn used_variables() {
         .as_ref()
         .unwrap()
         .used_variables()
-        .unwrap()
         .into_iter()
         .collect::<Vec<_>>();
     variables.sort();

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2347,7 +2347,7 @@ impl FetchDependencyGraphNode {
         let subgraph_schema = query_graph.schema_by_source(&self.subgraph_name)?;
 
         let variable_usages = {
-            let set = selection.used_variables()?;
+            let set = selection.used_variables();
             let mut list = set.into_iter().cloned().collect::<Vec<_>>();
             list.sort();
             list
@@ -2541,7 +2541,7 @@ fn operation_for_entities_fetch(
     let mut variable_definitions: Vec<Node<VariableDefinition>> =
         Vec::with_capacity(all_variable_definitions.len() + 1);
     variable_definitions.push(representations_variable_definition(subgraph_schema)?);
-    let used_variables = selection_set.used_variables()?;
+    let used_variables = selection_set.used_variables();
     variable_definitions.extend(
         all_variable_definitions
             .iter()
@@ -2624,7 +2624,7 @@ fn operation_for_query_fetch(
     variable_definitions: &[Node<VariableDefinition>],
     operation_name: &Option<Name>,
 ) -> Result<Operation, FederationError> {
-    let used_variables = selection_set.used_variables()?;
+    let used_variables = selection_set.used_variables();
     let variable_definitions = variable_definitions
         .iter()
         .filter(|definition| used_variables.contains(&definition.name))


### PR DESCRIPTION
There is a special case where `reuse_fragments()` can introduce a new variable reference, that is not part of the operation definition it is called on.

If you have a fragment `B` that is used inside a different fragment `A`, where `B`'s runtime types do not intersect with the parent type where fragment `A` is used, `B` is essentially a dead branch. It will never be executed. Because most of the federation code works on expanded selection sets, the dead branch is not present at all. However, when we try to reuse fragments, the dead branch may be re-added. Fragment reuse checks also work on expanded selection sets, so it's as if the fragment `B`'s selections do not exist while we consider if fragment `A` should be used. That means fragment `A` may be used, introducing the dead branch `B`. If `B` contains a variable reference, we have just produced an invalid query. It's a bit tricky to follow in text but the test should clarify.

Ideally, we would not re-add any dead branches at all. I tried a few approaches to do that, and it is definitely possible, but I think it's more work than we should give to fragment reuse, as we hope to replace it with a better strategy anyways. This patch simply ignores any fragments that use variables that aren't declared in the operation.

To do that i have to be able to collect all used variables from a fragment, including through named fragment spreads. It turns out that we can actually do that very easily because a `FragmentSpreadSelection` records the selection set of its named fragment. `used_variables()` does not have to return an error anymore so we can simplify that a bit as well.