### PR TITLE
fix debug concurrency

### DIFF
--- a/apollo-router/src/plugins/connectors/http.rs
+++ b/apollo-router/src/plugins/connectors/http.rs
@@ -2,6 +2,7 @@
 
 use hyper::body::HttpBody;
 
+use super::plugin::ConnectorDebugHttpRequest;
 use crate::plugins::connectors::error::Error as ConnectorError;
 use crate::plugins::connectors::make_requests::ResponseKey;
 
@@ -30,4 +31,5 @@ impl<T: HttpBody> From<ConnectorError> for Result<T> {
 pub(crate) struct Response<T: HttpBody> {
     pub(crate) result: Result<T>,
     pub(crate) key: ResponseKey,
+    pub(crate) debug_request: Option<ConnectorDebugHttpRequest>,
 }

--- a/apollo-router/src/plugins/connectors/http.rs
+++ b/apollo-router/src/plugins/connectors/http.rs
@@ -5,6 +5,7 @@ use hyper::body::HttpBody;
 use super::plugin::ConnectorDebugHttpRequest;
 use crate::plugins::connectors::error::Error as ConnectorError;
 use crate::plugins::connectors::make_requests::ResponseKey;
+use crate::services::router::body::RouterBody;
 
 /// A result of a connector
 pub(crate) enum Result<T: HttpBody> {
@@ -30,6 +31,13 @@ impl<T: HttpBody> From<ConnectorError> for Result<T> {
 /// The result of a connector and the associated response key
 pub(crate) struct Response<T: HttpBody> {
     pub(crate) result: Result<T>,
+    pub(crate) key: ResponseKey,
+    pub(crate) debug_request: Option<ConnectorDebugHttpRequest>,
+}
+
+#[derive(Debug)]
+pub(crate) struct Request {
+    pub(crate) request: http::Request<RouterBody>,
     pub(crate) key: ResponseKey,
     pub(crate) debug_request: Option<ConnectorDebugHttpRequest>,
 }


### PR DESCRIPTION
instead of inserting into the debug extension twice, we can pass around the debug request object and insert the request and response at the same time, ensuring that we never match a response to the wrong request

also stops passing the schema into handle_requests—the selection set we pass in is schema-aware

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
