### PR TITLE
Remove changes to FetchNode::response_at_path

### DIFF
--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -371,7 +371,6 @@ impl FetchNode {
         &self,
         service: BoxService,
         subgraph_request: SubgraphRequest,
-        service_name: &str,
         current_dir: &Path,
         schema: &Schema,
         paths: Vec<Vec<Path>>,
@@ -391,13 +390,13 @@ impl FetchNode {
                     FetchError::SubrequestHttpError { .. } => *inner,
                     _ => FetchError::SubrequestHttpError {
                         status_code: None,
-                        service: service_name.to_string(),
+                        service: self.service_name.to_string(),
                         reason: inner.to_string(),
                     },
                 },
                 Err(e) => FetchError::SubrequestHttpError {
                     status_code: None,
-                    service: service_name.to_string(),
+                    service: self.service_name.to_string(),
                     reason: e.to_string(),
                 },
             }) {
@@ -410,13 +409,13 @@ impl FetchNode {
             Ok(res) => res.response.into_parts(),
         };
 
-        super::log::trace_subfetch(service_name, operation_str, &variables, &response);
+        super::log::trace_subfetch(&self.service_name, operation_str, &variables, &response);
 
         if !response.is_primary() {
             return (
                 Value::default(),
                 vec![FetchError::SubrequestUnexpectedPatchResponse {
-                    service: service_name.to_string(),
+                    service: self.service_name.to_string(),
                 }
                 .to_graphql_error(Some(current_dir.to_owned()))],
             );

--- a/apollo-router/src/query_planner/fetch.rs
+++ b/apollo-router/src/query_planner/fetch.rs
@@ -16,7 +16,6 @@ use tracing::instrument;
 use tracing::Instrument;
 
 use super::rewrites;
-use super::rewrites::DataRewrite;
 use super::selection::execute_selection_set;
 use super::selection::Selection;
 use super::subgraph_context::ContextualArguments;
@@ -369,12 +368,11 @@ impl Variables {
 impl FetchNode {
     #[allow(clippy::too_many_arguments)]
     pub(crate) async fn subgraph_fetch(
+        &self,
         service: BoxService,
         subgraph_request: SubgraphRequest,
         service_name: &str,
         current_dir: &Path,
-        requires: &[Selection],
-        output_rewrites: &Option<Vec<DataRewrite>>,
         schema: &Schema,
         paths: Vec<Vec<Path>>,
         operation_str: &str,
@@ -424,15 +422,7 @@ impl FetchNode {
             );
         }
 
-        let (value, errors) = Self::response_at_path(
-            schema,
-            current_dir,
-            paths,
-            response,
-            requires,
-            output_rewrites,
-            service_name,
-        );
+        let (value, errors) = self.response_at_path(schema, current_dir, paths, response);
         (value, errors)
     }
 
@@ -455,15 +445,13 @@ impl FetchNode {
 
     #[instrument(skip_all, level = "debug", name = "response_insert")]
     pub(crate) fn response_at_path<'a>(
+        &'a self,
         schema: &Schema,
         current_dir: &'a Path,
         inverted_paths: Vec<Vec<Path>>,
         response: graphql::Response,
-        requires: &[Selection],
-        output_rewrites: &Option<Vec<DataRewrite>>,
-        service_name: &str,
     ) -> (Value, Vec<Error>) {
-        if !requires.is_empty() {
+        if !self.requires.is_empty() {
             let entities_path = Path(vec![json_ext::PathElement::Key(
                 "_entities".to_string(),
                 None,
@@ -521,7 +509,7 @@ impl FetchNode {
                         let mut value = Value::default();
 
                         for (index, mut entity) in array.into_iter().enumerate() {
-                            rewrites::apply_rewrites(schema, &mut entity, output_rewrites);
+                            rewrites::apply_rewrites(schema, &mut entity, &self.output_rewrites);
 
                             if let Some(paths) = inverted_paths.get(index) {
                                 if paths.len() > 1 {
@@ -547,7 +535,7 @@ impl FetchNode {
             if errors.is_empty() {
                 tracing::warn!(
                     "Subgraph response from '{}' was missing key `_entities` and had no errors. This is likely a bug in the subgraph.",
-                    service_name
+                    self.service_name
                 );
             }
 
@@ -577,7 +565,7 @@ impl FetchNode {
                 })
                 .collect();
             let mut data = response.data.unwrap_or_default();
-            rewrites::apply_rewrites(schema, &mut data, output_rewrites);
+            rewrites::apply_rewrites(schema, &mut data, &self.output_rewrites);
             (Value::from_path(current_dir, data), errors)
         }
     }

--- a/apollo-router/src/services/fetch_service.rs
+++ b/apollo-router/src/services/fetch_service.rs
@@ -186,10 +186,9 @@ impl FetchService {
         };
 
         let aqs = aliased_operation.to_string(); // TODO
-        let sns = service_name.clone();
         let current_dir = current_dir.clone();
         let service = subgraph_service_factory
-            .create(&sns)
+            .create(&service_name.clone())
             .expect("we already checked that the service exists during planning; qed");
 
         let mut subgraph_request = SubgraphRequest::builder()
@@ -219,7 +218,6 @@ impl FetchService {
                 .subgraph_fetch(
                     service,
                     subgraph_request,
-                    &sns,
                     &current_dir,
                     &schema,
                     variables.inverted_paths,


### PR DESCRIPTION
Reverts changes to the `FetchNode::response_at_path` function that were made for Connectors. The function is now identical to what it was before - only the visibility has changed so it can be called from `FetchService`. Most notably, this adds back the `&self` parameter. This simplifies the calling code, which already had access to the `FetchNode` and can just pass a reference to it in directly, rather than destructuring out fields to be passed to the function.

This is a minor code refactor - no functional changes were made.

<!-- [CNN-371] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-371]: https://apollographql.atlassian.net/browse/CNN-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ