### PR TITLE
chore(federation): fixed the error formating of "excessive number of combinations"

### DIFF
--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -3178,9 +3178,9 @@ impl SimultaneousPaths {
                 product.saturating_mul(options.len())
             });
         if num_options > 1_000_000 {
-            return Err(FederationError::internal(
-                "flat_cartesian_product: excessive number of combinations: {num_options}",
-            ));
+            return Err(FederationError::internal(format!(
+                "flat_cartesian_product: excessive number of combinations: {num_options}"
+            )));
         }
         let mut product = Vec::with_capacity(num_options);
 


### PR DESCRIPTION
Previously, the number wasn't included in the error and the placeholder `{num_options}` was printed as is. The actual number is now displayed in the message.

This is a simple error message fix. No behavior changes are expected.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests