### PR TITLE
Validate connector entity resolver arguments

### DIFF
--- a/apollo-federation/src/sources/connect/validation/coordinates.rs
+++ b/apollo-federation/src/sources/connect/validation/coordinates.rs
@@ -140,3 +140,12 @@ pub(super) fn connect_directive_entity_argument_coordinate(
 ) -> String {
     format!("`@{connect_directive_entity_argument}({CONNECT_ENTITY_ARGUMENT_NAME}: {value})` on `{object_name}.{field}`", object_name = object.name)
 }
+
+pub(super) fn field_with_connect_directive_entity_true_coordinate(
+    connect_directive_entity_argument: &Name,
+    value: &Value,
+    object: &Node<ObjectType>,
+    field: &Name,
+) -> String {
+    format!("`{object_name}.{field}` with `@{connect_directive_entity_argument}({CONNECT_ENTITY_ARGUMENT_NAME}: {value})`", object_name = object.name)
+}

--- a/apollo-federation/src/sources/connect/validation/entity.rs
+++ b/apollo-federation/src/sources/connect/validation/entity.rs
@@ -45,12 +45,14 @@ pub(super) fn validate_entity_arg(
                         .collect(),
                 })
                 // TODO: Allow interfaces
-            } else if field.ty.is_list() || schema.get_object(field.ty.inner_named_type()).is_none()
+            } else if field.ty.is_list()
+                || schema.get_object(field.ty.inner_named_type()).is_none()
+                || field.ty.is_non_null()
             {
                 messages.push(Message {
                     code: Code::EntityTypeInvalid,
                     message: format!(
-                        "{coordinate} is invalid. Entities can only be non-list, object types.",
+                        "{coordinate} is invalid. Entities can only be non-list, nullable, object types.",
                         coordinate = connect_directive_entity_argument_coordinate(
                             connect_directive_name,
                             entity_arg_value.as_ref(),

--- a/apollo-federation/src/sources/connect/validation/entity.rs
+++ b/apollo-federation/src/sources/connect/validation/entity.rs
@@ -1,8 +1,14 @@
+use apollo_compiler::ast::Argument;
 use apollo_compiler::ast::FieldDefinition;
+use apollo_compiler::ast::InputValueDefinition;
+use apollo_compiler::ast::Value;
 use apollo_compiler::parser::SourceMap;
 use apollo_compiler::schema::Component;
 use apollo_compiler::schema::Directive;
+use apollo_compiler::schema::ExtendedType;
+use apollo_compiler::schema::InputObjectType;
 use apollo_compiler::schema::ObjectType;
+use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::Schema;
 
@@ -10,6 +16,8 @@ use super::coordinates::connect_directive_entity_argument_coordinate;
 use super::extended_type::ObjectCategory;
 use super::Code;
 use super::Message;
+use crate::sources::connect::expand::visitors::FieldVisitor;
+use crate::sources::connect::expand::visitors::GroupVisitor;
 use crate::sources::connect::spec::schema::CONNECT_ENTITY_ARGUMENT_NAME;
 
 pub(super) fn validate_entity_arg(
@@ -66,8 +74,221 @@ pub(super) fn validate_entity_arg(
                         .collect(),
                 })
             }
+
+            // Validate the arguments to the entity resolver (but if the field was determined to be
+            // invalid for an entity resolver above, don't bother validating the field arguments).
+            if messages.is_empty() {
+                if field.arguments.is_empty() {
+                    messages.push(Message {
+                        code: Code::EntityResolverArgumentMismatch,
+                        message: format!(
+                            "{coordinate} is missing entity resolver arguments.",
+                            coordinate = connect_directive_entity_argument_coordinate(
+                                connect_directive_name,
+                                entity_arg_value.as_ref(),
+                                object,
+                                &field.name,
+                            ),
+                        ),
+                        locations: entity_arg
+                            .line_column_range(source_map)
+                            .into_iter()
+                            .collect(),
+                    });
+                } else if let Some(object_type) = schema.get_object(field.ty.inner_named_type()) {
+                    if let Some(message) = (ArgumentVisitor {
+                        schema,
+                        connect_directive_name,
+                        entity_arg,
+                        entity_arg_value,
+                        object,
+                        source_map,
+                        field: &field.name,
+                    })
+                    .walk(Group::Root {
+                        field,
+                        entity_type: object_type,
+                    })
+                    .err()
+                    {
+                        messages.push(message);
+                    }
+                };
+            }
         }
     }
 
     messages
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Group<'schema> {
+    Root {
+        field: &'schema Node<FieldDefinition>,
+        entity_type: &'schema Node<ObjectType>,
+    },
+    Child {
+        input_type: &'schema Node<InputObjectType>,
+        entity_type: &'schema ExtendedType,
+    },
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Field<'schema> {
+    node: &'schema Node<InputValueDefinition>,
+    input_type: &'schema ExtendedType,
+    entity_type: &'schema ExtendedType,
+}
+
+/// Visitor for entity resolver arguments.
+struct ArgumentVisitor<'schema> {
+    schema: &'schema Schema,
+    connect_directive_name: &'schema Name,
+    entity_arg: &'schema Node<Argument>,
+    entity_arg_value: &'schema Node<Value>,
+    object: &'schema Node<ObjectType>,
+    source_map: &'schema SourceMap,
+    field: &'schema Name,
+}
+
+impl<'schema> GroupVisitor<Group<'schema>, Field<'schema>> for ArgumentVisitor<'schema> {
+    fn try_get_group_for_field(
+        &self,
+        field: &Field<'schema>,
+    ) -> Result<Option<Group<'schema>>, Self::Error> {
+        Ok(
+            if let ExtendedType::InputObject(input_object_type) = field.input_type {
+                Some(Group::Child {
+                    input_type: input_object_type,
+                    entity_type: field.entity_type,
+                })
+            } else {
+                None
+            },
+        )
+    }
+
+    fn enter_group(&mut self, group: &Group<'schema>) -> Result<Vec<Field<'schema>>, Self::Error> {
+        match group {
+            Group::Root { field, entity_type, .. } => field.arguments.iter().filter_map(|arg| {
+                if let Some(input_type) = self.schema.types.get(arg.ty.inner_named_type()) {
+                    if let Some(entity_type) = entity_type.fields.get(&*arg.name)
+                        .and_then(|entity_field| self.schema.types.get(entity_field.ty.inner_named_type())) {
+                        Some(Ok(Field {
+                            node: arg,
+                            input_type,
+                            entity_type,
+                        }))
+                    } else {
+                        Some(Err(Message {
+                            code: Code::EntityResolverArgumentMismatch,
+                            message: format!(
+                                "{coordinate} has invalid entity resolver arguments. Argument `{arg_name}` does not exist as a field on entity type `{entity_type}`.",
+                                coordinate = connect_directive_entity_argument_coordinate(
+                                    self.connect_directive_name,
+                                    self.entity_arg_value.as_ref(),
+                                    self.object,
+                                    &field.name
+                                ),
+                                arg_name = &*arg.name,
+                                entity_type = entity_type.name,
+                            ),
+                            locations: arg
+                                .line_column_range(self.source_map)
+                                .into_iter()
+                                .chain(self.entity_arg.line_column_range(self.source_map))
+                                .collect(),
+                        }))
+                    }
+                } else {
+                    // The input type is missing - this will be reported elsewhere, so just ignore
+                    None
+                }
+            }).collect(),
+            Group::Child { input_type, entity_type, .. } => {
+                if let ExtendedType::Object(entity_object_type) = entity_type {
+                    input_type.fields.iter().filter_map(|(name, input_field)| {
+                        if let Some(entity_field) = entity_object_type.fields.get(name) {
+                            let entity_field_type = entity_field.ty.inner_named_type();
+                            if let Some(input_type) = self.schema.types.get(input_field.ty.inner_named_type()) {
+                                self.schema.types.get(entity_field_type).map(|entity_type| Ok(Field {
+                                        node: input_field,
+                                        input_type,
+                                        entity_type,
+                                    }))
+                            } else {
+                                // The input type is missing - this will be reported elsewhere, so just ignore
+                                None
+                            }
+                        } else {
+                            Some(Err(Message {
+                                code: Code::EntityResolverArgumentMismatch,
+                                message: format!(
+                                    "{coordinate} has invalid entity resolver arguments. Field `{name}` on `{input_type}` does not exist on `{entity_type}`.",
+                                    coordinate = connect_directive_entity_argument_coordinate(
+                                        self.connect_directive_name,
+                                        self.entity_arg_value.as_ref(),
+                                        self.object,
+                                        self.field,
+                                    ),
+                                    input_type = input_type.name,
+                                    entity_type = entity_object_type.name,
+                                ),
+                                locations: input_field
+                                    .line_column_range(self.source_map)
+                                    .into_iter()
+                                    .chain(self.entity_arg.line_column_range(self.source_map))
+                                    .collect(),
+                            }))
+                    }
+                    }).collect()
+                } else {
+                    // Entity type was not an object type - this will be reported by field visitor
+                    Ok(vec![])
+                }
+            },
+        }
+    }
+
+    fn exit_group(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl<'schema> FieldVisitor<Field<'schema>> for ArgumentVisitor<'schema> {
+    type Error = Message;
+
+    fn visit(&mut self, field: Field<'schema>) -> Result<(), Self::Error> {
+        let ok = match field.input_type {
+            ExtendedType::InputObject(_) => field.entity_type.is_object(),
+            ExtendedType::Scalar(_) | ExtendedType::Enum(_) => {
+                field.input_type == field.entity_type
+            }
+            _ => true,
+        };
+        if ok {
+            Ok(())
+        } else {
+            Err(Message {
+                code: Code::EntityResolverArgumentMismatch,
+                message: format!(
+                    "{coordinate} has invalid entity resolver arguments. Mismatched type on field `{field_name}` - expected `{entity_type}` but found `{input_type}`.",
+                    coordinate = connect_directive_entity_argument_coordinate(
+                        self.connect_directive_name,
+                        self.entity_arg_value.as_ref(),
+                        self.object,
+                        self.field,
+                    ),
+                    field_name = field.node.name.as_str(),
+                    input_type = field.input_type.name(),
+                    entity_type = field.entity_type.name(),
+                ),
+                locations: field.node
+                    .line_column_range(self.source_map)
+                    .into_iter()
+                    .chain(self.entity_arg.line_column_range(self.source_map))
+                    .collect(),
+            })
+        }
+    }
 }

--- a/apollo-federation/src/sources/connect/validation/entity.rs
+++ b/apollo-federation/src/sources/connect/validation/entity.rs
@@ -21,6 +21,9 @@ use super::coordinates::field_with_connect_directive_entity_true_coordinate;
 use super::extended_type::ObjectCategory;
 use super::Code;
 use super::Message;
+use crate::link::federation_spec_definition::FEDERATION_FIELDS_ARGUMENT_NAME;
+use crate::link::federation_spec_definition::FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC;
+use crate::link::federation_spec_definition::FEDERATION_RESOLVABLE_ARGUMENT_NAME;
 use crate::sources::connect::expand::visitors::FieldVisitor;
 use crate::sources::connect::expand::visitors::GroupVisitor;
 use crate::sources::connect::spec::schema::CONNECT_ENTITY_ARGUMENT_NAME;
@@ -104,9 +107,20 @@ pub(super) fn validate_entity_arg(
                     let key_fields = object_type
                         .directives
                         .iter()
-                        .filter(|directive| directive.name == "key")
+                        .filter(|directive| directive.name == FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC)
+                        .filter(|directive| {
+                            directive
+                                .arguments
+                                .iter()
+                                .find(|arg| arg.name == FEDERATION_RESOLVABLE_ARGUMENT_NAME)
+                                .and_then(|arg| arg.value.to_bool())
+                                .unwrap_or(true)
+                        })
                         .filter_map(|directive| {
-                            directive.arguments.iter().find(|arg| arg.name == "fields")
+                            directive
+                                .arguments
+                                .iter()
+                                .find(|arg| arg.name == FEDERATION_FIELDS_ARGUMENT_NAME)
                         })
                         .map(|fields| &*fields.value)
                         .filter_map(|key_fields| key_fields.as_str())

--- a/apollo-federation/src/sources/connect/validation/entity.rs
+++ b/apollo-federation/src/sources/connect/validation/entity.rs
@@ -396,7 +396,7 @@ impl<'schema> ArgumentVisitor<'schema> {
                     Some(Err(Message {
                         code: Code::EntityResolverArgumentMismatch,
                         message: format!(
-                            "{coordinate} has invalid arguments. Field `{name}` on `{input_type}` does not exist on `{entity_type}`.",
+                            "{coordinate} has invalid arguments. Field `{name}` on `{input_type}` does not have a matching field `{name}` on `{entity_type}`.",
                             coordinate = field_with_connect_directive_entity_true_coordinate(
                                 self.connect_directive_name,
                                 self.entity_arg_value.as_ref(),

--- a/apollo-federation/src/sources/connect/validation/entity.rs
+++ b/apollo-federation/src/sources/connect/validation/entity.rs
@@ -338,7 +338,7 @@ impl<'schema> ArgumentVisitor<'schema> {
         &mut self,
         child_input_type: &'schema Node<InputObjectType>,
         entity_type: &'schema ExtendedType,
-        key_selections: &Vec<Selection>,
+        key_selections: &[Selection],
         root_entity_type: &'schema Name,
     ) -> Result<
         Vec<Field<'schema>>,

--- a/apollo-federation/src/sources/connect/validation/entity.rs
+++ b/apollo-federation/src/sources/connect/validation/entity.rs
@@ -17,6 +17,7 @@ use apollo_compiler::Node;
 use apollo_compiler::Schema;
 
 use super::coordinates::connect_directive_entity_argument_coordinate;
+use super::coordinates::field_with_connect_directive_entity_true_coordinate;
 use super::extended_type::ObjectCategory;
 use super::Code;
 use super::Message;
@@ -64,7 +65,7 @@ pub(super) fn validate_entity_arg(
                 messages.push(Message {
                     code: Code::EntityTypeInvalid,
                     message: format!(
-                        "{coordinate} is invalid. Entities can only be non-list, nullable, object types.",
+                        "{coordinate} is invalid. Entity connectors must return non-list, nullable, object types.",
                         coordinate = connect_directive_entity_argument_coordinate(
                             connect_directive_name,
                             entity_arg_value.as_ref(),
@@ -86,8 +87,8 @@ pub(super) fn validate_entity_arg(
                     messages.push(Message {
                         code: Code::EntityResolverArgumentMismatch,
                         message: format!(
-                            "{coordinate} is missing entity resolver arguments.",
-                            coordinate = connect_directive_entity_argument_coordinate(
+                            "{coordinate} must have arguments. See https://preview-docs.apollographql.com/graphos/connectors/directives/#rules-for-entity-true",
+                            coordinate = field_with_connect_directive_entity_true_coordinate(
                                 connect_directive_name,
                                 entity_arg_value.as_ref(),
                                 object,
@@ -246,8 +247,8 @@ impl<'schema> FieldVisitor<Field<'schema>> for ArgumentVisitor<'schema> {
             Err(Message {
                 code: Code::EntityResolverArgumentMismatch,
                 message: format!(
-                    "{coordinate} has invalid entity resolver arguments. Mismatched type on field `{field_name}` - expected `{entity_type}` but found `{input_type}`.",
-                    coordinate = connect_directive_entity_argument_coordinate(
+                    "{coordinate} has invalid arguments. Mismatched type on field `{field_name}` - expected `{entity_type}` but found `{input_type}`.",
+                    coordinate = field_with_connect_directive_entity_true_coordinate(
                         self.connect_directive_name,
                         self.entity_arg_value.as_ref(),
                         self.object,
@@ -309,8 +310,8 @@ impl<'schema> ArgumentVisitor<'schema> {
                     Some(Err(Message {
                         code: Code::EntityResolverArgumentMismatch,
                         message: format!(
-                            "{coordinate} has invalid entity resolver arguments. Argument `{arg_name}` does not exist as a field on entity type `{entity_type}`.",
-                            coordinate = connect_directive_entity_argument_coordinate(
+                            "{coordinate} has invalid arguments. Argument `{arg_name}` does not have a matching field `{arg_name}` on type `{entity_type}`.",
+                            coordinate = field_with_connect_directive_entity_true_coordinate(
                                 self.connect_directive_name,
                                 self.entity_arg_value.as_ref(),
                                 self.object,
@@ -381,8 +382,8 @@ impl<'schema> ArgumentVisitor<'schema> {
                     Some(Err(Message {
                         code: Code::EntityResolverArgumentMismatch,
                         message: format!(
-                            "{coordinate} has invalid entity resolver arguments. Field `{name}` on `{input_type}` does not exist on `{entity_type}`.",
-                            coordinate = connect_directive_entity_argument_coordinate(
+                            "{coordinate} has invalid arguments. Field `{name}` on `{input_type}` does not exist on `{entity_type}`.",
+                            coordinate = field_with_connect_directive_entity_true_coordinate(
                                 self.connect_directive_name,
                                 self.entity_arg_value.as_ref(),
                                 self.object,
@@ -432,12 +433,12 @@ impl<'schema> ArgumentVisitor<'schema> {
             Err(Message {
                 code: Code::EntityResolverArgumentMismatch,
                 message: format!(
-                    "{coordinate} has invalid entity resolver arguments. {name} does not exist as a key field on entity type `{entity_type}`.",
+                    "{coordinate} has invalid arguments. {name} does not match a field in a `@key` on type `{entity_type}`.",
                     name = match input_type {
                         Some(input_type) => format!("Field `{name}` on input type `{input_type}`"),
                         None => format!("Argument `{name}`"),
                     },
-                    coordinate = connect_directive_entity_argument_coordinate(
+                    coordinate = field_with_connect_directive_entity_true_coordinate(
                         self.connect_directive_name,
                         self.entity_arg_value.as_ref(),
                         self.object,

--- a/apollo-federation/src/sources/connect/validation/entity.rs
+++ b/apollo-federation/src/sources/connect/validation/entity.rs
@@ -2,12 +2,16 @@ use apollo_compiler::ast::Argument;
 use apollo_compiler::ast::FieldDefinition;
 use apollo_compiler::ast::InputValueDefinition;
 use apollo_compiler::ast::Value;
+use apollo_compiler::executable::FieldSet;
+use apollo_compiler::executable::Selection;
+use apollo_compiler::parser::Parser;
 use apollo_compiler::parser::SourceMap;
 use apollo_compiler::schema::Component;
 use apollo_compiler::schema::Directive;
 use apollo_compiler::schema::ExtendedType;
 use apollo_compiler::schema::InputObjectType;
 use apollo_compiler::schema::ObjectType;
+use apollo_compiler::validation::Valid;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::Schema;
@@ -96,6 +100,26 @@ pub(super) fn validate_entity_arg(
                             .collect(),
                     });
                 } else if let Some(object_type) = schema.get_object(field.ty.inner_named_type()) {
+                    let key_fields = object_type
+                        .directives
+                        .iter()
+                        .find(|directive| directive.name == "key")
+                        .and_then(|directive| {
+                            directive.arguments.iter().find(|arg| arg.name == "fields")
+                        })
+                        .map(|fields| &*fields.value)
+                        .and_then(|key_fields| key_fields.as_str())
+                        .and_then(|fields| {
+                            Parser::new()
+                                .parse_field_set(
+                                    Valid::assume_valid_ref(schema),
+                                    object_type.name.clone(),
+                                    fields.to_string(),
+                                    "",
+                                )
+                                .ok()
+                        });
+
                     if let Some(message) = (ArgumentVisitor {
                         schema,
                         connect_directive_name,
@@ -104,6 +128,7 @@ pub(super) fn validate_entity_arg(
                         object,
                         source_map,
                         field: &field.name,
+                        key_fields,
                     })
                     .walk(Group::Root {
                         field,
@@ -121,7 +146,7 @@ pub(super) fn validate_entity_arg(
     messages
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 enum Group<'schema> {
     Root {
         field: &'schema Node<FieldDefinition>,
@@ -130,17 +155,28 @@ enum Group<'schema> {
     Child {
         input_type: &'schema Node<InputObjectType>,
         entity_type: &'schema ExtendedType,
+        key_selection: Option<Selection>,
+        root_entity_type: &'schema Name,
     },
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct Field<'schema> {
     node: &'schema Node<InputValueDefinition>,
     input_type: &'schema ExtendedType,
     entity_type: &'schema ExtendedType,
+    key_selection: Option<Selection>,
+    root_entity_type: &'schema Name,
 }
 
-/// Visitor for entity resolver arguments.
+/// Visitor for entity resolver arguments. This validates that three thing match:
+///
+/// * The input type fields
+/// * The entity type fields
+/// * The entity type key fields from the `@key` directive, if present
+///
+/// Since input types may contain fields with subtypes, and the fields of those subtypes can be
+/// part of composite keys, this potentially requires visiting a tree.
 struct ArgumentVisitor<'schema> {
     schema: &'schema Schema,
     connect_directive_name: &'schema Name,
@@ -149,6 +185,7 @@ struct ArgumentVisitor<'schema> {
     object: &'schema Node<ObjectType>,
     source_map: &'schema SourceMap,
     field: &'schema Name,
+    key_fields: Option<FieldSet>,
 }
 
 impl<'schema> GroupVisitor<Group<'schema>, Field<'schema>> for ArgumentVisitor<'schema> {
@@ -157,10 +194,13 @@ impl<'schema> GroupVisitor<Group<'schema>, Field<'schema>> for ArgumentVisitor<'
         field: &Field<'schema>,
     ) -> Result<Option<Group<'schema>>, Self::Error> {
         Ok(
+            // Each input type within an argument to the entity field is another group to visit
             if let ExtendedType::InputObject(input_object_type) = field.input_type {
                 Some(Group::Child {
                     input_type: input_object_type,
                     entity_type: field.entity_type,
+                    key_selection: field.key_selection.clone(),
+                    root_entity_type: field.root_entity_type,
                 })
             } else {
                 None
@@ -170,83 +210,16 @@ impl<'schema> GroupVisitor<Group<'schema>, Field<'schema>> for ArgumentVisitor<'
 
     fn enter_group(&mut self, group: &Group<'schema>) -> Result<Vec<Field<'schema>>, Self::Error> {
         match group {
-            Group::Root { field, entity_type, .. } => field.arguments.iter().filter_map(|arg| {
-                if let Some(input_type) = self.schema.types.get(arg.ty.inner_named_type()) {
-                    if let Some(entity_type) = entity_type.fields.get(&*arg.name)
-                        .and_then(|entity_field| self.schema.types.get(entity_field.ty.inner_named_type())) {
-                        Some(Ok(Field {
-                            node: arg,
-                            input_type,
-                            entity_type,
-                        }))
-                    } else {
-                        Some(Err(Message {
-                            code: Code::EntityResolverArgumentMismatch,
-                            message: format!(
-                                "{coordinate} has invalid entity resolver arguments. Argument `{arg_name}` does not exist as a field on entity type `{entity_type}`.",
-                                coordinate = connect_directive_entity_argument_coordinate(
-                                    self.connect_directive_name,
-                                    self.entity_arg_value.as_ref(),
-                                    self.object,
-                                    &field.name
-                                ),
-                                arg_name = &*arg.name,
-                                entity_type = entity_type.name,
-                            ),
-                            locations: arg
-                                .line_column_range(self.source_map)
-                                .into_iter()
-                                .chain(self.entity_arg.line_column_range(self.source_map))
-                                .collect(),
-                        }))
-                    }
-                } else {
-                    // The input type is missing - this will be reported elsewhere, so just ignore
-                    None
-                }
-            }).collect(),
-            Group::Child { input_type, entity_type, .. } => {
-                if let ExtendedType::Object(entity_object_type) = entity_type {
-                    input_type.fields.iter().filter_map(|(name, input_field)| {
-                        if let Some(entity_field) = entity_object_type.fields.get(name) {
-                            let entity_field_type = entity_field.ty.inner_named_type();
-                            if let Some(input_type) = self.schema.types.get(input_field.ty.inner_named_type()) {
-                                self.schema.types.get(entity_field_type).map(|entity_type| Ok(Field {
-                                        node: input_field,
-                                        input_type,
-                                        entity_type,
-                                    }))
-                            } else {
-                                // The input type is missing - this will be reported elsewhere, so just ignore
-                                None
-                            }
-                        } else {
-                            Some(Err(Message {
-                                code: Code::EntityResolverArgumentMismatch,
-                                message: format!(
-                                    "{coordinate} has invalid entity resolver arguments. Field `{name}` on `{input_type}` does not exist on `{entity_type}`.",
-                                    coordinate = connect_directive_entity_argument_coordinate(
-                                        self.connect_directive_name,
-                                        self.entity_arg_value.as_ref(),
-                                        self.object,
-                                        self.field,
-                                    ),
-                                    input_type = input_type.name,
-                                    entity_type = entity_object_type.name,
-                                ),
-                                locations: input_field
-                                    .line_column_range(self.source_map)
-                                    .into_iter()
-                                    .chain(self.entity_arg.line_column_range(self.source_map))
-                                    .collect(),
-                            }))
-                    }
-                    }).collect()
-                } else {
-                    // Entity type was not an object type - this will be reported by field visitor
-                    Ok(vec![])
-                }
-            },
+            Group::Root {
+                field, entity_type, ..
+            } => self.enter_root_group(field, entity_type),
+            Group::Child {
+                input_type,
+                entity_type,
+                key_selection,
+                root_entity_type,
+                ..
+            } => self.enter_child_group(input_type, entity_type, key_selection, root_entity_type),
         }
     }
 
@@ -290,5 +263,168 @@ impl<'schema> FieldVisitor<Field<'schema>> for ArgumentVisitor<'schema> {
                     .collect(),
             })
         }
+    }
+}
+
+impl<'schema> ArgumentVisitor<'schema> {
+    fn enter_root_group(
+        &mut self,
+        field: &'schema Node<FieldDefinition>,
+        entity_type: &'schema Node<ObjectType>,
+    ) -> Result<
+        Vec<Field<'schema>>,
+        <ArgumentVisitor<'schema> as FieldVisitor<Field<'schema>>>::Error,
+    > {
+        // At the root level, visit each argument to the entity field
+        field.arguments.iter().filter_map(|arg| {
+            if let Some(input_type) = self.schema.types.get(arg.ty.inner_named_type()) {
+
+                // If the entity type has a `@key` directive, check that the argument corresponds to a field in the key
+                let key_selection = if let Some(key_fields) = &self.key_fields {
+                    match self.find_key(&key_fields.selection_set.selections, &arg.name, arg, None, &entity_type.name) {
+                        Ok(selection) => Some(selection),
+                        Err(message) => return Some(Err(message)),
+                    }
+                } else {
+                    None
+                };
+
+                // Check that the argument has a corresponding field on the entity type
+                let root_entity_type = &entity_type.name;
+                if let Some(entity_type) = entity_type.fields.get(&*arg.name)
+                    .and_then(|entity_field| self.schema.types.get(entity_field.ty.inner_named_type())) {
+                    Some(Ok(Field {
+                        node: arg,
+                        input_type,
+                        entity_type,
+                        root_entity_type,
+                        key_selection,
+                    }))
+                } else {
+                    Some(Err(Message {
+                        code: Code::EntityResolverArgumentMismatch,
+                        message: format!(
+                            "{coordinate} has invalid entity resolver arguments. Argument `{arg_name}` does not exist as a field on entity type `{entity_type}`.",
+                            coordinate = connect_directive_entity_argument_coordinate(
+                                self.connect_directive_name,
+                                self.entity_arg_value.as_ref(),
+                                self.object,
+                                &field.name
+                            ),
+                            arg_name = &*arg.name,
+                            entity_type = entity_type.name,
+                        ),
+                        locations: arg
+                            .line_column_range(self.source_map)
+                            .into_iter()
+                            .chain(self.entity_arg.line_column_range(self.source_map))
+                            .collect(),
+                    }))
+                }
+            } else {
+                // The input type is missing - this will be reported elsewhere, so just ignore
+                None
+            }
+        }).collect()
+    }
+
+    fn enter_child_group(
+        &mut self,
+        child_input_type: &'schema Node<InputObjectType>,
+        entity_type: &'schema ExtendedType,
+        key_selection: &Option<Selection>,
+        root_entity_type: &'schema Name,
+    ) -> Result<
+        Vec<Field<'schema>>,
+        <ArgumentVisitor<'schema> as FieldVisitor<Field<'schema>>>::Error,
+    > {
+        // At the child level, visit each field on the input type
+        if let ExtendedType::Object(entity_object_type) = entity_type {
+            child_input_type.fields.iter().filter_map(|(name, input_field)| {
+                if let Some(entity_field) = entity_object_type.fields.get(name) {
+                    let entity_field_type = entity_field.ty.inner_named_type();
+                    if let Some(input_type) = self.schema.types.get(input_field.ty.inner_named_type()) {
+
+                        // Check that the field on the input type corresponds to a key field
+                        let key_selection = if let Some(field) = key_selection.as_ref().and_then(|key_selection| key_selection.as_field()) {
+                            match self.find_key(&field.selection_set.selections, name, input_field, Some(&child_input_type.name), root_entity_type) {
+                                Ok(selection) => Some(selection),
+                                Err(message) => return Some(Err(message)),
+                            }
+                        } else {
+                            None
+                        };
+
+                        self.schema.types.get(entity_field_type).map(|entity_type| Ok(Field {
+                            node: input_field,
+                            input_type,
+                            entity_type,
+                            root_entity_type,
+                            key_selection,
+                        }))
+                    } else {
+                        // The input type is missing - this will be reported elsewhere, so just ignore
+                        None
+                    }
+                } else {
+                    // The input type field does not have a corresponding field on the entity type
+                    Some(Err(Message {
+                        code: Code::EntityResolverArgumentMismatch,
+                        message: format!(
+                            "{coordinate} has invalid entity resolver arguments. Field `{name}` on `{input_type}` does not exist on `{entity_type}`.",
+                            coordinate = connect_directive_entity_argument_coordinate(
+                                self.connect_directive_name,
+                                self.entity_arg_value.as_ref(),
+                                self.object,
+                                self.field,
+                            ),
+                            input_type = child_input_type.name,
+                            entity_type = entity_object_type.name,
+                        ),
+                        locations: input_field
+                            .line_column_range(self.source_map)
+                            .into_iter()
+                            .chain(self.entity_arg.line_column_range(self.source_map))
+                            .collect(),
+                    }))
+                }
+            }).collect()
+        } else {
+            // Entity type was not an object type - this will be reported by field visitor
+            Ok(vec![])
+        }
+    }
+
+    fn find_key<'a, T: IntoIterator<Item = &'a Selection>>(
+        &self,
+        selections: T,
+        name: &str,
+        node: &Node<InputValueDefinition>,
+        input_type: Option<&Name>,
+        entity_type: &Name,
+    ) -> Result<Selection, <ArgumentVisitor<'schema> as FieldVisitor<Field<'schema>>>::Error> {
+        selections.into_iter().find(|selection| {
+            selection.as_field().map(|field| field.name == *name).unwrap_or(false)
+        }).ok_or(Message {
+            code: Code::EntityResolverArgumentMismatch,
+            message: format!(
+                "{coordinate} has invalid entity resolver arguments. {name} does not exist as a key field on entity type `{entity_type}`.",
+                name = match input_type {
+                    Some(input_type) => format!("Field `{name}` on input type `{input_type}`"),
+                    None => format!("Argument `{name}`"),
+                },
+                coordinate = connect_directive_entity_argument_coordinate(
+                    self.connect_directive_name,
+                    self.entity_arg_value.as_ref(),
+                    self.object,
+                    self.field,
+                ),
+            ),
+            locations: node
+                .line_column_range(self.source_map)
+                .into_iter()
+                .chain(self.entity_arg.line_column_range(self.source_map))
+                .collect(),
+        }).cloned()
     }
 }

--- a/apollo-federation/src/sources/connect/validation/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/mod.rs
@@ -426,6 +426,8 @@ pub enum Code {
     MissingHttpMethod,
     /// The `entity` argument should only be used on the root `Query` field.
     EntityNotOnRootQuery,
+    /// The arguments to the entity reference resolver do not match the entity type.
+    EntityResolverArgumentMismatch,
     /// The `entity` argument should only be used with non-list, nullable, object types.
     EntityTypeInvalid,
     /// A syntax error in `selection`

--- a/apollo-federation/src/sources/connect/validation/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/mod.rs
@@ -426,7 +426,7 @@ pub enum Code {
     MissingHttpMethod,
     /// The `entity` argument should only be used on the root `Query` field.
     EntityNotOnRootQuery,
-    /// The `entity` argument should only be used with non-list, object types.
+    /// The `entity` argument should only be used with non-list, nullable, object types.
     EntityTypeInvalid,
     /// A syntax error in `selection`
     InvalidJsonSelection,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_input_type_missing.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_input_type_missing.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_input_type_missing.graphql
+---
+[]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_key_mismatch.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_key_mismatch.graphql.snap
@@ -1,0 +1,27 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_key_mismatch.graphql
+---
+[
+    Message {
+        code: EntityResolverArgumentMismatch,
+        message: "`@connect(entity: true)` on `Query.product` has invalid entity resolver arguments. Argument `id` does not exist as a key field on entity type `Product`.",
+        locations: [
+            LineColumn {
+                line: 13,
+                column: 9,
+            }..LineColumn {
+                line: 13,
+                column: 16,
+            },
+            LineColumn {
+                line: 18,
+                column: 9,
+            }..LineColumn {
+                line: 18,
+                column: 21,
+            },
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_key_mismatch.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_key_mismatch.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_e
 [
     Message {
         code: EntityResolverArgumentMismatch,
-        message: "`@connect(entity: true)` on `Query.product` has invalid entity resolver arguments. Argument `id` does not exist as a key field on entity type `Product`.",
+        message: "`Query.product` with `@connect(entity: true)` has invalid arguments. Argument `id` does not match a field in a `@key` on type `Product`.",
         locations: [
             LineColumn {
                 line: 13,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_key_mismatch_composite_key.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_key_mismatch_composite_key.graphql.snap
@@ -1,0 +1,27 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_key_mismatch_composite_key.graphql
+---
+[
+    Message {
+        code: EntityResolverArgumentMismatch,
+        message: "`@connect(entity: true)` on `Query.product` has invalid entity resolver arguments. Field `id` on input type `CountryInput` does not exist as a key field on entity type `Product`.",
+        locations: [
+            LineColumn {
+                line: 50,
+                column: 5,
+            }..LineColumn {
+                line: 50,
+                column: 12,
+            },
+            LineColumn {
+                line: 19,
+                column: 9,
+            }..LineColumn {
+                line: 19,
+                column: 21,
+            },
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_key_mismatch_composite_key.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_key_mismatch_composite_key.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_e
 [
     Message {
         code: EntityResolverArgumentMismatch,
-        message: "`@connect(entity: true)` on `Query.product` has invalid entity resolver arguments. Field `id` on input type `CountryInput` does not exist as a key field on entity type `Product`.",
+        message: "`Query.product` with `@connect(entity: true)` has invalid arguments. Field `id` on input type `CountryInput` does not match a field in a `@key` on type `Product`.",
         locations: [
             LineColumn {
                 line: 50,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_key_mismatch_multiple_keys.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_key_mismatch_multiple_keys.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_e
 [
     Message {
         code: EntityResolverArgumentMismatch,
-        message: "`@connect(entity: true)` on `Query.product` has invalid entity resolver arguments. Field `id` on input type `CountryInput` does not exist as a key field on entity type `Product`.",
+        message: "`Query.product` with `@connect(entity: true)` has invalid arguments. Field `id` on input type `CountryInput` does not match a field in a `@key` on type `Product`.",
         locations: [
             LineColumn {
                 line: 51,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_key_mismatch_multiple_keys.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_key_mismatch_multiple_keys.graphql.snap
@@ -1,0 +1,27 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_key_mismatch_multiple_keys.graphql
+---
+[
+    Message {
+        code: EntityResolverArgumentMismatch,
+        message: "`@connect(entity: true)` on `Query.product` has invalid entity resolver arguments. Field `id` on input type `CountryInput` does not exist as a key field on entity type `Product`.",
+        locations: [
+            LineColumn {
+                line: 51,
+                column: 5,
+            }..LineColumn {
+                line: 51,
+                column: 12,
+            },
+            LineColumn {
+                line: 19,
+                column: 9,
+            }..LineColumn {
+                line: 19,
+                column: 21,
+            },
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_name_mismatch.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_name_mismatch.graphql.snap
@@ -1,0 +1,27 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_name_mismatch.graphql
+---
+[
+    Message {
+        code: EntityResolverArgumentMismatch,
+        message: "`@connect(entity: true)` on `Query.product` has invalid entity resolver arguments. Argument `id` does not exist as a field on entity type `Product`.",
+        locations: [
+            LineColumn {
+                line: 13,
+                column: 9,
+            }..LineColumn {
+                line: 13,
+                column: 16,
+            },
+            LineColumn {
+                line: 18,
+                column: 9,
+            }..LineColumn {
+                line: 18,
+                column: 21,
+            },
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_name_mismatch.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_name_mismatch.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_e
 [
     Message {
         code: EntityResolverArgumentMismatch,
-        message: "`@connect(entity: true)` on `Query.product` has invalid entity resolver arguments. Argument `id` does not exist as a field on entity type `Product`.",
+        message: "`Query.product` with `@connect(entity: true)` has invalid arguments. Argument `id` does not have a matching field `id` on type `Product`.",
         locations: [
             LineColumn {
                 line: 13,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_name_mismatch_composite_key.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_name_mismatch_composite_key.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_e
 [
     Message {
         code: EntityResolverArgumentMismatch,
-        message: "`Query.product` with `@connect(entity: true)` has invalid arguments. Field `id` on `CountryInput` does not exist on `Country`.",
+        message: "`Query.product` with `@connect(entity: true)` has invalid arguments. Field `id` on `CountryInput` does not have a matching field `id` on `Country`.",
         locations: [
             LineColumn {
                 line: 49,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_name_mismatch_composite_key.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_name_mismatch_composite_key.graphql.snap
@@ -1,0 +1,27 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_name_mismatch_composite_key.graphql
+---
+[
+    Message {
+        code: EntityResolverArgumentMismatch,
+        message: "`@connect(entity: true)` on `Query.product` has invalid entity resolver arguments. Field `id` on `CountryInput` does not exist on `Country`.",
+        locations: [
+            LineColumn {
+                line: 49,
+                column: 5,
+            }..LineColumn {
+                line: 49,
+                column: 12,
+            },
+            LineColumn {
+                line: 19,
+                column: 9,
+            }..LineColumn {
+                line: 19,
+                column: 21,
+            },
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_name_mismatch_composite_key.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_name_mismatch_composite_key.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_e
 [
     Message {
         code: EntityResolverArgumentMismatch,
-        message: "`@connect(entity: true)` on `Query.product` has invalid entity resolver arguments. Field `id` on `CountryInput` does not exist on `Country`.",
+        message: "`Query.product` with `@connect(entity: true)` has invalid arguments. Field `id` on `CountryInput` does not exist on `Country`.",
         locations: [
             LineColumn {
                 line: 49,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_not_object_type.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_not_object_type.graphql.snap
@@ -1,0 +1,27 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_not_object_type.graphql
+---
+[
+    Message {
+        code: EntityResolverArgumentMismatch,
+        message: "`@connect(entity: true)` on `Query.product` has invalid entity resolver arguments. Mismatched type on field `id` - expected `ID` but found `ProductInput`.",
+        locations: [
+            LineColumn {
+                line: 13,
+                column: 9,
+            }..LineColumn {
+                line: 13,
+                column: 26,
+            },
+            LineColumn {
+                line: 18,
+                column: 9,
+            }..LineColumn {
+                line: 18,
+                column: 21,
+            },
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_not_object_type.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_not_object_type.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_e
 [
     Message {
         code: EntityResolverArgumentMismatch,
-        message: "`@connect(entity: true)` on `Query.product` has invalid entity resolver arguments. Mismatched type on field `id` - expected `ID` but found `ProductInput`.",
+        message: "`Query.product` with `@connect(entity: true)` has invalid arguments. Mismatched type on field `id` - expected `ID` but found `ProductInput`.",
         locations: [
             LineColumn {
                 line: 13,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_type_mismatch.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_type_mismatch.graphql.snap
@@ -1,0 +1,27 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_type_mismatch.graphql
+---
+[
+    Message {
+        code: EntityResolverArgumentMismatch,
+        message: "`@connect(entity: true)` on `Query.product` has invalid entity resolver arguments. Mismatched type on field `id` - expected `ID` but found `String`.",
+        locations: [
+            LineColumn {
+                line: 13,
+                column: 9,
+            }..LineColumn {
+                line: 13,
+                column: 20,
+            },
+            LineColumn {
+                line: 18,
+                column: 9,
+            }..LineColumn {
+                line: 18,
+                column: 21,
+            },
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_type_mismatch.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_arg_type_mismatch.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_e
 [
     Message {
         code: EntityResolverArgumentMismatch,
-        message: "`@connect(entity: true)` on `Query.product` has invalid entity resolver arguments. Mismatched type on field `id` - expected `ID` but found `String`.",
+        message: "`Query.product` with `@connect(entity: true)` has invalid arguments. Mismatched type on field `id` - expected `ID` but found `String`.",
         locations: [
             LineColumn {
                 line: 13,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_args_missing.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_args_missing.graphql.snap
@@ -1,0 +1,20 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_args_missing.graphql
+---
+[
+    Message {
+        code: EntityResolverArgumentMismatch,
+        message: "`@connect(entity: true)` on `Query.product` is missing entity resolver arguments.",
+        locations: [
+            LineColumn {
+                line: 16,
+                column: 9,
+            }..LineColumn {
+                line: 16,
+                column: 21,
+            },
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_args_missing.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_field_args_missing.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_e
 [
     Message {
         code: EntityResolverArgumentMismatch,
-        message: "`@connect(entity: true)` on `Query.product` is missing entity resolver arguments.",
+        message: "`Query.product` with `@connect(entity: true)` must have arguments. See https://preview-docs.apollographql.com/graphos/connectors/directives/#rules-for-entity-true",
         locations: [
             LineColumn {
                 line: 16,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_on_list_type.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_on_list_type.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_e
 [
     Message {
         code: EntityTypeInvalid,
-        message: "`@connect(entity: true)` on `Query.users` is invalid. Entities can only be non-list, nullable, object types.",
+        message: "`@connect(entity: true)` on `Query.users` is invalid. Entity connectors must return non-list, nullable, object types.",
         locations: [
             LineColumn {
                 line: 8,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_on_list_type.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_on_list_type.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_e
 [
     Message {
         code: EntityTypeInvalid,
-        message: "`@connect(entity: true)` on `Query.users` is invalid. Entities can only be non-list, object types.",
+        message: "`@connect(entity: true)` on `Query.users` is invalid. Entities can only be non-list, nullable, object types.",
         locations: [
             LineColumn {
                 line: 8,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_on_non_entity_field.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_on_non_entity_field.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_e
 [
     Message {
         code: EntityTypeInvalid,
-        message: "`@connect(entity: true)` on `Query.name` is invalid. Entities can only be non-list, nullable, object types.",
+        message: "`@connect(entity: true)` on `Query.name` is invalid. Entity connectors must return non-list, nullable, object types.",
         locations: [
             LineColumn {
                 line: 8,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_on_non_null_type.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_on_non_null_type.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_e
 [
     Message {
         code: EntityTypeInvalid,
-        message: "`@connect(entity: true)` on `Query.users` is invalid. Entities can only be non-list, nullable, object types.",
+        message: "`@connect(entity: true)` on `Query.user` is invalid. Entities can only be non-list, nullable, object types.",
         locations: [
             LineColumn {
                 line: 8,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_on_non_null_type.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_on_non_null_type.graphql.snap
@@ -1,12 +1,12 @@
 ---
 source: apollo-federation/src/sources/connect/validation/mod.rs
 expression: "format!(\"{:#?}\", errors)"
-input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_on_non_entity_field.graphql
+input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_on_non_null_type.graphql
 ---
 [
     Message {
         code: EntityTypeInvalid,
-        message: "`@connect(entity: true)` on `Query.name` is invalid. Entities can only be non-list, nullable, object types.",
+        message: "`@connect(entity: true)` on `Query.users` is invalid. Entities can only be non-list, nullable, object types.",
         locations: [
             LineColumn {
                 line: 8,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_on_non_null_type.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_entity_arg_on_non_null_type.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_e
 [
     Message {
         code: EntityTypeInvalid,
-        message: "`@connect(entity: true)` on `Query.user` is invalid. Entities can only be non-list, nullable, object types.",
+        message: "`@connect(entity: true)` on `Query.user` is invalid. Entity connectors must return non-list, nullable, object types.",
         locations: [
             LineColumn {
                 line: 8,

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_entity_arg_field_arg_key_multiple_keys.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_entity_arg_field_arg_key_multiple_keys.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/valid_entity_arg_field_arg_key_multiple_keys.graphql
+---
+[]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_entity_arg_field_arg_key_non_resolvable.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_entity_arg_field_arg_key_non_resolvable.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/valid_entity_arg_field_arg_key_non_resolvable.graphql
+---
+[]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_entity_arg_field_arg_keys_disjoint.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_entity_arg_field_arg_keys_disjoint.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/valid_entity_arg_field_arg_keys_disjoint.graphql
+---
+[]

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_input_type_missing.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_input_type_missing.graphql
@@ -1,0 +1,42 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/federation/v2.8"
+    import: ["@key"]
+)
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    product(
+        id: ID!
+        store: StoreInput!
+    ): Product
+    @connect(
+        http: { GET: "http://myapi/region/{$args.store.country.region}/country/{$args.store.country.id}/store/{$args.store.id}/products/{$args.id}" }
+        selection: "id store { id country { id region } } name"
+        entity: true
+    )
+}
+
+type Product @key(fields: "id store { id country { id region } }") {
+    id: ID!
+    store: Store!
+    name: String
+}
+
+type Store {
+    id: ID!
+    country: Country
+}
+
+type Country {
+    id: ID!
+    region: Region
+}
+
+enum Region {
+    AMERICAS,
+    EUROPE
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_key_mismatch.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_key_mismatch.graphql
@@ -14,12 +14,13 @@ type Query {
     ): Product
     @connect(
         http: { GET: "http://myapi/products/{$args.id}" }
-        selection: "not_named_id name"
+        selection: "id key_id name"
         entity: true
     )
 }
 
-type Product {
-    not_named_id: ID!
+type Product @key(fields: "key_id") {
+    id: ID!
+    key_id: ID!
     name: String
 }

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_key_mismatch_composite_key.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_key_mismatch_composite_key.graphql
@@ -1,0 +1,52 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/federation/v2.8"
+    import: ["@key"]
+)
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    product(
+        id: ID!
+        store: StoreInput!
+    ): Product
+    @connect(
+        http: { GET: "http://myapi/region/{$args.store.country.region}/country/{$args.store.country.id}/store/{$args.store.id}/products/{$args.id}" }
+        selection: "id store { id country { id key_id region } } name"
+        entity: true
+    )
+}
+
+type Product @key(fields: "id store { id country { key_id region } }") {
+    id: ID!
+    store: Store!
+    name: String
+}
+
+type Store {
+    id: ID!
+    country: Country
+}
+
+type Country {
+    id: ID!
+    key_id: ID!
+    region: Region
+}
+
+input StoreInput {
+    id: ID!
+    country: CountryInput
+}
+
+enum Region {
+    AMERICAS,
+    EUROPE
+}
+input CountryInput {
+    id: ID!
+    region: Region
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_key_mismatch_multiple_keys.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_key_mismatch_multiple_keys.graphql
@@ -1,0 +1,53 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/federation/v2.8"
+    import: ["@key"]
+)
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    product(
+        id: ID!
+        store: StoreInput!
+    ): Product
+    @connect(
+        http: { GET: "http://myapi/region/{$args.store.country.region}/country/{$args.store.country.id}/store/{$args.store.id}/products/{$args.id}" }
+        selection: "id store { id country { id key_id key_id2 region } } name"
+        entity: true
+    )
+}
+
+type Product @key(fields: "id store { id country { key_id region } }") @key(fields: "id store { id country { key_id2 region } }") {
+    id: ID!
+    store: Store!
+    name: String
+}
+
+type Store {
+    id: ID!
+    country: Country
+}
+
+type Country {
+    id: ID!
+    key_id: ID!
+    key_id2: ID!
+    region: Region
+}
+
+input StoreInput {
+    id: ID!
+    country: CountryInput
+}
+
+enum Region {
+    AMERICAS,
+    EUROPE
+}
+input CountryInput {
+    id: ID!
+    region: Region
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_name_mismatch.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_name_mismatch.graphql
@@ -1,0 +1,25 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/federation/v2.8"
+    import: ["@key"]
+)
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    product(
+        id: ID!
+    ): Product
+    @connect(
+        http: { GET: "http://myapi/products/{$args.id}" }
+        selection: "not_named_id name"
+        entity: true
+    )
+}
+
+type Product @key(fields: "not_named_id") {
+    not_named_id: ID!
+    name: String
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_name_mismatch_composite_key.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_name_mismatch_composite_key.graphql
@@ -1,0 +1,51 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/federation/v2.8"
+    import: ["@key"]
+)
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    product(
+        id: ID!
+        store: StoreInput!
+    ): Product
+    @connect(
+        http: { GET: "http://myapi/region/{$args.store.country.region}/country/{$args.store.country.id}/store/{$args.store.id}/products/{$args.id}" }
+        selection: "id store { id country { not_named_id region } } name"
+        entity: true
+    )
+}
+
+type Product @key(fields: "id store { id country { not_named_id region } }") {
+    id: ID!
+    store: Store!
+    name: String
+}
+
+type Store {
+    id: ID!
+    country: Country
+}
+
+type Country {
+    not_named_id: ID!
+    region: Region
+}
+
+input StoreInput {
+    id: ID!
+    country: CountryInput
+}
+
+enum Region {
+    AMERICAS,
+    EUROPE
+}
+input CountryInput {
+    id: ID!
+    region: Region
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_not_object_type.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_not_object_type.graphql
@@ -1,0 +1,29 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/federation/v2.8"
+    import: ["@key"]
+)
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    product(
+        id: ProductInput!
+    ): Product
+    @connect(
+        http: { GET: "http://myapi/products/{$args.input.id}" }
+        selection: "id name"
+        entity: true
+    )
+}
+
+type Product @key(fields: "id") {
+    id: ID!
+    name: String
+}
+
+input ProductInput {
+    id: ID!
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_type_mismatch.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_arg_type_mismatch.graphql
@@ -1,0 +1,25 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/federation/v2.8"
+    import: ["@key"]
+)
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    product(
+        id: String!
+    ): Product
+    @connect(
+        http: { GET: "http://myapi/products/{$args.id}" }
+        selection: "id name"
+        entity: true
+    )
+}
+
+type Product @key(fields: "id") {
+    id: ID!
+    name: String
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_args_missing.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_field_args_missing.graphql
@@ -1,0 +1,23 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/federation/v2.8"
+    import: ["@key"]
+)
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    product: Product
+    @connect(
+        http: { GET: "http://myapi/products/{$args.id}" }
+        selection: "id name"
+        entity: true
+    )
+}
+
+type Product @key(fields: "id") {
+    id: ID!
+    name: String
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_on_field.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_on_field.graphql
@@ -2,9 +2,9 @@ extend schema
   @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect"])
 
 type Query {
-  user: User
+  user(id: ID!): User
     @connect(
-      http: { GET: "http://127.0.0.1:8000/resources" }
+      http: { GET: "http://127.0.0.1:8000/resources/{$args.id}" }
       entity: true
       selection: "id name"
     )

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_on_non_null_type.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_on_non_null_type.graphql
@@ -1,0 +1,16 @@
+extend schema
+  @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect"])
+
+type Query {
+  users: User!
+    @connect(
+      http: { GET: "http://127.0.0.1:8000/resources" }
+      entity: true
+      selection: "id name"
+    )
+}
+
+type User {
+  id: ID!
+  name: String!
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_on_non_null_type.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_entity_arg_on_non_null_type.graphql
@@ -2,9 +2,9 @@ extend schema
   @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect"])
 
 type Query {
-  users: User!
+  user(id: ID!): User!
     @connect(
-      http: { GET: "http://127.0.0.1:8000/resources" }
+      http: { GET: "http://127.0.0.1:8000/resources/{$args.id}" }
       entity: true
       selection: "id name"
     )

--- a/apollo-federation/src/sources/connect/validation/test_data/valid_entity_arg_field_arg_key_multiple_keys.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/valid_entity_arg_field_arg_key_multiple_keys.graphql
@@ -1,0 +1,52 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/federation/v2.8"
+    import: ["@key"]
+)
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    product(
+        id: ID!
+        store: StoreInput!
+    ): Product
+    @connect(
+        http: { GET: "http://myapi/region/{$args.store.country.region}/country/{$args.store.country.id}/store/{$args.store.id}/products/{$args.id}" }
+        selection: "id store { id country { id key_id region } } name"
+        entity: true
+    )
+}
+
+type Product @key(fields: "id store { id country { key_id region } }") @key(fields: "id store { id country { id region } }") {
+    id: ID!
+    store: Store!
+    name: String
+}
+
+type Store {
+    id: ID!
+    country: Country
+}
+
+type Country {
+    id: ID!
+    key_id: ID!
+    region: Region
+}
+
+input StoreInput {
+    id: ID!
+    country: CountryInput
+}
+
+enum Region {
+    AMERICAS,
+    EUROPE
+}
+input CountryInput {
+    id: ID!
+    region: Region
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/valid_entity_arg_field_arg_key_non_resolvable.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/valid_entity_arg_field_arg_key_non_resolvable.graphql
@@ -1,0 +1,23 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/federation/v2.8"
+    import: ["@key"]
+)
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    product(id: ID!): Product
+    @connect(
+        http: { GET: "http://127.0.0.1:8000/v1/products/{$args.id}" }
+        entity: true
+        selection: "id name"
+    )
+}
+
+type Product @key(fields: "id", resolvable: false) {
+    id: ID!
+    name: String!
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/valid_entity_arg_field_arg_keys_disjoint.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/valid_entity_arg_field_arg_keys_disjoint.graphql
@@ -1,0 +1,25 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/federation/v2.8"
+    import: ["@key"]
+)
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect", "@source"]
+)
+
+@source(name: "v1", http: { baseURL: "http://localhost" })
+@source(name: "v2", http: { baseURL: "http://localhost" })
+
+type Query {
+    productById(id: ID!): Product
+    @connect(source: "v1" http: { GET: "/products/{$args.id}" } selection: "id sku name" entity: true)
+    productBySku(sku: ID!): Product
+    @connect(source: "v2" http: { GET: "/products/{$args.sku}" } selection: "id sku name" entity: true)
+}
+
+type Product @key(fields: "id") @key(fields: "sku") {
+    id: ID!
+    sku: ID!
+    name: String
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/valid_entity_arg_on_field.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/valid_entity_arg_on_field.graphql
@@ -2,9 +2,9 @@ extend schema
   @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect"])
 
 type Query {
-  user: User
+  user(id: ID!): User
     @connect(
-      http: { GET: "http://127.0.0.1:8000/resources" }
+      http: { GET: "http://127.0.0.1:8000/resources/{$args.id}" }
       entity: true
       selection: "id name"
     )


### PR DESCRIPTION
Add validation for entity resolver arguments on connectors.

* Validate that the return type is nullable
* Validate that the field has arguments
* Validate that the arguments match the returned entity type fields (both name and type)
* Validate that the arguments match the `@key` directives on the entity type, if any

Since arguments can be input types with fields that are themselves input types, this requires using a visitor to visit the tree of fields and types. It also requires parsing the `@key` directive field set.

<!-- [CNN-292] --> 

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**


**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-292]: https://apollographql.atlassian.net/browse/CNN-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ