### PR TITLE
adjust log levels for introspection and query planner mismatches

### DIFF
--- a/apollo-router/src/query_planner/dual_introspection.rs
+++ b/apollo-router/src/query_planner/dual_introspection.rs
@@ -32,11 +32,11 @@ pub(crate) fn compare_introspection_responses(
             }
             is_matched = js_response.data == rust_response.data;
             if is_matched {
-                tracing::debug!("Introspection match! 🎉")
+                tracing::trace!("Introspection match! 🎉")
             } else {
                 tracing::debug!("Introspection mismatch");
                 tracing::trace!("Introspection query:\n{query}");
-                tracing::trace!("Introspection diff:\n{}", {
+                tracing::debug!("Introspection diff:\n{}", {
                     let rust = rust_response
                         .data
                         .as_ref()

--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -153,7 +153,7 @@ impl BothModeComparisonJob {
                 let match_result = opt_plan_node_matches(js_root_node, &rust_root_node);
                 is_matched = match_result.is_ok();
                 match match_result {
-                    Ok(_) => tracing::debug!("JS and Rust query plans match{operation_desc}! 🎉"),
+                    Ok(_) => tracing::trace!("JS and Rust query plans match{operation_desc}! 🎉"),
                     Err(err) => {
                         tracing::debug!("JS v.s. Rust query plan mismatch{operation_desc}");
                         tracing::debug!("{}", err.full_description());

--- a/apollo-router/tests/integration/introspection.rs
+++ b/apollo-router/tests/integration/introspection.rs
@@ -239,7 +239,7 @@ async fn both_mode_integration() {
             ",
         )
         .supergraph("../examples/graphql/local.graphql")
-        .log("error,apollo_router=info,apollo_router::query_planner=debug")
+        .log("error,apollo_router=info,apollo_router::query_planner=trace")
         .build()
         .await;
     router.start().await;


### PR DESCRIPTION
At this point majority of the comparison cases in query planner semantic diffing match, we can move the trace for matched case to `trace`.

And in order to get a better insight on introspection mismatches, the log level for introspection comparison diff is moved up to `debug`.