### PR TITLE
docs: remove preview from demand control in nav

### DIFF
--- a/docs/source/config.json
+++ b/docs/source/config.json
@@ -44,8 +44,7 @@
         "Demand Control" : [
           "/executing-operations/demand-control",
           [
-            "enterprise",
-            "preview"
+            "enterprise"
           ]
         ],
         "Privacy and Data Collection": "/privacy"
@@ -68,8 +67,7 @@
           ["enterprise", "preview"]
         ],
         "Client Protocol: HTTP Multipart": ["/executing-operations/subscription-multipart-protocol", ["enterprise"]]
-      },
-      "Demand Control": ["/executing-operations/demand-control", ["enterprise", "preview"]]
+      }
     },
     "Telemetry and Monitoring": {
       "Overview": "/configuration/telemetry/overview",


### PR DESCRIPTION
This PR removes the "Preview" icon next to demand control in the docs nav. It also removes the page from showing up from two places in the nav.