### PR TITLE
execute supergraph query selector also on events

### DIFF
--- a/.changesets/fix_bnjjj_fix_supergraph_query_selector.md
+++ b/.changesets/fix_bnjjj_fix_supergraph_query_selector.md
@@ -1,0 +1,20 @@
+### Execute supergraph query selector also on events ([PR #5764](https://github.com/apollographql/router/pull/5764))
+
+The `query: root_fields` selector works on `response` stage for events right now but it should also work on `event_response`. This configuration is now working:
+
+```yaml
+telemetry:
+  instrumentation:
+    events:
+      supergraph:
+        OPERATION_LIMIT_INFO:
+          message: operation limit info
+          on: event_response
+          level: info
+          attributes:
+            graphql.operation.name: true
+            query.root_fields:
+              query: root_fields
+``` 
+
+By [@bnjjj](https://github.com/bnjjj) in https://github.com/apollographql/router/pull/5764


### PR DESCRIPTION
The `query: root_fields` selector works on `response` stage for events right now but it should also work on `event_response`. This configuration is now working:

```yaml
telemetry:
  instrumentation:
    events:
      supergraph:
        OPERATION_LIMIT_INFO:
          message: operation limit info
          on: event_response
          level: info
          attributes:
            graphql.operation.name: true
            query.root_fields:
              query: root_fields
``` 

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
