### PR TITLE
Fix datadog sample propagation

### DIFF
--- a/apollo-router/src/plugins/telemetry/reload.rs
+++ b/apollo-router/src/plugins/telemetry/reload.rs
@@ -35,7 +35,6 @@ use crate::plugins::telemetry::formatters::FilteringFormatter;
 use crate::plugins::telemetry::otel;
 use crate::plugins::telemetry::otel::OpenTelemetryLayer;
 use crate::plugins::telemetry::otel::PreSampledTracer;
-use crate::plugins::telemetry::tracing::datadog_exporter::DatadogTraceState;
 use crate::plugins::telemetry::tracing::reload::ReloadTracer;
 use crate::tracer::TraceId;
 
@@ -141,9 +140,7 @@ pub(crate) fn prepare_context(context: Context) -> Context {
                 tracer.new_span_id(),
                 TraceFlags::default(),
                 false,
-                TraceState::default()
-                    .with_measuring(true)
-                    .with_priority_sampling(true),
+                TraceState::default(),
             );
             return context.with_remote_span_context(span_context);
         }

--- a/apollo-router/tests/integration/telemetry/fixtures/datadog_no_sample.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/datadog_no_sample.router.yaml
@@ -1,0 +1,24 @@
+telemetry:
+  apollo:
+    field_level_instrumentation_sampler: always_off
+  exporters:
+    tracing:
+      experimental_response_trace_id:
+        enabled: true
+        header_name: apollo-custom-trace-id
+        format: datadog
+      common:
+        service_name: router
+        # NOT always_off to allow us to test a sampling probability of zero
+        sampler: 0.0
+      datadog:
+        enabled: true
+        batch_processor:
+          scheduled_delay: 100ms
+        fixed_span_names: false
+        enable_span_mapping: false
+  instrumentation:
+    spans:
+      mode: spec_compliant
+
+


### PR DESCRIPTION
#5788 introduced a regression where samping was being set on propagated headers regardless of the sampling decision in the router or upstream.

This PR reverts the code in question and adds a test to check that a non-sampled request will not result in sampling in the downstream subgraph service.


<!-- start metadata -->
---
<!-- ROUTER-734 -->
**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

* Bug fix so no docs change.
* Integration test rather than unit test because this is telemetry.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
