### PR TITLE
fix(federation): always update conditions on FetchSelectionSet updates

### DIFF
--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2479,7 +2479,8 @@ impl FetchDependencyGraphNode {
         })?;
 
         // this function removes unnecessary pieces of the query plan requires selection set.
-        fn trim_requires_selection_node(
+        // PORT NOTE: this function was called trimSelectioNodes in the JS implementation
+        fn trim_requires_selection_set(
             selection_set: &executable::SelectionSet,
         ) -> Vec<executable::Selection> {
             selection_set
@@ -2488,7 +2489,7 @@ impl FetchDependencyGraphNode {
                 .filter_map(|s| match s {
                     executable::Selection::Field(field) => Some(executable::Selection::from(
                         executable::Field::new(field.name.clone(), field.definition.clone())
-                            .with_selections(trim_requires_selection_node(&field.selection_set)),
+                            .with_selections(trim_requires_selection_set(&field.selection_set)),
                     )),
                     executable::Selection::InlineFragment(inline_fragment) => {
                         let new_fragment = if inline_fragment.type_condition.is_some() {
@@ -2500,7 +2501,7 @@ impl FetchDependencyGraphNode {
                                 inline_fragment.selection_set.ty.clone(),
                             )
                         }
-                        .with_selections(trim_requires_selection_node(
+                        .with_selections(trim_requires_selection_set(
                             &inline_fragment.selection_set,
                         ));
                         Some(executable::Selection::from(new_fragment))
@@ -2517,7 +2518,7 @@ impl FetchDependencyGraphNode {
                 .as_ref()
                 .map(executable::SelectionSet::try_from)
                 .transpose()?
-                .map(|selection_set| trim_requires_selection_node(&selection_set)),
+                .map(|selection_set| trim_requires_selection_set(&selection_set)),
             operation_document,
             operation_name,
             operation_kind: self.root_kind.into(),

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2881,6 +2881,9 @@ impl FetchSelectionSet {
 
     fn add_selections(&mut self, selection_set: &Arc<SelectionSet>) -> Result<(), FederationError> {
         Arc::make_mut(&mut self.selection_set).add_selection_set(selection_set)?;
+        // TODO: when calling this multiple times, maybe only re-compute conditions at the end?
+        // Or make it lazily-initialized and computed on demand?
+        self.conditions = self.selection_set.conditions()?;
         Ok(())
     }
 }

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -2492,18 +2492,18 @@ impl FetchDependencyGraphNode {
                             .with_selections(trim_requires_selection_set(&field.selection_set)),
                     )),
                     executable::Selection::InlineFragment(inline_fragment) => {
-                        let new_fragment = if inline_fragment.type_condition.is_some() {
-                            executable::InlineFragment::with_type_condition(
-                                inline_fragment.type_condition.clone().unwrap(),
-                            )
-                        } else {
-                            executable::InlineFragment::without_type_condition(
-                                inline_fragment.selection_set.ty.clone(),
-                            )
-                        }
-                        .with_selections(trim_requires_selection_set(
-                            &inline_fragment.selection_set,
-                        ));
+                        let new_fragment = inline_fragment
+                            .type_condition
+                            .clone()
+                            .map(executable::InlineFragment::with_type_condition)
+                            .unwrap_or_else(|| {
+                                executable::InlineFragment::without_type_condition(
+                                    inline_fragment.selection_set.ty.clone(),
+                                )
+                            })
+                            .with_selections(trim_requires_selection_set(
+                                &inline_fragment.selection_set,
+                            ));
                         Some(executable::Selection::from(new_fragment))
                     }
                     executable::Selection::FragmentSpread(_) => None,

--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -1079,3 +1079,327 @@ fn test_merging_fetches_reset_cached_costs() {
     "###
     );
 }
+
+
+#[test]
+fn handles_multiple_conditions_on_abstract_types() {
+    let planner = planner!(
+        agency: r#"
+        type Agency @key(fields: "id") {
+          id: ID!
+          companyName: String
+        }
+
+        type Group @key(fields: "id") {
+          id: ID!
+          name: String
+        }
+
+        extend union PublisherType = Agency | Group
+        "#,
+        books: r#"
+        type Book @key(fields: "id") {
+          id: ID!
+          title: String
+        }
+
+        type Query {
+          books: [Book]
+        }
+        "#,
+        inventory: r#"
+        interface Product {
+          id: ID!
+          dimensions: ProductDimension
+          delivery(zip: String): DeliveryEstimates
+        }
+
+        type Book implements Product @key(fields: "id") {
+          id: ID!
+          dimensions: ProductDimension @external
+          delivery(zip: String): DeliveryEstimates
+            @requires(fields: "dimensions { size weight }")
+        }
+
+        type Magazine implements Product @key(fields: "id") {
+          id: ID!
+          dimensions: ProductDimension @external
+          delivery(zip: String): DeliveryEstimates
+            @requires(fields: "dimensions { size weight }")
+        }
+
+        type ProductDimension @shareable {
+          size: String
+          weight: Float
+        }
+
+        type DeliveryEstimates {
+          estimatedDelivery: String
+          fastestDelivery: String
+        }
+        "#,
+        magazines: r#"
+        type Magazine @key(fields: "id") {
+          id: ID!
+          title: String
+        }
+
+        type Query {
+          magazines: [Magazine]
+        }
+        "#,
+        products: r#"
+        type Query {
+          products: [Product]
+          similar(id: ID!): [Product]
+        }
+
+        interface Product {
+          id: ID!
+          sku: String
+          dimensions: ProductDimension
+          createdBy: User
+          hidden: Boolean @inaccessible
+        }
+
+        interface Similar {
+          similar: [Product]
+        }
+
+        type ProductDimension @shareable {
+          size: String
+          weight: Float
+        }
+
+        type Book implements Product & Similar @key(fields: "id") {
+          id: ID!
+          sku: String
+          dimensions: ProductDimension @shareable
+          createdBy: User
+          similar: [Book]
+          hidden: Boolean
+          publisherType: PublisherType
+        }
+
+        type Magazine implements Product & Similar @key(fields: "id") {
+          id: ID!
+          sku: String
+          dimensions: ProductDimension @shareable
+          createdBy: User
+          similar: [Magazine]
+          hidden: Boolean
+          publisherType: PublisherType
+        }
+
+        union PublisherType = Agency | Self
+
+        type Agency {
+          id: ID! @shareable
+        }
+
+        type Self {
+          email: String
+        }
+
+        type User @key(fields: "email") {
+          email: ID!
+          totalProductsCreated: Int @shareable
+        }
+        "#,
+        reviews: r#"
+        type Book implements Product & Similar @key(fields: "id") {
+          id: ID!
+          reviewsCount: Int!
+          reviewsScore: Float! @shareable
+          reviews: [Review!]!
+          similar: [Book] @external
+          reviewsOfSimilar: [Review!]! @requires(fields: "similar { id }")
+        }
+
+        type Magazine implements Product & Similar @key(fields: "id") {
+          id: ID!
+          reviewsCount: Int!
+          reviewsScore: Float! @shareable
+          reviews: [Review!]!
+          similar: [Magazine] @external
+          reviewsOfSimilar: [Review!]! @requires(fields: "similar { id }")
+        }
+
+        interface Product {
+          id: ID!
+          reviewsCount: Int!
+          reviewsScore: Float!
+          reviews: [Review!]!
+        }
+
+        interface Similar {
+          similar: [Product]
+        }
+
+        type Query {
+          review(id: Int!): Review
+        }
+
+        type Review {
+          id: Int!
+          body: String!
+          product: Product
+        }
+        "#,
+        users: r#"
+        type User @key(fields: "email") {
+          email: ID!
+          name: String
+          totalProductsCreated: Int @shareable
+        }
+        "#,
+    );
+
+    assert_plan!(
+      &planner,
+      r#"
+      query ($title: Boolean = true) {
+        products {
+          id
+          reviews {
+            product {
+              id
+              ... on Book @include(if: $title) {
+                title
+                ... on Book @skip(if: $title) {
+                  sku
+                }
+              }
+              ... on Magazine {
+                sku
+              }
+            }
+          }
+        }
+      }
+      "#,
+      @r###"
+        QueryPlan {
+          Sequence {
+            Fetch(service: "products") {
+              {
+                products {
+                  __typename
+                  id
+                  ... on Book {
+                    __typename
+                    id
+                  }
+                  ... on Magazine {
+                    __typename
+                    id
+                  }
+                }
+              }
+            },
+            Flatten(path: "products.@") {
+              Fetch(service: "reviews") {
+                {
+                  ... on Book {
+                    __typename
+                    id
+                  }
+                  ... on Magazine {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on Book {
+                    reviews {
+                      product {
+                        __typename
+                        id
+                        ... on Book @include(if: $title) {
+                          __typename
+                          id
+                          ... on Book @skip(if: $title) {
+                            __typename
+                            id
+                          }
+                        }
+                        ... on Magazine {
+                          __typename
+                          id
+                        }
+                      }
+                    }
+                  }
+                  ... on Magazine {
+                    reviews {
+                      product {
+                        __typename
+                        id
+                        ... on Book @include(if: $title) {
+                          __typename
+                          id
+                          ... on Book @skip(if: $title) {
+                            __typename
+                            id
+                          }
+                        }
+                        ... on Magazine {
+                          __typename
+                          id
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+            },
+            Parallel {
+              Flatten(path: "products.@.reviews.@.product") {
+                Fetch(service: "products") {
+                  {
+                    ... on Book {
+                      ... on Book {
+                        __typename
+                        id
+                      }
+                    }
+                    ... on Magazine {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on Book @skip(if: $title) {
+                      ... on Book @include(if: $title) {
+                        sku
+                      }
+                    }
+                    ... on Magazine {
+                      sku
+                    }
+                  }
+                },
+              },
+              Include(if: $title) {
+                Flatten(path: "products.@.reviews.@.product") {
+                  Fetch(service: "books") {
+                    {
+                      ... on Book {
+                        __typename
+                        id
+                      }
+                    } =>
+                    {
+                      ... on Book {
+                        title
+                      }
+                    }
+                  },
+                },
+              },
+            },
+          },
+        }
+      "###
+    );
+}

--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -1080,7 +1080,6 @@ fn test_merging_fetches_reset_cached_costs() {
     );
 }
 
-
 #[test]
 fn handles_multiple_conditions_on_abstract_types() {
     let planner = planner!(

--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -474,10 +474,8 @@ fn it_executes_mutation_operations_in_sequence() {
     );
 }
 
-/// @requires references external field indirectly {
+/// @requires references external field indirectly
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure (appears to be visiting wrong subgraph)
 fn key_where_at_external_is_not_at_top_level_of_selection_of_requires() {
     // Field issue where we were seeing a FetchGroup created where the fields used by the key to jump subgraphs
     // were not properly fetched. In the below test, this test will ensure that 'k2' is properly collected

--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -1083,58 +1083,10 @@ fn test_merging_fetches_reset_cached_costs() {
 #[test]
 fn handles_multiple_conditions_on_abstract_types() {
     let planner = planner!(
-        agency: r#"
-        type Agency @key(fields: "id") {
-          id: ID!
-          companyName: String
-        }
-
-        type Group @key(fields: "id") {
-          id: ID!
-          name: String
-        }
-
-        extend union PublisherType = Agency | Group
-        "#,
         books: r#"
         type Book @key(fields: "id") {
           id: ID!
           title: String
-        }
-
-        type Query {
-          books: [Book]
-        }
-        "#,
-        inventory: r#"
-        interface Product {
-          id: ID!
-          dimensions: ProductDimension
-          delivery(zip: String): DeliveryEstimates
-        }
-
-        type Book implements Product @key(fields: "id") {
-          id: ID!
-          dimensions: ProductDimension @external
-          delivery(zip: String): DeliveryEstimates
-            @requires(fields: "dimensions { size weight }")
-        }
-
-        type Magazine implements Product @key(fields: "id") {
-          id: ID!
-          dimensions: ProductDimension @external
-          delivery(zip: String): DeliveryEstimates
-            @requires(fields: "dimensions { size weight }")
-        }
-
-        type ProductDimension @shareable {
-          size: String
-          weight: Float
-        }
-
-        type DeliveryEstimates {
-          estimatedDelivery: String
-          fastestDelivery: String
         }
         "#,
         magazines: r#"
@@ -1142,27 +1094,16 @@ fn handles_multiple_conditions_on_abstract_types() {
           id: ID!
           title: String
         }
-
-        type Query {
-          magazines: [Magazine]
-        }
         "#,
         products: r#"
         type Query {
           products: [Product]
-          similar(id: ID!): [Product]
         }
 
         interface Product {
           id: ID!
           sku: String
           dimensions: ProductDimension
-          createdBy: User
-          hidden: Boolean @inaccessible
-        }
-
-        interface Similar {
-          similar: [Product]
         }
 
         type ProductDimension @shareable {
@@ -1170,86 +1111,38 @@ fn handles_multiple_conditions_on_abstract_types() {
           weight: Float
         }
 
-        type Book implements Product & Similar @key(fields: "id") {
+        type Book implements Product @key(fields: "id") {
           id: ID!
           sku: String
           dimensions: ProductDimension @shareable
-          createdBy: User
-          similar: [Book]
-          hidden: Boolean
-          publisherType: PublisherType
         }
 
-        type Magazine implements Product & Similar @key(fields: "id") {
+        type Magazine implements Product @key(fields: "id") {
           id: ID!
           sku: String
           dimensions: ProductDimension @shareable
-          createdBy: User
-          similar: [Magazine]
-          hidden: Boolean
-          publisherType: PublisherType
-        }
-
-        union PublisherType = Agency | Self
-
-        type Agency {
-          id: ID! @shareable
-        }
-
-        type Self {
-          email: String
-        }
-
-        type User @key(fields: "email") {
-          email: ID!
-          totalProductsCreated: Int @shareable
         }
         "#,
         reviews: r#"
-        type Book implements Product & Similar @key(fields: "id") {
+        type Book implements Product @key(fields: "id") {
           id: ID!
-          reviewsCount: Int!
-          reviewsScore: Float! @shareable
           reviews: [Review!]!
-          similar: [Book] @external
-          reviewsOfSimilar: [Review!]! @requires(fields: "similar { id }")
         }
 
-        type Magazine implements Product & Similar @key(fields: "id") {
+        type Magazine implements Product @key(fields: "id") {
           id: ID!
-          reviewsCount: Int!
-          reviewsScore: Float! @shareable
           reviews: [Review!]!
-          similar: [Magazine] @external
-          reviewsOfSimilar: [Review!]! @requires(fields: "similar { id }")
         }
 
         interface Product {
           id: ID!
-          reviewsCount: Int!
-          reviewsScore: Float!
           reviews: [Review!]!
-        }
-
-        interface Similar {
-          similar: [Product]
-        }
-
-        type Query {
-          review(id: Int!): Review
         }
 
         type Review {
           id: Int!
           body: String!
           product: Product
-        }
-        "#,
-        users: r#"
-        type User @key(fields: "email") {
-          email: ID!
-          name: String
-          totalProductsCreated: Int @shareable
         }
         "#,
     );

--- a/apollo-federation/tests/query_plan/supergraphs/handles_multiple_conditions_on_abstract_types.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_multiple_conditions_on_abstract_types.graphql
@@ -1,13 +1,10 @@
-# Composed from subgraphs with hash: b02bcb144827da22d7ae0774957bc5cf09d69b61
+# Composed from subgraphs with hash: 1b8ed03436d12bd5fe1dc3487873cc027b7f81da
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
-  @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
 {
   query: Query
 }
-
-directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
@@ -23,64 +20,27 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-type Agency
-  @join__type(graph: AGENCY, key: "id")
-  @join__type(graph: PRODUCTS)
-{
-  id: ID!
-  companyName: String @join__field(graph: AGENCY)
-}
-
-type Book implements Product & Similar
-  @join__implements(graph: INVENTORY, interface: "Product")
+type Book implements Product
   @join__implements(graph: PRODUCTS, interface: "Product")
-  @join__implements(graph: PRODUCTS, interface: "Similar")
   @join__implements(graph: REVIEWS, interface: "Product")
-  @join__implements(graph: REVIEWS, interface: "Similar")
   @join__type(graph: BOOKS, key: "id")
-  @join__type(graph: INVENTORY, key: "id")
   @join__type(graph: PRODUCTS, key: "id")
   @join__type(graph: REVIEWS, key: "id")
 {
   id: ID!
   title: String @join__field(graph: BOOKS)
-  dimensions: ProductDimension @join__field(graph: INVENTORY, external: true) @join__field(graph: PRODUCTS)
-  delivery(zip: String): DeliveryEstimates @join__field(graph: INVENTORY, requires: "dimensions { size weight }")
   sku: String @join__field(graph: PRODUCTS)
-  createdBy: User @join__field(graph: PRODUCTS)
-  similar: [Book] @join__field(graph: PRODUCTS) @join__field(graph: REVIEWS, external: true)
-  hidden: Boolean @join__field(graph: PRODUCTS)
-  publisherType: PublisherType @join__field(graph: PRODUCTS)
-  reviewsCount: Int! @join__field(graph: REVIEWS)
-  reviewsScore: Float! @join__field(graph: REVIEWS)
+  dimensions: ProductDimension @join__field(graph: PRODUCTS)
   reviews: [Review!]! @join__field(graph: REVIEWS)
-  reviewsOfSimilar: [Review!]! @join__field(graph: REVIEWS, requires: "similar { id }")
-}
-
-type DeliveryEstimates
-  @join__type(graph: INVENTORY)
-{
-  estimatedDelivery: String
-  fastestDelivery: String
-}
-
-type Group
-  @join__type(graph: AGENCY, key: "id")
-{
-  id: ID!
-  name: String
 }
 
 scalar join__FieldSet
 
 enum join__Graph {
-  AGENCY @join__graph(name: "agency", url: "none")
   BOOKS @join__graph(name: "books", url: "none")
-  INVENTORY @join__graph(name: "inventory", url: "none")
   MAGAZINES @join__graph(name: "magazines", url: "none")
   PRODUCTS @join__graph(name: "products", url: "none")
   REVIEWS @join__graph(name: "reviews", url: "none")
-  USERS @join__graph(name: "users", url: "none")
 }
 
 scalar link__Import
@@ -97,79 +57,44 @@ enum link__Purpose {
   EXECUTION
 }
 
-type Magazine implements Product & Similar
-  @join__implements(graph: INVENTORY, interface: "Product")
+type Magazine implements Product
   @join__implements(graph: PRODUCTS, interface: "Product")
-  @join__implements(graph: PRODUCTS, interface: "Similar")
   @join__implements(graph: REVIEWS, interface: "Product")
-  @join__implements(graph: REVIEWS, interface: "Similar")
-  @join__type(graph: INVENTORY, key: "id")
   @join__type(graph: MAGAZINES, key: "id")
   @join__type(graph: PRODUCTS, key: "id")
   @join__type(graph: REVIEWS, key: "id")
 {
   id: ID!
-  dimensions: ProductDimension @join__field(graph: INVENTORY, external: true) @join__field(graph: PRODUCTS)
-  delivery(zip: String): DeliveryEstimates @join__field(graph: INVENTORY, requires: "dimensions { size weight }")
   title: String @join__field(graph: MAGAZINES)
   sku: String @join__field(graph: PRODUCTS)
-  createdBy: User @join__field(graph: PRODUCTS)
-  similar: [Magazine] @join__field(graph: PRODUCTS) @join__field(graph: REVIEWS, external: true)
-  hidden: Boolean @join__field(graph: PRODUCTS)
-  publisherType: PublisherType @join__field(graph: PRODUCTS)
-  reviewsCount: Int! @join__field(graph: REVIEWS)
-  reviewsScore: Float! @join__field(graph: REVIEWS)
+  dimensions: ProductDimension @join__field(graph: PRODUCTS)
   reviews: [Review!]! @join__field(graph: REVIEWS)
-  reviewsOfSimilar: [Review!]! @join__field(graph: REVIEWS, requires: "similar { id }")
 }
 
 interface Product
-  @join__type(graph: INVENTORY)
   @join__type(graph: PRODUCTS)
   @join__type(graph: REVIEWS)
 {
   id: ID!
-  dimensions: ProductDimension @join__field(graph: INVENTORY) @join__field(graph: PRODUCTS)
-  delivery(zip: String): DeliveryEstimates @join__field(graph: INVENTORY)
   sku: String @join__field(graph: PRODUCTS)
-  createdBy: User @join__field(graph: PRODUCTS)
-  hidden: Boolean @inaccessible @join__field(graph: PRODUCTS)
-  reviewsCount: Int! @join__field(graph: REVIEWS)
-  reviewsScore: Float! @join__field(graph: REVIEWS)
+  dimensions: ProductDimension @join__field(graph: PRODUCTS)
   reviews: [Review!]! @join__field(graph: REVIEWS)
 }
 
 type ProductDimension
-  @join__type(graph: INVENTORY)
   @join__type(graph: PRODUCTS)
 {
   size: String
   weight: Float
 }
 
-union PublisherType
-  @join__type(graph: AGENCY)
-  @join__type(graph: PRODUCTS)
-  @join__unionMember(graph: AGENCY, member: "Agency")
-  @join__unionMember(graph: PRODUCTS, member: "Agency")
-  @join__unionMember(graph: AGENCY, member: "Group")
-  @join__unionMember(graph: PRODUCTS, member: "Self")
- = Agency | Group | Self
-
 type Query
-  @join__type(graph: AGENCY)
   @join__type(graph: BOOKS)
-  @join__type(graph: INVENTORY)
   @join__type(graph: MAGAZINES)
   @join__type(graph: PRODUCTS)
   @join__type(graph: REVIEWS)
-  @join__type(graph: USERS)
 {
-  books: [Book] @join__field(graph: BOOKS)
-  magazines: [Magazine] @join__field(graph: MAGAZINES)
   products: [Product] @join__field(graph: PRODUCTS)
-  similar(id: ID!): [Product] @join__field(graph: PRODUCTS)
-  review(id: Int!): Review @join__field(graph: REVIEWS)
 }
 
 type Review
@@ -178,26 +103,4 @@ type Review
   id: Int!
   body: String!
   product: Product
-}
-
-type Self
-  @join__type(graph: PRODUCTS)
-{
-  email: String
-}
-
-interface Similar
-  @join__type(graph: PRODUCTS)
-  @join__type(graph: REVIEWS)
-{
-  similar: [Product]
-}
-
-type User
-  @join__type(graph: PRODUCTS, key: "email")
-  @join__type(graph: USERS, key: "email")
-{
-  email: ID!
-  totalProductsCreated: Int
-  name: String @join__field(graph: USERS)
 }

--- a/apollo-federation/tests/query_plan/supergraphs/handles_multiple_conditions_on_abstract_types.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_multiple_conditions_on_abstract_types.graphql
@@ -1,0 +1,203 @@
+# Composed from subgraphs with hash: b02bcb144827da22d7ae0774957bc5cf09d69b61
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
+{
+  query: Query
+}
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type Agency
+  @join__type(graph: AGENCY, key: "id")
+  @join__type(graph: PRODUCTS)
+{
+  id: ID!
+  companyName: String @join__field(graph: AGENCY)
+}
+
+type Book implements Product & Similar
+  @join__implements(graph: INVENTORY, interface: "Product")
+  @join__implements(graph: PRODUCTS, interface: "Product")
+  @join__implements(graph: PRODUCTS, interface: "Similar")
+  @join__implements(graph: REVIEWS, interface: "Product")
+  @join__implements(graph: REVIEWS, interface: "Similar")
+  @join__type(graph: BOOKS, key: "id")
+  @join__type(graph: INVENTORY, key: "id")
+  @join__type(graph: PRODUCTS, key: "id")
+  @join__type(graph: REVIEWS, key: "id")
+{
+  id: ID!
+  title: String @join__field(graph: BOOKS)
+  dimensions: ProductDimension @join__field(graph: INVENTORY, external: true) @join__field(graph: PRODUCTS)
+  delivery(zip: String): DeliveryEstimates @join__field(graph: INVENTORY, requires: "dimensions { size weight }")
+  sku: String @join__field(graph: PRODUCTS)
+  createdBy: User @join__field(graph: PRODUCTS)
+  similar: [Book] @join__field(graph: PRODUCTS) @join__field(graph: REVIEWS, external: true)
+  hidden: Boolean @join__field(graph: PRODUCTS)
+  publisherType: PublisherType @join__field(graph: PRODUCTS)
+  reviewsCount: Int! @join__field(graph: REVIEWS)
+  reviewsScore: Float! @join__field(graph: REVIEWS)
+  reviews: [Review!]! @join__field(graph: REVIEWS)
+  reviewsOfSimilar: [Review!]! @join__field(graph: REVIEWS, requires: "similar { id }")
+}
+
+type DeliveryEstimates
+  @join__type(graph: INVENTORY)
+{
+  estimatedDelivery: String
+  fastestDelivery: String
+}
+
+type Group
+  @join__type(graph: AGENCY, key: "id")
+{
+  id: ID!
+  name: String
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  AGENCY @join__graph(name: "agency", url: "none")
+  BOOKS @join__graph(name: "books", url: "none")
+  INVENTORY @join__graph(name: "inventory", url: "none")
+  MAGAZINES @join__graph(name: "magazines", url: "none")
+  PRODUCTS @join__graph(name: "products", url: "none")
+  REVIEWS @join__graph(name: "reviews", url: "none")
+  USERS @join__graph(name: "users", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Magazine implements Product & Similar
+  @join__implements(graph: INVENTORY, interface: "Product")
+  @join__implements(graph: PRODUCTS, interface: "Product")
+  @join__implements(graph: PRODUCTS, interface: "Similar")
+  @join__implements(graph: REVIEWS, interface: "Product")
+  @join__implements(graph: REVIEWS, interface: "Similar")
+  @join__type(graph: INVENTORY, key: "id")
+  @join__type(graph: MAGAZINES, key: "id")
+  @join__type(graph: PRODUCTS, key: "id")
+  @join__type(graph: REVIEWS, key: "id")
+{
+  id: ID!
+  dimensions: ProductDimension @join__field(graph: INVENTORY, external: true) @join__field(graph: PRODUCTS)
+  delivery(zip: String): DeliveryEstimates @join__field(graph: INVENTORY, requires: "dimensions { size weight }")
+  title: String @join__field(graph: MAGAZINES)
+  sku: String @join__field(graph: PRODUCTS)
+  createdBy: User @join__field(graph: PRODUCTS)
+  similar: [Magazine] @join__field(graph: PRODUCTS) @join__field(graph: REVIEWS, external: true)
+  hidden: Boolean @join__field(graph: PRODUCTS)
+  publisherType: PublisherType @join__field(graph: PRODUCTS)
+  reviewsCount: Int! @join__field(graph: REVIEWS)
+  reviewsScore: Float! @join__field(graph: REVIEWS)
+  reviews: [Review!]! @join__field(graph: REVIEWS)
+  reviewsOfSimilar: [Review!]! @join__field(graph: REVIEWS, requires: "similar { id }")
+}
+
+interface Product
+  @join__type(graph: INVENTORY)
+  @join__type(graph: PRODUCTS)
+  @join__type(graph: REVIEWS)
+{
+  id: ID!
+  dimensions: ProductDimension @join__field(graph: INVENTORY) @join__field(graph: PRODUCTS)
+  delivery(zip: String): DeliveryEstimates @join__field(graph: INVENTORY)
+  sku: String @join__field(graph: PRODUCTS)
+  createdBy: User @join__field(graph: PRODUCTS)
+  hidden: Boolean @inaccessible @join__field(graph: PRODUCTS)
+  reviewsCount: Int! @join__field(graph: REVIEWS)
+  reviewsScore: Float! @join__field(graph: REVIEWS)
+  reviews: [Review!]! @join__field(graph: REVIEWS)
+}
+
+type ProductDimension
+  @join__type(graph: INVENTORY)
+  @join__type(graph: PRODUCTS)
+{
+  size: String
+  weight: Float
+}
+
+union PublisherType
+  @join__type(graph: AGENCY)
+  @join__type(graph: PRODUCTS)
+  @join__unionMember(graph: AGENCY, member: "Agency")
+  @join__unionMember(graph: PRODUCTS, member: "Agency")
+  @join__unionMember(graph: AGENCY, member: "Group")
+  @join__unionMember(graph: PRODUCTS, member: "Self")
+ = Agency | Group | Self
+
+type Query
+  @join__type(graph: AGENCY)
+  @join__type(graph: BOOKS)
+  @join__type(graph: INVENTORY)
+  @join__type(graph: MAGAZINES)
+  @join__type(graph: PRODUCTS)
+  @join__type(graph: REVIEWS)
+  @join__type(graph: USERS)
+{
+  books: [Book] @join__field(graph: BOOKS)
+  magazines: [Magazine] @join__field(graph: MAGAZINES)
+  products: [Product] @join__field(graph: PRODUCTS)
+  similar(id: ID!): [Product] @join__field(graph: PRODUCTS)
+  review(id: Int!): Review @join__field(graph: REVIEWS)
+}
+
+type Review
+  @join__type(graph: REVIEWS)
+{
+  id: Int!
+  body: String!
+  product: Product
+}
+
+type Self
+  @join__type(graph: PRODUCTS)
+{
+  email: String
+}
+
+interface Similar
+  @join__type(graph: PRODUCTS)
+  @join__type(graph: REVIEWS)
+{
+  similar: [Product]
+}
+
+type User
+  @join__type(graph: PRODUCTS, key: "email")
+  @join__type(graph: USERS, key: "email")
+{
+  email: ID!
+  totalProductsCreated: Int
+  name: String @join__field(graph: USERS)
+}


### PR DESCRIPTION
In JS implementation, conditions were recalculated at the very end when we were creating final selection set. We were missing condition update in one of the update paths.

<!-- fixes ROUTER-652 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
