### PR TITLE
telemetry: add metrics for Rust vs. Deno configuration values

### DIFF
--- a/.changesets/config_renee_router_768_mode_metrics.md
+++ b/.changesets/config_renee_router_768_mode_metrics.md
@@ -1,0 +1,9 @@
+### Add metrics for Rust vs. Deno configuration values ([PR #6056](https://github.com/apollographql/router/pull/6056))
+
+We are working on migrating the implementation of several JavaScript components in the router to native Rust versions.
+
+To track this work, the router now reports the values of the following configuration options to Apollo:
+- `apollo.router.config.experimental_query_planner_mode`
+- `apollo.router.config.experimental_introspection_mode`
+
+By [@goto-bus-stop](https://github.com/goto-bus-stop) in https://github.com/apollographql/router/pull/6056

--- a/apollo-router/src/configuration/metrics.rs
+++ b/apollo-router/src/configuration/metrics.rs
@@ -48,6 +48,7 @@ impl Metrics {
         data.populate_license_instrument(license_state);
         data.populate_user_plugins_instrument(configuration);
         data.populate_query_planner_experimental_parallelism(configuration);
+        data.populate_deno_or_rust_mode_instruments(configuration);
         data.into()
     }
 }
@@ -532,6 +533,36 @@ impl InstrumentData {
             );
         }
     }
+
+    /// Populate metrics on the rollout of experimental Rust replacements of JavaScript code.
+    pub(crate) fn populate_deno_or_rust_mode_instruments(&mut self, configuration: &Configuration) {
+        let experimental_query_planner_mode = match configuration.experimental_query_planner_mode {
+            super::QueryPlannerMode::Legacy => "legacy",
+            super::QueryPlannerMode::Both => "both",
+            super::QueryPlannerMode::BothBestEffort => "both_best_effort",
+            super::QueryPlannerMode::New => "new",
+        };
+        let experimental_introspection_mode = match configuration.experimental_introspection_mode {
+            super::IntrospectionMode::Legacy => "legacy",
+            super::IntrospectionMode::Both => "both",
+            super::IntrospectionMode::New => "new",
+        };
+
+        self.data.insert(
+            "apollo.router.config.experimental_query_planner_mode".to_string(),
+            (
+                1,
+                HashMap::from_iter([("mode".to_string(), experimental_query_planner_mode.into())]),
+            ),
+        );
+        self.data.insert(
+            "apollo.router.config.experimental_introspection_mode".to_string(),
+            (
+                1,
+                HashMap::from_iter([("mode".to_string(), experimental_introspection_mode.into())]),
+            ),
+        );
+    }
 }
 
 impl From<InstrumentData> for Metrics {
@@ -564,6 +595,8 @@ mod test {
 
     use crate::configuration::metrics::InstrumentData;
     use crate::configuration::metrics::Metrics;
+    use crate::configuration::IntrospectionMode;
+    use crate::configuration::QueryPlannerMode;
     use crate::uplink::license_enforcement::LicenseState;
     use crate::Configuration;
 
@@ -635,6 +668,42 @@ mod test {
         configuration.plugins.plugins = Some(custom_plugins);
         let mut data = InstrumentData::default();
         data.populate_user_plugins_instrument(&configuration);
+        let _metrics: Metrics = data.into();
+        assert_non_zero_metrics_snapshot!();
+    }
+
+    #[test]
+    fn test_experimental_mode_metrics() {
+        let mut data = InstrumentData::default();
+        data.populate_deno_or_rust_mode_instruments(&Configuration {
+            experimental_introspection_mode: IntrospectionMode::Legacy,
+            experimental_query_planner_mode: QueryPlannerMode::Both,
+            ..Default::default()
+        });
+        let _metrics: Metrics = data.into();
+        assert_non_zero_metrics_snapshot!();
+    }
+
+    #[test]
+    fn test_experimental_mode_metrics_2() {
+        let mut data = InstrumentData::default();
+        // Default query planner value should still be reported
+        data.populate_deno_or_rust_mode_instruments(&Configuration {
+            experimental_introspection_mode: IntrospectionMode::New,
+            ..Default::default()
+        });
+        let _metrics: Metrics = data.into();
+        assert_non_zero_metrics_snapshot!();
+    }
+
+    #[test]
+    fn test_experimental_mode_metrics_3() {
+        let mut data = InstrumentData::default();
+        data.populate_deno_or_rust_mode_instruments(&Configuration {
+            experimental_introspection_mode: IntrospectionMode::New,
+            experimental_query_planner_mode: QueryPlannerMode::New,
+            ..Default::default()
+        });
         let _metrics: Metrics = data.into();
         assert_non_zero_metrics_snapshot!();
     }

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__experimental_mode_metrics.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__experimental_mode_metrics.snap
@@ -1,0 +1,16 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.non_zero()"
+---
+- name: apollo.router.config.experimental_introspection_mode
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          mode: legacy
+- name: apollo.router.config.experimental_query_planner_mode
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          mode: both

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__experimental_mode_metrics_2.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__experimental_mode_metrics_2.snap
@@ -1,0 +1,16 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.non_zero()"
+---
+- name: apollo.router.config.experimental_introspection_mode
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          mode: new
+- name: apollo.router.config.experimental_query_planner_mode
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          mode: both_best_effort

--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__experimental_mode_metrics_3.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__metrics__test__experimental_mode_metrics_3.snap
@@ -1,0 +1,16 @@
+---
+source: apollo-router/src/configuration/metrics.rs
+expression: "&metrics.non_zero()"
+---
+- name: apollo.router.config.experimental_introspection_mode
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          mode: new
+- name: apollo.router.config.experimental_query_planner_mode
+  data:
+    datapoints:
+      - value: 1
+        attributes:
+          mode: new


### PR DESCRIPTION
We have metrics comparing Rust and JS QP / introspection, which implies we know how many customers are running `both` versions. But we don’t really know who is opting out, and we also have no way to know if someone is using `new`, which we hope to try out with specific customers soon.

This reports configuration values to Apollo:
- `apollo.router.config.experimental_query_planner_mode` with `mode={legacy,both_best_effort,both,new}`
- `apollo.router.config.experimental_introspection_mode` with `mode={legacy,both,new}`

**Todo**:
- [x] This does need a changeset

<!-- [ROUTER-768] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-768]: https://apollographql.atlassian.net/browse/ROUTER-768?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ