### PR TITLE
Fix query plan cache gauges that stopped working after hot reload

### DIFF
--- a/.changesets/fix_bryn_fix_gauges.md
+++ b/.changesets/fix_bryn_fix_gauges.md
@@ -1,0 +1,9 @@
+### Query plan cache gauges stop working after hot reload ([PR #5996](https://github.com/apollographql/router/pull/5996))
+
+When the router reloads the schema or config, the query plan cache gauges stop working. These are:
+* `apollo.router.cache.storage.estimated_size`
+* `apollo_router_cache_size`
+
+The gauges will now continue to function after a router hot reload. 
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5996

--- a/apollo-router/src/cache/mod.rs
+++ b/apollo-router/src/cache/mod.rs
@@ -137,6 +137,10 @@ where
     pub(crate) fn in_memory_cache(&self) -> InMemoryCache<K, V> {
         self.storage.in_memory_cache()
     }
+
+    pub(crate) fn activate(&self) {
+        self.storage.activate()
+    }
 }
 
 pub(crate) struct Entry<K: KeyType, V: ValueType> {

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 
 use lru::LruCache;
 use opentelemetry::metrics::MeterProvider;
-use opentelemetry_api::metrics::Meter;
 use opentelemetry_api::metrics::ObservableGauge;
 use opentelemetry_api::metrics::Unit;
 use opentelemetry_api::KeyValue;
@@ -53,13 +52,14 @@ pub(crate) type InMemoryCache<K, V> = Arc<Mutex<LruCache<K, V>>>;
 // a suitable implementation.
 #[derive(Clone)]
 pub(crate) struct CacheStorage<K: KeyType, V: ValueType> {
-    caller: String,
+    caller: &'static str,
     inner: Arc<Mutex<LruCache<K, V>>>,
     redis: Option<RedisCacheStorage>,
     cache_size: Arc<AtomicI64>,
     cache_estimated_storage: Arc<AtomicI64>,
-    _cache_size_gauge: ObservableGauge<i64>,
-    _cache_estimated_storage_gauge: ObservableGauge<i64>,
+    // It's OK for these to be mutexes as they are only initialized once
+    cache_size_gauge: Arc<std::sync::Mutex<Option<ObservableGauge<i64>>>>,
+    cache_estimated_storage_gauge: Arc<std::sync::Mutex<Option<ObservableGauge<i64>>>>,
 }
 
 impl<K, V> CacheStorage<K, V>
@@ -72,18 +72,12 @@ where
         config: Option<RedisCache>,
         caller: &'static str,
     ) -> Result<Self, BoxError> {
-        // Because calculating the cache size is expensive we do this as we go rather than iterating. This means storing the values for the gauges
-        let meter: opentelemetry::metrics::Meter = metrics::meter_provider().meter(METER_NAME);
-        let (cache_size, cache_size_gauge) = Self::create_cache_size_gauge(&meter, caller);
-        let (cache_estimated_storage, cache_estimated_storage_gauge) =
-            Self::create_cache_estimated_storage_size_gauge(&meter, caller);
-
         Ok(Self {
-            _cache_size_gauge: cache_size_gauge,
-            _cache_estimated_storage_gauge: cache_estimated_storage_gauge,
-            cache_size,
-            cache_estimated_storage,
-            caller: caller.to_string(),
+            cache_size_gauge: Default::default(),
+            cache_estimated_storage_gauge: Default::default(),
+            cache_size: Default::default(),
+            cache_estimated_storage: Default::default(),
+            caller,
             inner: Arc::new(Mutex::new(LruCache::new(max_capacity))),
             redis: if let Some(config) = config {
                 let required_to_start = config.required_to_start;
@@ -107,13 +101,11 @@ where
         })
     }
 
-    fn create_cache_size_gauge(
-        meter: &Meter,
-        caller: &'static str,
-    ) -> (Arc<AtomicI64>, ObservableGauge<i64>) {
-        let current_cache_size = Arc::new(AtomicI64::new(0));
-        let current_cache_size_for_gauge = current_cache_size.clone();
-        let cache_size_gauge = meter
+    fn create_cache_size_gauge(&self) -> ObservableGauge<i64> {
+        let meter: opentelemetry::metrics::Meter = metrics::meter_provider().meter(METER_NAME);
+        let current_cache_size_for_gauge = self.cache_size.clone();
+        let caller = self.caller;
+        meter
             // TODO move to dot naming convention
             .i64_observable_gauge("apollo_router_cache_size")
             .with_description("Cache size")
@@ -126,16 +118,13 @@ where
                     ],
                 )
             })
-            .init();
-        (current_cache_size, cache_size_gauge)
+            .init()
     }
 
-    fn create_cache_estimated_storage_size_gauge(
-        meter: &Meter,
-        caller: &'static str,
-    ) -> (Arc<AtomicI64>, ObservableGauge<i64>) {
-        let cache_estimated_storage = Arc::new(AtomicI64::new(0));
-        let cache_estimated_storage_for_gauge = cache_estimated_storage.clone();
+    fn create_cache_estimated_storage_size_gauge(&self) -> ObservableGauge<i64> {
+        let meter: opentelemetry::metrics::Meter = metrics::meter_provider().meter(METER_NAME);
+        let cache_estimated_storage_for_gauge = self.cache_estimated_storage.clone();
+        let caller = self.caller;
         let cache_estimated_storage_gauge = meter
             .i64_observable_gauge("apollo.router.cache.storage.estimated_size")
             .with_description("Estimated cache storage")
@@ -154,7 +143,7 @@ where
                 }
             })
             .init();
-        (cache_estimated_storage, cache_estimated_storage_gauge)
+        cache_estimated_storage_gauge
     }
 
     /// `init_from_redis` is called with values newly deserialized from Redis cache
@@ -291,6 +280,17 @@ where
     #[cfg(test)]
     pub(crate) async fn len(&self) -> usize {
         self.inner.lock().await.len()
+    }
+
+    pub(crate) fn activate(&self) {
+        // Gauges MUST be created after the meter provider is initialized
+        // This means that on reload we need a non-fallible way to recreate the gauges, hence this function.
+        *self.cache_size_gauge.lock().expect("lock poisoned") =
+            Some(self.create_cache_size_gauge());
+        *self
+            .cache_estimated_storage_gauge
+            .lock()
+            .expect("lock poisoned") = Some(self.create_cache_estimated_storage_size_gauge());
     }
 }
 

--- a/apollo-router/src/cache/storage.rs
+++ b/apollo-router/src/cache/storage.rs
@@ -350,6 +350,7 @@ mod test {
                 CacheStorage::new(NonZeroUsize::new(10).unwrap(), None, "test")
                     .await
                     .unwrap();
+            cache.activate();
 
             cache.insert("test".to_string(), Stuff {}).await;
             assert_gauge!(
@@ -385,6 +386,7 @@ mod test {
                 CacheStorage::new(NonZeroUsize::new(10).unwrap(), None, "test")
                     .await
                     .unwrap();
+            cache.activate();
 
             cache.insert("test".to_string(), Stuff {}).await;
             // This metric won't exist
@@ -418,6 +420,7 @@ mod test {
                 CacheStorage::new(NonZeroUsize::new(1).unwrap(), None, "test")
                     .await
                     .unwrap();
+            cache.activate();
 
             cache
                 .insert(

--- a/apollo-router/src/metrics/aggregation.rs
+++ b/apollo-router/src/metrics/aggregation.rs
@@ -99,9 +99,6 @@ pub(crate) enum InstrumentWrapper {
     F64Histogram {
         _keep_alive: Arc<Histogram<f64>>,
     },
-    U64Gauge {
-        _keep_alive: Arc<ObservableGauge<u64>>,
-    },
 }
 
 #[derive(Eq, PartialEq, Hash)]

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -84,6 +84,12 @@ pub(crate) struct CachingQueryPlanner<T: Clone> {
     legacy_introspection_caching: bool,
 }
 
+impl<T: Clone> CachingQueryPlanner<T> {
+    pub(crate) fn activate(&self) {
+        self.cache.activate()
+    }
+}
+
 fn init_query_plan_from_redis(
     subgraph_schemas: &SubgraphSchemas,
     cache_entry: &mut Result<QueryPlannerContent, Arc<QueryPlannerError>>,

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -797,6 +797,7 @@ impl PluggableSupergraphServiceBuilder {
 
         let schema = self.planner.schema();
         let subgraph_schemas = self.planner.subgraph_schemas();
+
         let query_planner_service = CachingQueryPlanner::new(
             self.planner,
             schema.clone(),
@@ -814,13 +815,9 @@ impl PluggableSupergraphServiceBuilder {
             }
         }
 
-        /*for (_, service) in self.subgraph_services.iter_mut() {
-            if let Some(subgraph) =
-                (service as &mut dyn std::any::Any).downcast_mut::<SubgraphService>()
-            {
-                subgraph.client_factory.plugins = plugins.clone();
-            }
-        }*/
+        // We need a non-fallible hook so that once we know we are going live with a pipeline we do final initialization.
+        // For now just shoe-horn something in, but if we ever reintroduce the query planner hook in plugins and activate then this can be made clean.
+        query_planner_service.activate();
 
         let subgraph_service_factory = Arc::new(SubgraphServiceFactory::new(
             self.subgraph_services


### PR DESCRIPTION
When a hot reload happens the opentelemetry meter provider is refreshed.

Gauges in particular MUST be created after this refresh has happened.

The query planner pipeline is currently created outside of the plugin lifecycle, and therefore does not have the opportunity to do this.

We can consider reintroducing the `query_planner` and `activate` hooks in plugins in future it would probably help, or have some equivalent. But for now this PR just adds an `activate` call that is threaded right down to the `CacheStorage`. This can be called on the query planner pipeline after telemetry has been activated.

This is tested in integration test by starting the router without prometheus and then adding it after a reload.


<!-- start metadata -->
---
<!-- Partially fixes ROUTER-702 -->
**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*
* Bug fix, no docs needed
* No perf impact

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
