### PR TITLE
add the ability for gt/lt conditions to parse the string selector to number

### DIFF
--- a/.changesets/fix_bnjjj_improve_gt_lt_conditions.md
+++ b/.changesets/fix_bnjjj_improve_gt_lt_conditions.md
@@ -1,0 +1,21 @@
+### Add the ability for `gt`/`lt` conditions to parse the string selector to number ([PR #5758](https://github.com/apollographql/router/pull/5758))
+
+This will enable the ability to have gt/lt conditions on header selectors for example, if you want to put a specific attribute on a span if the `content-length` header is greater than 100:
+
+```yaml
+telemetry:
+  instrumentation:
+    spans:
+      mode: spec_compliant
+      router:
+        attributes:
+          trace_id: true
+          payload_is_to_big: # Set this attribute to true if the value of content-length header is > than 100
+            static: true
+            condition:
+              gt:
+              - request_header: "content-length"
+              - 100
+``` 
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/5758

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -409,6 +409,18 @@ pub(crate) enum AttributeValue {
     Array(AttributeArray),
 }
 
+impl AttributeValue {
+    pub(crate) fn as_f64(&self) -> Option<f64> {
+        match self {
+            AttributeValue::Bool(_) => None,
+            AttributeValue::I64(v) => Some(*v as f64),
+            AttributeValue::F64(v) => Some(*v),
+            AttributeValue::String(v) => v.parse::<f64>().ok(),
+            AttributeValue::Array(_) => None,
+        }
+    }
+}
+
 impl From<String> for AttributeValue {
     fn from(value: String) -> Self {
         AttributeValue::String(value)

--- a/apollo-router/src/plugins/telemetry/config_new/conditions.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/conditions.rs
@@ -89,15 +89,26 @@ where
                         gt[1] = SelectorOrValue::Value(r);
                         None
                     }
-                    (Some(l), Some(r)) => {
-                        if l > r {
-                            *self = Condition::True;
-                            Some(true)
-                        } else {
-                            *self = Condition::False;
-                            Some(false)
+                    (Some(l), Some(r)) => match (l.as_f64(), r.as_f64()) {
+                        (Some(l), Some(r)) => {
+                            if l > r {
+                                *self = Condition::True;
+                                Some(true)
+                            } else {
+                                *self = Condition::False;
+                                Some(false)
+                            }
                         }
-                    }
+                        _ => {
+                            if l > r {
+                                *self = Condition::True;
+                                Some(true)
+                            } else {
+                                *self = Condition::False;
+                                Some(false)
+                            }
+                        }
+                    },
                 }
             }
             Condition::Lt(lt) => {
@@ -113,15 +124,26 @@ where
                         lt[1] = SelectorOrValue::Value(r);
                         None
                     }
-                    (Some(l), Some(r)) => {
-                        if l < r {
-                            *self = Condition::True;
-                            Some(true)
-                        } else {
-                            *self = Condition::False;
-                            Some(false)
+                    (Some(l), Some(r)) => match (l.as_f64(), r.as_f64()) {
+                        (Some(l), Some(r)) => {
+                            if l < r {
+                                *self = Condition::True;
+                                Some(true)
+                            } else {
+                                *self = Condition::False;
+                                Some(false)
+                            }
                         }
-                    }
+                        _ => {
+                            if l < r {
+                                *self = Condition::True;
+                                Some(true)
+                            } else {
+                                *self = Condition::False;
+                                Some(false)
+                            }
+                        }
+                    },
                 }
             }
             Condition::Exists(exist) => {
@@ -577,6 +599,7 @@ mod test {
 
     #[test]
     fn test_condition_gt() {
+        test_gt("2", "1", "1");
         test_gt(2, 1, 1);
         test_gt(2.0, 1.0, 1.0);
         test_gt("b", "a", "a");
@@ -604,8 +627,10 @@ mod test {
 
     #[test]
     fn test_condition_lt() {
+        test_lt("1", "2", "2");
         test_lt(1, 2, 2);
         test_lt(1.0, 2.0, 2.0);
+        test_lt("1.0", "2.0", "2.0");
         test_lt("a", "b", "b");
         assert_eq!(lt(true, false).req(None), Some(false));
         assert_eq!(lt(false, true).req(None), Some(true));
@@ -707,6 +732,8 @@ mod test {
 
         assert_eq!(gt(Req, 1).req(Some(2i64)), Some(true));
         assert_eq!(gt(Req, 1).req(None), None);
+        assert_eq!(gt("2", Req).req(Some(1i64)), Some(true));
+        assert_eq!(gt("2.1", Req).req(Some(1i64)), Some(true));
         assert_eq!(gt(2, Req).req(Some(1i64)), Some(true));
         assert_eq!(gt(2, Req).req(None), None);
         assert_eq!(gt(Req, Req).req(Some(1i64)), Some(false));
@@ -745,6 +772,7 @@ mod test {
         assert_eq!(lt(2, 1).evaluate_drop(), Some(false));
         assert_eq!(lt(Static(1), 2).evaluate_drop(), Some(true));
         assert_eq!(lt(2, Static(1)).evaluate_drop(), Some(false));
+        assert_eq!(gt("2", "1").evaluate_drop(), Some(true));
         assert_eq!(gt(2, 1).evaluate_drop(), Some(true));
         assert_eq!(gt(1, 2).evaluate_drop(), Some(false));
         assert_eq!(gt(Static(2), 1).evaluate_drop(), Some(true));


### PR DESCRIPTION
This will enable the ability to have gt/lt conditions on header selectors for example, if you want to put a specific attribute on a span if the `content-length` header is greater than 100:

```yaml
telemetry:
  instrumentation:
    spans:
      mode: spec_compliant
      router:
        attributes:
          trace_id: true
          payload_is_to_big: # Set this attribute to true if the value of content-length header is > than 100
            static: true
            condition:
              gt:
              - request_header: "content-length"
              - 100
``` 

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
