### PR TITLE
Fix usage reporting of enum values in deferred requests

### DIFF
--- a/apollo-router/src/apollo_studio_interop/mod.rs
+++ b/apollo-router/src/apollo_studio_interop/mod.rs
@@ -285,18 +285,17 @@ pub(crate) fn extract_enums_from_response(
     operation_name: Option<&str>,
     schema: &Valid<Schema>,
     response_body: &Object,
-) -> ReferencedEnums {
-    let mut result = ReferencedEnums::new();
+    existing_refs: &mut ReferencedEnums,
+) {
     if let Some(operation) = query.operation(operation_name) {
         extract_enums_from_selection_set(
             &operation.selection_set,
             &query.fragments,
             schema,
             response_body,
-            &mut result,
+            existing_refs,
         );
     }
-    result
 }
 
 fn add_enum_value_to_map(

--- a/apollo-router/src/apollo_studio_interop/tests.rs
+++ b/apollo-router/src/apollo_studio_interop/tests.rs
@@ -130,12 +130,15 @@ fn enums_from_response(
     let query = Query::parse(query_str, operation_name, &schema, &config).unwrap();
     let response_body: Object = serde_json::from_str(response_body_str).unwrap();
 
+    let mut result = ReferencedEnums::new();
     extract_enums_from_response(
         Arc::new(query),
         operation_name,
         schema.supergraph_schema(),
         &response_body,
-    )
+        &mut result,
+    );
+    result
 }
 
 #[test(tokio::test)]

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -1526,9 +1526,10 @@ impl Telemetry {
                 // If extended references or enums from responses are populated, we want to add them to the SingleStatsReport
                 let extended_references = context
                     .extensions()
-                    .with_lock(|mut lock| lock.remove::<ExtendedReferenceStats>())
+                    .with_lock(|lock| lock.get::<ExtendedReferenceStats>().cloned())
                     .unwrap_or_default();
-                // todo test extended references as well somehow
+                // Clear the enum values from responses when we send them in a report so that we properly report enum response
+                // values for deferred responses and subscriptions.
                 let enum_response_references = context
                     .extensions()
                     .with_lock(|mut lock| lock.remove::<ReferencedEnums>())
@@ -1595,7 +1596,6 @@ impl Telemetry {
                 }
             }
         } else {
-            // todo is the issue here?
             // Usage reporting was missing, so it counts as one operation.
             SingleStatsReport {
                 licensed_operation_count_by_type: LicensedOperationCountByType {

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -1526,11 +1526,12 @@ impl Telemetry {
                 // If extended references or enums from responses are populated, we want to add them to the SingleStatsReport
                 let extended_references = context
                     .extensions()
-                    .with_lock(|lock| lock.get::<ExtendedReferenceStats>().cloned())
+                    .with_lock(|mut lock| lock.remove::<ExtendedReferenceStats>())
                     .unwrap_or_default();
+                // todo test extended references as well somehow
                 let enum_response_references = context
                     .extensions()
-                    .with_lock(|lock| lock.get::<ReferencedEnums>().cloned())
+                    .with_lock(|mut lock| lock.remove::<ReferencedEnums>())
                     .unwrap_or_default();
 
                 SingleStatsReport {
@@ -1594,6 +1595,7 @@ impl Telemetry {
                 }
             }
         } else {
+            // todo is the issue here?
             // Usage reporting was missing, so it counts as one operation.
             SingleStatsReport {
                 licensed_operation_count_by_type: LicensedOperationCountByType {

--- a/apollo-router/src/services/execution/service.rs
+++ b/apollo-router/src/services/execution/service.rs
@@ -291,6 +291,7 @@ impl ExecutionService {
             && response.data.is_none()
             && response.errors.is_empty()
         {
+            // todo: empty signature in this case?
             return response.into();
         }
 
@@ -353,16 +354,20 @@ impl ExecutionService {
 
             nullified_paths.extend(paths);
 
-            let referenced_enums = if let (ApolloMetricsReferenceMode::Extended, Some(Value::Object(response_body))) = (metrics_ref_mode, &response.data) {
+            let mut referenced_enums = context
+                .extensions()
+                .with_lock(|lock| lock.get::<ReferencedEnums>().cloned())
+                .unwrap_or_default();
+            if let (ApolloMetricsReferenceMode::Extended, Some(Value::Object(response_body))) = (metrics_ref_mode, &response.data) {
                 extract_enums_from_response(
                     query.clone(),
                     operation_name,
                     schema.api_schema(),
                     response_body,
+                    &mut referenced_enums,
                 )
-            } else {
-                ReferencedEnums::new()
             };
+
             context
                     .extensions()
                     .with_lock(|mut lock| lock.insert::<ReferencedEnums>(referenced_enums));

--- a/apollo-router/src/services/execution/service.rs
+++ b/apollo-router/src/services/execution/service.rs
@@ -291,7 +291,6 @@ impl ExecutionService {
             && response.data.is_none()
             && response.errors.is_empty()
         {
-            // todo: empty signature in this case?
             return response.into();
         }
 


### PR DESCRIPTION
Fixes reporting of the enum values from responses in extended references for deferred requests. Deferred requests include two passes through the format response function, so we need to add to an existing map of enums rather than overwriting it on each pass. We also clear the map when submitting a report so that subscription reports only include the enum values referenced in responses from the particular query in the subscription request/event.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
