### PR TITLE
docs: Clarify terminating client requests with Rhai exception must be thrown from supergraph

### DIFF
--- a/docs/source/customizations/rhai-api.mdx
+++ b/docs/source/customizations/rhai-api.mdx
@@ -54,10 +54,11 @@ log_trace("trace-level log message");
 
 ## Terminating client requests
 
-Your Rhai script can terminate the associated client request that triggered it. To do so, it throws an exception. This returns an `Internal Server Error` to the client with a `500` response code.
+Your Rhai script can terminate the associated client request that triggered it. To do so, it must throw an exception from the supergraph service. This returns an `Internal Server Error` to the client with a `500` response code.
 
 For example:
 ```rhai
+// Must throw exception from supergraph service
 fn supergraph_service(service) {
     // Define a closure to process our response
     let f = |response| {
@@ -75,6 +76,7 @@ The key must be a number and the message must be something which can be converte
 
 For example:
 ```rhai
+// Must throw exception from supergraph service
 fn supergraph_service(service) {
     // Define a closure to process our response
     let f = |response| {
@@ -93,6 +95,7 @@ You can also `throw` a valid GraphQL response, which will be deserialized and de
 
 For example:
 ```rhai
+// Must throw exception from supergraph service
 fn supergraph_service(service) {
     // Define a closure to process our request
     let f = |request| {


### PR DESCRIPTION
Clarify in text and code samples that throwing exception to terminate client requests from Rhai must happen from supergraph service.