### PR TITLE
Remove tracing-fluent-assertions dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,7 +628,6 @@ dependencies = [
  "tower-test",
  "tracing",
  "tracing-core",
- "tracing-fluent-assertions",
  "tracing-futures",
  "tracing-opentelemetry",
  "tracing-serde",
@@ -7632,17 +7631,6 @@ checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-fluent-assertions"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12de1a8c6bcfee614305e836308b596bbac831137a04c61f7e5b0b0bf2cfeaf6"
-dependencies = [
- "tracing",
- "tracing-core",
- "tracing-subscriber",
 ]
 
 [[package]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -338,7 +338,6 @@ tower-test = "0.4.0"
 
 # See note above in this file about `^tracing` packages which also applies to
 # these dev dependencies.
-tracing-fluent-assertions = "0.3.0"
 tracing-subscriber = { version = "0.3.18", default-features = false, features = [
     "env-filter",
     "fmt",

--- a/apollo-router/src/plugins/connectors/snapshots/apollo_router__plugins__connectors__tests__tracing_connect_span.snap
+++ b/apollo-router/src/plugins/connectors/snapshots/apollo_router__plugins__connectors__tests__tracing_connect_span.snap
@@ -1,0 +1,79 @@
+---
+source: apollo-router/src/plugins/connectors/tests.rs
+expression: span
+---
+{
+  "name": "apollo_router::plugins::connectors::tests::root",
+  "record": {
+    "entries": [],
+    "metadata": {
+      "name": "root",
+      "target": "apollo_router::plugins::connectors::tests",
+      "level": "ERROR",
+      "module_path": "apollo_router::plugins::connectors::tests",
+      "fields": {
+        "names": []
+      }
+    }
+  },
+  "children": {
+    "apollo_router::services::connector_service::connect": {
+      "name": "apollo_router::services::connector_service::connect",
+      "record": {
+        "entries": [
+          [
+            "otel.kind",
+            "INTERNAL"
+          ],
+          [
+            "apollo.connector.type",
+            "http"
+          ],
+          [
+            "apollo.connector.field.name",
+            "users"
+          ],
+          [
+            "apollo.connector.selection",
+            "{\n  id\n  name\n}"
+          ],
+          [
+            "apollo_private.sent_time_offset",
+            "[sent_time_offset_redacted]"
+          ],
+          [
+            "apollo.connector.detail",
+            "{\"GET\":\"/users\"}"
+          ],
+          [
+            "apollo.connector.source.name",
+            "json"
+          ],
+          [
+            "apollo.connector.source.detail",
+            "[source_detail_redacted]"
+          ]
+        ],
+        "metadata": {
+          "name": "connect",
+          "target": "apollo_router::services::connector_service",
+          "level": "INFO",
+          "module_path": "apollo_router::services::connector_service",
+          "fields": {
+            "names": [
+              "otel.kind",
+              "apollo.connector.type",
+              "apollo.connector.detail",
+              "apollo.connector.field.name",
+              "apollo.connector.selection",
+              "apollo.connector.source.name",
+              "apollo.connector.source.detail",
+              "apollo_private.sent_time_offset"
+            ]
+          }
+        }
+      },
+      "children": {}
+    }
+  }
+}


### PR DESCRIPTION
There was feedback in #5108 about adding a dependency on [tracing-fluent-assertions](https://crates.io/crates/tracing-fluent-assertions) when there are already other dependencies in use to test tracing. Instead, use the existing `test-snap` dependency to create a snapshot of the connectors span.

<!-- [CNN-367] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-367]: https://apollographql.atlassian.net/browse/CNN-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ