### PR TITLE
chore(federation): remove `for_each_element`

### DIFF
--- a/apollo-federation/src/schema/field_set.rs
+++ b/apollo-federation/src/schema/field_set.rs
@@ -10,8 +10,8 @@ use crate::error::FederationError;
 use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
 use crate::operation::NamedFragments;
+use crate::operation::Selection;
 use crate::operation::SelectionSet;
-use crate::query_graph::graph_path::OpPathElement;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::FieldDefinitionPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
@@ -23,28 +23,39 @@ use crate::schema::ValidFederationSchema;
 // Federation spec does not allow the alias syntax in field set strings.
 // However, since `parse_field_set` uses the standard GraphQL parser, which allows aliases,
 // we need this secondary check to ensure that aliases are not used.
-fn check_absence_of_aliases(
-    selection_set: &SelectionSet,
-    code_str: &str,
-) -> Result<(), FederationError> {
-    let mut alias_errors = vec![];
-    selection_set.for_each_element(&mut |elem| {
-        let OpPathElement::Field(field) = elem else {
-            return Ok(());
-        };
-        let Some(alias) = &field.alias else {
-            return Ok(());
-        };
-        alias_errors.push(SingleFederationError::UnsupportedFeature {
-            // PORT_NOTE: The JS version also quotes the directive name in the error message.
-            //            For example, "aliases are not currently supported in @requires".
-            message: format!(
-                r#"Cannot use alias "{}" in "{}": aliases are not currently supported in the used directive"#,
-                alias, code_str)
-        });
+fn check_absence_of_aliases(selection_set: &SelectionSet) -> Result<(), FederationError> {
+    fn visit_selection_set(
+        errors: &mut MultipleFederationErrors,
+        selection_set: &SelectionSet,
+    ) -> Result<(), FederationError> {
+        for selection in selection_set.iter() {
+            match selection {
+                Selection::FragmentSpread(_) => {
+                    return Err(FederationError::internal(
+                        "check_absence_of_aliases(): unexpected fragment spread",
+                    ))
+                }
+                Selection::InlineFragment(frag) => check_absence_of_aliases(&frag.selection_set)?,
+                Selection::Field(field) => {
+                    if let Some(alias) = &field.field.alias {
+                        errors.push(SingleFederationError::UnsupportedFeature {
+                            // PORT_NOTE: The JS version also quotes the directive name in the error message.
+                            //            For example, "aliases are not currently supported in @requires".
+                            message: format!(r#"Cannot use alias "{alias}" in "{}": aliases are not currently supported in the used directive"#, field.field)
+                        }.into());
+                    }
+                    if let Some(selection_set) = &field.selection_set {
+                        visit_selection_set(errors, selection_set)?;
+                    }
+                }
+            }
+        }
         Ok(())
-    })?;
-    MultipleFederationErrors::from_iter(alias_errors).into_result()
+    }
+
+    let mut errors = MultipleFederationErrors { errors: vec![] };
+    visit_selection_set(&mut errors, selection_set)?;
+    errors.into_result()
 }
 
 // TODO: In the JS codebase, this has some error-rewriting to help give the user better hints around
@@ -69,7 +80,7 @@ pub(crate) fn parse_field_set(
         SelectionSet::from_selection_set(&field_set.selection_set, &named_fragments, schema)?;
 
     // Validate the field set has no aliases.
-    check_absence_of_aliases(&selection_set, value)?;
+    check_absence_of_aliases(&selection_set)?;
 
     Ok(selection_set)
 }
@@ -238,8 +249,8 @@ mod tests {
         assert_eq!(
             err.to_string(),
             r#"The following errors occurred:
-  - Cannot use alias "r1" in "r1: r s q1: q": aliases are not currently supported in the used directive
-  - Cannot use alias "q1" in "r1: r s q1: q": aliases are not currently supported in the used directive"#
+  - Cannot use alias "r1" in "r1: r": aliases are not currently supported in the used directive
+  - Cannot use alias "q1" in "q1: q": aliases are not currently supported in the used directive"#
         );
         Ok(())
     }


### PR DESCRIPTION
Today's 15-minute cleanup :)

This set of functions is used in one place, and it has some odd behaviours. In JS, an "element" is free, because its data structures are built on element/selection set pairings. But we don't have the "element" type exactly in our data structures, our closest equivalent is the `Selection` type. Therefore the `for_each_element` function had to convert types including some inexpensive, but non-zero clones.

`for_each_element` also translates named fragment spreads to inline fragments. AFAICT, this is a historical artifact ported from JS, as the only place where `for_each_element` was used does not support named fragment spreads to begin with.

I replaced it, for now, with a manual visitor. I think it might make sense to have something like a `for_each_selection` API but it's honestly not that much harder to do it manually...
