### PR TITLE
Temporarily pin CI to Rust nightly-2024-09-22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,9 +355,9 @@ commands:
             equal: [ *arm_linux_test_executor, << parameters.platform >> ]
           steps:
             - run:
-                name: Install nightly Rust to build the fuzzers
+                name: Install nightly-2024-09-22 Rust to build the fuzzers
                 command: |
-                  rustup install nightly
+                  rustup install nightly-2024-09-22
 
   install_extra_tools:
     steps:
@@ -523,7 +523,7 @@ commands:
           path: ./target/nextest/ci/junit.xml
   fuzz_build:
     steps:
-      - run: cargo +nightly fuzz build
+      - run: cargo +nightly-2024-09-22 fuzz build
 
 jobs:
   lint:


### PR DESCRIPTION
We use Rust nightly on CI in order to check that fuzz targets can still compile. With current latest nightly we’re running into a compiler panic: https://github.com/rust-lang/rust/issues/130769

To unblock merging PRs, this pins the nightly version used on CI to a slightly older one that does not have this panic. This should be reverted after the panic is fixed in a new Rust nightly.