### PR TITLE
Fix bugs identified by interface object tests

### DIFF
--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -2169,7 +2169,7 @@ impl OpGraphPath {
         let Some(self_edge) = self.edges[diff_pos] else {
             return Ok(false);
         };
-        let Some(other_edge) = self.edges[diff_pos] else {
+        let Some(other_edge) = other.edges[diff_pos] else {
             return Ok(false);
         };
         let other_edge_weight = other.graph.edge_weight(other_edge)?;
@@ -2190,7 +2190,7 @@ impl OpGraphPath {
         // from the interface while the other one from an implementation, they won't be technically
         // the "same" edge index. So we check that both are key-resolution edges, to the same
         // subgraph and type, and with the same condition.
-        let Some(other_next_edge) = self.edges[diff_pos + 1] else {
+        let Some(other_next_edge) = other.edges[diff_pos + 1] else {
             return Ok(false);
         };
         let (_, self_edge_tail) = other.graph.edge_endpoints(self_edge)?;
@@ -3429,13 +3429,13 @@ impl SimultaneousPathsWithLazyIndirectPaths {
                         "{} indirect paths",
                         paths_with_non_collecting_edges.paths.len()
                     );
-                    for paths_with_non_collecting_edges in
+                    for path_with_non_collecting_edges in
                         paths_with_non_collecting_edges.paths.iter()
                     {
-                        debug!("For indirect path {paths_with_non_collecting_edges}:");
+                        debug!("For indirect path {path_with_non_collecting_edges}:");
                         let span = debug_span!(" |");
                         let _gaurd = span.enter();
-                        let (advance_options, _) = paths_with_non_collecting_edges
+                        let (advance_options, _) = path_with_non_collecting_edges
                             .advance_with_operation_element(
                                 supergraph_schema.clone(),
                                 operation_element,
@@ -3458,7 +3458,7 @@ impl SimultaneousPathsWithLazyIndirectPaths {
                         if advance_options.is_empty() {
                             return Err(FederationError::internal(format!(
                                 "Unexpected empty options after non-collecting path {} for {}",
-                                paths_with_non_collecting_edges, operation_element,
+                                path_with_non_collecting_edges, operation_element,
                             )));
                         }
                         // There is a special case we can deal with now. Namely, suppose we have a
@@ -3485,7 +3485,7 @@ impl SimultaneousPathsWithLazyIndirectPaths {
                         // the new path renders unnecessary. Do note that we only make that check
                         // when the new option is a single-path option, because this gets kind of
                         // complicated otherwise.
-                        if paths_with_non_collecting_edges.tail_is_interface_object()? {
+                        if path_with_non_collecting_edges.tail_is_interface_object()? {
                             for indirect_option in &advance_options {
                                 if indirect_option.0.len() == 1 {
                                     let mut new_options = vec![];

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -1493,7 +1493,7 @@ impl FetchDependencyGraph {
                         input_selection_set.contains(sub_selection_set)
                     }))
                 } else if !implementation_input_selections.is_empty() {
-                    Ok(interface_input_selections.iter().all(|input| {
+                    Ok(implementation_input_selections.iter().all(|input| {
                         let Some(input_selection_set) = input.selection_set() else {
                             return false;
                         };

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
@@ -40,8 +40,6 @@ const SUBGRAPH2: &str = r#"
 "#;
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure (fetch node for `iFromS1.y` is missing)
 fn can_use_a_key_on_an_interface_object_type() {
     let planner = planner!(
         S1: SUBGRAPH1,
@@ -223,8 +221,6 @@ fn does_not_rely_on_an_interface_object_directly_for_typename() {
 }
 
 #[test]
-#[should_panic(expected = r#"snapshot assertion"#)]
-// TODO: investigate this failure (missing fetch node for `iFromS2 { ... on I { y } }`)
 fn does_not_rely_on_an_interface_object_directly_if_a_specific_implementation_is_requested() {
     let planner = planner!(
         S1: SUBGRAPH1,
@@ -294,7 +290,7 @@ fn does_not_rely_on_an_interface_object_directly_if_a_specific_implementation_is
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
+#[should_panic(expected = "assertion `left == right` failed")]
 // TODO: investigate this failure (fetch node for `iFromS1.y` is missing)
 fn can_use_a_key_on_an_interface_object_type_even_for_a_concrete_implementation() {
     let planner = planner!(
@@ -423,8 +419,6 @@ fn handles_query_of_an_interface_field_for_a_specific_implementation_when_query_
 }
 
 #[test]
-#[should_panic(expected = r#"snapshot assertion"#)]
-// TODO: investigate this failure (missing fetch node for "everything.@ { ... on I { expansiveField } }")
 fn it_avoids_buffering_interface_object_results_that_may_have_to_be_filtered_with_lists() {
     let planner = planner!(
         S1: r#"
@@ -517,8 +511,6 @@ fn it_avoids_buffering_interface_object_results_that_may_have_to_be_filtered_wit
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure (missing fetch nodes for i.x and i.y)
 fn it_handles_requires_on_concrete_type_of_field_provided_by_interface_object() {
     let planner = planner!(
         S1: r#"
@@ -613,8 +605,6 @@ fn it_handles_requires_on_concrete_type_of_field_provided_by_interface_object() 
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure (missing fetch node for `i.t.relatedIs.id`)
 fn it_handles_interface_object_in_nested_entity() {
     let planner = planner!(
         S1: r#"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
@@ -290,8 +290,6 @@ fn does_not_rely_on_an_interface_object_directly_if_a_specific_implementation_is
 }
 
 #[test]
-#[should_panic(expected = "assertion `left == right` failed")]
-// TODO: investigate this failure (fetch node for `iFromS1.y` is missing)
 fn can_use_a_key_on_an_interface_object_type_even_for_a_concrete_implementation() {
     let planner = planner!(
         S1: SUBGRAPH1,
@@ -350,12 +348,18 @@ fn can_use_a_key_on_an_interface_object_type_even_for_a_concrete_implementation(
     let rewrite = rewrites[0].clone();
     match rewrite.deref() {
         FetchDataRewrite::ValueSetter(v) => {
-            assert_eq!(v.path.len(), 1);
+            assert_eq!(v.path.len(), 2);
             match &v.path[0] {
                 FetchDataPathElement::TypenameEquals(typename) => {
                     assert_eq!(*typename, apollo_compiler::name!("A"))
                 }
                 _ => unreachable!("Expected FetchDataPathElement::TypenameEquals path"),
+            }
+            match &v.path[1] {
+                FetchDataPathElement::Key(name, _conditions) => {
+                    assert_eq!(*name, apollo_compiler::name!("__typename"))
+                }
+                _ => unreachable!("Expected FetchDataPathElement::Key path"),
             }
             assert_eq!(v.set_value_to, "I");
         }

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
@@ -710,8 +710,6 @@ fn it_handles_interface_object_in_nested_entity() {
 }
 
 #[test]
-#[should_panic(expected = "snapshot assertion")]
-// TODO: investigate this failure
 fn it_handles_interface_object_input_rewrites_when_cloning_dependency_graph() {
     let planner = planner!(
         S1: r#"
@@ -791,6 +789,22 @@ fn it_handles_interface_object_input_rewrites_when_cloning_dependency_graph() {
               }
             },
             Parallel {
+              Flatten(path: "i.i2") {
+                Fetch(service: "S4") {
+                  {
+                    ... on T {
+                      __typename
+                      t1
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      __typename
+                      t2
+                    }
+                  }
+                },
+              },
               Flatten(path: "i") {
                 Fetch(service: "S2") {
                   {
@@ -802,22 +816,6 @@ fn it_handles_interface_object_input_rewrites_when_cloning_dependency_graph() {
                   {
                     ... on I {
                       i3
-                    }
-                  }
-                },
-              },
-              Flatten(path: "i.i2") {
-                Fetch(service: "S3") {
-                  {
-                    ... on T {
-                      __typename
-                      t1
-                    }
-                  } =>
-                  {
-                    ... on T {
-                      __typename
-                      t2
                     }
                   }
                 },


### PR DESCRIPTION
<!-- ROUTER-557 -->

This PR:
- Fixes bugs identified by failing tests in `interface_object.rs`.
- Fixes a test bug in `can_use_a_key_on_an_interface_object_type_even_for_a_concrete_implementation()`, which was asserting the incorrect result for plan rewrites ([JS for comparison](https://github.com/apollographql/federation/blob/%40apollo/query-planner%402.7.8/query-planner-js/src/__tests__/buildPlan.interfaceObject.test.ts#L334)).
- Adjusts a snapshot assertion in the test `it_handles_interface_object_input_rewrites_when_cloning_dependency_graph()` to account for traversal ordering differences with JS. (The parallel node order is different, and `S3` is replaced with `S4` due to the subgraphs being equivalent/plan costs being equal.)

After this PR, all `interface_object.rs` tests are passing.