### PR TITLE
Report connectors errors as fetch errors

### DIFF
--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__normalize_names__it_expands_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__normalize_names__it_expands_supergraph-2.snap
@@ -61,6 +61,7 @@ expression: connectors.by_service_name
             },
         ),
         config: None,
+        max_requests: None,
         entity_resolver: None,
     },
     "connectors-subgraph_Query_user_0": Connector {
@@ -138,6 +139,7 @@ expression: connectors.by_service_name
             },
         ),
         config: None,
+        max_requests: None,
         entity_resolver: Some(
             Explicit,
         ),

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__realistic__it_expands_supergraph-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/apollo_federation__sources__connect__expand__tests__realistic__it_expands_supergraph-2.snap
@@ -98,6 +98,7 @@ expression: connectors.by_service_name
             },
         ),
         config: None,
+        max_requests: None,
         entity_resolver: None,
     },
     "connectors_Query_usersByCompany_0": Connector {

--- a/apollo-federation/src/sources/connect/header.rs
+++ b/apollo-federation/src/sources/connect/header.rs
@@ -36,8 +36,7 @@ impl HeaderValue {
     /// Replace variable references in the header value with the given variable definitions.
     ///
     /// # Errors
-    /// Returns an error if a variable used in the header value is not defined or if a variable
-    /// value is not a string.
+    /// Returns an error if a variable used in the header value is not defined.
     pub fn interpolate(&self, vars: &Map<ByteString, JSON>) -> Result<String, String> {
         let mut result = String::new();
         for part in &self.parts {

--- a/apollo-router/src/plugins/connectors/error.rs
+++ b/apollo-router/src/plugins/connectors/error.rs
@@ -1,6 +1,10 @@
 //! Connectors error types.
 
+use apollo_federation::sources::connect::Connector;
+
+use crate::graphql;
 use crate::graphql::ErrorExtension;
+use crate::json_ext::Path;
 
 /// Errors that apply to all connector types. These errors represent a problem invoking the
 /// connector, as opposed to an error returned from the connector itself.
@@ -8,6 +12,26 @@ use crate::graphql::ErrorExtension;
 pub(crate) enum Error {
     /// Request limit exceeded
     RequestLimitExceeded,
+}
+
+impl Error {
+    /// Create a GraphQL error from this error.
+    #[must_use]
+    pub(crate) fn to_graphql_error(
+        &self,
+        connector: &Connector,
+        path: Option<Path>,
+    ) -> crate::error::Error {
+        let builder = graphql::Error::builder()
+            .message(self.to_string())
+            .extension_code(self.extension_code())
+            .extension("service", connector.id.label.clone());
+        if let Some(path) = path {
+            builder.path(path).build()
+        } else {
+            builder.build()
+        }
+    }
 }
 
 impl ErrorExtension for Error {

--- a/apollo-router/src/plugins/connectors/tests.rs
+++ b/apollo-router/src/plugins/connectors/tests.rs
@@ -277,7 +277,7 @@ async fn max_requests() {
         {
           "message": "Request limit exceeded",
           "extensions": {
-            "connector": "connectors.json http: GET /users/{$args.id!}",
+            "service": "connectors.json http: GET /users/{$args.id!}",
             "code": "REQUEST_LIMIT_EXCEEDED"
           }
         }
@@ -343,7 +343,7 @@ async fn source_max_requests() {
         {
           "message": "Request limit exceeded",
           "extensions": {
-            "connector": "connectors.json http: GET /users/{$args.id!}",
+            "service": "connectors.json http: GET /users/{$args.id!}",
             "code": "REQUEST_LIMIT_EXCEEDED"
           }
         }
@@ -538,10 +538,14 @@ async fn basic_errors() {
       "data": null,
       "errors": [
         {
-          "message": "http error: 404 Not Found",
+          "message": "HTTP fetch failed from 'connectors.json http: GET /users': 404: Not Found",
           "extensions": {
-            "connector": "connectors.json http: GET /users",
-            "code": "404"
+            "code": "SUBREQUEST_HTTP_ERROR",
+            "service": "connectors.json http: GET /users",
+            "reason": "404: Not Found",
+            "http": {
+              "status": 404
+            }
           }
         }
       ]


### PR DESCRIPTION
With connectors, the subgraph service and connector service are called from a fetch service. This created some differences in how errors from the subgraph service were being reported through the fetch service compared to when the subgraph service was called directly. These differences have been removed, so errors from the subgraph service, or errors when invoking the subgraph service, will be reported exactly as before - always as `FetchError::SubrequestHttpError`.

Additionally, HTTP errors from a connector REST API call are now also reported as `FetchError::SubrequestHttpError`, with the connector information in the `service` extension.

```json
{
  "message": "HTTP fetch failed from 'posts.jsonPlaceholder http: GET /users/{$this.id!}/postsd': 404: Not Found",
  "extensions": {
    "code": "SUBREQUEST_HTTP_ERROR",
    "service": "posts.jsonPlaceholder http: GET /users/{$this.id!}/postsd",
    "reason": "404: Not Found",
    "http": {
      "status": 404
    }
  }
}
```

`FetchError::SubrequestHttpError` is consistently converted to a GraphQL error through `to_graphql_error`.

The `connectors::Error::RequestLimitExceeded` error from the connector service now also has a `to_graphql_error` function, and is reported out slightly differently since it is not an HTTP error (connectors will not make the HTTP request at all once the request limit is exceeded). The connector information is now included in the `service` extension in this case for consistency with the HTTP errors.

```json
{
  "message": "Request limit exceeded",
  "extensions": {
    "service": "posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",
    "code": "REQUEST_LIMIT_EXCEEDED"
  }
}
```

<!-- [CNN-370] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-370]: https://apollographql.atlassian.net/browse/CNN-370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ