### PR TITLE
docs: use equals in log specifier

### DIFF
--- a/docs/source/configuration/telemetry/exporters/logging/overview.mdx
+++ b/docs/source/configuration/telemetry/exporters/logging/overview.mdx
@@ -59,7 +59,7 @@ APOLLO_ROUTER_LOG=debug
 For another example, every line below sets the same log levels:
 
 ```
-RUST_LOG=hyper=debug,apollo_router::info,h2=trace
+RUST_LOG=hyper=debug,apollo_router=info,h2=trace
 APOLLO_ROUTER_LOG=hyper=debug,info,h2=trace
 --log=hyper=debug,info,h2=trace
 ```


### PR DESCRIPTION
`::` is just wrong.