### PR TITLE
test(federation): added `FetchDependencyGraph::to_dot` method

### DIFF
--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2270,14 +2270,14 @@ impl std::fmt::Display for FetchDependencyGraph {
     }
 }
 
-// Necessary for `petgraph::dot::Dot` to compile, but executed.
+// Necessary for `petgraph::dot::Dot::with_attr_getters` calls to compile, but not executed.
 impl std::fmt::Display for FetchDependencyGraphNode {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         unimplemented!()
     }
 }
 
-// Necessary for `petgraph::dot::Dot` to compile, but executed.
+// Necessary for `petgraph::dot::Dot::with_attr_getters` calls to compile, but not executed.
 impl std::fmt::Display for FetchDependencyGraphEdge {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         unimplemented!()

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2273,14 +2273,14 @@ impl std::fmt::Display for FetchDependencyGraph {
 // Necessary for `petgraph::dot::Dot::with_attr_getters` calls to compile, but not executed.
 impl std::fmt::Display for FetchDependencyGraphNode {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        unimplemented!()
+        Err(std::fmt::Error)
     }
 }
 
 // Necessary for `petgraph::dot::Dot::with_attr_getters` calls to compile, but not executed.
 impl std::fmt::Display for FetchDependencyGraphEdge {
     fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        unimplemented!()
+        Err(std::fmt::Error)
     }
 }
 

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2284,8 +2284,8 @@ impl std::fmt::Display for FetchDependencyGraphEdge {
     }
 }
 
-// GraphViz output for QueryGraph
 impl FetchDependencyGraph {
+    // GraphViz output for FetchDependencyGraph
     pub fn to_dot(&self) -> String {
         fn label_node(node_id: NodeIndex, node: &FetchDependencyGraphNode) -> String {
             let label_str = node.multiline_display(node_id).to_string();


### PR DESCRIPTION
- Generates a string representing the graph in GraphViz dot format.
- Useful for debugging.

It generates diagram like this:

![image](https://github.com/user-attachments/assets/cd322038-00de-427f-aa63-38a1129ebb07)

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests