### PR TITLE
feat: ease of use debugging

### DIFF
--- a/.changesets/config_musket_minute_linen_kitchen.md
+++ b/.changesets/config_musket_minute_linen_kitchen.md
@@ -1,0 +1,5 @@
+### Include hostname on heaptrack path, specify pod lifecycle ([Issue #5789](https://github.com/apollographql/router/issues/5789))
+
+Use hostname in the heaptrack path to identify an individual container/instance/machine where the router is running. Additionally, allow the specification of restartPolicy on deployment (defaults to `Always` which is kubernetes default)
+
+By [@cyberhck](https://github.com/cyberhck) in https://github.com/apollographql/router/pull/5850

--- a/.changesets/config_musket_minute_linen_kitchen.md
+++ b/.changesets/config_musket_minute_linen_kitchen.md
@@ -1,5 +1,7 @@
 ### Include hostname on heaptrack path, specify pod lifecycle ([Issue #5789](https://github.com/apollographql/router/issues/5789))
 
-Use hostname in the heaptrack path to identify an individual container/instance/machine where the router is running. Additionally, allow the specification of restartPolicy on deployment (defaults to `Always` which is kubernetes default)
+Use hostname in the heaptrack path to identify an individual container/instance/machine where the router is running. This means the filepath for heaptrack output will change.
+
+Additionally, allow the specification of restartPolicy on deployment (defaults to `Always` which is kubernetes default)
 
 By [@cyberhck](https://github.com/cyberhck) in https://github.com/apollographql/router/pull/5850

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -65,7 +65,7 @@ RUN \
 \nset -e \
 \n \
 \nif [ -f "/usr/bin/heaptrack" ]; then \
-\n    exec heaptrack -o /dist/data/router_heaptrack /dist/router "$@" \
+\n    exec heaptrack -o /dist/data/router_heaptrack/${hostname} /dist/router "$@" \
 \nelse \
 \n    exec /dist/router "$@" \
 \nfi \

--- a/dockerfiles/Dockerfile.router
+++ b/dockerfiles/Dockerfile.router
@@ -65,7 +65,7 @@ RUN \
 \nset -e \
 \n \
 \nif [ -f "/usr/bin/heaptrack" ]; then \
-\n    exec heaptrack -o /dist/data/router_heaptrack/${hostname} /dist/router "$@" \
+\n    exec heaptrack -o /dist/data/$(hostname)/router_heaptrack  /dist/router "$@" \
 \nelse \
 \n    exec /dist/router "$@" \
 \nfi \

--- a/helm/chart/router/README.md
+++ b/helm/chart/router/README.md
@@ -79,6 +79,7 @@ helm show values oci://ghcr.io/apollographql/helm-charts/router
 | probes.readiness | object | `{"initialDelaySeconds":0}` | Configure readiness probe |
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
+| restartPolicy | string | `"Always"` | Sets the restart policy of pods |
 | rollingUpdate | object | `{}` | Sets the [rolling update strategy parameters](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#rolling-update-deployment).  Can take absolute values or % values. |
 | router | object | `{"args":["--hot-reload"],"configuration":{"health_check":{"listen":"0.0.0.0:8088"},"supergraph":{"listen":"0.0.0.0:4000"}}}` | See https://www.apollographql.com/docs/router/configuration/overview/#yaml-config-file for yaml structure |
 | securityContext | object | `{}` |  |

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -48,9 +48,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "router.serviceAccountName" . }}
-      {{- if .Values.restartPolicy}}
+      {{- if .Values.restartPolicy }}
       restartPolicy: {{.Values.restartPolicy}}
-      {{-end}}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "router.serviceAccountName" . }}
+      {{- if .Values.restartPolicy}}
+      restartPolicy: {{.Values.restartPolicy}}
+      {{-end}}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/helm/chart/router/values.yaml
+++ b/helm/chart/router/values.yaml
@@ -253,3 +253,6 @@ probes:
 
 # -- Sets the [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) for Deployment pods
 topologySpreadConstraints: []
+
+# -- Sets the restart policy of pods
+restartPolicy: Always


### PR DESCRIPTION
When we want to use debug mode, we can only get 1 file per node in Kubernetes, this change allows us to do 2 things:
- set `restartPolicy` of pod as desired.
- add hostname in path for collecting healtrack data.

Fixes #5789

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
