### PR TITLE
Enable force datadog agent sampling disabled

### DIFF
--- a/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
+++ b/apollo-router/src/configuration/snapshots/apollo_router__configuration__tests__schema_generation.snap
@@ -7267,8 +7267,9 @@ expression: "&schema"
       "additionalProperties": false,
       "properties": {
         "datadog_agent_sampling": {
-          "default": false,
-          "description": "Use datadog agent sampling. This means that all spans will be sent to the Datadog agent and the `sampling.priority` attribute will be used to control if the span will then be sent to Datadog.",
+          "default": null,
+          "description": "Use datadog agent sampling. This means that all spans will be sent to the Datadog agent and the `sampling.priority` attribute will be used to control if the span will then be sent to Datadog. This option is enabled by default if you are using the Datadog native exporter but can be explicitly disabled.",
+          "nullable": true,
           "type": "boolean"
         },
         "max_attributes_per_event": {

--- a/apollo-router/src/plugins/telemetry/config.rs
+++ b/apollo-router/src/plugins/telemetry/config.rs
@@ -350,7 +350,7 @@ pub(crate) struct TracingCommon {
     pub(crate) sampler: SamplerOption,
     /// Use datadog agent sampling. This means that all spans will be sent to the Datadog agent
     /// and the `sampling.priority` attribute will be used to control if the span will then be sent to Datadog.
-    /// This option is true if you are using the Datadog native exporter.
+    /// This option is enabled by default if you are using the Datadog native exporter but can be explicitly disabled.
     pub(crate) datadog_agent_sampling: Option<bool>,
     /// Whether to use parent based sampling
     pub(crate) parent_based_sampler: bool,

--- a/apollo-router/tests/integration/telemetry/fixtures/datadog.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/datadog.router.yaml
@@ -13,7 +13,6 @@ telemetry:
         resource:
           env: local1
           service.version: router_version_override
-        datadog_agent_sampling: true
       datadog:
         enabled: true
         batch_processor:

--- a/apollo-router/tests/integration/telemetry/fixtures/datadog_agent_sampling_disabled.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/datadog_agent_sampling_disabled.router.yaml
@@ -5,16 +5,23 @@ telemetry:
         enabled: true
         header_name: apollo-custom-trace-id
         format: datadog
+      propagation:
+        trace_context: true
+        jaeger: true
       common:
         service_name: router
+        resource:
+          env: local1
+          service.version: router_version_override
+        datadog_agent_sampling: false
       datadog:
         enabled: true
         batch_processor:
           scheduled_delay: 100ms
-        fixed_span_names: false
-        enable_span_mapping: false
   instrumentation:
     spans:
       mode: spec_compliant
-
+      supergraph:
+        attributes:
+          graphql.operation.name: true
 

--- a/apollo-router/tests/integration/telemetry/fixtures/datadog_agent_sampling_disabled.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/datadog_agent_sampling_disabled.router.yaml
@@ -1,4 +1,6 @@
 telemetry:
+  apollo:
+    field_level_instrumentation_sampler: always_off
   exporters:
     tracing:
       experimental_response_trace_id:
@@ -14,6 +16,7 @@ telemetry:
           env: local1
           service.version: router_version_override
         datadog_agent_sampling: false
+        sampler: always_off
       datadog:
         enabled: true
         batch_processor:

--- a/apollo-router/tests/integration/telemetry/fixtures/datadog_no_sample.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/datadog_no_sample.router.yaml
@@ -11,7 +11,6 @@ telemetry:
         service_name: router
         # NOT always_off to allow us to test a sampling probability of zero
         sampler: 0.0
-        datadog_agent_sampling: true
       datadog:
         enabled: true
         batch_processor:

--- a/apollo-router/tests/integration/telemetry/fixtures/datadog_override_span_names.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/datadog_override_span_names.router.yaml
@@ -7,7 +7,6 @@ telemetry:
         format: datadog
       common:
         service_name: router
-        datadog_agent_sampling: true
       datadog:
         enabled: true
         # Span mapping will always override the span name as far as the test agent is concerned

--- a/apollo-router/tests/integration/telemetry/fixtures/datadog_override_span_names_late.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/datadog_override_span_names_late.router.yaml
@@ -7,7 +7,6 @@ telemetry:
         format: datadog
       common:
         service_name: router
-        datadog_agent_sampling: true
       datadog:
         enabled: true
         # Span mapping will always override the span name as far as the test agent is concerned

--- a/apollo-router/tests/integration/telemetry/fixtures/datadog_resource_mapping_default.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/datadog_resource_mapping_default.router.yaml
@@ -7,7 +7,6 @@ telemetry:
         format: datadog
       common:
         service_name: router
-        datadog_agent_sampling: true
       datadog:
         enabled: true
         enable_span_mapping: true

--- a/apollo-router/tests/integration/telemetry/fixtures/datadog_resource_mapping_override.router.yaml
+++ b/apollo-router/tests/integration/telemetry/fixtures/datadog_resource_mapping_override.router.yaml
@@ -7,7 +7,6 @@ telemetry:
         format: datadog
       common:
         service_name: router
-        datadog_agent_sampling: true
       datadog:
         enabled: true
         enable_span_mapping: true

--- a/docs/source/configuration/telemetry/exporters/tracing/datadog.mdx
+++ b/docs/source/configuration/telemetry/exporters/tracing/datadog.mdx
@@ -92,6 +92,10 @@ telemetry:
       common:
         # Only 10 percent of spans will be forwarded from the Datadog agent to Datadog. Experiment to find a value that is good for you!
         sampler: 0.1
+
+        # This is set to true by default if the Datadog exporter is enabled.
+        datadog_agent_sampling: true
+
       datadog:
         enabled: true
         # Optional endpoint, either 'default' or a URL (Defaults to http://127.0.0.1:8126)
@@ -110,7 +114,7 @@ telemetry:
           graphql.operation.name: true
 ```
 
-Note that `datadog_agent_sampling` is automatically enabled when using the native Datadog exporter and cannot be disabled.
+Note that `datadog_agent_sampling` is automatically enabled when using the native Datadog exporter but can be overridden if sampled APM metrics are desired.
 
 > [!IMPORTANT]
 > Sending all spans to the datadog agent may require that you tweak the `batch_processor` settings in your exporter config. This applies to both OTLP and the Datadog native exporter.

--- a/docs/source/configuration/telemetry/exporters/tracing/overview.mdx
+++ b/docs/source/configuration/telemetry/exporters/tracing/overview.mdx
@@ -125,6 +125,7 @@ telemetry:
          sampler: 0.1
 
          # Send all spans to the Datadog agent.
+         # This is enabled by default Datadog exporter is enabled, but may be overridden to false if you want to only have sampled traces.
          datadog_agent_sampling: true
 ```
 


### PR DESCRIPTION
Related to #6017. 
When datadog exporter is used the router will enable agent sampling by default.
We now allow the user to override this by setting the configuration option explicitly.

```
telemetry:
  exporters:
    tracing:
      common:
        datadog_agent_sampling: false

```


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
