### PR TITLE
Fix panic when running from performance test

### DIFF
--- a/apollo-router/src/plugins/connectors/http_json_transport.rs
+++ b/apollo-router/src/plugins/connectors/http_json_transport.rs
@@ -151,7 +151,7 @@ fn make_uri(
 
 // URLTemplate expects a map with flat dot-delimited keys.
 fn flatten_keys(inputs: &IndexMap<String, Value>) -> Map<ByteString, Value> {
-    let mut flat = serde_json_bytes::Map::new();
+    let mut flat = serde_json_bytes::Map::with_capacity(inputs.len());
     for (key, value) in inputs {
         flatten_keys_recursive(value, &mut flat, key.clone());
     }
@@ -162,12 +162,7 @@ fn flatten_keys_recursive(inputs: &Value, flat: &mut Map<ByteString, Value>, pre
     match inputs {
         Value::Object(map) => {
             for (key, value) in map {
-                let new_prefix = format!(
-                    "{prefix}.{key}",
-                    prefix = prefix.as_str(),
-                    key = key.as_str()
-                );
-                flatten_keys_recursive(value, flat, new_prefix);
+                flatten_keys_recursive(value, flat, [prefix.as_str(), ".", key.as_str()].concat());
             }
         }
         _ => {

--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -139,7 +139,7 @@ async fn execute(
         let request_limit = lock
             .get::<Arc<RequestLimits>>()
             .map(|limits| limits.get((&connector.id).into(), connector.max_requests))
-            .expect("missing request limit");
+            .unwrap_or(None);
         (debug, request_limit)
     });
 


### PR DESCRIPTION

Fix a panic I ran into when running performance tests. Also fix a hot spot around string concatenation and allocation that I noticed in the flame graph.

Fixes #**issue_number**

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
