### PR TITLE
feat: Adds More Options For Liveness/Readiness Probe

### DIFF
--- a/helm/chart/router/templates/deployment.yaml
+++ b/helm/chart/router/templates/deployment.yaml
@@ -120,11 +120,19 @@ spec:
               path: {{ (.Values.router.configuration.health_check.path | default "/health") }}{{"?live"}}
               port: {{ splitList ":" ((index .Values.router.configuration "health_check").listen | default ":8088") | last }}
             initialDelaySeconds: {{  ((.Values.probes).liveness).initialDelaySeconds | default 0 }}
+            periodSeconds: {{ ((.Values.probes).liveness).periodSeconds | default 10 }}
+            timeoutSeconds: {{ ((.Values.probes).liveness).timeoutSeconds | default 1 }}
+            successThreshold: {{ ((.Values.probes).liveness).successThreshold | default 1 }}
+            failureThreshold: {{ ((.Values.probes).liveness).failureThreshold | default 3 }}
           readinessProbe:
             httpGet:
               path:  {{ (.Values.router.configuration.health_check.path | default "/health") }}{{"?ready"}}
               port: {{ (splitList ":"  ((index .Values.router.configuration "health_check").listen | default ":8088")) | last }}
             initialDelaySeconds: {{ ((.Values.probes).readiness).initialDelaySeconds | default 0 }}
+            periodSeconds: {{ ((.Values.probes).readiness).periodSeconds | default 10 }}
+            timeoutSeconds: {{ ((.Values.probes).readiness).timeoutSeconds | default 1 }}
+            successThreshold: {{ ((.Values.probes).readiness).successThreshold | default 1 }}
+            failureThreshold: {{ ((.Values.probes).readiness).failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if or .Values.router.configuration  .Values.extraVolumeMounts }}

--- a/helm/chart/router/values.yaml
+++ b/helm/chart/router/values.yaml
@@ -247,9 +247,17 @@ probes:
   # -- Configure readiness probe
   readiness:
     initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
   # -- Configure liveness probe
   liveness:
     initialDelaySeconds: 0
+    periodSeconds: 10
+    timeoutSeconds: 1
+    successThreshold: 1
+    failureThreshold: 3
 
 # -- Sets the [topology spread constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) for Deployment pods
 topologySpreadConstraints: []


### PR DESCRIPTION
Makes the liveness/readiness probes a little more customizable.

Fixes #2363

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

Tested this change with a helm template and chart rendered fine:

`cd helm/chart/router`
`helm template router ./ --debug -f ./values.yaml`

Defaults were retrieved from describing our router pods in k8s.

```
    Liveness:   http-get http://:8088/health%3Flive delay=0s timeout=1s period=10s #success=1 #failure=3
    Readiness:  http-get http://:8088/health%3Fready delay=0s timeout=1s period=10s #success=1 #failure=3
```

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
