### PR TITLE
Moves tests for `FallibleIterator`

### DIFF
--- a/apollo-federation/src/utils/fallible_iterator.rs
+++ b/apollo-federation/src/utils/fallible_iterator.rs
@@ -77,9 +77,7 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
     /// the iterator will yield the `Err` in its place. Lastly, if the predicate yields `Ok(true)`,
     /// the iterator will yield `Ok(val)`.
     ///
-    /// ```rust
-    /// use apollo_federation::utils::FallibleIterator;
-    ///
+    /// ```ignore
     /// // A totally accurate prime checker
     /// fn is_prime(i: usize) -> Result<bool, ()> {
     ///   match i {
@@ -113,9 +111,7 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
     /// method is very similar to `Itertools::filter_ok` except the predicate for this method is
     /// fallible.
     ///
-    /// ```rust
-    /// use apollo_federation::utils::FallibleIterator;
-    ///
+    /// ```ignore
     /// // A totally accurate prime checker
     /// fn is_prime(i: usize) -> Result<bool, ()> {
     ///   match i {
@@ -147,9 +143,7 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
     /// `Ok(false)`, the returned value will be `Ok(false)`. If that item is `Err`, than that `Err`
     /// is returned.
     ///
-    /// ```rust
-    /// use apollo_federation::utils::FallibleIterator;
-    ///
+    /// ```ignore
     /// // A totally accurate prime checker
     /// fn is_prime(i: usize) -> Result<bool, ()> {
     ///   match i {
@@ -188,19 +182,11 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
     /// is `Ok`, it is given to the predicate. If the predicate returns `false`, this method
     /// returns `Ok(false)`.
     ///
-    /// ```rust
-    /// use apollo_federation::utils::FallibleIterator;
-    ///
-    /// type Item = Result<usize, ()>;
-    ///
-    /// fn is_even(i: usize) -> bool {
-    ///     i % 2 == 0
-    /// }
-    ///
-    /// let first_values: Vec<Item>  = vec![];
-    /// let second_values: Vec<Item> = vec![Ok(1), Err(())];
-    /// let third_values: Vec<Item>  = vec![Ok(0), Ok(1), Ok(2)];
-    /// let fourth_values: Vec<Item> = vec![Err(()), Ok(0)];
+    /// ```ignore
+    /// let first_values = vec![];
+    /// let second_values = vec![Ok(1), Err(())];
+    /// let third_values = vec![Ok(0), Ok(1), Ok(2)];
+    /// let fourth_values = vec![Err(()), Ok(0)];
     ///
     /// assert_eq!(Ok(true), first_values.into_iter().ok_and_all(is_even));
     /// assert_eq!(Ok(false), second_values.into_iter().ok_and_all(is_even));
@@ -224,11 +210,7 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
     /// predicate returns `Err`, that `Err` is returned. If the predicate returns `Ok(false)`,
     /// `Ok(false)` is returned. By default, this function returned `Ok(true)`.
     ///
-    /// ```rust
-    /// use apollo_federation::utils::FallibleIterator;
-    ///
-    /// type Item = Result<usize, ()>;
-    ///
+    /// ```ignore
     /// // A totally accurate prime checker
     /// fn is_prime(i: usize) -> Result<bool, ()> {
     ///   match i {
@@ -238,12 +220,12 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
     ///   }
     /// }
     ///
-    /// let first_values: Vec<Item>  = vec![];
-    /// let second_values: Vec<Item> = vec![Ok(0), Err(())];
-    /// let third_values: Vec<Item>  = vec![Ok(2), Ok(3)];
-    /// let fourth_values: Vec<Item> = vec![Err(()), Ok(2)];
-    /// let fifth_values: Vec<Item>  = vec![Ok(2), Err(())];
-    /// let sixth_values: Vec<Item>  = vec![Ok(4), Ok(3)];
+    /// let first_values = vec![];
+    /// let second_values = vec![Ok(0), Err(())];
+    /// let third_values = vec![Ok(2), Ok(3)];
+    /// let fourth_values = vec![Err(()), Ok(2)];
+    /// let fifth_values = vec![Ok(2), Err(())];
+    /// let sixth_values = vec![Ok(4), Ok(3)];
     ///
     /// assert_eq!(Ok(true), first_values.into_iter().and_then_all(is_prime));
     /// assert_eq!(Err(()), second_values.into_iter().and_then_all(is_prime));
@@ -275,9 +257,7 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
     /// `Ok(true)`, the returned value will be `Ok(true)`. If that item is `Err`, than that `Err`
     /// is returned.
     ///
-    /// ```rust
-    /// use apollo_federation::utils::FallibleIterator;
-    ///
+    /// ```ignore
     /// // A totally accurate prime checker
     /// fn is_prime(i: usize) -> Result<bool, ()> {
     ///   match i {
@@ -316,19 +296,11 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
     /// is `Ok`, it is given to the predicate. If the predicate returns `true`, this method returns
     /// `Ok(true)`.
     ///
-    /// ```rust
-    /// use apollo_federation::utils::FallibleIterator;
-    ///
-    /// type Item = Result<usize, ()>;
-    ///
-    /// fn is_even(i: usize) -> bool {
-    ///     i % 2 == 0
-    /// }
-    ///
-    /// let first_values: Vec<Item>  = vec![];
-    /// let second_values: Vec<Item> = vec![Ok(0), Err(())];
-    /// let third_values: Vec<Item>  = vec![Ok(1), Ok(3)];
-    /// let fourth_values: Vec<Item> = vec![Err(()), Ok(0)];
+    /// ```ignore
+    /// let first_values = vec![];
+    /// let second_values = vec![Ok(0), Err(())];
+    /// let third_values = vec![Ok(1), Ok(3)];
+    /// let fourth_values = vec![Err(()), Ok(0)];
     ///
     /// assert_eq!(Ok(false), first_values.into_iter().ok_and_any(is_even));
     /// assert_eq!(Ok(true), second_values.into_iter().ok_and_any(is_even));
@@ -352,11 +324,7 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
     /// predicate returns `Err`, that `Err` is returned. If the predicate returns `Ok(true)`,
     /// `Ok(true)` is returned. By default, this function returned `Ok(false)`.
     ///
-    /// ```rust
-    /// use apollo_federation::utils::FallibleIterator;
-    ///
-    /// type Item = Result<usize, ()>;
-    ///
+    /// ```ignore
     /// // A totally accurate prime checker
     /// fn is_prime(i: usize) -> Result<bool, ()> {
     ///   match i {
@@ -366,12 +334,12 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
     ///   }
     /// }
     ///
-    /// let first_values: Vec<Item>  = vec![];
-    /// let second_values: Vec<Item> = vec![Ok(0), Err(())];
-    /// let third_values: Vec<Item>  = vec![Ok(3), Ok(4)];
-    /// let fourth_values: Vec<Item> = vec![Err(()), Ok(2)];
-    /// let fifth_values: Vec<Item> = vec![Ok(2), Err(())];
-    /// let sixth_values: Vec<Item> = vec![Ok(4), Ok(5)];
+    /// let first_values = vec![];
+    /// let second_values = vec![Ok(0), Err(())];
+    /// let third_values = vec![Ok(3), Ok(4)];
+    /// let fourth_values = vec![Err(()), Ok(2)];
+    /// let fifth_values = vec![Ok(2), Err(())];
+    /// let sixth_values = vec![Ok(4), Ok(5)];
     ///
     /// assert_eq!(Ok(false), first_values.into_iter().and_then_any(is_prime));
     /// assert_eq!(Err(()), second_values.into_iter().and_then_any(is_prime));
@@ -525,5 +493,109 @@ where
 
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|res| res.or_else(&mut self.map))
+    }
+}
+
+// Ideally, these would be doc tests, but gating access to the `utils` module is messy.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    type Item = Result<usize, ()>;
+
+    fn is_prime(i: usize) -> Result<bool, ()> {
+        match i {
+            0 | 1 => Err(()), // 0 and 1 are neither prime or composite
+            2 | 3 => Ok(true),
+            _ => Ok(false), // Every other number is composite, I guess
+        }
+    }
+
+    fn is_even(i: usize) -> bool {
+        i % 2 == 0
+    }
+
+    fn test_fallible_filter() {
+        let vals = (1..6).fallible_filter(|i| is_prime(*i));
+        itertools::assert_equal(vals, vec![Err(()), Ok(2), Ok(3)]);
+    }
+
+    fn test_and_then_filter() {
+        let vals = vec![Ok(0), Err(()), Err(()), Ok(3), Ok(4)]
+            .into_iter()
+            .and_then_filter(|i| is_prime(*i));
+        itertools::assert_equal(vals, vec![Err(()), Err(()), Err(()), Ok(3)]);
+    }
+
+    fn test_fallible_all() {
+        assert_eq!(Ok(true), [].into_iter().fallible_all(is_prime));
+        assert_eq!(Ok(true), (2..4).fallible_all(is_prime));
+        assert_eq!(Err(()), (1..4).fallible_all(is_prime));
+        assert_eq!(Ok(false), (2..5).fallible_all(is_prime));
+        assert_eq!(Err(()), (1..5).fallible_all(is_prime));
+    }
+
+    fn test_ok_and_all() {
+        let first_values: Vec<Item> = vec![];
+        let second_values: Vec<Item> = vec![Ok(1), Err(())];
+        let third_values: Vec<Item> = vec![Ok(0), Ok(1), Ok(2)];
+        let fourth_values: Vec<Item> = vec![Err(()), Ok(0)];
+
+        assert_eq!(Ok(true), first_values.into_iter().ok_and_all(is_even));
+        assert_eq!(Ok(false), second_values.into_iter().ok_and_all(is_even));
+        assert_eq!(Ok(false), third_values.into_iter().ok_and_all(is_even));
+        assert_eq!(Err(()), fourth_values.into_iter().ok_and_all(is_even));
+    }
+
+    fn test_and_then_all() {
+        let first_values: Vec<Item> = vec![];
+        let second_values: Vec<Item> = vec![Ok(0), Err(())];
+        let third_values: Vec<Item> = vec![Ok(2), Ok(3)];
+        let fourth_values: Vec<Item> = vec![Err(()), Ok(2)];
+        let fifth_values: Vec<Item> = vec![Ok(2), Err(())];
+        let sixth_values: Vec<Item> = vec![Ok(4), Ok(3)];
+
+        assert_eq!(Ok(true), first_values.into_iter().and_then_all(is_prime));
+        assert_eq!(Err(()), second_values.into_iter().and_then_all(is_prime));
+        assert_eq!(Ok(true), third_values.into_iter().and_then_all(is_prime));
+        assert_eq!(Err(()), fourth_values.into_iter().and_then_all(is_prime));
+        assert_eq!(Err(()), fifth_values.into_iter().and_then_all(is_prime));
+        assert_eq!(Ok(false), sixth_values.into_iter().and_then_all(is_prime));
+    }
+
+    fn test_fallible_any() {
+        assert_eq!(Ok(false), [].into_iter().fallible_any(is_prime));
+        assert_eq!(Ok(true), (2..5).fallible_any(is_prime));
+        assert_eq!(Ok(false), (4..5).fallible_any(is_prime));
+        assert_eq!(Err(()), (1..4).fallible_any(is_prime));
+        assert_eq!(Err(()), (1..5).fallible_any(is_prime));
+    }
+
+    fn test_ok_and_any() {
+        let first_values: Vec<Item> = vec![];
+        let second_values: Vec<Item> = vec![Ok(0), Err(())];
+        let third_values: Vec<Item> = vec![Ok(1), Ok(3)];
+        let fourth_values: Vec<Item> = vec![Err(()), Ok(0)];
+
+        assert_eq!(Ok(false), first_values.into_iter().ok_and_any(is_even));
+        assert_eq!(Ok(true), second_values.into_iter().ok_and_any(is_even));
+        assert_eq!(Ok(false), third_values.into_iter().ok_and_any(is_even));
+        assert_eq!(Err(()), fourth_values.into_iter().ok_and_any(is_even));
+    }
+
+    fn test_and_then_any() {
+        let first_values: Vec<Item> = vec![];
+        let second_values: Vec<Item> = vec![Ok(0), Err(())];
+        let third_values: Vec<Item> = vec![Ok(3), Ok(4)];
+        let fourth_values: Vec<Item> = vec![Err(()), Ok(2)];
+        let fifth_values: Vec<Item> = vec![Ok(2), Err(())];
+        let sixth_values: Vec<Item> = vec![Ok(4), Ok(5)];
+
+        assert_eq!(Ok(false), first_values.into_iter().and_then_any(is_prime));
+        assert_eq!(Err(()), second_values.into_iter().and_then_any(is_prime));
+        assert_eq!(Ok(true), third_values.into_iter().and_then_any(is_prime));
+        assert_eq!(Err(()), fourth_values.into_iter().and_then_any(is_prime));
+        assert_eq!(Ok(true), fifth_values.into_iter().and_then_any(is_prime));
+        assert_eq!(Ok(false), sixth_values.into_iter().and_then_any(is_prime));
     }
 }

--- a/apollo-federation/src/utils/mod.rs
+++ b/apollo-federation/src/utils/mod.rs
@@ -2,4 +2,5 @@
 
 mod fallible_iterator;
 pub mod logging;
+
 pub(crate) use fallible_iterator::*;


### PR DESCRIPTION
When I created the `FallibleIterator` extension trait, all of the tests were doc tests. Due to a visibility issue, these tests were failing. Moreover, doc tests (at least for `apollo-federation`) are not checked in CI. These makes running `cargo test` locally annoying because you see a bunch of failures and unhelpful in CI because they aren't ran.

To fix this, I added `ignore` too all examples in the docs and copied the examples into unit tests.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
