### PR TITLE
WIP: arrow method validation

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/README.md
+++ b/apollo-federation/src/sources/connect/json_selection/README.md
@@ -763,12 +763,12 @@ isObject: value->typeof->eq("object")
 
 # Takes any number of pairs [candidate, value], and returns value for
 # the first candidate that equals the input data. If none of the
-# pairs match, a runtime error is reported, but a single-element
-# [<default>] array as the final argument guarantees a default value.
+# pairs match, a runtime error is reported, but a last array whose
+# candidate is `@` guarantees a default value.
 __typename: kind->match(
     ["dog", "Canine"],
     ["cat", "Feline"],
-    ["Exotic"]
+    [@, "Exotic"]
 )
 
 # Like ->match, but expects the first element of each pair to evaluate

--- a/apollo-federation/src/sources/connect/json_selection/mod.rs
+++ b/apollo-federation/src/sources/connect/json_selection/mod.rs
@@ -14,6 +14,7 @@ pub use apply_to::*;
 // unused lint warning. If pretty code is needed in not test code, feel free to
 // remove the `#[cfg(test)]`.
 pub(crate) use known_var::*;
+pub(crate) use lit_expr::LitExpr;
 pub(crate) use location::Ranged;
 pub use parser::*;
 #[cfg(test)]

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -1079,8 +1079,8 @@ pub(crate) fn parse_string_literal(input: Span) -> IResult<Span, WithRange<Strin
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
-pub(super) struct MethodArgs {
-    pub(super) args: Vec<WithRange<LitExpr>>,
+pub(crate) struct MethodArgs {
+    pub(crate) args: Vec<WithRange<LitExpr>>,
     pub(super) range: OffsetRange,
 }
 

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -297,7 +297,7 @@ impl ExternalVarPaths for NamedSelection {
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct PathSelection {
-    pub(super) path: WithRange<PathList>,
+    pub(crate) path: WithRange<PathList>,
 }
 
 // Like NamedSelection, PathSelection is an AST structure that takes its range
@@ -378,7 +378,7 @@ impl From<PathList> for PathSelection {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub(super) enum PathList {
+pub(crate) enum PathList {
     // A VarPath must start with a variable (either $identifier, $, or @),
     // followed by any number of PathStep items (the WithRange<PathList>).
     // Because we represent the @ quasi-variable using PathList::Var, this

--- a/apollo-federation/src/sources/connect/validation/mod.rs
+++ b/apollo-federation/src/sources/connect/validation/mod.rs
@@ -542,6 +542,10 @@ pub enum Code {
     UnsupportedVariableType,
     /// A path variable is nullable, which can cause errors at runtime
     NullablePathVariable,
+    /// A method name is not known
+    UnknownMethod,
+    /// A method requires a different number of inputs
+    IncorrectArity,
 }
 
 impl Code {

--- a/apollo-federation/src/sources/connect/validation/selection.rs
+++ b/apollo-federation/src/sources/connect/validation/selection.rs
@@ -30,6 +30,7 @@ use crate::sources::connect::json_selection::PathList;
 use crate::sources::connect::json_selection::Ranged;
 use crate::sources::connect::spec::schema::CONNECT_SELECTION_ARGUMENT_NAME;
 use crate::sources::connect::validation::coordinates::connect_directive_http_body_coordinate;
+use crate::sources::connect::validation::graphql::SchemaInfo;
 use crate::sources::connect::validation::selection::visitor::visit;
 use crate::sources::connect::validation::selection::visitor::SelectionPart;
 use crate::sources::connect::validation::selection::visitor::Visitor;

--- a/apollo-federation/src/sources/connect/validation/selection/visitor.rs
+++ b/apollo-federation/src/sources/connect/validation/selection/visitor.rs
@@ -1,0 +1,288 @@
+use crate::sources::connect::expand::visitors::FieldVisitor;
+use crate::sources::connect::expand::visitors::GroupVisitor;
+use crate::sources::connect::json_selection::LitExpr;
+use crate::sources::connect::json_selection::MethodArgs;
+use crate::sources::connect::json_selection::NamedSelection;
+use crate::sources::connect::json_selection::PathList;
+use crate::sources::connect::JSONSelection;
+use crate::sources::connect::SubSelection;
+
+/// A JSON Selection visitor
+pub(super) trait Visitor {
+    type Error;
+
+    /// Visit a JSON Selection part. The visitor is guaranteed that all children of this part will
+    /// be visited before [`Visitor::end_visit`] is called. A mutable reference is required since
+    /// the visitor will typically require modifying internal state.
+    fn visit(&mut self, part: &SelectionPart) -> Result<(), Self::Error>;
+
+    /// End visiting a JSON Selection part. This is called after all children of a part have been
+    /// visited. The default implementation does nothing.
+    fn end_visit(&mut self, _part: &SelectionPart) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+/// A part of a JSON Selection to be visited
+#[derive(Clone, Debug)]
+pub(super) enum SelectionPart<'schema> {
+    JSONSelection(&'schema JSONSelection),
+    LitExpr(&'schema LitExpr),
+    MethodArgs(&'schema MethodArgs),
+    NamedSelection(&'schema NamedSelection),
+    PathList(&'schema PathList),
+    SubSelection(&'schema SubSelection),
+}
+
+/// Visit a JSON Selection, invoking a visitor on each part
+pub(super) fn visit<V: Visitor>(selection: &JSONSelection, mut visitor: V) -> Result<(), V::Error> {
+    SelectionWalker {
+        visitor: &mut visitor,
+        stack: vec![],
+    }
+    .walk(SelectionGroup::Root {
+        children: vec![SelectionPart::JSONSelection(selection)],
+    })
+}
+
+/// Walks a JSON Selection and invokes a visitor
+struct SelectionWalker<'schema, V: Visitor> {
+    pub(super) visitor: &'schema mut V,
+    pub(super) stack: Vec<SelectionPart<'schema>>,
+}
+
+enum SelectionGroup<'schema> {
+    Root {
+        children: Vec<SelectionPart<'schema>>,
+    },
+    Child {
+        parent: SelectionPart<'schema>,
+        children: Vec<SelectionPart<'schema>>,
+    },
+    Empty {
+        parent: SelectionPart<'schema>,
+    },
+}
+
+impl<'schema> SelectionGroup<'schema> {
+    fn children(&self) -> Vec<SelectionPart<'schema>> {
+        match self {
+            SelectionGroup::Root { children } => children.clone(),
+            SelectionGroup::Child { children, .. } => children.clone(),
+            SelectionGroup::Empty { .. } => vec![],
+        }
+    }
+}
+
+impl<'schema> SelectionGroup<'schema> {
+    fn new(parent: SelectionPart<'schema>, children: Vec<SelectionPart<'schema>>) -> Self {
+        SelectionGroup::Child { parent, children }
+    }
+
+    fn empty(parent: SelectionPart<'schema>) -> Self {
+        SelectionGroup::Empty { parent }
+    }
+}
+
+impl<'schema, V: Visitor> GroupVisitor<SelectionGroup<'schema>, SelectionPart<'schema>>
+    for SelectionWalker<'schema, V>
+{
+    fn try_get_group_for_field(
+        &self,
+        field: &SelectionPart<'schema>,
+    ) -> Result<Option<SelectionGroup<'schema>>, Self::Error> {
+        // Leaf nodes should return [`SelectionGroup::Empty`] rather than `None` to ensure that
+        // `exit_group` is called on the empty group, which in turn exits the visitor.
+        let field = field.clone();
+        let result = Ok(match field {
+            SelectionPart::JSONSelection(json_selection) => match json_selection {
+                JSONSelection::Named(sub_selection) => Some(SelectionGroup::new(
+                    field,
+                    vec![SelectionPart::SubSelection(sub_selection)],
+                )),
+                JSONSelection::Path(path_selection) => Some(SelectionGroup::new(
+                    field,
+                    vec![SelectionPart::PathList(&path_selection.path)],
+                )),
+            },
+            SelectionPart::LitExpr(lit_expr) => match lit_expr {
+                LitExpr::Path(path_selection) => Some(SelectionGroup::new(
+                    field,
+                    vec![SelectionPart::PathList(&path_selection.path)],
+                )),
+                LitExpr::Object(obj) => Some(SelectionGroup::new(
+                    field,
+                    obj.values()
+                        .collect::<Vec<_>>()
+                        .iter()
+                        .map(|value| SelectionPart::LitExpr(value))
+                        .collect(),
+                )),
+                LitExpr::Array(array) => Some(SelectionGroup::new(
+                    field,
+                    array
+                        .iter()
+                        .map(|value| SelectionPart::LitExpr(value))
+                        .collect(),
+                )),
+                LitExpr::String(_) | LitExpr::Number(_) | LitExpr::Bool(_) | LitExpr::Null => {
+                    Some(SelectionGroup::empty(field))
+                }
+            },
+            SelectionPart::NamedSelection(selection) => match selection {
+                NamedSelection::Field(_, _, Some(sub_selection)) => Some(SelectionGroup::new(
+                    field,
+                    vec![SelectionPart::SubSelection(sub_selection)],
+                )),
+                NamedSelection::Path(_, path_selection) => Some(SelectionGroup::new(
+                    field,
+                    vec![SelectionPart::PathList(&path_selection.path)],
+                )),
+                NamedSelection::Group(_, sub_selection) => Some(SelectionGroup::new(
+                    field,
+                    vec![SelectionPart::SubSelection(sub_selection)],
+                )),
+                NamedSelection::Field(_, _, None) => Some(SelectionGroup::empty(field)),
+            },
+            SelectionPart::MethodArgs(args) => Some(SelectionGroup::new(
+                field,
+                args.args
+                    .iter()
+                    .map(|value| SelectionPart::LitExpr(value))
+                    .collect(),
+            )),
+            SelectionPart::PathList(path_list) => match path_list {
+                PathList::Var(_, path_list) => Some(SelectionGroup::new(
+                    field,
+                    vec![SelectionPart::PathList(path_list)],
+                )),
+                PathList::Key(_, path_list) => Some(SelectionGroup::new(
+                    field,
+                    vec![SelectionPart::PathList(path_list)],
+                )),
+                PathList::Expr(lit, path_list) => Some(SelectionGroup::new(
+                    field,
+                    vec![
+                        SelectionPart::LitExpr(lit),
+                        SelectionPart::PathList(path_list),
+                    ],
+                )),
+                PathList::Method(_, args, path_list) => {
+                    let mut children = vec![];
+                    if let Some(args) = args {
+                        children.push(SelectionPart::MethodArgs(args));
+                    }
+                    children.push(SelectionPart::PathList(path_list));
+                    Some(SelectionGroup::new(field, children))
+                }
+                PathList::Selection(sub_selection) => Some(SelectionGroup::new(
+                    field,
+                    vec![SelectionPart::SubSelection(sub_selection)],
+                )),
+                PathList::Empty => Some(SelectionGroup::empty(field)),
+            },
+            SelectionPart::SubSelection(selection) => Some(SelectionGroup::new(
+                field,
+                selection
+                    .selections_iter()
+                    .map(SelectionPart::NamedSelection)
+                    .collect(),
+            )),
+        });
+        result
+    }
+
+    fn enter_group(
+        &mut self,
+        group: &SelectionGroup<'schema>,
+    ) -> Result<Vec<SelectionPart<'schema>>, Self::Error> {
+        if let SelectionGroup::Child { parent, .. } = group {
+            self.stack.push(parent.clone());
+        }
+        Ok(group.children())
+    }
+
+    fn exit_group(&mut self) -> Result<(), Self::Error> {
+        if let Some(field) = self.stack.pop() {
+            self.visitor.end_visit(&field)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'schema, V: Visitor> FieldVisitor<SelectionPart<'schema>> for SelectionWalker<'schema, V> {
+    type Error = V::Error;
+
+    fn visit(&mut self, field: SelectionPart<'schema>) -> Result<(), Self::Error> {
+        self.visitor.visit(&field)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::visit;
+    use super::SelectionPart;
+    use super::Visitor;
+    use crate::sources::connect::json_selection::PathList;
+    use crate::sources::connect::JSONSelection;
+
+    #[test]
+    fn test_walk() {
+        let mut entered = vec![];
+        let mut exited = vec![];
+
+        struct TestVisitor<'a> {
+            entered: &'a mut Vec<(String, usize)>,
+            exited: &'a mut Vec<(String, usize)>,
+        }
+        impl<'a> Visitor for TestVisitor<'a> {
+            type Error = ();
+
+            fn visit(&mut self, part: &SelectionPart) -> Result<(), Self::Error> {
+                if let SelectionPart::PathList(PathList::Method(name, args, _)) = part {
+                    self.entered.push((
+                        name.to_string(),
+                        args.as_ref().map(|args| args.args.len()).unwrap_or(0),
+                    ));
+                }
+                Ok(())
+            }
+
+            fn end_visit(&mut self, part: &SelectionPart) -> Result<(), Self::Error> {
+                if let SelectionPart::PathList(PathList::Method(name, args, _)) = part {
+                    self.exited.push((
+                        name.to_string(),
+                        args.as_ref().map(|args| args.args.len()).unwrap_or(0),
+                    ));
+                }
+                Ok(())
+            }
+        }
+
+        let (_, selection) =
+            JSONSelection::parse(r#"id name alias: foo->match(["one", one->first->size])"#)
+                .unwrap();
+
+        let visitor = TestVisitor {
+            entered: &mut entered,
+            exited: &mut exited,
+        };
+        assert_eq!(Ok(()), visit(&selection, visitor));
+        assert_eq!(
+            &[
+                (String::from("match"), 1usize),
+                (String::from("first"), 0usize),
+                (String::from("size"), 0usize)
+            ],
+            &entered.as_slice()
+        );
+        assert_eq!(
+            &[
+                (String::from("size"), 0usize),
+                (String::from("first"), 0usize),
+                (String::from("match"), 1usize)
+            ],
+            &exited.as_slice()
+        );
+    }
+}

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@empty_selection.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@empty_selection.graphql.snap
@@ -8,7 +8,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/empty_sel
         code: InvalidJsonSelection,
         message: "`@connect(selection:)` on `Query.resources` is empty",
         locations: [
-            13:18..13:29,
+            13:7..13:29,
         ],
     },
     Message {

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_arrow_method_arity.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_arrow_method_arity.graphql.snap
@@ -8,39 +8,21 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_s
         code: IncorrectArity,
         message: "`@connect(selection:)` on `Query.me` calls method `size` with the wrong number of arguments - expected 0, found 1",
         locations: [
-            LineColumn {
-                line: 11,
-                column: 20,
-            }..LineColumn {
-                line: 14,
-                column: 12,
-            },
+            11:20..14:12,
         ],
     },
     Message {
         code: UnresolvedField,
         message: "No connector resolves field `User.id`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
         locations: [
-            LineColumn {
-                line: 19,
-                column: 5,
-            }..LineColumn {
-                line: 19,
-                column: 12,
-            },
+            19:5..19:12,
         ],
     },
     Message {
         code: UnresolvedField,
         message: "No connector resolves field `User.invalid`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
         locations: [
-            LineColumn {
-                line: 20,
-                column: 5,
-            }..LineColumn {
-                line: 20,
-                column: 20,
-            },
+            20:5..20:20,
         ],
     },
 ]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_arrow_method_arity.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_arrow_method_arity.graphql.snap
@@ -8,7 +8,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_s
         code: IncorrectArity,
         message: "`@connect(selection:)` on `Query.me` calls method `size` with the wrong number of arguments - expected 0, found 1",
         locations: [
-            11:20..14:12,
+            13:27..13:31,
         ],
     },
     Message {

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_arrow_method_arity.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_arrow_method_arity.graphql.snap
@@ -1,0 +1,46 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_selection_arrow_method_arity.graphql
+---
+[
+    Message {
+        code: IncorrectArity,
+        message: "`@connect(selection:)` on `Query.me` calls method `size` with the wrong number of arguments - expected 0, found 1",
+        locations: [
+            LineColumn {
+                line: 11,
+                column: 20,
+            }..LineColumn {
+                line: 14,
+                column: 12,
+            },
+        ],
+    },
+    Message {
+        code: UnresolvedField,
+        message: "No connector resolves field `User.id`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
+        locations: [
+            LineColumn {
+                line: 19,
+                column: 5,
+            }..LineColumn {
+                line: 19,
+                column: 12,
+            },
+        ],
+    },
+    Message {
+        code: UnresolvedField,
+        message: "No connector resolves field `User.invalid`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
+        locations: [
+            LineColumn {
+                line: 20,
+                column: 5,
+            }..LineColumn {
+                line: 20,
+                column: 20,
+            },
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_unknown_arrow_method.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_unknown_arrow_method.graphql.snap
@@ -8,39 +8,21 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_s
         code: UnknownMethod,
         message: "`@connect(selection:)` on `Query.me` has a call to an unknown method `doesnotexist`",
         locations: [
-            LineColumn {
-                line: 11,
-                column: 20,
-            }..LineColumn {
-                line: 14,
-                column: 12,
-            },
+            11:20..14:12,
         ],
     },
     Message {
         code: UnresolvedField,
         message: "No connector resolves field `User.id`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
         locations: [
-            LineColumn {
-                line: 19,
-                column: 5,
-            }..LineColumn {
-                line: 19,
-                column: 12,
-            },
+            19:5..19:12,
         ],
     },
     Message {
         code: UnresolvedField,
         message: "No connector resolves field `User.invalid`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
         locations: [
-            LineColumn {
-                line: 20,
-                column: 5,
-            }..LineColumn {
-                line: 20,
-                column: 20,
-            },
+            20:5..20:20,
         ],
     },
 ]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_unknown_arrow_method.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_unknown_arrow_method.graphql.snap
@@ -8,7 +8,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_s
         code: UnknownMethod,
         message: "`@connect(selection:)` on `Query.me` has a call to an unknown method `doesnotexist`",
         locations: [
-            11:20..14:12,
+            13:40..13:52,
         ],
     },
     Message {

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_unknown_arrow_method.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid_selection_unknown_arrow_method.graphql.snap
@@ -1,0 +1,46 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/invalid_selection_unknown_arrow_method.graphql
+---
+[
+    Message {
+        code: UnknownMethod,
+        message: "`@connect(selection:)` on `Query.me` has a call to an unknown method `doesnotexist`",
+        locations: [
+            LineColumn {
+                line: 11,
+                column: 20,
+            }..LineColumn {
+                line: 14,
+                column: 12,
+            },
+        ],
+    },
+    Message {
+        code: UnresolvedField,
+        message: "No connector resolves field `User.id`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
+        locations: [
+            LineColumn {
+                line: 19,
+                column: 5,
+            }..LineColumn {
+                line: 19,
+                column: 12,
+            },
+        ],
+    },
+    Message {
+        code: UnresolvedField,
+        message: "No connector resolves field `User.invalid`. It must have a `@connect` directive or appear in `@connect(selection:)`.",
+        locations: [
+            LineColumn {
+                line: 20,
+                column: 5,
+            }..LineColumn {
+                line: 20,
+                column: 20,
+            },
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_selection_arrow_methods.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@valid_selection_arrow_methods.graphql.snap
@@ -1,0 +1,6 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/valid_selection_arrow_methods.graphql
+---
+[]

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_selection_arrow_method_arity.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_selection_arrow_method_arity.graphql
@@ -1,0 +1,21 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    me: User
+      @connect(
+        http: {GET: "http://127.0.0.1/something"},
+        selection: """
+        id
+        invalid: invalid->size("foo")
+        """
+      )
+}
+
+type User {
+    id: ID!
+    invalid: String
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/invalid_selection_unknown_arrow_method.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/invalid_selection_unknown_arrow_method.graphql
@@ -1,0 +1,21 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    me: User
+      @connect(
+        http: {GET: "http://127.0.0.1/something"},
+        selection: """
+        id
+        invalid: invalid->match([@, @->doesnotexist])
+        """
+      )
+}
+
+type User {
+    id: ID!
+    invalid: String
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/valid_selection_arrow_methods.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/valid_selection_arrow_methods.graphql
@@ -1,0 +1,43 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    me: User
+      @connect(
+        http: {GET: "http://127.0.0.1/something"},
+        selection: """
+        id
+        literal: $("foo")
+        array_literal: $([1, 2, 3])
+        echo: $->echo("foo")
+        match: $.match_input->match(
+          [1, "one"],
+          [2, "two"],
+          [@, $("unknown")],
+        )
+        map: $.name->map(@.first_name)
+        first: $([1, 2, 3])->first
+        last: $([1, 2, 3])->last
+        slice: $([1, 2, 3, 4, 5])->slice(1, 3)
+        size: $.people->size
+        entries: $.people->entries.key
+        """
+      )
+}
+
+type User {
+    id: ID!
+    array_literal: [Int],
+    literal: String,
+    echo: String,
+    match: String,
+    map: String,
+    first: Int,
+    last: Int,
+    slice: [Int],
+    size: Int,
+    entries: [String],
+}


### PR DESCRIPTION
Validation changes:
* Implement a JSON Selection visitor that can visit each part of a selection, including arrow methods
* Adds validation of arrow method names against the known list of public arrow methods
* Adds validation of arrow method arity
* Add a unit test that valid uses of arrow methods do not cause any validation errors
* Add a unit test with use of a non-existent arrow method name
* Add a unit test with use of an arrow method with incorrect arity

<img width="786" alt="method" src="https://github.com/user-attachments/assets/4af602ed-5892-474d-ae9b-573cad8e3c80">

JSON Selection changes:
* Makes some more of the JSON selection code `pub(crate)` so the validation code is able to visit all the places where an arrow method name can appear

Known Issues:
* There is currently an issue with another validation that reports on fields that do not have an associated connector. This keeps track of an `already_seen` list as the selection is validated. However, if any other validation fails and returns early, this validation will not see any remaining fields and incorrectly reports errors. This will need to be addressed separately, but the result can be seen in the test snapshots for this PR.
* The validation code requires significant knowledge about arrow methods, such as their names and arity (and in the future, type information and how it applies to both the HTTP response and GraphQL schema). This is currently just hard coded. There will need to be some mechanism to provide this information, ideally one that is extensible as new arrow methods are added.

<!-- [CNN-415] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[CNN-415]: https://apollographql.atlassian.net/browse/CNN-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ