### PR TITLE
Fix: Update the fragment naming convention so it matches the javascript one + allow router configuration to define if generate query fragments is enabled in the rust planner

### DIFF
--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -1652,7 +1652,7 @@ impl FragmentGenerator {
                 |condition| condition.to_string(),
             );
         let selections = frag.selection_set.selections.len();
-        let mut name = format!("_generated_on{type_condition}_{selections}");
+        let mut name = format!("_generated_on{type_condition}{selections}");
 
         let key = (type_condition, selections);
         let index = self

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/fragment_autogeneration.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/fragment_autogeneration.rs
@@ -53,14 +53,14 @@ fn it_respects_generate_query_fragments_option() {
         {
           t {
             __typename
-            ..._generated_onA_2_0
+            ..._generated_onA2_0
             ... on B {
               z
             }
           }
         }
 
-        fragment _generated_onA_2_0 on A {
+        fragment _generated_onA2_0 on A {
           x
           y
         }
@@ -105,21 +105,21 @@ fn it_handles_nested_fragment_generation() {
         {
           t {
             __typename
-            ..._generated_onA_3_0
+            ..._generated_onA3_0
           }
         }
 
-        fragment _generated_onA_2_0 on A {
+        fragment _generated_onA2_0 on A {
           x
           y
         }
 
-        fragment _generated_onA_3_0 on A {
+        fragment _generated_onA3_0 on A {
           x
           y
           t {
             __typename
-            ..._generated_onA_2_0
+            ..._generated_onA2_0
             ... on B {
               z
             }
@@ -159,11 +159,11 @@ fn it_handles_fragments_with_one_non_leaf_field() {
         {
           t {
             __typename
-            ..._generated_onA_1_0
+            ..._generated_onA1_0
           }
         }
 
-        fragment _generated_onA_1_0 on A {
+        fragment _generated_onA1_0 on A {
           t {
             __typename
             ... on B {
@@ -219,11 +219,11 @@ fn it_migrates_skip_include() {
         {
           t {
             __typename
-            ..._generated_onA_3_0
+            ..._generated_onA3_0
           }
         }
 
-        fragment _generated_onA_3_0 on A {
+        fragment _generated_onA3_0 on A {
           x
           y
           t {
@@ -277,15 +277,15 @@ fn it_identifies_and_reuses_equivalent_fragments_that_arent_identical() {
         {
           t {
             __typename
-            ..._generated_onA_2_0
+            ..._generated_onA2_0
           }
           t2 {
             __typename
-            ..._generated_onA_2_0
+            ..._generated_onA2_0
           }
         }
 
-        fragment _generated_onA_2_0 on A {
+        fragment _generated_onA2_0 on A {
           x
           y
         }
@@ -325,20 +325,20 @@ fn fragments_that_share_a_hash_but_are_not_identical_generate_their_own_fragment
         {
           t {
             __typename
-            ..._generated_onA_2_0
+            ..._generated_onA2_0
           }
           t2 {
             __typename
-            ..._generated_onA_2_1
+            ..._generated_onA2_1
           }
         }
 
-        fragment _generated_onA_2_0 on A {
+        fragment _generated_onA2_0 on A {
           x
           y
         }
 
-        fragment _generated_onA_2_1 on A {
+        fragment _generated_onA2_1 on A {
           y
           z
         }

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -182,7 +182,7 @@ impl PlannerMode {
                 .reuse_query_fragments
                 .unwrap_or(true),
             subgraph_graphql_validation: false,
-            generate_query_fragments: false,
+            generate_query_fragments: configuration.supergraph.generate_query_fragments,
             incremental_delivery:
                 apollo_federation::query_plan::query_planner::QueryPlanIncrementalDeliveryConfig {
                     enable_defer: configuration.supergraph.defer_support,


### PR DESCRIPTION

This changeset makes sure the rust planner fragment names match their javascript counterpart, and it makes sure the router configuration pertaining to fragment reuse is properly applied in the javascript and in the rust planner.
