### PR TITLE
deps: update apollo-compiler

### DIFF
--- a/.changesets/fix_renee_operation_variables.md
+++ b/.changesets/fix_renee_operation_variables.md
@@ -1,0 +1,11 @@
+### Fix GraphQL query directives validation bug
+
+GraphQL supports an obscure syntax, where a variable is used in a directive application on the same operation where the variable is declared.
+
+The router used to reject queries like this, but now they are accepted:
+
+```graphql
+query GetSomething($var: Int!) @someDirective(argument: $var) {
+  something
+}
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,9 +395,9 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "apollo-compiler"
-version = "1.0.0-beta.19"
+version = "1.0.0-beta.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b21b81064ebf506f5a4073f5ef7a3a9cfdba29904814fa3f42612b9055b37f2"
+checksum = "07961541ebb5c85cc02ea0f08357e31b30537674bbca818884f1fc658fa99116"
 dependencies = [
  "ahash",
  "apollo-parser",
@@ -410,16 +410,6 @@ dependencies = [
  "triomphe",
  "typed-arena",
  "uuid",
-]
-
-[[package]]
-name = "apollo-encoder"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee9f27b20841d14923dd5f0714a79f86360b23492d2f98ab5d1651471a56b7a4"
-dependencies = [
- "apollo-parser",
- "thiserror",
 ]
 
 [[package]]
@@ -464,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-parser"
-version = "0.7.7"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb7c8a9776825e5524b5ab3a7f478bf091a054180f244dff85814452cb87d90"
+checksum = "f17a43dc64e71ca7140e646b99bf86ae721ebb801d2aec44e29a654c4d035ab8"
 dependencies = [
  "memchr",
  "rowan",
@@ -647,7 +637,7 @@ version = "1.52.0"
 dependencies = [
  "apollo-parser",
  "apollo-router",
- "apollo-smith 0.5.0",
+ "apollo-smith",
  "arbitrary",
  "criterion",
  "memory-stats",
@@ -691,22 +681,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-smith"
-version = "0.5.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441a51f1055d2eebcda41b55066de925502e11c97097c6d1bab0da5bdeb5c70f"
-dependencies = [
- "apollo-encoder",
- "apollo-parser",
- "arbitrary",
- "once_cell",
- "thiserror",
-]
-
-[[package]]
-name = "apollo-smith"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae8c0ec27715028b24a0a98ac53e88ac4a980e6d519cdb37265d2f2c76c864a"
+checksum = "84ef0a8fba05f32a14d03eb3ff74f556cecca820012d5846770b839c75332b38"
 dependencies = [
  "apollo-compiler",
  "apollo-parser",
@@ -6144,7 +6121,7 @@ dependencies = [
  "apollo-compiler",
  "apollo-parser",
  "apollo-router",
- "apollo-smith 0.9.0",
+ "apollo-smith",
  "async-trait",
  "env_logger 0.10.2",
  "http 0.2.12",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,9 @@ debug = 1
 # Dependencies used in more than one place are specified here in order to keep versions in sync:
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
 [workspace.dependencies]
-apollo-compiler = "=1.0.0-beta.19"
-apollo-parser = "0.7.6"
-apollo-smith = { version = "0.5.0", features = ["parser-impl"] }
+apollo-compiler = "=1.0.0-beta.20"
+apollo-parser = "0.8.0"
+apollo-smith = "0.10.0"
 async-trait = "0.1.77"
 hex = { version = "0.4.3", features = ["serde"] }
 http = "0.2.11"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/handles_operations_with_directives.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/handles_operations_with_directives.rs
@@ -244,7 +244,7 @@ fn test_if_directives_with_arguments_applied_on_queries_are_ok() {
 }
 
 #[test]
-#[should_panic(expected = r#"unused variable: `$some_var`"#)]
+#[should_panic(expected = r#"snapshot assertion"#)]
 // TODO: investigate this failure
 fn subgraph_query_retains_the_query_variables_used_in_the_directives_applied_to_the_query() {
     let planner = planner!(

--- a/examples/supergraph-sdl/rust/Cargo.toml
+++ b/examples/supergraph-sdl/rust/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-apollo-compiler = "=1.0.0-beta.19"
+apollo-compiler = "=1.0.0-beta.20"
 apollo-router = { path = "../../../apollo-router" }
 async-trait = "0.1"
 tower = { version = "0.4", features = ["full"] }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,8 +12,8 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 apollo-compiler.workspace = true
-apollo-parser = "0.7.6"
-apollo-smith = "0.9.0"
+apollo-parser.workspace = true
+apollo-smith.workspace = true
 env_logger = "0.10.2"
 log = "0.4"
 reqwest = { workspace = true, features = ["json", "blocking"] }


### PR DESCRIPTION
`query ($var: Int) @directive(arg: $var)` is now accepted - it used to raise an unused variable error for `$var`.

I also moved some remaining apollo-rs dependency version declarations to use the `.workspace = true` syntax, to remove multiple versions of the same crate from the dependency tree.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests (federation snapshot test proves the fix)
    - [ ] Manual Tests

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
