### PR TITLE
fix(federation): change `HashMap`/`HashSet` usage to `IndexMap`/`IndexSet` to avoid non-determinism

### DIFF
--- a/apollo-federation/src/link/cost_spec_definition.rs
+++ b/apollo-federation/src/link/cost_spec_definition.rs
@@ -1,7 +1,6 @@
-use std::collections::HashMap;
-
 use apollo_compiler::ast::Argument;
 use apollo_compiler::ast::Directive;
+use apollo_compiler::collections::IndexMap;
 use apollo_compiler::name;
 use apollo_compiler::schema::Component;
 use apollo_compiler::schema::EnumType;
@@ -41,7 +40,7 @@ macro_rules! propagate_demand_control_directives {
             subgraph_schema: &FederationSchema,
             source: &$directives_ty,
             dest: &mut $directives_ty,
-            original_directive_names: &HashMap<Name, Name>,
+            original_directive_names: &IndexMap<Name, Name>,
         ) -> Result<(), FederationError> {
             let cost_directive_name = original_directive_names.get(&COST_DIRECTIVE_NAME_IN_SPEC);
             let cost_directive = cost_directive_name.and_then(|name| source.get(name.as_str()));
@@ -75,7 +74,7 @@ macro_rules! propagate_demand_control_directives_to_position {
             subgraph_schema: &mut FederationSchema,
             source: &Node<$source_ty>,
             dest: &$dest_ty,
-            original_directive_names: &HashMap<Name, Name>,
+            original_directive_names: &IndexMap<Name, Name>,
         ) -> Result<(), FederationError> {
             let cost_directive_name = original_directive_names.get(&COST_DIRECTIVE_NAME_IN_SPEC);
             let cost_directive =

--- a/apollo-federation/src/link/database.rs
+++ b/apollo-federation/src/link/database.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use apollo_compiler::ast::Directive;
 use apollo_compiler::ast::DirectiveLocation;
+use apollo_compiler::collections::IndexMap;
 use apollo_compiler::schema::DirectiveDefinition;
 use apollo_compiler::ty;
 use apollo_compiler::Schema;
@@ -46,10 +46,10 @@ pub fn links_metadata(schema: &Schema) -> Result<Option<LinksMetadata>, LinkErro
     // all of the @link usages (starting with the bootstrapping one) and extract their metadata.
     let link_name_in_schema = &bootstrap_directive.name;
     let mut links = Vec::new();
-    let mut by_identity = HashMap::new();
-    let mut by_name_in_schema = HashMap::new();
-    let mut types_by_imported_name = HashMap::new();
-    let mut directives_by_imported_name = HashMap::new();
+    let mut by_identity = IndexMap::default();
+    let mut by_name_in_schema = IndexMap::default();
+    let mut types_by_imported_name = IndexMap::default();
+    let mut directives_by_imported_name = IndexMap::default();
     let link_applications = schema
         .schema_definition
         .directives

--- a/apollo-federation/src/link/mod.rs
+++ b/apollo-federation/src/link/mod.rs
@@ -1,10 +1,10 @@
-use std::collections::HashMap;
 use std::fmt;
 use std::str;
 use std::sync::Arc;
 
 use apollo_compiler::ast::Directive;
 use apollo_compiler::ast::Value;
+use apollo_compiler::collections::IndexMap;
 use apollo_compiler::name;
 use apollo_compiler::schema::Component;
 use apollo_compiler::InvalidNameError;
@@ -387,10 +387,10 @@ pub struct LinkedElement {
 #[derive(Default, Eq, PartialEq, Debug)]
 pub struct LinksMetadata {
     pub(crate) links: Vec<Arc<Link>>,
-    pub(crate) by_identity: HashMap<Identity, Arc<Link>>,
-    pub(crate) by_name_in_schema: HashMap<Name, Arc<Link>>,
-    pub(crate) types_by_imported_name: HashMap<Name, (Arc<Link>, Arc<Import>)>,
-    pub(crate) directives_by_imported_name: HashMap<Name, (Arc<Link>, Arc<Import>)>,
+    pub(crate) by_identity: IndexMap<Identity, Arc<Link>>,
+    pub(crate) by_name_in_schema: IndexMap<Name, Arc<Link>>,
+    pub(crate) types_by_imported_name: IndexMap<Name, (Arc<Link>, Arc<Import>)>,
+    pub(crate) directives_by_imported_name: IndexMap<Name, (Arc<Link>, Arc<Import>)>,
 }
 
 impl LinksMetadata {

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::fmt::Debug;
 use std::fmt::Formatter;
 use std::iter;
@@ -1582,8 +1581,8 @@ fn add_core_feature_inaccessible(supergraph: &mut Schema) {
 // TODO use apollo_compiler::executable::FieldSet
 fn parse_keys<'a>(
     directives: impl Iterator<Item = &'a Component<Directive>> + Sized,
-) -> HashSet<&'a str> {
-    HashSet::from_iter(
+) -> IndexSet<&'a str> {
+    IndexSet::from_iter(
         directives
             .flat_map(|k| {
                 let field_set = directive_string_arg_value(k, &name!("fields")).unwrap();

--- a/apollo-federation/src/operation/contains.rs
+++ b/apollo-federation/src/operation/contains.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use apollo_compiler::collections::IndexMap;
 use apollo_compiler::executable;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
@@ -146,7 +145,7 @@ fn same_arguments(
     let right = right
         .iter()
         .map(|arg| (&arg.name, arg))
-        .collect::<HashMap<_, _>>();
+        .collect::<IndexMap<_, _>>();
 
     left.iter().all(|arg| {
         right

--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -35,10 +35,10 @@
 //! ## `reuse_fragments` methods (putting everything together)
 //! Recursive optimization of selection and selection sets.
 
-use std::collections::HashMap;
-use std::collections::HashSet;
 use std::sync::Arc;
 
+use apollo_compiler::collections::IndexMap;
+use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable;
 use apollo_compiler::executable::VariableDefinition;
 use apollo_compiler::Name;
@@ -67,7 +67,7 @@ use crate::schema::position::CompositeTypeDefinitionPosition;
 #[derive(Debug)]
 struct ReuseContext<'a> {
     fragments: &'a NamedFragments,
-    operation_variables: Option<HashSet<&'a Name>>,
+    operation_variables: Option<IndexSet<&'a Name>>,
 }
 
 impl<'a> ReuseContext<'a> {
@@ -392,7 +392,7 @@ impl NamedFragments {
 // `Option<FieldsConflictValidator>`. However, `None` validator makes it clearer that validation is
 // unnecessary.
 struct FieldsConflictValidator {
-    by_response_name: HashMap<Name, HashMap<Field, Option<Arc<FieldsConflictValidator>>>>,
+    by_response_name: IndexMap<Name, IndexMap<Field, Option<Arc<FieldsConflictValidator>>>>,
 }
 
 impl FieldsConflictValidator {
@@ -406,7 +406,8 @@ impl FieldsConflictValidator {
 
     fn for_level<'a>(level: &[&'a SelectionSet]) -> Self {
         // Group `level`'s fields by the response-name/field
-        let mut at_level: HashMap<Name, HashMap<Field, Vec<&'a SelectionSet>>> = HashMap::new();
+        let mut at_level: IndexMap<Name, IndexMap<Field, Vec<&'a SelectionSet>>> =
+            IndexMap::default();
         for selection_set in level {
             for field_selection in selection_set.field_selections() {
                 let response_name = field_selection.field.response_name();
@@ -421,10 +422,10 @@ impl FieldsConflictValidator {
         }
 
         // Collect validators per response-name/field
-        let mut by_response_name = HashMap::new();
+        let mut by_response_name = IndexMap::default();
         for (response_name, fields) in at_level {
-            let mut at_response_name: HashMap<Field, Option<Arc<FieldsConflictValidator>>> =
-                HashMap::new();
+            let mut at_response_name: IndexMap<Field, Option<Arc<FieldsConflictValidator>>> =
+                IndexMap::default();
             for (field, selection_sets) in fields {
                 if selection_sets.is_empty() {
                     at_response_name.insert(field, None);
@@ -631,7 +632,7 @@ struct FragmentRestrictionAtType {
 
 #[derive(Default)]
 struct FragmentRestrictionAtTypeCache {
-    map: HashMap<(Name, CompositeTypeDefinitionPosition), Arc<FragmentRestrictionAtType>>,
+    map: IndexMap<(Name, CompositeTypeDefinitionPosition), Arc<FragmentRestrictionAtType>>,
 }
 
 impl FragmentRestrictionAtTypeCache {
@@ -644,8 +645,8 @@ impl FragmentRestrictionAtTypeCache {
         // the lifetime does not really want to work out.
         // (&'cache mut self) -> Result<&'cache FragmentRestrictionAtType>
         match self.map.entry((fragment.name.clone(), ty.clone())) {
-            std::collections::hash_map::Entry::Occupied(entry) => Ok(Arc::clone(entry.get())),
-            std::collections::hash_map::Entry::Vacant(entry) => Ok(Arc::clone(
+            indexmap::map::Entry::Occupied(entry) => Ok(Arc::clone(entry.get())),
+            indexmap::map::Entry::Vacant(entry) => Ok(Arc::clone(
                 entry.insert(Arc::new(fragment.expanded_selection_set_at_type(ty)?)),
             )),
         }
@@ -866,7 +867,7 @@ impl SelectionSet {
     ) {
         // Note: It's not possible for two fragments to include each other. So, we don't need to
         //       worry about inclusion cycles.
-        let included_fragments: HashSet<Name> = applicable_fragments
+        let included_fragments: IndexSet<Name> = applicable_fragments
             .iter()
             .filter(|(fragment, _)| {
                 applicable_fragments
@@ -1249,8 +1250,12 @@ impl NamedFragments {
         )
     }
 
-    fn update_usages(usages: &mut HashMap<Name, u32>, fragment: &Node<Fragment>, usage_count: u32) {
-        let mut inner_usages = HashMap::new();
+    fn update_usages(
+        usages: &mut IndexMap<Name, u32>,
+        fragment: &Node<Fragment>,
+        usage_count: u32,
+    ) {
+        let mut inner_usages = IndexMap::default();
         fragment.collect_used_fragment_names(&mut inner_usages);
 
         for (name, inner_count) in inner_usages {
@@ -1625,7 +1630,7 @@ fn fragment_name(mut index: usize) -> Name {
 struct FragmentGenerator {
     fragments: NamedFragments,
     // XXX(@goto-bus-stop): This is temporary to support mismatch testing with JS!
-    names: HashMap<(String, usize), usize>,
+    names: IndexMap<(String, usize), usize>,
 }
 
 impl FragmentGenerator {

--- a/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::collections::HashMap;
 use std::fmt;
 use std::fmt::Write;
 use std::ops::Deref;
@@ -297,7 +296,7 @@ pub(crate) fn new_empty_fed_2_subgraph_schema() -> Result<FederationSchema, Fede
 
 struct TypeInfo {
     name: NamedType,
-    // HashMap<subgraph_enum_value: String, is_interface_object: bool>
+    // IndexMap<subgraph_enum_value: String, is_interface_object: bool>
     subgraph_info: IndexMap<Name, bool>,
 }
 
@@ -329,8 +328,8 @@ struct TypeInfos {
 /// when a custom directive's name conflicts with that of a default one.
 fn get_apollo_directive_names(
     supergraph_schema: &FederationSchema,
-) -> Result<HashMap<Name, Name>, FederationError> {
-    let mut hm: HashMap<Name, Name> = HashMap::new();
+) -> Result<IndexMap<Name, Name>, FederationError> {
+    let mut hm: IndexMap<Name, Name> = IndexMap::default();
     for directive in &supergraph_schema.schema().schema_definition.directives {
         if directive.name.as_str() == "link" {
             if let Ok(link) = Link::from_directive_application(directive) {
@@ -486,7 +485,7 @@ fn add_all_empty_subgraph_types(
     federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
     join_spec_definition: &'static JoinSpecDefinition,
     filtered_types: &Vec<TypeDefinitionPosition>,
-    original_directive_names: &HashMap<Name, Name>,
+    original_directive_names: &IndexMap<Name, Name>,
 ) -> Result<TypeInfos, FederationError> {
     let type_directive_definition =
         join_spec_definition.type_directive_definition(supergraph_schema)?;
@@ -788,7 +787,7 @@ fn extract_object_type_content(
     federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
     join_spec_definition: &JoinSpecDefinition,
     info: &[TypeInfo],
-    original_directive_names: &HashMap<Name, Name>,
+    original_directive_names: &IndexMap<Name, Name>,
 ) -> Result<(), FederationError> {
     let field_directive_definition =
         join_spec_definition.field_directive_definition(supergraph_schema)?;
@@ -964,7 +963,7 @@ fn extract_interface_type_content(
     federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
     join_spec_definition: &JoinSpecDefinition,
     info: &[TypeInfo],
-    original_directive_names: &HashMap<Name, Name>,
+    original_directive_names: &IndexMap<Name, Name>,
 ) -> Result<(), FederationError> {
     let field_directive_definition =
         join_spec_definition.field_directive_definition(supergraph_schema)?;
@@ -1252,7 +1251,7 @@ fn extract_enum_type_content(
     federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
     join_spec_definition: &JoinSpecDefinition,
     info: &[TypeInfo],
-    original_directive_names: &HashMap<Name, Name>,
+    original_directive_names: &IndexMap<Name, Name>,
 ) -> Result<(), FederationError> {
     // This was added in join 0.3, so it can genuinely be None.
     let enum_value_directive_definition =
@@ -1361,7 +1360,7 @@ fn extract_input_object_type_content(
     federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
     join_spec_definition: &JoinSpecDefinition,
     info: &[TypeInfo],
-    original_directive_names: &HashMap<Name, Name>,
+    original_directive_names: &IndexMap<Name, Name>,
 ) -> Result<(), FederationError> {
     let field_directive_definition =
         join_spec_definition.field_directive_definition(supergraph_schema)?;
@@ -1468,7 +1467,7 @@ fn add_subgraph_field(
     is_shareable: bool,
     field_directive_application: Option<&FieldDirectiveArguments>,
     cost_spec_definition: Option<&'static CostSpecDefinition>,
-    original_directive_names: &HashMap<Name, Name>,
+    original_directive_names: &IndexMap<Name, Name>,
 ) -> Result<(), FederationError> {
     let field_directive_application =
         field_directive_application.unwrap_or_else(|| &FieldDirectiveArguments {
@@ -1583,7 +1582,7 @@ fn add_subgraph_input_field(
     subgraph: &mut FederationSubgraph,
     field_directive_application: Option<&FieldDirectiveArguments>,
     cost_spec_definition: Option<&'static CostSpecDefinition>,
-    original_directive_names: &HashMap<Name, Name>,
+    original_directive_names: &IndexMap<Name, Name>,
 ) -> Result<(), FederationError> {
     let field_directive_application =
         field_directive_application.unwrap_or_else(|| &FieldDirectiveArguments {

--- a/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
@@ -1,6 +1,6 @@
-use std::collections::HashSet;
 use std::sync::Arc;
 
+use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable::DirectiveList;
 use apollo_compiler::executable::VariableDefinition;
 use apollo_compiler::Name;
@@ -50,7 +50,7 @@ pub(crate) struct FetchDependencyGraphToQueryPlanProcessor {
     operation_directives: Arc<DirectiveList>,
     operation_compression: SubgraphOperationCompression,
     operation_name: Option<Name>,
-    assigned_defer_labels: Option<HashSet<String>>,
+    assigned_defer_labels: Option<IndexSet<String>>,
     counter: u32,
 }
 
@@ -248,7 +248,7 @@ impl FetchDependencyGraphToQueryPlanProcessor {
         operation_directives: Arc<DirectiveList>,
         operation_compression: SubgraphOperationCompression,
         operation_name: Option<Name>,
-        assigned_defer_labels: Option<HashSet<String>>,
+        assigned_defer_labels: Option<IndexSet<String>>,
     ) -> Self {
         Self {
             variable_definitions,

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -2,7 +2,6 @@ use std::cell::Cell;
 use std::num::NonZeroU32;
 use std::sync::Arc;
 
-use apollo_compiler::collections::HashMap;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::validation::Valid;
@@ -778,7 +777,7 @@ fn compute_plan_for_defer_conditionals(
 pub(crate) struct RebasedFragments {
     original_fragments: NamedFragments,
     /// Map key: subgraph name
-    rebased_fragments: HashMap<Arc<str>, NamedFragments>,
+    rebased_fragments: IndexMap<Arc<str>, NamedFragments>,
 }
 
 impl RebasedFragments {

--- a/apollo-federation/src/sources/connect/url_path_template.rs
+++ b/apollo-federation/src/sources/connect/url_path_template.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::fmt::Display;
 
 use apollo_compiler::collections::IndexMap;
@@ -188,7 +187,7 @@ impl URLPathTemplate {
     }
 
     pub fn required_parameters(&self) -> Vec<String> {
-        let mut parameters = HashSet::new();
+        let mut parameters = IndexSet::default();
         for param_value in &self.path {
             parameters.extend(param_value.required_parameters());
         }

--- a/apollo-federation/tests/query_plan/build_query_plan_support.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_support.rs
@@ -1,8 +1,8 @@
-use std::collections::HashSet;
 use std::io::Read;
 use std::sync::Mutex;
 use std::sync::OnceLock;
 
+use apollo_compiler::collections::IndexSet;
 use apollo_federation::query_plan::query_planner::QueryPlanner;
 use apollo_federation::query_plan::query_planner::QueryPlannerConfig;
 use apollo_federation::query_plan::FetchNode;
@@ -96,7 +96,7 @@ pub(crate) fn compose(
     function_path: &'static str,
     subgraph_names_and_schemas: &[(&str, &str)],
 ) -> String {
-    let unique_names: std::collections::HashSet<_> = subgraph_names_and_schemas
+    let unique_names: IndexSet<_> = subgraph_names_and_schemas
         .iter()
         .map(|(name, _)| name)
         .collect();
@@ -127,7 +127,7 @@ pub(crate) fn compose(
     let prefix = "# Composed from subgraphs with hash: ";
 
     let test_name = function_path.rsplit("::").next().unwrap();
-    static SEEN_TEST_NAMES: OnceLock<Mutex<HashSet<&'static str>>> = OnceLock::new();
+    static SEEN_TEST_NAMES: OnceLock<Mutex<IndexSet<&'static str>>> = OnceLock::new();
     let new = SEEN_TEST_NAMES
         .get_or_init(Default::default)
         .lock()

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/requires.rs
@@ -877,8 +877,6 @@ fn it_handles_longer_require_chain() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure
 fn it_handles_complex_require_chain() {
     // Another "require chain" test but with more complexity as we have a require on multiple fields, some of which being
     // nested, and having requirements of their own.
@@ -994,40 +992,6 @@ fn it_handles_complex_require_chain() {
               }
             },
             Parallel {
-              Sequence {
-                Flatten(path: "t") {
-                  Fetch(service: "Subgraph2") {
-                    {
-                      ... on T {
-                        __typename
-                        id
-                      }
-                    } =>
-                    {
-                      ... on T {
-                        inner2_required
-                        inner1
-                      }
-                    }
-                  },
-                },
-                Flatten(path: "t") {
-                  Fetch(service: "Subgraph3") {
-                    {
-                      ... on T {
-                        __typename
-                        inner2_required
-                        id
-                      }
-                    } =>
-                    {
-                      ... on T {
-                        inner2
-                      }
-                    }
-                  },
-                },
-              },
               Flatten(path: "t") {
                 Fetch(service: "Subgraph7") {
                   {
@@ -1124,6 +1088,40 @@ fn it_handles_complex_require_chain() {
                     {
                       ... on Inner3Type {
                         inner3_nested
+                      }
+                    }
+                  },
+                },
+              },
+              Sequence {
+                Flatten(path: "t") {
+                  Fetch(service: "Subgraph2") {
+                    {
+                      ... on T {
+                        __typename
+                        id
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        inner2_required
+                        inner1
+                      }
+                    }
+                  },
+                },
+                Flatten(path: "t") {
+                  Fetch(service: "Subgraph3") {
+                    {
+                      ... on T {
+                        __typename
+                        inner2_required
+                        id
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        inner2
                       }
                     }
                   },


### PR DESCRIPTION
<!-- ROUTER-642 -->

One of the tests was failing with a non-deterministic QP snapshot failure. I suspected this was due to usage of `HashMap`/`HashSet`, and after converting all usages of them to `apollo_compiler`'s `IndexMap`/`IndexSet`, the test's QP snapshot is now consistent across 100 runs. (We probably don't need to convert all usages for this test to pass, but this may help reduce non-determinism/help reproducibility in the future.)