### PR TITLE
Add ability to reference request context values in headers

### DIFF
--- a/apollo-federation/src/sources/connect/header.rs
+++ b/apollo-federation/src/sources/connect/header.rs
@@ -113,7 +113,7 @@ fn identifier(input: &str) -> IResult<&str, &str> {
 }
 
 fn namespace(input: &str) -> IResult<&str, &str> {
-    recognize(tag("$config"))(input)
+    recognize(alt((tag("$config"), tag("$context"))))(input)
 }
 
 fn path(input: &str) -> IResult<&str, &str> {

--- a/apollo-federation/src/sources/connect/header.rs
+++ b/apollo-federation/src/sources/connect/header.rs
@@ -113,7 +113,7 @@ fn identifier(input: &str) -> IResult<&str, &str> {
 }
 
 fn namespace(input: &str) -> IResult<&str, &str> {
-    recognize(alt((tag("$config"), tag("$request.context"))))(input)
+    recognize(alt((tag("$config"), tag("$context"))))(input)
 }
 
 fn path(input: &str) -> IResult<&str, &str> {

--- a/apollo-federation/src/sources/connect/header.rs
+++ b/apollo-federation/src/sources/connect/header.rs
@@ -113,7 +113,7 @@ fn identifier(input: &str) -> IResult<&str, &str> {
 }
 
 fn namespace(input: &str) -> IResult<&str, &str> {
-    recognize(alt((tag("$config"), tag("$context"))))(input)
+    recognize(alt((tag("$config"), tag("$request.context"))))(input)
 }
 
 fn path(input: &str) -> IResult<&str, &str> {

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -70,7 +70,7 @@ pub(crate) async fn handle_responses<T: HttpBody>(
                     let mut res_data = {
                         let (res, apply_to_errors) = response_key.selection().apply_with_vars(
                             &json_data,
-                            &response_key.inputs().merge(connector.config.as_ref()),
+                            &response_key.inputs().merge(connector.config.as_ref(), None),
                         );
 
                         if let Some(ref debug) = debug {

--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -32,13 +32,13 @@ impl RequestInputs {
     pub(crate) fn merge(
         &self,
         config: Option<&CustomConfiguration>,
-        context: Option<Map<ByteString, Value>>,
+        request_context: Option<Map<ByteString, Value>>,
     ) -> IndexMap<String, Value> {
         let mut map = IndexMap::with_capacity_and_hasher(3, Default::default());
         map.insert("$args".to_string(), Value::Object(self.args.clone()));
         map.insert("$this".to_string(), Value::Object(self.this.clone()));
-        if let Some(context) = context {
-            map.insert("$context".to_string(), json!(context));
+        if let Some(context) = request_context {
+            map.insert("$request.context".to_string(), json!(context));
         }
         if let Some(config) = config {
             map.insert("$config".to_string(), json!(config));

--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -32,13 +32,13 @@ impl RequestInputs {
     pub(crate) fn merge(
         &self,
         config: Option<&CustomConfiguration>,
-        request_context: Option<Map<ByteString, Value>>,
+        context: Option<Map<ByteString, Value>>,
     ) -> IndexMap<String, Value> {
         let mut map = IndexMap::with_capacity_and_hasher(3, Default::default());
         map.insert("$args".to_string(), Value::Object(self.args.clone()));
         map.insert("$this".to_string(), Value::Object(self.this.clone()));
-        if let Some(context) = request_context {
-            map.insert("$request.context".to_string(), json!(context));
+        if let Some(context) = context {
+            map.insert("$context".to_string(), json!(context));
         }
         if let Some(config) = config {
             map.insert("$config".to_string(), json!(config));

--- a/apollo-router/src/plugins/connectors/testdata/steelthread.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/steelthread.graphql
@@ -1,8 +1,9 @@
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION)
   @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
-  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "json", http: {baseURL: "https://jsonplaceholder.typicode.com/", headers: [{name: "x-new-name", from: "x-rename-source"}, {name: "x-forward", from: "x-forward"}, {name: "x-insert", value: "inserted"}, {name: "x-config-variable-source", value: "before {$config.source.val} after"}]}})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "json", http: {baseURL: "https://jsonplaceholder.typicode.com/", headers: [{name: "x-new-name", from: "x-rename-source"}, {name: "x-forward", from: "x-forward"}, {name: "x-insert", value: "inserted"}, {name: "x-config-variable-source", value: "before {$config.source.val} after"}, {name: "x-context-value-source", value: "before {$context.val} after"}]}})
 {
   query: Query
 }
@@ -67,7 +68,7 @@ type Query
   @join__type(graph: CONNECTORS)
   @join__type(graph: GRAPHQL)
 {
-  users: [User] @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users", headers: [{name: "x-new-name", from: "x-rename-connect"}, {name: "x-insert-multi-value", value: "first,second"}, {name: "x-config-variable-connect", value: "before {$config.connect.val} after"}]}, selection: "id name"})
+  users: [User] @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users", headers: [{name: "x-new-name", from: "x-rename-connect"}, {name: "x-insert-multi-value", value: "first,second"}, {name: "x-config-variable-connect", value: "before {$config.connect.val} after"}, {name: "x-context-value-connect", value: "before {$context.val} after"}]}, selection: "id name"})
   me: User @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users/{$config.id}"}, selection: "id\nname\nusername"})
   user(id: ID!): User @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users/{$args.id}"}, selection: "id\nname\nusername", entity: true})
   posts: [Post] @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/posts"}, selection: "id title user: { id: userId }"})

--- a/apollo-router/src/plugins/connectors/testdata/steelthread.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/steelthread.graphql
@@ -3,7 +3,7 @@ schema
   @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
   @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION)
   @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
-  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "json", http: {baseURL: "https://jsonplaceholder.typicode.com/", headers: [{name: "x-new-name", from: "x-rename-source"}, {name: "x-forward", from: "x-forward"}, {name: "x-insert", value: "inserted"}, {name: "x-config-variable-source", value: "before {$config.source.val} after"}, {name: "x-context-value-source", value: "before {$request.context.val} after"}]}})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "json", http: {baseURL: "https://jsonplaceholder.typicode.com/", headers: [{name: "x-new-name", from: "x-rename-source"}, {name: "x-forward", from: "x-forward"}, {name: "x-insert", value: "inserted"}, {name: "x-config-variable-source", value: "before {$config.source.val} after"}, {name: "x-context-value-source", value: "before {$context.val} after"}]}})
 {
   query: Query
 }
@@ -68,7 +68,7 @@ type Query
   @join__type(graph: CONNECTORS)
   @join__type(graph: GRAPHQL)
 {
-  users: [User] @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users", headers: [{name: "x-new-name", from: "x-rename-connect"}, {name: "x-insert-multi-value", value: "first,second"}, {name: "x-config-variable-connect", value: "before {$config.connect.val} after"}, {name: "x-context-value-connect", value: "before {$request.context.val} after"}]}, selection: "id name"})
+  users: [User] @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users", headers: [{name: "x-new-name", from: "x-rename-connect"}, {name: "x-insert-multi-value", value: "first,second"}, {name: "x-config-variable-connect", value: "before {$config.connect.val} after"}, {name: "x-context-value-connect", value: "before {$context.val} after"}]}, selection: "id name"})
   me: User @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users/{$config.id}"}, selection: "id\nname\nusername"})
   user(id: ID!): User @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users/{$args.id}"}, selection: "id\nname\nusername", entity: true})
   posts: [Post] @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/posts"}, selection: "id title user: { id: userId }"})

--- a/apollo-router/src/plugins/connectors/testdata/steelthread.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/steelthread.graphql
@@ -3,7 +3,7 @@ schema
   @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
   @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION)
   @join__directive(graphs: [CONNECTORS], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect", "@source"]})
-  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "json", http: {baseURL: "https://jsonplaceholder.typicode.com/", headers: [{name: "x-new-name", from: "x-rename-source"}, {name: "x-forward", from: "x-forward"}, {name: "x-insert", value: "inserted"}, {name: "x-config-variable-source", value: "before {$config.source.val} after"}, {name: "x-context-value-source", value: "before {$context.val} after"}]}})
+  @join__directive(graphs: [CONNECTORS], name: "source", args: {name: "json", http: {baseURL: "https://jsonplaceholder.typicode.com/", headers: [{name: "x-new-name", from: "x-rename-source"}, {name: "x-forward", from: "x-forward"}, {name: "x-insert", value: "inserted"}, {name: "x-config-variable-source", value: "before {$config.source.val} after"}, {name: "x-context-value-source", value: "before {$request.context.val} after"}]}})
 {
   query: Query
 }
@@ -68,7 +68,7 @@ type Query
   @join__type(graph: CONNECTORS)
   @join__type(graph: GRAPHQL)
 {
-  users: [User] @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users", headers: [{name: "x-new-name", from: "x-rename-connect"}, {name: "x-insert-multi-value", value: "first,second"}, {name: "x-config-variable-connect", value: "before {$config.connect.val} after"}, {name: "x-context-value-connect", value: "before {$context.val} after"}]}, selection: "id name"})
+  users: [User] @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users", headers: [{name: "x-new-name", from: "x-rename-connect"}, {name: "x-insert-multi-value", value: "first,second"}, {name: "x-config-variable-connect", value: "before {$config.connect.val} after"}, {name: "x-context-value-connect", value: "before {$request.context.val} after"}]}, selection: "id name"})
   me: User @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users/{$config.id}"}, selection: "id\nname\nusername"})
   user(id: ID!): User @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/users/{$args.id}"}, selection: "id\nname\nusername", entity: true})
   posts: [Post] @join__field(graph: CONNECTORS) @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/posts"}, selection: "id title user: { id: userId }"})

--- a/apollo-router/src/plugins/connectors/testdata/steelthread.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/steelthread.yaml
@@ -1,5 +1,5 @@
 # rover supergraph compose --config apollo-router/src/plugins/connectors/testdata/steelthread.yaml > apollo-router/src/plugins/connectors/testdata/steelthread.graphql
-federation_version: =2.9.0-connectors.12
+federation_version: =2.10.0-alpha.0
 subgraphs:
   connectors:
     routing_url: none
@@ -23,6 +23,7 @@ subgraphs:
                 { name: "x-forward" from: "x-forward" }
                 { name: "x-insert" value: "inserted" }
                 { name: "x-config-variable-source" value: "before {$$config.source.val} after" }
+                { name: "x-context-value-source", value: "before {$$context.val} after" }
               ]
             }
           )
@@ -37,6 +38,7 @@ subgraphs:
                  {name: "x-new-name", from: "x-rename-connect"}
                  {name: "x-insert-multi-value", value: "first,second"}
                  {name: "x-config-variable-connect" value: "before {$$config.connect.val} after"}
+                 {name: "x-context-value-connect", value: "before {$$context.val} after"}
                 ]
               }
               selection: "id name"

--- a/apollo-router/src/plugins/connectors/tests.rs
+++ b/apollo-router/src/plugins/connectors/tests.rs
@@ -594,6 +594,10 @@ async fn test_headers() {
             headers.insert("x-rename-connect", "renamed-by-connect".parse().unwrap());
             headers.insert("x-forward", "forwarded".parse().unwrap());
             headers.append("x-forward", "forwarded-again".parse().unwrap());
+            request
+                .context
+                .insert("val", String::from("val-from-request-context"))
+                .unwrap();
         },
     )
     .await;
@@ -633,6 +637,14 @@ async fn test_headers() {
             .header(
                 HeaderName::from_str("x-config-variable-connect").unwrap(),
                 HeaderValue::from_str("before val-from-config-connect after").unwrap(),
+            )
+            .header(
+                HeaderName::from_str("x-context-value-source").unwrap(),
+                HeaderValue::from_str("before val-from-request-context after").unwrap(),
+            )
+            .header(
+                HeaderName::from_str("x-context-value-connect").unwrap(),
+                HeaderValue::from_str("before val-from-request-context after").unwrap(),
             )
             .path("/users")
             .build()],


### PR DESCRIPTION

Add the ability to define headers for connectors that reference request context values. For example, this allows REST API calls made by connectors to include a header with the JWT claims added by a Coprocessor.

<!-- [CNN-417] -->

---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-417]: https://apollographql.atlassian.net/browse/CNN-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ