### PR TITLE
fix(federation): fixed a mismatch after merging PR #5743

### DIFF
--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2362,6 +2362,14 @@ impl FetchDependencyGraphNode {
                 .cloned()
                 .collect::<Vec<_>>()
         };
+        let variable_usages = {
+            let mut list = variable_definitions
+                .iter()
+                .map(|var_def| var_def.name.clone())
+                .collect::<Vec<_>>();
+            list.sort();
+            list
+        };
 
         let mut operation = if self.is_entity_fetch {
             operation_for_entities_fetch(
@@ -2386,16 +2394,6 @@ impl FetchDependencyGraphNode {
         {
             operation.reuse_fragments(fragments)?;
         }
-
-        let variable_usages = {
-            let mut list = operation
-                .variables
-                .iter()
-                .map(|variable| variable.name.clone())
-                .collect::<Vec<_>>();
-            list.sort();
-            list
-        };
 
         let operation_document = operation.try_into()?;
 

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/handles_operations_with_directives.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/handles_operations_with_directives.rs
@@ -148,6 +148,9 @@ fn test_if_directives_at_the_operation_level_are_passed_down_to_subgraph_queries
         }
       }
     "#);
+    // This checks a regression where the `variable_usages` included the `representations` variable.
+    assert_eq!(b_fetch_nodes[0].variable_usages.len(), 0);
+    assert_eq!(b_fetch_nodes[1].variable_usages.len(), 0);
 }
 
 #[test]


### PR DESCRIPTION
Problem: FetchNode's `variable_usages` field incorrectly included the "representations" variable.

Fix: Restored `variable_usages` to be computed without using the operation's `variables` field.

<!-- [ROUTER-558] -->
<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests
