### PR TITLE
fix: make new `tracing.propagation.format` config optional

### DIFF
--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -4635,7 +4635,6 @@ expression: "&schema"
         }
       },
       "required": [
-        "format",
         "header_name"
       ],
       "type": "object"

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -324,6 +324,7 @@ pub(crate) struct RequestPropagation {
     pub(crate) header_name: Option<HeaderName>,
 
     /// The trace ID format that will be used when propagating to subgraph services.
+    #[serde(default)]
     pub(crate) format: TraceIdFormat,
 }
 


### PR DESCRIPTION
Use the default if it's not explicitly specified. Prevents a breaking change to existing configurations.
Follow-up to #5803 and #5802.

Note we also have a `tracing.experimental_response_trace_id.format` configuration that is required. Should that also be optional, with otel format as the default?