### PR TITLE
Ignore non-apollo directives when extracting demand control directives to subgraphs

### DIFF
--- a/apollo-federation/src/link/cost_spec_definition.rs
+++ b/apollo-federation/src/link/cost_spec_definition.rs
@@ -91,11 +91,9 @@ macro_rules! propagate_demand_control_directives_to_position {
 
             let list_size_directive_name =
                 original_directive_names.get(&LIST_SIZE_DIRECTIVE_NAME_IN_SPEC);
-            if let Some(list_size_directive) = source.directives.get(
-                list_size_directive_name
-                    .unwrap_or(&LIST_SIZE_DIRECTIVE_NAME_IN_SPEC)
-                    .as_str(),
-            ) {
+            let list_size_directive =
+                list_size_directive_name.and_then(|name| source.directives.get(name.as_str()));
+            if let Some(list_size_directive) = list_size_directive {
                 dest.insert_directive(
                     subgraph_schema,
                     Component::from(self.list_size_directive(

--- a/apollo-federation/src/link/cost_spec_definition.rs
+++ b/apollo-federation/src/link/cost_spec_definition.rs
@@ -44,11 +44,8 @@ macro_rules! propagate_demand_control_directives {
             original_directive_names: &HashMap<Name, Name>,
         ) -> Result<(), FederationError> {
             let cost_directive_name = original_directive_names.get(&COST_DIRECTIVE_NAME_IN_SPEC);
-            if let Some(cost_directive) = source.get(
-                cost_directive_name
-                    .unwrap_or(&COST_DIRECTIVE_NAME_IN_SPEC)
-                    .as_str(),
-            ) {
+            let cost_directive = cost_directive_name.and_then(|name| source.get(name.as_str()));
+            if let Some(cost_directive) = cost_directive {
                 dest.push($wrap_ty(self.cost_directive(
                     subgraph_schema,
                     cost_directive.arguments.clone(),
@@ -57,11 +54,9 @@ macro_rules! propagate_demand_control_directives {
 
             let list_size_directive_name =
                 original_directive_names.get(&LIST_SIZE_DIRECTIVE_NAME_IN_SPEC);
-            if let Some(list_size_directive) = source.get(
-                list_size_directive_name
-                    .unwrap_or(&LIST_SIZE_DIRECTIVE_NAME_IN_SPEC)
-                    .as_str(),
-            ) {
+            let list_size_directive =
+                list_size_directive_name.and_then(|name| source.get(name.as_str()));
+            if let Some(list_size_directive) = list_size_directive {
                 dest.push($wrap_ty(self.list_size_directive(
                     subgraph_schema,
                     list_size_directive.arguments.clone(),

--- a/apollo-federation/src/link/cost_spec_definition.rs
+++ b/apollo-federation/src/link/cost_spec_definition.rs
@@ -78,11 +78,9 @@ macro_rules! propagate_demand_control_directives_to_position {
             original_directive_names: &HashMap<Name, Name>,
         ) -> Result<(), FederationError> {
             let cost_directive_name = original_directive_names.get(&COST_DIRECTIVE_NAME_IN_SPEC);
-            if let Some(cost_directive) = source.directives.get(
-                cost_directive_name
-                    .unwrap_or(&COST_DIRECTIVE_NAME_IN_SPEC)
-                    .as_str(),
-            ) {
+            let cost_directive =
+                cost_directive_name.and_then(|name| source.directives.get(name.as_str()));
+            if let Some(cost_directive) = cost_directive {
                 dest.insert_directive(
                     subgraph_schema,
                     Component::from(

--- a/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -343,7 +343,6 @@ fn get_apollo_directive_names(
             }
         }
     }
-    println!("{:?}", hm);
     Ok(hm)
 }
 

--- a/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -50,6 +50,7 @@ use crate::link::join_spec_definition::JoinSpecDefinition;
 use crate::link::join_spec_definition::TypeDirectiveArguments;
 use crate::link::spec::Identity;
 use crate::link::spec::Version;
+use crate::link::spec::APOLLO_SPEC_DOMAIN;
 use crate::link::spec_definition::SpecDefinition;
 use crate::link::Link;
 use crate::link::DEFAULT_LINK_NAME;
@@ -308,19 +309,41 @@ struct TypeInfos {
     input_object_types: Vec<TypeInfo>,
 }
 
-fn get_original_directive_names(
+/// Builds a map of original name to new name for Apollo feature directives. This is
+/// used to handle cases where a directive is renamed via an import statement. For
+/// example, importing a directive with a custom name like
+/// ```graphql
+/// @link(url: "https://specs.apollo.dev/cost/v0.1", import: [{ name: "@cost", as: "@renamedCost" }])
+/// ```
+/// results in a map entry of `cost -> renamedCost` with the `@` prefix removed.
+///
+/// If the directive is imported under its default name, that also results in an entry. So,
+/// ```graphql
+/// @link(url: "https://specs.apollo.dev/cost/v0.1", import: ["@cost"])
+/// ```
+/// results in a map entry of `cost -> cost`. This duals as a way to check if a directive
+/// is included in the supergraph schema.
+///
+/// **Important:** This map does _not_ include directives imported from identities other
+/// than `specs.apollo.dev`. This helps us avoid extracting directives to subgraphs
+/// when a custom directive's name conflicts with that of a default one.
+fn get_apollo_directive_names(
     supergraph_schema: &FederationSchema,
 ) -> Result<HashMap<Name, Name>, FederationError> {
     let mut hm: HashMap<Name, Name> = HashMap::new();
     for directive in &supergraph_schema.schema().schema_definition.directives {
         if directive.name.as_str() == "link" {
             if let Ok(link) = Link::from_directive_application(directive) {
+                if link.url.identity.domain != APOLLO_SPEC_DOMAIN {
+                    continue;
+                }
                 for import in link.imports {
                     hm.insert(import.element.clone(), import.imported_name().clone());
                 }
             }
         }
     }
+    println!("{:?}", hm);
     Ok(hm)
 }
 
@@ -332,7 +355,7 @@ fn extract_subgraphs_from_fed_2_supergraph(
     join_spec_definition: &'static JoinSpecDefinition,
     filtered_types: &Vec<TypeDefinitionPosition>,
 ) -> Result<(), FederationError> {
-    let original_directive_names = get_original_directive_names(supergraph_schema)?;
+    let original_directive_names = get_apollo_directive_names(supergraph_schema)?;
 
     let TypeInfos {
         object_types,

--- a/apollo-federation/tests/extract_subgraphs.rs
+++ b/apollo-federation/tests/extract_subgraphs.rs
@@ -524,7 +524,7 @@ fn does_not_extract_demand_control_directive_name_conflicts() {
           query: Query
         }
         
-        directive @cost(name: String!) on FIELD_DEFINITION
+        directive @cost(name: String!) on FIELD_DEFINITION | SCALAR
         
         directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
         
@@ -575,12 +575,15 @@ fn does_not_extract_demand_control_directive_name_conflicts() {
           """
           EXECUTION
         }
+
+        scalar ExpensiveInt @cost(name: "expensiveInt")
+          @join__type(graph: SUBGRAPH_A)
         
         type Query
           @join__type(graph: SUBGRAPH_A)
           @join__type(graph: SUBGRAPH_B)
         {
-          a: Int @join__field(graph: SUBGRAPH_A) @cost(name: "cost")
+          a: ExpensiveInt @join__field(graph: SUBGRAPH_A) @cost(name: "cost")
           b: [Int] @join__field(graph: SUBGRAPH_B) @listSize(name: "listSize")
         }
     "#)

--- a/apollo-federation/tests/extract_subgraphs.rs
+++ b/apollo-federation/tests/extract_subgraphs.rs
@@ -604,3 +604,96 @@ fn does_not_extract_demand_control_directive_name_conflicts() {
     }
     insta::assert_snapshot!(snapshot);
 }
+
+#[test]
+fn does_not_extract_renamed_demand_control_directive_name_conflicts() {
+    let subgraphs = Supergraph::new(r#"
+        schema
+          @link(url: "https://specs.apollo.dev/link/v1.0")
+          @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+          @link(url: "https://example.com/myCustomDirective/v1.0", import: [{name: "@cost", as: "@renamedCost"}])
+          @link(url: "https://example.com/myOtherCustomDirective/v1.0", import: [{name: "@listSize", as: "@renamedListSize"}])
+        {
+          query: Query
+        }
+        
+        directive @renamedCost(name: String!) on FIELD_DEFINITION | SCALAR
+        
+        directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+        
+        directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+        
+        directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+        
+        directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+        
+        directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+        
+        directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+        
+        directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+        
+        directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+        
+        directive @renamedListSize(name: String!) on FIELD_DEFINITION
+        
+        input join__ContextArgument {
+          name: String!
+          type: String!
+          context: String!
+          selection: join__FieldValue!
+        }
+        
+        scalar join__DirectiveArguments
+        
+        scalar join__FieldSet
+        
+        scalar join__FieldValue
+        
+        enum join__Graph {
+          SUBGRAPH_A @join__graph(name: "subgraph-a", url: "")
+          SUBGRAPH_B @join__graph(name: "subgraph-b", url: "")
+        }
+        
+        scalar link__Import
+        
+        enum link__Purpose {
+          """
+          `SECURITY` features provide metadata necessary to securely resolve fields.
+          """
+          SECURITY
+        
+          """
+          `EXECUTION` features provide metadata necessary for operation execution.
+          """
+          EXECUTION
+        }
+
+        scalar ExpensiveInt @renamedCost(name: "expensiveInt")
+          @join__type(graph: SUBGRAPH_A)
+        
+        type Query
+          @join__type(graph: SUBGRAPH_A)
+          @join__type(graph: SUBGRAPH_B)
+        {
+          a: ExpensiveInt @join__field(graph: SUBGRAPH_A) @renamedCost(name: "cost")
+          b: [Int] @join__field(graph: SUBGRAPH_B) @renamedListSize(name: "listSize")
+        }
+    "#)
+    .expect("parses")
+    .extract_subgraphs()
+    .expect("extracts");
+
+    let mut snapshot = String::new();
+    for (_name, subgraph) in subgraphs {
+        use std::fmt::Write;
+
+        _ = writeln!(
+            &mut snapshot,
+            "{}\n---\n{}",
+            subgraph.name,
+            subgraph.schema.schema()
+        );
+    }
+    insta::assert_snapshot!(snapshot);
+}

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__does_not_extract_demand_control_directive_name_conflicts.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__does_not_extract_demand_control_directive_name_conflicts.snap
@@ -1,0 +1,139 @@
+---
+source: apollo-federation/tests/extract_subgraphs.rs
+expression: snapshot
+---
+subgraph-a
+---
+schema {
+  query: Query
+}
+
+extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.9")
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @federation__key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @federation__shareable on OBJECT | FIELD_DEFINITION
+
+directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @federation__override(from: String!, label: String) on FIELD_DEFINITION
+
+directive @federation__composeDirective(name: String) repeatable on SCHEMA
+
+directive @federation__interfaceObject on OBJECT
+
+directive @federation__authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+
+directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  \`SECURITY\` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  \`EXECUTION\` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar federation__FieldSet
+
+scalar federation__Scope
+
+type Query {
+  a: Int
+  _service: _Service!
+}
+
+scalar _Any
+
+type _Service {
+  sdl: String
+}
+
+subgraph-b
+---
+schema {
+  query: Query
+}
+
+extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.9")
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @federation__key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @federation__shareable on OBJECT | FIELD_DEFINITION
+
+directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @federation__override(from: String!, label: String) on FIELD_DEFINITION
+
+directive @federation__composeDirective(name: String) repeatable on SCHEMA
+
+directive @federation__interfaceObject on OBJECT
+
+directive @federation__authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+
+directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  \`SECURITY\` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  \`EXECUTION\` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar federation__FieldSet
+
+scalar federation__Scope
+
+type Query {
+  b: [Int]
+  _service: _Service!
+}
+
+scalar _Any
+
+type _Service {
+  sdl: String
+}

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__does_not_extract_demand_control_directive_name_conflicts.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__does_not_extract_demand_control_directive_name_conflicts.snap
@@ -59,8 +59,10 @@ scalar federation__FieldSet
 
 scalar federation__Scope
 
+scalar ExpensiveInt
+
 type Query {
-  a: Int
+  a: ExpensiveInt
   _service: _Service!
 }
 

--- a/apollo-federation/tests/snapshots/main__extract_subgraphs__does_not_extract_renamed_demand_control_directive_name_conflicts.snap
+++ b/apollo-federation/tests/snapshots/main__extract_subgraphs__does_not_extract_renamed_demand_control_directive_name_conflicts.snap
@@ -1,0 +1,141 @@
+---
+source: apollo-federation/tests/extract_subgraphs.rs
+expression: snapshot
+---
+subgraph-a
+---
+schema {
+  query: Query
+}
+
+extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.9")
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @federation__key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @federation__shareable on OBJECT | FIELD_DEFINITION
+
+directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @federation__override(from: String!, label: String) on FIELD_DEFINITION
+
+directive @federation__composeDirective(name: String) repeatable on SCHEMA
+
+directive @federation__interfaceObject on OBJECT
+
+directive @federation__authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+
+directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  \`SECURITY\` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  \`EXECUTION\` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar federation__FieldSet
+
+scalar federation__Scope
+
+scalar ExpensiveInt
+
+type Query {
+  a: ExpensiveInt
+  _service: _Service!
+}
+
+scalar _Any
+
+type _Service {
+  sdl: String
+}
+
+subgraph-b
+---
+schema {
+  query: Query
+}
+
+extend schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/federation/v2.9")
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @federation__key(fields: federation__FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+
+directive @federation__requires(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__provides(fields: federation__FieldSet!) on FIELD_DEFINITION
+
+directive @federation__external(reason: String) on OBJECT | FIELD_DEFINITION
+
+directive @federation__tag(name: String!) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+directive @federation__extends on OBJECT | INTERFACE
+
+directive @federation__shareable on OBJECT | FIELD_DEFINITION
+
+directive @federation__inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @federation__override(from: String!, label: String) on FIELD_DEFINITION
+
+directive @federation__composeDirective(name: String) repeatable on SCHEMA
+
+directive @federation__interfaceObject on OBJECT
+
+directive @federation__authenticated on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__requiresScopes(scopes: [[federation__Scope!]!]!) on FIELD_DEFINITION | OBJECT | INTERFACE | SCALAR | ENUM
+
+directive @federation__cost(weight: Int!) on ARGUMENT_DEFINITION | ENUM | FIELD_DEFINITION | INPUT_FIELD_DEFINITION | OBJECT | SCALAR
+
+directive @federation__listSize(assumedSize: Int, slicingArguments: [String!], sizedFields: [String!], requireOneSlicingArgument: Boolean = true) on FIELD_DEFINITION
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  \`SECURITY\` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """
+  \`EXECUTION\` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+scalar federation__FieldSet
+
+scalar federation__Scope
+
+type Query {
+  b: [Int]
+  _service: _Service!
+}
+
+scalar _Any
+
+type _Service {
+  sdl: String
+}


### PR DESCRIPTION
When users set up a custom directive which conflicts with demand control directive names, we would incorrectly try to extract that to subgraphs as the federation directive. This updates the extraction code to ignore non-apollo directives when propagating demand control directives to subgraphs.

<!-- ROUTER-613 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
