### PR TITLE
docs: Use specific URL examples in New Relic

### DIFF
--- a/docs/source/configuration/telemetry/exporters/metrics/new-relic.mdx
+++ b/docs/source/configuration/telemetry/exporters/metrics/new-relic.mdx
@@ -6,11 +6,19 @@ description: Configure the New Relic exporter for metrics via OpenTelemetry Prot
 
 Enable and configure the [OTLP exporter](./otlp) for metrics in the GraphOS Router or Apollo Router Core for use with [New Relic](https://newrelic.com/).
 
-For general tracing configuration, refer to [Router Metrics Configuration](./overview).
+For general metrics configuration, refer to [Router Metrics Configuration](./overview).
 
 ## New Relic configuration
 
-To configure the router, enable the [OTLP exporter](./otlp#configuration) and set `temporality: delta`, `endpoint: <new-relic-endpoint>` and `api-key: <new-relic-api-key>`. For example: 
+To configure the router, enable the [OTLP exporter](./otlp#configuration), with `temporality: delta`, and the appropriate endpoint and New Relic API key.
+
+<Note>
+
+For New Relic, `temporality: delta` must be set and the value of the `endpoint` **must** end with `/v1/metrics`.  The example below uses a common default for New Relic.  Check your New Relic account to verify the correct value as the actual domain may vary by region.
+
+</Note>
+
+For example: 
 
 ```yaml title="router.yaml"
 telemetry:
@@ -18,23 +26,19 @@ telemetry:
     metrics:
       otlp:
         enabled: true
+        protocol: grpc
+
         # Temporality MUST be set to delta. Failure to do this will result in incorrect metrics.
         temporality: delta
-        # Endpoint for your region.
-        endpoint: <new-relic-endpoint>
-        protocol: grpc
+
+        # Ensure the endpoint provided ends with "/v1/metrics"
+        # Be sure to use the correct URL for your region.
+        endpoint: https://otlp.nr-data.net:4317/v1/metrics
         grpc:
           metadata:
-            "api-key":
-              - <new-relic-api-key>
-
+            api-key:
+              - "<new-relic-api-key>"
 ```
-
-<Note>
-
-**You must set `temporality: delta`**, otherwise metrics will not be visible in New Relic.
-
-</Note>
 
 For more details about New Relic configuration, see [New Relic's docs on OpenTelemetry configuration](https://docs.newrelic.com/docs/more-integrations/open-source-telemetry-integrations/opentelemetry/get-started/opentelemetry-set-up-your-app/#review-settings).
 

--- a/docs/source/configuration/telemetry/exporters/metrics/new-relic.mdx
+++ b/docs/source/configuration/telemetry/exporters/metrics/new-relic.mdx
@@ -10,7 +10,7 @@ For general metrics configuration, refer to [Router Metrics Configuration](./ove
 
 ## New Relic configuration
 
-To configure the router, enable the [OTLP exporter](./otlp#configuration), with `temporality: delta`, and the appropriate endpoint and New Relic API key.
+To configure the router, enable the [OTLP exporter](./otlp#configuration) with `temporality: delta` and the appropriate endpoint and New Relic API key.
 
 <Note>
 


### PR DESCRIPTION
New Relic configuration requires the use of the trailing `/v1/metrics` values, not just the initial part of the URL.

<!-- [ROUTER-687] -->

[ROUTER-687]: https://apollographql.atlassian.net/browse/ROUTER-687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ