### PR TITLE
Add missing docs for connectors modules

### DIFF
--- a/apollo-router/src/services/connect.rs
+++ b/apollo-router/src/services/connect.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)] // FIXME
+//! Connect service request and response types.
 
 use std::sync::Arc;
 

--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -1,4 +1,4 @@
-//! Tower fetcher for fetch node execution.
+//! Tower service for connectors.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -47,6 +47,7 @@ pub(crate) const APOLLO_CONNECTOR_SOURCE_NAME: Key =
 pub(crate) const APOLLO_CONNECTOR_SOURCE_DETAIL: Key =
     Key::from_static_str("apollo.connector.source.detail");
 
+/// A service for executing connector requests.
 #[derive(Clone)]
 pub(crate) struct ConnectorService {
     pub(crate) http_service_factory: Arc<IndexMap<String, HttpClientServiceFactory>>,

--- a/apollo-router/src/services/fetch.rs
+++ b/apollo-router/src/services/fetch.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)] // FIXME
+//! Fetch request and response types.
 
 use std::sync::Arc;
 

--- a/apollo-router/src/services/fetch_service.rs
+++ b/apollo-router/src/services/fetch_service.rs
@@ -29,6 +29,8 @@ use crate::services::FetchResponse;
 use crate::services::SubgraphServiceFactory;
 use crate::spec::Schema;
 
+/// The fetch service delegates to either the subgraph service or connector service depending
+/// on whether connectors are present in the subgraph.
 #[derive(Clone)]
 pub(crate) struct FetchService {
     pub(crate) subgraph_service_factory: Arc<SubgraphServiceFactory>,


### PR DESCRIPTION
The connectors PR had a comment about the `![allow(missing_docs)]` attribute. These actually had no effect, since the types are not `pub`. These are removed, and I added a few module and type docs.

<!-- [CNN-374] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-374]: https://apollographql.atlassian.net/browse/CNN-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ