### PR TITLE
Remove `test_updated` from release workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1101,20 +1101,6 @@ workflows:
               ignore: /.*/
             tags:
               only: /v.*/
-      - test_updated:
-          requires:
-            - lint
-            - check_helm
-            - check_compliance
-          matrix:
-            parameters:
-              platform:
-                [ amd_linux_test ]
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /v.*/
       - test:
           requires:
             - lint
@@ -1133,7 +1119,6 @@ workflows:
           requires:
             - pre_verify_release
             - test
-            - test_updated
           matrix:
             parameters:
               platform:


### PR DESCRIPTION
Originally pointed at `dev`, but this test is designed to catch issues for consumers of the `apollo-router` crate, so we'd need to replace it with something else for that use-case.

Since `next` doesn't _have_ any crate consumers yet, it should be safe to remove it to speed along alphas. We can replace it once we don't have to be pinned to an older version of Rust anymore (soon on next 🤞) which will resolve most of the failures.

Since I'm thinking about it, when we replace it we should also move crate publishing to CI, since this is designed to protect the crates, not the binaries.