### PR TITLE
docs: rename experimental query planner mode title

### DIFF
--- a/docs/source/configuration/experimental_query_planner_mode.mdx
+++ b/docs/source/configuration/experimental_query_planner_mode.mdx
@@ -1,5 +1,5 @@
 ---
-title: Experimental Query Planning Mode 
+title: Experimental Query Planner Mode 
 subtitle: Switch between legacy and native query planning
 noIndex: true
 ---


### PR DESCRIPTION
The file previously used "experimental query **planning** mode" instead of "experimental query **planner** mode", which did not match the feature flag name. This fixes the name to match the feature flag.