### PR TITLE
Fix introspection bug, run off Tokio threads, enable "both" mode

### DIFF
--- a/.changesets/config_introspection_both.md
+++ b/.changesets/config_introspection_both.md
@@ -1,0 +1,14 @@
+### Enable both introspection implementation by default ([PR #6014](https://github.com/apollographql/router/pull/6014))
+
+As part of the process to replace JavaScript schema introspection with a more performant Rust implementation in the router, we are enabling the router to run both implementations as a default. This allows us to definitively assess reliability and stability of Rust implementation before completely removing JavaScript one. As before, it's possible to toggle between implementations using the `experimental_introspection_mode` config key. Possible values are: `new` (runs only Rust-based validation), `legacy` (runs only JS-based validation), `both` (runs both in comparison, logging errors if a difference arises).
+
+The `both` mode is now the default, which will result in **no client-facing impact** but will record the metrics for the outcome of comparison as a `apollo.router.operations.introspection.both` counter. If this counter in your metrics has `rust_error = true` or `is_matched = false`, please open an issue.
+
+Schema introspection itself is disabled by default, so the above has no effect unless it is enabled in configuration:
+
+```yaml
+supergraph:
+  introspection: true
+```
+
+By [@SimonSapin](https://github.com/SimonSapin) in https://github.com/apollographql/router/pull/6014

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,9 +159,9 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "apollo-compiler"
-version = "1.0.0-beta.22"
+version = "1.0.0-beta.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6feccaf8fab00732a73dd3a40e4aaa7a1106ceef3c0bfbc591c4e0ba27e07774"
+checksum = "875f39060728ac3e775fc3fe5421225d6df92c4d5155a9524cdb198f05006d36"
 dependencies = [
  "ahash",
  "apollo-parser",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-smith"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10e88b295221ae9d2af63d5eac86cb1f47ec8449e7440253d7772fc305a6c200"
+checksum = "40cff1a5989a471714cfdf53f24d0948b7f77631ab3dbd25b2f6eacbf58e5261"
 dependencies = [
  "apollo-compiler",
  "apollo-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,9 @@ debug = 1
 # Dependencies used in more than one place are specified here in order to keep versions in sync:
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
 [workspace.dependencies]
-apollo-compiler = "=1.0.0-beta.22"
+apollo-compiler = "=1.0.0-beta.23"
 apollo-parser = "0.8.0"
-apollo-smith = "0.12.0"
+apollo-smith = "0.13.0"
 async-trait = "0.1.77"
 hex = { version = "0.4.3", features = ["serde"] }
 http = "0.2.11"

--- a/apollo-router/src/configuration/mod.rs
+++ b/apollo-router/src/configuration/mod.rs
@@ -239,10 +239,10 @@ pub(crate) enum IntrospectionMode {
     /// Use the new Rust-based implementation.
     New,
     /// Use the old JavaScript-based implementation.
-    #[default]
     Legacy,
     /// Use Rust-based and Javascript-based implementations side by side,
     /// logging warnings if the implementations disagree.
+    #[default]
     Both,
 }
 

--- a/apollo-router/src/query_planner/bridge_query_planner.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner.rs
@@ -1,6 +1,5 @@
 //! Calls out to nodejs query planner
 
-use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::fmt::Write;
@@ -578,7 +577,11 @@ impl BridgeQueryPlanner {
                         }
                         Err(e) => Err(e),
                     };
-                    Self::compare_introspection_responses(js_result_clone, rust_result);
+                    super::dual_introspection::compare_introspection_responses(
+                        &key.original_query,
+                        js_result_clone,
+                        rust_result,
+                    );
                 })
                 .await
                 .expect("Introspection comparison panicked");
@@ -616,137 +619,6 @@ impl BridgeQueryPlanner {
             &variable_values,
         );
         Ok(response.into())
-    }
-
-    fn compare_introspection_responses(
-        mut js_result: Result<graphql::Response, QueryPlannerError>,
-        mut rust_result: Result<graphql::Response, QueryPlannerError>,
-    ) {
-        let is_matched;
-        match (&mut js_result, &mut rust_result) {
-            (Err(_), Err(_)) => {
-                is_matched = true;
-            }
-            (Err(err), Ok(_)) => {
-                is_matched = false;
-                tracing::warn!("JS introspection error: {err}")
-            }
-            (Ok(_), Err(err)) => {
-                is_matched = false;
-                tracing::warn!("Rust introspection error: {err}")
-            }
-            (Ok(js_response), Ok(rust_response)) => {
-                if let (Some(js_data), Some(rust_data)) =
-                    (&mut js_response.data, &mut rust_response.data)
-                {
-                    json_sort_arrays(js_data);
-                    json_sort_arrays(rust_data);
-                }
-                is_matched = js_response.data == rust_response.data;
-                if is_matched {
-                    tracing::debug!("Introspection match! 🎉")
-                } else {
-                    tracing::debug!("Introspection mismatch");
-                    tracing::trace!("Introspection diff:\n{}", {
-                        let rust = rust_response
-                            .data
-                            .as_ref()
-                            .map(|d| serde_json::to_string_pretty(&d).unwrap())
-                            .unwrap_or_default();
-                        let js = js_response
-                            .data
-                            .as_ref()
-                            .map(|d| serde_json::to_string_pretty(&d).unwrap())
-                            .unwrap_or_default();
-                        let diff = similar::TextDiff::from_lines(&js, &rust);
-                        diff.unified_diff()
-                            .context_radius(10)
-                            .header("JS", "Rust")
-                            .to_string()
-                    })
-                }
-            }
-        }
-
-        u64_counter!(
-            "apollo.router.operations.introspection.both",
-            "Comparing JS v.s. Rust introspection",
-            1,
-            "generation.is_matched" = is_matched,
-            "generation.js_error" = js_result.is_err(),
-            "generation.rust_error" = rust_result.is_err()
-        );
-
-        fn json_sort_arrays(value: &mut Value) {
-            match value {
-                Value::Array(array) => {
-                    for item in array.iter_mut() {
-                        json_sort_arrays(item)
-                    }
-                    array.sort_by(json_compare)
-                }
-                Value::Object(object) => {
-                    for (_key, value) in object {
-                        json_sort_arrays(value)
-                    }
-                }
-                Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
-            }
-        }
-
-        fn json_compare(a: &Value, b: &Value) -> Ordering {
-            match (a, b) {
-                (Value::Null, Value::Null) => Ordering::Equal,
-                (Value::Bool(a), Value::Bool(b)) => a.cmp(b),
-                (Value::Number(a), Value::Number(b)) => {
-                    a.as_f64().unwrap().total_cmp(&b.as_f64().unwrap())
-                }
-                (Value::String(a), Value::String(b)) => a.cmp(b),
-                (Value::Array(a), Value::Array(b)) => iter_cmp(a, b, json_compare),
-                (Value::Object(a), Value::Object(b)) => {
-                    iter_cmp(a, b, |(key_a, a), (key_b, b)| {
-                        debug_assert_eq!(key_a, key_b); // Response object keys are in selection set order
-                        json_compare(a, b)
-                    })
-                }
-                _ => json_discriminant(a).cmp(&json_discriminant(b)),
-            }
-        }
-
-        // TODO: use `Iterator::cmp_by` when available:
-        // https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.cmp_by
-        // https://github.com/rust-lang/rust/issues/64295
-        fn iter_cmp<T>(
-            a: impl IntoIterator<Item = T>,
-            b: impl IntoIterator<Item = T>,
-            cmp: impl Fn(T, T) -> Ordering,
-        ) -> Ordering {
-            use itertools::Itertools;
-            for either_or_both in a.into_iter().zip_longest(b) {
-                match either_or_both {
-                    itertools::EitherOrBoth::Both(a, b) => {
-                        let ordering = cmp(a, b);
-                        if ordering != Ordering::Equal {
-                            return ordering;
-                        }
-                    }
-                    itertools::EitherOrBoth::Left(_) => return Ordering::Less,
-                    itertools::EitherOrBoth::Right(_) => return Ordering::Greater,
-                }
-            }
-            Ordering::Equal
-        }
-
-        fn json_discriminant(value: &Value) -> u8 {
-            match value {
-                Value::Null => 0,
-                Value::Bool(_) => 1,
-                Value::Number(_) => 2,
-                Value::String(_) => 3,
-                Value::Array(_) => 4,
-                Value::Object(_) => 5,
-            }
-        }
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/apollo-router/src/query_planner/dual_introspection.rs
+++ b/apollo-router/src/query_planner/dual_introspection.rs
@@ -1,0 +1,138 @@
+use std::cmp::Ordering;
+
+use serde_json_bytes::Value;
+
+use crate::error::QueryPlannerError;
+use crate::graphql;
+
+pub(crate) fn compare_introspection_responses(
+    query: &str,
+    mut js_result: Result<graphql::Response, QueryPlannerError>,
+    mut rust_result: Result<graphql::Response, QueryPlannerError>,
+) {
+    let is_matched;
+    match (&mut js_result, &mut rust_result) {
+        (Err(_), Err(_)) => {
+            is_matched = true;
+        }
+        (Err(err), Ok(_)) => {
+            is_matched = false;
+            tracing::warn!("JS introspection error: {err}")
+        }
+        (Ok(_), Err(err)) => {
+            is_matched = false;
+            tracing::warn!("Rust introspection error: {err}")
+        }
+        (Ok(js_response), Ok(rust_response)) => {
+            if let (Some(js_data), Some(rust_data)) =
+                (&mut js_response.data, &mut rust_response.data)
+            {
+                json_sort_arrays(js_data);
+                json_sort_arrays(rust_data);
+            }
+            is_matched = js_response.data == rust_response.data;
+            if is_matched {
+                tracing::trace!("Introspection query:\n{query}");
+                tracing::debug!("Introspection match! 🎉")
+            } else {
+                tracing::debug!("Introspection mismatch");
+                tracing::trace!("Introspection query:\n{query}");
+                tracing::trace!("Introspection diff:\n{}", {
+                    let rust = rust_response
+                        .data
+                        .as_ref()
+                        .map(|d| serde_json::to_string_pretty(&d).unwrap())
+                        .unwrap_or_default();
+                    let js = js_response
+                        .data
+                        .as_ref()
+                        .map(|d| serde_json::to_string_pretty(&d).unwrap())
+                        .unwrap_or_default();
+                    let diff = similar::TextDiff::from_lines(&js, &rust);
+                    diff.unified_diff()
+                        .context_radius(10)
+                        .header("JS", "Rust")
+                        .to_string()
+                })
+            }
+        }
+    }
+
+    u64_counter!(
+        "apollo.router.operations.introspection.both",
+        "Comparing JS v.s. Rust introspection",
+        1,
+        "generation.is_matched" = is_matched,
+        "generation.js_error" = js_result.is_err(),
+        "generation.rust_error" = rust_result.is_err()
+    );
+}
+
+fn json_sort_arrays(value: &mut Value) {
+    match value {
+        Value::Array(array) => {
+            for item in array.iter_mut() {
+                json_sort_arrays(item)
+            }
+            array.sort_by(json_compare)
+        }
+        Value::Object(object) => {
+            for (_key, value) in object {
+                json_sort_arrays(value)
+            }
+        }
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+fn json_compare(a: &Value, b: &Value) -> Ordering {
+    match (a, b) {
+        (Value::Null, Value::Null) => Ordering::Equal,
+        (Value::Bool(a), Value::Bool(b)) => a.cmp(b),
+        (Value::Number(a), Value::Number(b)) => a.as_f64().unwrap().total_cmp(&b.as_f64().unwrap()),
+        (Value::String(a), Value::String(b)) => a.cmp(b),
+        (Value::Array(a), Value::Array(b)) => iter_cmp(a, b, json_compare),
+        (Value::Object(a), Value::Object(b)) => {
+            iter_cmp(a, b, |(key_a, a), (key_b, b)| {
+                debug_assert_eq!(key_a, key_b); // Response object keys are in selection set order
+                json_compare(a, b)
+            })
+        }
+        _ => json_discriminant(a).cmp(&json_discriminant(b)),
+    }
+}
+
+// TODO: use `Iterator::cmp_by` when available:
+// https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.cmp_by
+// https://github.com/rust-lang/rust/issues/64295
+fn iter_cmp<T>(
+    a: impl IntoIterator<Item = T>,
+    b: impl IntoIterator<Item = T>,
+    cmp: impl Fn(T, T) -> Ordering,
+) -> Ordering {
+    use itertools::Itertools;
+    for either_or_both in a.into_iter().zip_longest(b) {
+        match either_or_both {
+            itertools::EitherOrBoth::Both(a, b) => {
+                let ordering = cmp(a, b);
+                if ordering != Ordering::Equal {
+                    return ordering;
+                }
+            }
+            itertools::EitherOrBoth::Left(_) => return Ordering::Less,
+            itertools::EitherOrBoth::Right(_) => return Ordering::Greater,
+        }
+    }
+    Ordering::Equal
+}
+
+fn json_discriminant(value: &Value) -> u8 {
+    match value {
+        Value::Null => 0,
+        Value::Bool(_) => 1,
+        Value::Number(_) => 2,
+        Value::String(_) => 3,
+        Value::Array(_) => 4,
+        Value::Object(_) => 5,
+    }
+}

--- a/apollo-router/src/query_planner/dual_introspection.rs
+++ b/apollo-router/src/query_planner/dual_introspection.rs
@@ -32,7 +32,6 @@ pub(crate) fn compare_introspection_responses(
             }
             is_matched = js_response.data == rust_response.data;
             if is_matched {
-                tracing::trace!("Introspection query:\n{query}");
                 tracing::debug!("Introspection match! 🎉")
             } else {
                 tracing::debug!("Introspection mismatch");

--- a/apollo-router/src/query_planner/mod.rs
+++ b/apollo-router/src/query_planner/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod bridge_query_planner;
 mod bridge_query_planner_pool;
 mod caching_query_planner;
 mod convert;
+mod dual_introspection;
 pub(crate) mod dual_query_planner;
 mod execution;
 pub(crate) mod fetch;

--- a/apollo-router/tests/integration/introspection.rs
+++ b/apollo-router/tests/integration/introspection.rs
@@ -249,8 +249,6 @@ async fn both_mode_integration() {
             "query": include_str!("../fixtures/introspect_full_schema.graphql"),
         }))
         .await;
-    // TODO: should be a match after https://apollographql.atlassian.net/browse/ROUTER-703
-    // router.assert_log_contains("Introspection match! 🎉").await;
-    router.assert_log_contains("Introspection mismatch").await;
+    router.assert_log_contains("Introspection match! 🎉").await;
     router.graceful_shutdown().await;
 }

--- a/apollo-router/tests/integration/introspection.rs
+++ b/apollo-router/tests/integration/introspection.rs
@@ -233,7 +233,7 @@ async fn both_mode_integration() {
     let mut router = IntegrationTest::builder()
         .config(
             "
-                experimental_introspection_mode: both
+                # `experimental_introspection_mode` now defaults to `both`
                 supergraph:
                     introspection: true
             ",

--- a/examples/supergraph-sdl/rust/Cargo.toml
+++ b/examples/supergraph-sdl/rust/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-apollo-compiler = "=1.0.0-beta.22"
+apollo-compiler = "=1.0.0-beta.23"
 apollo-router = { path = "../../../apollo-router" }
 async-trait = "0.1"
 tower = { version = "0.4", features = ["full"] }


### PR DESCRIPTION
* Update apollo-compiler to fix ROUTER-703 introspection incorrectly listing unused built-in scalars: https://github.com/apollographql/apollo-rs/pull/911
* Run Rust introspection off of Tokio threads, with the same reasoning as for the query planner in https://github.com/apollographql/router/pull/5998
* Enable introspection "both" mode by default. The legacy implementation is still used in the response but both are run and their results compared. The result of comparing both responses is logged at `DEBUG` level. At `TRACE` level, mismatches print the full query and the response diff. Example usage: `router --log error,apollo_router=info,apollo_router::query_planner::dual_introspection=trace`

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
