### PR TITLE
Finalize defer support in Rust QP

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -205,12 +205,14 @@ pub(crate) struct NormalizedDefer {
     pub operation: Operation,
     pub has_defers: bool,
     pub assigned_defer_labels: IndexSet<String>,
-    pub defer_conditions: IndexMap<String, IndexSet<String>>,
+    pub defer_conditions: IndexMap<Name, IndexSet<String>>,
 }
 
 struct DeferNormalizer {
     used_labels: HashSet<String>,
+    assigned_labels: IndexSet<String>,
     problems: HashSet<SelectionKey>,
+    conditions: IndexMap<Name, IndexSet<String>>,
     label_offset: usize,
 }
 
@@ -220,6 +222,8 @@ impl DeferNormalizer {
             used_labels: HashSet::default(),
             problems: HashSet::default(),
             label_offset: 0,
+            assigned_labels: IndexSet::default(),
+            conditions: IndexMap::default(),
         };
         let mut stack = selection_set
             .into_iter()
@@ -268,9 +272,14 @@ impl DeferNormalizer {
             let digest = format!("qp__{}", self.label_offset);
             self.label_offset += 1;
             if !self.used_labels.contains(&digest) {
+                self.assigned_labels.insert(digest.clone());
                 return digest;
             }
         }
+    }
+
+    fn register_condition(&mut self, label: String, cond: Name) {
+        self.conditions.entry(cond).or_default().insert(label);
     }
 }
 
@@ -325,11 +334,8 @@ impl Operation {
     ///    `@defer` application that has `if: false`.
     // PORT_NOTE(@goto-bus-stop): It might make sense for the returned data structure to *be* the
     // `DeferNormalizer` from the JS side
-    #[allow(clippy::unnecessary_fold)]
     pub(crate) fn with_normalized_defer(mut self) -> NormalizedDefer {
         if self.has_defer() {
-            // PORT_NOTE:
-            // TODO: Can this set use &str instead of strings?
             let mut normalizer = DeferNormalizer::new(&self.selection_set);
             println!("Before normalization: {}", self.selection_set);
             if !normalizer.problems.is_empty() {
@@ -340,8 +346,8 @@ impl Operation {
             NormalizedDefer {
                 operation: self,
                 has_defers: true,
-                assigned_defer_labels: IndexSet::default(),
-                defer_conditions: IndexMap::default(),
+                assigned_defer_labels: normalizer.assigned_labels,
+                defer_conditions: normalizer.conditions,
             }
         } else {
             NormalizedDefer {
@@ -366,6 +372,14 @@ impl Operation {
     pub(crate) fn without_defer(mut self) -> Self {
         if self.has_defer() {
             self.selection_set.without_defer();
+        }
+        debug_assert!(!self.has_defer());
+        self
+    }
+
+    pub(crate) fn reduce_defer(mut self, labels: &IndexSet<String>) -> Self {
+        if self.has_defer() {
+            self.selection_set.reduce_defer(labels);
         }
         debug_assert!(!self.has_defer());
         self
@@ -2873,6 +2887,28 @@ impl SelectionSet {
         debug_assert!(!self.has_defer());
     }
 
+    fn reduce_defer(&mut self, labels: &IndexSet<String>) {
+        for (_key, mut selection) in Arc::make_mut(&mut self.selections).iter_mut() {
+            if let SelectionValue::InlineFragment(inline) = &selection {
+                // TODO: Do we want to ignore an error here?
+                if let Ok(Some(args)) = inline.get().inline_fragment.defer_directive_arguments() {
+                    // TODO(@goto-bus-stop): doing this changes the key of the selection!
+                    // We have to rebuild the selection map.
+                    if args
+                        .label
+                        .as_ref()
+                        .is_some_and(|label| labels.contains(label))
+                    {
+                        selection.get_directives_mut().remove_one("defer");
+                    }
+                }
+            }
+            if let Some(set) = selection.get_selection_set_mut() {
+                set.without_defer();
+            }
+        }
+    }
+
     fn has_defer(&self) -> bool {
         self.selections.values().any(|s| s.has_defer())
     }
@@ -3653,6 +3689,11 @@ impl InlineFragmentSelection {
         if remove_defer {
             todo!();
             // return;
+        }
+
+        // NOTE: If this is `Some`, it will be a variable.
+        if let Some(BooleanOrVariable::Variable(cond)) = args_copy.if_.clone() {
+            normalizer.register_condition(args_copy.label.clone().unwrap(), cond);
         }
 
         if args_copy == args {

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -243,20 +243,60 @@ impl Operation {
         })
     }
 
+    /// Returns this operation but modified to "normalize" all the @defer applications.
+    ///
+    /// "Normalized" in this context means that all the `@defer` application in the resulting
+    /// operation will:
+    ///  - have a (unique) label. Which implies that this method generates a label for any `@defer`
+    ///    not having a label.
+    ///  - have a non-trivial `if` condition, if any. By non-trivial, we mean that the condition
+    ///    will be a variable and not an hard-coded `true` or `false`. To do this, this method will
+    ///    remove the condition of any `@defer` that has `if: true`, and will completely remove any
+    ///    `@defer` application that has `if: false`.
     // PORT_NOTE(@goto-bus-stop): It might make sense for the returned data structure to *be* the
     // `DeferNormalizer` from the JS side
+    #[allow(clippy::unnecessary_fold)]
     pub(crate) fn with_normalized_defer(self) -> NormalizedDefer {
-        NormalizedDefer {
-            operation: self,
-            has_defers: false,
-            assigned_defer_labels: IndexSet::default(),
-            defer_conditions: IndexMap::default(),
-        }
-        // TODO(@TylerBloom): Once defer is implement, the above statement needs to be replaced
-        // with the commented-out one below. This is part of FED-95
-        /*
         if self.has_defer() {
-            todo!("@defer not implemented");
+            // PORT_NOTE:
+            // TODO: Can this set use &str instead of strings?
+            fn collect_labels(labels: &mut HashSet<String>, selection: &Selection) -> bool {
+                // TODO: Does this need to be checking FragmentSpread + InlineFragment or just
+                // spreads? The JS code checks "FragmentSelection"
+                if let Selection::InlineFragment(inline) = selection {
+                    if let Some(label) = inline
+                        .inline_fragment
+                        .data()
+                        .defer_directive_arguments()
+                        // TODO: Ideally, a version of this method exists that doesn't return a
+                        // Result...
+                        .unwrap()
+                        .and_then(|dirs| dirs.label)
+                    {
+                        labels.insert(label.clone());
+                    }
+                }
+                selection
+                    .selection_set()
+                    .iter()
+                    .flat_map(|set| set.iter())
+                    .fold(false, |acc, op| acc || collect_labels(labels, op))
+            }
+            let mut labels = HashSet::default();
+            let must_normalize_defers = self
+                .selection_set
+                .iter()
+                // Yes, this looks like an `any`, but we specifically don't want to short circuit.
+                .fold(false, |acc, sel| acc || collect_labels(&mut labels, sel));
+            if must_normalize_defers {
+                self.selection_set.normalize_defers(&labels);
+            }
+            NormalizedDefer {
+                operation: self,
+                has_defers: true,
+                assigned_defer_labels: todo!(), // IndexSet::default(),
+                defer_conditions: todo!(),      // IndexMap::default(),
+            }
         } else {
             NormalizedDefer {
                 operation: self,
@@ -265,7 +305,6 @@ impl Operation {
                 defer_conditions: IndexMap::default(),
             }
         }
-        */
     }
 
     fn has_defer(&self) -> bool {

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -426,12 +426,12 @@ impl OpPathElement {
     /// ignored).
     pub(crate) fn without_defer(&self) -> Option<Self> {
         match self {
-            Self::Field(_) => Some(self.clone()), // unchanged
+            Self::Field(_) => Some(self.clone()),
             Self::InlineFragment(inline_fragment) => {
-                // TODO(@goto-bus-stop): is this not exactly the wrong way around?
                 let updated_directives: DirectiveList = inline_fragment
                     .directives
-                    .get_all("defer")
+                    .iter()
+                    .filter(|directive| directive.name != "defer")
                     .cloned()
                     .collect();
                 if inline_fragment.type_condition_position.is_none()

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -3782,25 +3782,6 @@ impl OpPath {
     }
 }
 
-impl TryFrom<&'_ OpPath> for Vec<QueryPathElement> {
-    type Error = FederationError;
-
-    fn try_from(value: &'_ OpPath) -> Result<Self, Self::Error> {
-        value
-            .0
-            .iter()
-            .map(|path_element| {
-                Ok(match path_element.as_ref() {
-                    OpPathElement::Field(field) => QueryPathElement::Field(field.try_into()?),
-                    OpPathElement::InlineFragment(inline) => {
-                        QueryPathElement::InlineFragment(inline.try_into()?)
-                    }
-                })
-            })
-            .collect()
-    }
-}
-
 pub(crate) fn concat_paths_in_parents(
     first: &Option<Arc<OpPath>>,
     second: &Option<Arc<OpPath>>,

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -48,7 +48,6 @@ use crate::query_graph::QueryGraphEdgeTransition;
 use crate::query_graph::QueryGraphNodeType;
 use crate::query_plan::query_planner::EnabledOverrideConditions;
 use crate::query_plan::FetchDataPathElement;
-use crate::query_plan::QueryPathElement;
 use crate::query_plan::QueryPlanCost;
 use crate::schema::position::AbstractTypeDefinitionPosition;
 use crate::schema::position::CompositeTypeDefinitionPosition;

--- a/apollo-federation/src/query_plan/display.rs
+++ b/apollo-federation/src/query_plan/display.rs
@@ -149,7 +149,7 @@ impl FlattenNode {
         node.write_indented(state)?;
 
         state.dedent()?;
-        state.write("},")
+        state.write("}")
     }
 }
 

--- a/apollo-federation/src/query_plan/display.rs
+++ b/apollo-federation/src/query_plan/display.rs
@@ -169,9 +169,9 @@ impl ConditionNode {
                 state.indent()?;
                 if_clause.write_indented(state)?;
                 state.dedent()?;
-                state.write("},")?;
+                state.write("}")?;
 
-                state.write("Else {")?;
+                state.write(" Else {")?;
                 state.indent()?;
                 else_clause.write_indented(state)?;
                 state.dedent()?;
@@ -235,12 +235,12 @@ impl PrimaryDeferBlock {
         } = self;
         state.write("Primary {")?;
         if sub_selection.is_some() || node.is_some() {
-            // Manually indent and write the newline
-            // to prevent a duplicate indent from `.new_line()` and `.initial_indent_level()`.
-            state.indent_no_new_line();
-            state.write("\n")?;
-
             if let Some(sub_selection) = sub_selection {
+                // Manually indent and write the newline
+                // to prevent a duplicate indent from `.new_line()` and `.initial_indent_level()`.
+                state.indent_no_new_line();
+                state.write("\n")?;
+
                 state.write(
                     sub_selection
                         .serialize()
@@ -250,7 +250,11 @@ impl PrimaryDeferBlock {
                     state.write(":")?;
                     state.new_line()?;
                 }
+            } else {
+                // Indent to match the Some() case
+                state.indent()?;
             }
+
             if let Some(node) = node {
                 node.write_indented(state)?;
             }

--- a/apollo-federation/src/query_plan/display.rs
+++ b/apollo-federation/src/query_plan/display.rs
@@ -117,7 +117,7 @@ impl SequenceNode {
 
         write_indented_lines(state, nodes, |state, node| node.write_indented(state))?;
 
-        state.write("}")
+        state.write("},")
     }
 }
 
@@ -128,7 +128,7 @@ impl ParallelNode {
 
         write_indented_lines(state, nodes, |state, node| node.write_indented(state))?;
 
-        state.write("}")
+        state.write("},")
     }
 }
 
@@ -149,7 +149,7 @@ impl FlattenNode {
         node.write_indented(state)?;
 
         state.dedent()?;
-        state.write("}")
+        state.write("},")
     }
 }
 

--- a/apollo-federation/src/query_plan/display.rs
+++ b/apollo-federation/src/query_plan/display.rs
@@ -117,7 +117,7 @@ impl SequenceNode {
 
         write_indented_lines(state, nodes, |state, node| node.write_indented(state))?;
 
-        state.write("},")
+        state.write("}")
     }
 }
 
@@ -128,7 +128,7 @@ impl ParallelNode {
 
         write_indented_lines(state, nodes, |state, node| node.write_indented(state))?;
 
-        state.write("},")
+        state.write("}")
     }
 }
 
@@ -215,7 +215,7 @@ impl DeferNode {
 
         primary.write_indented(state)?;
         if !deferred.is_empty() {
-            state.write(", [")?;
+            state.write(" [")?;
             write_indented_lines(state, deferred, |state, deferred| {
                 deferred.write_indented(state)
             })?;
@@ -284,17 +284,21 @@ impl DeferredDeferBlock {
             }
         }
         state.write("\"")?;
+        /*
         if let Some(label) = label {
             state.write(", label: \"")?;
             state.write(label)?;
             state.write("\"")?;
         }
+        */
         state.write(") {")?;
         if sub_selection.is_some() || node.is_some() {
             state.indent()?;
 
             if let Some(sub_selection) = sub_selection {
                 write_selections(state, &sub_selection.selections)?;
+                state.write(":")?;
+                state.new_line()?;
             }
             if let Some(node) = node {
                 node.write_indented(state)?;

--- a/apollo-federation/src/query_plan/display.rs
+++ b/apollo-federation/src/query_plan/display.rs
@@ -235,7 +235,10 @@ impl PrimaryDeferBlock {
         } = self;
         state.write("Primary {")?;
         if sub_selection.is_some() || node.is_some() {
-            state.indent()?;
+            // Manually indent and write the newline
+            // to prevent a duplicate indent from `.new_line()` and `.initial_indent_level()`.
+            state.indent_no_new_line();
+            state.write("\n")?;
 
             if let Some(sub_selection) = sub_selection {
                 state.write(
@@ -267,6 +270,7 @@ impl DeferredDeferBlock {
             sub_selection,
             node,
         } = self;
+
         state.write("Deferred(depends: [")?;
         if let Some((DeferredDependency { id }, rest)) = depends.split_first() {
             state.write(id)?;
@@ -284,14 +288,11 @@ impl DeferredDeferBlock {
             }
         }
         state.write("\"")?;
-        /*
         if let Some(label) = label {
-            state.write(", label: \"")?;
-            state.write(label)?;
-            state.write("\"")?;
+            state.write_fmt(format_args!(r#", label: "{label}""#))?;
         }
-        */
         state.write(") {")?;
+
         if sub_selection.is_some() || node.is_some() {
             state.indent()?;
 
@@ -306,6 +307,7 @@ impl DeferredDeferBlock {
 
             state.dedent()?;
         }
+
         state.write("},")
     }
 }

--- a/apollo-federation/src/query_plan/fetch_dependency_graph.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph.rs
@@ -1695,7 +1695,11 @@ impl FetchDependencyGraph {
             if node.defer_ref == child.defer_ref {
                 children.push(child_index);
             } else {
-                println!("{} == {}", DisplayOption(node.defer_ref.as_ref()), DisplayOption(child.defer_ref.as_ref()));
+                println!(
+                    "{} == {}",
+                    DisplayOption(node.defer_ref.as_ref()),
+                    DisplayOption(child.defer_ref.as_ref())
+                );
                 let Some(child_defer_ref) = &child.defer_ref else {
                     // FIXME: We should not be unwrapping here. Does a `DisplayOption` make sense?
                     let parent_defer_ref = node.defer_ref.as_ref().unwrap();
@@ -4022,7 +4026,10 @@ fn extract_defer_from_operation(
     };
 
     // PORT_NOTE: The original TypeScript code has an assertion here.
-    let updated_defer_ref = defer_args.label.as_ref().ok_or_else(|| FederationError::internal("All defers should have a label at this point"))?;
+    let updated_defer_ref = defer_args
+        .label
+        .as_ref()
+        .ok_or_else(|| FederationError::internal("All defers should have a label at this point"))?;
     let updated_operation_element = operation_element.without_defer();
     let updated_path_to_defer_parent = match updated_operation_element {
         None => Default::default(), // empty OpPath

--- a/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
@@ -293,6 +293,7 @@ impl FetchDependencyGraphProcessor<Option<PlanNode>, DeferredDeferBlock>
         value: Option<PlanNode>,
     ) -> Option<PlanNode> {
         let mut value = value?;
+        println!("Processing {value} with conditions {conditions:?}");
         match conditions {
             Conditions::Boolean(condition) => {
                 // Note that currently `ConditionNode` only works for variables

--- a/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
@@ -6,9 +6,11 @@ use apollo_compiler::Name;
 use apollo_compiler::Node;
 
 use super::query_planner::SubgraphOperationCompression;
+use super::QueryPathElement;
 use crate::error::FederationError;
 use crate::operation::DirectiveList;
 use crate::operation::SelectionSet;
+use crate::query_graph::graph_path::OpPathElement;
 use crate::query_graph::QueryGraph;
 use crate::query_plan::conditions::Conditions;
 use crate::query_plan::fetch_dependency_graph::DeferredInfo;
@@ -339,6 +341,32 @@ impl FetchDependencyGraphProcessor<Option<PlanNode>, DeferredDeferBlock>
         defer_info: &DeferredInfo,
         node: Option<PlanNode>,
     ) -> Result<DeferredDeferBlock, FederationError> {
+        /// Produce a query path with only the relevant elements: fields and type conditions.
+        fn op_path_to_query_path(
+            path: &[Arc<OpPathElement>],
+        ) -> Result<Vec<QueryPathElement>, FederationError> {
+            path.iter()
+                .map(
+                    |element| -> Result<Option<QueryPathElement>, FederationError> {
+                        match &**element {
+                            OpPathElement::Field(field) => {
+                                Ok(Some(QueryPathElement::Field(field.try_into()?)))
+                            }
+                            OpPathElement::InlineFragment(inline) => {
+                                match &inline.type_condition_position {
+                                    Some(_) => Ok(Some(QueryPathElement::InlineFragment(
+                                        inline.try_into()?,
+                                    ))),
+                                    None => Ok(None),
+                                }
+                            }
+                        }
+                    },
+                )
+                .filter_map(|result| result.transpose())
+                .collect::<Result<Vec<_>, _>>()
+        }
+
         Ok(DeferredDeferBlock {
             depends: defer_info
                 .dependencies
@@ -355,7 +383,7 @@ impl FetchDependencyGraphProcessor<Option<PlanNode>, DeferredDeferBlock>
             } else {
                 Some(defer_info.label.clone())
             },
-            query_path: defer_info.path.full_path.as_ref().try_into()?,
+            query_path: op_path_to_query_path(&defer_info.path.full_path)?,
             // Note that if the deferred block has nested @defer,
             // then the `value` is going to be a `DeferNode`
             // and we'll use it's own `subselection`, so we don't need it here.

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -12,6 +12,7 @@ use apollo_compiler::Name;
 use itertools::Itertools;
 use serde::Serialize;
 
+use crate::operation::NormalizedDefer;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
 use crate::link::federation_spec_definition::FederationSpecDefinition;
@@ -407,37 +408,29 @@ impl QueryPlanner {
             &self.interface_types_with_interface_objects,
         )?;
 
-        let (normalized_operation, assigned_defer_labels, defer_conditions, has_defers) = (
-            normalized_operation.without_defer(),
-            None,
-            None::<IndexMap<String, IndexSet<String>>>,
-            false,
-        );
-        /* TODO(TylerBloom): After defer is impl-ed and after the private preview, the call
-         * above needs to be replaced with this if-else expression.
-        if self.config.incremental_delivery.enable_defer {
-            let NormalizedDefer {
-                operation,
-                assigned_defer_labels,
-                defer_conditions,
-                has_defers,
-            } = normalized_operation.with_normalized_defer();
-            if has_defers && is_subscription {
-                return Err(SingleFederationError::DeferredSubscriptionUnsupported.into());
-            }
-            (
-                operation,
-                Some(assigned_defer_labels),
-                Some(defer_conditions),
-                has_defers,
-            )
-        } else {
-            // If defer is not enabled, we remove all @defer from the query. This feels cleaner do this once here than
-            // having to guard all the code dealing with defer later, and is probably less error prone too (less likely
-            // to end up passing through a @defer to a subgraph by mistake).
-            (normalized_operation.without_defer(), None, None, false)
-        };
-        */
+        let (normalized_operation, assigned_defer_labels, defer_conditions, has_defers) =
+            if self.config.incremental_delivery.enable_defer {
+                let NormalizedDefer {
+                    operation,
+                    assigned_defer_labels,
+                    defer_conditions,
+                    has_defers,
+                } = normalized_operation.with_normalized_defer();
+                if has_defers && is_subscription {
+                    return Err(SingleFederationError::DeferredSubscriptionUnsupported.into());
+                }
+                (
+                    operation,
+                    Some(assigned_defer_labels),
+                    Some(defer_conditions),
+                    has_defers,
+                )
+            } else {
+                // If defer is not enabled, we remove all @defer from the query. This feels cleaner do this once here than
+                // having to guard all the code dealing with defer later, and is probably less error prone too (less likely
+                // to end up passing through a @defer to a subgraph by mistake).
+                (normalized_operation.without_defer(), None, None, false)
+            };
 
         if normalized_operation.selection_set.is_empty() {
             return Ok(QueryPlan::default());

--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -32,6 +32,7 @@ fn some_name() {
 */
 
 mod debug_max_evaluated_plans_configuration;
+mod defer;
 mod fetch_operation_names;
 mod field_merging_with_skip_and_include;
 mod fragment_autogeneration;

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/defer.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/defer.rs
@@ -39,35 +39,35 @@ fn defer_test_handles_simple_defer_without_defer_enabled() {
             }
         "#,
         @r###"
-          QueryPlan {
-            Sequence {
-              Fetch(service: "Subgraph1") {
-                {
-                  t {
-                    __typename
-                    id
-                  }
-                }
-              },
-              Flatten(path: "t") {
-                Fetch(service: "Subgraph2") {
-                  {
-                    ... on T {
-                      __typename
-                      id
-                    }
-                  } =>
-                  {
-                    ... on T {
-                      v1
-                      v2
-                    }
-                  }
-                },
-              }
+    QueryPlan {
+      Sequence {
+        Fetch(service: "Subgraph1") {
+          {
+            t {
+              __typename
+              id
             }
           }
-        "###
+        },
+        Flatten(path: "t") {
+          Fetch(service: "Subgraph2") {
+            {
+              ... on T {
+                __typename
+                id
+              }
+            } =>
+            {
+              ... on T {
+                v1
+                v2
+              }
+            }
+          },
+        },
+      },
+    }
+    "###
     );
 }
 
@@ -104,64 +104,64 @@ fn defer_test_handles_simple_defer_with_defer_enabled() {
             }
         "#,
         @r###"
-          QueryPlan {
-            Defer {
-              Primary {
-                    {
-                  t {
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            t {
+              v1
+            }
+          }:
+          Sequence {
+            Fetch(service: "Subgraph1", id: 0) {
+              {
+                t {
+                  __typename
+                  id
+                }
+              }
+            },
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2") {
+                {
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
                     v1
                   }
-                }:
-                Sequence {
-                  Fetch(service: "Subgraph1", id: 0) {
-                    {
-                      t {
-                        __typename
-                        id
-                      }
-                    }
-                  },
-                  Flatten(path: "t") {
-                    Fetch(service: "Subgraph2") {
-                      {
-                        ... on T {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          v1
-                        }
-                      }
-                    },
-                  },
                 }
-              }, [
-                Deferred(depends: [0], path: "t") {
-                  {
-                    v2
-                  }:
-                  Flatten(path: "t") {
-                    Fetch(service: "Subgraph2") {
-                      {
-                        ... on T {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          v2
-                        }
-                      }
-                    },
-                  }
-                },
-              ]
+              },
             },
-          }
-        "###
+          },
+        }, [
+          Deferred(depends: [0], path: "t") {
+            {
+              v2
+            }:
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2") {
+                {
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
+                    v2
+                  }
+                }
+              },
+            },
+          },
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -206,54 +206,55 @@ fn defer_test_non_router_based_defer() {
             }
         "#,
         @r###"
-          QueryPlan {
-            Defer {
-              Primary {
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            t {
+              v {
+                a
+              }
+            }
+          }:
+          Sequence {
+            Fetch(service: "Subgraph1") {
+              {
+                t {
+                  __typename
+                  id
+                }
+              }
+            },
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2") {
                 {
-                  t {
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
                     v {
                       a
+                      b
                     }
                   }
-                }:
-                Sequence {
-                  Fetch(service: "Subgraph1") {
-                    {
-                      t {
-                        __typename
-                        id
-                      }
-                    }
-                  },
-                  Flatten(path: "t") {
-                    Fetch(service: "Subgraph2") {
-                      {
-                        ... on T {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          v {
-                            a
-                            b
-                          }
-                        }
-                      }
-                    },
-                  },
                 }
-              }, [
-                Deferred(depends: [], path: "t/v") {
-                  {
-                    b
-                  }:
-                },
-              ]
+              },
             },
-          }
-        "###
+          },
+        }, [
+          Deferred(depends: [], path: "t/v") {
+            {
+              b
+            }:
+            
+          },
+        ]
+      },
+    }
+    "###
     );
 
     // @defer on entity but with no @key
@@ -489,48 +490,48 @@ fn defer_test_defer_resuming_in_the_same_subgraph() {
           }
         "#,
         @r###"
-        QueryPlan {
-          Defer {
-            Primary {
-              {
-                t {
-                  v0
-                }
-              }:
-              Fetch(service: "Subgraph1", id: 0) {
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            t {
+              v0
+            }
+          }:
+          Fetch(service: "Subgraph1", id: 0) {
+            {
+              t {
+                __typename
+                v0
+                id
+              }
+            }
+          },
+        }, [
+          Deferred(depends: [0], path: "t") {
+            {
+              v1
+            }:
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph1") {
                 {
-                  t {
+                  ... on T {
                     __typename
-                    v0
                     id
                   }
-                }
-              }
-            }, [
-              Deferred(depends: [0], path: "t") {
+                } =>
                 {
-                  v1
-                }:
-                Flatten(path: "t") {
-                  Fetch(service: "Subgraph1") {
-                    {
-                      ... on T {
-                        __typename
-                        id
-                      }
-                    } =>
-                    {
-                      ... on T {
-                        v1
-                      }
-                    }
-                  },
+                  ... on T {
+                    v1
+                  }
                 }
               },
-            ]
+            },
           },
-        }
-        "###
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -713,126 +714,126 @@ fn defer_test_multiple_non_nested_defer_plus_label_handling() {
           }
         "#,
         @r###"
-        QueryPlan {
-          Defer {
-            Primary {
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            t {
+              v0
+              v3 {
+                x
+              }
+            }
+          }:
+          Sequence {
+            Fetch(service: "Subgraph1", id: 0) {
               {
                 t {
+                  __typename
+                  id
                   v0
-                  v3 {
+                }
+              }
+            },
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2", id: 1) {
+                {
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
+                    v3 {
+                      __typename
+                      id
+                    }
+                  }
+                }
+              },
+            },
+            Flatten(path: "t.v3") {
+              Fetch(service: "Subgraph3") {
+                {
+                  ... on U {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on U {
                     x
                   }
                 }
-              }:
-              Sequence {
-                Fetch(service: "Subgraph1", id: 0) {
-                  {
-                    t {
-                      __typename
-                      id
-                      v0
-                    }
-                  }
-                },
-                Flatten(path: "t") {
-                  Fetch(service: "Subgraph2", id: 1) {
-                    {
-                      ... on T {
-                        __typename
-                        id
-                      }
-                    } =>
-                    {
-                      ... on T {
-                        v3 {
-                          __typename
-                          id
-                        }
-                      }
-                    }
-                  },
-                },
-                Flatten(path: "t.v3") {
-                  Fetch(service: "Subgraph3") {
-                    {
-                      ... on U {
-                        __typename
-                        id
-                      }
-                    } =>
-                    {
-                      ... on U {
-                        x
-                      }
-                    }
-                  },
-                },
-              }
-            }, [
-              Deferred(depends: [0], path: "t") {
-                {
-                  v2
-                }:
-                Flatten(path: "t") {
-                  Fetch(service: "Subgraph2") {
-                    {
-                      ... on T {
-                        __typename
-                        id
-                      }
-                    } =>
-                    {
-                      ... on T {
-                        v2
-                      }
-                    }
-                  },
-                }
               },
-              Deferred(depends: [0], path: "t", label: "defer_v1") {
-                {
-                  v1
-                }:
-                Flatten(path: "t") {
-                  Fetch(service: "Subgraph1") {
-                    {
-                      ... on T {
-                        __typename
-                        id
-                      }
-                    } =>
-                    {
-                      ... on T {
-                        v1
-                      }
-                    }
-                  },
-                }
-              },
-              Deferred(depends: [1], path: "t/v3", label: "defer_in_v3") {
-                {
-                  y
-                }:
-                Flatten(path: "t.v3") {
-                  Fetch(service: "Subgraph3") {
-                    {
-                      ... on U {
-                        __typename
-                        id
-                      }
-                    } =>
-                    {
-                      ... on U {
-                        y
-                      }
-                    }
-                  },
-                }
-              },
-            ]
+            },
           },
-        }
-        "###
+        }, [
+          Deferred(depends: [0], path: "t") {
+            {
+              v2
+            }:
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2") {
+                {
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
+                    v2
+                  }
+                }
+              },
+            },
+          },
+          Deferred(depends: [0], path: "t", label: "defer_v1") {
+            {
+              v1
+            }:
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph1") {
+                {
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
+                    v1
+                  }
+                }
+              },
+            },
+          },
+          Deferred(depends: [1], path: "t/v3", label: "defer_in_v3") {
+            {
+              y
+            }:
+            Flatten(path: "t.v3") {
+              Fetch(service: "Subgraph3") {
+                {
+                  ... on U {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on U {
+                    y
+                  }
+                }
+              },
+            },
+          },
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -886,107 +887,107 @@ fn defer_test_nested_defer_on_entities() {
             }
         "#,
         @r###"
-          QueryPlan {
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            me {
+              name
+            }
+          }:
+          Fetch(service: "Subgraph1", id: 0) {
+            {
+              me {
+                __typename
+                name
+                id
+              }
+            }
+          },
+        }, [
+          Deferred(depends: [0], path: "me") {
             Defer {
               Primary {
                 {
-                  me {
-                    name
-                  }
-                }:
-                Fetch(service: "Subgraph1", id: 0) {
-                  {
-                    me {
-                      __typename
-                      name
-                      id
+                  ... on User {
+                    messages {
+                      body
+                      author {
+                        name
+                      }
                     }
                   }
-                }
-              }, [
-                Deferred(depends: [0], path: "me") {
-                  Defer {
-                    Primary {
+                }:
+                Sequence {
+                  Flatten(path: "me") {
+                    Fetch(service: "Subgraph2", id: 1) {
+                      {
+                        ... on User {
+                          __typename
+                          id
+                        }
+                      } =>
                       {
                         ... on User {
                           messages {
                             body
                             author {
-                              name
+                              __typename
+                              id
                             }
                           }
                         }
-                      }:
-                      Sequence {
-                        Flatten(path: "me") {
-                          Fetch(service: "Subgraph2", id: 1) {
-                            {
-                              ... on User {
-                                __typename
-                                id
-                              }
-                            } =>
-                            {
-                              ... on User {
-                                messages {
-                                  body
-                                  author {
-                                    __typename
-                                    id
-                                  }
-                                }
-                              }
-                            }
-                          },
-                        },
-                        Flatten(path: "me.messages.@.author") {
-                          Fetch(service: "Subgraph1") {
-                            {
-                              ... on User {
-                                __typename
-                                id
-                              }
-                            } =>
-                            {
-                              ... on User {
-                                name
-                              }
-                            }
-                          },
-                        },
                       }
-                    }, [
-                      Deferred(depends: [1], path: "me/messages/author") {
-                        {
+                    },
+                  },
+                  Flatten(path: "me.messages.@.author") {
+                    Fetch(service: "Subgraph1") {
+                      {
+                        ... on User {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on User {
+                          name
+                        }
+                      }
+                    },
+                  },
+                },
+              }, [
+                Deferred(depends: [1], path: "me/messages/author") {
+                  {
+                    messages {
+                      body
+                    }
+                  }:
+                  Flatten(path: "me.messages.@.author") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on User {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on User {
                           messages {
                             body
                           }
-                        }:
-                        Flatten(path: "me.messages.@.author") {
-                          Fetch(service: "Subgraph2") {
-                            {
-                              ... on User {
-                                __typename
-                                id
-                              }
-                            } =>
-                            {
-                              ... on User {
-                                messages {
-                                  body
-                                }
-                              }
-                            }
-                          },
                         }
-                      },
-                    ]
-                  }
+                      }
+                    },
+                  },
                 },
               ]
             },
-          }
-        "###
+          },
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -1039,57 +1040,56 @@ fn defer_test_defer_on_value_types() {
           }
         "#,
         @r###"
-        QueryPlan {
-          Defer {
-            Primary {
-              :
-              Fetch(service: "Subgraph1", id: 0) {
-                {
-                  me {
-                    __typename
-                    id
-                  }
-                }
+    QueryPlan {
+      Defer {
+        Primary {
+          Fetch(service: "Subgraph1", id: 0) {
+            {
+              me {
+                __typename
+                id
               }
-            }, [
-              Deferred(depends: [0], path: "me") {
-                Defer {
-                  Primary {
-                    :
-                    Flatten(path: "me") {
-                      Fetch(service: "Subgraph2") {
-                        {
-                          ... on User {
-                            __typename
-                            id
-                          }
-                        } =>
-                        {
-                          ... on User {
-                            messages {
-                              body {
-                                lines
-                              }
-                            }
-                          }
-                        }
-                      },
-                    }
-                  }, [
-                    Deferred(depends: [], path: "me/messages") {
-                      {
-                        body {
-                          lines
-                        }
-                      }:
-                    },
-                  ]
-                }
-              },
-            ]
+            }
           },
-        }
-        "###
+        }, [
+          Deferred(depends: [0], path: "me") {
+            Defer {
+              Primary {
+                Flatten(path: "me") {
+                  Fetch(service: "Subgraph2") {
+                    {
+                      ... on User {
+                        __typename
+                        id
+                      }
+                    } =>
+                    {
+                      ... on User {
+                        messages {
+                          body {
+                            lines
+                          }
+                        }
+                      }
+                    }
+                  },
+                },
+              }, [
+                Deferred(depends: [], path: "me/messages") {
+                  {
+                    body {
+                      lines
+                    }
+                  }:
+                  
+                },
+              ]
+            },
+          },
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -1131,73 +1131,73 @@ fn defer_test_direct_nesting_on_entity() {
           }
         "#,
         @r###"
-        QueryPlan {
-          Defer {
-            Primary {
-              {
-                me {
-                  name
-                }
-              }:
-              Fetch(service: "Subgraph1", id: 0) {
-                {
-                  me {
-                    __typename
-                    name
-                    id
-                  }
-                }
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            me {
+              name
+            }
+          }:
+          Fetch(service: "Subgraph1", id: 0) {
+            {
+              me {
+                __typename
+                name
+                id
               }
-            }, [
-              Deferred(depends: [0], path: "me") {
-                Defer {
-                  Primary {
+            }
+          },
+        }, [
+          Deferred(depends: [0], path: "me") {
+            Defer {
+              Primary {
+                {
+                  age
+                }:
+                Flatten(path: "me") {
+                  Fetch(service: "Subgraph2") {
                     {
-                      age
-                    }:
-                    Flatten(path: "me") {
-                      Fetch(service: "Subgraph2") {
-                        {
-                          ... on User {
-                            __typename
-                            id
-                          }
-                        } =>
-                        {
-                          ... on User {
-                            age
-                          }
-                        }
-                      },
+                      ... on User {
+                        __typename
+                        id
+                      }
+                    } =>
+                    {
+                      ... on User {
+                        age
+                      }
                     }
-                  }, [
-                    Deferred(depends: [0], path: "me") {
+                  },
+                },
+              }, [
+                Deferred(depends: [0], path: "me") {
+                  {
+                    address
+                  }:
+                  Flatten(path: "me") {
+                    Fetch(service: "Subgraph2") {
                       {
-                        address
-                      }:
-                      Flatten(path: "me") {
-                        Fetch(service: "Subgraph2") {
-                          {
-                            ... on User {
-                              __typename
-                              id
-                            }
-                          } =>
-                          {
-                            ... on User {
-                              address
-                            }
-                          }
-                        },
+                        ... on User {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on User {
+                          address
+                        }
                       }
                     },
-                  ]
-                }
-              },
-            ]
+                  },
+                },
+              ]
+            },
           },
-        }
-        "###
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -1234,43 +1234,44 @@ fn defer_test_direct_nesting_on_value_type() {
           }
         "#,
         @r###"
-        QueryPlan {
-          Defer {
-            Primary {
-              {
-                me {
-                  name
-                }
-              }:
-              Fetch(service: "Subgraph1") {
-                {
-                  me {
-                    name
-                    age
-                    address
-                  }
-                }
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            me {
+              name
+            }
+          }:
+          Fetch(service: "Subgraph1") {
+            {
+              me {
+                name
+                age
+                address
               }
-            }, [
-              Deferred(depends: [], path: "me") {
-                Defer {
-                  Primary {
-                    {
-                      age
-                    }:
-                  }, [
-                    Deferred(depends: [], path: "me") {
-                      {
-                        address
-                      }:
-                    },
-                  ]
-                }
-              },
-            ]
+            }
           },
-        }
-        "###
+        }, [
+          Deferred(depends: [], path: "me") {
+            Defer {
+              Primary {
+                {
+                  age
+                }
+              }, [
+                Deferred(depends: [], path: "me") {
+                  {
+                    address
+                  }:
+                  
+                },
+              ]
+            },
+          },
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -1310,38 +1311,38 @@ fn defer_test_defer_on_enity_but_with_unuseful_key() {
             }
         "#,
         @r###"
-          QueryPlan {
+    QueryPlan {
+      Defer {
+        Primary {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                a
+                b
+              }
+            }
+          },
+        }, [
+          Deferred(depends: [], path: "t") {
             Defer {
               Primary {
-                :
-                Fetch(service: "Subgraph1") {
-                  {
-                    t {
-                      a
-                      b
-                    }
-                  }
+                {
+                  a
                 }
               }, [
                 Deferred(depends: [], path: "t") {
-                  Defer {
-                    Primary {
-                      {
-                        a
-                      }:
-                    }, [
-                      Deferred(depends: [], path: "t") {
-                        {
-                          b
-                        }:
-                      },
-                    ]
-                  }
+                  {
+                    b
+                  }:
+                  
                 },
               ]
             },
-          }
-        "###
+          },
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -1394,94 +1395,94 @@ fn defer_test_defer_on_mutation_in_same_subgraph() {
             }
         "#,
         @r###"
-          QueryPlan {
-            Defer {
-              Primary {
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            update1 {
+              v0
+            }
+            update2 {
+              v1
+            }
+          }:
+          Fetch(service: "Subgraph1", id: 0) {
+            {
+              update1 {
+                __typename
+                v0
+                id
+              }
+              update2 {
+                __typename
+                v1
+                id
+              }
+            }
+          },
+        }, [
+          Deferred(depends: [0], path: "update1") {
+            {
+              v1
+            }:
+            Flatten(path: "update1") {
+              Fetch(service: "Subgraph1") {
                 {
-                  update1 {
-                    v0
+                  ... on T {
+                    __typename
+                    id
                   }
-                  update2 {
+                } =>
+                {
+                  ... on T {
                     v1
-                  }
-                }:
-                Fetch(service: "Subgraph1", id: 0) {
-                  {
-                    update1 {
-                      __typename
-                      v0
-                      id
-                    }
-                    update2 {
-                      __typename
-                      v1
-                      id
-                    }
                   }
                 }
-              }, [
-                Deferred(depends: [0], path: "update1") {
-                  {
-                    v1
-                  }:
-                  Flatten(path: "update1") {
-                    Fetch(service: "Subgraph1") {
-                      {
-                        ... on T {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          v1
-                        }
-                      }
-                    },
-                  }
-                },
-                Deferred(depends: [0], path: "update2") {
-                  {
-                    v0
-                    v2
-                  }:
-                  Parallel {
-                    Flatten(path: "update2") {
-                      Fetch(service: "Subgraph2") {
-                        {
-                          ... on T {
-                            __typename
-                            id
-                          }
-                        } =>
-                        {
-                          ... on T {
-                            v2
-                          }
-                        }
-                      },
-                    },
-                    Flatten(path: "update2") {
-                      Fetch(service: "Subgraph1") {
-                        {
-                          ... on T {
-                            __typename
-                            id
-                          }
-                        } =>
-                        {
-                          ... on T {
-                            v0
-                          }
-                        }
-                      },
-                    },
-                  }
-                },
-              ]
+              },
             },
-          }
-        "###
+          },
+          Deferred(depends: [0], path: "update2") {
+            {
+              v0
+              v2
+            }:
+            Parallel {
+              Flatten(path: "update2") {
+                Fetch(service: "Subgraph1") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      v0
+                    }
+                  }
+                },
+              },
+              Flatten(path: "update2") {
+                Fetch(service: "Subgraph2") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      v2
+                    }
+                  }
+                },
+              },
+            },
+          },
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -1937,66 +1938,66 @@ fn defer_test_requirements_of_deferred_fields_are_deferred() {
             }
         "#,
         @r###"
-          QueryPlan {
-            Defer {
-              Primary {
-                {
-                  t {
-                    v1
-                  }
-                }:
-                Fetch(service: "Subgraph1", id: 0) {
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            t {
+              v1
+            }
+          }:
+          Fetch(service: "Subgraph1", id: 0) {
+            {
+              t {
+                __typename
+                v1
+                id
+              }
+            }
+          },
+        }, [
+          Deferred(depends: [0], path: "t") {
+            {
+              v2
+            }:
+            Sequence {
+              Flatten(path: "t") {
+                Fetch(service: "Subgraph3") {
                   {
-                    t {
+                    ... on T {
                       __typename
-                      v1
                       id
                     }
-                  }
-                }
-              }, [
-                Deferred(depends: [0], path: "t") {
+                  } =>
                   {
-                    v2
-                  }:
-                  Sequence {
-                    Flatten(path: "t") {
-                      Fetch(service: "Subgraph3") {
-                        {
-                          ... on T {
-                            __typename
-                            id
-                          }
-                        } =>
-                        {
-                          ... on T {
-                            v3
-                          }
-                        }
-                      },
-                    },
-                    Flatten(path: "t") {
-                      Fetch(service: "Subgraph2") {
-                        {
-                          ... on T {
-                            __typename
-                            v3
-                            id
-                          }
-                        } =>
-                        {
-                          ... on T {
-                            v2
-                          }
-                        }
-                      },
-                    },
+                    ... on T {
+                      v3
+                    }
                   }
                 },
-              ]
+              },
+              Flatten(path: "t") {
+                Fetch(service: "Subgraph2") {
+                  {
+                    ... on T {
+                      __typename
+                      v3
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      v2
+                    }
+                  }
+                },
+              },
             },
-          }
-        "###
+          },
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -2044,48 +2045,48 @@ fn defer_test_provides_are_ignored_for_deferred_fields() {
             }
         "#,
         @r###"
-          QueryPlan {
-            Defer {
-              Primary {
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            t {
+              v1
+            }
+          }:
+          Fetch(service: "Subgraph1", id: 0) {
+            {
+              t {
+                __typename
+                v1
+                id
+              }
+            }
+          },
+        }, [
+          Deferred(depends: [0], path: "t") {
+            {
+              v2
+            }:
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2") {
                 {
-                  t {
-                    v1
+                  ... on T {
+                    __typename
+                    id
                   }
-                }:
-                Fetch(service: "Subgraph1", id: 0) {
-                  {
-                    t {
-                      __typename
-                      v1
-                      id
-                    }
+                } =>
+                {
+                  ... on T {
+                    v2
                   }
                 }
-              }, [
-                Deferred(depends: [0], path: "t") {
-                  {
-                    v2
-                  }:
-                  Flatten(path: "t") {
-                    Fetch(service: "Subgraph2") {
-                      {
-                        ... on T {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          v2
-                        }
-                      }
-                    },
-                  }
-                },
-              ]
+              },
             },
-          }
-        "###
+          },
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -2130,71 +2131,71 @@ fn defer_test_defer_on_query_root_type() {
           }
         "#,
         @r###"
-        QueryPlan {
-          Defer {
-            Primary {
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            op2 {
+              x
+              y
+              next {
+                op3
+              }
+            }
+          }:
+          Sequence {
+            Fetch(service: "Subgraph1", id: 0) {
               {
                 op2 {
                   x
                   y
                   next {
+                    __typename
+                  }
+                }
+              }
+            },
+            Flatten(path: "op2.next") {
+              Fetch(service: "Subgraph2") {
+                {
+                  ... on Query {
                     op3
                   }
                 }
-              }:
-              Sequence {
-                Fetch(service: "Subgraph1", id: 0) {
+              },
+            },
+          },
+        }, [
+          Deferred(depends: [0], path: "op2/next") {
+            {
+              op1
+              op4
+            }:
+            Parallel {
+              Flatten(path: "op2.next") {
+                Fetch(service: "Subgraph1") {
                   {
-                    op2 {
-                      x
-                      y
-                      next {
-                        __typename
-                      }
+                    ... on Query {
+                      op1
                     }
                   }
                 },
-                Flatten(path: "op2.next") {
-                  Fetch(service: "Subgraph2") {
-                    {
-                      ... on Query {
-                        op3
-                      }
-                    }
-                  },
-                },
-              }
-            }, [
-              Deferred(depends: [0], path: "op2/next") {
-                {
-                  op1
-                  op4
-                }:
-                Parallel {
-                  Flatten(path: "op2.next") {
-                    Fetch(service: "Subgraph2") {
-                      {
-                        ... on Query {
-                          op4
-                        }
-                      }
-                    },
-                  },
-                  Flatten(path: "op2.next") {
-                    Fetch(service: "Subgraph1") {
-                      {
-                        ... on Query {
-                          op1
-                        }
-                      }
-                    },
-                  },
-                }
               },
-            ]
+              Flatten(path: "op2.next") {
+                Fetch(service: "Subgraph2") {
+                  {
+                    ... on Query {
+                      op4
+                    }
+                  }
+                },
+              },
+            },
           },
-        }
-        "###
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -2232,53 +2233,51 @@ fn defer_test_defer_on_everything_queried() {
           }
         "#,
         @r###"
-        QueryPlan {
-          Defer {
-            Primary {
-              :
-            }, [
-              Deferred(depends: [], path: "") {
-                {
-                  t {
-                    x
-                    y
+    QueryPlan {
+      Defer {
+        Primary {}, [
+          Deferred(depends: [], path: "") {
+            {
+              t {
+                x
+                y
+              }
+            }:
+            Sequence {
+              Flatten(path: "") {
+                Fetch(service: "Subgraph1") {
+                  {
+                    ... on Query {
+                      t {
+                        __typename
+                        id
+                        x
+                      }
+                    }
                   }
-                }:
-                Sequence {
-                  Flatten(path: "") {
-                    Fetch(service: "Subgraph1") {
-                      {
-                        ... on Query {
-                          t {
-                            __typename
-                            id
-                            x
-                          }
-                        }
-                      }
-                    },
-                  },
-                  Flatten(path: "t") {
-                    Fetch(service: "Subgraph2") {
-                      {
-                        ... on T {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          y
-                        }
-                      }
-                    },
-                  },
-                }
+                },
               },
-            ]
+              Flatten(path: "t") {
+                Fetch(service: "Subgraph2") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      y
+                    }
+                  }
+                },
+              },
+            },
           },
-        }
-        "###
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -2316,61 +2315,60 @@ fn defer_test_defer_everything_within_entity() {
           }
         "#,
         @r###"
-        QueryPlan {
-          Defer {
-            Primary {
-              :
-              Fetch(service: "Subgraph1", id: 0) {
-                {
-                  t {
-                    __typename
-                    id
-                  }
-                }
+    QueryPlan {
+      Defer {
+        Primary {
+          Fetch(service: "Subgraph1", id: 0) {
+            {
+              t {
+                __typename
+                id
               }
-            }, [
-              Deferred(depends: [0], path: "t") {
-                {
-                  x
-                  y
-                }:
-                Parallel {
-                  Flatten(path: "t") {
-                    Fetch(service: "Subgraph2") {
-                      {
-                        ... on T {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          y
-                        }
-                      }
-                    },
-                  },
-                  Flatten(path: "t") {
-                    Fetch(service: "Subgraph1") {
-                      {
-                        ... on T {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          x
-                        }
-                      }
-                    },
-                  },
-                }
-              },
-            ]
+            }
           },
-        }
-        "###
+        }, [
+          Deferred(depends: [0], path: "t") {
+            {
+              x
+              y
+            }:
+            Parallel {
+              Flatten(path: "t") {
+                Fetch(service: "Subgraph1") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      x
+                    }
+                  }
+                },
+              },
+              Flatten(path: "t") {
+                Fetch(service: "Subgraph2") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      y
+                    }
+                  }
+                },
+              },
+            },
+          },
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -2408,81 +2406,79 @@ fn defer_test_defer_with_conditions_and_labels() {
           }
         "#,
         @r###"
-          QueryPlan {
-            Condition(if: $cond) {
-              Then {
-                Defer {
-                  Primary {
-                    {
-                      t {
-                        x
-                      }
-                    }:
-                    Fetch(service: "Subgraph1", id: 0) {
-                      {
-                        t {
-                          __typename
-                          x
-                          id
-                        }
-                      }
-                    }
-                  }, [
-                    Deferred(depends: [0], path: "t"${
-                      label ? `, label: "${label}"` : ''
-                    }) {
-                      {
-                        y
-                      }:
-                      Flatten(path: "t") {
-                        Fetch(service: "Subgraph2") {
-                          {
-                            ... on T {
-                              __typename
-                              id
-                            }
-                          } =>
-                          {
-                            ... on T {
-                              y
-                            }
-                          }
-                        },
-                      }
-                    },
-                  ]
+    QueryPlan {
+      Condition(if: $cond) {
+        Then {
+          Defer {
+            Primary {
+              {
+                t {
+                  x
                 }
-              } Else {
-                Sequence {
-                  Fetch(service: "Subgraph1") {
+              }:
+              Fetch(service: "Subgraph1", id: 0) {
+                {
+                  t {
+                    __typename
+                    x
+                    id
+                  }
+                }
+              },
+            }, [
+              Deferred(depends: [0], path: "t") {
+                {
+                  y
+                }:
+                Flatten(path: "t") {
+                  Fetch(service: "Subgraph2") {
                     {
-                      t {
+                      ... on T {
                         __typename
                         id
-                        x
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        y
                       }
                     }
                   },
-                  Flatten(path: "t") {
-                    Fetch(service: "Subgraph2") {
-                      {
-                        ... on T {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          y
-                        }
-                      }
-                    },
-                  },
+                },
+              },
+            ]
+          },
+        } Else {
+          Sequence {
+            Fetch(service: "Subgraph1") {
+              {
+                t {
+                  __typename
+                  id
+                  x
                 }
               }
             },
-          }
-        "###
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2") {
+                {
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
+                    y
+                  }
+                }
+              },
+            },
+          },
+        },
+      },
+    }
+    "###
     );
     // with explicit label
     assert_plan!(planner,
@@ -2607,61 +2603,61 @@ fn defer_test_defer_with_condition_on_single_subgraph() {
             }
         "#,
         @r###"
-          QueryPlan {
-            Condition(if: $cond) {
-              Then {
-                Defer {
-                  Primary {
-                    {
-                      t {
-                        x
-                      }
-                    }:
-                    Fetch(service: "Subgraph1", id: 0) {
-                      {
-                        t {
-                          __typename
-                          x
-                          id
-                        }
-                      }
-                    }
-                  }, [
-                    Deferred(depends: [0], path: "t") {
-                      {
-                        y
-                      }:
-                      Flatten(path: "t") {
-                        Fetch(service: "Subgraph1") {
-                          {
-                            ... on T {
-                              __typename
-                              id
-                            }
-                          } =>
-                          {
-                            ... on T {
-                              y
-                            }
-                          }
-                        },
-                      }
-                    },
-                  ]
+    QueryPlan {
+      Condition(if: $cond) {
+        Then {
+          Defer {
+            Primary {
+              {
+                t {
+                  x
                 }
-              } Else {
-                Fetch(service: "Subgraph1") {
-                  {
-                    t {
-                      x
-                      y
-                    }
+              }:
+              Fetch(service: "Subgraph1", id: 0) {
+                {
+                  t {
+                    __typename
+                    x
+                    id
                   }
                 }
+              },
+            }, [
+              Deferred(depends: [0], path: "t") {
+                {
+                  y
+                }:
+                Flatten(path: "t") {
+                  Fetch(service: "Subgraph1") {
+                    {
+                      ... on T {
+                        __typename
+                        id
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        y
+                      }
+                    }
+                  },
+                },
+              },
+            ]
+          },
+        } Else {
+          Fetch(service: "Subgraph1") {
+            {
+              t {
+                x
+                y
               }
-            },
-          }
-        "###
+            }
+          },
+        },
+      },
+    }
+    "###
     );
 }
 
@@ -3077,59 +3073,60 @@ fn defer_test_interface_has_different_definitions_between_subgraphs() {
           }
         "#,
         @r###"
-        QueryPlan {
-          Defer {
-            Primary {
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            i {
+              a
+              ... on T {
+                b
+              }
+            }
+          }:
+          Sequence {
+            Fetch(service: "Subgraph1") {
               {
                 i {
+                  __typename
                   a
+                  ... on T {
+                    __typename
+                    id
+                    a
+                  }
+                  c
+                }
+              }
+            },
+            Flatten(path: "i") {
+              Fetch(service: "Subgraph2") {
+                {
+                  ... on T {
+                    __typename
+                    id
+                    a
+                  }
+                } =>
+                {
                   ... on T {
                     b
                   }
                 }
-              }:
-              Sequence {
-                Fetch(service: "Subgraph1") {
-                  {
-                    i {
-                      __typename
-                      a
-                      ... on T {
-                        __typename
-                        id
-                        a
-                      }
-                      c
-                    }
-                  }
-                },
-                Flatten(path: "i") {
-                  Fetch(service: "Subgraph2") {
-                    {
-                      ... on T {
-                        __typename
-                        id
-                        a
-                      }
-                    } =>
-                    {
-                      ... on T {
-                        b
-                      }
-                    }
-                  },
-                },
-              }
-            }, [
-              Deferred(depends: [], path: "i") {
-                {
-                  c
-                }:
               },
-            ]
+            },
           },
-        }
-        "###
+        }, [
+          Deferred(depends: [], path: "i") {
+            {
+              c
+            }:
+            
+          },
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -3169,47 +3166,46 @@ fn defer_test_named_fragments_simple() {
             }
         "#,
         @r###"
-          QueryPlan {
-            Defer {
-              Primary {
-                :
-                Fetch(service: "Subgraph1", id: 0) {
-                  {
-                    t {
-                      __typename
-                      id
-                    }
+    QueryPlan {
+      Defer {
+        Primary {
+          Fetch(service: "Subgraph1", id: 0) {
+            {
+              t {
+                __typename
+                id
+              }
+            }
+          },
+        }, [
+          Deferred(depends: [0], path: "t") {
+            {
+              ... on T {
+                x
+                y
+              }
+            }:
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2") {
+                {
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
+                    x
+                    y
                   }
                 }
-              }, [
-                Deferred(depends: [0], path: "t") {
-                  {
-                    ... on T {
-                      x
-                      y
-                    }
-                  }:
-                  Flatten(path: "t") {
-                    Fetch(service: "Subgraph2") {
-                      {
-                        ... on T {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          x
-                          y
-                        }
-                      }
-                    },
-                  }
-                },
-              ]
+              },
             },
-          }
-        "###
+          },
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -3256,70 +3252,70 @@ fn defer_test_fragments_expand_into_same_field_regardless_of_defer() {
             }
         "#,
         @r###"
-          QueryPlan {
-            Defer {
-              Primary {
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            t {
+              x
+              y
+            }
+          }:
+          Sequence {
+            Fetch(service: "Subgraph1", id: 0) {
+              {
+                t {
+                  __typename
+                  id
+                }
+              }
+            },
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2") {
                 {
-                  t {
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
                     x
                     y
                   }
-                }:
-                Sequence {
-                  Fetch(service: "Subgraph1", id: 0) {
-                    {
-                      t {
-                        __typename
-                        id
-                      }
-                    }
-                  },
-                  Flatten(path: "t") {
-                    Fetch(service: "Subgraph2") {
-                      {
-                        ... on T {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          x
-                          y
-                        }
-                      }
-                    },
-                  },
                 }
-              }, [
-                Deferred(depends: [0], path: "t") {
-                  {
-                    ... on T {
-                      y
-                      z
-                    }
-                  }:
-                  Flatten(path: "t") {
-                    Fetch(service: "Subgraph2") {
-                      {
-                        ... on T {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          y
-                          z
-                        }
-                      }
-                    },
-                  }
-                },
-              ]
+              },
             },
-          }
-        "###
+          },
+        }, [
+          Deferred(depends: [0], path: "t") {
+            {
+              ... on T {
+                y
+                z
+              }
+            }:
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2") {
+                {
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
+                    y
+                    z
+                  }
+                }
+              },
+            },
+          },
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -3365,52 +3361,52 @@ fn defer_test_can_request_typename_in_fragment() {
             }
         "#,
         @r###"
-          QueryPlan {
-            Defer {
-              Primary {
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            t {
+              x
+            }
+          }:
+          Fetch(service: "Subgraph1", id: 0) {
+            {
+              t {
+                __typename
+                id
+                x
+              }
+            }
+          },
+        }, [
+          Deferred(depends: [0], path: "t") {
+            {
+              ... on T {
+                __typename
+                y
+              }
+            }:
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2") {
                 {
-                  t {
-                    x
+                  ... on T {
+                    __typename
+                    id
                   }
-                }:
-                Fetch(service: "Subgraph1", id: 0) {
-                  {
-                    t {
-                      __typename
-                      id
-                      x
-                    }
+                } =>
+                {
+                  ... on T {
+                    __typename
+                    y
                   }
                 }
-              }, [
-                Deferred(depends: [0], path: "t") {
-                  {
-                    ... on T {
-                      __typename
-                      y
-                    }
-                  }:
-                  Flatten(path: "t") {
-                    Fetch(service: "Subgraph2") {
-                      {
-                        ... on T {
-                          __typename
-                          id
-                        }
-                      } =>
-                      {
-                        ... on T {
-                          __typename
-                          y
-                        }
-                      }
-                    },
-                  }
-                },
-              ]
+              },
             },
-          }
-        "###
+          },
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -3452,68 +3448,68 @@ fn defer_test_do_not_merge_query_branches_with_defer() {
           }
         "#,
         @r###"
-        QueryPlan {
-          Defer {
-            Primary {
-              {
-                t {
-                  a
-                }
-              }:
-              Fetch(service: "Subgraph1", id: 0) {
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            t {
+              a
+            }
+          }:
+          Fetch(service: "Subgraph1", id: 0) {
+            {
+              t {
+                __typename
+                a
+                id
+              }
+            }
+          },
+        }, [
+          Deferred(depends: [0], path: "t") {
+            {
+              c
+            }:
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph2") {
                 {
-                  t {
+                  ... on T {
                     __typename
-                    a
                     id
                   }
-                }
-              }
-            }, [
-              Deferred(depends: [0], path: "t") {
+                } =>
                 {
-                  c
-                }:
-                Flatten(path: "t") {
-                  Fetch(service: "Subgraph2") {
-                    {
-                      ... on T {
-                        __typename
-                        id
-                      }
-                    } =>
-                    {
-                      ... on T {
-                        c
-                      }
-                    }
-                  },
+                  ... on T {
+                    c
+                  }
                 }
               },
-              Deferred(depends: [0], path: "t") {
-                {
-                  b
-                }:
-                Flatten(path: "t") {
-                  Fetch(service: "Subgraph1") {
-                    {
-                      ... on T {
-                        __typename
-                        id
-                      }
-                    } =>
-                    {
-                      ... on T {
-                        b
-                      }
-                    }
-                  },
-                }
-              },
-            ]
+            },
           },
-        }
-        "###
+          Deferred(depends: [0], path: "t") {
+            {
+              b
+            }:
+            Flatten(path: "t") {
+              Fetch(service: "Subgraph1") {
+                {
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
+                    b
+                  }
+                }
+              },
+            },
+          },
+        ]
+      },
+    }
+    "###
     );
 }
 
@@ -3616,56 +3612,56 @@ fn defer_test_the_path_in_defer_includes_traversed_fragments() {
           }
         "#,
         @r###"
-        QueryPlan {
-          Defer {
-            Primary {
-              {
-                i {
-                  ... on A {
-                    t {
-                      v1
-                    }
-                  }
+    QueryPlan {
+      Defer {
+        Primary {
+          {
+            i {
+              ... on A {
+                t {
+                  v1
                 }
-              }:
-              Fetch(service: "Subgraph1", id: 0) {
-                {
-                  i {
+              }
+            }
+          }:
+          Fetch(service: "Subgraph1", id: 0) {
+            {
+              i {
+                __typename
+                ... on A {
+                  t {
                     __typename
-                    ... on A {
-                      t {
-                        __typename
-                        v1
-                        id
-                      }
-                    }
+                    v1
+                    id
                   }
                 }
               }
-            }, [
-              Deferred(depends: [0], path: "i/... on A/t") {
+            }
+          },
+        }, [
+          Deferred(depends: [0], path: "i/... on A/t") {
+            {
+              v2
+            }:
+            Flatten(path: "i.t") {
+              Fetch(service: "Subgraph1") {
                 {
-                  v2
-                }:
-                Flatten(path: "i.t") {
-                  Fetch(service: "Subgraph1") {
-                    {
-                      ... on T {
-                        __typename
-                        id
-                      }
-                    } =>
-                    {
-                      ... on T {
-                        v2
-                      }
-                    }
-                  },
+                  ... on T {
+                    __typename
+                    id
+                  }
+                } =>
+                {
+                  ... on T {
+                    v2
+                  }
                 }
               },
-            ]
+            },
           },
-        }
-        "###
+        ]
+      },
+    }
+    "###
     );
 }

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/defer.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/defer.rs
@@ -72,7 +72,7 @@ fn defer_test_handles_simple_defer_without_defer_enabled() {
 }
 
 #[test]
-fn defer_test_handles_simple_defer() {
+fn defer_test_handles_simple_defer_with_defer_enabled() {
     let planner = planner!(
         config = config_with_defer(),
         Subgraph1: r#"
@@ -107,7 +107,7 @@ fn defer_test_handles_simple_defer() {
           QueryPlan {
             Defer {
               Primary {
-                {
+                    {
                   t {
                     v1
                   }
@@ -658,7 +658,7 @@ fn defer_test_defer_multiple_fields_in_different_subgraphs() {
 }
 
 #[test]
-fn defer_test_multiple_non_nested_defer_plus_lable_handling() {
+fn defer_test_multiple_non_nested_defer_plus_label_handling() {
     let planner = planner!(
         config = config_with_defer(),
         Subgraph1: r#"
@@ -837,7 +837,7 @@ fn defer_test_multiple_non_nested_defer_plus_lable_handling() {
 }
 
 #[test]
-fn defer_test_nested_defer_on_entities() {
+fn deefer_test_nested_defer_on_entities() {
     let planner = planner!(
         config = config_with_defer(),
           Subgraph1: r#"
@@ -1094,7 +1094,7 @@ fn defer_test_defer_on_value_types() {
 }
 
 #[test]
-fn defer_test_direct_nesting_on_entity() {
+fn deefer_test_direct_nesting_on_entity() {
     let planner = planner!(
         config = config_with_defer(),
         Subgraph1: r#"
@@ -1202,7 +1202,7 @@ fn defer_test_direct_nesting_on_entity() {
 }
 
 #[test]
-fn defer_test_direct_nesting_on_value_type() {
+fn deefer_test_direct_nesting_on_value_type() {
     let planner = planner!(
         config = config_with_defer(),
         Subgraph1: r#"
@@ -1275,7 +1275,7 @@ fn defer_test_direct_nesting_on_value_type() {
 }
 
 #[test]
-fn defer_test_defer_on_enity_but_with_unuseful_key() {
+fn deefer_test_defer_on_enity_but_with_unuseful_key() {
     let planner = planner!(
         config = config_with_defer(),
           Subgraph1: r#"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/defer.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/defer.rs
@@ -64,8 +64,8 @@ fn defer_test_handles_simple_defer_without_defer_enabled() {
                     }
                   }
                 },
-              },
-            },
+              }
+            }
           }
         "###
     );
@@ -837,7 +837,7 @@ fn defer_test_multiple_non_nested_defer_plus_label_handling() {
 }
 
 #[test]
-fn deefer_test_nested_defer_on_entities() {
+fn defer_test_nested_defer_on_entities() {
     let planner = planner!(
         config = config_with_defer(),
           Subgraph1: r#"
@@ -1094,7 +1094,7 @@ fn defer_test_defer_on_value_types() {
 }
 
 #[test]
-fn deefer_test_direct_nesting_on_entity() {
+fn defer_test_direct_nesting_on_entity() {
     let planner = planner!(
         config = config_with_defer(),
         Subgraph1: r#"
@@ -1202,7 +1202,7 @@ fn deefer_test_direct_nesting_on_entity() {
 }
 
 #[test]
-fn deefer_test_direct_nesting_on_value_type() {
+fn defer_test_direct_nesting_on_value_type() {
     let planner = planner!(
         config = config_with_defer(),
         Subgraph1: r#"
@@ -1275,7 +1275,7 @@ fn deefer_test_direct_nesting_on_value_type() {
 }
 
 #[test]
-fn deefer_test_defer_on_enity_but_with_unuseful_key() {
+fn defer_test_defer_on_enity_but_with_unuseful_key() {
     let planner = planner!(
         config = config_with_defer(),
           Subgraph1: r#"

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/defer.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/defer.rs
@@ -1,0 +1,3671 @@
+use apollo_federation::query_plan::query_planner::QueryPlannerConfig;
+
+fn config_with_defer() -> QueryPlannerConfig {
+    let mut config = QueryPlannerConfig::default();
+    config.incremental_delivery.enable_defer = true;
+    config
+}
+
+#[test]
+fn defer_test_handles_simple_defer_without_defer_enabled() {
+    let planner = planner!(
+        Subgraph1: r#"
+        type Query {
+            t: T
+        }
+
+        type T @key(fields: "id") {
+            id: ID!
+        }
+        "#,
+        Subgraph2: r#"
+        type T @key(fields: "id") {
+            id: ID!
+            v1: Int
+            v2: Int
+        }
+        "#,
+    );
+    // without defer-support enabled
+    assert_plan!(planner,
+        r#"
+            {
+              t {
+                v1
+                ... @defer {
+                  v2
+                }
+              }
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Sequence {
+              Fetch(service: "Subgraph1") {
+                {
+                  t {
+                    __typename
+                    id
+                  }
+                }
+              },
+              Flatten(path: "t") {
+                Fetch(service: "Subgraph2") {
+                  {
+                    ... on T {
+                      __typename
+                      id
+                    }
+                  } =>
+                  {
+                    ... on T {
+                      v1
+                      v2
+                    }
+                  }
+                },
+              },
+            },
+          }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_handles_simple_defer() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+        type Query {
+            t: T
+        }
+
+        type T @key(fields: "id") {
+            id: ID!
+        }
+        "#,
+        Subgraph2: r#"
+        type T @key(fields: "id") {
+            id: ID!
+            v1: Int
+            v2: Int
+        }
+        "#,
+    );
+    assert_plan!(planner,
+        r#"
+            {
+              t {
+                v1
+                ... @defer {
+                  v2
+                }
+              }
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Defer {
+              Primary {
+                {
+                  t {
+                    v1
+                  }
+                }:
+                Sequence {
+                  Fetch(service: "Subgraph1", id: 0) {
+                    {
+                      t {
+                        __typename
+                        id
+                      }
+                    }
+                  },
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          v1
+                        }
+                      }
+                    },
+                  },
+                }
+              }, [
+                Deferred(depends: [0], path: "t") {
+                  {
+                    v2
+                  }:
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          v2
+                        }
+                      }
+                    },
+                  }
+                },
+              ]
+            },
+          }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_non_router_based_defer() {
+    // @defer on value type
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+        type Query {
+            t: T
+        }
+
+        type T @key(fields: "id") {
+            id: ID!
+        }
+        "#,
+        Subgraph2: r#"
+        type T @key(fields: "id") {
+            id: ID!
+            v: V
+        }
+
+        type V {
+            a: Int
+            b: Int
+        }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+            {
+              t {
+                v {
+                  a
+                  ... @defer {
+                    b
+                  }
+                }
+              }
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Defer {
+              Primary {
+                {
+                  t {
+                    v {
+                      a
+                    }
+                  }
+                }:
+                Sequence {
+                  Fetch(service: "Subgraph1") {
+                    {
+                      t {
+                        __typename
+                        id
+                      }
+                    }
+                  },
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          v {
+                            a
+                            b
+                          }
+                        }
+                      }
+                    },
+                  },
+                }
+              }, [
+                Deferred(depends: [], path: "t/v") {
+                  {
+                    b
+                  }:
+                },
+              ]
+            },
+          }
+        "###
+    );
+
+    // @defer on entity but with no @key
+    // While the @defer in the operation is on an entity, the @key in the first subgraph
+    // is explicitely marked as non-resovable, so we cannot use it to actually defer the
+    // fetch to `v1`. Note that example still compose because, defer excluded, `v1` can
+    // still be fetched for all queries (which is only `t` here).
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+        type Query {
+            t: T
+        }
+
+        type T @key(fields: "id", resolvable: false) {
+            id: ID!
+            v1: String
+        }
+        "#,
+        Subgraph2: r#"
+        type T @key(fields: "id") {
+            id: ID!
+            v2: String
+        }
+        "#,
+    );
+    assert_plan!(planner,
+        r#"
+            {
+              t {
+                ... @defer {
+                  v1
+                }
+                v2
+              }
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Defer {
+              Primary {
+                {
+                  t {
+                    v2
+                  }
+                }:
+                Sequence {
+                  Fetch(service: "Subgraph1") {
+                    {
+                      t {
+                        __typename
+                        id
+                        v1
+                      }
+                    }
+                  },
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          v2
+                        }
+                      }
+                    },
+                  },
+                }
+              }, [
+                Deferred(depends: [], path: "t") {
+                  {
+                    v1
+                  }:
+                },
+              ]
+            },
+          }
+        "###
+    );
+
+    // @defer on value type but with entity afterwards
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+        type Query {
+            t: T
+        }
+
+        type T @key(fields: "id") {
+            id: ID!
+        }
+
+        type U @key(fields: "id") {
+            id: ID!
+            x: Int
+        }
+        "#,
+
+        Subgraph2: r#"
+        type T @key(fields: "id") {
+            id: ID!
+            v: V
+        }
+
+        type V {
+            a: Int
+            u: U
+        }
+
+        type U @key(fields: "id") {
+            id: ID!
+        }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+            {
+              t {
+                v {
+                  a
+                  ... @defer {
+                    u {
+                      x
+                    }
+                  }
+                }
+              }
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Defer {
+              Primary {
+                {
+                  t {
+                    v {
+                      a
+                    }
+                  }
+                }:
+                Sequence {
+                  Fetch(service: "Subgraph1") {
+                    {
+                      t {
+                        __typename
+                        id
+                      }
+                    }
+                  },
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2", id: 0) {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          v {
+                            a
+                            u {
+                              __typename
+                              id
+                            }
+                          }
+                        }
+                      }
+                    },
+                  },
+                }
+              }, [
+                Deferred(depends: [0], path: "t/v") {
+                  {
+                    u {
+                      x
+                    }
+                  }:
+                  Flatten(path: "t.v.u") {
+                    Fetch(service: "Subgraph1") {
+                      {
+                        ... on U {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on U {
+                          x
+                        }
+                      }
+                    },
+                  }
+                },
+              ]
+            },
+          }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_defer_resuming_in_the_same_subgraph() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            v0: String
+            v1: String
+          }
+          "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+          {
+            t {
+              v0
+              ... @defer {
+                v1
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Defer {
+            Primary {
+              {
+                t {
+                  v0
+                }
+              }:
+              Fetch(service: "Subgraph1", id: 0) {
+                {
+                  t {
+                    __typename
+                    v0
+                    id
+                  }
+                }
+              }
+            }, [
+              Deferred(depends: [0], path: "t") {
+                {
+                  v1
+                }:
+                Flatten(path: "t") {
+                  Fetch(service: "Subgraph1") {
+                    {
+                      ... on T {
+                        __typename
+                        id
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        v1
+                      }
+                    }
+                  },
+                }
+              },
+            ]
+          },
+        }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_defer_multiple_fields_in_different_subgraphs() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            v0: String
+            v1: String
+          }
+        "#,
+
+        Subgraph2: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            v2: String
+          }
+        "#,
+        Subgraph3: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            v3: String
+          }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+          {
+            t {
+              v0
+              ... @defer {
+                v1
+                v2
+                v3
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Defer {
+            Primary {
+              {
+                t {
+                  v0
+                }
+              }:
+              Fetch(service: "Subgraph1", id: 0) {
+                {
+                  t {
+                    __typename
+                    v0
+                    id
+                  }
+                }
+              }
+            }, [
+              Deferred(depends: [0], path: "t") {
+                {
+                  v1
+                  v2
+                  v3
+                }:
+                Parallel {
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph3") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          v3
+                        }
+                      }
+                    },
+                  },
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          v2
+                        }
+                      }
+                    },
+                  },
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph1") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          v1
+                        }
+                      }
+                    },
+                  },
+                }
+              },
+            ]
+          },
+        }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_multiple_non_nested_defer_plus_lable_handling() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            v0: String
+            v1: String
+          }
+        "#,
+        Subgraph2: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            v2: String
+            v3: U
+          }
+
+          type U @key(fields: "id") {
+            id: ID!
+          }
+        "#,
+        Subgraph3: r#"
+          type U @key(fields: "id") {
+            id: ID!
+            x: Int
+            y: Int
+          }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+          {
+            t {
+              v0
+              ... @defer(label: "defer_v1") {
+                v1
+              }
+              ... @defer {
+                v2
+              }
+              v3 {
+                x
+                ... @defer(label: "defer_in_v3") {
+                  y
+                }
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Defer {
+            Primary {
+              {
+                t {
+                  v0
+                  v3 {
+                    x
+                  }
+                }
+              }:
+              Sequence {
+                Fetch(service: "Subgraph1", id: 0) {
+                  {
+                    t {
+                      __typename
+                      id
+                      v0
+                    }
+                  }
+                },
+                Flatten(path: "t") {
+                  Fetch(service: "Subgraph2", id: 1) {
+                    {
+                      ... on T {
+                        __typename
+                        id
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        v3 {
+                          __typename
+                          id
+                        }
+                      }
+                    }
+                  },
+                },
+                Flatten(path: "t.v3") {
+                  Fetch(service: "Subgraph3") {
+                    {
+                      ... on U {
+                        __typename
+                        id
+                      }
+                    } =>
+                    {
+                      ... on U {
+                        x
+                      }
+                    }
+                  },
+                },
+              }
+            }, [
+              Deferred(depends: [0], path: "t") {
+                {
+                  v2
+                }:
+                Flatten(path: "t") {
+                  Fetch(service: "Subgraph2") {
+                    {
+                      ... on T {
+                        __typename
+                        id
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        v2
+                      }
+                    }
+                  },
+                }
+              },
+              Deferred(depends: [0], path: "t", label: "defer_v1") {
+                {
+                  v1
+                }:
+                Flatten(path: "t") {
+                  Fetch(service: "Subgraph1") {
+                    {
+                      ... on T {
+                        __typename
+                        id
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        v1
+                      }
+                    }
+                  },
+                }
+              },
+              Deferred(depends: [1], path: "t/v3", label: "defer_in_v3") {
+                {
+                  y
+                }:
+                Flatten(path: "t.v3") {
+                  Fetch(service: "Subgraph3") {
+                    {
+                      ... on U {
+                        __typename
+                        id
+                      }
+                    } =>
+                    {
+                      ... on U {
+                        y
+                      }
+                    }
+                  },
+                }
+              },
+            ]
+          },
+        }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_nested_defer_on_entities() {
+    let planner = planner!(
+        config = config_with_defer(),
+          Subgraph1: r#"
+            type Query {
+              me: User
+            }
+
+            type User @key(fields: "id") {
+              id: ID!
+              name: String
+            }
+          "#,
+          Subgraph2: r#"
+            type User @key(fields: "id") {
+              id: ID!
+              messages: [Message]
+            }
+
+            type Message @key(fields: "id") {
+              id: ID!
+              body: String
+              author: User
+            }
+          "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+            {
+              me {
+                name
+                ... on User @defer {
+                  messages {
+                    body
+                    author {
+                      name
+                      ... @defer {
+                        messages {
+                          body
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Defer {
+              Primary {
+                {
+                  me {
+                    name
+                  }
+                }:
+                Fetch(service: "Subgraph1", id: 0) {
+                  {
+                    me {
+                      __typename
+                      name
+                      id
+                    }
+                  }
+                }
+              }, [
+                Deferred(depends: [0], path: "me") {
+                  Defer {
+                    Primary {
+                      {
+                        ... on User {
+                          messages {
+                            body
+                            author {
+                              name
+                            }
+                          }
+                        }
+                      }:
+                      Sequence {
+                        Flatten(path: "me") {
+                          Fetch(service: "Subgraph2", id: 1) {
+                            {
+                              ... on User {
+                                __typename
+                                id
+                              }
+                            } =>
+                            {
+                              ... on User {
+                                messages {
+                                  body
+                                  author {
+                                    __typename
+                                    id
+                                  }
+                                }
+                              }
+                            }
+                          },
+                        },
+                        Flatten(path: "me.messages.@.author") {
+                          Fetch(service: "Subgraph1") {
+                            {
+                              ... on User {
+                                __typename
+                                id
+                              }
+                            } =>
+                            {
+                              ... on User {
+                                name
+                              }
+                            }
+                          },
+                        },
+                      }
+                    }, [
+                      Deferred(depends: [1], path: "me/messages/author") {
+                        {
+                          messages {
+                            body
+                          }
+                        }:
+                        Flatten(path: "me.messages.@.author") {
+                          Fetch(service: "Subgraph2") {
+                            {
+                              ... on User {
+                                __typename
+                                id
+                              }
+                            } =>
+                            {
+                              ... on User {
+                                messages {
+                                  body
+                                }
+                              }
+                            }
+                          },
+                        }
+                      },
+                    ]
+                  }
+                },
+              ]
+            },
+          }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_defer_on_value_types() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+          type Query {
+            me: User
+          }
+
+          type User @key(fields: "id") {
+            id: ID!
+            name: String
+          }
+        "#,
+        Subgraph2: r#"
+          type User @key(fields: "id") {
+            id: ID!
+            messages: [Message]
+          }
+
+          type Message {
+            id: ID!
+            body: MessageBody
+          }
+
+          type MessageBody {
+            paragraphs: [String]
+            lines: Int
+          }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+          {
+            me {
+              ... @defer {
+                messages {
+                  ... @defer {
+                    body {
+                      lines
+                    }
+                  }
+                }
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Defer {
+            Primary {
+              :
+              Fetch(service: "Subgraph1", id: 0) {
+                {
+                  me {
+                    __typename
+                    id
+                  }
+                }
+              }
+            }, [
+              Deferred(depends: [0], path: "me") {
+                Defer {
+                  Primary {
+                    :
+                    Flatten(path: "me") {
+                      Fetch(service: "Subgraph2") {
+                        {
+                          ... on User {
+                            __typename
+                            id
+                          }
+                        } =>
+                        {
+                          ... on User {
+                            messages {
+                              body {
+                                lines
+                              }
+                            }
+                          }
+                        }
+                      },
+                    }
+                  }, [
+                    Deferred(depends: [], path: "me/messages") {
+                      {
+                        body {
+                          lines
+                        }
+                      }:
+                    },
+                  ]
+                }
+              },
+            ]
+          },
+        }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_direct_nesting_on_entity() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+          type Query {
+            me: User
+          }
+
+          type User @key(fields: "id") {
+            id: ID!
+            name: String
+          }
+        "#,
+        Subgraph2: r#"
+          type User @key(fields: "id") {
+            id: ID!
+            age: Int
+            address: String
+          }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+          {
+            me {
+              name
+              ... @defer {
+                age
+                ... @defer {
+                  address
+                }
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Defer {
+            Primary {
+              {
+                me {
+                  name
+                }
+              }:
+              Fetch(service: "Subgraph1", id: 0) {
+                {
+                  me {
+                    __typename
+                    name
+                    id
+                  }
+                }
+              }
+            }, [
+              Deferred(depends: [0], path: "me") {
+                Defer {
+                  Primary {
+                    {
+                      age
+                    }:
+                    Flatten(path: "me") {
+                      Fetch(service: "Subgraph2") {
+                        {
+                          ... on User {
+                            __typename
+                            id
+                          }
+                        } =>
+                        {
+                          ... on User {
+                            age
+                          }
+                        }
+                      },
+                    }
+                  }, [
+                    Deferred(depends: [0], path: "me") {
+                      {
+                        address
+                      }:
+                      Flatten(path: "me") {
+                        Fetch(service: "Subgraph2") {
+                          {
+                            ... on User {
+                              __typename
+                              id
+                            }
+                          } =>
+                          {
+                            ... on User {
+                              address
+                            }
+                          }
+                        },
+                      }
+                    },
+                  ]
+                }
+              },
+            ]
+          },
+        }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_direct_nesting_on_value_type() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+          type Query {
+            me: User
+          }
+
+          type User {
+            id: ID!
+            name: String
+            age: Int
+            address: String
+          }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+          {
+            me {
+              name
+              ... @defer {
+                age
+                ... @defer {
+                  address
+                }
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Defer {
+            Primary {
+              {
+                me {
+                  name
+                }
+              }:
+              Fetch(service: "Subgraph1") {
+                {
+                  me {
+                    name
+                    age
+                    address
+                  }
+                }
+              }
+            }, [
+              Deferred(depends: [], path: "me") {
+                Defer {
+                  Primary {
+                    {
+                      age
+                    }:
+                  }, [
+                    Deferred(depends: [], path: "me") {
+                      {
+                        address
+                      }:
+                    },
+                  ]
+                }
+              },
+            ]
+          },
+        }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_defer_on_enity_but_with_unuseful_key() {
+    let planner = planner!(
+        config = config_with_defer(),
+          Subgraph1: r#"
+            type Query {
+              t: T
+            }
+
+            type T {
+              id: ID! @shareable
+              a: Int
+              b: Int
+            }
+          "#,
+          Subgraph2: r#"
+            type T @key(fields: "id") {
+              id: ID!
+            }
+          "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+            {
+              t {
+                ... @defer {
+                  a
+                  ... @defer {
+                    b
+                  }
+                }
+              }
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Defer {
+              Primary {
+                :
+                Fetch(service: "Subgraph1") {
+                  {
+                    t {
+                      a
+                      b
+                    }
+                  }
+                }
+              }, [
+                Deferred(depends: [], path: "t") {
+                  Defer {
+                    Primary {
+                      {
+                        a
+                      }:
+                    }, [
+                      Deferred(depends: [], path: "t") {
+                        {
+                          b
+                        }:
+                      },
+                    ]
+                  }
+                },
+              ]
+            },
+          }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_defer_on_mutation_in_same_subgraph() {
+    let planner = planner!(
+        config = config_with_defer(),
+          Subgraph1: r#"
+            type Query {
+              t: T
+            }
+
+            type Mutation {
+              update1: T
+              update2: T
+            }
+
+            type T @key(fields: "id") {
+              id: ID!
+              v0: String
+              v1: String
+            }
+          "#,
+          Subgraph2: r#"
+            type T @key(fields: "id") {
+              id: ID!
+              v2: String
+            }
+          "#,
+    );
+
+    // What matters here is that the updates (that go to different fields) are correctly done in sequence,
+    // and that defers have proper dependency set.
+    assert_plan!(planner,
+        r#"
+            mutation mut {
+              update1 {
+                v0
+                ... @defer {
+                  v1
+                }
+              }
+              update2 {
+                v1
+                ... @defer {
+                  v0
+                  v2
+                }
+              }
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Defer {
+              Primary {
+                {
+                  update1 {
+                    v0
+                  }
+                  update2 {
+                    v1
+                  }
+                }:
+                Fetch(service: "Subgraph1", id: 0) {
+                  {
+                    update1 {
+                      __typename
+                      v0
+                      id
+                    }
+                    update2 {
+                      __typename
+                      v1
+                      id
+                    }
+                  }
+                }
+              }, [
+                Deferred(depends: [0], path: "update1") {
+                  {
+                    v1
+                  }:
+                  Flatten(path: "update1") {
+                    Fetch(service: "Subgraph1") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          v1
+                        }
+                      }
+                    },
+                  }
+                },
+                Deferred(depends: [0], path: "update2") {
+                  {
+                    v0
+                    v2
+                  }:
+                  Parallel {
+                    Flatten(path: "update2") {
+                      Fetch(service: "Subgraph2") {
+                        {
+                          ... on T {
+                            __typename
+                            id
+                          }
+                        } =>
+                        {
+                          ... on T {
+                            v2
+                          }
+                        }
+                      },
+                    },
+                    Flatten(path: "update2") {
+                      Fetch(service: "Subgraph1") {
+                        {
+                          ... on T {
+                            __typename
+                            id
+                          }
+                        } =>
+                        {
+                          ... on T {
+                            v0
+                          }
+                        }
+                      },
+                    },
+                  }
+                },
+              ]
+            },
+          }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_defer_on_mutation_on_different_subgraphs() {
+    let planner = planner!(
+        config = config_with_defer(),
+          Subgraph1: r#"
+            type Query {
+              t: T
+            }
+
+            type Mutation {
+              update1: T
+            }
+
+            type T @key(fields: "id") {
+              id: ID!
+              v0: String
+              v1: String
+            }
+          "#,
+          Subgraph2: r#"
+            type Mutation {
+              update2: T
+            }
+
+            type T @key(fields: "id") {
+              id: ID!
+              v2: String
+            }
+          "#,
+    );
+
+    // What matters here is that the updates (that go to different fields) are correctly done in sequence,
+    // and that defers have proper dependency set.
+    assert_plan!(planner,
+        r#"
+            mutation mut {
+              update1 {
+                v0
+                ... @defer {
+                  v1
+                }
+              }
+              update2 {
+                v1
+                ... @defer {
+                  v0
+                  v2
+                }
+              }
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Defer {
+              Primary {
+                {
+                  update1 {
+                    v0
+                  }
+                  update2 {
+                    v1
+                  }
+                }:
+                Sequence {
+                  Fetch(service: "Subgraph1", id: 0) {
+                    {
+                      update1 {
+                        __typename
+                        v0
+                        id
+                      }
+                    }
+                  },
+                  Fetch(service: "Subgraph2", id: 1) {
+                    {
+                      update2 {
+                        __typename
+                        id
+                      }
+                    }
+                  },
+                  Flatten(path: "update2") {
+                    Fetch(service: "Subgraph1") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          v1
+                        }
+                      }
+                    },
+                  },
+                }
+              }, [
+                Deferred(depends: [0], path: "update1") {
+                  {
+                    v1
+                  }:
+                  Flatten(path: "update1") {
+                    Fetch(service: "Subgraph1") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          v1
+                        }
+                      }
+                    },
+                  }
+                },
+                Deferred(depends: [1], path: "update2") {
+                  {
+                    v0
+                    v2
+                  }:
+                  Parallel {
+                    Flatten(path: "update2") {
+                      Fetch(service: "Subgraph2") {
+                        {
+                          ... on T {
+                            __typename
+                            id
+                          }
+                        } =>
+                        {
+                          ... on T {
+                            v2
+                          }
+                        }
+                      },
+                    },
+                    Flatten(path: "update2") {
+                      Fetch(service: "Subgraph1") {
+                        {
+                          ... on T {
+                            __typename
+                            id
+                          }
+                        } =>
+                        {
+                          ... on T {
+                            v0
+                          }
+                        }
+                      },
+                    },
+                  }
+                },
+              ]
+            },
+          }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_defer_on_multi_dependency_deferred_section() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id0") {
+            id0: ID!
+            v1: Int
+          }
+        "#,
+        Subgraph2: r#"
+          type T @key(fields: "id0") @key(fields: "id1") {
+            id0: ID!
+            id1: ID!
+            v2: Int
+          }
+        "#,
+        Subgraph3: r#"
+          type T @key(fields: "id0") @key(fields: "id2") {
+            id0: ID!
+            id2: ID!
+            v3: Int
+          }
+        "#,
+        Subgraph4: r#"
+          type T @key(fields: "id1 id2") {
+            id1: ID!
+            id2: ID!
+            v4: Int
+          }
+        "#,
+    );
+
+    assert_plan!(&planner,
+        r#"
+          {
+            t {
+              v1
+              v2
+              v3
+              ... @defer {
+                v4
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Defer {
+            Primary {
+              {
+                t {
+                  v1
+                  v2
+                  v3
+                }
+              }:
+              Sequence {
+                Fetch(service: "Subgraph1") {
+                  {
+                    t {
+                      __typename
+                      id0
+                      v1
+                    }
+                  }
+                },
+                Parallel {
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph3", id: 0) {
+                      {
+                        ... on T {
+                          __typename
+                          id0
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          v3
+                          id2
+                        }
+                      }
+                    },
+                  },
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2", id: 1) {
+                      {
+                        ... on T {
+                          __typename
+                          id0
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          v2
+                          id1
+                        }
+                      }
+                    },
+                  },
+                },
+              }
+            }, [
+              Deferred(depends: [0, 1], path: "t") {
+                {
+                  v4
+                }:
+                Flatten(path: "t") {
+                  Fetch(service: "Subgraph4") {
+                    {
+                      ... on T {
+                        __typename
+                        id1
+                        id2
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        v4
+                      }
+                    }
+                  },
+                }
+              },
+            ]
+          },
+        }
+        "###
+    );
+
+    // TODO: the following plan is admittedly not as effecient as it could be, as the 2 queries to
+    // subgraph 2 and 3 are done in the "primary" section, but all they do is handle transitive
+    // key dependencies for the deferred block, so it would make more sense to defer those fetches
+    // as well. It is however tricky to both improve this here _and_ maintain the plan generate
+    // just above (which is admittedly optimial). More precisely, what the code currently does is
+    // that when it gets to a defer, then it defers the fetch that gets the deferred fields (the
+    // fetch to subgraph 4 here), but it puts the "condition" resolution for the key of that fetch
+    // in the non-deferred section. Here, resolving that fetch conditions is what creates the
+    // dependency on the the fetches to subgraph 2 and 3, and so those get non-deferred.
+    // Now, it would be reasonably simple to say that when we resolve the "conditions" for a deferred
+    // fetch, then the first "hop" is non-deferred, but any following ones do get deferred, which
+    // would move the 2 fetches to subgraph 2 and 3 in the deferred section. The problem is that doing
+    // that wholesale means that in the previous example above, we'd keep the 2 non-deferred fetches
+    // to subgraph 2 and 3 for v2 and v3, but we would then have new deferred fetches to those
+    // subgraphs in the deferred section to now get the key id1 and id2, and that is in turn arguably
+    // non-optimal. So ideally, the code would be able to distinguish between those 2 cases and
+    // do the most optimal thing in each cases, but it's not that simple to do with the current
+    // code.
+    // Taking a step back, this "inefficiency" only exists where there is a @key "chain", and while
+    // such chains have their uses, they are likely pretty rare in the first place. And as the
+    // generated plan is not _that_ bad either, optimizing this feels fairly low priority and
+    // we leave it for "later".
+    assert_plan!(planner,
+        r#"
+          {
+            t {
+              v1
+              ... @defer {
+                v4
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Defer {
+            Primary {
+              {
+                t {
+                  v1
+                }
+              }:
+              Sequence {
+                Fetch(service: "Subgraph1") {
+                  {
+                    t {
+                      __typename
+                      v1
+                      id0
+                    }
+                  }
+                },
+                Parallel {
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph3", id: 0) {
+                      {
+                        ... on T {
+                          __typename
+                          id0
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          id2
+                        }
+                      }
+                    },
+                  },
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2", id: 1) {
+                      {
+                        ... on T {
+                          __typename
+                          id0
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          id1
+                        }
+                      }
+                    },
+                  },
+                },
+              }
+            }, [
+              Deferred(depends: [0, 1], path: "t") {
+                {
+                  v4
+                }:
+                Flatten(path: "t") {
+                  Fetch(service: "Subgraph4") {
+                    {
+                      ... on T {
+                        __typename
+                        id1
+                        id2
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        v4
+                      }
+                    }
+                  },
+                }
+              },
+            ]
+          },
+        }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_requirements_of_deferred_fields_are_deferred() {
+    let planner = planner!(
+        config = config_with_defer(),
+          Subgraph1: r#"
+            type Query {
+              t: T
+            }
+
+            type T @key(fields: "id") {
+              id: ID!
+              v1: Int
+            }
+          "#,
+          Subgraph2: r#"
+            type T @key(fields: "id") {
+              id: ID!
+              v2: Int @requires(fields: "v3")
+              v3: Int @external
+            }
+          "#,
+          Subgraph3: r#"
+            type T @key(fields: "id") {
+              id: ID!
+              v3: Int
+            }
+          "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+            {
+              t {
+                v1
+                ... @defer {
+                  v2
+                }
+              }
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Defer {
+              Primary {
+                {
+                  t {
+                    v1
+                  }
+                }:
+                Fetch(service: "Subgraph1", id: 0) {
+                  {
+                    t {
+                      __typename
+                      v1
+                      id
+                    }
+                  }
+                }
+              }, [
+                Deferred(depends: [0], path: "t") {
+                  {
+                    v2
+                  }:
+                  Sequence {
+                    Flatten(path: "t") {
+                      Fetch(service: "Subgraph3") {
+                        {
+                          ... on T {
+                            __typename
+                            id
+                          }
+                        } =>
+                        {
+                          ... on T {
+                            v3
+                          }
+                        }
+                      },
+                    },
+                    Flatten(path: "t") {
+                      Fetch(service: "Subgraph2") {
+                        {
+                          ... on T {
+                            __typename
+                            v3
+                            id
+                          }
+                        } =>
+                        {
+                          ... on T {
+                            v2
+                          }
+                        }
+                      },
+                    },
+                  }
+                },
+              ]
+            },
+          }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_provides_are_ignored_for_deferred_fields() {
+    // NOTE: this test tests the currently implemented behaviour, which ignore @provides when it
+    // concerns a deferred field. However, this is the behaviour implemented at the moment more
+    // because it is the simplest option and it's not illogical, but it is not the only possibly
+    // valid option. In particular, one could make the case that if a subgraph has a `@provides`,
+    // then this probably means that the subgraph can provide the field "cheaply" (why have
+    // a `@provides` otherwise?), and so that ignoring the @defer (instead of ignoring the @provides)
+    // is preferable. We can change to this behaviour later if we decide that it is preferable since
+    // the responses sent to the end-user would be the same regardless.
+
+    let planner = planner!(
+        config = config_with_defer(),
+          Subgraph1: r#"
+            type Query {
+              t: T @provides(fields: "v2")
+            }
+
+            type T @key(fields: "id") {
+              id: ID!
+              v1: Int
+              v2: Int @external
+            }
+          "#,
+          Subgraph2: r#"
+            type T @key(fields: "id") {
+              id: ID!
+              v2: Int @shareable
+            }
+          "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+            {
+              t {
+                v1
+                ... @defer {
+                  v2
+                }
+              }
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Defer {
+              Primary {
+                {
+                  t {
+                    v1
+                  }
+                }:
+                Fetch(service: "Subgraph1", id: 0) {
+                  {
+                    t {
+                      __typename
+                      v1
+                      id
+                    }
+                  }
+                }
+              }, [
+                Deferred(depends: [0], path: "t") {
+                  {
+                    v2
+                  }:
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          v2
+                        }
+                      }
+                    },
+                  }
+                },
+              ]
+            },
+          }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_defer_on_query_root_type() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+          type Query {
+            op1: Int
+            op2: A
+          }
+
+          type A {
+            x: Int
+            y: Int
+            next: Query
+          }
+        "#,
+        Subgraph2: r#"
+          type Query {
+            op3: Int
+            op4: Int
+          }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+          {
+            op2 {
+              x
+              y
+              next {
+                op3
+                ... @defer {
+                  op1
+                  op4
+                }
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Defer {
+            Primary {
+              {
+                op2 {
+                  x
+                  y
+                  next {
+                    op3
+                  }
+                }
+              }:
+              Sequence {
+                Fetch(service: "Subgraph1", id: 0) {
+                  {
+                    op2 {
+                      x
+                      y
+                      next {
+                        __typename
+                      }
+                    }
+                  }
+                },
+                Flatten(path: "op2.next") {
+                  Fetch(service: "Subgraph2") {
+                    {
+                      ... on Query {
+                        op3
+                      }
+                    }
+                  },
+                },
+              }
+            }, [
+              Deferred(depends: [0], path: "op2/next") {
+                {
+                  op1
+                  op4
+                }:
+                Parallel {
+                  Flatten(path: "op2.next") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on Query {
+                          op4
+                        }
+                      }
+                    },
+                  },
+                  Flatten(path: "op2.next") {
+                    Fetch(service: "Subgraph1") {
+                      {
+                        ... on Query {
+                          op1
+                        }
+                      }
+                    },
+                  },
+                }
+              },
+            ]
+          },
+        }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_defer_on_everything_queried() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            x: Int
+          }
+        "#,
+        Subgraph2: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            y: Int
+          }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+          {
+            ... @defer {
+              t {
+                x
+                y
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Defer {
+            Primary {
+              :
+            }, [
+              Deferred(depends: [], path: "") {
+                {
+                  t {
+                    x
+                    y
+                  }
+                }:
+                Sequence {
+                  Flatten(path: "") {
+                    Fetch(service: "Subgraph1") {
+                      {
+                        ... on Query {
+                          t {
+                            __typename
+                            id
+                            x
+                          }
+                        }
+                      }
+                    },
+                  },
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          y
+                        }
+                      }
+                    },
+                  },
+                }
+              },
+            ]
+          },
+        }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_defer_everything_within_entity() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            x: Int
+          }
+        "#,
+        Subgraph2: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            y: Int
+          }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+          {
+            t {
+              ... @defer {
+                x
+                y
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Defer {
+            Primary {
+              :
+              Fetch(service: "Subgraph1", id: 0) {
+                {
+                  t {
+                    __typename
+                    id
+                  }
+                }
+              }
+            }, [
+              Deferred(depends: [0], path: "t") {
+                {
+                  x
+                  y
+                }:
+                Parallel {
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          y
+                        }
+                      }
+                    },
+                  },
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph1") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          x
+                        }
+                      }
+                    },
+                  },
+                }
+              },
+            ]
+          },
+        }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_defer_with_conditions_and_labels() {
+    let planner = planner!(config = config_with_defer(),
+          Subgraph1: r#"
+            type Query {
+              t: T
+            }
+
+            type T @key(fields: "id") {
+              id: ID!
+              x: Int
+            }
+          "#,
+          Subgraph2: r#"
+            type T @key(fields: "id") {
+              id: ID!
+              y: Int
+            }
+          "#,
+    );
+
+    // without explicit label
+    assert_plan!(&planner,
+        r#"
+          query($cond: Boolean) {
+            t {
+              x
+              ... @defer(if: $cond) {
+                y
+              }
+            }
+          }
+        "#,
+        @r###"
+          QueryPlan {
+            Condition(if: $cond) {
+              Then {
+                Defer {
+                  Primary {
+                    {
+                      t {
+                        x
+                      }
+                    }:
+                    Fetch(service: "Subgraph1", id: 0) {
+                      {
+                        t {
+                          __typename
+                          x
+                          id
+                        }
+                      }
+                    }
+                  }, [
+                    Deferred(depends: [0], path: "t"${
+                      label ? `, label: "${label}"` : ''
+                    }) {
+                      {
+                        y
+                      }:
+                      Flatten(path: "t") {
+                        Fetch(service: "Subgraph2") {
+                          {
+                            ... on T {
+                              __typename
+                              id
+                            }
+                          } =>
+                          {
+                            ... on T {
+                              y
+                            }
+                          }
+                        },
+                      }
+                    },
+                  ]
+                }
+              } Else {
+                Sequence {
+                  Fetch(service: "Subgraph1") {
+                    {
+                      t {
+                        __typename
+                        id
+                        x
+                      }
+                    }
+                  },
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          y
+                        }
+                      }
+                    },
+                  },
+                }
+              }
+            },
+          }
+        "###
+    );
+    // with explicit label
+    assert_plan!(planner,
+        r#"
+          query($cond: Boolean) {
+            t {
+              x
+              ... @defer(label: "testLabel" if: $cond) {
+                y
+              }
+            }
+          }
+        "#,
+        @r###"
+          QueryPlan {
+            Condition(if: $cond) {
+              Then {
+                Defer {
+                  Primary {
+                    {
+                      t {
+                        x
+                      }
+                    }:
+                    Fetch(service: "Subgraph1", id: 0) {
+                      {
+                        t {
+                          __typename
+                          x
+                          id
+                        }
+                      }
+                    }
+                  }, [
+                    Deferred(depends: [0], path: "t"${
+                      label ? `, label: "${label}"` : ''
+                    }) {
+                      {
+                        y
+                      }:
+                      Flatten(path: "t") {
+                        Fetch(service: "Subgraph2") {
+                          {
+                            ... on T {
+                              __typename
+                              id
+                            }
+                          } =>
+                          {
+                            ... on T {
+                              y
+                            }
+                          }
+                        },
+                      }
+                    },
+                  ]
+                }
+              } Else {
+                Sequence {
+                  Fetch(service: "Subgraph1") {
+                    {
+                      t {
+                        __typename
+                        id
+                        x
+                      }
+                    }
+                  },
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          y
+                        }
+                      }
+                    },
+                  },
+                }
+              }
+            },
+          }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_defer_with_condition_on_single_subgraph() {
+    // This test mostly serves to illustrate why we handle @defer conditions with `ConditionNode` instead of
+    // just generating only the plan with the @defer and ignoring the `DeferNode` at execution: this is
+    // because doing can result in sub-par execution for the case where the @defer is disabled (unless of
+    // course the execution "merges" fetch groups, but it's not trivial to do so).
+
+    let planner = planner!(config = config_with_defer(),
+          Subgraph1: r#"
+            type Query {
+              t: T
+            }
+
+            type T @key(fields: "id") {
+              id: ID!
+              x: Int
+              y: Int
+            }
+          "#,
+    );
+    assert_plan!(planner,
+        r#"
+            query ($cond: Boolean) {
+              t {
+                x
+                ... @defer(if: $cond) {
+                  y
+                }
+              }
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Condition(if: $cond) {
+              Then {
+                Defer {
+                  Primary {
+                    {
+                      t {
+                        x
+                      }
+                    }:
+                    Fetch(service: "Subgraph1", id: 0) {
+                      {
+                        t {
+                          __typename
+                          x
+                          id
+                        }
+                      }
+                    }
+                  }, [
+                    Deferred(depends: [0], path: "t") {
+                      {
+                        y
+                      }:
+                      Flatten(path: "t") {
+                        Fetch(service: "Subgraph1") {
+                          {
+                            ... on T {
+                              __typename
+                              id
+                            }
+                          } =>
+                          {
+                            ... on T {
+                              y
+                            }
+                          }
+                        },
+                      }
+                    },
+                  ]
+                }
+              } Else {
+                Fetch(service: "Subgraph1") {
+                  {
+                    t {
+                      x
+                      y
+                    }
+                  }
+                }
+              }
+            },
+          }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_defer_with_mutliple_conditions_and_labels() {
+    let planner = planner!(config = config_with_defer(),
+          Subgraph1: r#"
+            type Query {
+              t: T
+            }
+
+            type T @key(fields: "id") {
+              id: ID!
+              x: Int
+              u: U
+            }
+
+            type U @key(fields: "id") {
+              id: ID!
+              a: Int
+            }
+          "#,
+          Subgraph2: r#"
+            type T @key(fields: "id") {
+              id: ID!
+              y: Int
+            }
+          "#,
+          Subgraph3: r#"
+            type U @key(fields: "id") {
+              id: ID!
+              b: Int
+            }
+          "#,
+    );
+    assert_plan!(planner,
+        r#"
+            query ($cond1: Boolean, $cond2: Boolean) {
+              t {
+                x
+                ... @defer(if: $cond1, label: "foo") {
+                  y
+                }
+                ... @defer(if: $cond2, label: "bar") {
+                  u {
+                    a
+                    ... @defer(if: $cond1) {
+                      b
+                    }
+                  }
+                }
+              }
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Condition(if: $cond1) {
+              Then {
+                Condition(if: $cond2) {
+                  Then {
+                    Defer {
+                      Primary {
+                        {
+                          t {
+                            x
+                          }
+                        }:
+                        Fetch(service: "Subgraph1", id: 0) {
+                          {
+                            t {
+                              __typename
+                              x
+                              id
+                            }
+                          }
+                        }
+                      }, [
+                        Deferred(depends: [0], path: "t", label: "bar") {
+                          Defer {
+                            Primary {
+                              {
+                                u {
+                                  a
+                                }
+                              }:
+                              Flatten(path: "t") {
+                                Fetch(service: "Subgraph1", id: 1) {
+                                  {
+                                    ... on T {
+                                      __typename
+                                      id
+                                    }
+                                  } =>
+                                  {
+                                    ... on T {
+                                      u {
+                                        __typename
+                                        a
+                                        id
+                                      }
+                                    }
+                                  }
+                                },
+                              }
+                            }, [
+                              Deferred(depends: [1], path: "t/u") {
+                                {
+                                  b
+                                }:
+                                Flatten(path: "t.u") {
+                                  Fetch(service: "Subgraph3") {
+                                    {
+                                      ... on U {
+                                        __typename
+                                        id
+                                      }
+                                    } =>
+                                    {
+                                      ... on U {
+                                        b
+                                      }
+                                    }
+                                  },
+                                }
+                              },
+                            ]
+                          }
+                        },
+                        Deferred(depends: [0], path: "t", label: "foo") {
+                          {
+                            y
+                          }:
+                          Flatten(path: "t") {
+                            Fetch(service: "Subgraph2") {
+                              {
+                                ... on T {
+                                  __typename
+                                  id
+                                }
+                              } =>
+                              {
+                                ... on T {
+                                  y
+                                }
+                              }
+                            },
+                          }
+                        },
+                      ]
+                    }
+                  } Else {
+                    Defer {
+                      Primary {
+                        {
+                          t {
+                            x
+                            u {
+                              a
+                            }
+                          }
+                        }:
+                        Fetch(service: "Subgraph1", id: 0) {
+                          {
+                            t {
+                              __typename
+                              x
+                              id
+                              u {
+                                __typename
+                                a
+                                id
+                              }
+                            }
+                          }
+                        }
+                      }, [
+                        Deferred(depends: [0], path: "t", label: "foo") {
+                          {
+                            y
+                          }:
+                          Flatten(path: "t") {
+                            Fetch(service: "Subgraph2") {
+                              {
+                                ... on T {
+                                  __typename
+                                  id
+                                }
+                              } =>
+                              {
+                                ... on T {
+                                  y
+                                }
+                              }
+                            },
+                          }
+                        },
+                        Deferred(depends: [0], path: "t/u") {
+                          {
+                            b
+                          }:
+                          Flatten(path: "t.u") {
+                            Fetch(service: "Subgraph3") {
+                              {
+                                ... on U {
+                                  __typename
+                                  id
+                                }
+                              } =>
+                              {
+                                ... on U {
+                                  b
+                                }
+                              }
+                            },
+                          }
+                        },
+                      ]
+                    }
+                  }
+                }
+              } Else {
+                Condition(if: $cond2) {
+                  Then {
+                    Defer {
+                      Primary {
+                        {
+                          t {
+                            x
+                            y
+                          }
+                        }:
+                        Sequence {
+                          Fetch(service: "Subgraph1", id: 0) {
+                            {
+                              t {
+                                __typename
+                                id
+                                x
+                              }
+                            }
+                          },
+                          Flatten(path: "t") {
+                            Fetch(service: "Subgraph2") {
+                              {
+                                ... on T {
+                                  __typename
+                                  id
+                                }
+                              } =>
+                              {
+                                ... on T {
+                                  y
+                                }
+                              }
+                            },
+                          },
+                        }
+                      }, [
+                        Deferred(depends: [0], path: "t", label: "bar") {
+                          {
+                            u {
+                              a
+                              b
+                            }
+                          }:
+                          Sequence {
+                            Flatten(path: "t") {
+                              Fetch(service: "Subgraph1") {
+                                {
+                                  ... on T {
+                                    __typename
+                                    id
+                                  }
+                                } =>
+                                {
+                                  ... on T {
+                                    u {
+                                      __typename
+                                      id
+                                      a
+                                    }
+                                  }
+                                }
+                              },
+                            },
+                            Flatten(path: "t.u") {
+                              Fetch(service: "Subgraph3") {
+                                {
+                                  ... on U {
+                                    __typename
+                                    id
+                                  }
+                                } =>
+                                {
+                                  ... on U {
+                                    b
+                                  }
+                                }
+                              },
+                            },
+                          }
+                        },
+                      ]
+                    }
+                  } Else {
+                    Sequence {
+                      Fetch(service: "Subgraph1") {
+                        {
+                          t {
+                            __typename
+                            id
+                            x
+                            u {
+                              __typename
+                              id
+                              a
+                            }
+                          }
+                        }
+                      },
+                      Parallel {
+                        Flatten(path: "t") {
+                          Fetch(service: "Subgraph2") {
+                            {
+                              ... on T {
+                                __typename
+                                id
+                              }
+                            } =>
+                            {
+                              ... on T {
+                                y
+                              }
+                            }
+                          },
+                        },
+                        Flatten(path: "t.u") {
+                          Fetch(service: "Subgraph3") {
+                            {
+                              ... on U {
+                                __typename
+                                id
+                              }
+                            } =>
+                            {
+                              ... on U {
+                                b
+                              }
+                            }
+                          },
+                        },
+                      },
+                    }
+                  }
+                }
+              }
+            },
+          }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_interface_has_different_definitions_between_subgraphs() {
+    // This test exists to ensure an early bug is fixed: that bug was in the code building
+    // the `subselection` of `DeferNode` in the plan, and was such that those subselections
+    // were created with links to subgraph types instead the supergraph ones. As a result,
+    // we were sometimes trying to add a field (`b` in the example here) to version of a
+    // type that didn't had that field (the definition of `I` in Subgraph1 here), hence
+    // running into an assertion error.
+
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+          type Query {
+            i: I
+          }
+
+          interface I {
+            a: Int
+            c: Int
+          }
+
+          type T implements I @key(fields: "id") {
+            id: ID!
+            a: Int
+            c: Int
+          }
+        "#,
+        Subgraph2: r#"
+          interface I {
+            b: Int
+          }
+
+          type T implements I @key(fields: "id") {
+            id: ID!
+            a: Int @external
+            b: Int @requires(fields: "a")
+          }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+          query Dimensions {
+            i {
+              a
+              b
+              ... @defer {
+                c
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Defer {
+            Primary {
+              {
+                i {
+                  a
+                  ... on T {
+                    b
+                  }
+                }
+              }:
+              Sequence {
+                Fetch(service: "Subgraph1") {
+                  {
+                    i {
+                      __typename
+                      a
+                      ... on T {
+                        __typename
+                        id
+                        a
+                      }
+                      c
+                    }
+                  }
+                },
+                Flatten(path: "i") {
+                  Fetch(service: "Subgraph2") {
+                    {
+                      ... on T {
+                        __typename
+                        id
+                        a
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        b
+                      }
+                    }
+                  },
+                },
+              }
+            }, [
+              Deferred(depends: [], path: "i") {
+                {
+                  c
+                }:
+              },
+            ]
+          },
+        }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_named_fragments_simple() {
+    let planner = planner!(
+        config = config_with_defer(),
+          Subgraph1: r#"
+            type Query {
+              t: T
+            }
+
+            type T @key(fields: "id") {
+              id: ID!
+            }
+          "#,
+          Subgraph2: r#"
+            type T @key(fields: "id") {
+              id: ID!
+              x: Int
+              y: Int
+            }
+          "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+            {
+              t {
+                ...TestFragment @defer
+              }
+            }
+
+            fragment TestFragment on T {
+              x
+              y
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Defer {
+              Primary {
+                :
+                Fetch(service: "Subgraph1", id: 0) {
+                  {
+                    t {
+                      __typename
+                      id
+                    }
+                  }
+                }
+              }, [
+                Deferred(depends: [0], path: "t") {
+                  {
+                    ... on T {
+                      x
+                      y
+                    }
+                  }:
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          x
+                          y
+                        }
+                      }
+                    },
+                  }
+                },
+              ]
+            },
+          }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_fragments_expand_into_same_field_regardless_of_defer() {
+    let planner = planner!(
+        config = config_with_defer(),
+          Subgraph1: r#"
+            type Query {
+              t: T
+            }
+
+            type T @key(fields: "id") {
+              id: ID!
+            }
+          "#,
+          Subgraph2: r#"
+            type T @key(fields: "id") {
+              id: ID!
+              x: Int
+              y: Int
+              z: Int
+            }
+          "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+            {
+              t {
+                ...Fragment1
+                ...Fragment2 @defer
+              }
+            }
+
+            fragment Fragment1 on T {
+              x
+              y
+            }
+
+            fragment Fragment2 on T {
+              y
+              z
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Defer {
+              Primary {
+                {
+                  t {
+                    x
+                    y
+                  }
+                }:
+                Sequence {
+                  Fetch(service: "Subgraph1", id: 0) {
+                    {
+                      t {
+                        __typename
+                        id
+                      }
+                    }
+                  },
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          x
+                          y
+                        }
+                      }
+                    },
+                  },
+                }
+              }, [
+                Deferred(depends: [0], path: "t") {
+                  {
+                    ... on T {
+                      y
+                      z
+                    }
+                  }:
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          y
+                          z
+                        }
+                      }
+                    },
+                  }
+                },
+              ]
+            },
+          }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_can_request_typename_in_fragment() {
+    // NOTE: There is nothing super special about __typename in theory, but because it's a field
+    // that is always available in all subghraph (for a type the subgraph has), it tends to create
+    // multiple options for the query planner, and so excercises some code-paths that triggered an
+    // early bug in the handling of `@defer`
+    // (https://github.com/apollographql/federation/issues/2128).
+    let planner = planner!(
+        config = config_with_defer(),
+          Subgraph1: r#"
+            type Query {
+              t: T
+            }
+
+            type T @key(fields: "id") {
+              id: ID!
+              x: Int
+            }
+          "#,
+          Subgraph2: r#"
+            type T @key(fields: "id") {
+              id: ID!
+              y: Int
+            }
+          "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+            {
+              t {
+                ...OnT @defer
+                x
+              }
+            }
+
+            fragment OnT on T {
+              y
+              __typename
+            }
+        "#,
+        @r###"
+          QueryPlan {
+            Defer {
+              Primary {
+                {
+                  t {
+                    x
+                  }
+                }:
+                Fetch(service: "Subgraph1", id: 0) {
+                  {
+                    t {
+                      __typename
+                      id
+                      x
+                    }
+                  }
+                }
+              }, [
+                Deferred(depends: [0], path: "t") {
+                  {
+                    ... on T {
+                      __typename
+                      y
+                    }
+                  }:
+                  Flatten(path: "t") {
+                    Fetch(service: "Subgraph2") {
+                      {
+                        ... on T {
+                          __typename
+                          id
+                        }
+                      } =>
+                      {
+                        ... on T {
+                          __typename
+                          y
+                        }
+                      }
+                    },
+                  }
+                },
+              ]
+            },
+          }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_do_not_merge_query_branches_with_defer() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            a: Int
+            b: Int
+          }
+        "#,
+        Subgraph2: r#"
+          type T @key(fields: "id") {
+            id: ID!
+            c: Int
+          }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+          {
+            t {
+              a
+              ... @defer {
+                b
+              }
+              ... @defer {
+                c
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Defer {
+            Primary {
+              {
+                t {
+                  a
+                }
+              }:
+              Fetch(service: "Subgraph1", id: 0) {
+                {
+                  t {
+                    __typename
+                    a
+                    id
+                  }
+                }
+              }
+            }, [
+              Deferred(depends: [0], path: "t") {
+                {
+                  c
+                }:
+                Flatten(path: "t") {
+                  Fetch(service: "Subgraph2") {
+                    {
+                      ... on T {
+                        __typename
+                        id
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        c
+                      }
+                    }
+                  },
+                }
+              },
+              Deferred(depends: [0], path: "t") {
+                {
+                  b
+                }:
+                Flatten(path: "t") {
+                  Fetch(service: "Subgraph1") {
+                    {
+                      ... on T {
+                        __typename
+                        id
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        b
+                      }
+                    }
+                  },
+                }
+              },
+            ]
+          },
+        }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_defer_only_the_key_of_an_entity() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+          type Query {
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            v0: String
+          }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+          {
+            t {
+              v0
+              ... @defer {
+                id
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Defer {
+            Primary {
+              {
+                t {
+                  v0
+                }
+              }:
+              Fetch(service: "Subgraph1") {
+                {
+                  t {
+                    v0
+                    id
+                  }
+                }
+              }
+            }, [
+              Deferred(depends: [], path: "t") {
+                {
+                  id
+                }:
+              },
+            ]
+          },
+        }
+        "###
+    );
+}
+
+#[test]
+fn defer_test_the_path_in_defer_includes_traversed_fragments() {
+    let planner = planner!(
+        config = config_with_defer(),
+        Subgraph1: r#"
+          type Query {
+            i: I
+          }
+
+          interface I {
+            x: Int
+          }
+
+          type A implements I {
+            x: Int
+            t: T
+          }
+
+          type T @key(fields: "id") {
+            id: ID!
+            v1: String
+            v2: String
+          }
+        "#,
+    );
+
+    assert_plan!(planner,
+        r#"
+          {
+            i {
+              ... on A {
+                t {
+                  v1
+                  ... @defer {
+                    v2
+                  }
+                }
+              }
+            }
+          }
+        "#,
+        @r###"
+        QueryPlan {
+          Defer {
+            Primary {
+              {
+                i {
+                  ... on A {
+                    t {
+                      v1
+                    }
+                  }
+                }
+              }:
+              Fetch(service: "Subgraph1", id: 0) {
+                {
+                  i {
+                    __typename
+                    ... on A {
+                      t {
+                        __typename
+                        v1
+                        id
+                      }
+                    }
+                  }
+                }
+              }
+            }, [
+              Deferred(depends: [0], path: "i/... on A/t") {
+                {
+                  v2
+                }:
+                Flatten(path: "i.t") {
+                  Fetch(service: "Subgraph1") {
+                    {
+                      ... on T {
+                        __typename
+                        id
+                      }
+                    } =>
+                    {
+                      ... on T {
+                        v2
+                      }
+                    }
+                  },
+                }
+              },
+            ]
+          },
+        }
+        "###
+    );
+}

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/subscriptions.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/subscriptions.rs
@@ -135,12 +135,7 @@ fn basic_subscription_with_single_subgraph() {
     );
 }
 
-// TODO(@TylerBloom): Currently, all defer directives are stripped out, so this does not panic
-// quite as expected. Instead, it panics because the snapshots doesn't match. Once this behavior is
-// changed, this should panic with an error along the lines of "@defer can't be used with
-// subscriptions".
 #[test]
-#[should_panic(expected = "snapshot assertion")]
 // TODO: Subscription handling
 fn trying_to_use_defer_with_a_subcription_results_in_an_error() {
     let config = QueryPlannerConfig {

--- a/apollo-federation/tests/query_plan/supergraphs/deeefer_test_defer_on_enity_but_with_unuseful_key.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/deeefer_test_defer_on_enity_but_with_unuseful_key.graphql
@@ -1,0 +1,58 @@
+# Composed from subgraphs with hash: 079b7585c6ddde9109092e87a9e6b1883fe14863
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  a: Int @join__field(graph: SUBGRAPH1)
+  b: Int @join__field(graph: SUBGRAPH1)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/deeefer_test_direct_nesting_on_entity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/deeefer_test_direct_nesting_on_entity.graphql
@@ -1,0 +1,59 @@
+# Composed from subgraphs with hash: 5979400be8ca67a267f7b19d7210a130124af873
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  me: User @join__field(graph: SUBGRAPH1)
+}
+
+type User
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  name: String @join__field(graph: SUBGRAPH1)
+  age: Int @join__field(graph: SUBGRAPH2)
+  address: String @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/deeefer_test_direct_nesting_on_value_type.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/deeefer_test_direct_nesting_on_value_type.graphql
@@ -1,0 +1,56 @@
+# Composed from subgraphs with hash: 138c8975ff5f174a024e6275a2dd306edaf9738d
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  me: User
+}
+
+type User
+  @join__type(graph: SUBGRAPH1)
+{
+  id: ID!
+  name: String
+  age: Int
+  address: String
+}

--- a/apollo-federation/tests/query_plan/supergraphs/deeefer_test_nested_defer_on_entities.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/deeefer_test_nested_defer_on_entities.graphql
@@ -1,0 +1,66 @@
+# Composed from subgraphs with hash: ffc037cbf7cb575e1c03ea0a6c7dfb21123d614c
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Message
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  body: String
+  author: User
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  me: User @join__field(graph: SUBGRAPH1)
+}
+
+type User
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  name: String @join__field(graph: SUBGRAPH1)
+  messages: [Message] @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/deefer_test_defer_on_enity_but_with_unuseful_key.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/deefer_test_defer_on_enity_but_with_unuseful_key.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 079b7585c6ddde9109092e87a9e6b1883fe14863
+# Composed from subgraphs with hash: e9d8806fbdfd92a23a7dd2af1e343ff3b6de4a7c
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/deefer_test_defer_on_enity_but_with_unuseful_key.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/deefer_test_defer_on_enity_but_with_unuseful_key.graphql
@@ -1,0 +1,58 @@
+# Composed from subgraphs with hash: 079b7585c6ddde9109092e87a9e6b1883fe14863
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  a: Int @join__field(graph: SUBGRAPH1)
+  b: Int @join__field(graph: SUBGRAPH1)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/deefer_test_direct_nesting_on_entity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/deefer_test_direct_nesting_on_entity.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 5979400be8ca67a267f7b19d7210a130124af873
+# Composed from subgraphs with hash: 355f15f0f2699fd21731b0403286c513357860d3
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/deefer_test_direct_nesting_on_entity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/deefer_test_direct_nesting_on_entity.graphql
@@ -1,0 +1,59 @@
+# Composed from subgraphs with hash: 5979400be8ca67a267f7b19d7210a130124af873
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  me: User @join__field(graph: SUBGRAPH1)
+}
+
+type User
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  name: String @join__field(graph: SUBGRAPH1)
+  age: Int @join__field(graph: SUBGRAPH2)
+  address: String @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/deefer_test_direct_nesting_on_value_type.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/deefer_test_direct_nesting_on_value_type.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 138c8975ff5f174a024e6275a2dd306edaf9738d
+# Composed from subgraphs with hash: f507628640adf8891453e78dbd4280a132706b11
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/deefer_test_direct_nesting_on_value_type.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/deefer_test_direct_nesting_on_value_type.graphql
@@ -1,0 +1,56 @@
+# Composed from subgraphs with hash: 138c8975ff5f174a024e6275a2dd306edaf9738d
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  me: User
+}
+
+type User
+  @join__type(graph: SUBGRAPH1)
+{
+  id: ID!
+  name: String
+  age: Int
+  address: String
+}

--- a/apollo-federation/tests/query_plan/supergraphs/deefer_test_multiple_non_nested_defer_plus_label_handling.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/deefer_test_multiple_non_nested_defer_plus_label_handling.graphql
@@ -1,0 +1,71 @@
+# Composed from subgraphs with hash: 4f34d97066066e236d3289e49357b55e3eb8980f
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+  SUBGRAPH3 @join__graph(name: "Subgraph3", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__type(graph: SUBGRAPH3)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v0: String @join__field(graph: SUBGRAPH1)
+  v1: String @join__field(graph: SUBGRAPH1)
+  v2: String @join__field(graph: SUBGRAPH2)
+  v3: U @join__field(graph: SUBGRAPH2)
+}
+
+type U
+  @join__type(graph: SUBGRAPH2, key: "id")
+  @join__type(graph: SUBGRAPH3, key: "id")
+{
+  id: ID!
+  x: Int @join__field(graph: SUBGRAPH3)
+  y: Int @join__field(graph: SUBGRAPH3)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/deefer_test_nested_defer_on_entities.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/deefer_test_nested_defer_on_entities.graphql
@@ -1,0 +1,66 @@
+# Composed from subgraphs with hash: ffc037cbf7cb575e1c03ea0a6c7dfb21123d614c
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Message
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  body: String
+  author: User
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  me: User @join__field(graph: SUBGRAPH1)
+}
+
+type User
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  name: String @join__field(graph: SUBGRAPH1)
+  messages: [Message] @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/deefer_test_nested_defer_on_entities.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/deefer_test_nested_defer_on_entities.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: ffc037cbf7cb575e1c03ea0a6c7dfb21123d614c
+# Composed from subgraphs with hash: 1ddb9374f772bf962933f20e08543315e8df2b01
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_can_request_typename_in_fragment.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_can_request_typename_in_fragment.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 3f43c5bf1334fdeb2dc5c48116efb1f7e00634b2
+# Composed from subgraphs with hash: e2543fc649c80a566b573ebfad36fc0f7458a3a4
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_can_request_typename_in_fragment.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_can_request_typename_in_fragment.graphql
@@ -1,0 +1,58 @@
+# Composed from subgraphs with hash: 3f43c5bf1334fdeb2dc5c48116efb1f7e00634b2
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  x: Int @join__field(graph: SUBGRAPH1)
+  y: Int @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_everything_within_entity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_everything_within_entity.graphql
@@ -1,0 +1,58 @@
+# Composed from subgraphs with hash: b938f791cf52076a8b5dc7194bed37f96c46d389
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  x: Int @join__field(graph: SUBGRAPH1)
+  y: Int @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_everything_within_entity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_everything_within_entity.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: b938f791cf52076a8b5dc7194bed37f96c46d389
+# Composed from subgraphs with hash: 428d657ed6389527be73c6ad949cd2fc4da01b20
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_multiple_fields_in_different_subgraphs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_multiple_fields_in_different_subgraphs.graphql
@@ -1,0 +1,63 @@
+# Composed from subgraphs with hash: 86e8219ff327f6972a829eb0c8c3ee477110094f
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+  SUBGRAPH3 @join__graph(name: "Subgraph3", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__type(graph: SUBGRAPH3)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+  @join__type(graph: SUBGRAPH3, key: "id")
+{
+  id: ID!
+  v0: String @join__field(graph: SUBGRAPH1)
+  v1: String @join__field(graph: SUBGRAPH1)
+  v2: String @join__field(graph: SUBGRAPH2)
+  v3: String @join__field(graph: SUBGRAPH3)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_multiple_fields_in_different_subgraphs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_multiple_fields_in_different_subgraphs.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 86e8219ff327f6972a829eb0c8c3ee477110094f
+# Composed from subgraphs with hash: 6de814e8aeb455e136ac8627284d67ef4806de57
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_enity_but_with_unuseful_key.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_enity_but_with_unuseful_key.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 079b7585c6ddde9109092e87a9e6b1883fe14863
+# Composed from subgraphs with hash: e9d8806fbdfd92a23a7dd2af1e343ff3b6de4a7c
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_enity_but_with_unuseful_key.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_enity_but_with_unuseful_key.graphql
@@ -1,0 +1,58 @@
+# Composed from subgraphs with hash: 079b7585c6ddde9109092e87a9e6b1883fe14863
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  a: Int @join__field(graph: SUBGRAPH1)
+  b: Int @join__field(graph: SUBGRAPH1)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_everything_queried.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_everything_queried.graphql
@@ -1,0 +1,58 @@
+# Composed from subgraphs with hash: b938f791cf52076a8b5dc7194bed37f96c46d389
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  x: Int @join__field(graph: SUBGRAPH1)
+  y: Int @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_everything_queried.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_everything_queried.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: b938f791cf52076a8b5dc7194bed37f96c46d389
+# Composed from subgraphs with hash: 428d657ed6389527be73c6ad949cd2fc4da01b20
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_multi_dependency_deferred_section.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_multi_dependency_deferred_section.graphql
@@ -1,0 +1,70 @@
+# Composed from subgraphs with hash: 5bce5567a6a673f3cf1cc4e38b4b1bc331d331aa
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+  SUBGRAPH3 @join__graph(name: "Subgraph3", url: "none")
+  SUBGRAPH4 @join__graph(name: "Subgraph4", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__type(graph: SUBGRAPH3)
+  @join__type(graph: SUBGRAPH4)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id0")
+  @join__type(graph: SUBGRAPH2, key: "id0")
+  @join__type(graph: SUBGRAPH2, key: "id1")
+  @join__type(graph: SUBGRAPH3, key: "id0")
+  @join__type(graph: SUBGRAPH3, key: "id2")
+  @join__type(graph: SUBGRAPH4, key: "id1 id2")
+{
+  id0: ID! @join__field(graph: SUBGRAPH1) @join__field(graph: SUBGRAPH2) @join__field(graph: SUBGRAPH3)
+  v1: Int @join__field(graph: SUBGRAPH1)
+  id1: ID! @join__field(graph: SUBGRAPH2) @join__field(graph: SUBGRAPH4)
+  v2: Int @join__field(graph: SUBGRAPH2)
+  id2: ID! @join__field(graph: SUBGRAPH3) @join__field(graph: SUBGRAPH4)
+  v3: Int @join__field(graph: SUBGRAPH3)
+  v4: Int @join__field(graph: SUBGRAPH4)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_multi_dependency_deferred_section.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_multi_dependency_deferred_section.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 5bce5567a6a673f3cf1cc4e38b4b1bc331d331aa
+# Composed from subgraphs with hash: cb3bc5e47277ef2c4a364fa62067cfc2426974ec
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_mutation_in_same_subgraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_mutation_in_same_subgraph.graphql
@@ -1,15 +1,17 @@
-# Composed from subgraphs with hash: ef4c9ccbc6416e11d78e40f3944fe80d97840d46
+# Composed from subgraphs with hash: e33e3ea89ff4340ccd53321764ac7f1a2684eb3f
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
   mutation: Mutation
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -20,6 +22,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_mutation_in_same_subgraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_mutation_in_same_subgraph.graphql
@@ -1,0 +1,67 @@
+# Composed from subgraphs with hash: ef4c9ccbc6416e11d78e40f3944fe80d97840d46
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+  mutation: Mutation
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Mutation
+  @join__type(graph: SUBGRAPH1)
+{
+  update1: T
+  update2: T
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v0: String @join__field(graph: SUBGRAPH1)
+  v1: String @join__field(graph: SUBGRAPH1)
+  v2: String @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_mutation_on_different_subgraphs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_mutation_on_different_subgraphs.graphql
@@ -1,15 +1,17 @@
-# Composed from subgraphs with hash: 763458a66d45cefeb74c579054b92eb939e8d4a4
+# Composed from subgraphs with hash: 557c634741b7e9f2f4288edb43724e47f1983d19
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
   mutation: Mutation
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -20,6 +22,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_mutation_on_different_subgraphs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_mutation_on_different_subgraphs.graphql
@@ -1,0 +1,68 @@
+# Composed from subgraphs with hash: 763458a66d45cefeb74c579054b92eb939e8d4a4
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+  mutation: Mutation
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Mutation
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  update1: T @join__field(graph: SUBGRAPH1)
+  update2: T @join__field(graph: SUBGRAPH2)
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v0: String @join__field(graph: SUBGRAPH1)
+  v1: String @join__field(graph: SUBGRAPH1)
+  v2: String @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_query_root_type.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_query_root_type.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 0275722ce9d00c8ddda80f6392ecfda9e57f4650
+# Composed from subgraphs with hash: 0a1dc62b0c2282030c10f0e0f777f635d6abd3ba
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -27,6 +29,8 @@ type A
   y: Int
   next: Query
 }
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_query_root_type.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_query_root_type.graphql
@@ -1,0 +1,60 @@
+# Composed from subgraphs with hash: 0275722ce9d00c8ddda80f6392ecfda9e57f4650
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type A
+  @join__type(graph: SUBGRAPH1)
+{
+  x: Int
+  y: Int
+  next: Query
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  op1: Int @join__field(graph: SUBGRAPH1)
+  op2: A @join__field(graph: SUBGRAPH1)
+  op3: Int @join__field(graph: SUBGRAPH2)
+  op4: Int @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_value_types.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_value_types.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 56b984ccb2f5103cf48c928fa6dbfdf6241d246f
+# Composed from subgraphs with hash: 01170823ab6c07812976d0983a101d49a319af5c
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_value_types.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_on_value_types.graphql
@@ -1,0 +1,72 @@
+# Composed from subgraphs with hash: 56b984ccb2f5103cf48c928fa6dbfdf6241d246f
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Message
+  @join__type(graph: SUBGRAPH2)
+{
+  id: ID!
+  body: MessageBody
+}
+
+type MessageBody
+  @join__type(graph: SUBGRAPH2)
+{
+  paragraphs: [String]
+  lines: Int
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  me: User @join__field(graph: SUBGRAPH1)
+}
+
+type User
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  name: String @join__field(graph: SUBGRAPH1)
+  messages: [Message] @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_only_the_key_of_an_entity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_only_the_key_of_an_entity.graphql
@@ -1,0 +1,54 @@
+# Composed from subgraphs with hash: 090e8054d9b700d46d4398935e6a6965da147637
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  t: T
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  v0: String
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_only_the_key_of_an_entity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_only_the_key_of_an_entity.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 090e8054d9b700d46d4398935e6a6965da147637
+# Composed from subgraphs with hash: 176bb27a622184464209652e70141da92aeef370
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_resuming_in_the_same_subgraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_resuming_in_the_same_subgraph.graphql
@@ -1,0 +1,55 @@
+# Composed from subgraphs with hash: 51e4835a55ada9c462934404353a737345678355
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  t: T
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  v0: String
+  v1: String
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_resuming_in_the_same_subgraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_resuming_in_the_same_subgraph.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 51e4835a55ada9c462934404353a737345678355
+# Composed from subgraphs with hash: 0e99f2e41acb0f707744e78845a55271589146e6
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_condition_on_single_subgraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_condition_on_single_subgraph.graphql
@@ -1,0 +1,55 @@
+# Composed from subgraphs with hash: 3ab23a19c1a9ce9f1d4cd5199feffa7cee599de4
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  t: T
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  x: Int
+  y: Int
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_condition_on_single_subgraph.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_condition_on_single_subgraph.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 3ab23a19c1a9ce9f1d4cd5199feffa7cee599de4
+# Composed from subgraphs with hash: 59e305d633b6e337422f6431c32cc58defa07302
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_conditions_and_labels.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_conditions_and_labels.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 3f43c5bf1334fdeb2dc5c48116efb1f7e00634b2
+# Composed from subgraphs with hash: e2543fc649c80a566b573ebfad36fc0f7458a3a4
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_conditions_and_labels.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_conditions_and_labels.graphql
@@ -1,0 +1,58 @@
+# Composed from subgraphs with hash: 3f43c5bf1334fdeb2dc5c48116efb1f7e00634b2
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  x: Int @join__field(graph: SUBGRAPH1)
+  y: Int @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_mutliple_conditions_and_labels.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_mutliple_conditions_and_labels.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 3809c6d4285c16cff3f6b1a387f5fd8ec68ba568
+# Composed from subgraphs with hash: 2135cbed03439b8658c0113e4663849c991e244b
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_mutliple_conditions_and_labels.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_defer_with_mutliple_conditions_and_labels.graphql
@@ -1,0 +1,70 @@
+# Composed from subgraphs with hash: 3809c6d4285c16cff3f6b1a387f5fd8ec68ba568
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+  SUBGRAPH3 @join__graph(name: "Subgraph3", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__type(graph: SUBGRAPH3)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  x: Int @join__field(graph: SUBGRAPH1)
+  u: U @join__field(graph: SUBGRAPH1)
+  y: Int @join__field(graph: SUBGRAPH2)
+}
+
+type U
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH3, key: "id")
+{
+  id: ID!
+  a: Int @join__field(graph: SUBGRAPH1)
+  b: Int @join__field(graph: SUBGRAPH3)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_direct_nesting_on_entity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_direct_nesting_on_entity.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 5979400be8ca67a267f7b19d7210a130124af873
+# Composed from subgraphs with hash: 355f15f0f2699fd21731b0403286c513357860d3
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_direct_nesting_on_entity.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_direct_nesting_on_entity.graphql
@@ -1,0 +1,59 @@
+# Composed from subgraphs with hash: 5979400be8ca67a267f7b19d7210a130124af873
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  me: User @join__field(graph: SUBGRAPH1)
+}
+
+type User
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  name: String @join__field(graph: SUBGRAPH1)
+  age: Int @join__field(graph: SUBGRAPH2)
+  address: String @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_direct_nesting_on_value_type.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_direct_nesting_on_value_type.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 138c8975ff5f174a024e6275a2dd306edaf9738d
+# Composed from subgraphs with hash: f507628640adf8891453e78dbd4280a132706b11
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_direct_nesting_on_value_type.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_direct_nesting_on_value_type.graphql
@@ -1,0 +1,56 @@
+# Composed from subgraphs with hash: 138c8975ff5f174a024e6275a2dd306edaf9738d
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  me: User
+}
+
+type User
+  @join__type(graph: SUBGRAPH1)
+{
+  id: ID!
+  name: String
+  age: Int
+  address: String
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_do_not_merge_query_branches_with_defer.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_do_not_merge_query_branches_with_defer.graphql
@@ -1,0 +1,59 @@
+# Composed from subgraphs with hash: 313c26ad59da24d6aec7c376cf2eb527f8a3928f
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  a: Int @join__field(graph: SUBGRAPH1)
+  b: Int @join__field(graph: SUBGRAPH1)
+  c: Int @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_do_not_merge_query_branches_with_defer.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_do_not_merge_query_branches_with_defer.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 313c26ad59da24d6aec7c376cf2eb527f8a3928f
+# Composed from subgraphs with hash: 6af2331e8c3844fbee6c3888b80b44f51cd5bd3d
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_fragments_expand_into_same_field_regardless_of_defer.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_fragments_expand_into_same_field_regardless_of_defer.graphql
@@ -1,0 +1,59 @@
+# Composed from subgraphs with hash: e92ed2faf488321da56461f4f352baf63ae35eaf
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  x: Int @join__field(graph: SUBGRAPH2)
+  y: Int @join__field(graph: SUBGRAPH2)
+  z: Int @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_fragments_expand_into_same_field_regardless_of_defer.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_fragments_expand_into_same_field_regardless_of_defer.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: e92ed2faf488321da56461f4f352baf63ae35eaf
+# Composed from subgraphs with hash: 5382aae137e16d1dfb9955e2a5118b49c75320ea
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_handles_simple_defer.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_handles_simple_defer.graphql
@@ -1,0 +1,58 @@
+# Composed from subgraphs with hash: 012996ded628bc66cae7576d019a76e0088a53d4
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v1: Int @join__field(graph: SUBGRAPH2)
+  v2: Int @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_handles_simple_defer_with_defer_enabled.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_handles_simple_defer_with_defer_enabled.graphql
@@ -1,0 +1,58 @@
+# Composed from subgraphs with hash: 012996ded628bc66cae7576d019a76e0088a53d4
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v1: Int @join__field(graph: SUBGRAPH2)
+  v2: Int @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_handles_simple_defer_with_defer_enabled.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_handles_simple_defer_with_defer_enabled.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 012996ded628bc66cae7576d019a76e0088a53d4
+# Composed from subgraphs with hash: f7c59d88291d4be94f4c484dc849118a08361e69
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_handles_simple_defer_without_defer_enabled.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_handles_simple_defer_without_defer_enabled.graphql
@@ -1,0 +1,58 @@
+# Composed from subgraphs with hash: 012996ded628bc66cae7576d019a76e0088a53d4
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v1: Int @join__field(graph: SUBGRAPH2)
+  v2: Int @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_handles_simple_defer_without_defer_enabled.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_handles_simple_defer_without_defer_enabled.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 012996ded628bc66cae7576d019a76e0088a53d4
+# Composed from subgraphs with hash: f7c59d88291d4be94f4c484dc849118a08361e69
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_interface_has_different_definitions_between_subgraphs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_interface_has_different_definitions_between_subgraphs.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: ae77e3f82782908c6b570a784b30bb2e13fa19ef
+# Composed from subgraphs with hash: d280d3aae78ad7080c8df8b5a8982d70a4000a78
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -28,6 +30,8 @@ interface I
   c: Int @join__field(graph: SUBGRAPH1)
   b: Int @join__field(graph: SUBGRAPH2)
 }
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_interface_has_different_definitions_between_subgraphs.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_interface_has_different_definitions_between_subgraphs.graphql
@@ -1,0 +1,70 @@
+# Composed from subgraphs with hash: ae77e3f82782908c6b570a784b30bb2e13fa19ef
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+interface I
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  a: Int @join__field(graph: SUBGRAPH1)
+  c: Int @join__field(graph: SUBGRAPH1)
+  b: Int @join__field(graph: SUBGRAPH2)
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  i: I @join__field(graph: SUBGRAPH1)
+}
+
+type T implements I
+  @join__implements(graph: SUBGRAPH1, interface: "I")
+  @join__implements(graph: SUBGRAPH2, interface: "I")
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  a: Int @join__field(graph: SUBGRAPH1) @join__field(graph: SUBGRAPH2, external: true)
+  c: Int @join__field(graph: SUBGRAPH1)
+  b: Int @join__field(graph: SUBGRAPH2, requires: "a")
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_multiple_non_nested_defer_plus_label_handling.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_multiple_non_nested_defer_plus_label_handling.graphql
@@ -1,0 +1,71 @@
+# Composed from subgraphs with hash: 4f34d97066066e236d3289e49357b55e3eb8980f
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+  SUBGRAPH3 @join__graph(name: "Subgraph3", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__type(graph: SUBGRAPH3)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v0: String @join__field(graph: SUBGRAPH1)
+  v1: String @join__field(graph: SUBGRAPH1)
+  v2: String @join__field(graph: SUBGRAPH2)
+  v3: U @join__field(graph: SUBGRAPH2)
+}
+
+type U
+  @join__type(graph: SUBGRAPH2, key: "id")
+  @join__type(graph: SUBGRAPH3, key: "id")
+{
+  id: ID!
+  x: Int @join__field(graph: SUBGRAPH3)
+  y: Int @join__field(graph: SUBGRAPH3)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_multiple_non_nested_defer_plus_label_handling.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_multiple_non_nested_defer_plus_label_handling.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 4f34d97066066e236d3289e49357b55e3eb8980f
+# Composed from subgraphs with hash: 09643fc5e0d3abcab8a0f25c0c1e4e16da4169a4
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_multiple_non_nested_defer_plus_lable_handling.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_multiple_non_nested_defer_plus_lable_handling.graphql
@@ -1,0 +1,71 @@
+# Composed from subgraphs with hash: 4f34d97066066e236d3289e49357b55e3eb8980f
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+  SUBGRAPH3 @join__graph(name: "Subgraph3", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__type(graph: SUBGRAPH3)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v0: String @join__field(graph: SUBGRAPH1)
+  v1: String @join__field(graph: SUBGRAPH1)
+  v2: String @join__field(graph: SUBGRAPH2)
+  v3: U @join__field(graph: SUBGRAPH2)
+}
+
+type U
+  @join__type(graph: SUBGRAPH2, key: "id")
+  @join__type(graph: SUBGRAPH3, key: "id")
+{
+  id: ID!
+  x: Int @join__field(graph: SUBGRAPH3)
+  y: Int @join__field(graph: SUBGRAPH3)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_named_fragments_simple.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_named_fragments_simple.graphql
@@ -1,0 +1,58 @@
+# Composed from subgraphs with hash: a3c177c8d17b3c08462113dee311feb0624b4439
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  x: Int @join__field(graph: SUBGRAPH2)
+  y: Int @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_named_fragments_simple.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_named_fragments_simple.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: a3c177c8d17b3c08462113dee311feb0624b4439
+# Composed from subgraphs with hash: 395eb0d8e844d7a54e82eec772f007fafcc37a8e
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_nested_defer_on_entities.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_nested_defer_on_entities.graphql
@@ -1,0 +1,66 @@
+# Composed from subgraphs with hash: ffc037cbf7cb575e1c03ea0a6c7dfb21123d614c
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Message
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  body: String
+  author: User
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  me: User @join__field(graph: SUBGRAPH1)
+}
+
+type User
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  name: String @join__field(graph: SUBGRAPH1)
+  messages: [Message] @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_nested_defer_on_entities.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_nested_defer_on_entities.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: ffc037cbf7cb575e1c03ea0a6c7dfb21123d614c
+# Composed from subgraphs with hash: 1ddb9374f772bf962933f20e08543315e8df2b01
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_non_router_based_defer.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_non_router_based_defer.graphql
@@ -1,0 +1,64 @@
+# Composed from subgraphs with hash: fdeeffa7aad20c2243c5218ca0c9a52df8f87b4a
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v: V @join__field(graph: SUBGRAPH2)
+}
+
+type V
+  @join__type(graph: SUBGRAPH2)
+{
+  a: Int
+  b: Int
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_non_router_based_defer.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_non_router_based_defer.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: fdeeffa7aad20c2243c5218ca0c9a52df8f87b4a
+# Composed from subgraphs with hash: 3bee990c996344aa1eb3a7211e3f497fcbe5e1a6
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_provides_are_ignored_for_deferred_fields.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_provides_are_ignored_for_deferred_fields.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 1a9d22f5cfc127a78164880a230d7ce7c5f85294
+# Composed from subgraphs with hash: 39be4a27050623ad7a03d8ae9fed684d1e0f3088
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_provides_are_ignored_for_deferred_fields.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_provides_are_ignored_for_deferred_fields.graphql
@@ -1,0 +1,58 @@
+# Composed from subgraphs with hash: 1a9d22f5cfc127a78164880a230d7ce7c5f85294
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1, provides: "v2")
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v1: Int @join__field(graph: SUBGRAPH1)
+  v2: Int @join__field(graph: SUBGRAPH1, external: true) @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_requirements_of_deferred_fields_are_deferred.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_requirements_of_deferred_fields_are_deferred.graphql
@@ -1,0 +1,62 @@
+# Composed from subgraphs with hash: 066f8fc43d90115b81744ef6902cac4ea9c5fee1
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+  SUBGRAPH3 @join__graph(name: "Subgraph3", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+  @join__type(graph: SUBGRAPH3)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+  @join__type(graph: SUBGRAPH3, key: "id")
+{
+  id: ID!
+  v1: Int @join__field(graph: SUBGRAPH1)
+  v2: Int @join__field(graph: SUBGRAPH2, requires: "v3")
+  v3: Int @join__field(graph: SUBGRAPH2, external: true) @join__field(graph: SUBGRAPH3)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_requirements_of_deferred_fields_are_deferred.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_requirements_of_deferred_fields_are_deferred.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 066f8fc43d90115b81744ef6902cac4ea9c5fee1
+# Composed from subgraphs with hash: b3f138a89fd35476e9e36002ae4c8c1ab51c4530
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -19,6 +21,8 @@ directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boole
 directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_the_path_in_defer_includes_traversed_fragments.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_the_path_in_defer_includes_traversed_fragments.graphql
@@ -1,0 +1,69 @@
+# Composed from subgraphs with hash: 1c8bef4da4392729d2fc688b1ae91139b88747e9
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type A implements I
+  @join__implements(graph: SUBGRAPH1, interface: "I")
+  @join__type(graph: SUBGRAPH1)
+{
+  x: Int
+  t: T
+}
+
+interface I
+  @join__type(graph: SUBGRAPH1)
+{
+  x: Int
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  i: I
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+  v1: String
+  v2: String
+}

--- a/apollo-federation/tests/query_plan/supergraphs/defer_test_the_path_in_defer_includes_traversed_fragments.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/defer_test_the_path_in_defer_includes_traversed_fragments.graphql
@@ -1,14 +1,16 @@
-# Composed from subgraphs with hash: 1c8bef4da4392729d2fc688b1ae91139b88747e9
+# Composed from subgraphs with hash: eea1ddd3f3e944aaeb5f39f8f9018fd32bcdaaf6
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
-  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
 {
   query: Query
 }
 
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
 directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
-directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
 directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
@@ -33,6 +35,8 @@ interface I
 {
   x: Int
 }
+
+scalar join__DirectiveArguments
 
 scalar join__FieldSet
 

--- a/apollo-federation/tests/query_plan/supergraphs/handles_simple_defer.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_simple_defer.graphql
@@ -1,0 +1,58 @@
+# Composed from subgraphs with hash: 012996ded628bc66cae7576d019a76e0088a53d4
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v1: Int @join__field(graph: SUBGRAPH2)
+  v2: Int @join__field(graph: SUBGRAPH2)
+}

--- a/apollo-federation/tests/query_plan/supergraphs/handles_simple_defer_without_defer_enabled.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/handles_simple_defer_without_defer_enabled.graphql
@@ -1,0 +1,58 @@
+# Composed from subgraphs with hash: 012996ded628bc66cae7576d019a76e0088a53d4
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+  SUBGRAPH2 @join__graph(name: "Subgraph2", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+  @join__type(graph: SUBGRAPH2)
+{
+  t: T @join__field(graph: SUBGRAPH1)
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+  @join__type(graph: SUBGRAPH2, key: "id")
+{
+  id: ID!
+  v1: Int @join__field(graph: SUBGRAPH2)
+  v2: Int @join__field(graph: SUBGRAPH2)
+}


### PR DESCRIPTION
Implemented support for `@defer` in the QP.

<!-- start metadata [ROUTER-527](https://apollographql.atlassian.net/browse/ROUTER-527) -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
