### PR TITLE
Refactor SelectionSet::merge_selections_into and remove unnecessary directives in Selection::from_element

### DIFF
--- a/apollo-federation/src/operation/merging.rs
+++ b/apollo-federation/src/operation/merging.rs
@@ -48,7 +48,7 @@ impl<'a> FieldSelectionValue<'a> {
         if self.get().selection_set.is_some() {
             let Some(other_selection_set) = &other.selection_set else {
                 return Err(FederationError::internal(format!(
-                    "Field \"{}\" has non-composite type but also has a selection set",
+                    "Field \"{}\" has composite type but not a selection set",
                     other_field.field_position,
                 )));
             };

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -2025,7 +2025,7 @@ impl SelectionSet {
             type_position,
             selections: Arc::new(SelectionMap::new()),
         };
-        merged.merge_selections_into(normalized_selections.iter())?;
+        merged.merge_selections_into(normalized_selections.iter(), false)?;
         Ok(merged)
     }
 
@@ -2122,7 +2122,7 @@ impl SelectionSet {
             type_position: self.type_position.clone(),
             selections: Arc::new(SelectionMap::new()),
         };
-        expanded.merge_selections_into(expanded_selections.iter())?;
+        expanded.merge_selections_into(expanded_selections.iter(), false)?;
         Ok(expanded)
     }
 
@@ -2651,7 +2651,7 @@ impl SelectionSet {
                     } else {
                         // add leaf
                         let selection = Selection::from_element(element, None)?;
-                        self.add_local_selection(&selection)?
+                        self.add_local_selection(&selection, true)?
                     }
                 } else {
                     let selection_set = selection_set
@@ -2667,7 +2667,7 @@ impl SelectionSet {
                         .transpose()?
                         .map(|selection_set| selection_set.without_unnecessary_fragments());
                     let selection = Selection::from_element(element, selection_set)?;
-                    self.add_local_selection(&selection)?
+                    self.add_local_selection(&selection, true)?
                 }
             }
             // If we don't have any path, we rebase and merge in the given sub selections at the root.

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -1701,6 +1701,16 @@ mod inline_fragment_selection {
                 selection_set: self.selection_set.clone(),
             }
         }
+        pub(crate) fn with_updated_directives_and_selection_set(
+            &self,
+            directives: impl Into<DirectiveList>,
+            selection_set: SelectionSet,
+        ) -> Self {
+            Self {
+                inline_fragment: self.inline_fragment.with_updated_directives(directives),
+                selection_set,
+            }
+        }
     }
 
     impl HasSelectionKey for InlineFragmentSelection {
@@ -2644,12 +2654,13 @@ impl SelectionSet {
                 let mut selection = Arc::make_mut(&mut self.selections)
                     .entry(ele.key())
                     .or_insert(|| {
+                        let unnecessary_directives = op_slice_condition_directives(path);
                         Selection::from_element(
                             element,
                             // We immediately add a selection afterward to make this selection set
                             // valid.
                             Some(SelectionSet::empty(self.schema.clone(), sub_selection_type)),
-                            None,
+                            Some(&unnecessary_directives),
                         )
                     })?;
                 match &mut selection {

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -794,22 +794,7 @@ impl Selection {
         // PORT_NOTE: This is TODO item is copied from the JS `selectionOfElement` function.
         // TODO: validate that the subSelection is ok for the element
         match element {
-            OpPathElement::Field(field) => {
-                if let Some(unnecessary_directives) = unnecessary_directives {
-                    let directives = field
-                        .directives
-                        .iter()
-                        .filter(|dir| !unnecessary_directives.contains(dir))
-                        .cloned()
-                        .collect::<DirectiveList>();
-                    Ok(Self::from_field(
-                        field.with_updated_directives(directives),
-                        sub_selections,
-                    ))
-                } else {
-                    Ok(Self::from_field(field, sub_selections))
-                }
-            }
+            OpPathElement::Field(field) => Ok(Self::from_field(field, sub_selections)),
             OpPathElement::InlineFragment(inline_fragment) => {
                 let Some(sub_selections) = sub_selections else {
                     return Err(FederationError::internal(

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -2066,7 +2066,7 @@ impl SelectionSet {
             type_position,
             selections: Arc::new(SelectionMap::new()),
         };
-        merged.merge_selections_into(normalized_selections.iter())?;
+        merged.merge_selections_into(normalized_selections.iter(), false)?;
         Ok(merged)
     }
 
@@ -2163,7 +2163,7 @@ impl SelectionSet {
             type_position: self.type_position.clone(),
             selections: Arc::new(SelectionMap::new()),
         };
-        expanded.merge_selections_into(expanded_selections.iter())?;
+        expanded.merge_selections_into(expanded_selections.iter(), false)?;
         Ok(expanded)
     }
 
@@ -2696,7 +2696,7 @@ impl SelectionSet {
                         // add leaf
                         let selection =
                             Selection::from_element(element, None, Some(&unneeded_directives))?;
-                        self.add_local_selection(&selection)?
+                        self.add_local_selection(&selection, true)?
                     }
                 } else {
                     let selection_set = selection_set
@@ -2717,7 +2717,7 @@ impl SelectionSet {
                         selection_set,
                         Some(&unneeded_directives),
                     )?;
-                    self.add_local_selection(&selection)?;
+                    self.add_local_selection(&selection, true)?;
                 }
             }
             // If we don't have any path, we rebase and merge in the given sub selections at the root.

--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -1007,7 +1007,7 @@ impl SelectionSet {
                 &fragment,
                 /*directives*/ &Default::default(),
             );
-            optimized.add_local_selection(&fragment_selection.into(), false)?;
+            optimized.add_local_selection(&fragment_selection.into())?;
         }
 
         optimized.add_local_selection_set(&not_covered_so_far)?;
@@ -1697,21 +1697,17 @@ impl FragmentGenerator {
                         self.visit_selection_set(selection_set)?;
                     }
                     new_selection_set
-                        .add_local_selection(&Selection::Field(Arc::clone(field.get())), false)?;
+                        .add_local_selection(&Selection::Field(Arc::clone(field.get())))?;
                 }
                 SelectionValue::FragmentSpread(frag) => {
-                    new_selection_set.add_local_selection(
-                        &Selection::FragmentSpread(Arc::clone(frag.get())),
-                        false,
-                    )?;
+                    new_selection_set
+                        .add_local_selection(&Selection::FragmentSpread(Arc::clone(frag.get())))?;
                 }
                 SelectionValue::InlineFragment(frag)
                     if !Self::is_worth_using(&frag.get().selection_set) =>
                 {
-                    new_selection_set.add_local_selection(
-                        &Selection::InlineFragment(Arc::clone(frag.get())),
-                        false,
-                    )?;
+                    new_selection_set
+                        .add_local_selection(&Selection::InlineFragment(Arc::clone(frag.get())))?;
                 }
                 SelectionValue::InlineFragment(mut candidate) => {
                     self.visit_selection_set(candidate.get_selection_set_mut())?;
@@ -1729,10 +1725,9 @@ impl FragmentGenerator {
                     // we can't just transfer them to the generated fragment spread,
                     // so we have to keep this inline fragment.
                     let Ok(skip_include) = skip_include else {
-                        new_selection_set.add_local_selection(
-                            &Selection::InlineFragment(Arc::clone(candidate.get())),
-                            false,
-                        )?;
+                        new_selection_set.add_local_selection(&Selection::InlineFragment(
+                            Arc::clone(candidate.get()),
+                        ))?;
                         continue;
                     };
 
@@ -1741,10 +1736,9 @@ impl FragmentGenerator {
                     // there's any directives on it. This code duplicates the body from the
                     // previous condition so it's very easy to remove when we're ready :)
                     if !skip_include.is_empty() {
-                        new_selection_set.add_local_selection(
-                            &Selection::InlineFragment(Arc::clone(candidate.get())),
-                            false,
-                        )?;
+                        new_selection_set.add_local_selection(&Selection::InlineFragment(
+                            Arc::clone(candidate.get()),
+                        ))?;
                         continue;
                     }
 
@@ -1769,8 +1763,8 @@ impl FragmentGenerator {
                         });
                         self.fragments.get(&name).unwrap()
                     };
-                    new_selection_set.add_local_selection(
-                        &Selection::from(FragmentSpreadSelection {
+                    new_selection_set.add_local_selection(&Selection::from(
+                        FragmentSpreadSelection {
                             spread: FragmentSpread::new(FragmentSpreadData {
                                 schema: selection_set.schema.clone(),
                                 fragment_name: existing.name.clone(),
@@ -1780,9 +1774,8 @@ impl FragmentGenerator {
                                 selection_id: crate::operation::SelectionId::new(),
                             }),
                             selection_set: existing.selection_set.clone(),
-                        }),
-                        false,
-                    )?;
+                        },
+                    ))?;
                 }
             }
         }

--- a/apollo-federation/src/operation/simplify.rs
+++ b/apollo-federation/src/operation/simplify.rs
@@ -460,7 +460,7 @@ impl SelectionSet {
             {
                 match selection_or_set {
                     SelectionOrSet::Selection(normalized_selection) => {
-                        normalized_selections.add_local_selection(&normalized_selection, false)?;
+                        normalized_selections.add_local_selection(&normalized_selection)?;
                     }
                     SelectionOrSet::SelectionSet(normalized_set) => {
                         // Since the `selection` has been expanded/lifted, we use

--- a/apollo-federation/src/operation/simplify.rs
+++ b/apollo-federation/src/operation/simplify.rs
@@ -460,7 +460,7 @@ impl SelectionSet {
             {
                 match selection_or_set {
                     SelectionOrSet::Selection(normalized_selection) => {
-                        normalized_selections.add_local_selection(&normalized_selection)?;
+                        normalized_selections.add_local_selection(&normalized_selection, false)?;
                     }
                     SelectionOrSet::SelectionSet(normalized_set) => {
                         // Since the `selection` has been expanded/lifted, we use

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -1204,7 +1204,7 @@ mod make_selection_tests {
                 base_selection_set.type_position.clone(),
                 selection.clone(),
             );
-            Selection::from_element(base.element().unwrap(), Some(subselections)).unwrap()
+            Selection::from_element(base.element().unwrap(), Some(subselections), None).unwrap()
         };
 
         let foo_with_a = clone_selection_at_path(foo, &[name!("a")]);
@@ -1331,7 +1331,7 @@ mod lazy_map_tests {
             let field_element =
                 Field::new_introspection_typename(s.schema(), &parent_type_pos, None);
             let typename_selection =
-                Selection::from_element(field_element.into(), /*subselection*/ None)?;
+                Selection::from_element(field_element.into(), /*subselection*/ None, None)?;
             // return `updated` and `typename_selection`
             Ok([updated, typename_selection].into_iter().collect())
         })

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -3656,6 +3656,18 @@ impl ClosedBranch {
     }
 }
 
+pub fn op_slice_condition_directives(path: &[Arc<OpPathElement>]) -> DirectiveList {
+    path.iter()
+        .flat_map(|path_element| {
+            path_element
+                .directives()
+                .iter()
+                .filter(|d| d.name == "include" || d.name == "skip")
+        })
+        .cloned()
+        .collect()
+}
+
 impl OpPath {
     pub fn len(&self) -> usize {
         self.0.len()
@@ -3678,16 +3690,7 @@ impl OpPath {
     }
 
     pub(crate) fn conditional_directives(&self) -> DirectiveList {
-        self.0
-            .iter()
-            .flat_map(|path_element| {
-                path_element
-                    .directives()
-                    .iter()
-                    .filter(|d| d.name == "include" || d.name == "skip")
-            })
-            .cloned()
-            .collect()
+        op_slice_condition_directives(&self.0)
     }
 
     /// Filter any fragment element in the provided path whose type condition does not exist in the provided schema.

--- a/apollo-federation/src/query_plan/conditions.rs
+++ b/apollo-federation/src/query_plan/conditions.rs
@@ -10,7 +10,6 @@ use serde::Serialize;
 
 use crate::error::FederationError;
 use crate::operation::DirectiveList;
-use crate::operation::HasSelectionKey;
 use crate::operation::Selection;
 use crate::operation::SelectionMap;
 use crate::operation::SelectionSet;

--- a/apollo-federation/src/query_plan/conditions.rs
+++ b/apollo-federation/src/query_plan/conditions.rs
@@ -262,14 +262,12 @@ pub(crate) fn remove_unneeded_top_level_fragment_directives(
                     // if there is no type condition we should preserve the directive info
                     selection_map.insert(selection.clone());
                 } else {
-                    let mut needed_directives: Vec<Node<Directive>> = Vec::new();
-                    if fragment.directives.len() > 0 {
-                        for directive in fragment.directives.iter() {
-                            if !unneded_directives.contains(directive) {
-                                needed_directives.push(directive.clone());
-                            }
-                        }
-                    }
+                    let needed_directives: Vec<Node<Directive>> = fragment
+                        .directives
+                        .iter()
+                        .filter(|directive| !unneded_directives.contains(directive))
+                        .cloned()
+                        .collect();
 
                     // We recurse, knowing that we'll stop as soon as we hit field selections, so this only cover the fragments
                     // at the "top-level" of the set.

--- a/apollo-federation/src/query_plan/conditions.rs
+++ b/apollo-federation/src/query_plan/conditions.rs
@@ -283,8 +283,10 @@ pub(crate) fn remove_unneeded_top_level_fragment_directives(
                     } else {
                         // We can skip some of the fragment directives directive.
                         let final_selection = inline_fragment
-                            .with_updated_directives(DirectiveList::from_iter(needed_directives))
-                            .with_updated_selection_set(updated_selections);
+                            .with_updated_directives_and_selection_set(
+                                DirectiveList::from_iter(needed_directives),
+                                updated_selections,
+                            );
                         selection_map.insert(Selection::InlineFragment(Arc::new(final_selection)));
                     }
                 }

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2759,6 +2759,7 @@ fn operation_for_entities_fetch(
             sibling_typename: None,
         })),
         Some(selection_set),
+        None,
     )?;
 
     let type_position: CompositeTypeDefinitionPosition = subgraph_schema
@@ -2870,7 +2871,17 @@ impl FetchSelectionSet {
         path_in_node: &OpPath,
         selection_set: Option<&Arc<SelectionSet>>,
     ) -> Result<(), FederationError> {
-        Arc::make_mut(&mut self.selection_set).add_at_path(path_in_node, selection_set)?;
+        let target = Arc::make_mut(&mut self.selection_set);
+        target.add_at_path(path_in_node, selection_set)?;
+        /* Don't not work. Triggers an issue when turning set into a plan node
+        let restripped_selection_set = remove_unneeded_top_level_fragment_directives(
+            target,
+            &path_in_node.conditional_directives(),
+        )?;
+        if !restripped_selection_set.is_empty() {
+            *target = restripped_selection_set;
+        }
+        */
         // TODO: when calling this multiple times, maybe only re-compute conditions at the end?
         // Or make it lazily-initialized and computed on demand?
         self.conditions = self.selection_set.conditions()?;

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2873,15 +2873,6 @@ impl FetchSelectionSet {
     ) -> Result<(), FederationError> {
         let target = Arc::make_mut(&mut self.selection_set);
         target.add_at_path(path_in_node, selection_set)?;
-        /* Don't not work. Triggers an issue when turning set into a plan node
-        let restripped_selection_set = remove_unneeded_top_level_fragment_directives(
-            target,
-            &path_in_node.conditional_directives(),
-        )?;
-        if !restripped_selection_set.is_empty() {
-            *target = restripped_selection_set;
-        }
-        */
         // TODO: when calling this multiple times, maybe only re-compute conditions at the end?
         // Or make it lazily-initialized and computed on demand?
         self.conditions = self.selection_set.conditions()?;

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/requires/include_skip.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/requires/include_skip.rs
@@ -1,13 +1,11 @@
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure (redundant inline spread)
 fn it_handles_a_simple_at_requires_triggered_within_a_conditional() {
     let planner = planner!(
         Subgraph1: r#"
             type Query {
               t: T
             }
-  
+
             type T @key(fields: "id") {
               id: ID!
               a: Int
@@ -73,7 +71,7 @@ fn it_handles_an_at_requires_triggered_conditionally() {
             type Query {
               t: T
             }
-  
+
             type T @key(fields: "id") {
               id: ID!
               a: Int
@@ -143,7 +141,7 @@ fn it_handles_an_at_requires_where_multiple_conditional_are_involved() {
             type Query {
               a: A
             }
-  
+
             type A @key(fields: "idA") {
               idA: ID!
             }
@@ -153,7 +151,7 @@ fn it_handles_an_at_requires_where_multiple_conditional_are_involved() {
               idA: ID!
               b: [B]
             }
-  
+
             type B @key(fields: "idB") {
               idB: ID!
               required: Int

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_a_simple_at_requires_triggered_within_a_conditional.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_a_simple_at_requires_triggered_within_a_conditional.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: d6db359dab5222fd4d4da957d4ece13e5dee392f
+# Composed from subgraphs with hash: 0e4eac66a889724333f86a54a0647cc4f694f511
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_an_at_requires_triggered_conditionally.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_an_at_requires_triggered_conditionally.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: d6db359dab5222fd4d4da957d4ece13e5dee392f
+# Composed from subgraphs with hash: 0e4eac66a889724333f86a54a0647cc4f694f511
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)

--- a/apollo-federation/tests/query_plan/supergraphs/it_handles_an_at_requires_where_multiple_conditional_are_involved.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_handles_an_at_requires_where_multiple_conditional_are_involved.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: cc5702c4822eb337c8ae95605bcb51812750cff8
+# Composed from subgraphs with hash: 2ea9dba0e4a9f205821228485cdd112ca0b0c17a
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)


### PR DESCRIPTION
This PR introduces two optimizations to `SelectionSet::merge_selections_into`.

The simpler of the two removes the intermediate buffers used in the method. Now, selections whose keys already exist in the selection map are immediately merged together. This means there is more recursion but no allocating buffers. It remains unclear if this will have any performance impact (positive or negative), but it simplifies the code by a fair amount. Because of this, all of the `*SelectionValue::merge_into` methods have also be refactored to take a single selection rather than an iterator. This removes more intermediate buffering.

The second change, which actually relates to the ticket, adds logic to `Selection::from_element` to remove optionally unnecessary directives from the element. The intention of this is to remove `@include`/`@skip` directives. There is already logic to remove these directives from the selection set beforehand, but this is incomplete without also removing those directives from the element that it is paired with to form a `Selection`.

<!-- Fixes [ROTUER-648](https://apollographql.atlassian.net/browse/ROUTER-648) -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
