### PR TITLE
Updating redis and subgraphs configs to be children of preview_entity…

### DIFF
--- a/docs/source/configuration/entity-caching.mdx
+++ b/docs/source/configuration/entity-caching.mdx
@@ -94,19 +94,19 @@ preview_entity_cache:
   subgraph:
     all:
       enabled: true
-      # Configure Redis
-      redis:
-        urls: ["redis://..."]
-        timeout: 2s # Optional, by default: 500ms
-        ttl: 24h # Optional, by default no expiration
-    # Configure entity caching per subgraph, overrides options from the "all" section
-    subgraphs:
-      products:
-        ttl: 120s # overrides the global TTL
-      inventory:
-        enabled: false # disable for a specific subgraph
-      accounts:
-        private_id: "user_id"
+  # Configure Redis
+  redis:
+    urls: ["redis://..."]
+    timeout: 2s # Optional, by default: 500ms
+    ttl: 24h # Optional, by default no expiration
+  # Configure entity caching per subgraph, overrides options from the "all" section
+  subgraphs:
+    products:
+    ttl: 120s # overrides the global TTL
+    inventory:
+      enabled: false # disable for a specific subgraph
+    accounts:
+      private_id: "user_id"
 ```
 
 ### Configure time to live (TTL)


### PR DESCRIPTION
…_cache

Customer shared that when they were configuring (through trial and error) they discovered that the `redis` config should be a child of `preview_entity_cache` - upon making this change, I believe the same is true for the `subgraphs` config.

*Description here*

Fixes #**issue_number**

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
