### PR TITLE
chore(federation): address two TODOs in `build_query_plan`

### DIFF
--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -4,6 +4,7 @@ use std::fmt::Display;
 use std::fmt::Formatter;
 use std::fmt::Write;
 
+use apollo_compiler::executable::GetOperationError;
 use apollo_compiler::validation::DiagnosticList;
 use apollo_compiler::validation::WithErrors;
 use apollo_compiler::InvalidNameError;
@@ -56,6 +57,8 @@ pub enum SingleFederationError {
     InvalidGraphQLName(#[from] InvalidNameError),
     #[error("Subgraph invalid: {message}")]
     InvalidSubgraph { message: String },
+    #[error("Operation name not found")]
+    UnknownOperation,
     #[error("{message}")]
     DirectiveDefinitionInvalid { message: String },
     #[error("{message}")]
@@ -225,6 +228,7 @@ impl SingleFederationError {
             SingleFederationError::InvalidGraphQL { .. }
             | SingleFederationError::InvalidGraphQLName(_) => ErrorCode::InvalidGraphQL,
             SingleFederationError::InvalidSubgraph { .. } => ErrorCode::InvalidGraphQL,
+            SingleFederationError::UnknownOperation => ErrorCode::InvalidGraphQL,
             SingleFederationError::DirectiveDefinitionInvalid { .. } => {
                 ErrorCode::DirectiveDefinitionInvalid
             }
@@ -403,6 +407,12 @@ impl SingleFederationError {
 impl From<InvalidNameError> for FederationError {
     fn from(err: InvalidNameError) -> Self {
         SingleFederationError::from(err).into()
+    }
+}
+
+impl From<GetOperationError> for FederationError {
+    fn from(_: GetOperationError) -> Self {
+        SingleFederationError::UnknownOperation.into()
     }
 }
 

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -330,15 +330,11 @@ impl QueryPlanner {
         document: &Valid<ExecutableDocument>,
         operation_name: Option<Name>,
     ) -> Result<QueryPlan, FederationError> {
-        let operation = document
-            .operations
-            .get(operation_name.as_ref().map(|name| name.as_str()))
-            // TODO(@goto-bus-stop) this is not an internal error, but a user error
-            .map_err(|_| FederationError::internal("requested operation does not exist"))?;
+        let operation = document.operations.get(operation_name.as_ref().map(|name| name.as_str()))?;
 
-        if operation.selection_set.selections.is_empty() {
+        if operation.selection_set.is_empty() {
             // This should never happen because `operation` comes from a known-valid document.
-            // TODO(@goto-bus-stop) it's probably fair to panic here :)
+            // We could panic here but we are returning a `Result` already anyways, so shrug!
             return Err(FederationError::internal(
                 "Invalid operation: empty selection set",
             ));
@@ -413,7 +409,7 @@ impl QueryPlanner {
         };
         */
 
-        if normalized_operation.selection_set.selections.is_empty() {
+        if normalized_operation.selection_set.is_empty() {
             return Ok(QueryPlan::default());
         }
 

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -330,7 +330,9 @@ impl QueryPlanner {
         document: &Valid<ExecutableDocument>,
         operation_name: Option<Name>,
     ) -> Result<QueryPlan, FederationError> {
-        let operation = document.operations.get(operation_name.as_ref().map(|name| name.as_str()))?;
+        let operation = document
+            .operations
+            .get(operation_name.as_ref().map(|name| name.as_str()))?;
 
         if operation.selection_set.is_empty() {
             // This should never happen because `operation` comes from a known-valid document.


### PR DESCRIPTION
Two small TODO comments.
- Return a `FederationError::UnknownOperation` when passed an operation name that does not exist.
- Remove the panic comment about empty selection sets: panicking doesn't add anything there, though it is technically unreachable.
