### PR TITLE
Allow sending the `subgraph.graphql.document` attribute to Studio via OTLP

### DIFF
--- a/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
+++ b/apollo-router/src/plugins/telemetry/tracing/apollo_telemetry.rs
@@ -62,6 +62,7 @@ use crate::plugins::telemetry::apollo_otlp_exporter::ApolloOtlpExporter;
 use crate::plugins::telemetry::config::ApolloMetricsReferenceMode;
 use crate::plugins::telemetry::config::Sampler;
 use crate::plugins::telemetry::config::SamplerOption;
+use crate::plugins::telemetry::config_new::attributes::SUBGRAPH_GRAPHQL_DOCUMENT;
 use crate::plugins::telemetry::config_new::cost::APOLLO_PRIVATE_COST_ACTUAL;
 use crate::plugins::telemetry::config_new::cost::APOLLO_PRIVATE_COST_ESTIMATED;
 use crate::plugins::telemetry::config_new::cost::APOLLO_PRIVATE_COST_RESULT;
@@ -150,9 +151,10 @@ const REPORTS_INCLUDE_ATTRS: [Key; 26] = [
 ];
 
 /// Additional attributes to include when sending to the OTLP protocol.
-const OTLP_EXT_INCLUDE_ATTRS: [Key; 5] = [
+const OTLP_EXT_INCLUDE_ATTRS: [Key; 6] = [
     OPERATION_SUBTYPE,
     EXT_TRACE_ID,
+    SUBGRAPH_GRAPHQL_DOCUMENT,
     opentelemetry_semantic_conventions::trace::HTTP_REQUEST_BODY_SIZE,
     opentelemetry_semantic_conventions::trace::HTTP_RESPONSE_BODY_SIZE,
     opentelemetry_semantic_conventions::trace::HTTP_RESPONSE_STATUS_CODE,


### PR DESCRIPTION
There is valuable information in OTel traces that is not being passed to Studio, specifically the GraphQL document being sent to a subgraph.  Today, we filter this attribute out from the Studio path.  

After this change, if a user is using the “recommended” attribute config or enables this with a specific attribute configuration, Router would allow the subgraph document to flow through to traces sent to Studio.  e.g.
```yaml
telemetry:
  instrumentation:
    spans:
      default_attribute_requirement_level: recommended
```

or
```yaml
telemetry:
  instrumentation:
    spans:
      subgraph:
        attributes:
          subgraph.graphql.document: true
```
We should decide if this is something that would make sense to enable.  There are potential downsides:

- More data will be sent on the wire to Studio to capture these GraphQL document payloads.
- Potentially PII could be included in any inline variables  

![image](https://github.com/user-attachments/assets/4b2e53f7-6d8f-434b-876b-708fa714cbea)

I'd feel less concerned about this if it was:
- Fully opt-in rather than being included with our "recommended" options
- Using the normalized operation string instead of the raw document

Fixes #**issue_number**

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
