### PR TITLE
Add `experimental_query_planner_mode: both_best_effort` config

### DIFF
--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -240,7 +240,8 @@ pub(crate) enum QueryPlannerMode {
     /// to run the Rust implementation and compare results,
     /// logging warnings if the implementations disagree.
     ///
-    /// Falls back to `legacy` if the the new planner does not support the schema
+    /// Falls back to `legacy` with a warning
+    /// if the the new planner does not support the schema
     /// (such as using legacy Apollo Federation 1)
     BothBestEffort,
 }

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -218,16 +218,31 @@ pub(crate) enum ApolloMetricsGenerationMode {
 /// Query planner modes.
 #[derive(Clone, PartialEq, Eq, Default, Derivative, Serialize, Deserialize, JsonSchema)]
 #[derivative(Debug)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub(crate) enum QueryPlannerMode {
     /// Use the new Rust-based implementation.
+    ///
+    /// Raises an error at Router startup if the the new planner does not support the schema
+    /// (such as using legacy Apollo Federation 1)
     New,
     /// Use the old JavaScript-based implementation.
     #[default]
     Legacy,
-    /// Use Rust-based and Javascript-based implementations side by side, logging warnings if the
-    /// implementations disagree.
+    /// Use primarily the Javascript-based implementation,
+    /// but also schedule background jobs to run the Rust implementation and compare results,
+    /// logging warnings if the implementations disagree.
+    ///
+    /// Raises an error at Router startup if the the new planner does not support the schema
+    /// (such as using legacy Apollo Federation 1)
     Both,
+    /// Use primarily the Javascript-based implementation,
+    /// but also schedule on a best-effort basis background jobs
+    /// to run the Rust implementation and compare results,
+    /// logging warnings if the implementations disagree.
+    ///
+    /// Falls back to `legacy` if the the new planner does not support the schema
+    /// (such as using legacy Apollo Federation 1)
+    BothBestEffort,
 }
 
 impl<'de> serde::Deserialize<'de> for Configuration {

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -4407,7 +4407,7 @@ expression: "&schema"
           "type": "string"
         },
         {
-          "description": "Use primarily the Javascript-based implementation, but also schedule on a best-effort basis background jobs to run the Rust implementation and compare results, logging warnings if the implementations disagree.\n\nFalls back to `legacy` if the the new planner does not support the schema (such as using legacy Apollo Federation 1)",
+          "description": "Use primarily the Javascript-based implementation, but also schedule on a best-effort basis background jobs to run the Rust implementation and compare results, logging warnings if the implementations disagree.\n\nFalls back to `legacy` with a warning if the the new planner does not support the schema (such as using legacy Apollo Federation 1)",
           "enum": [
             "both_best_effort"
           ],

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -4386,7 +4386,7 @@ expression: "&schema"
       "description": "Query planner modes.",
       "oneOf": [
         {
-          "description": "Use the new Rust-based implementation.",
+          "description": "Use the new Rust-based implementation.\n\nRaises an error at Router startup if the the new planner does not support the schema (such as using legacy Apollo Federation 1)",
           "enum": [
             "new"
           ],
@@ -4400,9 +4400,16 @@ expression: "&schema"
           "type": "string"
         },
         {
-          "description": "Use Rust-based and Javascript-based implementations side by side, logging warnings if the implementations disagree.",
+          "description": "Use primarily the Javascript-based implementation, but also schedule background jobs to run the Rust implementation and compare results, logging warnings if the implementations disagree.\n\nRaises an error at Router startup if the the new planner does not support the schema (such as using legacy Apollo Federation 1)",
           "enum": [
             "both"
+          ],
+          "type": "string"
+        },
+        {
+          "description": "Use primarily the Javascript-based implementation, but also schedule on a best-effort basis background jobs to run the Rust implementation and compare results, logging warnings if the implementations disagree.\n\nFalls back to `legacy` if the the new planner does not support the schema (such as using legacy Apollo Federation 1)",
+          "enum": [
+            "both_best_effort"
           ],
           "type": "string"
         }

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -161,7 +161,13 @@ impl PlannerMode {
             }
             QueryPlannerMode::BothBestEffort => match Self::rust(schema, configuration) {
                 Ok(planner) => Ok(Some(planner)),
-                Err(_) => Ok(None),
+                Err(error) => {
+                    tracing::warn!(
+                        "Failed to initialize the new query planner, \
+                         falling back to legacy: {error}"
+                    );
+                    Ok(None)
+                }
             },
         }
     }

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -137,6 +137,16 @@ impl PlannerMode {
                     "expected Rust QP instance for `experimental_query_planner_mode: both`",
                 ),
             },
+            QueryPlannerMode::BothBestEffort => {
+                if let Some(rust) = rust_planner {
+                    Self::Both {
+                        js: Self::js(&schema.raw_sdl, configuration, old_planner).await?,
+                        rust,
+                    }
+                } else {
+                    Self::Js(Self::js(&schema.raw_sdl, configuration, old_planner).await?)
+                }
+            }
         })
     }
 
@@ -149,6 +159,10 @@ impl PlannerMode {
             QueryPlannerMode::New | QueryPlannerMode::Both => {
                 Ok(Some(Self::rust(schema, configuration)?))
             }
+            QueryPlannerMode::BothBestEffort => match Self::rust(schema, configuration) {
+                Ok(planner) => Ok(Some(planner)),
+                Err(_) => Ok(None),
+            },
         }
     }
 

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -62,6 +62,7 @@ pub(crate) enum ConfigMode {
     // for now use the JS config as it expected to be identical to the Rust one
     Rust(Arc<QueryPlannerConfig>),
     Both(Arc<QueryPlannerConfig>),
+    BothBestEffort(Arc<QueryPlannerConfig>),
     Js(Arc<QueryPlannerConfig>),
 }
 
@@ -134,6 +135,9 @@ where
             }
             crate::configuration::QueryPlannerMode::Both => {
                 ConfigMode::Both(Arc::new(configuration.js_query_planner_config()))
+            }
+            crate::configuration::QueryPlannerMode::BothBestEffort => {
+                ConfigMode::BothBestEffort(Arc::new(configuration.js_query_planner_config()))
             }
         };
         Ok(Self {

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -842,7 +842,8 @@ fn can_use_with_experimental_query_planner(
 
             Ok(())
         }
-        crate::configuration::QueryPlannerMode::Legacy => Ok(()),
+        crate::configuration::QueryPlannerMode::Legacy
+        | crate::configuration::QueryPlannerMode::BothBestEffort => Ok(()),
     }
 }
 #[cfg(test)]

--- a/apollo-router/tests/integration/lifecycle.rs
+++ b/apollo-router/tests/integration/lifecycle.rs
@@ -460,3 +460,65 @@ fn test_plugin_ordering_push_trace(context: &Context, entry: String) {
         )
         .unwrap();
 }
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fed1_schema_with_legacy_qp() {
+    let mut router = IntegrationTest::builder()
+        .config("experimental_query_planner_mode: legacy")
+        .supergraph("../examples/graphql/local.graphql")
+        .build()
+        .await;
+    router.start().await;
+    router.assert_started().await;
+    router.execute_default_query().await;
+    router.graceful_shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fed1_schema_with_new_qp() {
+    let mut router = IntegrationTest::builder()
+        .config("experimental_query_planner_mode: new")
+        .supergraph("../examples/graphql/local.graphql")
+        .build()
+        .await;
+    router.start().await;
+    router
+        .assert_log_contains(
+            "could not create router: \
+             The supergraph schema failed to produce a valid API schema: \
+             Supergraphs composed with federation version 1 are not supported.",
+        )
+        .await;
+    router.assert_shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fed1_schema_with_both_qp() {
+    let mut router = IntegrationTest::builder()
+        .config("experimental_query_planner_mode: both")
+        .supergraph("../examples/graphql/local.graphql")
+        .build()
+        .await;
+    router.start().await;
+    router
+        .assert_log_contains(
+            "could not create router: \
+             The supergraph schema failed to produce a valid API schema: \
+             Supergraphs composed with federation version 1 are not supported.",
+        )
+        .await;
+    router.assert_shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn fed1_schema_with_both_best_effort_qp() {
+    let mut router = IntegrationTest::builder()
+        .config("experimental_query_planner_mode: both_best_effort")
+        .supergraph("../examples/graphql/local.graphql")
+        .build()
+        .await;
+    router.start().await;
+    router.assert_started().await;
+    router.execute_default_query().await;
+    router.graceful_shutdown().await;
+}

--- a/apollo-router/tests/integration/lifecycle.rs
+++ b/apollo-router/tests/integration/lifecycle.rs
@@ -518,6 +518,14 @@ async fn fed1_schema_with_both_best_effort_qp() {
         .build()
         .await;
     router.start().await;
+    router
+        .assert_log_contains(
+            "Failed to initialize the new query planner, falling back to legacy: \
+             The supergraph schema failed to produce a valid API schema: \
+             Supergraphs composed with federation version 1 are not supported. \
+             Please recompose your supergraph with federation version 2 or greater",
+        )
+        .await;
     router.assert_started().await;
     router.execute_default_query().await;
     router.graceful_shutdown().await;


### PR DESCRIPTION
Some supergraph schemas supported by current Router versions (notably those using Apollo Federation 1) are not supported by the new Rust query planner. When a user explicitly configures `experimental_query_planner_mode: new` or `experimental_query_planner_mode: both`, we want unsupported schemas to cause an error at Router startup in order to make the issue very visible.

This adds `experimental_query_planner_mode: both_best_effort` which is like `both` whenever possible, and silently falls back to `legacy` otherwise. This behavior makes it suitable to potentially become the new default config.

Fixes ROUTER-601

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
