### PR TITLE
Add support for include_subgraph_errors to connectors

### DIFF
--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -17,6 +17,7 @@ use crate::plugins::connectors::make_requests::ResponseTypeName;
 use crate::plugins::connectors::plugin::ConnectorContext;
 use crate::plugins::connectors::plugin::SelectionData;
 use crate::services::connect::Response;
+use crate::services::fetch::AddSubgraphNameExt;
 
 const ENTITIES: &str = "_entities";
 const TYPENAME: &str = "__typename";
@@ -163,7 +164,8 @@ pub(crate) async fn handle_responses<T: HttpBody>(
                                 parts.status.canonical_reason().unwrap_or("Unknown")
                             ),
                         }
-                        .to_graphql_error(None),
+                        .to_graphql_error(None)
+                        .add_subgraph_name(&connector.id.subgraph_name),
                     );
                     if let Some(ref debug) = debug {
                         match serde_json::from_slice(body) {
@@ -701,6 +703,9 @@ mod tests {
                                 "http": Object({
                                     "status": Number(404),
                                 }),
+                                "fetch_subgraph_name": String(
+                                    "subgraph_name",
+                                ),
                             },
                         },
                         Error {
@@ -720,6 +725,9 @@ mod tests {
                                 "http": Object({
                                     "status": Number(500),
                                 }),
+                                "fetch_subgraph_name": String(
+                                    "subgraph_name",
+                                ),
                             },
                         },
                     ],

--- a/apollo-router/src/plugins/include_subgraph_errors.rs
+++ b/apollo-router/src/plugins/include_subgraph_errors.rs
@@ -80,6 +80,7 @@ impl Plugin for IncludeSubgraphErrors {
         service
     }
 
+    // TODO: promote fetch_service to a plugin hook
     fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
         let all = self.config.all;
         let subgraphs = self.config.subgraphs.clone();

--- a/apollo-router/src/services/fetch_service.rs
+++ b/apollo-router/src/services/fetch_service.rs
@@ -15,6 +15,7 @@ use tracing::instrument::Instrumented;
 use tracing::Instrument;
 
 use super::connector_service::ConnectorServiceFactory;
+use super::fetch::AddSubgraphNameExt;
 use super::fetch::BoxService;
 use super::fetch::SubscriptionRequest;
 use super::new_service::ServiceFactory;
@@ -147,7 +148,8 @@ impl FetchService {
                         .build(),
                 )
                 .await
-                .map_to_graphql_error(subgraph_name, &current_dir.to_owned())
+                .map_to_graphql_error(subgraph_name.clone(), &current_dir.to_owned())
+                .add_subgraph_name(subgraph_name.as_str())
             {
                 Err(e) => {
                     return Ok((Value::default(), vec![e]));


### PR DESCRIPTION
If `include_subgraph_errors` if false for a subgraph containing connectors, any errors returned by connectors HTTP requests will be redacted from the response. Note that if the connectors debugging feature is enabled, information about the failed request will still be returned in the debug data.

Note that because the `include_subgraph_errors` plugin doesn't know about connectors, and connectors don't have access to the `include_subgraph_errors` plugin, there is no direct way to do the redaction. Instead, the connectors feature stores the subgraph name on the error as an extension, and the plugin checks for this extension to see if the error should be redacted.

With `include_subgraph_errors` set to `true`:

```json
{
  "data": null,
  "errors": [
    {
      "message": "HTTP fetch failed from 'posts.jsonPlaceholder http: GET /users/foo': 404: Not Found",
      "path": [],
      "extensions": {
        "code": "SUBREQUEST_HTTP_ERROR",
        "service": "posts.jsonPlaceholder http: GET /users/foo",
        "reason": "404: Not Found",
        "http": {
          "status": 404
        }
      }
    }
  ],
  "extensions": {
    "valueCompletion": [
      {
        "message": "Cannot return null for non-nullable field Query.users",
        "path": []
      }
    ]
  }
}
```

With `include_subgraph_errors` set to `false`:

```json
{
  "data": null,
  "errors": [
    {
      "message": "Subgraph errors redacted",
      "path": []
    }
  ],
  "extensions": {
    "valueCompletion": [
      {
        "message": "Cannot return null for non-nullable field Query.users",
        "path": []
      }
    ]
  }
}
```

<!-- [CNN-431] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-431]: https://apollographql.atlassian.net/browse/CNN-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ