### PR TITLE
disallow direct circular references

### DIFF
--- a/apollo-federation/src/sources/connect/validation/extended_type.rs
+++ b/apollo-federation/src/sources/connect/validation/extended_type.rs
@@ -166,19 +166,17 @@ fn validate_field(
     };
 
     // direct recursion isn't allowed, like a connector on User.friends: [User]
-    if matches!(category, ObjectCategory::Other) {
-        if &object.name == field.ty.inner_named_type() {
-            errors.push(Message {
+    if matches!(category, ObjectCategory::Other) && &object.name == field.ty.inner_named_type() {
+        errors.push(Message {
                     code: Code::CircularReference,
                     message: format!(
                         "Direct circular reference detected in `{}.{}: {}`. For more information, see https://go.apollo.dev/connectors/limitations#circular-references",
                         object.name,
                         field.name,
-                        field.ty.to_string()
+                        field.ty
                     ),
                     locations: field.line_column_range(source_map).into_iter().collect(),
                 });
-        }
     }
 
     errors.extend(validate_selection(field, connect_directive, object, schema));

--- a/apollo-federation/src/sources/connect/validation/extended_type.rs
+++ b/apollo-federation/src/sources/connect/validation/extended_type.rs
@@ -165,6 +165,22 @@ fn validate_field(
         return errors;
     };
 
+    // direct recursion isn't allowed, like a connector on User.friends: [User]
+    if matches!(category, ObjectCategory::Other) {
+        if &object.name == field.ty.inner_named_type() {
+            errors.push(Message {
+                    code: Code::CircularReference,
+                    message: format!(
+                        "Direct circular reference detected in `{}.{}: {}`. For more information, see https://go.apollo.dev/connectors/limitations#circular-references",
+                        object.name,
+                        field.name,
+                        field.ty.to_string()
+                    ),
+                    locations: field.line_column_range(source_map).into_iter().collect(),
+                });
+        }
+    }
+
     errors.extend(validate_selection(field, connect_directive, object, schema));
 
     errors.extend(validate_entity_arg(

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@circular_reference_3.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@circular_reference_3.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/validation/circular_reference_3.graphql
+---
+[Message { code: CircularReference, message: "Direct circular reference detected in `User.friends: [User!]!`. For more information, see https://go.apollo.dev/connectors/limitations#circular-references", locations: [LineColumn { line: 16, column: 3 }..LineColumn { line: 20, column: 6 }] }]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_on_field.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_on_field.graphql.snap
@@ -3,4 +3,4 @@ source: apollo-federation/src/sources/connect/validation/mod.rs
 expression: "format!(\"{:?}\", errors)"
 input_file: apollo-federation/src/sources/connect/validation/test_data/validation/invalid_entity_arg_on_field.graphql
 ---
-[Message { code: EntityNotOnRootQuery, message: "`@connect(entity: true)` on `User.bestFriend` is invalid. Entity resolvers can only be declared on root `Query` fields.", locations: [LineColumn { line: 19, column: 7 }..LineColumn { line: 19, column: 19 }] }]
+[Message { code: EntityNotOnRootQuery, message: "`@connect(entity: true)` on `User.favoriteColor` is invalid. Entity resolvers can only be declared on root `Query` fields.", locations: [LineColumn { line: 19, column: 7 }..LineColumn { line: 19, column: 19 }] }]

--- a/apollo-federation/src/sources/connect/validation/test_data/validation/circular_reference_3.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/validation/circular_reference_3.graphql
@@ -1,0 +1,21 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect"])
+
+type Query {
+  user(id: ID!): User
+    @connect(
+      entity: true
+      http: { GET: "http://127.0.0.1/me" }
+      selection: "id name"
+    )
+}
+
+type User {
+  id: ID!
+  name: String
+  friends: [User!]!  # this can't ever work because `{ user(id: ID!) { friends { friends { ... } } } }` will always fail
+    @connect(
+      http: { GET: "http://127.0.0.1/users/{$this.id}/friends" }
+      selection: "id name"
+    )
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/validation/invalid_entity_arg_on_field.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/validation/invalid_entity_arg_on_field.graphql
@@ -13,7 +13,7 @@ type Query {
 type User {
   id: ID!
   name: String!
-  bestFriend: User
+  favoriteColor: String
     @connect(
       http: { GET: "http://127.0.0.1:8000/resources" }
       entity: true


### PR DESCRIPTION
Using a second connector to create a relationship on the same type almost works.
```graphql
type Query {
  user(id: ID!): User @connect(entity: true, ..., selection: "id name")
}

type User {
  id: ID
  name: String
  friends: [User] @connect(..., selection: "id")
}
```
(This supports `{user{friends{name}}}`.)

But the query planner assumes it can repeatedly recurse and resolve the friends field multiple times with a single fetch.

`{user{friends{friends{...}}}`

```
QueryPlan {
  Sequence {
    Fetch(service: "users. http: GET http://localhost:4999/users/{$args.id!}") {
      {
        user(id: $userId) {
          __typename
          id
          name
        }
      }
    },
    Flatten(path: "user") {
      Fetch(service: "users. http: GET http://localhost:4999/users/{$this.id!}") {
        {
          ... on User {
            __typename
            id
          }
        } =>
        {
          ... on User {
            friends {
              id
              friends {
                id
              }
            }
          }
        }
      },
    },
  },
}
```

for now, we'll need to disallow this scenario to avoid surprising behavior (the inner `friends` field will always be null.)

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
