### PR TITLE
fix: pin rowan version to pass CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,6 +572,7 @@ dependencies = [
  "rhai",
  "rmp",
  "router-bridge",
+ "rowan",
  "rstack",
  "rust-embed",
  "rustls",

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -139,6 +139,9 @@ nu-ansi-term = "0.49"
 num-traits = "0.2.19"
 once_cell = "1.19.0"
 
+# Pin rowan to a version pre-MSRV bump. Remove if we update our rust-toolchain.
+rowan = "= 0.15.15"
+
 # Any package that starts with `opentelemetry` needs to be updated with care
 # because it is tightly intertwined with the `tracing` packages on account of
 # the `opentelemetry-tracing` package.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 # renovate-automation: rustc version
-channel = "1.76.0"
+channel = "1.76.0" # If updated, remove `rowan` dependency from apollo-router/Cargo.toml
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
Rowan increased its MSRV to 1.77 in a patch version. Pinning it to the previous patch release should fix the `updated` CI job.