### PR TITLE
connectors: fix JSONSelection pretty printing

### DIFF
--- a/apollo-router/src/plugins/connectors/plugin.rs
+++ b/apollo-router/src/plugins/connectors/plugin.rs
@@ -200,10 +200,26 @@ impl ConnectorContext {
     }
 }
 
+/// JSONSelection Request / Response Data
+///
+/// Contains all needed info and responses from the application of a JSONSelection
 pub(crate) struct SelectionData {
+    /// The original [`JSONSelection`] to resolve
     pub(crate) source: String,
+
+    /// A mapping of the original selection, taking into account renames and other
+    /// transformations requested by the client
+    ///
+    /// Refer to [`Self::source`] for the original, schema-supplied selection.
     pub(crate) transformed: String,
+
+    /// The result of applying the selection to JSON. An empty value
+    /// here can potentially mean that errors were encountered.
+    ///
+    /// Refer to [`Self::errors`] for any errors found during evaluation
     pub(crate) result: Option<serde_json_bytes::Value>,
+
+    /// A list of errors encountered during evaluation.
     pub(crate) errors: Vec<ApplyToError>,
 }
 


### PR DESCRIPTION
This commit fixes top-level selections from being erroneously wrapped in `{}`, better matching what the user specified in the original schema.

It also adds a bit of documentation to structs encountered during the fix.

<!-- [CNN-403] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-403]: https://apollographql.atlassian.net/browse/CNN-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ