### PR TITLE
Include request variables in demand control scoring

### DIFF
--- a/.changesets/fix_tninesling_demand_control_variable_check.md
+++ b/.changesets/fix_tninesling_demand_control_variable_check.md
@@ -1,0 +1,5 @@
+### Include request variables in demand control scoring ([PR #5995](https://github.com/apollographql/router/pull/5995))
+
+Fix demand control scoring for queries which use variables.
+
+By [@tninesling](https://github.com/tninesling) in https://github.com/apollographql/router/pull/5995

--- a/apollo-router/src/graphql/visitor.rs
+++ b/apollo-router/src/graphql/visitor.rs
@@ -1,13 +1,13 @@
-use serde_json_bytes::ByteString;
-use serde_json_bytes::Map;
 use serde_json_bytes::Value;
 
 use crate::graphql::Response;
+use crate::json_ext::Object;
 
 pub(crate) trait ResponseVisitor {
     fn visit_field(
         &mut self,
         request: &apollo_compiler::ExecutableDocument,
+        variables: &Object,
         _ty: &apollo_compiler::executable::NamedType,
         field: &apollo_compiler::executable::Field,
         value: &Value,
@@ -15,11 +15,17 @@ pub(crate) trait ResponseVisitor {
         match value {
             Value::Array(items) => {
                 for item in items {
-                    self.visit_list_item(request, field.ty().inner_named_type(), field, item);
+                    self.visit_list_item(
+                        request,
+                        variables,
+                        field.ty().inner_named_type(),
+                        field,
+                        item,
+                    );
                 }
             }
             Value::Object(children) => {
-                self.visit_selections(request, &field.selection_set, children);
+                self.visit_selections(request, variables, &field.selection_set, children);
             }
             _ => {}
         }
@@ -28,6 +34,7 @@ pub(crate) trait ResponseVisitor {
     fn visit_list_item(
         &mut self,
         request: &apollo_compiler::ExecutableDocument,
+        variables: &Object,
         _ty: &apollo_compiler::executable::NamedType,
         field: &apollo_compiler::executable::Field,
         value: &Value,
@@ -35,17 +42,22 @@ pub(crate) trait ResponseVisitor {
         match value {
             Value::Array(items) => {
                 for item in items {
-                    self.visit_list_item(request, _ty, field, item);
+                    self.visit_list_item(request, variables, _ty, field, item);
                 }
             }
             Value::Object(children) => {
-                self.visit_selections(request, &field.selection_set, children);
+                self.visit_selections(request, variables, &field.selection_set, children);
             }
             _ => {}
         }
     }
 
-    fn visit(&mut self, request: &apollo_compiler::ExecutableDocument, response: &Response) {
+    fn visit(
+        &mut self,
+        request: &apollo_compiler::ExecutableDocument,
+        response: &Response,
+        variables: &Object,
+    ) {
         if response.path.is_some() {
             // TODO: In this case, we need to find the selection inside `request` corresponding to the path so we can start zipping.
             // Exiting here means any implementing visitor will not operate on deffered responses.
@@ -54,10 +66,10 @@ pub(crate) trait ResponseVisitor {
 
         if let Some(Value::Object(children)) = &response.data {
             if let Some(operation) = &request.operations.anonymous {
-                self.visit_selections(request, &operation.selection_set, children);
+                self.visit_selections(request, variables, &operation.selection_set, children);
             }
             for operation in request.operations.named.values() {
-                self.visit_selections(request, &operation.selection_set, children);
+                self.visit_selections(request, variables, &operation.selection_set, children);
             }
         }
     }
@@ -65,21 +77,28 @@ pub(crate) trait ResponseVisitor {
     fn visit_selections(
         &mut self,
         request: &apollo_compiler::ExecutableDocument,
+        variables: &Object,
         selection_set: &apollo_compiler::executable::SelectionSet,
-        fields: &Map<ByteString, Value>,
+        fields: &Object,
     ) {
         for selection in &selection_set.selections {
             match selection {
                 apollo_compiler::executable::Selection::Field(inner_field) => {
                     if let Some(value) = fields.get(inner_field.name.as_str()) {
-                        self.visit_field(request, &selection_set.ty, inner_field.as_ref(), value);
+                        self.visit_field(
+                            request,
+                            variables,
+                            &selection_set.ty,
+                            inner_field.as_ref(),
+                            value,
+                        );
                     } else {
                         tracing::warn!("The response did not include a field corresponding to query field {:?}", inner_field);
                     }
                 }
                 apollo_compiler::executable::Selection::FragmentSpread(fragment_spread) => {
                     if let Some(fragment) = fragment_spread.fragment_def(request) {
-                        self.visit_selections(request, &fragment.selection_set, fields);
+                        self.visit_selections(request, variables, &fragment.selection_set, fields);
                     } else {
                         tracing::warn!(
                             "The fragment {} was not found in the query document.",
@@ -88,7 +107,12 @@ pub(crate) trait ResponseVisitor {
                     }
                 }
                 apollo_compiler::executable::Selection::InlineFragment(inline_fragment) => {
-                    self.visit_selections(request, &inline_fragment.selection_set, fields);
+                    self.visit_selections(
+                        request,
+                        variables,
+                        &inline_fragment.selection_set,
+                        fields,
+                    );
                 }
             }
         }
@@ -121,7 +145,7 @@ mod tests {
         let response = Response::from_bytes("test", Bytes::from_static(response_bytes)).unwrap();
 
         let mut visitor = FieldCounter::new();
-        visitor.visit(&request, &response);
+        visitor.visit(&request, &response, &Default::default());
         insta::with_settings!({sort_maps=>true}, { assert_yaml_snapshot!(visitor) })
     }
 
@@ -136,7 +160,7 @@ mod tests {
         let response = Response::from_bytes("test", Bytes::from_static(response_bytes)).unwrap();
 
         let mut visitor = FieldCounter::new();
-        visitor.visit(&request, &response);
+        visitor.visit(&request, &response, &Default::default());
         insta::with_settings!({sort_maps=>true}, { assert_yaml_snapshot!(visitor) })
     }
 
@@ -151,7 +175,7 @@ mod tests {
         let response = Response::from_bytes("test", Bytes::from_static(response_bytes)).unwrap();
 
         let mut visitor = FieldCounter::new();
-        visitor.visit(&request, &response);
+        visitor.visit(&request, &response, &Default::default());
         insta::with_settings!({sort_maps=>true}, { assert_yaml_snapshot!(visitor) })
     }
 
@@ -166,7 +190,7 @@ mod tests {
         let response = Response::from_bytes("test", Bytes::from_static(response_bytes)).unwrap();
 
         let mut visitor = FieldCounter::new();
-        visitor.visit(&request, &response);
+        visitor.visit(&request, &response, &Default::default());
         insta::with_settings!({sort_maps=>true}, { assert_yaml_snapshot!(visitor) })
     }
 
@@ -186,6 +210,7 @@ mod tests {
         fn visit_field(
             &mut self,
             request: &ExecutableDocument,
+            variables: &Object,
             _ty: &apollo_compiler::executable::NamedType,
             field: &apollo_compiler::executable::Field,
             value: &Value,
@@ -195,11 +220,17 @@ mod tests {
             match value {
                 Value::Array(items) => {
                     for item in items {
-                        self.visit_list_item(request, field.ty().inner_named_type(), field, item);
+                        self.visit_list_item(
+                            request,
+                            variables,
+                            field.ty().inner_named_type(),
+                            field,
+                            item,
+                        );
                     }
                 }
                 Value::Object(children) => {
-                    self.visit_selections(request, &field.selection_set, children);
+                    self.visit_selections(request, variables, &field.selection_set, children);
                 }
                 _ => {}
             }

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -479,12 +479,11 @@ impl ValueExt for Value {
         match self {
             Value::Null => apollo_compiler::ast::Value::Null,
             Value::Bool(b) => apollo_compiler::ast::Value::Boolean(*b),
+            Value::Number(n) if n.is_f64() => {
+                apollo_compiler::ast::Value::Float(n.as_f64().expect("is float").into())
+            }
             Value::Number(n) => {
-                if n.is_f64() {
-                    apollo_compiler::ast::Value::Float(n.as_f64().expect("is float").into())
-                } else {
-                    apollo_compiler::ast::Value::Int((n.as_i64().expect("is int") as i32).into())
-                }
+                apollo_compiler::ast::Value::Int((n.as_i64().expect("is int") as i32).into())
             }
             Value::String(s) => apollo_compiler::ast::Value::String(s.as_str().to_string()),
             Value::Array(inner_vars) => apollo_compiler::ast::Value::List(
@@ -508,7 +507,7 @@ impl ValueExt for Value {
     }
 
     fn as_i32(&self) -> Option<i32> {
-        self.as_i64().and_then(|i| i.to_i32())
+        self.as_i64()?.to_i32()
     }
 }
 

--- a/apollo-router/src/json_ext.rs
+++ b/apollo-router/src/json_ext.rs
@@ -5,6 +5,7 @@
 use std::cmp::min;
 use std::fmt;
 
+use num_traits::ToPrimitive;
 use once_cell::sync::Lazy;
 use regex::Captures;
 use regex::Regex;
@@ -144,6 +145,11 @@ pub(crate) trait ValueExt {
     /// function to handle `PathElement::Fragment`).
     #[track_caller]
     fn is_object_of_type(&self, schema: &Schema, maybe_type: &str) -> bool;
+
+    /// Convert this value to an instance of `apollo_compiler::ast::Value`
+    fn to_ast(&self) -> apollo_compiler::ast::Value;
+
+    fn as_i32(&self) -> Option<i32>;
 }
 
 impl ValueExt for Value {
@@ -467,6 +473,42 @@ impl ValueExt for Value {
                 .map_or(true, |typename| {
                     typename == maybe_type || schema.is_subtype(maybe_type, typename)
                 })
+    }
+
+    fn to_ast(&self) -> apollo_compiler::ast::Value {
+        match self {
+            Value::Null => apollo_compiler::ast::Value::Null,
+            Value::Bool(b) => apollo_compiler::ast::Value::Boolean(*b),
+            Value::Number(n) => {
+                if n.is_f64() {
+                    apollo_compiler::ast::Value::Float(n.as_f64().expect("is float").into())
+                } else {
+                    apollo_compiler::ast::Value::Int((n.as_i64().expect("is int") as i32).into())
+                }
+            }
+            Value::String(s) => apollo_compiler::ast::Value::String(s.as_str().to_string()),
+            Value::Array(inner_vars) => apollo_compiler::ast::Value::List(
+                inner_vars
+                    .iter()
+                    .map(|v| apollo_compiler::Node::new(v.to_ast()))
+                    .collect(),
+            ),
+            Value::Object(inner_vars) => apollo_compiler::ast::Value::Object(
+                inner_vars
+                    .iter()
+                    .map(|(k, v)| {
+                        (
+                            apollo_compiler::Name::new(k.as_str()).expect("is valid name"),
+                            apollo_compiler::Node::new(v.to_ast()),
+                        )
+                    })
+                    .collect(),
+            ),
+        }
+    }
+
+    fn as_i32(&self) -> Option<i32> {
+        self.as_i64().and_then(|i| i.to_i32())
     }
 }
 

--- a/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/custom_cost_query_with_variable_slicing_argument.graphql
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/custom_cost_query_with_variable_slicing_argument.graphql
@@ -1,0 +1,20 @@
+fragment Items on SizedField {
+  items {
+    id
+  }
+}
+
+query VariableTestQuery($costlyInput: InputTypeWithCost, $fieldCountVar: Int) {
+  fieldWithCost
+  argWithCost(arg: 3)
+  enumWithCost
+  inputWithCost(someInput: $costlyInput)
+  scalarWithCost
+  objectWithCost {
+    id
+  }
+  fieldWithListSize
+  fieldWithDynamicListSize(first: $fieldCountVar) {
+    ...Items
+  }
+}

--- a/apollo-router/src/plugins/demand_control/mod.rs
+++ b/apollo-router/src/plugins/demand_control/mod.rs
@@ -201,6 +201,12 @@ impl<'a> From<FieldLookupError<'a>> for DemandControlError {
     }
 }
 
+#[derive(Clone)]
+pub(crate) struct DemandControlContext {
+    pub(crate) strategy: Strategy,
+    pub(crate) variables: Object,
+}
+
 impl Context {
     pub(crate) fn insert_estimated_cost(&self, cost: f64) -> Result<(), DemandControlError> {
         self.insert(COST_ESTIMATED_KEY, cost)
@@ -250,6 +256,14 @@ impl Context {
     pub(crate) fn get_cost_strategy(&self) -> Result<Option<String>, DemandControlError> {
         self.get::<&str, String>(COST_STRATEGY_KEY)
             .map_err(|e| DemandControlError::ContextSerializationError(e.to_string()))
+    }
+
+    pub(crate) fn insert_demand_control_context(&self, ctx: DemandControlContext) {
+        self.extensions().with_lock(|mut lock| lock.insert(ctx));
+    }
+
+    pub(crate) fn get_demand_control_context(&self) -> Option<DemandControlContext> {
+        self.extensions().with_lock(|lock| lock.get().cloned())
     }
 }
 
@@ -306,10 +320,12 @@ impl Plugin for DemandControl {
             let strategy = self.strategy_factory.create();
             ServiceBuilder::new()
                 .checkpoint(move |req: execution::Request| {
-                    req.context.extensions().with_lock(|mut lock| {
-                        lock.insert(strategy.clone());
-                        lock.insert(req.supergraph_request.body().variables.clone());
-                    });
+                    req.context
+                        .insert_demand_control_context(DemandControlContext {
+                            strategy: strategy.clone(),
+                            variables: req.supergraph_request.body().variables.clone(),
+                        });
+
                     // On the request path we need to check for estimates, checkpoint is used to do this, short-circuiting the request if it's too expensive.
                     Ok(match strategy.on_execution_request(&req) {
                         Ok(_) => ControlFlow::Continue(req),
@@ -330,9 +346,11 @@ impl Plugin for DemandControl {
                         .context
                         .unsupported_executable_document()
                         .expect("must have document");
-                    let strategy = resp.context.extensions().with_lock(|lock| {
-                        lock.get::<Strategy>().expect("must have strategy").clone()
-                    });
+                    let strategy = resp
+                        .context
+                        .get_demand_control_context()
+                        .map(|ctx| ctx.strategy)
+                        .expect("must have strategy");
                     let context = resp.context.clone();
 
                     // We want to sequence this code to run after all the subgraph responses have been scored.
@@ -393,9 +411,7 @@ impl Plugin for DemandControl {
             let subgraph_name_map_fut = subgraph_name.to_owned();
             ServiceBuilder::new()
                 .checkpoint(move |req: subgraph::Request| {
-                    let strategy = req.context.extensions().with_lock(|lock| {
-                        lock.get::<Strategy>().expect("must have strategy").clone()
-                    });
+                    let strategy = req.context.get_demand_control_context().map(|c| c.strategy).expect("must have strategy");
 
                     // On the request path we need to check for estimates, checkpoint is used to do this, short-circuiting the request if it's too expensive.
                     Ok(match strategy.on_subgraph_request(&req) {
@@ -425,9 +441,7 @@ impl Plugin for DemandControl {
                     },
                     |(subgraph_name, req): (String, Arc<Valid<ExecutableDocument>>), fut| async move {
                         let resp: subgraph::Response = fut.await?;
-                        let strategy = resp.context.extensions().with_lock(|lock| {
-                            lock.get::<Strategy>().expect("must have strategy").clone()
-                        });
+                        let strategy = resp.context.get_demand_control_context().map(|c| c.strategy).expect("must have strategy");
                         Ok(match strategy.on_subgraph_response(req.as_ref(), &resp) {
                             Ok(_) => resp,
                             Err(err) => subgraph::Response::builder()
@@ -465,6 +479,7 @@ mod test {
     use crate::graphql::Response;
     use crate::metrics::FutureMetricsExt;
     use crate::plugins::demand_control::DemandControl;
+    use crate::plugins::demand_control::DemandControlContext;
     use crate::plugins::demand_control::DemandControlError;
     use crate::plugins::test::PluginTestHarness;
     use crate::query_planner::fetch::QueryHash;
@@ -623,7 +638,10 @@ mod test {
         let strategy = plugin.strategy_factory.create();
 
         let ctx = context();
-        ctx.extensions().with_lock(|mut lock| lock.insert(strategy));
+        ctx.insert_demand_control_context(DemandControlContext {
+            strategy,
+            variables: Default::default(),
+        });
         let mut req = subgraph::Request::fake_builder()
             .subgraph_name("test")
             .context(ctx)

--- a/apollo-router/src/plugins/telemetry/config_new/graphql/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/graphql/mod.rs
@@ -9,6 +9,7 @@ use tower::BoxError;
 use super::instruments::CustomCounter;
 use super::instruments::CustomInstruments;
 use crate::graphql::ResponseVisitor;
+use crate::json_ext::Object;
 use crate::plugins::telemetry::config_new::attributes::DefaultAttributeRequirementLevel;
 use crate::plugins::telemetry::config_new::extendable::Extendable;
 use crate::plugins::telemetry::config_new::graphql::attributes::GraphQLAttributes;
@@ -136,7 +137,13 @@ impl Instrumented for GraphQLInstruments {
                     ctx,
                     instruments: self,
                 }
-                .visit(&executable_document, response);
+                .visit(
+                    &executable_document,
+                    response,
+                    &ctx.extensions()
+                        .with_lock(|lock| lock.get().cloned())
+                        .unwrap_or_default(),
+                );
             }
         }
     }
@@ -161,6 +168,7 @@ impl<'a> ResponseVisitor for GraphQLInstrumentsVisitor<'a> {
     fn visit_field(
         &mut self,
         request: &ExecutableDocument,
+        variables: &Object,
         ty: &NamedType,
         field: &Field,
         value: &Value,
@@ -171,11 +179,17 @@ impl<'a> ResponseVisitor for GraphQLInstrumentsVisitor<'a> {
         match value {
             Value::Array(items) => {
                 for item in items {
-                    self.visit_list_item(request, field.ty().inner_named_type(), field, item);
+                    self.visit_list_item(
+                        request,
+                        variables,
+                        field.ty().inner_named_type(),
+                        field,
+                        item,
+                    );
                 }
             }
             Value::Object(children) => {
-                self.visit_selections(request, &field.selection_set, children);
+                self.visit_selections(request, variables, &field.selection_set, children);
             }
             _ => {}
         }

--- a/apollo-router/src/plugins/telemetry/config_new/graphql/mod.rs
+++ b/apollo-router/src/plugins/telemetry/config_new/graphql/mod.rs
@@ -140,8 +140,8 @@ impl Instrumented for GraphQLInstruments {
                 .visit(
                     &executable_document,
                     response,
-                    &ctx.extensions()
-                        .with_lock(|lock| lock.get().cloned())
+                    &ctx.get_demand_control_context()
+                        .map(|c| c.variables)
                         .unwrap_or_default(),
                 );
             }

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -1411,7 +1411,13 @@ impl Telemetry {
                                     config.apollo.experimental_local_field_metrics,
                                     ctx.unsupported_executable_document(),
                                 ) {
-                                    local_stat_recorder.visit(&query, &response);
+                                    local_stat_recorder.visit(
+                                        &query,
+                                        &response,
+                                        &ctx.extensions()
+                                            .with_lock(|lock| lock.get().cloned())
+                                            .unwrap_or_default(),
+                                    );
                                 }
 
                                 if operation_kind == OperationKind::Subscription {

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -95,7 +95,6 @@ use crate::metrics::filter::FilterMeterProvider;
 use crate::metrics::meter_provider;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
-use crate::plugins::demand_control;
 use crate::plugins::telemetry::apollo::ForwardHeaders;
 use crate::plugins::telemetry::apollo_exporter::proto::reports::trace::node::Id::ResponseName;
 use crate::plugins::telemetry::apollo_exporter::proto::reports::StatsContext;
@@ -1414,8 +1413,8 @@ impl Telemetry {
                                     local_stat_recorder.visit(
                                         &query,
                                         &response,
-                                        &ctx.extensions()
-                                            .with_lock(|lock| lock.get().cloned())
+                                        &ctx.get_demand_control_context()
+                                            .map(|c| c.variables)
                                             .unwrap_or_default(),
                                     );
                                 }
@@ -1520,8 +1519,8 @@ impl Telemetry {
                 let traces = Self::subgraph_ftv1_traces(context);
                 let per_type_stat = Self::per_type_stat(&traces, field_level_instrumentation_ratio);
                 let root_error_stats = Self::per_path_error_stats(&traces);
+                let strategy = context.get_demand_control_context().map(|c| c.strategy);
                 let limits_stats = context.extensions().with_lock(|guard| {
-                    let strategy = guard.get::<demand_control::strategy::Strategy>();
                     let query_limits = guard.get::<OperationLimits<u32>>();
                     SingleLimitsStats {
                         strategy: strategy.and_then(|s| serde_json::to_string(&s.mode).ok()),


### PR DESCRIPTION
We're missing variable support in demand control scoring, so they're currently not counted. Additionally, they don't get passed through to the list size directive, which prevents users from using variables as slicing arguments. This change includes the request variables in context extensions so they can be accessed from the demand control plugin pipeline.

This includes a small refactor to wrap some of the common scoring arguments (schema, request document, etc) into a scoring context to reduce the number of arguments to each function.

<!-- ROUTER-725 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [X] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
