### PR TITLE
Allow resolvable key fields to have no connect directive

### DIFF
--- a/apollo-federation/src/sources/connect/validation/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/mod.rs
@@ -28,12 +28,16 @@ use std::ops::Range;
 use apollo_compiler::ast::OperationType;
 use apollo_compiler::ast::Value;
 use apollo_compiler::collections::IndexSet;
+use apollo_compiler::executable::FieldSet;
 use apollo_compiler::name;
 use apollo_compiler::parser::LineColumn;
+use apollo_compiler::parser::Parser;
 use apollo_compiler::parser::SourceMap;
 use apollo_compiler::schema::Component;
 use apollo_compiler::schema::Directive;
 use apollo_compiler::schema::ExtendedType;
+use apollo_compiler::schema::ObjectType;
+use apollo_compiler::validation::Valid;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::Schema;
@@ -43,6 +47,9 @@ use itertools::Itertools;
 use source_name::SourceName;
 use url::Url;
 
+use crate::link::federation_spec_definition::FEDERATION_FIELDS_ARGUMENT_NAME;
+use crate::link::federation_spec_definition::FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC;
+use crate::link::federation_spec_definition::FEDERATION_RESOLVABLE_ARGUMENT_NAME;
 use crate::link::spec::Identity;
 use crate::link::Import;
 use crate::link::Link;
@@ -370,6 +377,42 @@ fn require_value_is_str<'a, Coordinate: Display>(
         message: format!("The value for {coordinate} must be a string."),
         locations: value.line_column_range(sources).into_iter().collect(),
     })
+}
+
+fn resolvable_key_fields<'a>(
+    object: &'a Node<ObjectType>,
+    schema: &'a Schema,
+) -> impl Iterator<Item = FieldSet> + 'a {
+    object
+        .directives
+        .iter()
+        .filter(|directive| directive.name == FEDERATION_KEY_DIRECTIVE_NAME_IN_SPEC)
+        .filter(|directive| {
+            directive
+                .arguments
+                .iter()
+                .find(|arg| arg.name == FEDERATION_RESOLVABLE_ARGUMENT_NAME)
+                .and_then(|arg| arg.value.to_bool())
+                .unwrap_or(true)
+        })
+        .filter_map(|directive| {
+            directive
+                .arguments
+                .iter()
+                .find(|arg| arg.name == FEDERATION_FIELDS_ARGUMENT_NAME)
+        })
+        .map(|fields| &*fields.value)
+        .filter_map(|key_fields| key_fields.as_str())
+        .filter_map(|fields| {
+            Parser::new()
+                .parse_field_set(
+                    Valid::assume_valid_ref(schema),
+                    object.name.clone(),
+                    fields.to_string(),
+                    "",
+                )
+                .ok()
+        })
 }
 
 type DirectiveName = Name;

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_no_connect_on_resolvable_key_field.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_no_connect_on_resolvable_key_field.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/valid_no_connect_on_resolvable_key_field.graphql
+---
+[]

--- a/apollo-federation/src/sources/connect/validation/test_data/valid_no_connect_on_resolvable_key_field.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/valid_no_connect_on_resolvable_key_field.graphql
@@ -1,0 +1,36 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/federation/v2.8"
+    import: ["@key"]
+)
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect", "@source"]
+)
+
+@source(name: "v2", http: { baseURL: "http://localhost" })
+
+type Query {
+    price(id: ID!): Price
+    @connect(source: "v2" http: { GET: "/price/{$args.id}" } selection: "id" entity: true)
+}
+
+type Sku {
+    id: ID!
+}
+
+type Product @key(fields: "sku { id }") {
+    sku: Sku!
+    price: Price
+    @connect(
+        source: "v2"
+        http: { GET: "/products/{$this.id}" }
+        selection: """
+        id: default_price
+        """
+    )
+}
+
+type Price {
+    id: ID!
+}


### PR DESCRIPTION

The validation to check that entity fields are resolvable through `@connect` directives was incorrectly marking resolvable key fields as errors. The key fields are now added to the list of visited fields to prevent this. This requires iterating down a tree of key fields if there are input types in use. That is implemented using a `Vec`-based stack instead of recursion, and it has checks to avoid cycles. Also added a unit test, and refactored some code to handle `@key` directives to avoid code duplication.

<!-- [CNN-456] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**


**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-456]: https://apollographql.atlassian.net/browse/CNN-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ