### PR TITLE
Skip creating a JS runtime when it would be unused

### DIFF
--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -17,7 +17,7 @@ const DEFAULT_INTROSPECTION_CACHE_CAPACITY: NonZeroUsize =
 /// A cache containing our well known introspection queries.
 pub(crate) struct Introspection {
     cache: CacheStorage<String, Response>,
-    planner: Arc<Planner<QueryPlanResult>>,
+    pub(crate) planner: Arc<Planner<QueryPlanResult>>,
 }
 
 impl Introspection {

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -30,7 +30,7 @@ use tower::Service;
 use super::PlanNode;
 use super::QueryKey;
 use crate::apollo_studio_interop::generate_usage_reporting;
-use crate::configuration::IntrospectionMode;
+use crate::configuration::IntrospectionMode as IntrospectionConfig;
 use crate::configuration::QueryPlannerMode;
 use crate::error::PlanErrors;
 use crate::error::QueryPlannerError;
@@ -79,7 +79,7 @@ pub(crate) struct BridgeQueryPlanner {
     planner: PlannerMode,
     schema: Arc<Schema>,
     subgraph_schemas: Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>>,
-    introspection: Option<Arc<Introspection>>,
+    introspection: IntrospectionMode,
     configuration: Arc<Configuration>,
     enable_authorization_directives: bool,
     _federation_instrument: ObservableGauge<u64>,
@@ -93,11 +93,15 @@ pub(crate) enum PlannerMode {
         js: Arc<Planner<QueryPlanResult>>,
         rust: Arc<QueryPlanner>,
     },
-    Rust {
-        rust: Arc<QueryPlanner>,
-        // TODO: remove when those other uses are fully ported to Rust
-        js_for_api_schema_and_introspection_and_operation_signature: Arc<Planner<QueryPlanResult>>,
-    },
+    Rust(Arc<QueryPlanner>),
+}
+
+#[derive(Clone)]
+enum IntrospectionMode {
+    Js(Arc<Introspection>),
+    Both(Arc<Introspection>),
+    Rust,
+    Disabled,
 }
 
 fn federation_version_instrument(federation_version: Option<i64>) -> ObservableGauge<u64> {
@@ -120,25 +124,19 @@ impl PlannerMode {
     async fn new(
         schema: &Schema,
         configuration: &Configuration,
-        old_planner: Option<Arc<Planner<QueryPlanResult>>>,
+        old_planner: &Option<Arc<Planner<QueryPlanResult>>>,
         rust_planner: Option<Arc<QueryPlanner>>,
     ) -> Result<Self, ServiceBuildError> {
         Ok(match configuration.experimental_query_planner_mode {
-            QueryPlannerMode::New => Self::Rust {
-                js_for_api_schema_and_introspection_and_operation_signature: Self::js(
-                    &schema.raw_sdl,
-                    configuration,
-                    old_planner,
-                )
-                .await?,
-                rust: rust_planner
+            QueryPlannerMode::New => Self::Rust(
+                rust_planner
                     .expect("expected Rust QP instance for `experimental_query_planner_mode: new`"),
-            },
+            ),
             QueryPlannerMode::Legacy => {
-                Self::Js(Self::js(&schema.raw_sdl, configuration, old_planner).await?)
+                Self::Js(Self::js_planner(&schema.raw_sdl, configuration, old_planner).await?)
             }
             QueryPlannerMode::Both => Self::Both {
-                js: Self::js(&schema.raw_sdl, configuration, old_planner).await?,
+                js: Self::js_planner(&schema.raw_sdl, configuration, old_planner).await?,
                 rust: rust_planner.expect(
                     "expected Rust QP instance for `experimental_query_planner_mode: both`",
                 ),
@@ -146,11 +144,11 @@ impl PlannerMode {
             QueryPlannerMode::BothBestEffort => {
                 if let Some(rust) = rust_planner {
                     Self::Both {
-                        js: Self::js(&schema.raw_sdl, configuration, old_planner).await?,
+                        js: Self::js_planner(&schema.raw_sdl, configuration, old_planner).await?,
                         rust,
                     }
                 } else {
-                    Self::Js(Self::js(&schema.raw_sdl, configuration, old_planner).await?)
+                    Self::Js(Self::js_planner(&schema.raw_sdl, configuration, old_planner).await?)
                 }
             }
         })
@@ -222,13 +220,13 @@ impl PlannerMode {
         Ok(Arc::new(result.map_err(ServiceBuildError::QpInitError)?))
     }
 
-    async fn js(
+    async fn js_planner(
         sdl: &str,
         configuration: &Configuration,
-        old_planner: Option<Arc<Planner<QueryPlanResult>>>,
+        old_js_planner: &Option<Arc<Planner<QueryPlanResult>>>,
     ) -> Result<Arc<Planner<QueryPlanResult>>, ServiceBuildError> {
         let query_planner_configuration = configuration.js_query_planner_config();
-        let planner = match old_planner {
+        let planner = match old_js_planner {
             None => Planner::new(sdl.to_owned(), query_planner_configuration).await?,
             Some(old_planner) => {
                 old_planner
@@ -239,17 +237,22 @@ impl PlannerMode {
         Ok(Arc::new(planner))
     }
 
-    fn js_for_api_schema_and_introspection_and_operation_signature(
+    async fn js_introspetion(
         &self,
-    ) -> &Arc<Planner<QueryPlanResult>> {
-        match self {
-            PlannerMode::Js(js) => js,
-            PlannerMode::Both { js, .. } => js,
-            PlannerMode::Rust {
-                js_for_api_schema_and_introspection_and_operation_signature,
-                ..
-            } => js_for_api_schema_and_introspection_and_operation_signature,
-        }
+        sdl: &str,
+        configuration: &Configuration,
+        old_js_planner: &Option<Arc<Planner<QueryPlanResult>>>,
+    ) -> Result<Arc<Introspection>, ServiceBuildError> {
+        let js_planner = match self {
+            Self::Js(js) => js.clone(),
+            Self::Both { js, .. } => js.clone(),
+            Self::Rust(_) => {
+                // JS "planner" (actually runtime) was not created for planning
+                // but is still needed for introspection, so create it now
+                Self::js_planner(sdl, configuration, old_js_planner).await?
+            }
+        };
+        Ok(Arc::new(Introspection::new(js_planner).await?))
     }
 
     async fn plan(
@@ -283,7 +286,7 @@ impl PlannerMode {
                 }
                 Ok(success)
             }
-            PlannerMode::Rust { rust, .. } => {
+            PlannerMode::Rust(rust) => {
                 let start = Instant::now();
 
                 let result = operation
@@ -368,7 +371,7 @@ impl PlannerMode {
         let js = match self {
             PlannerMode::Js(js) => js,
             PlannerMode::Both { js, .. } => js,
-            PlannerMode::Rust { rust, .. } => {
+            PlannerMode::Rust(rust) => {
                 return Ok(rust
                     .subgraph_schemas()
                     .iter()
@@ -396,21 +399,26 @@ impl BridgeQueryPlanner {
         rust_planner: Option<Arc<QueryPlanner>>,
     ) -> Result<Self, ServiceBuildError> {
         let planner =
-            PlannerMode::new(&schema, &configuration, old_js_planner, rust_planner).await?;
+            PlannerMode::new(&schema, &configuration, &old_js_planner, rust_planner).await?;
 
         let subgraph_schemas = Arc::new(planner.subgraphs().await?);
 
         let introspection = if configuration.supergraph.introspection {
-            Some(Arc::new(
-                Introspection::new(
+            match configuration.experimental_introspection_mode {
+                IntrospectionConfig::New => IntrospectionMode::Rust,
+                IntrospectionConfig::Legacy => IntrospectionMode::Js(
                     planner
-                        .js_for_api_schema_and_introspection_and_operation_signature()
-                        .clone(),
-                )
-                .await?,
-            ))
+                        .js_introspetion(&schema.raw_sdl, &configuration, &old_js_planner)
+                        .await?,
+                ),
+                IntrospectionConfig::Both => IntrospectionMode::Both(
+                    planner
+                        .js_introspetion(&schema.raw_sdl, &configuration, &old_js_planner)
+                        .await?,
+                ),
+            }
         } else {
-            None
+            IntrospectionMode::Disabled
         };
 
         let enable_authorization_directives =
@@ -431,10 +439,18 @@ impl BridgeQueryPlanner {
         })
     }
 
-    pub(crate) fn planner(&self) -> Arc<Planner<QueryPlanResult>> {
-        self.planner
-            .js_for_api_schema_and_introspection_and_operation_signature()
-            .clone()
+    pub(crate) fn js_planner(&self) -> Option<Arc<Planner<QueryPlanResult>>> {
+        match &self.planner {
+            PlannerMode::Js(js) => Some(js.clone()),
+            PlannerMode::Both { js, .. } => Some(js.clone()),
+            PlannerMode::Rust(_) => match &self.introspection {
+                IntrospectionMode::Js(js_introspection)
+                | IntrospectionMode::Both(js_introspection) => {
+                    Some(js_introspection.planner.clone())
+                }
+                IntrospectionMode::Rust | IntrospectionMode::Disabled => None,
+            },
+        }
     }
 
     #[cfg(test)]
@@ -494,11 +510,17 @@ impl BridgeQueryPlanner {
         key: QueryKey,
         doc: ParsedDocument,
     ) -> Result<QueryPlannerContent, QueryPlannerError> {
-        let Some(introspection) = &self.introspection else {
-            return Ok(QueryPlannerContent::IntrospectionDisabled);
-        };
-        let mode = self.configuration.experimental_introspection_mode;
-        let response = if mode != IntrospectionMode::New && doc.executable.operations.len() > 1 {
+        match &self.introspection {
+            IntrospectionMode::Disabled => return Ok(QueryPlannerContent::IntrospectionDisabled),
+            IntrospectionMode::Rust => {
+                return Ok(QueryPlannerContent::Response {
+                    response: Box::new(self.rust_introspection(&key, &doc)?),
+                });
+            }
+            IntrospectionMode::Js(_) | IntrospectionMode::Both(_) => {}
+        }
+
+        if doc.executable.operations.len() > 1 {
             // TODO: add an operation_name parameter to router-bridge to fix this?
             let error = graphql::Error::builder()
                 .message(
@@ -510,43 +532,42 @@ impl BridgeQueryPlanner {
             return Ok(QueryPlannerContent::Response {
                 response: Box::new(graphql::Response::builder().error(error).build()),
             });
-        } else {
-            match mode {
-                IntrospectionMode::Legacy => introspection
+        }
+
+        let response = match &self.introspection {
+            IntrospectionMode::Rust | IntrospectionMode::Disabled => unreachable!(), // returned above
+            IntrospectionMode::Js(js) => js
+                .execute(key.filtered_query)
+                .await
+                .map_err(QueryPlannerError::Introspection)?,
+            IntrospectionMode::Both(js) => {
+                let rust_result = match self.rust_introspection(&key, &doc) {
+                    Ok(response) => {
+                        if response.errors.is_empty() {
+                            Ok(response)
+                        } else {
+                            Err(QueryPlannerError::Introspection(IntrospectionError {
+                                message: Some(
+                                    response
+                                        .errors
+                                        .into_iter()
+                                        .map(|e| e.to_string())
+                                        .collect::<Vec<_>>()
+                                        .join(", "),
+                                ),
+                            }))
+                        }
+                    }
+                    Err(e) => Err(e),
+                };
+                let js_result = js
                     .execute(key.filtered_query)
                     .await
-                    .map_err(QueryPlannerError::Introspection)?,
-                IntrospectionMode::New => self.rust_introspection(&key, &doc)?,
-                IntrospectionMode::Both => {
-                    let rust_result = match self.rust_introspection(&key, &doc) {
-                        Ok(response) => {
-                            if response.errors.is_empty() {
-                                Ok(response)
-                            } else {
-                                Err(QueryPlannerError::Introspection(IntrospectionError {
-                                    message: Some(
-                                        response
-                                            .errors
-                                            .into_iter()
-                                            .map(|e| e.to_string())
-                                            .collect::<Vec<_>>()
-                                            .join(", "),
-                                    ),
-                                }))
-                            }
-                        }
-                        Err(e) => Err(e),
-                    };
-                    let js_result = introspection
-                        .execute(key.filtered_query)
-                        .await
-                        .map_err(QueryPlannerError::Introspection);
-                    self.compare_introspection_responses(js_result.clone(), rust_result);
-                    js_result?
-                }
+                    .map_err(QueryPlannerError::Introspection);
+                self.compare_introspection_responses(js_result.clone(), rust_result);
+                js_result?
             }
         };
-
         Ok(QueryPlannerContent::Response {
             response: Box::new(response),
         })

--- a/apollo-router/src/query_planner/bridge_query_planner_pool.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner_pool.rs
@@ -102,9 +102,9 @@ impl BridgeQueryPlannerPool {
             })?
             .subgraph_schemas();
 
-        let planners: Vec<_> = bridge_query_planners
+        let js_planners: Vec<_> = bridge_query_planners
             .iter()
-            .map(|p| p.planner().clone())
+            .filter_map(|p| p.js_planner())
             .collect();
 
         for mut planner in bridge_query_planners.into_iter() {
@@ -140,7 +140,7 @@ impl BridgeQueryPlannerPool {
         let (v8_heap_total, _v8_heap_total_gauge) = Self::create_heap_total_gauge(&meter);
 
         // initialize v8 metrics
-        if let Some(bridge_query_planner) = planners.first().cloned() {
+        if let Some(bridge_query_planner) = js_planners.first().cloned() {
             Self::get_v8_metrics(
                 bridge_query_planner,
                 v8_heap_used.clone(),
@@ -150,7 +150,7 @@ impl BridgeQueryPlannerPool {
         }
 
         Ok(Self {
-            js_planners: planners,
+            js_planners,
             sender,
             schema,
             subgraph_schemas,
@@ -190,7 +190,7 @@ impl BridgeQueryPlannerPool {
         (current_heap_total, heap_total_gauge)
     }
 
-    pub(crate) fn planners(&self) -> Vec<Arc<Planner<QueryPlanResult>>> {
+    pub(crate) fn js_planners(&self) -> Vec<Arc<Planner<QueryPlanResult>>> {
         self.js_planners.clone()
     }
 

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -382,8 +382,8 @@ where
 }
 
 impl CachingQueryPlanner<BridgeQueryPlannerPool> {
-    pub(crate) fn planners(&self) -> Vec<Arc<Planner<QueryPlanResult>>> {
-        self.delegate.planners()
+    pub(crate) fn js_planners(&self) -> Vec<Arc<Planner<QueryPlanResult>>> {
+        self.delegate.js_planners()
     }
 
     pub(crate) fn subgraph_schemas(

--- a/apollo-router/src/router_factory.rs
+++ b/apollo-router/src/router_factory.rs
@@ -294,34 +294,36 @@ impl YamlRouterFactory {
     ) -> Result<SupergraphCreator, BoxError> {
         let query_planner_span = tracing::info_span!("query_planner_creation");
         // QueryPlannerService takes an UnplannedRequest and outputs PlannedRequest
-        let bridge_query_planner =
-            match previous_supergraph.as_ref().map(|router| router.planners()) {
-                None => {
-                    BridgeQueryPlannerPool::new(
-                        schema.clone(),
-                        configuration.clone(),
-                        configuration
-                            .supergraph
-                            .query_planning
-                            .experimental_query_planner_parallelism()?,
-                    )
-                    .instrument(query_planner_span)
-                    .await?
-                }
-                Some(planners) => {
-                    BridgeQueryPlannerPool::new_from_planners(
-                        planners,
-                        schema.clone(),
-                        configuration.clone(),
-                        configuration
-                            .supergraph
-                            .query_planning
-                            .experimental_query_planner_parallelism()?,
-                    )
-                    .instrument(query_planner_span)
-                    .await?
-                }
-            };
+        let bridge_query_planner = match previous_supergraph
+            .as_ref()
+            .map(|router| router.js_planners())
+        {
+            None => {
+                BridgeQueryPlannerPool::new(
+                    schema.clone(),
+                    configuration.clone(),
+                    configuration
+                        .supergraph
+                        .query_planning
+                        .experimental_query_planner_parallelism()?,
+                )
+                .instrument(query_planner_span)
+                .await?
+            }
+            Some(js_planners) => {
+                BridgeQueryPlannerPool::new_from_planners(
+                    js_planners,
+                    schema.clone(),
+                    configuration.clone(),
+                    configuration
+                        .supergraph
+                        .query_planning
+                        .experimental_query_planner_parallelism()?,
+                )
+                .instrument(query_planner_span)
+                .await?
+            }
+        };
 
         let schema_changed = previous_supergraph
             .map(|supergraph_creator| supergraph_creator.schema().raw_sdl == schema.raw_sdl)

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -934,8 +934,8 @@ impl SupergraphCreator {
         self.query_planner_service.previous_cache()
     }
 
-    pub(crate) fn planners(&self) -> Vec<Arc<Planner<QueryPlanResult>>> {
-        self.query_planner_service.planners()
+    pub(crate) fn js_planners(&self) -> Vec<Arc<Planner<QueryPlanResult>>> {
+        self.query_planner_service.js_planners()
     }
 
     pub(crate) async fn warm_up_query_planner(


### PR DESCRIPTION
Test scenario on macOS:

* Run `cargo build --release`
* Run `/usr/bin/time -l target/release/router -c config.yaml -s schema.graphql` (`-l` makes the time command print the result of `getrusage`)
* Wait until `GraphQL endpoint exposed` log is printed
* Hit CTRL-C. (No operation was executed.)
* The `maximum resident set size` indicates peak memory use

Configuration files:

* "Before": default config with JS query planner and JS introspection
  ```yaml
  {}
  ```
* "After": Rust planner and Rust introspection
  ```yaml
  experimental_query_planner_mode: new
  experimental_introspection_mode: new
  ```

Results:

* Small schema: 81 → 41 MiB
* Large schema: 633 → 231 MiB

Fixes ROUTER-720

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
