### PR TITLE
Switch from askama to rinja

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,6 @@ dependencies = [
  "apollo-compiler",
  "apollo-federation",
  "arc-swap",
- "askama",
  "async-channel 1.9.0",
  "async-compression",
  "async-trait",
@@ -334,6 +333,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rhai",
+ "rinja",
  "rmp",
  "router-bridge",
  "rowan",
@@ -495,50 +495,6 @@ name = "ascii_utils"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
-
-[[package]]
-name = "askama"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
-dependencies = [
- "askama_derive",
- "askama_escape",
- "humansize",
- "num-traits",
- "percent-encoding",
-]
-
-[[package]]
-name = "askama_derive"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
-dependencies = [
- "askama_parser",
- "basic-toml",
- "mime",
- "mime_guess",
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.71",
-]
-
-[[package]]
-name = "askama_escape"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
-
-[[package]]
-name = "askama_parser"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
-dependencies = [
- "nom",
-]
 
 [[package]]
 name = "assert-json-diff"
@@ -2321,7 +2277,7 @@ dependencies = [
  "lazy_static",
  "mintex",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "thousands",
@@ -4525,6 +4481,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "once_map"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa7085055bbe9c8edbd982048dbcf8181794d4a81cb04a11931673e63cc18dc6"
+dependencies = [
+ "ahash",
+ "hashbrown 0.14.5",
+ "parking_lot",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5757,6 +5725,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "rinja"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277b2c2c91c4837a83e294e915853a3045bfc916940985e8bd6895bbc2805e0"
+dependencies = [
+ "humansize",
+ "itoa",
+ "num-traits",
+ "percent-encoding",
+ "rinja_derive",
+]
+
+[[package]]
+name = "rinja_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e122959e84d33680230169545c71498b8f162612c3a448006f746477c05062d7"
+dependencies = [
+ "basic-toml",
+ "memchr",
+ "mime",
+ "mime_guess",
+ "once_map",
+ "proc-macro2",
+ "quote",
+ "rinja_parser",
+ "rustc-hash 2.0.0",
+ "serde",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "rinja_parser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "530f3486f922197485c273f317c73a547f9e358cd8f9f421acdd935dec4c845e"
+dependencies = [
+ "memchr",
+ "nom",
+ "serde",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5836,7 +5847,7 @@ dependencies = [
  "countme",
  "hashbrown 0.14.5",
  "memoffset 0.9.1",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "text-size",
 ]
 
@@ -5899,6 +5910,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
 
 [[package]]
 name = "rustc_version"

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -64,7 +64,6 @@ ci = []
 features = ["docs_rs"]
 
 [dependencies]
-askama = "0.12.1"
 access-json = "0.1.0"
 anyhow = "1.0.86"
 apollo-compiler.workspace = true
@@ -138,6 +137,7 @@ notify = { version = "6.1.1", default-features = false, features = [
 nu-ansi-term = "0.49"
 num-traits = "0.2.19"
 once_cell = "1.19.0"
+rinja = "0.3.1"
 
 # Pin rowan to a version pre-MSRV bump. Remove if we update our rust-toolchain.
 rowan = "= 0.15.15"

--- a/apollo-router/src/services/layers/static_page.rs
+++ b/apollo-router/src/services/layers/static_page.rs
@@ -5,7 +5,6 @@
 
 use std::ops::ControlFlow;
 
-use askama::Template;
 use bytes::Bytes;
 use http::header::CONTENT_TYPE;
 use http::HeaderMap;
@@ -15,6 +14,7 @@ use mediatype::names::HTML;
 use mediatype::names::TEXT;
 use mediatype::MediaType;
 use mediatype::MediaTypeList;
+use rinja::Template;
 use tower::BoxError;
 use tower::Layer;
 use tower::Service;

--- a/licenses.html
+++ b/licenses.html
@@ -7364,10 +7364,10 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/djc/askama ">askama</a></li>
-                    <li><a href=" https://github.com/djc/askama ">askama_derive</a></li>
-                    <li><a href=" https://github.com/djc/askama ">askama_escape</a></li>
-                    <li><a href=" https://github.com/djc/askama ">askama_parser</a></li>
+                    <li><a href=" https://github.com/rinja-rs/rinja ">rinja</a></li>
+                    <li><a href=" https://github.com/rinja-rs/rinja ">rinja_derive</a></li>
+                    <li><a href=" https://github.com/rinja-rs/rinja ">rinja_escape</a></li>
+                    <li><a href=" https://github.com/rinja-rs/rinja ">rinja_parser</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004

--- a/xtask/src/commands/release/process.rs
+++ b/xtask/src/commands/release/process.rs
@@ -488,7 +488,7 @@ impl Process {
             .status()?;
 
         //Step 15
-        //FIXME: replace this step with an askama template
+        //FIXME: replace this step with a rinja template
         let perl = which::which("perl")?;
         let output = std::process::Command::new(&perl)
             .args([
@@ -754,7 +754,7 @@ impl Process {
         println!("{}", style("Updating release notes").bold().bright());
 
         // step 15
-        //FIXME: replace this step with an askama template
+        //FIXME: replace this step with a rinja template
         let perl = which::which("perl")?;
         let output = std::process::Command::new(&perl)
             .args([


### PR DESCRIPTION
Recently, me and another `askama` maintainer forked the project into `rinja`. For more details about the why, I wrote a blog post [here](https://blog.guillaume-gomez.fr/articles/2024-07-31+docs.rs+switching+jinja+template+framework+from+tera+to+rinja). But in short: `rinja` is ahead of `askama` now in a lot of areas so I think going forward, your project will benefit more from it.

If you're not interested about this switch, don't hesitate to close the PR.

If you want more information about `rinja`, don't hesitate to ask!