### PR TITLE
fix(federation): treat invalid subgraph operations as internal errors

### DIFF
--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2468,16 +2468,14 @@ impl FetchDependencyGraphNode {
         };
         let operation =
             operation_compression.compress(&self.subgraph_name, subgraph_schema, operation)?;
-        let operation_document = operation.try_into().map_err(|err| {
-            match err {
-                FederationError::SingleFederationError {
-                    inner: SingleFederationError::InvalidGraphQL { diagnostics },
-                    ..
-                } => {
-                    FederationError::internal(format!("Query planning produced an invalid subgraph operation.\n{diagnostics}"))
-                }
-                _ => err
-            }
+        let operation_document = operation.try_into().map_err(|err| match err {
+            FederationError::SingleFederationError {
+                inner: SingleFederationError::InvalidGraphQL { diagnostics },
+                ..
+            } => FederationError::internal(format!(
+                "Query planning produced an invalid subgraph operation.\n{diagnostics}"
+            )),
+            _ => err,
         })?;
 
         let node = super::PlanNode::Fetch(Box::new(super::FetchNode {

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2468,7 +2468,17 @@ impl FetchDependencyGraphNode {
         };
         let operation =
             operation_compression.compress(&self.subgraph_name, subgraph_schema, operation)?;
-        let operation_document = operation.try_into()?;
+        let operation_document = operation.try_into().map_err(|err| {
+            match err {
+                FederationError::SingleFederationError {
+                    inner: SingleFederationError::InvalidGraphQL { diagnostics },
+                    ..
+                } => {
+                    FederationError::internal(format!("Query planning produced an invalid subgraph operation.\n{diagnostics}"))
+                }
+                _ => err
+            }
+        })?;
 
         let node = super::PlanNode::Fetch(Box::new(super::FetchNode {
             subgraph_name: self.subgraph_name.clone(),


### PR DESCRIPTION
Currently, if we produce an invalid subgraph operation, it looks exactly the same as a validation error from the input query. This makes issues harder to debug.

This PR turns validation errors at the end of planning into internal errors, so we know where they come from, and so end users do not get confused about what a validation error means. The new error explicitly mentions that it's a bug in the query planner that should be reported to Apollo.

It's not possible to add a test for this, as it only triggers for bugs. I manually tested it with the bug that's fixed in #5785:

```
Details: Query planning produced an invalid subgraph operation.
Error: fragSpreadOnly directive is not supported for INLINE_FRAGMENT location
```