### PR TITLE
updated `non_trivial_followup_edges` to use `Vec`, instead of IndexSet

### DIFF
--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -1968,13 +1968,9 @@ impl FederatedQueryGraphBuilder {
         for edge in self.base.query_graph.graph.edge_indices() {
             let edge_weight = self.base.query_graph.edge_weight(edge)?;
             let (_, tail) = self.base.query_graph.edge_endpoints(edge)?;
-            let mut non_trivial_followups = IndexSet::default();
-            for followup_edge_ref in self
-                .base
-                .query_graph
-                .graph
-                .edges_directed(tail, Direction::Outgoing)
-            {
+            let out_edges = self.base.query_graph.out_edges(tail);
+            let mut non_trivial_followups = Vec::with_capacity(out_edges.len());
+            for followup_edge_ref in out_edges {
                 let followup_edge_weight = followup_edge_ref.weight();
                 match edge_weight.transition {
                     QueryGraphEdgeTransition::KeyResolution => {
@@ -2035,7 +2031,7 @@ impl FederatedQueryGraphBuilder {
                     }
                     _ => {}
                 }
-                non_trivial_followups.insert(followup_edge_ref.id());
+                non_trivial_followups.push(followup_edge_ref.id());
             }
             self.base
                 .query_graph

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -355,7 +355,7 @@ pub struct QueryGraph {
     /// significantly faster (and pretty easy). FWIW, when originally introduced, this optimization
     /// lowered composition validation on a big composition (100+ subgraphs) from ~4 minutes to
     /// ~10 seconds.
-    non_trivial_followup_edges: IndexMap<EdgeIndex, IndexSet<EdgeIndex>>,
+    non_trivial_followup_edges: IndexMap<EdgeIndex, Vec<EdgeIndex>>,
 }
 
 impl QueryGraph {
@@ -528,7 +528,7 @@ impl QueryGraph {
             })
     }
 
-    pub(crate) fn non_trivial_followup_edges(&self) -> &IndexMap<EdgeIndex, IndexSet<EdgeIndex>> {
+    pub(crate) fn non_trivial_followup_edges(&self) -> &IndexMap<EdgeIndex, Vec<EdgeIndex>> {
         &self.non_trivial_followup_edges
     }
 

--- a/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/interface_object.rs
@@ -790,7 +790,7 @@ fn it_handles_interface_object_input_rewrites_when_cloning_dependency_graph() {
             },
             Parallel {
               Flatten(path: "i.i2") {
-                Fetch(service: "S4") {
+                Fetch(service: "S3") {
                   {
                     ... on T {
                       __typename


### PR DESCRIPTION
### Background
`SimultaneousPathsWithLazyIndirectPaths::indirect_options` function acts as a tie-breaker when two options lead to the same plan costs, since the first one beats the others. Thus, the ordering of its return value gets to determine the shape of query plan in certain cases.

`indirect_options` calls `advance_with_non_collecting_and_type_preserving_transitions`, which in turn calls `GraphPath::next_edges`. In most cases, the `next_edges` method returns the `non_trivial_followup_edges` struct's value. The `non_trivial_followup_edges` stores its value in `IndexSet<EdgeIndex>` and its `iter()` method preserves its insertion order. Therefore, the ordering eventually depends on the order in which the set was constructed.

The `non_trivial_followup_edges` struct is constructed in the `precompute_non_trivial_followup_edges` function. Previously, it used `<QueryGraph>.graph.edges_directed()` to enumerate edges to insert into the struct. The `edges_directed()` method is known to return in an arbitrary order, while JS QP enumerates edges in the insertion order. That was the source of discrepancies.

### Solution
In JS QP, the corresponding implementation of `precompute_non_trivial_followup_edges` uses `QueryGraph.outEdges()` method to iterate edges. And the Rust QP has the corresponding `QueryGraph::out_edges` method, which sorts the edges to behave more like JS QP (and its comments describe the ordering issue in detail). Thus, using `out_edges`, instead of Petgraph's `edges_directed`, seemed the right thing here. After these changes, Rust QP code follows more closely to JS QP's.

Along with that,`non_trivial_followup_edges` struct is changed to use `Vec`, instead `IndexSet`. Since `precompute_non_trivial_followup_edges` won't visit the same edges twice, we don't need a "set" to remove duplicates. Also, since the capacity of `Vec` can be determined at the beginning, its construction won't cause any re-allocations.

(BTW, I was surprised that `IndexSet::iter()` iterates in the insertion order, not value order. I was expecting it to behave like C++'s `ordered_set`.)

### Alternative solution tried
I've applied `iter().rev()` on the `IndexSet<EdgeIndex>`, which also reduced a lot of mismatches. But, I don't think it will be exactly the same as JS QP.

### Test plan
One existing integration test changed, showing the different choice of subgraph.

I'm running the patch over the corpus to confirm its effect. I'll update once the run finishes.

<!-- [ROUTER-666] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests


[ROUTER-666]: https://apollographql.atlassian.net/browse/ROUTER-666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ