### PR TITLE
Fix introspection `deprecationReason` field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,9 +159,9 @@ checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "apollo-compiler"
-version = "1.0.0-beta.23"
+version = "1.0.0-beta.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875f39060728ac3e775fc3fe5421225d6df92c4d5155a9524cdb198f05006d36"
+checksum = "71153ad85c85f7aa63f0e0a5868912c220bb48e4c764556f5841d37fc17b0103"
 dependencies = [
  "ahash",
  "apollo-parser",
@@ -448,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-smith"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40cff1a5989a471714cfdf53f24d0948b7f77631ab3dbd25b2f6eacbf58e5261"
+checksum = "d89479524886fdbe62b124d3825879778680e0147304d1a6d32164418f8089a2"
 dependencies = [
  "apollo-compiler",
  "apollo-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,9 @@ debug = 1
 # Dependencies used in more than one place are specified here in order to keep versions in sync:
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
 [workspace.dependencies]
-apollo-compiler = "=1.0.0-beta.23"
+apollo-compiler = "=1.0.0-beta.24"
 apollo-parser = "0.8.0"
-apollo-smith = "0.13.0"
+apollo-smith = "0.14.0"
 async-trait = "0.1.77"
 hex = { version = "0.4.3", features = ["serde"] }
 http = "0.2.11"

--- a/apollo-federation/src/link/argument.rs
+++ b/apollo-federation/src/link/argument.rs
@@ -13,7 +13,7 @@ pub(crate) fn directive_optional_enum_argument(
     application: &Node<Directive>,
     name: &Name,
 ) -> Result<Option<Name>, FederationError> {
-    match application.argument_by_name(name) {
+    match application.specified_argument_by_name(name) {
         Some(value) => match value.deref() {
             Value::Enum(name) => Ok(Some(name.clone())),
             Value::Null => Ok(None),
@@ -48,7 +48,7 @@ pub(crate) fn directive_optional_string_argument<'doc>(
     application: &'doc Node<Directive>,
     name: &Name,
 ) -> Result<Option<&'doc str>, FederationError> {
-    match application.argument_by_name(name) {
+    match application.specified_argument_by_name(name) {
         Some(value) => match value.deref() {
             Value::String(name) => Ok(Some(name)),
             Value::Null => Ok(None),
@@ -83,7 +83,7 @@ pub(crate) fn directive_optional_boolean_argument(
     application: &Node<Directive>,
     name: &Name,
 ) -> Result<Option<bool>, FederationError> {
-    match application.argument_by_name(name) {
+    match application.specified_argument_by_name(name) {
         Some(value) => match value.deref() {
             Value::Boolean(value) => Ok(Some(*value)),
             Value::Null => Ok(None),
@@ -119,7 +119,7 @@ pub(crate) fn directive_optional_variable_boolean_argument(
     application: &Node<Directive>,
     name: &Name,
 ) -> Result<Option<BooleanOrVariable>, FederationError> {
-    match application.argument_by_name(name) {
+    match application.specified_argument_by_name(name) {
         Some(value) => match value.deref() {
             Value::Variable(name) => Ok(Some(BooleanOrVariable::Variable(name.clone()))),
             Value::Boolean(value) => Ok(Some(BooleanOrVariable::Boolean(*value))),

--- a/apollo-federation/src/link/database.rs
+++ b/apollo-federation/src/link/database.rs
@@ -33,10 +33,10 @@ pub fn links_metadata(schema: &Schema) -> Result<Option<LinksMetadata>, LinkErro
         return Err(LinkError::BootstrapError(format!(
             "the @link specification itself (\"{}\") is applied multiple times",
             extraneous_directive
-                .argument_by_name("url")
+                .specified_argument_by_name("url")
                 // XXX(@goto-bus-stop): @core compatibility is primarily to support old tests in other projects,
                 // and should be removed when those are updated.
-                .or(extraneous_directive.argument_by_name("feature"))
+                .or(extraneous_directive.specified_argument_by_name("feature"))
                 .and_then(|value| value.as_str().map(Cow::Borrowed))
                 .unwrap_or_else(|| Cow::Owned(Identity::link_identity().to_string()))
         )));
@@ -184,13 +184,13 @@ fn is_bootstrap_directive(schema: &Schema, directive: &Directive) -> bool {
     };
     if is_link_directive_definition(definition) {
         if let Some(url) = directive
-            .argument_by_name("url")
+            .specified_argument_by_name("url")
             .and_then(|value| value.as_str())
         {
             let url = url.parse::<Url>();
             let default_link_name = DEFAULT_LINK_NAME;
             let expected_name = directive
-                .argument_by_name("as")
+                .specified_argument_by_name("as")
                 .and_then(|value| value.as_str())
                 .unwrap_or(default_link_name.as_str());
             return url.map_or(false, |url| {
@@ -201,12 +201,12 @@ fn is_bootstrap_directive(schema: &Schema, directive: &Directive) -> bool {
         // XXX(@goto-bus-stop): @core compatibility is primarily to support old tests--should be
         // removed when those are updated.
         if let Some(url) = directive
-            .argument_by_name("feature")
+            .specified_argument_by_name("feature")
             .and_then(|value| value.as_str())
         {
             let url = url.parse::<Url>();
             let expected_name = directive
-                .argument_by_name("as")
+                .specified_argument_by_name("as")
                 .and_then(|value| value.as_str())
                 .unwrap_or("core");
             return url.map_or(false, |url| {

--- a/apollo-federation/src/link/mod.rs
+++ b/apollo-federation/src/link/mod.rs
@@ -275,9 +275,9 @@ impl Link {
     }
 
     pub fn from_directive_application(directive: &Node<Directive>) -> Result<Link, LinkError> {
-        let (url, is_link) = if let Some(value) = directive.argument_by_name("url") {
+        let (url, is_link) = if let Some(value) = directive.specified_argument_by_name("url") {
             (value, true)
-        } else if let Some(value) = directive.argument_by_name("feature") {
+        } else if let Some(value) = directive.specified_argument_by_name("feature") {
             // XXX(@goto-bus-stop): @core compatibility is primarily to support old tests--should be
             // removed when those are updated.
             (value, false)
@@ -303,11 +303,11 @@ impl Link {
         })?;
 
         let spec_alias = directive
-            .argument_by_name("as")
+            .specified_argument_by_name("as")
             .and_then(|arg| arg.as_str())
             .map(Name::new)
             .transpose()?;
-        let purpose = if let Some(value) = directive.argument_by_name("for") {
+        let purpose = if let Some(value) = directive.specified_argument_by_name("for") {
             Some(Purpose::from_value(value)?)
         } else {
             None
@@ -315,7 +315,7 @@ impl Link {
 
         let imports = if is_link {
             directive
-                .argument_by_name("import")
+                .specified_argument_by_name("import")
                 .and_then(|arg| arg.as_list())
                 .unwrap_or(&[])
                 .iter()

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -367,7 +367,7 @@ impl OpPathElement {
         ] {
             let directive_name: &'static str = (&kind).into();
             if let Some(application) = self.directives().get(directive_name) {
-                let Some(arg) = application.argument_by_name("if") else {
+                let Some(arg) = application.specified_argument_by_name("if") else {
                     return Err(FederationError::internal(format!(
                         "@{} missing required argument \"if\"",
                         directive_name

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -906,7 +906,10 @@ impl QueryGraph {
 
         ty.directives()
             .get_all(&key_directive_definition.name)
-            .filter_map(|key| key.argument_by_name("fields").and_then(|arg| arg.as_str()))
+            .filter_map(|key| {
+                key.specified_argument_by_name("fields")
+                    .and_then(|arg| arg.as_str())
+            })
             .map(|value| parse_field_set(schema, ty.name().clone(), value))
             .find_ok(|selection| {
                 !metadata

--- a/apollo-federation/src/query_plan/conditions.rs
+++ b/apollo-federation/src/query_plan/conditions.rs
@@ -99,7 +99,7 @@ impl Conditions {
                 "skip" => true,
                 _ => continue,
             };
-            let value = directive.argument_by_name("if").ok_or_else(|| {
+            let value = directive.specified_argument_by_name("if").ok_or_else(|| {
                 FederationError::internal(format!(
                     "missing if argument on @{}",
                     if negated { "skip" } else { "include" },
@@ -346,7 +346,7 @@ fn matches_condition_for_kind(
         return false;
     }
 
-    let value = directive.argument_by_name("if");
+    let value = directive.specified_argument_by_name("if");
 
     let matches_if_negated = match kind {
         ConditionKind::Include => false,

--- a/apollo-federation/src/supergraph/mod.rs
+++ b/apollo-federation/src/supergraph/mod.rs
@@ -2242,7 +2242,7 @@ fn extract_join_directives(
 
 fn join_directive_to_real_directive(directive: &Node<Directive>) -> (Directive, Vec<Name>) {
     let subgraph_enum_values = directive
-        .argument_by_name("graphs")
+        .specified_argument_by_name("graphs")
         .and_then(|arg| arg.as_list())
         .map(|list| {
             list.iter()
@@ -2259,13 +2259,13 @@ fn join_directive_to_real_directive(directive: &Node<Directive>) -> (Directive, 
         .expect("join__directive(graphs:) missing");
 
     let name = directive
-        .argument_by_name("name")
+        .specified_argument_by_name("name")
         .expect("join__directive(name:) is present")
         .as_str()
         .expect("join__directive(name:) is a string");
 
     let arguments = directive
-        .argument_by_name("args")
+        .specified_argument_by_name("args")
         .and_then(|a| a.as_object())
         .map(|args| {
             args.iter()

--- a/apollo-router/src/plugins/authorization/policy.rs
+++ b/apollo-router/src/plugins/authorization/policy.rs
@@ -111,7 +111,7 @@ fn policy_argument(
     opt_directive: Option<&impl AsRef<ast::Directive>>,
 ) -> impl Iterator<Item = String> + '_ {
     opt_directive
-        .and_then(|directive| directive.as_ref().argument_by_name("policies"))
+        .and_then(|directive| directive.as_ref().specified_argument_by_name("policies"))
         // outer array
         .and_then(|value| value.as_list())
         .into_iter()
@@ -205,7 +205,7 @@ fn policies_sets_argument(
     directive: &ast::Directive,
 ) -> impl Iterator<Item = HashSet<String>> + '_ {
     directive
-        .argument_by_name("policies")
+        .specified_argument_by_name("policies")
         // outer array
         .and_then(|value| value.as_list())
         .into_iter()

--- a/apollo-router/src/plugins/authorization/scopes.rs
+++ b/apollo-router/src/plugins/authorization/scopes.rs
@@ -111,7 +111,7 @@ fn scopes_argument(
     opt_directive: Option<&impl AsRef<ast::Directive>>,
 ) -> impl Iterator<Item = String> + '_ {
     opt_directive
-        .and_then(|directive| directive.as_ref().argument_by_name("scopes"))
+        .and_then(|directive| directive.as_ref().specified_argument_by_name("scopes"))
         // outer array
         .and_then(|value| value.as_list())
         .into_iter()
@@ -188,7 +188,7 @@ impl<'a> traverse::Visitor for ScopeExtractionVisitor<'a> {
 
 fn scopes_sets_argument(directive: &ast::Directive) -> impl Iterator<Item = HashSet<String>> + '_ {
     directive
-        .argument_by_name("scopes")
+        .specified_argument_by_name("scopes")
         // outer array
         .and_then(|value| value.as_list())
         .into_iter()

--- a/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/directives.rs
@@ -90,7 +90,7 @@ impl CostDirective {
             .get(&COST_DIRECTIVE_NAME)
             .and_then(|name| directives.get(name))
             .or(directives.get(&COST_DIRECTIVE_DEFAULT_NAME))
-            .and_then(|cost| cost.argument_by_name(&COST_DIRECTIVE_WEIGHT_ARGUMENT_NAME))
+            .and_then(|cost| cost.specified_argument_by_name(&COST_DIRECTIVE_WEIGHT_ARGUMENT_NAME))
             .and_then(|weight| weight.to_i32())
             .map(|weight| Self { weight })
     }
@@ -103,7 +103,7 @@ impl CostDirective {
             .get(&COST_DIRECTIVE_NAME)
             .and_then(|name| directives.get(name))
             .or(directives.get(&COST_DIRECTIVE_DEFAULT_NAME))
-            .and_then(|cost| cost.argument_by_name(&COST_DIRECTIVE_WEIGHT_ARGUMENT_NAME))
+            .and_then(|cost| cost.specified_argument_by_name(&COST_DIRECTIVE_WEIGHT_ARGUMENT_NAME))
             .and_then(|weight| weight.to_i32())
             .map(|weight| Self { weight })
     }
@@ -120,7 +120,7 @@ impl IncludeDirective {
         let directive = field
             .directives
             .get("include")
-            .and_then(|skip| skip.argument_by_name("if"))
+            .and_then(|skip| skip.specified_argument_by_name("if"))
             .and_then(|arg| arg.to_bool())
             .map(|cond| Self { is_included: cond });
 
@@ -167,10 +167,10 @@ impl DefinitionListSizeDirective {
             .or(definition.directives.get(&LIST_SIZE_DIRECTIVE_DEFAULT_NAME));
         if let Some(directive) = directive {
             let assumed_size = directive
-                .argument_by_name(&LIST_SIZE_DIRECTIVE_ASSUMED_SIZE_ARGUMENT_NAME)
+                .specified_argument_by_name(&LIST_SIZE_DIRECTIVE_ASSUMED_SIZE_ARGUMENT_NAME)
                 .and_then(|arg| arg.to_i32());
             let slicing_argument_names = directive
-                .argument_by_name(&LIST_SIZE_DIRECTIVE_SLICING_ARGUMENTS_ARGUMENT_NAME)
+                .specified_argument_by_name(&LIST_SIZE_DIRECTIVE_SLICING_ARGUMENTS_ARGUMENT_NAME)
                 .and_then(|arg| arg.as_list())
                 .map(|arg_list| {
                     arg_list
@@ -180,7 +180,7 @@ impl DefinitionListSizeDirective {
                         .collect()
                 });
             let sized_fields = directive
-                .argument_by_name(&LIST_SIZE_DIRECTIVE_SIZED_FIELDS_ARGUMENT_NAME)
+                .specified_argument_by_name(&LIST_SIZE_DIRECTIVE_SIZED_FIELDS_ARGUMENT_NAME)
                 .and_then(|arg| arg.as_list())
                 .map(|arg_list| {
                     arg_list
@@ -190,7 +190,9 @@ impl DefinitionListSizeDirective {
                         .collect()
                 });
             let require_one_slicing_argument = directive
-                .argument_by_name(&LIST_SIZE_DIRECTIVE_REQUIRE_ONE_SLICING_ARGUMENT_ARGUMENT_NAME)
+                .specified_argument_by_name(
+                    &LIST_SIZE_DIRECTIVE_REQUIRE_ONE_SLICING_ARGUMENT_ARGUMENT_NAME,
+                )
                 .and_then(|arg| arg.to_bool())
                 .unwrap_or(true);
 
@@ -275,7 +277,7 @@ impl RequiresDirective {
         let requires_arg = definition
             .directives
             .get("join__field")
-            .and_then(|requires| requires.argument_by_name("requires"))
+            .and_then(|requires| requires.specified_argument_by_name("requires"))
             .and_then(|arg| arg.as_str());
 
         if let Some(arg) = requires_arg {
@@ -302,7 +304,7 @@ impl SkipDirective {
         let directive = field
             .directives
             .get("skip")
-            .and_then(|skip| skip.argument_by_name("if"))
+            .and_then(|skip| skip.specified_argument_by_name("if"))
             .and_then(|arg| arg.to_bool())
             .map(|cond| Self { is_skipped: cond });
 

--- a/apollo-router/src/plugins/progressive_override/mod.rs
+++ b/apollo-router/src/plugins/progressive_override/mod.rs
@@ -91,7 +91,7 @@ fn collect_labels_from_schema(schema: &Schema) -> LabelsFromSchema {
         .flatten()
         .filter_map(|join_directive| {
             if let Some(override_label_arg) =
-                join_directive.argument_by_name(OVERRIDE_LABEL_ARG_NAME)
+                join_directive.specified_argument_by_name(OVERRIDE_LABEL_ARG_NAME)
             {
                 override_label_arg
                     .as_str()

--- a/apollo-router/src/query_planner/dual_introspection.rs
+++ b/apollo-router/src/query_planner/dual_introspection.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 
+use apollo_compiler::ast;
 use serde_json_bytes::Value;
 
 use crate::error::QueryPlannerError;
@@ -27,8 +28,8 @@ pub(crate) fn compare_introspection_responses(
             if let (Some(js_data), Some(rust_data)) =
                 (&mut js_response.data, &mut rust_response.data)
             {
-                json_sort_arrays(js_data);
-                json_sort_arrays(rust_data);
+                normalize_response(js_data);
+                normalize_response(rust_data);
             }
             is_matched = js_response.data == rust_response.data;
             if is_matched {
@@ -67,20 +68,69 @@ pub(crate) fn compare_introspection_responses(
     );
 }
 
-fn json_sort_arrays(value: &mut Value) {
+fn normalize_response(value: &mut Value) {
     match value {
         Value::Array(array) => {
             for item in array.iter_mut() {
-                json_sort_arrays(item)
+                normalize_response(item)
             }
             array.sort_by(json_compare)
         }
         Value::Object(object) => {
-            for (_key, value) in object {
-                json_sort_arrays(value)
+            for (key, value) in object {
+                if let Some(new_value) = normalize_default_value(key.as_str(), value) {
+                    *value = new_value
+                } else {
+                    normalize_response(value)
+                }
             }
         }
         Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => {}
+    }
+}
+
+/// When a default value is an input object, graphql-js seems to sort its fields by name
+fn normalize_default_value(key: &str, value: &Value) -> Option<Value> {
+    if key != "defaultValue" {
+        return None;
+    }
+    let default_value = value.as_str()?;
+    // We don’t have a parser entry point for a standalone GraphQL `Value`,
+    // so mint a document that contains that value.
+    let doc = format!("{{ field(arg: {default_value}) }}");
+    let doc = ast::Document::parse(doc, "").ok()?;
+    let parsed_default_value = &doc
+        .definitions
+        .first()?
+        .as_operation_definition()?
+        .selection_set
+        .first()?
+        .as_field()?
+        .arguments
+        .first()?
+        .value;
+    parsed_default_value.as_object()?;
+    let normalized = normalize_parsed_default_value(parsed_default_value);
+    Some(normalized.serialize().no_indent().to_string().into())
+}
+
+fn normalize_parsed_default_value(value: &ast::Value) -> ast::Value {
+    match value {
+        ast::Value::List(items) => ast::Value::List(
+            items
+                .iter()
+                .map(|item| normalize_parsed_default_value(item).into())
+                .collect(),
+        ),
+        ast::Value::Object(fields) => {
+            let mut new_fields: Vec<_> = fields
+                .iter()
+                .map(|(name, value)| (name.clone(), normalize_parsed_default_value(value).into()))
+                .collect();
+            new_fields.sort_by(|(name_1, _value_1), (name_2, _value_2)| name_1.cmp(name_2));
+            ast::Value::Object(new_fields)
+        }
+        v => v.clone(),
     }
 }
 

--- a/apollo-router/src/spec/query/change.rs
+++ b/apollo-router/src/spec/query/change.rs
@@ -286,7 +286,10 @@ impl<'a> QueryHashVisitor<'a> {
     fn hash_join_type(&mut self, name: &Name, directives: &DirectiveList) -> Result<(), BoxError> {
         if let Some(dir_name) = self.join_type_directive_name.as_deref() {
             if let Some(dir) = directives.get(dir_name) {
-                if let Some(key) = dir.argument_by_name("key").and_then(|arg| arg.as_str()) {
+                if let Some(key) = dir
+                    .specified_argument_by_name("key")
+                    .and_then(|arg| arg.as_str())
+                {
                     let mut parser = Parser::new();
                     if let Ok(field_set) = parser.parse_field_set(
                         Valid::assume_valid_ref(self.schema),
@@ -315,7 +318,7 @@ impl<'a> QueryHashVisitor<'a> {
         if let Some(dir_name) = self.join_field_directive_name.as_deref() {
             if let Some(dir) = directives.get(dir_name) {
                 if let Some(requires) = dir
-                    .argument_by_name("requires")
+                    .specified_argument_by_name("requires")
                     .and_then(|arg| arg.as_str())
                 {
                     if let Ok(parent_type) = Name::new(parent_type) {

--- a/apollo-router/src/spec/schema.rs
+++ b/apollo-router/src/spec/schema.rs
@@ -67,8 +67,10 @@ impl Schema {
         if let Some(join_enum) = definitions.get_enum("join__Graph") {
             for (name, url) in join_enum.values.iter().filter_map(|(_name, value)| {
                 let join_directive = value.directives.get("join__graph")?;
-                let name = join_directive.argument_by_name("name")?.as_str()?;
-                let url = join_directive.argument_by_name("url")?.as_str()?;
+                let name = join_directive
+                    .specified_argument_by_name("name")?
+                    .as_str()?;
+                let url = join_directive.specified_argument_by_name("url")?.as_str()?;
                 Some((name, url))
             }) {
                 if url.is_empty() {
@@ -220,7 +222,7 @@ impl Schema {
         for directive in &self.supergraph_schema().schema_definition.directives {
             let join_url = if directive.name == "core" {
                 let Some(feature) = directive
-                    .argument_by_name("feature")
+                    .specified_argument_by_name("feature")
                     .and_then(|value| value.as_str())
                 else {
                     continue;
@@ -229,7 +231,7 @@ impl Schema {
                 feature
             } else if directive.name == "link" {
                 let Some(url) = directive
-                    .argument_by_name("url")
+                    .specified_argument_by_name("url")
                     .and_then(|value| value.as_str())
                 else {
                     continue;
@@ -257,7 +259,7 @@ impl Schema {
             .filter(|dir| dir.name.as_str() == "link")
             .any(|link| {
                 if let Some(url_in_link) = link
-                    .argument_by_name("url")
+                    .specified_argument_by_name("url")
                     .and_then(|value| value.as_str())
                 {
                     let Some((base_url_in_link, version_in_link)) = url_in_link.rsplit_once("/v")
@@ -295,7 +297,7 @@ impl Schema {
             .filter(|dir| dir.name.as_str() == "link")
             .find(|link| {
                 if let Some(url_in_link) = link
-                    .argument_by_name("url")
+                    .specified_argument_by_name("url")
                     .and_then(|value| value.as_str())
                 {
                     let Some((base_url_in_link, version_in_link)) = url_in_link.rsplit_once("/v")
@@ -319,7 +321,7 @@ impl Schema {
                 }
             })
             .map(|link| {
-                link.argument_by_name("as")
+                link.specified_argument_by_name("as")
                     .and_then(|value| value.as_str().map(|s| s.to_string()))
                     .unwrap_or_else(|| default.to_string())
             })

--- a/apollo-router/src/spec/selection.rs
+++ b/apollo-router/src/spec/selection.rs
@@ -304,7 +304,7 @@ fn parse_defer(
         }
         let label = if condition != Condition::No {
             directive
-                .argument_by_name("label")
+                .specified_argument_by_name("label")
                 .and_then(|value| value.as_str())
                 .map(|str| str.to_owned())
         } else {
@@ -355,7 +355,7 @@ impl IncludeSkip {
 
 impl Condition {
     pub(crate) fn parse(directive: &executable::Directive) -> Option<Self> {
-        match directive.argument_by_name("if")?.as_ref() {
+        match directive.specified_argument_by_name("if")?.as_ref() {
             executable::Value::Boolean(true) => Some(Condition::Yes),
             executable::Value::Boolean(false) => Some(Condition::No),
             executable::Value::Variable(variable) => {

--- a/apollo-router/src/uplink/license_enforcement.rs
+++ b/apollo-router/src/uplink/license_enforcement.rs
@@ -104,7 +104,7 @@ impl ParsedLinkSpec {
         link_directive: &Directive,
     ) -> Option<Result<ParsedLinkSpec, url::ParseError>> {
         link_directive
-            .argument_by_name(LINK_URL_ARGUMENT)
+            .specified_argument_by_name(LINK_URL_ARGUMENT)
             .and_then(|value| {
                 let url_string = value.as_str();
                 let parsed_url = Url::parse(url_string.unwrap_or_default()).ok()?;
@@ -122,7 +122,7 @@ impl ParsedLinkSpec {
                     semver::Version::parse(format!("{}.0", &version_string).as_str()).ok()?;
 
                 let imported_as = link_directive
-                    .argument_by_name(LINK_AS_ARGUMENT)
+                    .specified_argument_by_name(LINK_AS_ARGUMENT)
                     .map(|as_arg| as_arg.as_str().unwrap_or_default().to_string());
 
                 Some(Ok(ParsedLinkSpec {
@@ -274,7 +274,9 @@ impl LicenseEnforcementReport {
                                     }
                                     _ => vec![],
                                 })
-                                .any(|directive| directive.argument_by_name(argument).is_some())
+                                .any(|directive| {
+                                    directive.specified_argument_by_name(argument).is_some()
+                                })
                             {
                                 schema_violations.push(SchemaViolation::DirectiveArgument {
                                     url: link_spec.url.to_string(),

--- a/apollo-router/tests/fixtures/introspect_full_schema.graphql
+++ b/apollo-router/tests/fixtures/introspect_full_schema.graphql
@@ -19,6 +19,9 @@ query IntrospectionQuery {
       args(includeDeprecated: true) {
         ...InputValue
       }
+      nonDeprecatedArgs: args {
+        name
+      }
     }
   }
 }
@@ -32,14 +35,23 @@ fragment FullType on __Type {
     args(includeDeprecated: true) {
       ...InputValue
     }
+    nonDeprecatedArgs: args {
+      name
+    }
     type {
       ...TypeRef
     }
     isDeprecated
     deprecationReason
   }
+  nonDeprecatedFields: fields {
+    name
+  }
   inputFields(includeDeprecated: true) {
     ...InputValue
+  }
+  nonDeprecatedInputFields: inputFields {
+    name
   }
   interfaces {
     ...TypeRef
@@ -49,6 +61,9 @@ fragment FullType on __Type {
     description
     isDeprecated
     deprecationReason
+  }
+  nonDeprecatedEnumValues: enumValues {
+    name
   }
   possibleTypes {
     ...TypeRef

--- a/apollo-router/tests/fixtures/schema_to_introspect.graphql
+++ b/apollo-router/tests/fixtures/schema_to_introspect.graphql
@@ -1,0 +1,89 @@
+"The schema"
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION) {
+  query: TheQuery
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(
+  graph: join__Graph
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+  isInterfaceObject: Boolean! = false
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(
+  graph: join__Graph!
+  member: String!
+) repeatable on UNION
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+scalar join__FieldSet
+scalar link__Import
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "subgraph1", url: "http://localhost:4001/graphql")
+}
+
+enum link__Purpose {
+  SECURITY
+  EXECUTION
+}
+
+"""
+Root query type
+"""
+type TheQuery implements I @join__type(graph: SUBGRAPH1) {
+  id: ID!
+  ints: [[Int!]]! @deprecated(reason: "…")
+  url(arg: In = { b: 4, a: 2 }): Url
+  union: U @deprecated(reason: null)
+}
+
+interface I @join__type(graph: SUBGRAPH1) {
+  id: ID!
+}
+
+input In @join__type(graph: SUBGRAPH1) {
+  a: Int! = 0 @deprecated(reason: null)
+  b: Int @deprecated
+}
+
+scalar Url @specifiedBy(url: "https://url.spec.whatwg.org/") @join__type(graph: SUBGRAPH1)
+
+union U @join__type(graph: SUBGRAPH1) = TheQuery | T
+
+type T @join__type(graph: SUBGRAPH1) {
+  enum: E @deprecated
+}
+
+enum E @join__type(graph: SUBGRAPH1) {
+  NEW
+  OLD @deprecated
+}

--- a/apollo-router/tests/integration/introspection.rs
+++ b/apollo-router/tests/integration/introspection.rs
@@ -238,17 +238,40 @@ async fn both_mode_integration() {
                     introspection: true
             ",
         )
-        .supergraph("../examples/graphql/local.graphql")
+        .supergraph("tests/fixtures/schema_to_introspect.graphql")
         .log("error,apollo_router=info,apollo_router::query_planner=trace")
         .build()
         .await;
     router.start().await;
     router.assert_started().await;
-    router
-        .execute_query(&json!({
-            "query": include_str!("../fixtures/introspect_full_schema.graphql"),
-        }))
-        .await;
+    let query = json!({
+        "query": include_str!("../fixtures/introspect_full_schema.graphql"),
+    });
+    let (_trace_id, response) = router.execute_query(&query).await;
+    insta::assert_json_snapshot!(response.json::<serde_json::Value>().await.unwrap());
     router.assert_log_contains("Introspection match! 🎉").await;
+    router.graceful_shutdown().await;
+}
+
+#[tokio::test]
+async fn integration() {
+    let mut router = IntegrationTest::builder()
+        .config(
+            "
+                experimental_introspection_mode: new
+                supergraph:
+                    introspection: true
+            ",
+        )
+        .supergraph("tests/fixtures/schema_to_introspect.graphql")
+        .build()
+        .await;
+    router.start().await;
+    router.assert_started().await;
+    let query = json!({
+        "query": include_str!("../fixtures/introspect_full_schema.graphql"),
+    });
+    let (_trace_id, response) = router.execute_query(&query).await;
+    insta::assert_json_snapshot!(response.json::<serde_json::Value>().await.unwrap());
     router.graceful_shutdown().await;
 }

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__introspection__both_mode_integration.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__introspection__both_mode_integration.snap
@@ -1,0 +1,1728 @@
+---
+source: apollo-router/tests/integration/introspection.rs
+expression: "response.json::<serde_json::Value>().await.unwrap()"
+---
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "TheQuery"
+      },
+      "mutationType": null,
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "TheQuery",
+          "description": "Root query type",
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ints",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "Int",
+                        "ofType": null
+                      }
+                    }
+                  }
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "…"
+            },
+            {
+              "name": "url",
+              "description": null,
+              "args": [
+                {
+                  "name": "arg",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "In",
+                    "ofType": null
+                  },
+                  "defaultValue": "{a: 2, b: 4}",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "nonDeprecatedArgs": [
+                {
+                  "name": "arg"
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Url",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "union",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "UNION",
+                "name": "U",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "id"
+            },
+            {
+              "name": "url"
+            },
+            {
+              "name": "union"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "I",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "I",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "id"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "TheQuery",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "In",
+          "description": null,
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": [
+            {
+              "name": "a",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "defaultValue": "0",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "b",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": true,
+              "deprecationReason": "No longer supported"
+            }
+          ],
+          "nonDeprecatedInputFields": [
+            {
+              "name": "a"
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Url",
+          "description": null,
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "UNION",
+          "name": "U",
+          "description": null,
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "TheQuery",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "T",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "T",
+          "description": null,
+          "fields": [
+            {
+              "name": "enum",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "E",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "No longer supported"
+            }
+          ],
+          "nonDeprecatedFields": [],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "E",
+          "description": null,
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "NEW",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OLD",
+              "description": null,
+              "isDeprecated": true,
+              "deprecationReason": "No longer supported"
+            }
+          ],
+          "nonDeprecatedEnumValues": [
+            {
+              "name": "NEW"
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Schema",
+          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+          "fields": [
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "types",
+              "description": "A list of all types supported by this server.",
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Type",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queryType",
+              "description": "The type that query operations will be rooted at.",
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mutationType",
+              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionType",
+              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "directives",
+              "description": "A list of all directives supported by this server.",
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Directive",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "description"
+            },
+            {
+              "name": "types"
+            },
+            {
+              "name": "queryType"
+            },
+            {
+              "name": "mutationType"
+            },
+            {
+              "name": "subscriptionType"
+            },
+            {
+              "name": "directives"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Type",
+          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByURL`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+          "fields": [
+            {
+              "name": "kind",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "__TypeKind",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "specifiedByURL",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fields",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "nonDeprecatedArgs": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Field",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interfaces",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "possibleTypes",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enumValues",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "nonDeprecatedArgs": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inputFields",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "nonDeprecatedArgs": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ofType",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "kind"
+            },
+            {
+              "name": "name"
+            },
+            {
+              "name": "description"
+            },
+            {
+              "name": "specifiedByURL"
+            },
+            {
+              "name": "fields"
+            },
+            {
+              "name": "interfaces"
+            },
+            {
+              "name": "possibleTypes"
+            },
+            {
+              "name": "enumValues"
+            },
+            {
+              "name": "inputFields"
+            },
+            {
+              "name": "ofType"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__TypeKind",
+          "description": "An enum describing what kind of type a given `__Type` is.",
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SCALAR",
+              "description": "Indicates this type is a scalar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NON_NULL",
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedEnumValues": [
+            {
+              "name": "SCALAR"
+            },
+            {
+              "name": "OBJECT"
+            },
+            {
+              "name": "INTERFACE"
+            },
+            {
+              "name": "UNION"
+            },
+            {
+              "name": "ENUM"
+            },
+            {
+              "name": "INPUT_OBJECT"
+            },
+            {
+              "name": "LIST"
+            },
+            {
+              "name": "NON_NULL"
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Field",
+          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "nonDeprecatedArgs": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "name"
+            },
+            {
+              "name": "description"
+            },
+            {
+              "name": "args"
+            },
+            {
+              "name": "type"
+            },
+            {
+              "name": "isDeprecated"
+            },
+            {
+              "name": "deprecationReason"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__InputValue",
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "defaultValue",
+              "description": "A GraphQL-formatted string representing the default value for this input value.",
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "name"
+            },
+            {
+              "name": "description"
+            },
+            {
+              "name": "type"
+            },
+            {
+              "name": "defaultValue"
+            },
+            {
+              "name": "isDeprecated"
+            },
+            {
+              "name": "deprecationReason"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__EnumValue",
+          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "name"
+            },
+            {
+              "name": "description"
+            },
+            {
+              "name": "isDeprecated"
+            },
+            {
+              "name": "deprecationReason"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Directive",
+          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isRepeatable",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locations",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "__DirectiveLocation",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "nonDeprecatedArgs": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "name"
+            },
+            {
+              "name": "description"
+            },
+            {
+              "name": "isRepeatable"
+            },
+            {
+              "name": "locations"
+            },
+            {
+              "name": "args"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__DirectiveLocation",
+          "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "QUERY",
+              "description": "Location adjacent to a query operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MUTATION",
+              "description": "Location adjacent to a mutation operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SUBSCRIPTION",
+              "description": "Location adjacent to a subscription operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD",
+              "description": "Location adjacent to a field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_DEFINITION",
+              "description": "Location adjacent to a fragment definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_SPREAD",
+              "description": "Location adjacent to a fragment spread.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INLINE_FRAGMENT",
+              "description": "Location adjacent to an inline fragment.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VARIABLE_DEFINITION",
+              "description": "Location adjacent to a variable definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCHEMA",
+              "description": "Location adjacent to a schema definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCALAR",
+              "description": "Location adjacent to a scalar definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Location adjacent to an object type definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD_DEFINITION",
+              "description": "Location adjacent to a field definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ARGUMENT_DEFINITION",
+              "description": "Location adjacent to an argument definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Location adjacent to an interface definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Location adjacent to a union definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Location adjacent to an enum definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM_VALUE",
+              "description": "Location adjacent to an enum value definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Location adjacent to an input object type definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_FIELD_DEFINITION",
+              "description": "Location adjacent to an input object field definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedEnumValues": [
+            {
+              "name": "QUERY"
+            },
+            {
+              "name": "MUTATION"
+            },
+            {
+              "name": "SUBSCRIPTION"
+            },
+            {
+              "name": "FIELD"
+            },
+            {
+              "name": "FRAGMENT_DEFINITION"
+            },
+            {
+              "name": "FRAGMENT_SPREAD"
+            },
+            {
+              "name": "INLINE_FRAGMENT"
+            },
+            {
+              "name": "VARIABLE_DEFINITION"
+            },
+            {
+              "name": "SCHEMA"
+            },
+            {
+              "name": "SCALAR"
+            },
+            {
+              "name": "OBJECT"
+            },
+            {
+              "name": "FIELD_DEFINITION"
+            },
+            {
+              "name": "ARGUMENT_DEFINITION"
+            },
+            {
+              "name": "INTERFACE"
+            },
+            {
+              "name": "UNION"
+            },
+            {
+              "name": "ENUM"
+            },
+            {
+              "name": "ENUM_VALUE"
+            },
+            {
+              "name": "INPUT_OBJECT"
+            },
+            {
+              "name": "INPUT_FIELD_DEFINITION"
+            }
+          ],
+          "possibleTypes": null
+        }
+      ],
+      "directives": [
+        {
+          "name": "defer",
+          "description": null,
+          "locations": [
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "label",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "if",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": "true",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedArgs": [
+            {
+              "name": "label"
+            },
+            {
+              "name": "if"
+            }
+          ]
+        },
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedArgs": [
+            {
+              "name": "if"
+            }
+          ]
+        },
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedArgs": [
+            {
+              "name": "if"
+            }
+          ]
+        },
+        {
+          "name": "deprecated",
+          "description": "Marks an element of a GraphQL schema as no longer supported.",
+          "locations": [
+            "FIELD_DEFINITION",
+            "ARGUMENT_DEFINITION",
+            "INPUT_FIELD_DEFINITION",
+            "ENUM_VALUE"
+          ],
+          "args": [
+            {
+              "name": "reason",
+              "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/).",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": "\"No longer supported\"",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedArgs": [
+            {
+              "name": "reason"
+            }
+          ]
+        },
+        {
+          "name": "specifiedBy",
+          "description": "Exposes a URL that specifies the behavior of this scalar.",
+          "locations": [
+            "SCALAR"
+          ],
+          "args": [
+            {
+              "name": "url",
+              "description": "The URL that specifies the behavior of this scalar.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedArgs": [
+            {
+              "name": "url"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__introspection__integration.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__introspection__integration.snap
@@ -1,0 +1,1728 @@
+---
+source: apollo-router/tests/integration/introspection.rs
+expression: "response.json::<serde_json::Value>().await.unwrap()"
+---
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "TheQuery"
+      },
+      "mutationType": null,
+      "subscriptionType": null,
+      "types": [
+        {
+          "kind": "OBJECT",
+          "name": "__Schema",
+          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations.",
+          "fields": [
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "types",
+              "description": "A list of all types supported by this server.",
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Type",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "queryType",
+              "description": "The type that query operations will be rooted at.",
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "mutationType",
+              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "subscriptionType",
+              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "directives",
+              "description": "A list of all directives supported by this server.",
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__Directive",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "description"
+            },
+            {
+              "name": "types"
+            },
+            {
+              "name": "queryType"
+            },
+            {
+              "name": "mutationType"
+            },
+            {
+              "name": "subscriptionType"
+            },
+            {
+              "name": "directives"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Type",
+          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.\n\nDepending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name, description and optional `specifiedByURL`, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types.",
+          "fields": [
+            {
+              "name": "kind",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "ENUM",
+                  "name": "__TypeKind",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "fields",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "nonDeprecatedArgs": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Field",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "interfaces",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "possibleTypes",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__Type",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enumValues",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "nonDeprecatedArgs": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__EnumValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "inputFields",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "nonDeprecatedArgs": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "__InputValue",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ofType",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "OBJECT",
+                "name": "__Type",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "specifiedByURL",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "kind"
+            },
+            {
+              "name": "name"
+            },
+            {
+              "name": "description"
+            },
+            {
+              "name": "fields"
+            },
+            {
+              "name": "interfaces"
+            },
+            {
+              "name": "possibleTypes"
+            },
+            {
+              "name": "enumValues"
+            },
+            {
+              "name": "inputFields"
+            },
+            {
+              "name": "ofType"
+            },
+            {
+              "name": "specifiedByURL"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__TypeKind",
+          "description": "An enum describing what kind of type a given `__Type` is.",
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "SCALAR",
+              "description": "Indicates this type is a scalar.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Indicates this type is an interface. `fields`, `interfaces`, and `possibleTypes` are valid fields.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "NON_NULL",
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedEnumValues": [
+            {
+              "name": "SCALAR"
+            },
+            {
+              "name": "OBJECT"
+            },
+            {
+              "name": "INTERFACE"
+            },
+            {
+              "name": "UNION"
+            },
+            {
+              "name": "ENUM"
+            },
+            {
+              "name": "INPUT_OBJECT"
+            },
+            {
+              "name": "LIST"
+            },
+            {
+              "name": "NON_NULL"
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Field",
+          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "nonDeprecatedArgs": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "name"
+            },
+            {
+              "name": "description"
+            },
+            {
+              "name": "args"
+            },
+            {
+              "name": "type"
+            },
+            {
+              "name": "isDeprecated"
+            },
+            {
+              "name": "deprecationReason"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__InputValue",
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "__Type",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "defaultValue",
+              "description": "A GraphQL-formatted string representing the default value for this input value.",
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "name"
+            },
+            {
+              "name": "description"
+            },
+            {
+              "name": "type"
+            },
+            {
+              "name": "defaultValue"
+            },
+            {
+              "name": "isDeprecated"
+            },
+            {
+              "name": "deprecationReason"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__EnumValue",
+          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isDeprecated",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "deprecationReason",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "name"
+            },
+            {
+              "name": "description"
+            },
+            {
+              "name": "isDeprecated"
+            },
+            {
+              "name": "deprecationReason"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "__Directive",
+          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor.",
+          "fields": [
+            {
+              "name": "name",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "description",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "locations",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "ENUM",
+                      "name": "__DirectiveLocation",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "args",
+              "description": null,
+              "args": [
+                {
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "nonDeprecatedArgs": [
+                {
+                  "name": "includeDeprecated"
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "__InputValue",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "isRepeatable",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "name"
+            },
+            {
+              "name": "description"
+            },
+            {
+              "name": "locations"
+            },
+            {
+              "name": "args"
+            },
+            {
+              "name": "isRepeatable"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "__DirectiveLocation",
+          "description": "A Directive can be adjacent to many parts of the GraphQL language, a __DirectiveLocation describes one such possible adjacencies.",
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "QUERY",
+              "description": "Location adjacent to a query operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "MUTATION",
+              "description": "Location adjacent to a mutation operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SUBSCRIPTION",
+              "description": "Location adjacent to a subscription operation.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD",
+              "description": "Location adjacent to a field.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_DEFINITION",
+              "description": "Location adjacent to a fragment definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FRAGMENT_SPREAD",
+              "description": "Location adjacent to a fragment spread.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INLINE_FRAGMENT",
+              "description": "Location adjacent to an inline fragment.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "VARIABLE_DEFINITION",
+              "description": "Location adjacent to a variable definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCHEMA",
+              "description": "Location adjacent to a schema definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "SCALAR",
+              "description": "Location adjacent to a scalar definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "description": "Location adjacent to an object type definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "FIELD_DEFINITION",
+              "description": "Location adjacent to a field definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ARGUMENT_DEFINITION",
+              "description": "Location adjacent to an argument definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "description": "Location adjacent to an interface definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "description": "Location adjacent to a union definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM",
+              "description": "Location adjacent to an enum definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ENUM_VALUE",
+              "description": "Location adjacent to an enum value definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "description": "Location adjacent to an input object type definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_FIELD_DEFINITION",
+              "description": "Location adjacent to an input object field definition.",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedEnumValues": [
+            {
+              "name": "QUERY"
+            },
+            {
+              "name": "MUTATION"
+            },
+            {
+              "name": "SUBSCRIPTION"
+            },
+            {
+              "name": "FIELD"
+            },
+            {
+              "name": "FRAGMENT_DEFINITION"
+            },
+            {
+              "name": "FRAGMENT_SPREAD"
+            },
+            {
+              "name": "INLINE_FRAGMENT"
+            },
+            {
+              "name": "VARIABLE_DEFINITION"
+            },
+            {
+              "name": "SCHEMA"
+            },
+            {
+              "name": "SCALAR"
+            },
+            {
+              "name": "OBJECT"
+            },
+            {
+              "name": "FIELD_DEFINITION"
+            },
+            {
+              "name": "ARGUMENT_DEFINITION"
+            },
+            {
+              "name": "INTERFACE"
+            },
+            {
+              "name": "UNION"
+            },
+            {
+              "name": "ENUM"
+            },
+            {
+              "name": "ENUM_VALUE"
+            },
+            {
+              "name": "INPUT_OBJECT"
+            },
+            {
+              "name": "INPUT_FIELD_DEFINITION"
+            }
+          ],
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Int",
+          "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "String",
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.",
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Boolean",
+          "description": "The `Boolean` scalar type represents `true` or `false`.",
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "ID",
+          "description": "The `ID` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as `\"4\"`) or integer (such as `4`) input value will be accepted as an ID.",
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TheQuery",
+          "description": "Root query type",
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "ints",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "NON_NULL",
+                      "name": null,
+                      "ofType": {
+                        "kind": "SCALAR",
+                        "name": "Int",
+                        "ofType": null
+                      }
+                    }
+                  }
+                }
+              },
+              "isDeprecated": true,
+              "deprecationReason": "…"
+            },
+            {
+              "name": "url",
+              "description": null,
+              "args": [
+                {
+                  "name": "arg",
+                  "description": null,
+                  "type": {
+                    "kind": "INPUT_OBJECT",
+                    "name": "In",
+                    "ofType": null
+                  },
+                  "defaultValue": "{b: 4, a: 2}",
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "nonDeprecatedArgs": [
+                {
+                  "name": "arg"
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Url",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "union",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "UNION",
+                "name": "U",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "id"
+            },
+            {
+              "name": "url"
+            },
+            {
+              "name": "union"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [
+            {
+              "kind": "INTERFACE",
+              "name": "I",
+              "ofType": null
+            }
+          ],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "INTERFACE",
+          "name": "I",
+          "description": null,
+          "fields": [
+            {
+              "name": "id",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedFields": [
+            {
+              "name": "id"
+            }
+          ],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "TheQuery",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "INPUT_OBJECT",
+          "name": "In",
+          "description": null,
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": [
+            {
+              "name": "a",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "defaultValue": "0",
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "b",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": true,
+              "deprecationReason": "No longer supported"
+            }
+          ],
+          "nonDeprecatedInputFields": [
+            {
+              "name": "a"
+            }
+          ],
+          "interfaces": null,
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "SCALAR",
+          "name": "Url",
+          "description": null,
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "UNION",
+          "name": "U",
+          "description": null,
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": [
+            {
+              "kind": "OBJECT",
+              "name": "TheQuery",
+              "ofType": null
+            },
+            {
+              "kind": "OBJECT",
+              "name": "T",
+              "ofType": null
+            }
+          ]
+        },
+        {
+          "kind": "OBJECT",
+          "name": "T",
+          "description": null,
+          "fields": [
+            {
+              "name": "enum",
+              "description": null,
+              "args": [],
+              "nonDeprecatedArgs": [],
+              "type": {
+                "kind": "ENUM",
+                "name": "E",
+                "ofType": null
+              },
+              "isDeprecated": true,
+              "deprecationReason": "No longer supported"
+            }
+          ],
+          "nonDeprecatedFields": [],
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": [],
+          "enumValues": null,
+          "nonDeprecatedEnumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "ENUM",
+          "name": "E",
+          "description": null,
+          "fields": null,
+          "nonDeprecatedFields": null,
+          "inputFields": null,
+          "nonDeprecatedInputFields": null,
+          "interfaces": null,
+          "enumValues": [
+            {
+              "name": "NEW",
+              "description": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "OLD",
+              "description": null,
+              "isDeprecated": true,
+              "deprecationReason": "No longer supported"
+            }
+          ],
+          "nonDeprecatedEnumValues": [
+            {
+              "name": "NEW"
+            }
+          ],
+          "possibleTypes": null
+        }
+      ],
+      "directives": [
+        {
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Skipped when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedArgs": [
+            {
+              "name": "if"
+            }
+          ]
+        },
+        {
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+          "locations": [
+            "FIELD",
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "if",
+              "description": "Included when true.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedArgs": [
+            {
+              "name": "if"
+            }
+          ]
+        },
+        {
+          "name": "deprecated",
+          "description": "Marks an element of a GraphQL schema as no longer supported.",
+          "locations": [
+            "FIELD_DEFINITION",
+            "ARGUMENT_DEFINITION",
+            "INPUT_FIELD_DEFINITION",
+            "ENUM_VALUE"
+          ],
+          "args": [
+            {
+              "name": "reason",
+              "description": "Explains why this element was deprecated, usually also including a suggestion for how to access supported similar data. Formatted using the Markdown syntax, as specified by [CommonMark](https://commonmark.org/).",
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": "\"No longer supported\"",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedArgs": [
+            {
+              "name": "reason"
+            }
+          ]
+        },
+        {
+          "name": "specifiedBy",
+          "description": "Exposes a URL that specifies the behavior of this scalar.",
+          "locations": [
+            "SCALAR"
+          ],
+          "args": [
+            {
+              "name": "url",
+              "description": "The URL that specifies the behavior of this scalar.",
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedArgs": [
+            {
+              "name": "url"
+            }
+          ]
+        },
+        {
+          "name": "defer",
+          "description": null,
+          "locations": [
+            "FRAGMENT_SPREAD",
+            "INLINE_FRAGMENT"
+          ],
+          "args": [
+            {
+              "name": "label",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "if",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Boolean",
+                  "ofType": null
+                }
+              },
+              "defaultValue": "true",
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "nonDeprecatedArgs": [
+            {
+              "name": "label"
+            },
+            {
+              "name": "if"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/examples/supergraph-sdl/rust/Cargo.toml
+++ b/examples/supergraph-sdl/rust/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-apollo-compiler = "=1.0.0-beta.23"
+apollo-compiler = "=1.0.0-beta.24"
 apollo-router = { path = "../../../apollo-router" }
 async-trait = "0.1"
 tower = { version = "0.4", features = ["full"] }


### PR DESCRIPTION
… to correctly return the default string instead of `null` for argument-less `@deprecated`.

https://github.com/apollographql/apollo-rs/pull/914 also renames `argument_for_name` to `specified_argument_for_name`, leaving the previous name for a new method that accounts for default value and nullability.

Additionally, introspection response comparison in "both" mode now tolerates differences in the ordering of input object fields in `defaultValue` strings.

Together, these two changes fix the remaining known sources of mismatch.


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
