### PR TITLE
Fix APQ and introspection gauges

### DIFF
--- a/.changesets/fix_bryn_fix_gauges.md
+++ b/.changesets/fix_bryn_fix_gauges.md
@@ -1,4 +1,4 @@
-### Gauges stop working after hot reload ([PR #5996](https://github.com/apollographql/router/pull/5996), [PR #5999](https://github.com/apollographql/router/pull/5999))
+### Gauges stop working after hot reload ([PR #5996](https://github.com/apollographql/router/pull/5996), [PR #5999](https://github.com/apollographql/router/pull/5999), [PR #5999](https://github.com/apollographql/router/pull/6012))
 
 When the router reloads the schema or config, some gauges stopped working. These were:
 * `apollo.router.cache.storage.estimated_size`
@@ -9,4 +9,6 @@ When the router reloads the schema or config, some gauges stopped working. These
 
 The gauges will now continue to function after a router hot reload. 
 
-By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5996 and https://github.com/apollographql/router/pull/5999
+As a result of this change, introspection queries will now share the same cache even when query planner pooling is used.
+
+By [@BrynCooke](https://github.com/BrynCooke) in https://github.com/apollographql/router/pull/5996 and https://github.com/apollographql/router/pull/5999 and https://github.com/apollographql/router/pull/6012

--- a/apollo-router/src/introspection.rs
+++ b/apollo-router/src/introspection.rs
@@ -14,6 +14,13 @@ use crate::query_planner::QueryPlanResult;
 const DEFAULT_INTROSPECTION_CACHE_CAPACITY: NonZeroUsize =
     unsafe { NonZeroUsize::new_unchecked(5) };
 
+pub(crate) async fn default_cache_storage() -> CacheStorage<String, Response> {
+    // This cannot fail as redis is not used.
+    CacheStorage::new(DEFAULT_INTROSPECTION_CACHE_CAPACITY, None, "introspection")
+        .await
+        .expect("failed to create cache storage")
+}
+
 /// A cache containing our well known introspection queries.
 pub(crate) struct Introspection {
     cache: CacheStorage<String, Response>,
@@ -21,18 +28,11 @@ pub(crate) struct Introspection {
 }
 
 impl Introspection {
-    pub(crate) async fn with_capacity(
+    pub(crate) async fn with_cache(
         planner: Arc<Planner<QueryPlanResult>>,
-        capacity: NonZeroUsize,
+        cache: CacheStorage<String, Response>,
     ) -> Result<Self, BoxError> {
-        Ok(Self {
-            cache: CacheStorage::new(capacity, None, "introspection").await?,
-            planner,
-        })
-    }
-
-    pub(crate) async fn new(planner: Arc<Planner<QueryPlanResult>>) -> Result<Self, BoxError> {
-        Self::with_capacity(planner, DEFAULT_INTROSPECTION_CACHE_CAPACITY).await
+        Ok(Self { cache, planner })
     }
 
     #[cfg(test)]
@@ -40,7 +40,11 @@ impl Introspection {
         planner: Arc<Planner<QueryPlanResult>>,
         cache: HashMap<String, Response>,
     ) -> Result<Self, BoxError> {
-        let this = Self::with_capacity(planner, cache.len().try_into().unwrap()).await?;
+        let this = Self::with_cache(
+            planner,
+            CacheStorage::new(cache.len().try_into().unwrap(), None, "introspection").await?,
+        )
+        .await?;
 
         for (query, response) in cache.into_iter() {
             this.cache.insert(query, response).await;

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -585,6 +585,7 @@ mod tests {
     use tower::Service;
 
     use super::*;
+    use crate::introspection::default_cache_storage;
     use crate::query_planner::BridgeQueryPlanner;
     use crate::services::layers::query_analysis::ParsedDocument;
     use crate::services::QueryPlannerContent;
@@ -671,9 +672,15 @@ mod tests {
             .unwrap_or_default();
         let supergraph_schema = schema.supergraph_schema().clone();
 
-        let mut planner = BridgeQueryPlanner::new(schema.into(), config.clone(), None, None)
-            .await
-            .unwrap();
+        let mut planner = BridgeQueryPlanner::new(
+            schema.into(),
+            config.clone(),
+            None,
+            None,
+            default_cache_storage().await,
+        )
+        .await
+        .unwrap();
 
         let ctx = Context::new();
         ctx.extensions()

--- a/apollo-router/src/plugins/test.rs
+++ b/apollo-router/src/plugins/test.rs
@@ -10,6 +10,7 @@ use tower::BoxError;
 use tower::ServiceBuilder;
 use tower_service::Service;
 
+use crate::introspection::default_cache_storage;
 use crate::plugin::DynPlugin;
 use crate::plugin::Plugin;
 use crate::plugin::PluginInit;
@@ -95,10 +96,15 @@ impl<T: Plugin> PluginTestHarness<T> {
             let sdl = schema.raw_sdl.clone();
             let supergraph = schema.supergraph_schema().clone();
             let rust_planner = PlannerMode::maybe_rust(&schema, &config).unwrap();
-            let planner =
-                BridgeQueryPlanner::new(schema.into(), Arc::new(config), None, rust_planner)
-                    .await
-                    .unwrap();
+            let planner = BridgeQueryPlanner::new(
+                schema.into(),
+                Arc::new(config),
+                None,
+                rust_planner,
+                default_cache_storage().await,
+            )
+            .await
+            .unwrap();
             (sdl, supergraph, planner.subgraph_schemas())
         } else {
             (

--- a/apollo-router/src/query_planner/bridge_query_planner_pool.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner_pool.rs
@@ -21,8 +21,11 @@ use tower::ServiceExt;
 
 use super::bridge_query_planner::BridgeQueryPlanner;
 use super::QueryPlanResult;
+use crate::cache::storage::CacheStorage;
 use crate::error::QueryPlannerError;
 use crate::error::ServiceBuildError;
+use crate::graphql::Response;
+use crate::introspection::default_cache_storage;
 use crate::metrics::meter_provider;
 use crate::query_planner::PlannerMode;
 use crate::services::QueryPlannerRequest;
@@ -46,6 +49,7 @@ pub(crate) struct BridgeQueryPlannerPool {
     v8_heap_used_gauge: Arc<Mutex<Option<ObservableGauge<u64>>>>,
     v8_heap_total: Arc<AtomicU64>,
     v8_heap_total_gauge: Arc<Mutex<Option<ObservableGauge<u64>>>>,
+    introspection_cache: CacheStorage<String, Response>,
 }
 
 impl BridgeQueryPlannerPool {
@@ -66,16 +70,28 @@ impl BridgeQueryPlannerPool {
 
         let mut old_js_planners_iterator = old_js_planners.into_iter();
 
-        (0..size.into()).for_each(|_| {
+        // All query planners in the pool now share the same introspection cache.
+        // This allows meaningful gauges, and it makes sense that queries should be cached across all planners.
+        let introspection_cache = default_cache_storage().await;
+
+        for _ in 0..size.into() {
             let schema = schema.clone();
             let configuration = configuration.clone();
             let rust_planner = rust_planner.clone();
+            let introspection_cache = introspection_cache.clone();
 
             let old_planner = old_js_planners_iterator.next();
             join_set.spawn(async move {
-                BridgeQueryPlanner::new(schema, configuration, old_planner, rust_planner).await
+                BridgeQueryPlanner::new(
+                    schema,
+                    configuration,
+                    old_planner,
+                    rust_planner,
+                    introspection_cache,
+                )
+                .await
             });
-        });
+        }
 
         let mut bridge_query_planners = Vec::new();
 
@@ -142,6 +158,7 @@ impl BridgeQueryPlannerPool {
             v8_heap_used_gauge: Default::default(),
             v8_heap_total,
             v8_heap_total_gauge: Default::default(),
+            introspection_cache,
         })
     }
 
@@ -218,6 +235,7 @@ impl BridgeQueryPlannerPool {
             Some(self.create_heap_used_gauge());
         *self.v8_heap_total_gauge.lock().expect("lock poisoned") =
             Some(self.create_heap_total_gauge());
+        self.introspection_cache.activate();
     }
 }
 

--- a/apollo-router/src/services/layers/apq.rs
+++ b/apollo-router/src/services/layers/apq.rs
@@ -55,6 +55,14 @@ pub(crate) struct APQLayer {
 }
 
 impl APQLayer {
+    pub(crate) fn activate(&self) {
+        if let Some(cache) = &self.cache {
+            cache.activate();
+        }
+    }
+}
+
+impl APQLayer {
     pub(crate) fn with_cache(cache: DeduplicatingCache<String, String>) -> Self {
         Self { cache: Some(cache) }
     }

--- a/apollo-router/src/services/router/service.rs
+++ b/apollo-router/src/services/router/service.rs
@@ -873,6 +873,14 @@ impl RouterCreator {
         } else {
             APQLayer::disabled()
         };
+        // There is a problem here.
+        // APQ isn't a plugin and so cannot participate in plugin lifecycle events.
+        // After telemetry `activate` NO part of the pipeline can fail as globals have been interacted with.
+        // However, the APQLayer uses DeduplicatingCache which is fallible. So if this fails on hot reload the router will be
+        // left in an inconsistent state and all metrics will likely stop working.
+        // Fixing this will require a larger refactor to bring APQ into the router lifecycle.
+        // For now just call activate to make the gauges work on the happy path.
+        apq_layer.activate();
 
         Ok(Self {
             supergraph_creator,

--- a/apollo-router/tests/common.rs
+++ b/apollo-router/tests/common.rs
@@ -523,7 +523,7 @@ impl IntegrationTest {
     pub fn execute_huge_query(
         &self,
     ) -> impl std::future::Future<Output = (TraceId, reqwest::Response)> {
-        self.execute_query_internal(&json!({"query":"query {topProducts{name, name, name, name, name, name, name, name, name, name}}","variables":{}}), None, None)
+        self.execute_query_internal(&json!({"query":"query {topProducts{name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name, name}}","variables":{}}), None, None)
     }
 
     #[allow(dead_code)]

--- a/apollo-router/tests/integration/telemetry/fixtures/prometheus.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/prometheus.router.yaml
@@ -1,5 +1,5 @@
 limits:
-  http_max_request_bytes: 60
+  http_max_request_bytes: 200
 telemetry:
   exporters:
     metrics:
@@ -9,18 +9,18 @@ telemetry:
         path: /metrics
       common:
         views:
-        - name: apollo_router_http_request_duration_seconds
-          aggregation:
-            histogram:
-              buckets:
-              - 0.1
-              - 0.5
-              - 1
-              - 2
-              - 3
-              - 4
-              - 5
-              - 100
+          - name: apollo_router_http_request_duration_seconds
+            aggregation:
+              histogram:
+                buckets:
+                  - 0.1
+                  - 0.5
+                  - 1
+                  - 2
+                  - 3
+                  - 4
+                  - 5
+                  - 100
         attributes:
           subgraph:
             all:
@@ -39,3 +39,10 @@ override_subgraph_url:
   products: http://localhost:4005
 include_subgraph_errors:
   all: true
+supergraph:
+  introspection: true
+apq:
+  router:
+    cache:
+      in_memory:
+        limit: 1000


### PR DESCRIPTION
Similar to the query planner gauges, these must be initialized after telemetry has been activated.

Fixes:
* `apollo_router_cache_size` for `APQ` and `introspection`

As a result of this change every query planner in the query planner pool will share the same cache storage for introspection queries. Otherwise many identical gauges are created, and they are not summed. It doesn't really make sense that each query planner should have a separate cache anyway.

Another issue was noticed, and commented on. APQLayer uses deduplicating cache which is fallible. This is initialized after telemetry has been activated, so if it fails it is likely that telemetry will stop working. This is not fixable without a larger refactor to bring APQ init forward, which is out of scope for this PR. We'll tackle router lifecycle as a larger holistic refactor later.

<!-- start metadata -->
---
<!-- ROUTER-702 -->
**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

**Exceptions**

* docs not needed because this is a bug fix.
* Added to existing integration tests because this is telemetry.

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
