### PR TITLE
connectors: track $this usage in selection

### DIFF
--- a/apollo-federation/src/sources/connect/expand/tests/schemas/expand/keys.graphql
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/expand/keys.graphql
@@ -1,0 +1,81 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.5", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/connect/v0.1", for: EXECUTION)
+  @join__directive(graphs: [ONE], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect"]})
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String, contextArguments: [join__ContextArgument!]) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+input join__ContextArgument {
+  name: String!
+  type: String!
+  context: String!
+  selection: join__FieldValue!
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+scalar join__FieldValue
+
+enum join__Graph {
+  ONE @join__graph(name: "one", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: ONE)
+{
+  t(id: ID!): T @join__directive(graphs: [ONE], name: "connect", args: {http: {GET: "http://localhost/ts/{$args.id}"}, selection: "id id2", entity: true})
+  t2(id: ID!, id2: ID!): T @join__directive(graphs: [ONE], name: "connect", args: {http: {GET: "http://localhost/ts/{$args.id}?id2={$args.id2}"}, selection: "id id2", entity: true})
+}
+
+type R
+  @join__type(graph: ONE)
+{
+  id: ID!
+  id2: ID!
+}
+
+type T
+  @join__type(graph: ONE, key: "id")
+{
+  id: ID!
+  id2: ID!
+  r1: R @join__directive(graphs: [ONE], name: "connect", args: {http: {GET: "http://localhost/rs/{$this.id}"}, selection: "id id2"})
+  r2: R @join__directive(graphs: [ONE], name: "connect", args: {http: {GET: "http://localhost/rs/{$this.id}?id2={$this.id2}"}, selection: "id id2"})
+  r3: R @join__directive(graphs: [ONE], name: "connect", args: {http: {GET: "http://localhost/rs/{$this.id}"}, selection: "id id2: $this.id2"})
+  r4: R @join__directive(graphs: [ONE], name: "connect", args: {http: {POST: "http://localhost/rs", body: "id: $this.id"}, selection: "id id2"})
+  r5: R @join__directive(graphs: [ONE], name: "connect", args: {http: {POST: "http://localhost/rs", body: "id: $this.id"}, selection: "id id2: $this.id2"})
+}

--- a/apollo-federation/src/sources/connect/expand/tests/schemas/expand/keys.yaml
+++ b/apollo-federation/src/sources/connect/expand/tests/schemas/expand/keys.yaml
@@ -1,0 +1,37 @@
+# rover supergraph compose --config apollo-federation/src/sources/connect/expand/tests/schemas/expand/keys.yaml > apollo-federation/src/sources/connect/expand/tests/schemas/expand/keys.graphql
+federation_version: =2.10.0-alpha.3
+subgraphs:
+  one:
+    routing_url: none
+    schema:
+      sdl: |
+        extend schema
+          @link(url: "https://specs.apollo.dev/federation/v2.8", import: ["@key"])
+          @link(url: "https://specs.apollo.dev/connect/v0.1", import: ["@connect"])
+        type Query {
+          t(id: ID!): T
+            @connect(                                                                                                   # expect `key: "id"`
+              http: { GET: "http://localhost/ts/{$$args.id}" }
+              selection: "id id2"
+              entity: true
+            )
+          t2(id: ID! id2: ID!): T
+            @connect(                                                                                                   # expect `key: "id id2"`
+              http: { GET: "http://localhost/ts/{$$args.id}?id2={$$args.id2}" }
+              selection: "id id2"
+              entity: true
+            )
+        }
+        type T @key(fields: "id") {
+          id: ID!
+          id2: ID!
+          r1: R @connect(http: { GET: "http://localhost/rs/{$$this.id}" }, selection: "id id2")                         # expect `key: "id"``
+          r2: R @connect(http: { GET: "http://localhost/rs/{$$this.id}?id2={$$this.id2}" }, selection: "id id2")        # expect `key: "id id2"`
+          r3: R @connect(http: { GET: "http://localhost/rs/{$$this.id}" }, selection: "id id2: $$this.id2")             # expect `key: "id id2"`
+          r4: R @connect(http: { POST: "http://localhost/rs" body: "id: $$this.id" }, selection: "id id2")              # expect `key: "id"`
+          r5: R @connect(http: { POST: "http://localhost/rs" body: "id: $$this.id" }, selection: "id id2: $$this.id2")  # expect `key: "id id2"`
+        }
+        type R {
+          id: ID!
+          id2: ID!
+        }

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql-2.snap
@@ -1,0 +1,639 @@
+---
+source: apollo-federation/src/sources/connect/expand/tests/mod.rs
+expression: connectors.by_service_name
+input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/keys.graphql
+---
+{
+    "one_Query_t_0": Connector {
+        id: ConnectId {
+            label: "one. http: GET http://localhost/ts/{$args.id!}",
+            subgraph_name: "one",
+            source_name: None,
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.t),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJsonTransport {
+            source_url: None,
+            connect_template: URLTemplate {
+                base: Some(
+                    Url {
+                        scheme: "http",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "localhost",
+                            ),
+                        ),
+                        port: None,
+                        path: "/",
+                        query: None,
+                        fragment: None,
+                    },
+                ),
+                path: [
+                    ParameterValue {
+                        parts: [
+                            Text(
+                                "ts",
+                            ),
+                        ],
+                    },
+                    ParameterValue {
+                        parts: [
+                            Var(
+                                VariableExpression {
+                                    var_path: "$args.id",
+                                    batch_separator: None,
+                                    required: true,
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                query: {},
+            },
+            method: Get,
+            headers: {},
+            body: None,
+        },
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "id2",
+                        None,
+                    ),
+                ],
+                star: None,
+            },
+        ),
+        config: None,
+        max_requests: None,
+        entity_resolver: Some(
+            Explicit,
+        ),
+    },
+    "one_Query_t2_0": Connector {
+        id: ConnectId {
+            label: "one. http: GET http://localhost/ts/{$args.id!}?id2={$args.id2}",
+            subgraph_name: "one",
+            source_name: None,
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(Query.t2),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJsonTransport {
+            source_url: None,
+            connect_template: URLTemplate {
+                base: Some(
+                    Url {
+                        scheme: "http",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "localhost",
+                            ),
+                        ),
+                        port: None,
+                        path: "/",
+                        query: None,
+                        fragment: None,
+                    },
+                ),
+                path: [
+                    ParameterValue {
+                        parts: [
+                            Text(
+                                "ts",
+                            ),
+                        ],
+                    },
+                    ParameterValue {
+                        parts: [
+                            Var(
+                                VariableExpression {
+                                    var_path: "$args.id",
+                                    batch_separator: None,
+                                    required: true,
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                query: {
+                    "id2": ParameterValue {
+                        parts: [
+                            Var(
+                                VariableExpression {
+                                    var_path: "$args.id2",
+                                    batch_separator: None,
+                                    required: false,
+                                },
+                            ),
+                        ],
+                    },
+                },
+            },
+            method: Get,
+            headers: {},
+            body: None,
+        },
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "id2",
+                        None,
+                    ),
+                ],
+                star: None,
+            },
+        ),
+        config: None,
+        max_requests: None,
+        entity_resolver: Some(
+            Explicit,
+        ),
+    },
+    "one_T_r1_0": Connector {
+        id: ConnectId {
+            label: "one. http: GET http://localhost/rs/{$this.id!}",
+            subgraph_name: "one",
+            source_name: None,
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(T.r1),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJsonTransport {
+            source_url: None,
+            connect_template: URLTemplate {
+                base: Some(
+                    Url {
+                        scheme: "http",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "localhost",
+                            ),
+                        ),
+                        port: None,
+                        path: "/",
+                        query: None,
+                        fragment: None,
+                    },
+                ),
+                path: [
+                    ParameterValue {
+                        parts: [
+                            Text(
+                                "rs",
+                            ),
+                        ],
+                    },
+                    ParameterValue {
+                        parts: [
+                            Var(
+                                VariableExpression {
+                                    var_path: "$this.id",
+                                    batch_separator: None,
+                                    required: true,
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                query: {},
+            },
+            method: Get,
+            headers: {},
+            body: None,
+        },
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "id2",
+                        None,
+                    ),
+                ],
+                star: None,
+            },
+        ),
+        config: None,
+        max_requests: None,
+        entity_resolver: Some(
+            Implicit,
+        ),
+    },
+    "one_T_r2_0": Connector {
+        id: ConnectId {
+            label: "one. http: GET http://localhost/rs/{$this.id!}?id2={$this.id2}",
+            subgraph_name: "one",
+            source_name: None,
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(T.r2),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJsonTransport {
+            source_url: None,
+            connect_template: URLTemplate {
+                base: Some(
+                    Url {
+                        scheme: "http",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "localhost",
+                            ),
+                        ),
+                        port: None,
+                        path: "/",
+                        query: None,
+                        fragment: None,
+                    },
+                ),
+                path: [
+                    ParameterValue {
+                        parts: [
+                            Text(
+                                "rs",
+                            ),
+                        ],
+                    },
+                    ParameterValue {
+                        parts: [
+                            Var(
+                                VariableExpression {
+                                    var_path: "$this.id",
+                                    batch_separator: None,
+                                    required: true,
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                query: {
+                    "id2": ParameterValue {
+                        parts: [
+                            Var(
+                                VariableExpression {
+                                    var_path: "$this.id2",
+                                    batch_separator: None,
+                                    required: false,
+                                },
+                            ),
+                        ],
+                    },
+                },
+            },
+            method: Get,
+            headers: {},
+            body: None,
+        },
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "id2",
+                        None,
+                    ),
+                ],
+                star: None,
+            },
+        ),
+        config: None,
+        max_requests: None,
+        entity_resolver: Some(
+            Implicit,
+        ),
+    },
+    "one_T_r3_0": Connector {
+        id: ConnectId {
+            label: "one. http: GET http://localhost/rs/{$this.id!}",
+            subgraph_name: "one",
+            source_name: None,
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(T.r3),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJsonTransport {
+            source_url: None,
+            connect_template: URLTemplate {
+                base: Some(
+                    Url {
+                        scheme: "http",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "localhost",
+                            ),
+                        ),
+                        port: None,
+                        path: "/",
+                        query: None,
+                        fragment: None,
+                    },
+                ),
+                path: [
+                    ParameterValue {
+                        parts: [
+                            Text(
+                                "rs",
+                            ),
+                        ],
+                    },
+                    ParameterValue {
+                        parts: [
+                            Var(
+                                VariableExpression {
+                                    var_path: "$this.id",
+                                    batch_separator: None,
+                                    required: true,
+                                },
+                            ),
+                        ],
+                    },
+                ],
+                query: {},
+            },
+            method: Get,
+            headers: {},
+            body: None,
+        },
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Path(
+                        Alias {
+                            name: "id2",
+                        },
+                        PathSelection {
+                            path: Var(
+                                $this,
+                                Key(
+                                    Field(
+                                        "id2",
+                                    ),
+                                    Empty,
+                                ),
+                            ),
+                        },
+                    ),
+                ],
+                star: None,
+            },
+        ),
+        config: None,
+        max_requests: None,
+        entity_resolver: Some(
+            Implicit,
+        ),
+    },
+    "one_T_r4_0": Connector {
+        id: ConnectId {
+            label: "one. http: POST http://localhost/rs",
+            subgraph_name: "one",
+            source_name: None,
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(T.r4),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJsonTransport {
+            source_url: None,
+            connect_template: URLTemplate {
+                base: Some(
+                    Url {
+                        scheme: "http",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "localhost",
+                            ),
+                        ),
+                        port: None,
+                        path: "/",
+                        query: None,
+                        fragment: None,
+                    },
+                ),
+                path: [
+                    ParameterValue {
+                        parts: [
+                            Text(
+                                "rs",
+                            ),
+                        ],
+                    },
+                ],
+                query: {},
+            },
+            method: Post,
+            headers: {},
+            body: Some(
+                Named(
+                    SubSelection {
+                        selections: [
+                            Path(
+                                Alias {
+                                    name: "id",
+                                },
+                                PathSelection {
+                                    path: Var(
+                                        $this,
+                                        Key(
+                                            Field(
+                                                "id",
+                                            ),
+                                            Empty,
+                                        ),
+                                    ),
+                                },
+                            ),
+                        ],
+                        star: None,
+                    },
+                ),
+            ),
+        },
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Field(
+                        None,
+                        "id2",
+                        None,
+                    ),
+                ],
+                star: None,
+            },
+        ),
+        config: None,
+        max_requests: None,
+        entity_resolver: Some(
+            Implicit,
+        ),
+    },
+    "one_T_r5_0": Connector {
+        id: ConnectId {
+            label: "one. http: POST http://localhost/rs",
+            subgraph_name: "one",
+            source_name: None,
+            directive: ObjectOrInterfaceFieldDirectivePosition {
+                field: Object(T.r5),
+                directive_name: "connect",
+                directive_index: 0,
+            },
+        },
+        transport: HttpJsonTransport {
+            source_url: None,
+            connect_template: URLTemplate {
+                base: Some(
+                    Url {
+                        scheme: "http",
+                        cannot_be_a_base: false,
+                        username: "",
+                        password: None,
+                        host: Some(
+                            Domain(
+                                "localhost",
+                            ),
+                        ),
+                        port: None,
+                        path: "/",
+                        query: None,
+                        fragment: None,
+                    },
+                ),
+                path: [
+                    ParameterValue {
+                        parts: [
+                            Text(
+                                "rs",
+                            ),
+                        ],
+                    },
+                ],
+                query: {},
+            },
+            method: Post,
+            headers: {},
+            body: Some(
+                Named(
+                    SubSelection {
+                        selections: [
+                            Path(
+                                Alias {
+                                    name: "id",
+                                },
+                                PathSelection {
+                                    path: Var(
+                                        $this,
+                                        Key(
+                                            Field(
+                                                "id",
+                                            ),
+                                            Empty,
+                                        ),
+                                    ),
+                                },
+                            ),
+                        ],
+                        star: None,
+                    },
+                ),
+            ),
+        },
+        selection: Named(
+            SubSelection {
+                selections: [
+                    Field(
+                        None,
+                        "id",
+                        None,
+                    ),
+                    Path(
+                        Alias {
+                            name: "id2",
+                        },
+                        PathSelection {
+                            path: Var(
+                                $this,
+                                Key(
+                                    Field(
+                                        "id2",
+                                    ),
+                                    Empty,
+                                ),
+                            ),
+                        },
+                    ),
+                ],
+                star: None,
+            },
+        ),
+        config: None,
+        max_requests: None,
+        entity_resolver: Some(
+            Implicit,
+        ),
+    },
+}

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql-3.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql-3.snap
@@ -1,0 +1,72 @@
+---
+source: apollo-federation/src/sources/connect/expand/tests/mod.rs
+expression: raw_sdl
+input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/keys.graphql
+---
+schema @link(url: "https://specs.apollo.dev/link/v1.0") @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY) @join__directive(graphs: [], name: "link", args: {url: "https://specs.apollo.dev/connect/v0.1"}) {
+  query: Query
+}
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on ENUM | INPUT_OBJECT | INTERFACE | OBJECT | SCALAR | UNION
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, overrideLabel: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on INTERFACE | OBJECT
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments!) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+enum link__Purpose {
+  """
+  SECURITY features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+  """EXECUTION features provide metadata necessary for operation execution."""
+  EXECUTION
+}
+
+scalar link__Import
+
+scalar join__FieldSet
+
+scalar join__DirectiveArguments
+
+enum join__Graph {
+  ONE_QUERY_T2_0 @join__graph(name: "one_Query_t2_0", url: "none")
+  ONE_QUERY_T_0 @join__graph(name: "one_Query_t_0", url: "none")
+  ONE_T_R1_0 @join__graph(name: "one_T_r1_0", url: "none")
+  ONE_T_R2_0 @join__graph(name: "one_T_r2_0", url: "none")
+  ONE_T_R3_0 @join__graph(name: "one_T_r3_0", url: "none")
+  ONE_T_R4_0 @join__graph(name: "one_T_r4_0", url: "none")
+  ONE_T_R5_0 @join__graph(name: "one_T_r5_0", url: "none")
+}
+
+type T @join__type(graph: ONE_QUERY_T2_0, key: "id id2") @join__type(graph: ONE_QUERY_T_0, key: "id") @join__type(graph: ONE_T_R1_0, key: "id") @join__type(graph: ONE_T_R2_0, key: "id id2") @join__type(graph: ONE_T_R3_0, key: "id id2") @join__type(graph: ONE_T_R4_0, key: "id") @join__type(graph: ONE_T_R5_0, key: "id id2") {
+  id: ID! @join__field(graph: ONE_QUERY_T2_0) @join__field(graph: ONE_QUERY_T_0) @join__field(graph: ONE_T_R1_0) @join__field(graph: ONE_T_R2_0) @join__field(graph: ONE_T_R3_0) @join__field(graph: ONE_T_R4_0) @join__field(graph: ONE_T_R5_0)
+  id2: ID! @join__field(graph: ONE_QUERY_T2_0) @join__field(graph: ONE_QUERY_T_0) @join__field(graph: ONE_T_R2_0) @join__field(graph: ONE_T_R3_0) @join__field(graph: ONE_T_R5_0)
+  r1: R @join__field(graph: ONE_T_R1_0)
+  r2: R @join__field(graph: ONE_T_R2_0)
+  r3: R @join__field(graph: ONE_T_R3_0)
+  r4: R @join__field(graph: ONE_T_R4_0)
+  r5: R @join__field(graph: ONE_T_R5_0)
+}
+
+type Query @join__type(graph: ONE_QUERY_T2_0) @join__type(graph: ONE_QUERY_T_0) @join__type(graph: ONE_T_R1_0) @join__type(graph: ONE_T_R2_0) @join__type(graph: ONE_T_R3_0) @join__type(graph: ONE_T_R4_0) @join__type(graph: ONE_T_R5_0) {
+  t2(id: ID!, id2: ID!): T @join__field(graph: ONE_QUERY_T2_0)
+  t(id: ID!): T @join__field(graph: ONE_QUERY_T_0)
+  _: ID @inaccessible @join__field(graph: ONE_T_R1_0) @join__field(graph: ONE_T_R2_0) @join__field(graph: ONE_T_R3_0) @join__field(graph: ONE_T_R4_0) @join__field(graph: ONE_T_R5_0)
+}
+
+type R @join__type(graph: ONE_T_R1_0) @join__type(graph: ONE_T_R2_0) @join__type(graph: ONE_T_R3_0) @join__type(graph: ONE_T_R4_0) @join__type(graph: ONE_T_R5_0) {
+  id: ID! @join__field(graph: ONE_T_R1_0) @join__field(graph: ONE_T_R2_0) @join__field(graph: ONE_T_R3_0) @join__field(graph: ONE_T_R4_0) @join__field(graph: ONE_T_R5_0)
+  id2: ID! @join__field(graph: ONE_T_R1_0) @join__field(graph: ONE_T_R2_0) @join__field(graph: ONE_T_R3_0) @join__field(graph: ONE_T_R4_0) @join__field(graph: ONE_T_R5_0)
+}

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql.snap
@@ -1,0 +1,26 @@
+---
+source: apollo-federation/src/sources/connect/expand/tests/mod.rs
+expression: api_schema
+input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/keys.graphql
+---
+directive @defer(label: String, if: Boolean! = true) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+type Query {
+  t(id: ID!): T
+  t2(id: ID!, id2: ID!): T
+}
+
+type R {
+  id: ID!
+  id2: ID!
+}
+
+type T {
+  id: ID!
+  id2: ID!
+  r1: R
+  r2: R
+  r3: R
+  r4: R
+  r5: R
+}


### PR DESCRIPTION
This PR adds support for tracking sibling relationships in the actual selection of a connector. Previous behaviour was to only track this sibling relationships from the transport body and HTTP path template.

<!-- [CNN-406] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-406]: https://apollographql.atlassian.net/browse/CNN-406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ