### PR TITLE
Use consistent `query` name in uplink metrics

### DIFF
--- a/.changesets/fix_renee_consistent_uplink_type.md
+++ b/.changesets/fix_renee_consistent_uplink_type.md
@@ -1,0 +1,5 @@
+### Fix inconsistent `type` attribute in `apollo.router.uplink.fetch.duration` metric ([PR #5816](https://github.com/apollographql/router/pull/5816))
+
+The router now always reports a short name in the `type` attribute for the `apollo.router.fetch.duration` metric, instead of sometimes using a fully-qualified Rust path and sometimes using a short name.
+
+By [@goto-bus-stop](https://github.com/goto-bus-stop) in https://github.com/apollographql/router/pull/5816

--- a/apollo-router/src/uplink/mod.rs
+++ b/apollo-router/src/uplink/mod.rs
@@ -414,7 +414,7 @@ where
                 tracing::info!(
                     histogram.apollo_router_uplink_fetch_duration_seconds =
                         now.elapsed().as_secs_f64(),
-                    query = std::any::type_name::<Query>(),
+                    query,
                     url = url.to_string(),
                     "kind" = "http_error",
                     error = e.to_string(),
@@ -441,7 +441,7 @@ fn query_name<Query>() -> &'static str {
     let mut query = std::any::type_name::<Query>();
     query = query
         .strip_suffix("Query")
-        .expect("Uplink structs mut be named xxxQuery")
+        .expect("Uplink structs must be named xxxQuery")
         .get(query.rfind("::").map(|index| index + 2).unwrap_or_default()..)
         .expect("cannot fail");
     query


### PR DESCRIPTION
I'm not sure if this is a legitimate issue but it looks weird.

The `apollo_router_uplink_fetch_duration_seconds` metric has a `query` attribute which normally contains a simplified name, such as `license` for `apollo_router::uplink::LicenseQuery` or `persistentquerymanifest` for `apollo_router::uplink::PersistentQueryManifestQuery`.

But if the uplink fetch *fails*, the query attribute instead contains the whole type name, `apollo_router::uplink::licensequery` instead of `license`.

I suspect these were meant to be the same?