### PR TITLE
Entity cache: return cached entities with errors

### DIFF
--- a/.changesets/feat_geal_return_response_with_errors.md
+++ b/.changesets/feat_geal_return_response_with_errors.md
@@ -1,0 +1,5 @@
+### Entity cache: return cached entities with errors ([PR #5776](https://github.com/apollographql/router/pull/5776))
+
+If we are requesting entities from a subgraph, where some of them are present in cache, and the subgraph is unavailable (ex: network issue), we want to return a response with the entities we got from the cache, other entities nullified, and an error pointing at the paths of unavailable entities.
+
+By [@Geal](https://github.com/Geal) in https://github.com/apollographql/router/pull/5776

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__missing_entities-2.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__missing_entities-2.snap
@@ -23,7 +23,12 @@ expression: response
   },
   "errors": [
     {
-      "message": "Organization not found"
+      "message": "Organization not found",
+      "path": [
+        "currentUser",
+        "allOrganizations",
+        2
+      ]
     }
   ]
 }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__missing_entities-2.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__missing_entities-2.snap
@@ -1,0 +1,29 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: response
+---
+{
+  "data": {
+    "currentUser": {
+      "allOrganizations": [
+        {
+          "id": "1",
+          "name": "Organization 1"
+        },
+        {
+          "id": "2",
+          "name": "Organization 2"
+        },
+        {
+          "id": "3",
+          "name": null
+        }
+      ]
+    }
+  },
+  "errors": [
+    {
+      "message": "Organization not found"
+    }
+  ]
+}

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__missing_entities.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__missing_entities.snap
@@ -1,0 +1,20 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: response
+---
+{
+  "data": {
+    "currentUser": {
+      "allOrganizations": [
+        {
+          "id": "1",
+          "name": "Organization 1"
+        },
+        {
+          "id": "2",
+          "name": "Organization 2"
+        }
+      ]
+    }
+  }
+}

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data-2.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data-2.snap
@@ -1,0 +1,30 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: response
+---
+{
+  "data": {
+    "currentUser": {
+      "allOrganizations": [
+        {
+          "id": "1",
+          "name": "Organization 1"
+        },,
+        {
+          "id": "2",
+          "name": null
+        },
+        {
+          "id": "3",
+          "name": "Organization 3"
+        }
+      ]
+    }
+  },
+  "errors": [
+    {
+      "message": "Organization not found",
+      "path": ["currentUser", "allOrganizations", 1]
+    }
+  ]
+}

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data-2.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data-2.snap
@@ -9,7 +9,7 @@ expression: response
         {
           "id": "1",
           "name": "Organization 1"
-        },,
+        },
         {
           "id": "2",
           "name": null
@@ -23,8 +23,17 @@ expression: response
   },
   "errors": [
     {
-      "message": "Organization not found",
-      "path": ["currentUser", "allOrganizations", 1]
+      "message": "HTTP fetch failed from 'orga': orga not found",
+      "path": [
+        "currentUser",
+        "allOrganizations",
+        1
+      ],
+      "extensions": {
+        "code": "SUBREQUEST_HTTP_ERROR",
+        "service": "orga",
+        "reason": "orga not found"
+      }
     }
   ]
 }

--- a/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data.snap
+++ b/apollo-router/src/plugins/cache/snapshots/apollo_router__plugins__cache__tests__no_data.snap
@@ -1,0 +1,20 @@
+---
+source: apollo-router/src/plugins/cache/tests.rs
+expression: response
+---
+{
+  "data": {
+    "currentUser": {
+      "allOrganizations": [
+        {
+          "id": "1",
+          "name": "Organization 1"
+        },
+        {
+          "id": "3",
+          "name": "Organization 3"
+        }
+      ]
+    }
+  }
+}

--- a/apollo-router/src/plugins/cache/tests.rs
+++ b/apollo-router/src/plugins/cache/tests.rs
@@ -9,7 +9,6 @@ use fred::prelude::RedisError;
 use fred::prelude::RedisValue;
 use http::header::CACHE_CONTROL;
 use http::HeaderValue;
-use http::StatusCode;
 use parking_lot::Mutex;
 use tower::ServiceExt;
 
@@ -639,7 +638,169 @@ async fn no_data() {
     let response = response.next_response().await.unwrap();
     insta::assert_json_snapshot!(response);
 
-    // Now testing without any mock subgraphs, all the data should come from the cache
+    let entity_cache = EntityCache::with_mocks(redis_cache.clone(), HashMap::new())
+        .await
+        .unwrap();
+
+    let subgraphs = MockedSubgraphs(
+        [(
+            "user",
+            MockSubgraph::builder()
+                .with_json(
+                    serde_json::json! {{"query":"{currentUser{allOrganizations{__typename id}}}"}},
+                    serde_json::json! {{"data": {"currentUser": { "allOrganizations": [
+                        {
+                            "__typename": "Organization",
+                            "id": "1"
+                        },
+                        {
+                            "__typename": "Organization",
+                            "id": "2"
+                        },
+                        {
+                            "__typename": "Organization",
+                            "id": "3"
+                        }
+                    ] }}}},
+                )
+                .with_header(CACHE_CONTROL, HeaderValue::from_static("no-store"))
+                .build(),
+        )]
+        .into_iter()
+        .collect(),
+    );
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true } }))
+        .unwrap()
+        .schema(SCHEMA)
+        .extra_plugin(entity_cache)
+        .subgraph_hook(|name, service| {
+            if name == "orga" {
+                let mut subgraph = MockSubgraphService::new();
+                subgraph
+                    .expect_call()
+                    .times(1)
+                    .returning(move |_req: subgraph::Request| Err("orga not found".into()));
+                subgraph.boxed()
+            } else {
+                service
+            }
+        })
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .query(query)
+        .context(Context::new())
+        .build()
+        .unwrap();
+    let mut response = service.oneshot(request).await.unwrap();
+    let response = response.next_response().await.unwrap();
+
+    insta::assert_json_snapshot!(response);
+}
+
+#[tokio::test]
+async fn missing_entities() {
+    let query = "query { currentUser { allOrganizations { id name } } }";
+
+    let subgraphs = MockedSubgraphs([
+        ("user", MockSubgraph::builder().with_json(
+                serde_json::json!{{"query":"{currentUser{allOrganizations{__typename id}}}"}},
+                serde_json::json!{{"data": {"currentUser": { "allOrganizations": [
+                    {
+                        "__typename": "Organization",
+                        "id": "1"
+                    },
+                    {
+                        "__typename": "Organization",
+                        "id": "2"
+                    }
+                ] }}}}
+        ).with_header(CACHE_CONTROL, HeaderValue::from_static("no-store")).build()),
+        ("orga", MockSubgraph::builder().with_json(
+            serde_json::json!{{
+                "query": "query($representations:[_Any!]!){_entities(representations:$representations){...on Organization{name}}}",
+            "variables": {
+                "representations": [
+                    {
+                        "id": "1",
+                        "__typename": "Organization",
+                    },
+                    {
+                        "id": "2",
+                        "__typename": "Organization",
+                    }
+                ]
+            }}},
+            serde_json::json!{{
+                "data": {
+                    "_entities": [
+                        {
+                            "name": "Organization 1",
+                        },
+                        {
+                            "name": "Organization 2"
+                        }
+                    ]
+            }
+            }}
+        ).with_header(CACHE_CONTROL, HeaderValue::from_static("public, max-age=3600")).build())
+    ].into_iter().collect());
+
+    let redis_cache = RedisCacheStorage::from_mocks(Arc::new(MockStore::new()))
+        .await
+        .unwrap();
+    let map = [
+        (
+            "user".to_string(),
+            Subgraph {
+                redis: None,
+                private_id: Some("sub".to_string()),
+                enabled: true,
+                ttl: None,
+                ..Default::default()
+            },
+        ),
+        (
+            "orga".to_string(),
+            Subgraph {
+                redis: None,
+                private_id: Some("sub".to_string()),
+                enabled: true,
+                ttl: None,
+                ..Default::default()
+            },
+        ),
+    ]
+    .into_iter()
+    .collect();
+    let entity_cache = EntityCache::with_mocks(redis_cache.clone(), map)
+        .await
+        .unwrap();
+
+    let service = TestHarness::builder()
+        .configuration_json(serde_json::json!({"include_subgraph_errors": { "all": true } }))
+        .unwrap()
+        .schema(SCHEMA)
+        .extra_plugin(entity_cache)
+        .extra_plugin(subgraphs)
+        .build_supergraph()
+        .await
+        .unwrap();
+
+    let request = supergraph::Request::fake_builder()
+        .query(query)
+        .context(Context::new())
+        .build()
+        .unwrap();
+    let mut response = service.oneshot(request).await.unwrap();
+    let response = response.next_response().await.unwrap();
+    insta::assert_json_snapshot!(response);
+
     let entity_cache = EntityCache::with_mocks(redis_cache.clone(), HashMap::new())
         .await
         .unwrap();
@@ -668,7 +829,7 @@ async fn no_data() {
                 "variables": {
                     "representations": [
                         {
-                            "id": "2",
+                            "id": "3",
                             "__typename": "Organization",
                         }
                     ]
@@ -687,24 +848,6 @@ async fn no_data() {
         .unwrap()
         .schema(SCHEMA)
         .extra_plugin(entity_cache)
-        .subgraph_hook(|name, service| {
-            if name == "orga" {
-                let mut subgraph = MockSubgraphService::new();
-                subgraph
-                    .expect_call()
-                    .times(1)
-                    .returning(move |req: subgraph::Request| {
-                        Err("orga not found".into())
-                        /*Ok(subgraph::Response::fake_builder()
-                        .context(req.context)
-                        .status_code(StatusCode::BAD_REQUEST)
-                        .build())*/
-                    });
-                subgraph.boxed()
-            } else {
-                service
-            }
-        })
         .extra_plugin(subgraphs)
         .build_supergraph()
         .await
@@ -717,7 +860,6 @@ async fn no_data() {
         .unwrap();
     let mut response = service.oneshot(request).await.unwrap();
     let response = response.next_response().await.unwrap();
-
     insta::assert_json_snapshot!(response);
 }
 

--- a/docs/source/configuration/entity-caching.mdx
+++ b/docs/source/configuration/entity-caching.mdx
@@ -133,6 +133,10 @@ The Router currently cannot know which types or fields should be cached, so it r
 
 To prevent transient errors from affecting the cache for a long duration, subgraph responses with errors are not cached.
 
+### Cached entities with unavailable subgraph
+
+If some entities were obtained from the cache, but the subgraphs that provided them are unavailable, the router will return a response with the cached entities, and the other entities nullified, along with an error message for the nullified entities.
+
 ### Authorization and entity caching
 
 When used alongside the router's [authorization directives](./authorization), cache entries are separated by authorization context. If a query contains fields that need a specific scope, the requests providing that scope have different cache entries from those not providing the scope. This means that data requiring authorization can still be safely cached and even shared across users, without needing invalidation when a user's roles change because their requests are automatically directed to a different part of the cache.

--- a/docs/source/configuration/entity-caching.mdx
+++ b/docs/source/configuration/entity-caching.mdx
@@ -135,7 +135,7 @@ To prevent transient errors from affecting the cache for a long duration, subgra
 
 ### Cached entities with unavailable subgraph
 
-If some entities were obtained from the cache, but the subgraphs that provided them are unavailable, the router will return a response with the cached entities, and the other entities nullified, along with an error message for the nullified entities.
+If some entities were obtained from the cache, but the subgraphs that provided them are unavailable, the router will return a response with the cached entities, and the other entities nullified (schema permitting), along with an error message for the nullified entities.
 
 ### Authorization and entity caching
 


### PR DESCRIPTION
<!-- [ROUTER-434] -->
If we are requesting entities from a subgraph, where some of them are present in cache, and the subgraph is unavailable (ex: network issue), we want to return a response with the entities we got from the cache, other entities nullified, and an error pointing at the paths of unavailable entities

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-434]: https://apollographql.atlassian.net/browse/ROUTER-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ