### PR TITLE
chore(federation): fix merged abstract types test

### DIFF
--- a/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/merged_abstract_types_handling.rs
@@ -632,8 +632,6 @@ fn handles_spread_unions_correctly() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure (reverse order of parallel fetches)
 fn handles_case_of_key_chains_in_parallel_requires() {
     let planner = planner!(
         Subgraph1: r#"
@@ -706,6 +704,22 @@ fn handles_case_of_key_chains_in_parallel_requires() {
             }
           },
           Parallel {
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph3") {
+                {
+                  ... on T2 {
+                    __typename
+                    id
+                    y
+                  }
+                } =>
+                {
+                  ... on T2 {
+                    z
+                  }
+                }
+              },
+            },
             Sequence {
               Flatten(path: "t") {
                 Fetch(service: "Subgraph2") {
@@ -736,22 +750,6 @@ fn handles_case_of_key_chains_in_parallel_requires() {
                     }
                   }
                 },
-              },
-            },
-            Flatten(path: "t") {
-              Fetch(service: "Subgraph3") {
-                {
-                  ... on T2 {
-                    __typename
-                    id
-                    y
-                  }
-                } =>
-                {
-                  ... on T2 {
-                    z
-                  }
-                }
               },
             },
           },


### PR DESCRIPTION
Due to the differences between JS and RS graph structures (JS is always topologically sorted) we occassionally end up with different parallel fetch node  order....

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
