### PR TITLE
Remove preview icon from demand control sidebar

### DIFF
--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -69,7 +69,7 @@
         ],
         "Client Protocol: HTTP Multipart": ["/executing-operations/subscription-multipart-protocol", ["enterprise"]]
       },
-      "Demand Control": ["/executing-operations/demand-control", ["enterprise", "preview"]]
+      "Demand Control": ["/executing-operations/demand-control", ["enterprise"]]
     },
     "Telemetry and Monitoring": {
       "Overview": "/configuration/telemetry/overview",


### PR DESCRIPTION
Demand control is now a GA feature. This removes the preview feature icon from the documentation sidebar.