### PR TITLE
feat(federation): respect the `subgraph_graphql_validation` option

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -3955,7 +3955,7 @@ impl TryFrom<Operation> for Valid<executable::ExecutableDocument> {
         document.fragments = fragments;
         document.operations.insert(operation);
         coerce_executable_values(value.schema.schema(), &mut document);
-        Ok(document.validate(value.schema.schema())?)
+        Ok(Valid::assume_valid(document))
     }
 }
 

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -3934,7 +3934,7 @@ impl From<&FragmentSpreadSelection> for executable::FragmentSpread {
     }
 }
 
-impl TryFrom<Operation> for Valid<executable::ExecutableDocument> {
+impl TryFrom<Operation> for executable::ExecutableDocument {
     type Error = FederationError;
 
     fn try_from(value: Operation) -> Result<Self, Self::Error> {
@@ -3955,7 +3955,17 @@ impl TryFrom<Operation> for Valid<executable::ExecutableDocument> {
         document.fragments = fragments;
         document.operations.insert(operation);
         coerce_executable_values(value.schema.schema(), &mut document);
-        Ok(Valid::assume_valid(document))
+        Ok(document)
+    }
+}
+
+impl TryFrom<Operation> for Valid<executable::ExecutableDocument> {
+    type Error = FederationError;
+
+    fn try_from(value: Operation) -> Result<Self, Self::Error> {
+        let schema = value.schema.clone();
+        let document: executable::ExecutableDocument = value.try_into()?;
+        Ok(document.validate(schema.schema())?)
     }
 }
 


### PR DESCRIPTION
- validate subgraph queries only when `subgraph_graphql_validation` configuration option is true.

<!-- [ROUTER-667] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-667]: https://apollographql.atlassian.net/browse/ROUTER-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ