### PR TITLE
Fix race condition when adding debug data to connector context

### DIFF
--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -12,6 +12,7 @@ use crate::plugins::connectors::plugin::ConnectorContext;
 use crate::plugins::connectors::plugin::SelectionData;
 use crate::services::connect::Response;
 use crate::services::router::body::RouterBody;
+use crate::Context;
 
 const ENTITIES: &str = "_entities";
 const TYPENAME: &str = "__typename";
@@ -35,7 +36,7 @@ pub(crate) enum HandleResponseError {
 pub(crate) async fn handle_responses(
     responses: Vec<http::Response<RouterBody>>,
     connector: &Connector,
-    debug: &mut Option<ConnectorContext>,
+    context: Context,
     _schema: &Valid<Schema>, // TODO for future apply_with_selection
 ) -> Result<Response, HandleResponseError> {
     use HandleResponseError::*;
@@ -58,9 +59,11 @@ pub(crate) async fn handle_responses(
 
         if parts.status.is_success() {
             let Ok(json_data) = serde_json::from_slice::<Value>(body) else {
-                if let Some(ref mut debug) = debug {
-                    debug.push_invalid_response(&parts, body);
-                }
+                context.extensions().with_lock(|mut lock| {
+                    if let Some(ref mut debug) = lock.get_mut::<ConnectorContext>() {
+                        debug.push_invalid_response(&parts, body);
+                    }
+                });
                 return Err(InvalidResponseBody(
                     "couldn't deserialize response body".into(),
                 ));
@@ -77,18 +80,20 @@ pub(crate) async fn handle_responses(
                     &response_key.inputs().merge(connector.config.as_ref()),
                 );
 
-                if let Some(ref mut debug) = debug {
-                    debug.push_response(
-                        &parts,
-                        &json_data,
-                        Some(SelectionData {
-                            source: connector.selection.to_string(),
-                            transformed: transformed_selection.to_string(),
-                            result: res.clone(),
-                            errors: apply_to_errors,
-                        }),
-                    );
-                }
+                context.extensions().with_lock(|mut lock| {
+                    if let Some(ref mut debug) = lock.get_mut::<ConnectorContext>() {
+                        debug.push_response(
+                            &parts,
+                            &json_data,
+                            Some(SelectionData {
+                                source: connector.selection.to_string(),
+                                transformed: transformed_selection.to_string(),
+                                result: res.clone(),
+                                errors: apply_to_errors,
+                            }),
+                        );
+                    }
+                });
                 res.unwrap_or_else(|| Value::Null)
             };
 
@@ -169,16 +174,18 @@ pub(crate) async fn handle_responses(
                 _ => {}
             };
 
-            if let Some(ref mut debug) = debug {
-                match serde_json::from_slice(body) {
-                    Ok(json_data) => {
-                        debug.push_response(&parts, &json_data, None);
-                    }
-                    Err(_) => {
-                        debug.push_invalid_response(&parts, body);
+            context.extensions().with_lock(|mut lock| {
+                if let Some(ref mut debug) = lock.get_mut::<ConnectorContext>() {
+                    match serde_json::from_slice(body) {
+                        Ok(json_data) => {
+                            debug.push_response(&parts, &json_data, None);
+                        }
+                        Err(_) => {
+                            debug.push_invalid_response(&parts, body);
+                        }
                     }
                 }
-            }
+            });
 
             errors.push(
                 graphql::Error::builder()
@@ -248,6 +255,7 @@ mod tests {
 
     use crate::plugins::connectors::make_requests::ResponseKey;
     use crate::plugins::connectors::make_requests::ResponseTypeName;
+    use crate::Context;
 
     #[tokio::test]
     async fn test_handle_responses_root_fields() {
@@ -300,10 +308,14 @@ mod tests {
 
         let schema = Schema::parse_and_validate("type Query { hello: String }", "./").unwrap();
 
-        let res =
-            super::handle_responses(vec![response1, response2], &connector, &mut None, &schema)
-                .await
-                .unwrap();
+        let res = super::handle_responses(
+            vec![response1, response2],
+            &connector,
+            Context::default(),
+            &schema,
+        )
+        .await
+        .unwrap();
 
         assert_debug_snapshot!(res, @r###"
         Response {
@@ -400,10 +412,14 @@ mod tests {
         )
         .unwrap();
 
-        let res =
-            super::handle_responses(vec![response1, response2], &connector, &mut None, &schema)
-                .await
-                .unwrap();
+        let res = super::handle_responses(
+            vec![response1, response2],
+            &connector,
+            Context::default(),
+            &schema,
+        )
+        .await
+        .unwrap();
 
         assert_debug_snapshot!(res, @r###"
         Response {
@@ -506,10 +522,14 @@ mod tests {
         )
         .unwrap();
 
-        let res =
-            super::handle_responses(vec![response1, response2], &connector, &mut None, &schema)
-                .await
-                .unwrap();
+        let res = super::handle_responses(
+            vec![response1, response2],
+            &connector,
+            Context::default(),
+            &schema,
+        )
+        .await
+        .unwrap();
 
         assert_debug_snapshot!(res, @r###"
         Response {
@@ -628,7 +648,7 @@ mod tests {
         let res = super::handle_responses(
             vec![response1, response2, response3],
             &connector,
-            &mut None,
+            Context::default(),
             &schema,
         )
         .await

--- a/apollo-router/src/plugins/connectors/plugin.rs
+++ b/apollo-router/src/plugins/connectors/plugin.rs
@@ -74,19 +74,21 @@ impl Plugin for Connectors {
                     res = match res {
                         Ok(mut res) => {
                             if is_enabled {
-                                if let Some(debug) = res
-                                    .context
-                                    .extensions()
-                                    .with_lock(|mut lock| lock.remove::<Arc<Mutex<ConnectorContext>>>())
+                                if let Some(debug) =
+                                    res.context.extensions().with_lock(|mut lock| {
+                                        lock.remove::<Arc<Mutex<ConnectorContext>>>()
+                                    })
                                 {
                                     let (parts, stream) = res.response.into_parts();
                                     let (mut first, rest) = stream.into_future().await;
 
                                     if let Some(first) = &mut first {
-                                        first.extensions.insert(
-                                            "apolloConnectorsDebugging",
-                                            json!({"version": "1", "data": debug.lock().clone().serialize() }),
-                                        );
+                                        if let Some(inner) = Arc::into_inner(debug) {
+                                            first.extensions.insert(
+                                                "apolloConnectorsDebugging",
+                                                json!({"version": "1", "data": inner.into_inner().serialize() }),
+                                            );
+                                        }
                                     }
                                     res.response = http::Response::from_parts(
                                         parts,


### PR DESCRIPTION
There was a race condition due to the way debug data was being added to the `ConnectorsContext`. The connectors context was removed from the request context extensions for each query, updated, then put back. If the query planner executed multiple queries in parallel, they would all try to do this at once. Once one of them successfully removed the connectors context, any others running concurrently would get back `None`.

The connectors context is now left in place rather than removed, and is accessed through `Option<Arc<Mutex<ConnectorsContext>>>`. This preserves a single lookup in the `Extensions` for each fetch. If the debug feature is not enabled, the option will be `None`. If it is enabled, the mutex is locked and the context is updated with the debug information.

<!-- [CNN-388] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-388]: https://apollographql.atlassian.net/browse/CNN-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ