### PR TITLE
Revert "Revert some IndexMap/Set changes that break `--release` builds for x86"

### DIFF
--- a/apollo-federation/src/link/cost_spec_definition.rs
+++ b/apollo-federation/src/link/cost_spec_definition.rs
@@ -1,6 +1,6 @@
 use apollo_compiler::ast::Argument;
 use apollo_compiler::ast::Directive;
-use apollo_compiler::collections::HashMap;
+use apollo_compiler::collections::IndexMap;
 use apollo_compiler::name;
 use apollo_compiler::schema::Component;
 use apollo_compiler::schema::EnumType;
@@ -40,7 +40,7 @@ macro_rules! propagate_demand_control_directives {
             subgraph_schema: &FederationSchema,
             source: &$directives_ty,
             dest: &mut $directives_ty,
-            original_directive_names: &HashMap<Name, Name>,
+            original_directive_names: &IndexMap<Name, Name>,
         ) -> Result<(), FederationError> {
             let cost_directive_name = original_directive_names.get(&COST_DIRECTIVE_NAME_IN_SPEC);
             let cost_directive = cost_directive_name.and_then(|name| source.get(name.as_str()));
@@ -74,7 +74,7 @@ macro_rules! propagate_demand_control_directives_to_position {
             subgraph_schema: &mut FederationSchema,
             source: &Node<$source_ty>,
             dest: &$dest_ty,
-            original_directive_names: &HashMap<Name, Name>,
+            original_directive_names: &IndexMap<Name, Name>,
         ) -> Result<(), FederationError> {
             let cost_directive_name = original_directive_names.get(&COST_DIRECTIVE_NAME_IN_SPEC);
             let cost_directive =

--- a/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
+++ b/apollo-federation/src/query_graph/extract_subgraphs_from_supergraph.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use apollo_compiler::ast::Argument;
 use apollo_compiler::ast::Directive;
 use apollo_compiler::ast::FieldDefinition;
-use apollo_compiler::collections::HashMap;
 use apollo_compiler::collections::IndexMap;
 use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable;
@@ -330,8 +329,8 @@ struct TypeInfos {
 /// when a custom directive's name conflicts with that of a default one.
 fn get_apollo_directive_names(
     supergraph_schema: &FederationSchema,
-) -> Result<HashMap<Name, Name>, FederationError> {
-    let mut hm: HashMap<Name, Name> = HashMap::default();
+) -> Result<IndexMap<Name, Name>, FederationError> {
+    let mut hm: IndexMap<Name, Name> = IndexMap::default();
     for directive in &supergraph_schema.schema().schema_definition.directives {
         if directive.name.as_str() == "link" {
             if let Ok(link) = Link::from_directive_application(directive) {
@@ -490,7 +489,7 @@ fn add_all_empty_subgraph_types(
     federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
     join_spec_definition: &'static JoinSpecDefinition,
     filtered_types: &Vec<TypeDefinitionPosition>,
-    original_directive_names: &HashMap<Name, Name>,
+    original_directive_names: &IndexMap<Name, Name>,
 ) -> Result<TypeInfos, FederationError> {
     let type_directive_definition =
         join_spec_definition.type_directive_definition(supergraph_schema)?;
@@ -792,7 +791,7 @@ fn extract_object_type_content(
     federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
     join_spec_definition: &JoinSpecDefinition,
     info: &[TypeInfo],
-    original_directive_names: &HashMap<Name, Name>,
+    original_directive_names: &IndexMap<Name, Name>,
 ) -> Result<(), FederationError> {
     let field_directive_definition =
         join_spec_definition.field_directive_definition(supergraph_schema)?;
@@ -968,7 +967,7 @@ fn extract_interface_type_content(
     federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
     join_spec_definition: &JoinSpecDefinition,
     info: &[TypeInfo],
-    original_directive_names: &HashMap<Name, Name>,
+    original_directive_names: &IndexMap<Name, Name>,
 ) -> Result<(), FederationError> {
     let field_directive_definition =
         join_spec_definition.field_directive_definition(supergraph_schema)?;
@@ -1256,7 +1255,7 @@ fn extract_enum_type_content(
     federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
     join_spec_definition: &JoinSpecDefinition,
     info: &[TypeInfo],
-    original_directive_names: &HashMap<Name, Name>,
+    original_directive_names: &IndexMap<Name, Name>,
 ) -> Result<(), FederationError> {
     // This was added in join 0.3, so it can genuinely be None.
     let enum_value_directive_definition =
@@ -1365,7 +1364,7 @@ fn extract_input_object_type_content(
     federation_spec_definitions: &IndexMap<Name, &'static FederationSpecDefinition>,
     join_spec_definition: &JoinSpecDefinition,
     info: &[TypeInfo],
-    original_directive_names: &HashMap<Name, Name>,
+    original_directive_names: &IndexMap<Name, Name>,
 ) -> Result<(), FederationError> {
     let field_directive_definition =
         join_spec_definition.field_directive_definition(supergraph_schema)?;
@@ -1472,7 +1471,7 @@ fn add_subgraph_field(
     is_shareable: bool,
     field_directive_application: Option<&FieldDirectiveArguments>,
     cost_spec_definition: Option<&'static CostSpecDefinition>,
-    original_directive_names: &HashMap<Name, Name>,
+    original_directive_names: &IndexMap<Name, Name>,
 ) -> Result<(), FederationError> {
     let field_directive_application =
         field_directive_application.unwrap_or_else(|| &FieldDirectiveArguments {
@@ -1587,7 +1586,7 @@ fn add_subgraph_input_field(
     subgraph: &mut FederationSubgraph,
     field_directive_application: Option<&FieldDirectiveArguments>,
     cost_spec_definition: Option<&'static CostSpecDefinition>,
-    original_directive_names: &HashMap<Name, Name>,
+    original_directive_names: &IndexMap<Name, Name>,
 ) -> Result<(), FederationError> {
     let field_directive_application =
         field_directive_application.unwrap_or_else(|| &FieldDirectiveArguments {


### PR DESCRIPTION
Reverts apollographql/router#5847

We won't need this anymore with a bigger refactor cleaning up compilation instead