### PR TITLE
connectors: add debug cli for expansion

### DIFF
--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -11,7 +11,10 @@ use apollo_federation::error::SingleFederationError;
 use apollo_federation::query_graph;
 use apollo_federation::query_plan::query_planner::QueryPlanner;
 use apollo_federation::query_plan::query_planner::QueryPlannerConfig;
+use apollo_federation::sources::connect::expand::expand_connectors;
+use apollo_federation::sources::connect::expand::ExpansionResult;
 use apollo_federation::subgraph;
+use apollo_federation::Supergraph;
 use bench::BenchOutput;
 use clap::Parser;
 
@@ -104,6 +107,19 @@ enum Command {
         #[command(flatten)]
         planner: QueryPlannerArgs,
     },
+
+    /// Expand connector-enabled supergraphs
+    Expand {
+        /// The path to the supergraph schema file, or `-` for stdin
+        supergraph_schema: PathBuf,
+
+        /// The output directory for the extracted subgraph schemas
+        destination_dir: Option<PathBuf>,
+
+        /// An optional prefix to match against expanded subgraph names
+        #[arg(long)]
+        filter_prefix: Option<String>,
+    },
 }
 
 impl QueryPlannerArgs {
@@ -154,6 +170,15 @@ fn main() -> ExitCode {
             operations_dir,
             planner,
         } => cmd_bench(&supergraph_schema, &operations_dir, planner),
+        Command::Expand {
+            supergraph_schema,
+            destination_dir,
+            filter_prefix,
+        } => cmd_expand(
+            &supergraph_schema,
+            destination_dir.as_ref(),
+            filter_prefix.as_ref().map(String::as_str),
+        ),
     };
     match result {
         Err(error) => {
@@ -292,6 +317,64 @@ fn cmd_extract(file_path: &Path, dest: Option<&PathBuf>) -> Result<(), Federatio
             println!(); // newline
         }
     }
+    Ok(())
+}
+
+fn cmd_expand(
+    file_path: &Path,
+    dest: Option<&PathBuf>,
+    filter_prefix: Option<&str>,
+) -> Result<(), FederationError> {
+    let original_supergraph = load_supergraph_file(file_path)?;
+    let ExpansionResult::Expanded { raw_sdl, .. } =
+        expand_connectors(&original_supergraph.schema.schema().serialize().to_string())?
+    else {
+        return Err(FederationError::internal(
+            "supplied supergraph has no connectors to expand",
+        ));
+    };
+
+    // Validate the schema
+    // TODO: If expansion errors here due to bugs, it can be very hard to trace
+    // what specific portion of the expansion process failed. Work will need to be
+    // done to expansion to allow for returning an error type that carries the error
+    // and the expanded subgraph as seen until the error.
+    let expanded = Supergraph::new(&raw_sdl)?;
+
+    let should_skip =
+        |name: &str| !matches!(filter_prefix, Some(prefix) if name.starts_with(prefix));
+
+    let subgraphs = expanded.extract_subgraphs()?;
+    if let Some(dest) = dest {
+        fs::create_dir_all(dest).map_err(|_| SingleFederationError::Internal {
+            message: "Error: directory creation failed".into(),
+        })?;
+        for (name, subgraph) in subgraphs {
+            // Skip any files not matching the prefix, if specified
+            if should_skip(&name) {
+                continue;
+            }
+
+            let subgraph_path = dest.join(format!("{}.graphql", name));
+            fs::write(subgraph_path, subgraph.schema.schema().to_string()).map_err(|_| {
+                SingleFederationError::Internal {
+                    message: "Error: file output failed".into(),
+                }
+            })?;
+        }
+    } else {
+        for (name, subgraph) in subgraphs {
+            // Skip any files not matching the prefix, if specified
+            if should_skip(&name) {
+                continue;
+            }
+
+            println!("[Subgraph `{}`]", name);
+            println!("{}", subgraph.schema.schema());
+            println!(); // newline
+        }
+    }
+
     Ok(())
 }
 

--- a/apollo-federation/cli/src/main.rs
+++ b/apollo-federation/cli/src/main.rs
@@ -177,7 +177,7 @@ fn main() -> ExitCode {
         } => cmd_expand(
             &supergraph_schema,
             destination_dir.as_ref(),
-            filter_prefix.as_ref().map(String::as_str),
+            filter_prefix.as_deref(),
         ),
     };
     match result {


### PR DESCRIPTION
This PR adds a new CLI option to apollo-federation to allow for just expanding supergraphs to either stdout or a specified folder.

```bash
cargo run -p apollo-federation-cli -- expand <SUPERGRAPH>
```

The command also supports specifying a prefix to limit which expanded subgraphs to show using the flag `--filter-prefix <PREFIX>`.

__Note: This is mainly for debugging expansion while we wait for a source-aware future. Do NOT rely on the output of this command for anything other than debugging or reference.__

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
