### PR TITLE
fix(federation): use supergraph when parsing requires fieldset

### DIFF
--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -1339,8 +1339,9 @@ impl FederatedQueryGraphBuilder {
                 let application = subgraph_data
                     .federation_spec_definition
                     .requires_directive_arguments(directive)?;
+                // @requires field set is validated against the supergraph
                 let conditions = parse_field_set(
-                    schema,
+                    &self.supergraph_schema,
                     field_definition_position.parent().type_name().clone(),
                     application.fields,
                 )?;

--- a/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -2107,7 +2107,6 @@ fn remove_inactive_applications(
                         .into();
                 // @requires needs to be validated against the supergraph schema
                 (fields, parent_type_pos, supergraph_schema.schema())
-                // (fields, parent_type_pos, schema.schema())
             }
         };
         // TODO: The assume_valid_ref() here is non-ideal, in the sense that the error messages we

--- a/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -464,7 +464,10 @@ fn extract_subgraphs_from_fed_2_supergraph(
         })
         .collect::<Vec<_>>();
     for subgraph in subgraphs.subgraphs.values_mut() {
-        remove_inactive_requires_and_provides_from_subgraph(&mut subgraph.schema)?;
+        remove_inactive_requires_and_provides_from_subgraph(
+            supergraph_schema,
+            &mut subgraph.schema,
+        )?;
         remove_unused_types_from_subgraph(&mut subgraph.schema)?;
         for definition in all_executable_directive_definitions.iter() {
             let pos = DirectiveDefinitionPosition {
@@ -1995,6 +1998,7 @@ fn add_federation_operations(
 /// unnecessarily. Besides, if a usage adds something useless, there is a chance it hasn't fully
 /// understood something, and warning about that fact through an error is more helpful.
 fn remove_inactive_requires_and_provides_from_subgraph(
+    supergraph_schema: &FederationSchema,
     schema: &mut FederationSchema,
 ) -> Result<(), FederationError> {
     let federation_spec_definition = get_federation_spec_definition_from_subgraph(schema)?;
@@ -2046,6 +2050,7 @@ fn remove_inactive_requires_and_provides_from_subgraph(
 
     for pos in object_or_interface_field_definition_positions {
         remove_inactive_applications(
+            supergraph_schema,
             schema,
             federation_spec_definition,
             FieldSetDirectiveKind::Requires,
@@ -2053,6 +2058,7 @@ fn remove_inactive_requires_and_provides_from_subgraph(
             pos.clone(),
         )?;
         remove_inactive_applications(
+            supergraph_schema,
             schema,
             federation_spec_definition,
             FieldSetDirectiveKind::Provides,
@@ -2070,6 +2076,7 @@ enum FieldSetDirectiveKind {
 }
 
 fn remove_inactive_applications(
+    supergraph_schema: &FederationSchema,
     schema: &mut FederationSchema,
     federation_spec_definition: &'static FederationSpecDefinition,
     directive_kind: FieldSetDirectiveKind,
@@ -2079,7 +2086,7 @@ fn remove_inactive_applications(
     let mut replacement_directives = Vec::new();
     let field = object_or_interface_field_definition_position.get(schema.schema())?;
     for directive in field.directives.get_all(name_in_schema) {
-        let (fields, parent_type_pos) = match directive_kind {
+        let (fields, parent_type_pos, is_requires_field_set) = match directive_kind {
             FieldSetDirectiveKind::Provides => {
                 let fields = federation_spec_definition
                     .provides_directive_arguments(directive)?
@@ -2087,7 +2094,7 @@ fn remove_inactive_applications(
                 let parent_type_pos: CompositeTypeDefinitionPosition = schema
                     .get_type(field.ty.inner_named_type().clone())?
                     .try_into()?;
-                (fields, parent_type_pos)
+                (fields, parent_type_pos, false)
             }
             FieldSetDirectiveKind::Requires => {
                 let fields = federation_spec_definition
@@ -2098,7 +2105,7 @@ fn remove_inactive_applications(
                         .parent()
                         .clone()
                         .into();
-                (fields, parent_type_pos)
+                (fields, parent_type_pos, true)
             }
         };
         // TODO: The assume_valid_ref() here is non-ideal, in the sense that the error messages we
@@ -2108,17 +2115,27 @@ fn remove_inactive_applications(
         // At best, we could try to shift this computation to after the subgraph schema validation
         // step, but its unclear at this time whether performing this shift affects correctness (and
         // it takes time to determine that). So for now, we keep this here.
-        let valid_schema = Valid::assume_valid_ref(schema.schema());
         // TODO: In the JS codebase, this function ends up getting additionally used in the schema
         // upgrader, where parsing the field set may error. In such cases, we end up skipping those
         // directives instead of returning error here, as it pollutes the list of error messages
         // during composition (another site in composition will properly check for field set
         // validity and give better error messaging).
-        let mut fields = parse_field_set_without_normalization(
-            valid_schema,
-            parent_type_pos.type_name().clone(),
-            fields,
-        )?;
+        let mut fields = if is_requires_field_set {
+            // @requires needs to be validated against the supergraph schema
+            let valid_supergraph_schema = Valid::assume_valid_ref(supergraph_schema.schema());
+            parse_field_set_without_normalization(
+                valid_supergraph_schema,
+                parent_type_pos.type_name().clone(),
+                fields,
+            )
+        } else {
+            let valid_schema = Valid::assume_valid_ref(schema.schema());
+            parse_field_set_without_normalization(
+                valid_schema,
+                parent_type_pos.type_name().clone(),
+                fields,
+            )
+        }?;
         let is_modified = remove_non_external_leaf_fields(schema, &mut fields)?;
         if is_modified {
             let replacement_directive = if fields.selections.is_empty() {

--- a/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -2124,10 +2124,10 @@ fn remove_inactive_applications(
         // during composition (another site in composition will properly check for field set
         // validity and give better error messaging).
         let mut fields = parse_field_set_without_normalization(
-                valid_schema,
-                parent_type_pos.type_name().clone(),
-                fields,
-            )?;
+            valid_schema,
+            parent_type_pos.type_name().clone(),
+            fields,
+        )?;
         let is_modified = remove_non_external_leaf_fields(schema, &mut fields)?;
         if is_modified {
             let replacement_directive = if fields.selections.is_empty() {

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
@@ -1736,3 +1736,107 @@ fn it_handles_multiple_requires_with_multiple_fetches() {
       "###
     );
 }
+
+
+#[test]
+fn handles_requires_from_supergraph() {
+    // This test verifies that @requires field selection set does not have to be locally satisfiable
+    // and is valid as long as it is satisfiable in the supergraph.
+    // In the test below, type U implements interface I only in the Subgraph1, but we can still use
+    // that type information in the @requires selection set in Subgraph2.
+    //
+    // NOTE: While GraphQL does not allow you to return raw interface data, it is still a valid schema.
+    // Since our interface field is marked as @external, its value should always be provided from
+    // other subgraph and should not be resolved locally (as that would lead to a runtime exception
+    // as we don't have any concrete type to return there).
+    let planner = planner!(
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            i: I
+          }
+
+          interface I {
+            name: String
+          }
+
+          type U implements I {
+            name: String @shareable
+            value: String
+          }
+        "#,
+        Subgraph2: r#"
+          interface I {
+            name: String
+          }
+
+          type U {
+            name: String @shareable
+            value: String @external
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            i: I @external
+            r: Int @requires(fields: "i { name ... on U { value } }")
+          }
+        "#,
+    );
+    assert_plan!(
+        &planner,
+        r#"
+          {
+            t {
+              r
+            }
+          }
+        "#,
+
+        @r###"
+        QueryPlan {
+          Sequence {
+            Fetch(service: "Subgraph1") {
+              {
+                t {
+                  __typename
+                  id
+                  i {
+                    __typename
+                    name
+                    ... on U {
+                      value
+                    }
+                  }
+                }
+              }
+            },
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2") {
+                {
+                  ... on T {
+                    __typename
+                    id
+                    i {
+                      name
+                      ... on U {
+                        value
+                      }
+                    }
+                  }
+                } =>
+                {
+                  ... on T {
+                    r
+                  }
+                }
+              },
+            },
+          },
+        }
+      "###
+    );
+}

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
@@ -1737,7 +1737,6 @@ fn it_handles_multiple_requires_with_multiple_fetches() {
     );
 }
 
-
 #[test]
 fn handles_requires_from_supergraph() {
     // This test verifies that @requires field selection set does not have to be locally satisfiable

--- a/apollo-federation/tests/query_plan/supergraphs/handles_requires_from_supergraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_requires_from_supergraph.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: 36dd36e8bdeee340c1bc4be4e18f482b49713d3e
+# Composed from subgraphs with hash: 46a2d6c6cf9956c08daa5b3faa018245cb5f9cfe
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
@@ -60,7 +60,7 @@ type T
   @join__type(graph: SUBGRAPH2, key: "id")
 {
   id: ID!
-  i: I! @join__field(graph: SUBGRAPH1) @join__field(graph: SUBGRAPH2, external: true)
+  i: I @join__field(graph: SUBGRAPH1) @join__field(graph: SUBGRAPH2, external: true)
   r: Int @join__field(graph: SUBGRAPH2, requires: "i { name ... on U { value } }")
 }
 

--- a/apollo-federation/tests/query_plan/supergraphs/handles_requires_from_supergraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_requires_from_supergraph.graphql
@@ -1,0 +1,74 @@
+# Composed from subgraphs with hash: 36dd36e8bdeee340c1bc4be4e18f482b49713d3e
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+interface I
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  name: String
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  i: I! @join__field(graph: SUBGRAPH1) @join__field(graph: SUBGRAPH2, external: true)
+  r: Int @join__field(graph: SUBGRAPH2, requires: "i { name ... on U { value } }")
+}
+
+type U implements I
+  @join__implements(graph: SUBGRAPH1, interface: "I")
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  name: String
+  value: String @join__field(graph: SUBGRAPH1) @join__field(graph: SUBGRAPH2, external: true)
+}


### PR DESCRIPTION
When parsing `@requires` field set selection we need to use supergraph schema instead of a target subgraph schema.

<!-- start metadata -->
<!-- Fixes https://apollographql.atlassian.net/browse/ROUTER-591 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
