### PR TITLE
Add connectors HTTP metrics

### DIFF
--- a/apollo-router/src/services/connector_service.rs
+++ b/apollo-router/src/services/connector_service.rs
@@ -181,7 +181,7 @@ async fn execute(
             );
 
             u64_counter!(
-                "apollo.router.http.connector.requests.total",
+                "apollo.router.http.connector.requests",
                 "Total number of HTTP requests made through connectors",
                 1,
                 "status" = res.http_response.status().as_u16().to_string(),

--- a/apollo-router/tests/integration/telemetry/fixtures/connectors.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/connectors.router.yaml
@@ -1,0 +1,29 @@
+telemetry:
+  exporters:
+    metrics:
+      prometheus:
+        listen: 127.0.0.1:4000
+        enabled: true
+        path: /metrics
+      common:
+        views:
+          - name: apollo_router_http_request_duration_seconds
+            aggregation:
+              histogram:
+                buckets:
+                  - 0.1
+                  - 0.5
+                  - 1
+                  - 2
+                  - 3
+                  - 4
+                  - 5
+                  - 100
+include_subgraph_errors:
+  all: true
+preview_connectors:
+  subgraphs:
+    connectors:
+      sources:
+        json:
+          override_url: https://jsonplaceholder.typicode.com/


### PR DESCRIPTION
Add connectors HTTP metrics:

* `apollo_router_http_connector_requests_total` - counts requests by subgraph/connector/status
* `apollo_router_http_connector_request_duration_seconds` - a histogram of request times by subgraph/connector

Example metric data:

```
# HELP apollo_router_http_connector_request_duration_seconds Duration of connectors HTTP requests
# TYPE apollo_router_http_connector_request_duration_seconds histogram
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",subgraph="posts",otel_scope_name="apollo/router",le="0.001"} 0
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",subgraph="posts",otel_scope_name="apollo/router",le="0.005"} 0
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",subgraph="posts",otel_scope_name="apollo/router",le="0.015"} 0
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",subgraph="posts",otel_scope_name="apollo/router",le="0.05"} 2
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",subgraph="posts",otel_scope_name="apollo/router",le="0.1"} 2
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",subgraph="posts",otel_scope_name="apollo/router",le="0.2"} 3
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",subgraph="posts",otel_scope_name="apollo/router",le="0.3"} 3
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",subgraph="posts",otel_scope_name="apollo/router",le="0.4"} 3
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",subgraph="posts",otel_scope_name="apollo/router",le="0.5"} 3
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",subgraph="posts",otel_scope_name="apollo/router",le="1"} 3
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",subgraph="posts",otel_scope_name="apollo/router",le="5"} 3
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",subgraph="posts",otel_scope_name="apollo/router",le="10"} 3
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",subgraph="posts",otel_scope_name="apollo/router",le="+Inf"} 3
apollo_router_http_connector_request_duration_seconds_sum{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",subgraph="posts",otel_scope_name="apollo/router"} 0.175789542
apollo_router_http_connector_request_duration_seconds_count{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",subgraph="posts",otel_scope_name="apollo/router"} 3
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",subgraph="posts",otel_scope_name="apollo/router",le="0.001"} 0
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",subgraph="posts",otel_scope_name="apollo/router",le="0.005"} 0
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",subgraph="posts",otel_scope_name="apollo/router",le="0.015"} 0
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",subgraph="posts",otel_scope_name="apollo/router",le="0.05"} 2
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",subgraph="posts",otel_scope_name="apollo/router",le="0.1"} 2
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",subgraph="posts",otel_scope_name="apollo/router",le="0.2"} 2
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",subgraph="posts",otel_scope_name="apollo/router",le="0.3"} 2
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",subgraph="posts",otel_scope_name="apollo/router",le="0.4"} 3
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",subgraph="posts",otel_scope_name="apollo/router",le="0.5"} 3
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",subgraph="posts",otel_scope_name="apollo/router",le="1"} 3
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",subgraph="posts",otel_scope_name="apollo/router",le="5"} 3
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",subgraph="posts",otel_scope_name="apollo/router",le="10"} 3
apollo_router_http_connector_request_duration_seconds_bucket{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",subgraph="posts",otel_scope_name="apollo/router",le="+Inf"} 3
apollo_router_http_connector_request_duration_seconds_sum{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",subgraph="posts",otel_scope_name="apollo/router"} 0.433746667
apollo_router_http_connector_request_duration_seconds_count{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",subgraph="posts",otel_scope_name="apollo/router"} 3
# HELP apollo_router_http_connector_requests_total Total number of HTTP requests made through connectors
# TYPE apollo_router_http_connector_requests_total counter
apollo_router_http_connector_requests_total{connector="posts.jsonPlaceholder http: GET /users/{$args.id!}",status="200",subgraph="posts",otel_scope_name="apollo/router"} 3
apollo_router_http_connector_requests_total{connector="posts.jsonPlaceholder http: GET /users/{$this.id!}/posts",status="200",subgraph="posts",otel_scope_name="apollo/router"} 3
```

<!-- [CNN-238] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-238]: https://apollographql.atlassian.net/browse/CNN-238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ