### PR TITLE
Unpin `apollo-compiler` and update related dependencies

### DIFF
--- a/.changesets/fix_trevor-scheer_unpin_compiler.md
+++ b/.changesets/fix_trevor-scheer_unpin_compiler.md
@@ -1,0 +1,5 @@
+### Unpin `apollo-compiler` workspace dependency, update related dependencies ([PR #5979](https://github.com/apollographql/router/pull/5979))
+
+This PR unpins the `apollo-compiler` workspace dependency, which allows dependents of the crates within this workspace to take updates to `apollo-compiler` out of sync.
+
+By [@trevor-scheer](https://github.com/trevor-scheer)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,9 +159,9 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "apollo-compiler"
-version = "1.0.0-beta.21"
+version = "1.0.0-beta.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9496debc2b28a7da94aa6329b653fae37e0f0ec44da93d82a8d5d2a6a82abe0e"
+checksum = "6feccaf8fab00732a73dd3a40e4aaa7a1106ceef3c0bfbc591c4e0ba27e07774"
 dependencies = [
  "ahash",
  "apollo-parser",
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-parser"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a43dc64e71ca7140e646b99bf86ae721ebb801d2aec44e29a654c4d035ab8"
+checksum = "9692c1bfa7e0628e5c46bd0538571dd469138a0f062290fd4bf90e20e46f05da"
 dependencies = [
  "memchr",
  "rowan",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-smith"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de03c56d7feec663e7f9e981cf4570db68a0901de8c4667f5b5d20321b88af6e"
+checksum = "10e88b295221ae9d2af63d5eac86cb1f47ec8449e7440253d7772fc305a6c200"
 dependencies = [
  "apollo-compiler",
  "apollo-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,9 @@ debug = 1
 # Dependencies used in more than one place are specified here in order to keep versions in sync:
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
 [workspace.dependencies]
-apollo-compiler = "=1.0.0-beta.21"
-apollo-parser = "0.8.0"
-apollo-smith = "0.11.0"
+apollo-compiler = "1.0.0-beta.22"
+apollo-parser = "0.8.2"
+apollo-smith = "0.12.0"
 async-trait = "0.1.77"
 hex = { version = "0.4.3", features = ["serde"] }
 http = "0.2.11"

--- a/examples/supergraph-sdl/rust/Cargo.toml
+++ b/examples/supergraph-sdl/rust/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-apollo-compiler = "=1.0.0-beta.21"
+apollo-compiler = "1.0.0-beta.22"
 apollo-router = { path = "../../../apollo-router" }
 async-trait = "0.1"
 tower = { version = "0.4", features = ["full"] }


### PR DESCRIPTION
Dependents of the `apollo-federation` crate are currently locked to the version of `apollo-compiler` that's pinned by this workspace. If we don't absolutely need to pin it (perhaps we do), it would be beneficial for the consumers of crates from this workspace if it were unpinned.