### PR TITLE
Normalize subgraph names when generating expanded enum values

### DIFF
--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -137,8 +137,6 @@ impl Merger {
         subgraphs.sort_by(|s1, s2| s1.name.cmp(&s2.name));
         let mut subgraphs_and_enum_values = Vec::new();
         for subgraph in &subgraphs {
-            // TODO: Implement JS codebase's name transform (which always generates a valid GraphQL
-            // name and avoids collisions).
             match EnumValue::new(&subgraph.name) {
                 Ok(enum_value) => subgraphs_and_enum_values.push((subgraph, enum_value)),
                 Err(err) => self.errors.push(err),

--- a/apollo-federation/src/sources/connect/expand/tests/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/tests/mod.rs
@@ -67,7 +67,8 @@ test_expands! {
     steelthread,
     types_used_twice,
     carryover,
-    circular
+    circular,
+    normalize_names
 }
 
 test_ignores! {

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/normalize_names.graphql
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/normalize_names.graphql
@@ -1,0 +1,61 @@
+schema
+@link(url: "https://specs.apollo.dev/link/v1.0")
+@link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+@join__directive(graphs: [CONNECTORS_SUBGRAPH], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
+@join__directive(graphs: [CONNECTORS_SUBGRAPH], name: "source", args: {name: "example", http: {baseURL: "http://example"}})
+{
+    query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+enum join__Graph {
+    CONNECTORS_SUBGRAPH @join__graph(name: "connectors-subgraph", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+    """
+    `SECURITY` features provide metadata necessary to securely resolve fields.
+    """
+    SECURITY
+
+    """
+    `EXECUTION` features provide metadata necessary for operation execution.
+    """
+    EXECUTION
+}
+
+type Query
+@join__type(graph: CONNECTORS_SUBGRAPH)
+{
+    users: [User] @join__field(graph: CONNECTORS_SUBGRAPH) @join__directive(graphs: [CONNECTORS_SUBGRAPH], name: "connect", args: {source: "example", http: {GET: "/"}, selection: "id a"})
+    user(id: ID!): User @join__field(graph: CONNECTORS_SUBGRAPH) @join__directive(graphs: [CONNECTORS_SUBGRAPH], name: "connect", args: {source: "example", http: {GET: "/{$args.id}"}, selection: "id a b", entity: true})
+}
+
+type User
+@join__type(graph: CONNECTORS_SUBGRAPH, key: "id")
+{
+    id: ID!
+    a: String @join__field(graph: CONNECTORS_SUBGRAPH)
+    b: String @join__field(graph: CONNECTORS_SUBGRAPH)
+}

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/normalize_names.yaml
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/normalize_names.yaml
@@ -1,0 +1,26 @@
+federation_version: =2.9.0-connectors.12
+subgraphs:
+  connectors-subgraph:
+    routing_url: none
+    schema:
+      sdl: |
+        extend schema
+          @link(
+            url: "https://specs.apollo.dev/federation/v2.7"
+            import: ["@key", "@external", "@requires"]
+          )
+          @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"])
+          @source(name: "example", http: { baseURL: "http://example" })
+
+        type Query {
+          users: [User] @connect(source: "example", http: { GET: "/" }, selection: "id a")
+
+          user(id: ID!): User
+            @connect(source: "example", http: { GET: "/{$$args.id}" }, selection: "id a b", entity: true)
+        }
+
+        type User @key(fields: "id") {
+          id: ID!
+          a: String
+          b: String
+        }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__normalize_names__it_expands_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__normalize_names__it_expands_supergraph-2.snap
@@ -1,0 +1,145 @@
+---
+source: apollo-federation/src/sources/connect/expand/tests/mod.rs
+expression: connectors.by_service_name
+---
+{
+    "connectors-subgraph_Query_users_0": Connector {
+        id: ConnectId {
+            label: "connectors-subgraph.example http: GET ",
+            subgraph_name: "connectors-subgraph",
+            source_name: Some(
+                "example",
+            ),
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.users),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJsonTransport {
+            source_url: Some(
+                Url {
+                    scheme: "http",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: Some(
+                        Domain(
+                            "example",
+                        ),
+                    ),
+                    port: None,
+                    path: "/",
+                    query: None,
+                    fragment: None,
+                },
+            ),
+            connect_template: URLTemplate {
+                base: None,
+                path: [],
+                query: {},
+            },
+            method: Get,
+            headers: {},
+            body: None,
+        },
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "a",
+                        None,
+                    ),
+                ],
+                star: None,
+            },
+        ),
+        config: None,
+        entity_resolver: None,
+    },
+    "connectors-subgraph_Query_user_0": Connector {
+        id: ConnectId {
+            label: "connectors-subgraph.example http: GET /{$args.id!}",
+            subgraph_name: "connectors-subgraph",
+            source_name: Some(
+                "example",
+            ),
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.user),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJsonTransport {
+            source_url: Some(
+                Url {
+                    scheme: "http",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: Some(
+                        Domain(
+                            "example",
+                        ),
+                    ),
+                    port: None,
+                    path: "/",
+                    query: None,
+                    fragment: None,
+                },
+            ),
+            connect_template: URLTemplate {
+                base: None,
+                path: [
+                    ParameterValue {
+                        parts: [
+                            Var(
+                                VariableExpression {
+                                    var_path: "$args.id",
+                                    batch_separator: None,
+                                    required: true,
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                query: {},
+            },
+            method: Get,
+            headers: {},
+            body: None,
+        },
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "a",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "b",
+                        None,
+                    ),
+                ],
+                star: None,
+            },
+        ),
+        config: None,
+        entity_resolver: Some(
+            Explicit,
+        ),
+    },
+}

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__normalize_names__it_expands_supergraph-3.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__normalize_names__it_expands_supergraph-3.snap
@@ -1,0 +1,54 @@
+---
+source: apollo-federation/src/sources/connect/expand/tests/mod.rs
+expression: raw_sdl
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) @join__directive(graphs: [], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1"}) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on ENUM | INPUT_OBJECT | INTERFACE | OBJECT | SCALAR | UNION
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on INTERFACE | OBJECT
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments!) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+enum link__Purpose {
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """EXECUTION features provide metadata necessary for operation execution."""
+  EXECUTION
+}
+
+scalar link__Import
+
+scalar join__FieldSet
+
+scalar join__DirectiveArguments
+
+enum join__Graph {
+  CONNECTORS_SUBGRAPH_QUERY_USER_0 @join__graph(name: "connectors-subgraph_Query_user_0", url: "none")
+  CONNECTORS_SUBGRAPH_QUERY_USERS_0 @join__graph(name: "connectors-subgraph_Query_users_0", url: "none")
+}
+
+type User @join__type(graph: CONNECTORS_SUBGRAPH_QUERY_USER_0, key: "id") @join__type(graph: CONNECTORS_SUBGRAPH_QUERY_USERS_0) {
+  a: String @join__field(graph: CONNECTORS_SUBGRAPH_QUERY_USER_0) @join__field(graph: CONNECTORS_SUBGRAPH_QUERY_USERS_0)
+  b: String @join__field(graph: CONNECTORS_SUBGRAPH_QUERY_USER_0)
+  id: ID! @join__field(graph: CONNECTORS_SUBGRAPH_QUERY_USER_0) @join__field(graph: CONNECTORS_SUBGRAPH_QUERY_USERS_0)
+}
+
+type Query @join__type(graph: CONNECTORS_SUBGRAPH_QUERY_USER_0) @join__type(graph: CONNECTORS_SUBGRAPH_QUERY_USERS_0) {
+  user(id: ID!): User @join__field(graph: CONNECTORS_SUBGRAPH_QUERY_USER_0)
+  users: [User] @join__field(graph: CONNECTORS_SUBGRAPH_QUERY_USERS_0)
+}

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__normalize_names__it_expands_supergraph.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__normalize_names__it_expands_supergraph.snap
@@ -1,0 +1,16 @@
+---
+source: apollo-federation/src/sources/connect/expand/tests/mod.rs
+expression: api_schema
+---
+directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+type Query {
+  users: [User]
+  user(id: ID!): User
+}
+
+type User {
+  id: ID!
+  a: String
+  b: String
+}


### PR DESCRIPTION
This _almost_ completely implements [the JS equivalent](https://github.com/apollographql/federation/blob/c4744da360235d8bb8270ea048f0e0fa5d03be1e/internals-js/src/specs/joinSpec.ts#L18), but I intentionally left out adding the `_` suffix, since it'll update _all_ our snapshots and be messy. It's not obvious to me _why_ that rule was in place initially, and clearly this pattern has been working for us so far, so 🤷.

Implemented with a new type, just so I could easily see all the things this impacts. I reduced/moved a couple clones while updating type signatures, since I was looking.

<!-- [CNN-399] -->

[CNN-399]: https://apollographql.atlassian.net/browse/CNN-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ