### PR TITLE
Fix v8 gauges on hot reload

### DIFF
--- a/.changesets/fix_bryn_fix_gauges.md
+++ b/.changesets/fix_bryn_fix_gauges.md
@@ -1,9 +1,12 @@
-### Query plan cache gauges stop working after hot reload ([PR #5996](https://github.com/apollographql/router/pull/5996))
+### Gauges stop working after hot reload ([PR #5996](https://github.com/apollographql/router/pull/5996), [PR #5999](https://github.com/apollographql/router/pull/5999))
 
-When the router reloads the schema or config, the query plan cache gauges stop working. These are:
+When the router reloads the schema or config, some gauges stopped working. These were:
 * `apollo.router.cache.storage.estimated_size`
 * `apollo_router_cache_size`
+* `apollo.router.v8.heap.used`
+* `apollo.router.v8.heap.total`
+* `apollo.router.query_planning.queued`
 
 The gauges will now continue to function after a router hot reload. 
 
-By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5996
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5996 and https://github.com/apollographql/router/pull/5999

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -85,12 +85,6 @@ pub(crate) struct CachingQueryPlanner<T: Clone> {
     legacy_introspection_caching: bool,
 }
 
-impl<T: Clone> CachingQueryPlanner<T> {
-    pub(crate) fn activate(&self) {
-        self.cache.activate()
-    }
-}
-
 fn init_query_plan_from_redis(
     subgraph_schemas: &SubgraphSchemas,
     cache_entry: &mut Result<QueryPlannerContent, Arc<QueryPlannerError>>,
@@ -398,6 +392,11 @@ impl CachingQueryPlanner<BridgeQueryPlannerPool> {
         &self,
     ) -> Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>> {
         self.delegate.subgraph_schemas()
+    }
+
+    pub(crate) fn activate(&self) {
+        self.cache.activate();
+        self.delegate.activate();
     }
 }
 

--- a/apollo-router/tests/integration/telemetry/metrics.rs
+++ b/apollo-router/tests/integration/telemetry/metrics.rs
@@ -237,4 +237,22 @@ async fn test_gauges_on_reload() {
     router
         .assert_metrics_contains(r#"apollo_router_cache_storage_estimated_size{kind="query planner",type="memory",otel_scope_name="apollo/router"} "#, None)
         .await;
+    router
+        .assert_metrics_contains(
+            r#"apollo_router_query_planning_queued{otel_scope_name="apollo/router"} "#,
+            None,
+        )
+        .await;
+    router
+        .assert_metrics_contains(
+            r#"apollo_router_v8_heap_total_bytes{otel_scope_name="apollo/router"} "#,
+            None,
+        )
+        .await;
+    router
+        .assert_metrics_contains(
+            r#"apollo_router_v8_heap_total_bytes{otel_scope_name="apollo/router"} "#,
+            None,
+        )
+        .await;
 }


### PR DESCRIPTION
The v8 heap usage and queue gauges were not working after hot reload.
This is because gauges MUST be created after the global meter provider is updated.
This builds on the work from #5996 by introducing an `activate` function to populate the gauges when we are ready.
The integration test from 5996 is extended to test for the extra metrics.
<!-- start metadata -->
---
<!-- Closes ROUTER-702 -->
**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

Bug fix, no docs needed
Unit tests don't capture reload of router, so this is done in integration tests.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
