### PR TITLE
Move cost context values into DashMap

### DIFF
--- a/apollo-router/src/plugins/telemetry/config_new/selectors.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/selectors.rs
@@ -14,7 +14,10 @@ use crate::plugin::serde::deserialize_json_query;
 use crate::plugin::serde::deserialize_jsonpath;
 use crate::plugins::cache::entity::CacheSubgraph;
 use crate::plugins::cache::metrics::CacheMetricContextKey;
-use crate::plugins::demand_control::CostContext;
+use crate::plugins::demand_control::COST_ACTUAL_CONTEXT_KEY;
+use crate::plugins::demand_control::COST_ESTIMATED_CONTEXT_KEY;
+use crate::plugins::demand_control::COST_RESULT_CONTEXT_KEY;
+use crate::plugins::demand_control::COST_STRATEGY_CONTEXT_KEY;
 use crate::plugins::telemetry::config::AttributeValue;
 use crate::plugins::telemetry::config::TraceIdFormat;
 use crate::plugins::telemetry::config_new::cost::CostValue;
@@ -1090,14 +1093,29 @@ impl Selector for SupergraphSelector {
                 val.maybe_to_otel_value()
             }
             .or_else(|| default.maybe_to_otel_value()),
-            SupergraphSelector::Cost { cost } => ctx.extensions().with_lock(|lock| {
-                lock.get::<CostContext>().map(|cost_result| match cost {
-                    CostValue::Estimated => cost_result.estimated.into(),
-                    CostValue::Actual => cost_result.actual.into(),
-                    CostValue::Delta => cost_result.delta().into(),
-                    CostValue::Result => cost_result.result.into(),
-                })
-            }),
+            SupergraphSelector::Cost { cost } => match cost {
+                CostValue::Estimated => ctx
+                    .get::<&str, f64>(COST_ESTIMATED_CONTEXT_KEY)
+                    .ok()
+                    .flatten()
+                    .map(opentelemetry::Value::from),
+                CostValue::Actual => ctx
+                    .get::<&str, f64>(COST_ACTUAL_CONTEXT_KEY)
+                    .ok()
+                    .flatten()
+                    .map(opentelemetry::Value::from),
+                CostValue::Delta => ctx
+                    .get::<&str, f64>(COST_ESTIMATED_CONTEXT_KEY)
+                    .ok()
+                    .flatten()
+                    .zip(ctx.get::<&str, f64>(COST_ACTUAL_CONTEXT_KEY).ok().flatten())
+                    .map(|(estimated, actual)| (estimated - actual).into()),
+                CostValue::Result => ctx
+                    .get::<&str, String>(COST_RESULT_CONTEXT_KEY)
+                    .ok()
+                    .flatten()
+                    .map(opentelemetry::Value::from),
+            },
             SupergraphSelector::OnGraphQLError { on_graphql_error } if *on_graphql_error => {
                 if ctx.get_json_value(CONTAINS_GRAPHQL_ERROR)
                     == Some(serde_json_bytes::Value::Bool(true))


### PR DESCRIPTION
Moves demand control cost values from the non-serializable context extensions to the serializable context map. This allows Rhai scripts and coprocessors to access this data.

<!-- ROUTER-443 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
