### PR TITLE
added `cost` in `QueryPlan` struct

### DIFF
--- a/apollo-federation/src/query_plan/display.rs
+++ b/apollo-federation/src/query_plan/display.rs
@@ -10,6 +10,7 @@ impl QueryPlan {
     fn write_indented(&self, state: &mut State<'_, '_>) -> fmt::Result {
         let Self {
             node,
+            cost: _,
             statistics: _,
         } = self;
         state.write("QueryPlan {")?;

--- a/apollo-federation/src/query_plan/mod.rs
+++ b/apollo-federation/src/query_plan/mod.rs
@@ -21,6 +21,8 @@ pub type QueryPlanCost = f64;
 #[derive(Debug, Default, PartialEq, Serialize)]
 pub struct QueryPlan {
     pub node: Option<TopLevelPlanNode>,
+    /// `cost` can be NaN, if the cost is not computed or irrelevant.
+    pub cost: QueryPlanCost,
     pub statistics: QueryPlanningStatistics,
 }
 
@@ -251,9 +253,14 @@ pub enum QueryPathElement {
 }
 
 impl QueryPlan {
-    fn new(node: impl Into<TopLevelPlanNode>, statistics: QueryPlanningStatistics) -> Self {
+    fn new(
+        node: impl Into<TopLevelPlanNode>,
+        cost: QueryPlanCost,
+        statistics: QueryPlanningStatistics,
+    ) -> Self {
         Self {
             node: Some(node.into()),
+            cost,
             statistics,
         }
     }

--- a/apollo-router/src/query_planner/convert.rs
+++ b/apollo-router/src/query_planner/convert.rs
@@ -12,6 +12,7 @@ use crate::query_planner::subscription;
 pub(crate) fn convert_root_query_plan_node(js: &next::QueryPlan) -> Option<plan::PlanNode> {
     let next::QueryPlan {
         node,
+        cost: _,
         statistics: _,
     } = js;
     option(node)


### PR DESCRIPTION
This is not used yet, but we can use it for tests and (later) QP comparison.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests