### PR TITLE
Rust intropsection: disable max depth rule

### DIFF
--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -559,12 +559,6 @@ impl BridgeQueryPlanner {
     ) -> Result<graphql::Response, QueryPlannerError> {
         let schema = self.schema.api_schema();
         let operation = doc.get_operation(key.operation_name.as_deref())?;
-        apollo_compiler::execution::check_introspection_max_depth(&doc.executable, operation)
-            .map_err(|_e| {
-                QueryPlannerError::Introspection(IntrospectionError {
-                    message: Some("Maximum introspection depth exceeded".to_owned()),
-                })
-            })?;
         let variable_values = Default::default();
         let variable_values =
             apollo_compiler::execution::coerce_variable_values(schema, operation, &variable_values)


### PR DESCRIPTION
**This targets the `1.54.0` branch.**

This protection against introspection queries generating huge responses was added recently in graphql-js https://github.com/graphql/graphql-js/pull/4118 and ported to rust https://github.com/apollographql/apollo-rs/pull/904, but is not yet present in the graphql-js version used by router-bridge.

This disables it for now from Rust introspection, in order to match the current state of JS introspection.

Adding this rule (in both implementations) can be revisited separately. In particular: the depth limit is hard-coded to 3. Is that the right number? Should it be configurable? Is the rule checking the right set of fields?