### PR TITLE
chore(federation): refactor fragment usage counting

### DIFF
--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -1166,14 +1166,11 @@ impl NamedFragments {
     }
 
     /// The inner loop body of `reduce` method.
-    /// - Takes i32 `min_usage_to_optimize` since `collect_used_fragment_names` counts usages in
-    ///   i32.
     fn reduce_inner(
         &mut self,
         selection_set: &SelectionSet,
         min_usage_to_optimize: u32,
     ) -> Result<SelectionSet, FederationError> {
-        // Initial computation of fragment usages in `selection_set`.
         let mut usages = selection_set.used_fragments();
 
         // Short-circuiting: Nothing was used => Drop everything (selection_set is unchanged).


### PR DESCRIPTION
Today's 25 minute cleanup:
- Moves the `collect_used_fragment_names` family of functions to one place in the source file.
- Remove an unnecessary temporary selection set clone (‼️)
- Use `u32` to store the counts as they can never be negative.
- Instead of clearing the internal map with `NamedFragments.retain(false)`, replace the whole structure with an empty one.
