### PR TITLE
Remove `test_updated` from release workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1101,20 +1101,6 @@ workflows:
               ignore: /.*/
             tags:
               only: /v.*/
-      - test_updated:
-          requires:
-            - lint
-            - check_helm
-            - check_compliance
-          matrix:
-            parameters:
-              platform:
-                [ amd_linux_test ]
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /v.*/
       - test:
           requires:
             - lint
@@ -1133,7 +1119,6 @@ workflows:
           requires:
             - pre_verify_release
             - test
-            - test_updated
           matrix:
             parameters:
               platform:


### PR DESCRIPTION
We've had a couple of releases blocked at the final step by this job, because some dependency updates their MSRV. We use `Cargo.lock` to build our binaries, so it shouldn't matter if we can't pass tests on the _latest_ versions of those dependencies.