### PR TITLE
Add deny lints to QP

### DIFF
--- a/apollo-federation/src/api_schema.rs
+++ b/apollo-federation/src/api_schema.rs
@@ -110,7 +110,7 @@ pub struct ApiSchemaOptions {
     pub include_stream: bool,
 }
 
-pub fn to_api_schema(
+pub(crate) fn to_api_schema(
     schema: ValidFederationSchema,
     options: ApiSchemaOptions,
 ) -> Result<ValidFederationSchema, FederationError> {

--- a/apollo-federation/src/compat.rs
+++ b/apollo-federation/src/compat.rs
@@ -76,7 +76,7 @@ fn retain_semantic_directives_ast(directives: &mut apollo_compiler::ast::Directi
 
 /// Remove non-semantic directive applications from the schema representation.
 /// This only keeps directive applications that are observable in introspection.
-pub fn remove_non_semantic_directives(schema: &mut Schema) {
+pub(crate) fn remove_non_semantic_directives(schema: &mut Schema) {
     let root_definitions = schema.schema_definition.make_mut();
     retain_semantic_directives(&mut root_definitions.directives);
 
@@ -241,7 +241,7 @@ fn coerce_arguments_default_values(
 /// This is not what we would want to do for coercion in a real execution scenario, but it matches
 /// a behaviour in graphql-js so we can compare API schema results between federation-next and JS
 /// federation. We can consider removing this when we no longer rely on JS federation.
-pub fn coerce_schema_default_values(schema: &mut Schema) {
+pub(crate) fn coerce_schema_default_values(schema: &mut Schema) {
     // Keep a copy of the types in the schema so we can mutate the schema while walking it.
     let types = schema.types.clone();
 
@@ -357,7 +357,7 @@ fn coerce_operation_values(schema: &Valid<Schema>, operation: &mut Node<executab
     coerce_selection_set_values(schema, &mut operation.selection_set);
 }
 
-pub fn coerce_executable_values(schema: &Valid<Schema>, document: &mut ExecutableDocument) {
+pub(crate) fn coerce_executable_values(schema: &Valid<Schema>, document: &mut ExecutableDocument) {
     if let Some(operation) = &mut document.operations.anonymous {
         coerce_operation_values(schema, operation);
     }
@@ -369,7 +369,7 @@ pub fn coerce_executable_values(schema: &Valid<Schema>, document: &mut Executabl
 /// Applies default value coercion and removes non-semantic directives so that
 /// the apollo-rs serialized output of the schema matches the result of
 /// `printSchema(buildSchema()` in graphql-js.
-pub fn make_print_schema_compatible(schema: &mut Schema) {
+pub(crate) fn make_print_schema_compatible(schema: &mut Schema) {
     remove_non_semantic_directives(schema);
     coerce_schema_default_values(schema);
 }

--- a/apollo-federation/src/display_helpers.rs
+++ b/apollo-federation/src/display_helpers.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 use std::fmt::Debug;
 use std::fmt::Display;
-use std::ops::Deref;
 
 use serde::Serializer;
 
@@ -23,7 +22,7 @@ impl<'a, 'b> State<'a, 'b> {
     }
 
     pub(crate) fn write<T: fmt::Display>(&mut self, value: T) -> fmt::Result {
-        write!(self.output, "{}", value)
+        write!(self.output, "{value}")
     }
 
     pub(crate) fn write_fmt(&mut self, args: fmt::Arguments<'_>) -> fmt::Result {
@@ -114,23 +113,6 @@ where
     S: Serializer,
 {
     ser.serialize_str(&data.to_string())
-}
-
-pub(crate) fn serialize_option_as_string<T, S>(data: &Option<T>, ser: S) -> Result<S::Ok, S::Error>
-where
-    T: Display,
-    S: Serializer,
-{
-    serialize_as_string(&DisplayOption(data.as_ref()), ser)
-}
-
-pub(crate) fn serialize_vec_as_string<P, T, S>(data: &P, ser: S) -> Result<S::Ok, S::Error>
-where
-    P: Deref<Target = Vec<T>>,
-    T: Display,
-    S: Serializer,
-{
-    serialize_as_string(&DisplaySlice(data), ser)
 }
 
 pub(crate) fn serialize_optional_vec_as_string<T, S>(

--- a/apollo-federation/src/display_helpers.rs
+++ b/apollo-federation/src/display_helpers.rs
@@ -21,7 +21,7 @@ impl<'a, 'b> State<'a, 'b> {
         self.indent_level
     }
 
-    pub(crate) fn write<T: fmt::Display>(&mut self, value: T) -> fmt::Result {
+    pub(crate) fn write<T: Display>(&mut self, value: T) -> fmt::Result {
         write!(self.output, "{value}")
     }
 

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -13,10 +13,7 @@
 //! See [Router documentation](https://www.apollographql.com/docs/router/federation-version-support/)
 //! for which Federation versions are supported by which Router versions.
 
-// TODO: This is fine while we're iterating, but should be removed later.
-#![allow(dead_code)]
-// TODO: silence false positives (apollo_compiler::Name) and investigate the rest
-#![allow(clippy::mutable_key_type)]
+#![deny(dead_code)]
 
 mod api_schema;
 mod compat;

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -13,7 +13,20 @@
 //! See [Router documentation](https://www.apollographql.com/docs/router/federation-version-support/)
 //! for which Federation versions are supported by which Router versions.
 
-#![deny(dead_code)]
+#![deny(
+    rustdoc::broken_intra_doc_links,
+    unreachable_pub,
+    unreachable_patterns,
+    unused,
+    unused_qualifications,
+    dead_code,
+    while_true,
+    trivial_casts,
+    trivial_bounds,
+    trivial_numeric_casts,
+    unconditional_panic,
+    clippy::all
+)]
 
 mod api_schema;
 mod compat;

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -13,7 +13,7 @@
 //! See [Router documentation](https://www.apollographql.com/docs/router/federation-version-support/)
 //! for which Federation versions are supported by which Router versions.
 
-#![deny(
+#![warn(
     rustdoc::broken_intra_doc_links,
     unreachable_pub,
     unreachable_patterns,

--- a/apollo-federation/src/lib.rs
+++ b/apollo-federation/src/lib.rs
@@ -21,9 +21,6 @@
     unused_qualifications,
     dead_code,
     while_true,
-    trivial_casts,
-    trivial_bounds,
-    trivial_numeric_casts,
     unconditional_panic,
     clippy::all
 )]

--- a/apollo-federation/src/link/cost_spec_definition.rs
+++ b/apollo-federation/src/link/cost_spec_definition.rs
@@ -147,11 +147,6 @@ impl CostSpecDefinition {
         apollo_compiler::ast::DirectiveList,
         Node::new
     );
-    propagate_demand_control_directives!(
-        propagate_demand_control_schema_directives,
-        apollo_compiler::schema::DirectiveList,
-        Component::from
-    );
 
     propagate_demand_control_directives_to_position!(
         propagate_demand_control_directives_for_enum,

--- a/apollo-federation/src/link/graphql_definition.rs
+++ b/apollo-federation/src/link/graphql_definition.rs
@@ -80,15 +80,6 @@ impl Display for BooleanOrVariable {
     }
 }
 
-impl BooleanOrVariable {
-    pub(crate) fn to_ast_value(&self) -> Value {
-        match self {
-            BooleanOrVariable::Boolean(b) => Value::Boolean(*b),
-            BooleanOrVariable::Variable(name) => Value::Variable(name.clone()),
-        }
-    }
-}
-
 impl From<BooleanOrVariable> for Value {
     fn from(b: BooleanOrVariable) -> Self {
         match b {

--- a/apollo-federation/src/link/inaccessible_spec_definition.rs
+++ b/apollo-federation/src/link/inaccessible_spec_definition.rs
@@ -58,7 +58,7 @@ impl InaccessibleSpecDefinition {
     /// # Errors
     /// Returns an error if the schema specifies an `@inaccessible` spec version that is not
     /// supported by this version of the apollo-federation crate.
-    pub fn get_from_schema(
+    pub(crate) fn get_from_schema(
         schema: &FederationSchema,
     ) -> Result<Option<&'static Self>, FederationError> {
         let inaccessible_link = match schema
@@ -78,11 +78,11 @@ impl InaccessibleSpecDefinition {
         ))
     }
 
-    pub fn validate_inaccessible(&self, schema: &FederationSchema) -> Result<(), FederationError> {
+    pub(crate) fn validate_inaccessible(&self, schema: &FederationSchema) -> Result<(), FederationError> {
         validate_inaccessible(schema, self)
     }
 
-    pub fn remove_inaccessible_elements(
+    pub(crate) fn remove_inaccessible_elements(
         &self,
         schema: &mut FederationSchema,
     ) -> Result<(), FederationError> {
@@ -519,7 +519,7 @@ impl IsInaccessibleExt for position::ObjectTypeDefinitionPosition {
         Ok(object.directives.has(inaccessible_directive))
     }
 }
-impl IsInaccessibleExt for position::ObjectFieldDefinitionPosition {
+impl IsInaccessibleExt for ObjectFieldDefinitionPosition {
     fn is_inaccessible(
         &self,
         schema: &FederationSchema,
@@ -533,7 +533,7 @@ impl IsInaccessibleExt for position::ObjectFieldDefinitionPosition {
                 .is_inaccessible(schema, inaccessible_directive)?)
     }
 }
-impl IsInaccessibleExt for position::ObjectFieldArgumentDefinitionPosition {
+impl IsInaccessibleExt for ObjectFieldArgumentDefinitionPosition {
     fn is_inaccessible(
         &self,
         schema: &FederationSchema,
@@ -557,7 +557,7 @@ impl IsInaccessibleExt for position::InterfaceTypeDefinitionPosition {
         Ok(interface.directives.has(inaccessible_directive))
     }
 }
-impl IsInaccessibleExt for position::InterfaceFieldDefinitionPosition {
+impl IsInaccessibleExt for InterfaceFieldDefinitionPosition {
     fn is_inaccessible(
         &self,
         schema: &FederationSchema,
@@ -571,7 +571,7 @@ impl IsInaccessibleExt for position::InterfaceFieldDefinitionPosition {
                 .is_inaccessible(schema, inaccessible_directive)?)
     }
 }
-impl IsInaccessibleExt for position::InterfaceFieldArgumentDefinitionPosition {
+impl IsInaccessibleExt for InterfaceFieldArgumentDefinitionPosition {
     fn is_inaccessible(
         &self,
         schema: &FederationSchema,
@@ -595,7 +595,7 @@ impl IsInaccessibleExt for position::InputObjectTypeDefinitionPosition {
         Ok(input_object.directives.has(inaccessible_directive))
     }
 }
-impl IsInaccessibleExt for position::InputObjectFieldDefinitionPosition {
+impl IsInaccessibleExt for InputObjectFieldDefinitionPosition {
     fn is_inaccessible(
         &self,
         schema: &FederationSchema,
@@ -639,7 +639,7 @@ impl IsInaccessibleExt for position::EnumTypeDefinitionPosition {
         Ok(enum_.directives.has(inaccessible_directive))
     }
 }
-impl IsInaccessibleExt for position::EnumValueDefinitionPosition {
+impl IsInaccessibleExt for EnumValueDefinitionPosition {
     fn is_inaccessible(
         &self,
         schema: &FederationSchema,

--- a/apollo-federation/src/link/inaccessible_spec_definition.rs
+++ b/apollo-federation/src/link/inaccessible_spec_definition.rs
@@ -5,7 +5,6 @@ use apollo_compiler::collections::IndexSet;
 use apollo_compiler::name;
 use apollo_compiler::schema::Component;
 use apollo_compiler::schema::ComponentName;
-use apollo_compiler::schema::Directive;
 use apollo_compiler::schema::DirectiveDefinition;
 use apollo_compiler::schema::DirectiveLocation;
 use apollo_compiler::schema::ExtendedType;
@@ -52,21 +51,6 @@ impl InaccessibleSpecDefinition {
             },
             minimum_federation_version,
         }
-    }
-
-    pub(crate) fn inaccessible_directive(
-        &self,
-        schema: &FederationSchema,
-    ) -> Result<Directive, FederationError> {
-        let name_in_schema = self
-            .directive_name_in_schema(schema, &INACCESSIBLE_DIRECTIVE_NAME_IN_SPEC)?
-            .ok_or_else(|| SingleFederationError::Internal {
-                message: "Unexpectedly could not find inaccessible spec in schema".to_owned(),
-            })?;
-        Ok(Directive {
-            name: name_in_schema,
-            arguments: Vec::new(),
-        })
     }
 
     /// Returns the `@inaccessible` spec used in the given schema, if any.

--- a/apollo-federation/src/link/inaccessible_spec_definition.rs
+++ b/apollo-federation/src/link/inaccessible_spec_definition.rs
@@ -78,7 +78,10 @@ impl InaccessibleSpecDefinition {
         ))
     }
 
-    pub(crate) fn validate_inaccessible(&self, schema: &FederationSchema) -> Result<(), FederationError> {
+    pub(crate) fn validate_inaccessible(
+        &self,
+        schema: &FederationSchema,
+    ) -> Result<(), FederationError> {
         validate_inaccessible(schema, self)
     }
 

--- a/apollo-federation/src/merge.rs
+++ b/apollo-federation/src/merge.rs
@@ -1578,20 +1578,6 @@ fn add_core_feature_inaccessible(supergraph: &mut Schema) {
     );
 }
 
-// TODO use apollo_compiler::executable::FieldSet
-fn parse_keys<'a>(
-    directives: impl Iterator<Item = &'a Component<Directive>> + Sized,
-) -> IndexSet<&'a str> {
-    IndexSet::from_iter(
-        directives
-            .flat_map(|k| {
-                let field_set = directive_string_arg_value(k, &name!("fields")).unwrap();
-                field_set.split_whitespace()
-            })
-            .collect::<Vec<&str>>(),
-    )
-}
-
 fn merge_directive(
     supergraph_directives: &mut IndexMap<Name, Node<DirectiveDefinition>>,
     directive: &Node<DirectiveDefinition>,

--- a/apollo-federation/src/operation/contains.rs
+++ b/apollo-federation/src/operation/contains.rs
@@ -51,7 +51,11 @@ impl Containment {
 }
 
 impl Selection {
-    pub(crate) fn containment(&self, other: &Selection, options: ContainmentOptions) -> Containment {
+    pub(crate) fn containment(
+        &self,
+        other: &Selection,
+        options: ContainmentOptions,
+    ) -> Containment {
         match (self, other) {
             (Selection::Field(self_field), Selection::Field(other_field)) => {
                 self_field.containment(other_field, options)
@@ -75,7 +79,11 @@ impl Selection {
 }
 
 impl FieldSelection {
-    pub(crate) fn containment(&self, other: &FieldSelection, options: ContainmentOptions) -> Containment {
+    pub(crate) fn containment(
+        &self,
+        other: &FieldSelection,
+        options: ContainmentOptions,
+    ) -> Containment {
         if self.field.name() != other.field.name()
             || self.field.alias != other.field.alias
             || self.field.arguments != other.field.arguments
@@ -98,7 +106,11 @@ impl FieldSelection {
 }
 
 impl FragmentSpreadSelection {
-    pub(crate) fn containment(&self, other: &Selection, options: ContainmentOptions) -> Containment {
+    pub(crate) fn containment(
+        &self,
+        other: &Selection,
+        options: ContainmentOptions,
+    ) -> Containment {
         match other {
             // Using keys here means that @defer fragments never compare equal.
             // This is a bit odd but it is consistent: the selection set data structure would not
@@ -112,7 +124,11 @@ impl FragmentSpreadSelection {
 }
 
 impl InlineFragmentSelection {
-    pub(crate) fn containment(&self, other: &Selection, options: ContainmentOptions) -> Containment {
+    pub(crate) fn containment(
+        &self,
+        other: &Selection,
+        options: ContainmentOptions,
+    ) -> Containment {
         match other {
             // Using keys here means that @defer fragments never compare equal.
             // This is a bit odd but it is consistent: the selection set data structure would not

--- a/apollo-federation/src/operation/contains.rs
+++ b/apollo-federation/src/operation/contains.rs
@@ -95,11 +95,6 @@ impl FieldSelection {
             }
         }
     }
-
-    /// Returns true if this selection is a superset of the other selection.
-    pub fn contains(&self, other: &FieldSelection) -> bool {
-        self.containment(other, Default::default()).is_contained()
-    }
 }
 
 impl FragmentSpreadSelection {
@@ -113,11 +108,6 @@ impl FragmentSpreadSelection {
                 .containment(&other.selection_set, options),
             _ => Containment::NotContained,
         }
-    }
-
-    /// Returns true if this selection is a superset of the other selection.
-    pub fn contains(&self, other: &Selection) -> bool {
-        self.containment(other, Default::default()).is_contained()
     }
 }
 
@@ -135,11 +125,6 @@ impl InlineFragmentSelection {
             }
             _ => Containment::NotContained,
         }
-    }
-
-    /// Returns true if this selection is a superset of the other selection.
-    pub fn contains(&self, other: &Selection) -> bool {
-        self.containment(other, Default::default()).is_contained()
     }
 }
 

--- a/apollo-federation/src/operation/contains.rs
+++ b/apollo-federation/src/operation/contains.rs
@@ -13,10 +13,10 @@ pub(super) fn is_deferred_selection(directives: &executable::DirectiveList) -> b
 
 /// Options for the `.containment()` family of selection functions.
 #[derive(Debug, Clone, Copy)]
-pub struct ContainmentOptions {
+pub(crate) struct ContainmentOptions {
     /// If the right-hand side has a __typename selection but the left-hand side does not,
     /// still consider the left-hand side to contain the right-hand side.
-    pub ignore_missing_typename: bool,
+    pub(crate) ignore_missing_typename: bool,
 }
 
 // Currently Default *can* be derived, but if we add a new option
@@ -31,7 +31,7 @@ impl Default for ContainmentOptions {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Containment {
+pub(crate) enum Containment {
     /// The left-hand selection does not fully contain right-hand selection.
     NotContained,
     /// The left-hand selection fully contains the right-hand selection, and more.
@@ -41,17 +41,17 @@ pub enum Containment {
 }
 impl Containment {
     /// Returns true if the right-hand selection set is strictly contained or equal.
-    pub fn is_contained(self) -> bool {
+    pub(crate) fn is_contained(self) -> bool {
         matches!(self, Containment::StrictlyContained | Containment::Equal)
     }
 
-    pub fn is_equal(self) -> bool {
+    pub(crate) fn is_equal(self) -> bool {
         matches!(self, Containment::Equal)
     }
 }
 
 impl Selection {
-    pub fn containment(&self, other: &Selection, options: ContainmentOptions) -> Containment {
+    pub(crate) fn containment(&self, other: &Selection, options: ContainmentOptions) -> Containment {
         match (self, other) {
             (Selection::Field(self_field), Selection::Field(other_field)) => {
                 self_field.containment(other_field, options)
@@ -69,13 +69,13 @@ impl Selection {
     }
 
     /// Returns true if this selection is a superset of the other selection.
-    pub fn contains(&self, other: &Selection) -> bool {
+    pub(crate) fn contains(&self, other: &Selection) -> bool {
         self.containment(other, Default::default()).is_contained()
     }
 }
 
 impl FieldSelection {
-    pub fn containment(&self, other: &FieldSelection, options: ContainmentOptions) -> Containment {
+    pub(crate) fn containment(&self, other: &FieldSelection, options: ContainmentOptions) -> Containment {
         if self.field.name() != other.field.name()
             || self.field.alias != other.field.alias
             || self.field.arguments != other.field.arguments
@@ -98,7 +98,7 @@ impl FieldSelection {
 }
 
 impl FragmentSpreadSelection {
-    pub fn containment(&self, other: &Selection, options: ContainmentOptions) -> Containment {
+    pub(crate) fn containment(&self, other: &Selection, options: ContainmentOptions) -> Containment {
         match other {
             // Using keys here means that @defer fragments never compare equal.
             // This is a bit odd but it is consistent: the selection set data structure would not
@@ -112,7 +112,7 @@ impl FragmentSpreadSelection {
 }
 
 impl InlineFragmentSelection {
-    pub fn containment(&self, other: &Selection, options: ContainmentOptions) -> Containment {
+    pub(crate) fn containment(&self, other: &Selection, options: ContainmentOptions) -> Containment {
         match other {
             // Using keys here means that @defer fragments never compare equal.
             // This is a bit odd but it is consistent: the selection set data structure would not
@@ -129,7 +129,7 @@ impl InlineFragmentSelection {
 }
 
 impl SelectionSet {
-    pub fn containment(&self, other: &Self, options: ContainmentOptions) -> Containment {
+    pub(crate) fn containment(&self, other: &Self, options: ContainmentOptions) -> Containment {
         if other.selections.len() > self.selections.len() {
             // If `other` has more selections but we're ignoring missing __typename, then in the case where
             // `other` has a __typename but `self` does not, then we need the length of `other` to be at
@@ -179,7 +179,7 @@ impl SelectionSet {
     }
 
     /// Returns true if this selection is a superset of the other selection.
-    pub fn contains(&self, other: &Self) -> bool {
+    pub(crate) fn contains(&self, other: &Self) -> bool {
         self.containment(other, Default::default()).is_contained()
     }
 }

--- a/apollo-federation/src/operation/directive_list.rs
+++ b/apollo-federation/src/operation/directive_list.rs
@@ -181,7 +181,7 @@ impl Deref for DirectiveList {
 }
 
 impl Hash for DirectiveList {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         state.write_u64(self.inner.as_ref().map_or(0, |inner| inner.hash))
     }
 }

--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -1600,32 +1600,6 @@ impl Operation {
     }
 }
 
-/// Returns a consistent GraphQL name for the given index.
-fn fragment_name(mut index: usize) -> Name {
-    /// https://spec.graphql.org/draft/#NameContinue
-    const NAME_CHARS: &str = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
-    /// https://spec.graphql.org/draft/#NameStart
-    const NAME_START_CHARS: &str = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_";
-
-    if index < NAME_START_CHARS.len() {
-        Name::new_static_unchecked(&NAME_START_CHARS[index..index + 1])
-    } else {
-        let mut s = String::new();
-
-        let i = index % NAME_START_CHARS.len();
-        s.push(NAME_START_CHARS.as_bytes()[i].into());
-        index /= NAME_START_CHARS.len();
-
-        while index > 0 {
-            let i = index % NAME_CHARS.len();
-            s.push(NAME_CHARS.as_bytes()[i].into());
-            index /= NAME_CHARS.len();
-        }
-
-        Name::new_unchecked(&s)
-    }
-}
-
 #[derive(Debug, Default)]
 struct FragmentGenerator {
     fragments: NamedFragments,
@@ -1634,10 +1608,6 @@ struct FragmentGenerator {
 }
 
 impl FragmentGenerator {
-    fn next_name(&self) -> Name {
-        fragment_name(self.fragments.len())
-    }
-
     // XXX(@goto-bus-stop): This is temporary to support mismatch testing with JS!
     // In the future, we will just use `.next_name()`.
     fn generate_name(&mut self, frag: &InlineFragmentSelection) -> Name {
@@ -1816,6 +1786,32 @@ mod tests {
             validate_operation(&$operation.schema, &optimized.to_string());
             insta::assert_snapshot!(optimized, @$expected)
         }};
+    }
+
+    /// Returns a consistent GraphQL name for the given index.
+    fn fragment_name(mut index: usize) -> Name {
+        /// https://spec.graphql.org/draft/#NameContinue
+        const NAME_CHARS: &str = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_";
+        /// https://spec.graphql.org/draft/#NameStart
+        const NAME_START_CHARS: &str = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_";
+
+        if index < NAME_START_CHARS.len() {
+            Name::new_static_unchecked(&NAME_START_CHARS[index..index + 1])
+        } else {
+            let mut s = String::new();
+
+            let i = index % NAME_START_CHARS.len();
+            s.push(NAME_START_CHARS.as_bytes()[i].into());
+            index /= NAME_START_CHARS.len();
+
+            while index > 0 {
+                let i = index % NAME_CHARS.len();
+                s.push(NAME_CHARS.as_bytes()[i].into());
+                index /= NAME_CHARS.len();
+            }
+
+            Name::new_unchecked(&s)
+        }
     }
 
     #[test]
@@ -2281,12 +2277,12 @@ mod tests {
             type Query {
                 t: T
             }
-    
+
             type T {
                 a: A
                 b: Int
             }
-    
+
             type A {
                 x: String
                 y: String
@@ -2312,14 +2308,14 @@ mod tests {
                 x
                 y
             }
-    
+
             fragment FT on T {
                 a {
                 __typename
                 ...FA
                 }
             }
-    
+
             query {
                 t {
                 ...FT
@@ -2346,19 +2342,19 @@ mod tests {
               type Query {
                 t: T
               }
-        
+
               type T {
                 a: String
                 b: B
                 c: Int
                 d: D
               }
-        
+
               type B {
                 x: String
                 y: String
               }
-        
+
               type D {
                 m: String
                 n: String
@@ -2376,7 +2372,7 @@ mod tests {
                     m
                   }
                 }
-        
+
                 {
                   t {
                     ...FragT
@@ -2415,23 +2411,23 @@ mod tests {
           type Query {
             i: I
           }
-    
+
           interface I {
             a: String
           }
-    
+
           type T implements I {
             a: String
             b: B
             c: Int
             d: D
           }
-    
+
           type B {
             x: String
             y: String
           }
-    
+
           type D {
             m: String
             n: String
@@ -2449,7 +2445,7 @@ mod tests {
                 m
               }
             }
-    
+
             {
               i {
                 ... on T {
@@ -2489,19 +2485,19 @@ mod tests {
               type Query {
                 t: T
               }
-        
+
               type T {
                 a: String
                 b: B
                 c: Int
                 d: D
               }
-        
+
               type B {
                 x: String
                 y: String
               }
-        
+
               type D {
                 m: String
                 n: String
@@ -2527,7 +2523,7 @@ mod tests {
                     m
                   }
                 }
-        
+
                 fragment Frag2 on T {
                   a
                   b {
@@ -2539,7 +2535,7 @@ mod tests {
                     n
                   }
                 }
-        
+
                 {
                   t {
                     ...Frag1
@@ -2573,11 +2569,11 @@ mod tests {
               type Query {
                 t: T
               }
-        
+
               interface I {
                 x: String
               }
-        
+
               type T implements I {
                 x: String
                 a: String
@@ -2591,7 +2587,7 @@ mod tests {
                     a
                   }
                 }
-        
+
                 {
                   t {
                     ...FragI
@@ -2615,12 +2611,12 @@ mod tests {
               type Query {
                 t: T
               }
-        
+
               type T {
                 a: String
                 u: U
               }
-        
+
               type U {
                 x: String
                 y: String
@@ -2631,7 +2627,7 @@ mod tests {
                 fragment Frag1 on T {
                   a
                 }
-        
+
                 fragment Frag2 on T {
                   u {
                     x
@@ -2639,13 +2635,13 @@ mod tests {
                   }
                   ...Frag1
                 }
-        
+
                 fragment Frag3 on Query {
                   t {
                     ...Frag2
                   }
                 }
-        
+
                 {
                   ...Frag3
                 }
@@ -2670,16 +2666,16 @@ mod tests {
               type Query {
                 t1: T1
               }
-        
+
               interface I {
                 x: Int
               }
-        
+
               type T1 implements I {
                 x: Int
                 y: Int
               }
-        
+
               type T2 implements I {
                 x: Int
                 z: Int
@@ -2695,7 +2691,7 @@ mod tests {
                     z
                   }
                 }
-        
+
                 {
                   t1 {
                     ...FragOnI
@@ -2718,24 +2714,24 @@ mod tests {
               type Query {
                 i2: I2
               }
-        
+
               interface I1 {
                 x: Int
               }
-        
+
               interface I2 {
                 y: Int
               }
-        
+
               interface I3 {
                 z: Int
               }
-        
+
               type T1 implements I1 & I2 {
                 x: Int
                 y: Int
               }
-        
+
               type T2 implements I1 & I3 {
                 x: Int
                 z: Int
@@ -2751,7 +2747,7 @@ mod tests {
                     z
                   }
                 }
-        
+
                 {
                   i2 {
                     ...FragOnI1
@@ -2781,13 +2777,13 @@ mod tests {
               type Query {
                 t1: T1
               }
-        
+
               union U = T1 | T2
-        
+
               type T1 {
                 x: Int
               }
-        
+
               type T2 {
                 y: Int
               }
@@ -2802,7 +2798,7 @@ mod tests {
                     y
                   }
                 }
-        
+
                 {
                   t1 {
                     ...OnU
@@ -2912,18 +2908,18 @@ mod tests {
               type Query {
                 t1: T1
               }
-        
+
               union U1 = T1 | T2 | T3
               union U2 =      T2 | T3
-        
+
               type T1 {
                 x: Int
               }
-        
+
               type T2 {
                 y: Int
               }
-        
+
               type T3 {
                 z: Int
               }
@@ -2935,7 +2931,7 @@ mod tests {
                   ...Outer
                 }
               }
-        
+
               fragment Outer on U1 {
                 ... on T1 {
                   x
@@ -2947,7 +2943,7 @@ mod tests {
                   ... Inner
                 }
               }
-        
+
               fragment Inner on U2 {
                 ... on T2 {
                   y
@@ -3006,23 +3002,23 @@ mod tests {
               type Query {
                 t1: T1
               }
-        
+
               union U1 = T1 | T2 | T3
               union U2 =      T2 | T3
-        
+
               type T1 {
                 x: Int
               }
-        
+
               type T2 {
                 y1: Y
                 y2: Y
               }
-        
+
               type T3 {
                 z: Int
               }
-        
+
               type Y {
                 v: Int
               }
@@ -3034,7 +3030,7 @@ mod tests {
                   ...Outer
                 }
               }
-        
+
               fragment Outer on U1 {
                 ... on T1 {
                   x
@@ -3046,7 +3042,7 @@ mod tests {
                   ... Inner
                 }
               }
-        
+
               fragment Inner on U2 {
                 ... on T2 {
                   y1 {
@@ -3057,7 +3053,7 @@ mod tests {
                   }
                 }
               }
-        
+
               fragment WillBeUnused on Y {
                 v
               }
@@ -3092,14 +3088,14 @@ mod tests {
                 t1: T
                 t2: T
               }
-        
+
               type T {
                 a1: Int
                 a2: Int
                 b1: B
                 b2: B
               }
-        
+
               type B {
                 x: Int
                 y: Int
@@ -3115,7 +3111,7 @@ mod tests {
                   ...TFields
                 }
               }
-        
+
               fragment TFields on T {
                 ...DirectFieldsOfT
                 b1 {
@@ -3125,12 +3121,12 @@ mod tests {
                   ...BFields
                 }
               }
-        
+
               fragment DirectFieldsOfT on T {
                 a1
                 a2
               }
-        
+
               fragment BFields on B {
                 x
                 y
@@ -3213,7 +3209,7 @@ mod tests {
                   t2: T
                   t3: T
                 }
-        
+
                 type T {
                   a: Int
                   b: Int
@@ -3226,7 +3222,7 @@ mod tests {
                   fragment DirectiveInDef on T {
                     a @include(if: $cond1)
                   }
-        
+
                   query myQuery($cond1: Boolean!, $cond2: Boolean!) {
                     t1 {
                       a
@@ -3263,7 +3259,7 @@ mod tests {
                   t2: T
                   t3: T
                 }
-        
+
                 type T {
                   a: Int
                   b: Int
@@ -3276,7 +3272,7 @@ mod tests {
                   fragment NoDirectiveDef on T {
                     a
                   }
-        
+
                   query myQuery($cond1: Boolean!) {
                     t1 {
                       ...NoDirectiveDef

--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -747,7 +747,7 @@ impl SelectionSet {
 
     /// Returns true if the selection set would select cleanly from the given type in the given
     /// schema.
-    pub fn can_rebase_on(
+    pub(crate) fn can_rebase_on(
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
         schema: &ValidFederationSchema,

--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -337,20 +337,6 @@ impl FieldSelection {
         }
     }
 
-    /// Returns a field selection "equivalent" to the one represented by this object, but such that its parent type
-    /// is the one provided as argument.
-    ///
-    /// Obviously, this operation will only succeed if this selection (both the field itself and its subselections)
-    /// make sense from the provided parent type. If this is not the case, this method will throw.
-    pub(crate) fn rebase_on(
-        &self,
-        parent_type: &CompositeTypeDefinitionPosition,
-        named_fragments: &NamedFragments,
-        schema: &ValidFederationSchema,
-    ) -> Result<FieldSelection, FederationError> {
-        self.rebase_inner(parent_type, named_fragments, schema, Default::default())
-    }
-
     fn can_add_to(
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
@@ -660,15 +646,6 @@ impl InlineFragmentSelection {
         }
     }
 
-    pub(crate) fn rebase_on(
-        &self,
-        parent_type: &CompositeTypeDefinitionPosition,
-        named_fragments: &NamedFragments,
-        schema: &ValidFederationSchema,
-    ) -> Result<Selection, FederationError> {
-        self.rebase_inner(parent_type, named_fragments, schema, Default::default())
-    }
-
     fn can_add_to(
         &self,
         parent_type: &CompositeTypeDefinitionPosition,
@@ -690,16 +667,6 @@ impl InlineFragmentSelection {
         } else {
             Ok(true)
         }
-    }
-
-    fn can_rebase_on(
-        &self,
-        parent_type: &CompositeTypeDefinitionPosition,
-        parent_schema: &ValidFederationSchema,
-    ) -> bool {
-        self.inline_fragment
-            .can_rebase_on(parent_type, parent_schema)
-            .0
     }
 }
 

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -1506,7 +1506,9 @@ fn add_at_path_collapses_unnecessary_fragments() {
             Some(
                 &SelectionSet::parse(
                     schema.clone(),
-                    InterfaceTypeDefinitionPosition::new(name!("X")).into(),
+                    InterfaceTypeDefinitionPosition {
+                        type_name: name!("X"),
+                    }.into(),
                     "... on C { d }",
                 )
                 .unwrap()

--- a/apollo-federation/src/operation/tests/mod.rs
+++ b/apollo-federation/src/operation/tests/mod.rs
@@ -1366,11 +1366,7 @@ mod lazy_map_tests {
     }
 }
 
-fn field_element(
-    schema: &ValidFederationSchema,
-    object: apollo_compiler::Name,
-    field: apollo_compiler::Name,
-) -> OpPathElement {
+fn field_element(schema: &ValidFederationSchema, object: Name, field: Name) -> OpPathElement {
     OpPathElement::Field(super::Field::new(super::FieldData {
         schema: schema.clone(),
         field_position: ObjectTypeDefinitionPosition::new(object)
@@ -1508,7 +1504,8 @@ fn add_at_path_collapses_unnecessary_fragments() {
                     schema.clone(),
                     InterfaceTypeDefinitionPosition {
                         type_name: name!("X"),
-                    }.into(),
+                    }
+                    .into(),
                     "... on C { d }",
                 )
                 .unwrap()

--- a/apollo-federation/src/query_graph/condition_resolver.rs
+++ b/apollo-federation/src/query_graph/condition_resolver.rs
@@ -31,6 +31,8 @@ pub(crate) enum ConditionResolution {
         path_tree: Option<Arc<OpPathTree>>,
     },
     Unsatisfied {
+        // NOTE: This seems to be a false positive...
+        #[allow(dead_code)]
         reason: Option<UnsatisfiedConditionReason>,
     },
 }
@@ -53,7 +55,7 @@ impl ConditionResolution {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_more::IsVariant)]
 pub(crate) enum ConditionResolutionCacheResult {
     /// Cache hit.
     Hit(ConditionResolution),
@@ -61,20 +63,6 @@ pub(crate) enum ConditionResolutionCacheResult {
     Miss,
     /// The value can't be cached; Or, an incompatible value is already in cache.
     NotApplicable,
-}
-
-impl ConditionResolutionCacheResult {
-    pub(crate) fn is_hit(&self) -> bool {
-        matches!(self, Self::Hit(_))
-    }
-
-    pub(crate) fn is_miss(&self) -> bool {
-        matches!(self, Self::Miss)
-    }
-
-    pub(crate) fn is_not_applicable(&self) -> bool {
-        matches!(self, Self::NotApplicable)
-    }
 }
 
 pub(crate) struct ConditionResolverCache {
@@ -179,7 +167,7 @@ mod tests {
                 &empty_destinations,
                 &empty_conditions
             )
-            .is_hit());
+            .is_hit(),);
 
         let edge2 = EdgeIndex::new(2);
 

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -769,14 +769,7 @@ impl Display for Unadvanceable {
 }
 
 #[derive(Debug, Clone, strum_macros::Display, serde::Serialize)]
-enum UnadvanceableReason {
-    UnsatisfiableKeyCondition,
-    UnsatisfiableRequiresCondition,
-    UnresolvableInterfaceObject,
-    NoMatchingTransition,
-    UnreachableType,
-    IgnoredIndirectPath,
-}
+enum UnadvanceableReason {}
 
 /// One of the options for a `ClosedBranch` (see the documentation of that struct for details). Note
 /// there is an optimization here, in that if some ending section of the path within the GraphQL
@@ -1983,12 +1976,6 @@ impl OpGraphPath {
             })
             .collect();
         (new_self, new_others)
-    }
-
-    pub(crate) fn is_overridden_by(&self, other: &Self) -> bool {
-        self.overriding_path_ids
-            .iter()
-            .any(|overriding_id| other.own_path_ids.contains(overriding_id))
     }
 
     pub(crate) fn subgraph_jumps(&self) -> Result<u32, FederationError> {
@@ -3712,7 +3699,7 @@ impl OpPath {
     }
 
     pub(crate) fn is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.len() == 0
     }
 
     pub(crate) fn strip_prefix(&self, maybe_prefix: &Self) -> Option<Self> {

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -279,7 +279,7 @@ impl Deref for OpPath {
     }
 }
 
-impl std::fmt::Display for OpPath {
+impl Display for OpPath {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         for (i, element) in self.0.iter().enumerate() {
             if i > 0 {
@@ -568,7 +568,7 @@ impl std::fmt::Debug for SimultaneousPaths {
     }
 }
 
-impl std::fmt::Display for SimultaneousPaths {
+impl Display for SimultaneousPaths {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         self.fmt_indented(&mut IndentedFormatter::new(f))
     }
@@ -794,7 +794,7 @@ impl ClosedPath {
     }
 }
 
-impl std::fmt::Display for ClosedPath {
+impl Display for ClosedPath {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if let Some(ref selection_set) = self.selection_set {
             write!(f, "{} -> {}", self.paths, selection_set)
@@ -3589,7 +3589,7 @@ impl SimultaneousPathsWithLazyIndirectPaths {
 
 // PORT_NOTE: JS passes a ConditionResolver here, we do not: see port note for
 // `SimultaneousPathsWithLazyIndirectPaths`
-pub fn create_initial_options(
+pub(crate) fn create_initial_options(
     initial_path: GraphPath<OpGraphPathTrigger, Option<EdgeIndex>>,
     initial_type: &QueryGraphNodeType,
     initial_context: OpGraphPathContext,
@@ -3694,7 +3694,7 @@ impl ClosedBranch {
 }
 
 impl OpPath {
-    pub fn len(&self) -> usize {
+    pub(crate) fn len(&self) -> usize {
         self.0.len()
     }
 

--- a/apollo-federation/src/query_graph/graph_path.rs
+++ b/apollo-federation/src/query_graph/graph_path.rs
@@ -769,6 +769,7 @@ impl Display for Unadvanceable {
 }
 
 #[derive(Debug, Clone, strum_macros::Display, serde::Serialize)]
+// PORT_NOTE: This is only used by composition, which is not ported to Rust yet.
 enum UnadvanceableReason {}
 
 /// One of the options for a `ClosedBranch` (see the documentation of that struct for details). Note

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -528,10 +528,6 @@ impl QueryGraph {
             })
     }
 
-    pub(crate) fn non_trivial_followup_edges(&self) -> &IndexMap<EdgeIndex, Vec<EdgeIndex>> {
-        &self.non_trivial_followup_edges
-    }
-
     /// All outward edges from the given node (including self-key and self-root-type-resolution
     /// edges). Primarily used by `@defer`, when needing to re-enter a subgraph for a deferred
     /// section.

--- a/apollo-federation/src/query_graph/mod.rs
+++ b/apollo-federation/src/query_graph/mod.rs
@@ -69,7 +69,7 @@ pub(crate) struct QueryGraphNode {
 }
 
 impl QueryGraphNode {
-    pub fn is_root_node(&self) -> bool {
+    pub(crate) fn is_root_node(&self) -> bool {
         matches!(self.type_, QueryGraphNodeType::FederatedRootType(_))
     }
 }

--- a/apollo-federation/src/query_graph/output.rs
+++ b/apollo-federation/src/query_graph/output.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 
 use petgraph::dot::Config;
 use petgraph::dot::Dot;
-use petgraph::graph::DiGraph;
 use petgraph::graph::EdgeIndex;
 use petgraph::stable_graph::StableGraph;
 
@@ -14,7 +13,6 @@ use crate::query_graph::QueryGraph;
 use crate::query_graph::QueryGraphEdge;
 use crate::query_graph::QueryGraphNode;
 
-type InnerGraph = DiGraph<QueryGraphNode, QueryGraphEdge>;
 type StableInnerGraph = StableGraph<QueryGraphNode, QueryGraphEdge>;
 
 //////////////////////////////////////////////////////////////////////////////

--- a/apollo-federation/src/query_plan/conditions.rs
+++ b/apollo-federation/src/query_plan/conditions.rs
@@ -26,12 +26,6 @@ pub(crate) enum Conditions {
     Boolean(bool),
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) enum Condition {
-    Variable(VariableCondition),
-    Boolean(bool),
-}
-
 /// A list of variable conditions, represented as a map from variable names to whether that variable
 /// is negated in the condition. We maintain the invariant that there's at least one condition (i.e.
 /// the map is non-empty), and that there's at most one condition per variable name.
@@ -45,23 +39,6 @@ impl VariableConditions {
     fn new_unchecked(map: IndexMap<Name, bool>) -> Self {
         debug_assert!(!map.is_empty());
         Self(Arc::new(map))
-    }
-
-    pub fn insert(&mut self, name: Name, negated: bool) {
-        Arc::make_mut(&mut self.0).insert(name, negated);
-    }
-
-    /// Returns true if there are no conditions.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
-    /// Returns a variable condition by name.
-    pub fn get(&self, name: &str) -> Option<VariableCondition> {
-        self.0.get_key_value(name).map(|(variable, &negated)| {
-            let variable = variable.clone();
-            VariableCondition { variable, negated }
-        })
     }
 
     /// Returns whether a variable condition is negated, or None if there is no condition for the variable name.
@@ -182,13 +159,6 @@ impl Conditions {
                 Conditions::Variables(self_vars)
             }
         }
-    }
-}
-
-fn is_constant_condition(condition: &Conditions) -> bool {
-    match condition {
-        Conditions::Variables(_) => false,
-        Conditions::Boolean(_) => true,
     }
 }
 

--- a/apollo-federation/src/query_plan/conditions.rs
+++ b/apollo-federation/src/query_plan/conditions.rs
@@ -42,11 +42,11 @@ impl VariableConditions {
     }
 
     /// Returns whether a variable condition is negated, or None if there is no condition for the variable name.
-    pub fn is_negated(&self, name: &str) -> Option<bool> {
+    pub(crate) fn is_negated(&self, name: &str) -> Option<bool> {
         self.0.get(name).copied()
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&Name, bool)> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = (&Name, bool)> {
         self.0.iter().map(|(name, &negated)| (name, negated))
     }
 }

--- a/apollo-federation/src/query_plan/query_planner.rs
+++ b/apollo-federation/src/query_plan/query_planner.rs
@@ -16,7 +16,6 @@ use super::fetch_dependency_graph::FetchIdGenerator;
 use super::ConditionNode;
 use crate::error::FederationError;
 use crate::error::SingleFederationError;
-use crate::link::federation_spec_definition::FederationSpecDefinition;
 use crate::operation::normalize_operation;
 use crate::operation::NamedFragments;
 use crate::operation::NormalizedDefer;
@@ -53,7 +52,6 @@ use crate::ApiSchemaOptions;
 use crate::Supergraph;
 
 pub(crate) const CONTEXT_DIRECTIVE: &str = "context";
-pub(crate) const JOIN_FIELD: &str = "join__field";
 
 #[derive(Debug, Clone, Hash)]
 pub struct QueryPlannerConfig {
@@ -226,8 +224,6 @@ pub struct QueryPlanner {
     federated_query_graph: Arc<QueryGraph>,
     supergraph_schema: ValidFederationSchema,
     api_schema: ValidFederationSchema,
-    subgraph_federation_spec_definitions:
-        Arc<IndexMap<Arc<str>, &'static FederationSpecDefinition>>,
     /// A set of the names of interface types for which at least one subgraph use an
     /// @interfaceObject to abstract that interface.
     interface_types_with_interface_objects: IndexSet<InterfaceTypeDefinitionPosition>,
@@ -338,9 +334,6 @@ impl QueryPlanner {
             federated_query_graph: Arc::new(query_graph),
             supergraph_schema,
             api_schema,
-            // TODO(@goto-bus-stop): not sure how this is going to be used,
-            // keeping empty for the moment
-            subgraph_federation_spec_definitions: Default::default(),
             interface_types_with_interface_objects,
             abstract_types_with_inconsistent_runtime_types,
         })

--- a/apollo-federation/src/query_plan/query_planning_traversal.rs
+++ b/apollo-federation/src/query_plan/query_planning_traversal.rs
@@ -134,16 +134,16 @@ impl std::fmt::Debug for PlanInfo {
 #[derive(Serialize)]
 pub(crate) struct BestQueryPlanInfo {
     /// The fetch dependency graph for this query plan.
-    pub fetch_dependency_graph: FetchDependencyGraph,
+    pub(crate) fetch_dependency_graph: FetchDependencyGraph,
     /// The path tree for the closed branch options chosen for this query plan.
-    pub path_tree: Arc<OpPathTree>,
+    pub(crate) path_tree: Arc<OpPathTree>,
     /// The cost of this query plan.
-    pub cost: QueryPlanCost,
+    pub(crate) cost: QueryPlanCost,
 }
 
 impl BestQueryPlanInfo {
     // PORT_NOTE: The equivalent of `createEmptyPlan` in the JS codebase.
-    pub fn empty(parameters: &QueryPlanningParameters) -> Self {
+    pub(crate) fn empty(parameters: &QueryPlanningParameters) -> Self {
         Self {
             fetch_dependency_graph: FetchDependencyGraph::new(
                 parameters.supergraph_schema.clone(),
@@ -163,7 +163,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
         feature = "snapshot_tracing",
         tracing::instrument(level = "trace", skip_all, name = "QueryPlanningTraversal::new")
     )]
-    pub fn new(
+    pub(crate) fn new(
         // TODO(@goto-bus-stop): This probably needs a mutable reference for some of the
         // yet-unimplemented methods, and storing a mutable ref in `Self` here smells bad.
         // The ownership of `QueryPlanningParameters` is awkward and should probably be
@@ -270,7 +270,7 @@ impl<'a: 'b, 'b> QueryPlanningTraversal<'a, 'b> {
             name = "QueryPlanningTraversal::find_best_plan"
         )
     )]
-    pub fn find_best_plan(mut self) -> Result<Option<BestQueryPlanInfo>, FederationError> {
+    pub(crate) fn find_best_plan(mut self) -> Result<Option<BestQueryPlanInfo>, FederationError> {
         self.find_best_plan_inner()?;
         Ok(self.best_plan)
     }

--- a/apollo-federation/src/schema/argument_composition_strategies.rs
+++ b/apollo-federation/src/schema/argument_composition_strategies.rs
@@ -5,6 +5,7 @@ use lazy_static::lazy_static;
 
 use crate::schema::FederationSchema;
 
+#[allow(dead_code)]
 #[derive(Clone, Copy)]
 pub(crate) enum ArgumentCompositionStrategy {
     Max,
@@ -55,17 +56,6 @@ impl ArgumentCompositionStrategy {
             Self::Sum => SUM_STRATEGY.merge_values(values),
             Self::Intersection => INTERSECTION_STRATEGY.merge_values(values),
             Self::Union => UNION_STRATEGY.merge_values(values),
-        }
-    }
-
-    pub fn from_str(s: &str) -> Option<Self> {
-        match s {
-            "MAX" => Some(Self::Max),
-            "MIN" => Some(Self::Min),
-            "SUM" => Some(Self::Sum),
-            "INTERSECTION" => Some(Self::Intersection),
-            "UNION" => Some(Self::Union),
-            _ => None,
         }
     }
 }

--- a/apollo-federation/src/schema/argument_composition_strategies.rs
+++ b/apollo-federation/src/schema/argument_composition_strategies.rs
@@ -29,7 +29,7 @@ lazy_static! {
 }
 
 impl ArgumentCompositionStrategy {
-    pub fn name(&self) -> &str {
+    pub(crate) fn name(&self) -> &str {
         match self {
             Self::Max => MAX_STRATEGY.name(),
             Self::Min => MIN_STRATEGY.name(),
@@ -39,7 +39,7 @@ impl ArgumentCompositionStrategy {
         }
     }
 
-    pub fn is_type_supported(&self, schema: &FederationSchema, ty: &Type) -> Result<(), String> {
+    pub(crate) fn is_type_supported(&self, schema: &FederationSchema, ty: &Type) -> Result<(), String> {
         match self {
             Self::Max => MAX_STRATEGY.is_type_supported(schema, ty),
             Self::Min => MIN_STRATEGY.is_type_supported(schema, ty),
@@ -49,7 +49,7 @@ impl ArgumentCompositionStrategy {
         }
     }
 
-    pub fn merge_values(&self, values: &[Value]) -> Value {
+    pub(crate) fn merge_values(&self, values: &[Value]) -> Value {
         match self {
             Self::Max => MAX_STRATEGY.merge_values(values),
             Self::Min => MIN_STRATEGY.merge_values(values),
@@ -78,7 +78,7 @@ pub(crate) trait ArgumentComposition {
 
 #[derive(Clone)]
 pub(crate) struct FixedTypeSupportValidator {
-    pub supported_types: Vec<Type>,
+    pub(crate) supported_types: Vec<Type>,
 }
 
 impl FixedTypeSupportValidator {

--- a/apollo-federation/src/schema/argument_composition_strategies.rs
+++ b/apollo-federation/src/schema/argument_composition_strategies.rs
@@ -39,7 +39,11 @@ impl ArgumentCompositionStrategy {
         }
     }
 
-    pub(crate) fn is_type_supported(&self, schema: &FederationSchema, ty: &Type) -> Result<(), String> {
+    pub(crate) fn is_type_supported(
+        &self,
+        schema: &FederationSchema,
+        ty: &Type,
+    ) -> Result<(), String> {
         match self {
             Self::Max => MAX_STRATEGY.is_type_supported(schema, ty),
             Self::Min => MIN_STRATEGY.is_type_supported(schema, ty),

--- a/apollo-federation/src/schema/field_set.rs
+++ b/apollo-federation/src/schema/field_set.rs
@@ -17,7 +17,6 @@ use crate::schema::position::FieldDefinitionPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::position::ObjectTypeDefinitionPosition;
 use crate::schema::position::UnionTypeDefinitionPosition;
-use crate::schema::FederationSchema;
 use crate::schema::ValidFederationSchema;
 
 // Federation spec does not allow the alias syntax in field set strings.
@@ -165,37 +164,6 @@ pub(crate) fn collect_target_fields_from_field_set(
         }
     }
     Ok(fields)
-}
-
-// PORT_NOTE: This is meant as a companion function for collect_target_fields_from_field_set(), as
-// some callers will also want to include interface field implementations.
-pub(crate) fn add_interface_field_implementations(
-    fields: Vec<FieldDefinitionPosition>,
-    schema: &FederationSchema,
-) -> Result<Vec<FieldDefinitionPosition>, FederationError> {
-    let mut new_fields = vec![];
-    for field in fields {
-        let interface_field = if let FieldDefinitionPosition::Interface(field) = &field {
-            Some(field.clone())
-        } else {
-            None
-        };
-        new_fields.push(field);
-        if let Some(interface_field) = interface_field {
-            for implementing_type in &schema
-                .referencers
-                .get_interface_type(&interface_field.type_name)?
-                .object_types
-            {
-                new_fields.push(
-                    implementing_type
-                        .field(interface_field.field_name.clone())
-                        .into(),
-                );
-            }
-        }
-    }
-    Ok(new_fields)
 }
 
 #[cfg(test)]

--- a/apollo-federation/src/schema/mod.rs
+++ b/apollo-federation/src/schema/mod.rs
@@ -163,10 +163,6 @@ impl FederationSchema {
         })
     }
 
-    pub(crate) fn validate(self) -> Result<ValidFederationSchema, FederationError> {
-        self.validate_or_return_self().map_err(|e| e.1)
-    }
-
     /// Similar to `Self::validate` but returns `self` as part of the error should it be needed by
     /// the caller
     pub(crate) fn validate_or_return_self(
@@ -230,10 +226,6 @@ impl ValidFederationSchema {
         let schema = FederationSchema::new(schema.into_inner())?;
 
         Self::new_assume_valid(schema).map_err(|(_schema, error)| error)
-    }
-
-    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.schema, &other.schema)
     }
 
     /// Construct a ValidFederationSchema by assuming the given FederationSchema is valid.

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -5463,7 +5463,7 @@ mod tests {
         .unwrap();
 
         let position = InterfaceTypeDefinitionPosition {
-            type_name: name!("UserProfile")
+            type_name: name!("UserProfile"),
         };
         position.remove_recursive(&mut schema).unwrap();
 

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -232,13 +232,6 @@ impl TypeDefinitionPosition {
             )),
         }
     }
-
-    pub(crate) fn try_get<'schema>(
-        &self,
-        schema: &'schema Schema,
-    ) -> Option<&'schema ExtendedType> {
-        self.get(schema).ok()
-    }
 }
 
 fallible_conversions!(TypeDefinitionPosition::Scalar -> ScalarTypeDefinitionPosition);
@@ -285,45 +278,6 @@ impl OutputTypeDefinitionPosition {
             OutputTypeDefinitionPosition::Union(type_) => &type_.type_name,
             OutputTypeDefinitionPosition::Enum(type_) => &type_.type_name,
         }
-    }
-
-    fn describe(&self) -> &'static str {
-        match self {
-            OutputTypeDefinitionPosition::Scalar(_) => ScalarTypeDefinitionPosition::EXPECTED,
-            OutputTypeDefinitionPosition::Object(_) => ObjectTypeDefinitionPosition::EXPECTED,
-            OutputTypeDefinitionPosition::Interface(_) => InterfaceTypeDefinitionPosition::EXPECTED,
-            OutputTypeDefinitionPosition::Union(_) => UnionTypeDefinitionPosition::EXPECTED,
-            OutputTypeDefinitionPosition::Enum(_) => EnumTypeDefinitionPosition::EXPECTED,
-        }
-    }
-
-    pub(crate) fn get<'schema>(
-        &self,
-        schema: &'schema Schema,
-    ) -> Result<&'schema ExtendedType, PositionLookupError> {
-        let name = self.type_name();
-        let ty = schema
-            .types
-            .get(name)
-            .ok_or_else(|| PositionLookupError::TypeMissing(name.clone()))?;
-        match (ty, self) {
-            (ExtendedType::Scalar(_), OutputTypeDefinitionPosition::Scalar(_))
-            | (ExtendedType::Object(_), OutputTypeDefinitionPosition::Object(_))
-            | (ExtendedType::Interface(_), OutputTypeDefinitionPosition::Interface(_))
-            | (ExtendedType::Union(_), OutputTypeDefinitionPosition::Union(_))
-            | (ExtendedType::Enum(_), OutputTypeDefinitionPosition::Enum(_)) => Ok(ty),
-            _ => Err(PositionLookupError::TypeWrongKind(
-                name.clone(),
-                self.describe(),
-            )),
-        }
-    }
-
-    pub(crate) fn try_get<'schema>(
-        &self,
-        schema: &'schema Schema,
-    ) -> Option<&'schema ExtendedType> {
-        self.get(schema).ok()
     }
 }
 
@@ -447,13 +401,6 @@ impl CompositeTypeDefinitionPosition {
             )),
         }
     }
-
-    pub(crate) fn try_get<'schema>(
-        &self,
-        schema: &'schema Schema,
-    ) -> Option<&'schema ExtendedType> {
-        self.get(schema).ok()
-    }
 }
 
 fallible_conversions!(CompositeTypeDefinitionPosition::Object -> ObjectTypeDefinitionPosition);
@@ -489,73 +436,6 @@ impl AbstractTypeDefinitionPosition {
             AbstractTypeDefinitionPosition::Union(type_) => &type_.type_name,
         }
     }
-
-    fn describe(&self) -> &'static str {
-        match self {
-            AbstractTypeDefinitionPosition::Interface(_) => {
-                InterfaceTypeDefinitionPosition::EXPECTED
-            }
-            AbstractTypeDefinitionPosition::Union(_) => UnionTypeDefinitionPosition::EXPECTED,
-        }
-    }
-
-    pub(crate) fn field(
-        &self,
-        field_name: Name,
-    ) -> Result<FieldDefinitionPosition, FederationError> {
-        match self {
-            AbstractTypeDefinitionPosition::Interface(type_) => Ok(type_.field(field_name).into()),
-            AbstractTypeDefinitionPosition::Union(type_) => {
-                let field = type_.introspection_typename_field();
-                if *field.field_name() == field_name {
-                    Ok(field.into())
-                } else {
-                    Err(FederationError::internal(format!(
-                        r#"Union types don't have field "{}", only "{}""#,
-                        field_name,
-                        field.field_name(),
-                    )))
-                }
-            }
-        }
-    }
-
-    pub(crate) fn introspection_typename_field(&self) -> FieldDefinitionPosition {
-        match self {
-            AbstractTypeDefinitionPosition::Interface(type_) => {
-                type_.introspection_typename_field().into()
-            }
-            AbstractTypeDefinitionPosition::Union(type_) => {
-                type_.introspection_typename_field().into()
-            }
-        }
-    }
-
-    pub(crate) fn get<'schema>(
-        &self,
-        schema: &'schema Schema,
-    ) -> Result<&'schema ExtendedType, PositionLookupError> {
-        let name = self.type_name();
-        let ty = schema
-            .types
-            .get(name)
-            .ok_or_else(|| PositionLookupError::TypeMissing(name.clone()))?;
-        match (ty, self) {
-            (ExtendedType::Interface(_), AbstractTypeDefinitionPosition::Interface(_))
-            | (ExtendedType::Union(_), AbstractTypeDefinitionPosition::Union(_)) => Ok(ty),
-            _ => Err(PositionLookupError::TypeWrongKind(
-                name.clone(),
-                self.describe(),
-            )),
-        }
-    }
-
-    pub(crate) fn try_get<'schema>(
-        &self,
-        schema: &'schema Schema,
-    ) -> Option<&'schema ExtendedType> {
-        self.get(schema).ok()
-    }
 }
 
 fallible_conversions!(AbstractTypeDefinitionPosition::Interface -> InterfaceTypeDefinitionPosition);
@@ -590,17 +470,6 @@ impl ObjectOrInterfaceTypeDefinitionPosition {
         }
     }
 
-    fn describe(&self) -> &'static str {
-        match self {
-            ObjectOrInterfaceTypeDefinitionPosition::Object(_) => {
-                ObjectTypeDefinitionPosition::EXPECTED
-            }
-            ObjectOrInterfaceTypeDefinitionPosition::Interface(_) => {
-                InterfaceTypeDefinitionPosition::EXPECTED
-            }
-        }
-    }
-
     pub(crate) fn field(&self, field_name: Name) -> ObjectOrInterfaceFieldDefinitionPosition {
         match self {
             ObjectOrInterfaceTypeDefinitionPosition::Object(type_) => {
@@ -608,17 +477,6 @@ impl ObjectOrInterfaceTypeDefinitionPosition {
             }
             ObjectOrInterfaceTypeDefinitionPosition::Interface(type_) => {
                 type_.field(field_name).into()
-            }
-        }
-    }
-
-    pub(crate) fn introspection_typename_field(&self) -> FieldDefinitionPosition {
-        match self {
-            ObjectOrInterfaceTypeDefinitionPosition::Object(type_) => {
-                type_.introspection_typename_field().into()
-            }
-            ObjectOrInterfaceTypeDefinitionPosition::Interface(type_) => {
-                type_.introspection_typename_field().into()
             }
         }
     }
@@ -638,34 +496,6 @@ impl ObjectOrInterfaceTypeDefinitionPosition {
                 Ok(Box::new(type_.fields(schema)?.map(|field| field.into())))
             }
         }
-    }
-
-    pub(crate) fn get<'schema>(
-        &self,
-        schema: &'schema Schema,
-    ) -> Result<&'schema ExtendedType, PositionLookupError> {
-        let name = self.type_name();
-        let ty = schema
-            .types
-            .get(name)
-            .ok_or_else(|| PositionLookupError::TypeMissing(name.clone()))?;
-        match (ty, self) {
-            (ExtendedType::Object(_), ObjectOrInterfaceTypeDefinitionPosition::Object(_))
-            | (ExtendedType::Interface(_), ObjectOrInterfaceTypeDefinitionPosition::Interface(_)) => {
-                Ok(ty)
-            }
-            _ => Err(PositionLookupError::TypeWrongKind(
-                name.clone(),
-                self.describe(),
-            )),
-        }
-    }
-
-    pub(crate) fn try_get<'schema>(
-        &self,
-        schema: &'schema Schema,
-    ) -> Option<&'schema ExtendedType> {
-        self.get(schema).ok()
     }
 }
 
@@ -761,22 +591,11 @@ impl Debug for ObjectOrInterfaceFieldDefinitionPosition {
 impl ObjectOrInterfaceFieldDefinitionPosition {
     const EXPECTED: &'static str = "an object/interface field";
 
-    pub(crate) fn type_name(&self) -> &Name {
-        match self {
-            ObjectOrInterfaceFieldDefinitionPosition::Object(field) => &field.type_name,
-            ObjectOrInterfaceFieldDefinitionPosition::Interface(field) => &field.type_name,
-        }
-    }
-
     pub(crate) fn field_name(&self) -> &Name {
         match self {
             ObjectOrInterfaceFieldDefinitionPosition::Object(field) => &field.field_name,
             ObjectOrInterfaceFieldDefinitionPosition::Interface(field) => &field.field_name,
         }
-    }
-
-    pub(crate) fn is_introspection_typename_field(&self) -> bool {
-        *self.field_name() == *INTROSPECTION_TYPENAME_FIELD_NAME
     }
 
     pub(crate) fn parent(&self) -> ObjectOrInterfaceTypeDefinitionPosition {
@@ -890,29 +709,6 @@ impl SchemaDefinitionPosition {
             .make_mut()
             .directives
             .retain(|other_directive| other_directive.name != name);
-        if is_link {
-            schema.links_metadata = links_metadata(&schema.schema)?.map(Box::new);
-        }
-        Ok(())
-    }
-
-    /// Remove a directive application from the schema definition.
-    pub(crate) fn remove_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: &Component<Directive>,
-    ) -> Result<(), FederationError> {
-        let is_link = Self::is_link(schema, &directive.name)?;
-        let schema_definition = self.make_mut(&mut schema.schema);
-        if !schema_definition.directives.iter().any(|other_directive| {
-            (other_directive.name == directive.name) && !other_directive.ptr_eq(directive)
-        }) {
-            self.remove_directive_name_references(&mut schema.referencers, &directive.name);
-        }
-        schema_definition
-            .make_mut()
-            .directives
-            .retain(|other_directive| !other_directive.ptr_eq(directive));
         if is_link {
             schema.links_metadata = links_metadata(&schema.schema)?.map(Box::new);
         }
@@ -1079,49 +875,6 @@ impl SchemaRootDefinitionPosition {
         schema: &'schema Schema,
     ) -> Option<&'schema ComponentName> {
         self.get(schema).ok()
-    }
-
-    fn make_mut<'schema>(
-        &self,
-        schema: &'schema mut Schema,
-    ) -> Result<&'schema mut ComponentName, FederationError> {
-        let schema_definition = self.parent().make_mut(schema).make_mut();
-
-        match self.root_kind {
-            SchemaRootDefinitionKind::Query => schema_definition.query.as_mut().ok_or_else(|| {
-                SingleFederationError::Internal {
-                    message: format!("Schema definition has no root {} type", self),
-                }
-                .into()
-            }),
-            SchemaRootDefinitionKind::Mutation => {
-                schema_definition.mutation.as_mut().ok_or_else(|| {
-                    SingleFederationError::Internal {
-                        message: format!("Schema definition has no root {} type", self),
-                    }
-                    .into()
-                })
-            }
-            SchemaRootDefinitionKind::Subscription => {
-                schema_definition.subscription.as_mut().ok_or_else(|| {
-                    SingleFederationError::Internal {
-                        message: format!("Schema definition has no root {} type", self),
-                    }
-                    .into()
-                })
-            }
-        }
-    }
-
-    fn try_make_mut<'schema>(
-        &self,
-        schema: &'schema mut Schema,
-    ) -> Option<&'schema mut ComponentName> {
-        if self.try_get(schema).is_some() {
-            self.make_mut(schema).ok()
-        } else {
-            None
-        }
     }
 
     pub(crate) fn insert(
@@ -1386,35 +1139,6 @@ impl ScalarTypeDefinitionPosition {
         Ok(Some(referencers))
     }
 
-    /// Remove this scalar type from the schema
-    pub(crate) fn remove_recursive(
-        &self,
-        schema: &mut FederationSchema,
-    ) -> Result<(), FederationError> {
-        let Some(referencers) = self.remove_internal(schema)? else {
-            return Ok(());
-        };
-        for field in referencers.object_fields {
-            field.remove_recursive(schema)?;
-        }
-        for argument in referencers.object_field_arguments {
-            argument.remove(schema)?;
-        }
-        for field in referencers.interface_fields {
-            field.remove_recursive(schema)?;
-        }
-        for argument in referencers.interface_field_arguments {
-            argument.remove(schema)?;
-        }
-        for field in referencers.input_object_fields {
-            field.remove_recursive(schema)?;
-        }
-        for argument in referencers.directive_arguments {
-            argument.remove(schema)?;
-        }
-        Ok(())
-    }
-
     fn remove_internal(
         &self,
         schema: &mut FederationSchema,
@@ -1469,26 +1193,6 @@ impl ScalarTypeDefinitionPosition {
             .make_mut()
             .directives
             .retain(|other_directive| other_directive.name != name);
-    }
-
-    /// Remove a directive application.
-    pub(crate) fn remove_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: &Component<Directive>,
-    ) {
-        let Some(type_) = self.try_make_mut(&mut schema.schema) else {
-            return;
-        };
-        if !type_.directives.iter().any(|other_directive| {
-            (other_directive.name == directive.name) && !other_directive.ptr_eq(directive)
-        }) {
-            self.remove_directive_name_references(&mut schema.referencers, &directive.name);
-        }
-        type_
-            .make_mut()
-            .directives
-            .retain(|other_directive| !other_directive.ptr_eq(directive));
     }
 
     fn insert_references(
@@ -1816,26 +1520,6 @@ impl ObjectTypeDefinitionPosition {
             .retain(|other_directive| other_directive.name != name);
     }
 
-    /// Remove a directive application.
-    pub(crate) fn remove_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: &Component<Directive>,
-    ) {
-        let Some(type_) = self.try_make_mut(&mut schema.schema) else {
-            return;
-        };
-        if !type_.directives.iter().any(|other_directive| {
-            (other_directive.name == directive.name) && !other_directive.ptr_eq(directive)
-        }) {
-            self.remove_directive_name_references(&mut schema.referencers, &directive.name);
-        }
-        type_
-            .make_mut()
-            .directives
-            .retain(|other_directive| !other_directive.ptr_eq(directive));
-    }
-
     pub(crate) fn insert_implements_interface(
         &self,
         schema: &mut FederationSchema,
@@ -2051,10 +1735,6 @@ pub(crate) struct ObjectFieldDefinitionPosition {
 }
 
 impl ObjectFieldDefinitionPosition {
-    pub(crate) fn is_introspection_typename_field(&self) -> bool {
-        self.field_name == *INTROSPECTION_TYPENAME_FIELD_NAME
-    }
-
     pub(crate) fn parent(&self) -> ObjectTypeDefinitionPosition {
         ObjectTypeDefinitionPosition {
             type_name: self.type_name.clone(),
@@ -2475,38 +2155,6 @@ impl ObjectFieldArgumentDefinitionPosition {
         }
     }
 
-    pub(crate) fn insert(
-        &self,
-        schema: &mut FederationSchema,
-        argument: Node<InputValueDefinition>,
-    ) -> Result<(), FederationError> {
-        if self.argument_name != argument.name {
-            return Err(SingleFederationError::Internal {
-                message: format!(
-                    "Object field argument \"{}\" given argument named \"{}\"",
-                    self, argument.name,
-                ),
-            }
-            .into());
-        }
-        if self.try_get(&schema.schema).is_some() {
-            // TODO: Handle old spec edge case of arguments with non-unique names
-            return Err(SingleFederationError::Internal {
-                message: format!(
-                    "Object field argument \"{}\" already exists in schema",
-                    self,
-                ),
-            }
-            .into());
-        }
-        self.parent()
-            .make_mut(&mut schema.schema)?
-            .make_mut()
-            .arguments
-            .push(argument);
-        self.insert_references(self.get(&schema.schema)?, &mut schema.referencers)
-    }
-
     /// Remove this argument from the field.
     ///
     /// This can make the schema invalid if this is an implementing field of an interface.
@@ -2523,30 +2171,6 @@ impl ObjectFieldArgumentDefinitionPosition {
         Ok(())
     }
 
-    pub(crate) fn insert_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: Node<Directive>,
-    ) -> Result<(), FederationError> {
-        let argument = self.make_mut(&mut schema.schema)?;
-        if argument
-            .directives
-            .iter()
-            .any(|other_directive| other_directive.ptr_eq(&directive))
-        {
-            return Err(SingleFederationError::Internal {
-                message: format!(
-                    "Directive application \"@{}\" already exists on object field argument \"{}\"",
-                    directive.name, self,
-                ),
-            }
-            .into());
-        }
-        let name = directive.name.clone();
-        argument.make_mut().directives.push(directive);
-        self.insert_directive_name_references(&mut schema.referencers, &name)
-    }
-
     /// Remove a directive application from this position by name.
     pub(crate) fn remove_directive_name(&self, schema: &mut FederationSchema, name: &str) {
         let Some(argument) = self.try_make_mut(&mut schema.schema) else {
@@ -2557,26 +2181,6 @@ impl ObjectFieldArgumentDefinitionPosition {
             .make_mut()
             .directives
             .retain(|other_directive| other_directive.name != name);
-    }
-
-    /// Remove a directive application.
-    pub(crate) fn remove_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: &Node<Directive>,
-    ) {
-        let Some(argument) = self.try_make_mut(&mut schema.schema) else {
-            return;
-        };
-        if !argument.directives.iter().any(|other_directive| {
-            (other_directive.name == directive.name) && !other_directive.ptr_eq(directive)
-        }) {
-            self.remove_directive_name_references(&mut schema.referencers, &directive.name);
-        }
-        argument
-            .make_mut()
-            .directives
-            .retain(|other_directive| !other_directive.ptr_eq(directive));
     }
 
     fn insert_references(
@@ -2729,10 +2333,6 @@ pub(crate) struct InterfaceTypeDefinitionPosition {
 
 impl InterfaceTypeDefinitionPosition {
     const EXPECTED: &'static str = "an interface type";
-
-    pub(crate) fn new(type_name: Name) -> Self {
-        Self { type_name }
-    }
 
     pub(crate) fn field(&self, field_name: Name) -> InterfaceFieldDefinitionPosition {
         InterfaceFieldDefinitionPosition {
@@ -2988,26 +2588,6 @@ impl InterfaceTypeDefinitionPosition {
             .retain(|other_directive| other_directive.name != name);
     }
 
-    /// Remove a directive application.
-    pub(crate) fn remove_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: &Component<Directive>,
-    ) {
-        let Some(type_) = self.try_make_mut(&mut schema.schema) else {
-            return;
-        };
-        if !type_.directives.iter().any(|other_directive| {
-            (other_directive.name == directive.name) && !other_directive.ptr_eq(directive)
-        }) {
-            self.remove_directive_name_references(&mut schema.referencers, &directive.name);
-        }
-        type_
-            .make_mut()
-            .directives
-            .retain(|other_directive| !other_directive.ptr_eq(directive));
-    }
-
     pub(crate) fn insert_implements_interface(
         &self,
         schema: &mut FederationSchema,
@@ -3154,10 +2734,6 @@ pub(crate) struct InterfaceFieldDefinitionPosition {
 }
 
 impl InterfaceFieldDefinitionPosition {
-    pub(crate) fn is_introspection_typename_field(&self) -> bool {
-        self.field_name == *INTROSPECTION_TYPENAME_FIELD_NAME
-    }
-
     pub(crate) fn parent(&self) -> InterfaceTypeDefinitionPosition {
         InterfaceTypeDefinitionPosition {
             type_name: self.type_name.clone(),
@@ -3576,38 +3152,6 @@ impl InterfaceFieldArgumentDefinitionPosition {
         }
     }
 
-    pub(crate) fn insert(
-        &self,
-        schema: &mut FederationSchema,
-        argument: Node<InputValueDefinition>,
-    ) -> Result<(), FederationError> {
-        if self.argument_name != argument.name {
-            return Err(SingleFederationError::Internal {
-                message: format!(
-                    "Interface field argument \"{}\" given argument named \"{}\"",
-                    self, argument.name,
-                ),
-            }
-            .into());
-        }
-        if self.try_get(&schema.schema).is_some() {
-            // TODO: Handle old spec edge case of arguments with non-unique names
-            return Err(SingleFederationError::Internal {
-                message: format!(
-                    "Interface field argument \"{}\" already exists in schema",
-                    self,
-                ),
-            }
-            .into());
-        }
-        self.parent()
-            .make_mut(&mut schema.schema)?
-            .make_mut()
-            .arguments
-            .push(argument);
-        self.insert_references(self.get(&schema.schema)?, &mut schema.referencers)
-    }
-
     /// Remove this argument from its field definition.
     ///
     /// This can make the schema invalid if this argument is required and also declared in
@@ -3625,32 +3169,6 @@ impl InterfaceFieldArgumentDefinitionPosition {
         Ok(())
     }
 
-    pub(crate) fn insert_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: Node<Directive>,
-    ) -> Result<(), FederationError> {
-        let argument = self.make_mut(&mut schema.schema)?;
-        if argument
-            .directives
-            .iter()
-            .any(|other_directive| other_directive.ptr_eq(&directive))
-        {
-            return Err(
-                SingleFederationError::Internal {
-                    message: format!(
-                        "Directive application \"@{}\" already exists on interface field argument \"{}\"",
-                        directive.name,
-                        self,
-                    )
-                }.into()
-            );
-        }
-        let name = directive.name.clone();
-        argument.make_mut().directives.push(directive);
-        self.insert_directive_name_references(&mut schema.referencers, &name)
-    }
-
     /// Remove a directive application from this position by name.
     pub(crate) fn remove_directive_name(&self, schema: &mut FederationSchema, name: &str) {
         let Some(argument) = self.try_make_mut(&mut schema.schema) else {
@@ -3661,26 +3179,6 @@ impl InterfaceFieldArgumentDefinitionPosition {
             .make_mut()
             .directives
             .retain(|other_directive| other_directive.name != name);
-    }
-
-    /// Remove a directive application.
-    pub(crate) fn remove_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: &Node<Directive>,
-    ) {
-        let Some(argument) = self.try_make_mut(&mut schema.schema) else {
-            return;
-        };
-        if !argument.directives.iter().any(|other_directive| {
-            (other_directive.name == directive.name) && !other_directive.ptr_eq(directive)
-        }) {
-            self.remove_directive_name_references(&mut schema.referencers, &directive.name);
-        }
-        argument
-            .make_mut()
-            .directives
-            .retain(|other_directive| !other_directive.ptr_eq(directive));
     }
 
     fn insert_references(
@@ -3835,10 +3333,6 @@ pub(crate) struct UnionTypeDefinitionPosition {
 
 impl UnionTypeDefinitionPosition {
     const EXPECTED: &'static str = "a union type";
-
-    pub(crate) fn new(type_name: Name) -> Self {
-        Self { type_name }
-    }
 
     pub(crate) fn introspection_typename_field(&self) -> UnionTypenameFieldDefinitionPosition {
         UnionTypenameFieldDefinitionPosition {
@@ -4052,26 +3546,6 @@ impl UnionTypeDefinitionPosition {
             .retain(|other_directive| other_directive.name != name);
     }
 
-    /// Remove a directive application.
-    pub(crate) fn remove_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: &Component<Directive>,
-    ) {
-        let Some(type_) = self.try_make_mut(&mut schema.schema) else {
-            return;
-        };
-        if !type_.directives.iter().any(|other_directive| {
-            (other_directive.name == directive.name) && !other_directive.ptr_eq(directive)
-        }) {
-            self.remove_directive_name_references(&mut schema.referencers, &directive.name);
-        }
-        type_
-            .make_mut()
-            .directives
-            .retain(|other_directive| !other_directive.ptr_eq(directive));
-    }
-
     pub(crate) fn insert_member(
         &self,
         schema: &mut FederationSchema,
@@ -4223,13 +3697,6 @@ impl UnionTypenameFieldDefinitionPosition {
                     name!("__typename"),
                 )
             })
-    }
-
-    pub(crate) fn try_get<'schema>(
-        &self,
-        schema: &'schema Schema,
-    ) -> Option<&'schema Component<FieldDefinition>> {
-        self.get(schema).ok()
     }
 
     fn insert_references(&self, referencers: &mut Referencers) -> Result<(), FederationError> {
@@ -4429,35 +3896,6 @@ impl EnumTypeDefinitionPosition {
         Ok(Some(referencers))
     }
 
-    /// Remove this enum from the schema, and recursively remove its references.
-    pub(crate) fn remove_recursive(
-        &self,
-        schema: &mut FederationSchema,
-    ) -> Result<(), FederationError> {
-        let Some(referencers) = self.remove_internal(schema)? else {
-            return Ok(());
-        };
-        for field in referencers.object_fields {
-            field.remove_recursive(schema)?;
-        }
-        for argument in referencers.object_field_arguments {
-            argument.remove(schema)?;
-        }
-        for field in referencers.interface_fields {
-            field.remove_recursive(schema)?;
-        }
-        for argument in referencers.interface_field_arguments {
-            argument.remove(schema)?;
-        }
-        for field in referencers.input_object_fields {
-            field.remove_recursive(schema)?;
-        }
-        for argument in referencers.directive_arguments {
-            argument.remove(schema)?;
-        }
-        Ok(())
-    }
-
     fn remove_internal(
         &self,
         schema: &mut FederationSchema,
@@ -4512,26 +3950,6 @@ impl EnumTypeDefinitionPosition {
             .make_mut()
             .directives
             .retain(|other_directive| other_directive.name != name);
-    }
-
-    /// Remove a directive application.
-    pub(crate) fn remove_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: &Component<Directive>,
-    ) {
-        let Some(type_) = self.try_make_mut(&mut schema.schema) else {
-            return;
-        };
-        if !type_.directives.iter().any(|other_directive| {
-            (other_directive.name == directive.name) && !other_directive.ptr_eq(directive)
-        }) {
-            self.remove_directive_name_references(&mut schema.referencers, &directive.name);
-        }
-        type_
-            .make_mut()
-            .directives
-            .retain(|other_directive| !other_directive.ptr_eq(directive));
     }
 
     fn insert_references(
@@ -4699,47 +4117,6 @@ impl EnumValueDefinitionPosition {
         Ok(())
     }
 
-    /// Remove this value from the enum definition. If it is the only value in the enum,
-    /// recursively remove the enum from the schema as well.
-    pub(crate) fn remove_recursive(
-        &self,
-        schema: &mut FederationSchema,
-    ) -> Result<(), FederationError> {
-        self.remove(schema)?;
-        let parent = self.parent();
-        let Some(type_) = parent.try_get(&schema.schema) else {
-            return Ok(());
-        };
-        if type_.values.is_empty() {
-            parent.remove_recursive(schema)?;
-        }
-        Ok(())
-    }
-
-    pub(crate) fn insert_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: Node<Directive>,
-    ) -> Result<(), FederationError> {
-        let value = self.make_mut(&mut schema.schema)?;
-        if value
-            .directives
-            .iter()
-            .any(|other_directive| other_directive.ptr_eq(&directive))
-        {
-            return Err(SingleFederationError::Internal {
-                message: format!(
-                    "Directive application \"@{}\" already exists on enum value \"{}\"",
-                    directive.name, self,
-                ),
-            }
-            .into());
-        }
-        let name = directive.name.clone();
-        value.make_mut().directives.push(directive);
-        self.insert_directive_name_references(&mut schema.referencers, &name)
-    }
-
     /// Remove a directive application from this position by name.
     pub(crate) fn remove_directive_name(&self, schema: &mut FederationSchema, name: &str) {
         let Some(value) = self.try_make_mut(&mut schema.schema) else {
@@ -4752,36 +4129,15 @@ impl EnumValueDefinitionPosition {
             .retain(|other_directive| other_directive.name != name);
     }
 
-    /// Remove a directive application.
-    pub(crate) fn remove_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: &Node<Directive>,
-    ) {
-        let Some(value) = self.try_make_mut(&mut schema.schema) else {
-            return;
-        };
-        if !value.directives.iter().any(|other_directive| {
-            (other_directive.name == directive.name) && !other_directive.ptr_eq(directive)
-        }) {
-            self.remove_directive_name_references(&mut schema.referencers, &directive.name);
-        }
-        value
-            .make_mut()
-            .directives
-            .retain(|other_directive| !other_directive.ptr_eq(directive));
-    }
-
     fn insert_references(
         &self,
         value: &Component<EnumValueDefinition>,
         referencers: &mut Referencers,
     ) -> Result<(), FederationError> {
         if is_graphql_reserved_name(&self.value_name) {
-            return Err(SingleFederationError::Internal {
-                message: format!("Cannot insert reserved enum value \"{}\"", self),
-            }
-            .into());
+            return Err(FederationError::internal(format!(
+                "Cannot insert reserved enum value \"{self}\""
+            )));
         }
         validate_node_directives(value.directives.deref())?;
         for directive_reference in value.directives.iter() {
@@ -5078,25 +4434,6 @@ impl InputObjectTypeDefinitionPosition {
     }
 
     /// Remove a directive application.
-    pub(crate) fn remove_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: &Component<Directive>,
-    ) {
-        let Some(type_) = self.try_make_mut(&mut schema.schema) else {
-            return;
-        };
-        if !type_.directives.iter().any(|other_directive| {
-            (other_directive.name == directive.name) && !other_directive.ptr_eq(directive)
-        }) {
-            self.remove_directive_name_references(&mut schema.referencers, &directive.name);
-        }
-        type_
-            .make_mut()
-            .directives
-            .retain(|other_directive| !other_directive.ptr_eq(directive));
-    }
-
     fn insert_references(
         &self,
         type_: &Node<InputObjectType>,
@@ -5287,30 +4624,6 @@ impl InputObjectFieldDefinitionPosition {
         Ok(())
     }
 
-    pub(crate) fn insert_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: Node<Directive>,
-    ) -> Result<(), FederationError> {
-        let field = self.make_mut(&mut schema.schema)?;
-        if field
-            .directives
-            .iter()
-            .any(|other_directive| other_directive.ptr_eq(&directive))
-        {
-            return Err(SingleFederationError::Internal {
-                message: format!(
-                    "Directive application \"@{}\" already exists on input object field \"{}\"",
-                    directive.name, self,
-                ),
-            }
-            .into());
-        }
-        let name = directive.name.clone();
-        field.make_mut().directives.push(directive);
-        self.insert_directive_name_references(&mut schema.referencers, &name)
-    }
-
     /// Remove a directive application from this position by name.
     pub(crate) fn remove_directive_name(&self, schema: &mut FederationSchema, name: &str) {
         let Some(field) = self.try_make_mut(&mut schema.schema) else {
@@ -5321,26 +4634,6 @@ impl InputObjectFieldDefinitionPosition {
             .make_mut()
             .directives
             .retain(|other_directive| other_directive.name != name);
-    }
-
-    /// Remove a directive application.
-    pub(crate) fn remove_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: &Node<Directive>,
-    ) {
-        let Some(field) = self.try_make_mut(&mut schema.schema) else {
-            return;
-        };
-        if !field.directives.iter().any(|other_directive| {
-            (other_directive.name == directive.name) && !other_directive.ptr_eq(directive)
-        }) {
-            self.remove_directive_name_references(&mut schema.referencers, &directive.name);
-        }
-        field
-            .make_mut()
-            .directives
-            .retain(|other_directive| !other_directive.ptr_eq(directive));
     }
 
     fn insert_references(
@@ -5512,17 +4805,6 @@ impl DirectiveDefinitionPosition {
             .directive_definitions
             .get_mut(&self.directive_name)
             .ok_or_else(|| PositionLookupError::DirectiveMissing(self.clone()))
-    }
-
-    fn try_make_mut<'schema>(
-        &self,
-        schema: &'schema mut Schema,
-    ) -> Option<&'schema mut Node<DirectiveDefinition>> {
-        if self.try_get(schema).is_some() {
-            self.make_mut(schema).ok()
-        } else {
-            None
-        }
     }
 
     pub(crate) fn pre_insert(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
@@ -5753,35 +5035,6 @@ impl DirectiveArgumentDefinitionPosition {
         }
     }
 
-    pub(crate) fn insert(
-        &self,
-        schema: &mut FederationSchema,
-        argument: Node<InputValueDefinition>,
-    ) -> Result<(), FederationError> {
-        if self.argument_name != argument.name {
-            return Err(SingleFederationError::Internal {
-                message: format!(
-                    "Directive argument \"{}\" given argument named \"{}\"",
-                    self, argument.name,
-                ),
-            }
-            .into());
-        }
-        if self.try_get(&schema.schema).is_some() {
-            // TODO: Handle old spec edge case of arguments with non-unique names
-            return Err(SingleFederationError::Internal {
-                message: format!("Directive argument \"{}\" already exists in schema", self,),
-            }
-            .into());
-        }
-        self.parent()
-            .make_mut(&mut schema.schema)?
-            .make_mut()
-            .arguments
-            .push(argument);
-        self.insert_references(self.get(&schema.schema)?, &mut schema.referencers)
-    }
-
     /// Remove this argument definition from its directive. Any applications of the directive that
     /// use this argument will become invalid.
     pub(crate) fn remove(&self, schema: &mut FederationSchema) -> Result<(), FederationError> {
@@ -5797,30 +5050,6 @@ impl DirectiveArgumentDefinitionPosition {
         Ok(())
     }
 
-    pub(crate) fn insert_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: Node<Directive>,
-    ) -> Result<(), FederationError> {
-        let argument = self.make_mut(&mut schema.schema)?;
-        if argument
-            .directives
-            .iter()
-            .any(|other_directive| other_directive.ptr_eq(&directive))
-        {
-            return Err(SingleFederationError::Internal {
-                message: format!(
-                    "Directive application \"@{}\" already exists on directive argument \"{}\"",
-                    directive.name, self,
-                ),
-            }
-            .into());
-        }
-        let name = directive.name.clone();
-        argument.make_mut().directives.push(directive);
-        self.insert_directive_name_references(&mut schema.referencers, &name)
-    }
-
     /// Remove a directive application from this position by name.
     pub(crate) fn remove_directive_name(&self, schema: &mut FederationSchema, name: &str) {
         let Some(argument) = self.try_make_mut(&mut schema.schema) else {
@@ -5831,26 +5060,6 @@ impl DirectiveArgumentDefinitionPosition {
             .make_mut()
             .directives
             .retain(|other_directive| other_directive.name != name);
-    }
-
-    /// Remove a directive application.
-    pub(crate) fn remove_directive(
-        &self,
-        schema: &mut FederationSchema,
-        directive: &Node<Directive>,
-    ) {
-        let Some(argument) = self.try_make_mut(&mut schema.schema) else {
-            return;
-        };
-        if !argument.directives.iter().any(|other_directive| {
-            (other_directive.name == directive.name) && !other_directive.ptr_eq(directive)
-        }) {
-            self.remove_directive_name_references(&mut schema.referencers, &directive.name);
-        }
-        argument
-            .make_mut()
-            .directives
-            .retain(|other_directive| !other_directive.ptr_eq(directive));
     }
 
     fn insert_references(
@@ -6253,7 +5462,9 @@ mod tests {
         )
         .unwrap();
 
-        let position = InterfaceTypeDefinitionPosition::new(name!("UserProfile"));
+        let position = InterfaceTypeDefinitionPosition {
+            type_name: name!("UserProfile")
+        };
         position.remove_recursive(&mut schema).unwrap();
 
         insta::assert_snapshot!(schema.schema(), @r#"

--- a/apollo-federation/src/schema/referencer.rs
+++ b/apollo-federation/src/schema/referencer.rs
@@ -42,30 +42,6 @@ impl Referencers {
             || self.input_object_types.contains_key(name)
     }
 
-    pub(crate) fn get_scalar_type(
-        &self,
-        name: &str,
-    ) -> Result<&ScalarTypeReferencers, FederationError> {
-        self.scalar_types.get(name).ok_or_else(|| {
-            SingleFederationError::Internal {
-                message: "Scalar type referencers unexpectedly missing type".to_owned(),
-            }
-            .into()
-        })
-    }
-
-    pub(crate) fn get_object_type(
-        &self,
-        name: &str,
-    ) -> Result<&ObjectTypeReferencers, FederationError> {
-        self.object_types.get(name).ok_or_else(|| {
-            SingleFederationError::Internal {
-                message: "Object type referencers unexpectedly missing type".to_owned(),
-            }
-            .into()
-        })
-    }
-
     pub(crate) fn get_interface_type(
         &self,
         name: &str,
@@ -73,42 +49,6 @@ impl Referencers {
         self.interface_types.get(name).ok_or_else(|| {
             SingleFederationError::Internal {
                 message: "Interface type referencers unexpectedly missing type".to_owned(),
-            }
-            .into()
-        })
-    }
-
-    pub(crate) fn get_union_type(
-        &self,
-        name: &str,
-    ) -> Result<&UnionTypeReferencers, FederationError> {
-        self.union_types.get(name).ok_or_else(|| {
-            SingleFederationError::Internal {
-                message: "Union type referencers unexpectedly missing type".to_owned(),
-            }
-            .into()
-        })
-    }
-
-    pub(crate) fn get_enum_type(
-        &self,
-        name: &str,
-    ) -> Result<&EnumTypeReferencers, FederationError> {
-        self.enum_types.get(name).ok_or_else(|| {
-            SingleFederationError::Internal {
-                message: "Enum type referencers unexpectedly missing type".to_owned(),
-            }
-            .into()
-        })
-    }
-
-    pub(crate) fn get_input_object_type(
-        &self,
-        name: &str,
-    ) -> Result<&InputObjectTypeReferencers, FederationError> {
-        self.input_object_types.get(name).ok_or_else(|| {
-            SingleFederationError::Internal {
-                message: "Input object type referencers unexpectedly missing type".to_owned(),
             }
             .into()
         })

--- a/apollo-federation/src/schema/subgraph_metadata.rs
+++ b/apollo-federation/src/schema/subgraph_metadata.rs
@@ -8,11 +8,8 @@ use crate::link::spec::Version;
 use crate::link::spec_definition::SpecDefinition;
 use crate::operation::Selection;
 use crate::operation::SelectionSet;
-use crate::schema::field_set::add_interface_field_implementations;
 use crate::schema::field_set::collect_target_fields_from_field_set;
-use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::FieldDefinitionPosition;
-use crate::schema::position::ObjectOrInterfaceFieldDefinitionPosition;
 use crate::schema::position::ObjectOrInterfaceTypeDefinitionPosition;
 use crate::schema::FederationSchema;
 
@@ -26,7 +23,6 @@ fn unwrap_schema(fed_schema: &Valid<FederationSchema>) -> &Valid<Schema> {
 #[derive(Debug, Clone)]
 pub(crate) struct SubgraphMetadata {
     federation_spec_definition: &'static FederationSpecDefinition,
-    is_fed2: bool,
     external_metadata: ExternalMetadata,
 }
 
@@ -35,23 +31,15 @@ impl SubgraphMetadata {
         schema: &Valid<FederationSchema>,
         federation_spec_definition: &'static FederationSpecDefinition,
     ) -> Result<Self, FederationError> {
-        let is_fed2 = federation_spec_definition
-            .version()
-            .satisfies(&Version { major: 2, minor: 0 });
         let external_metadata = ExternalMetadata::new(schema, federation_spec_definition)?;
         Ok(Self {
             federation_spec_definition,
-            is_fed2,
             external_metadata,
         })
     }
 
     pub(crate) fn federation_spec_definition(&self) -> &'static FederationSpecDefinition {
         self.federation_spec_definition
-    }
-
-    pub(crate) fn is_fed2(&self) -> bool {
-        self.is_fed2
     }
 
     pub(crate) fn external_metadata(&self) -> &ExternalMetadata {
@@ -70,9 +58,6 @@ pub(crate) struct ExternalMetadata {
     /// Fields with an `@external` directive that can't actually be external due to also being
     /// referenced in a `@key` directive.
     fake_external_fields: IndexSet<FieldDefinitionPosition>,
-    /// Fields that are only sometimes external, and sometimes reachable due to being included
-    /// in a `@provides` directive.
-    provided_fields: IndexSet<FieldDefinitionPosition>,
     /// Fields that are external because their parent type has an `@external` directive.
     fields_on_external_types: IndexSet<FieldDefinitionPosition>,
 }
@@ -85,7 +70,6 @@ impl ExternalMetadata {
         let external_fields = Self::collect_external_fields(federation_spec_definition, schema)?;
         let fake_external_fields =
             Self::collect_fake_externals(federation_spec_definition, schema)?;
-        let provided_fields = Self::collect_provided_fields(federation_spec_definition, schema)?;
         // We do not collect @external on types for Fed 1 schemas since those will be discarded by
         // the schema upgrader. The schema upgrader, through calls to `is_external()`, relies on the
         // populated `fields_on_external_types` set to inform when @shareable should be
@@ -103,7 +87,6 @@ impl ExternalMetadata {
         Ok(Self {
             external_fields,
             fake_external_fields,
-            provided_fields,
             fields_on_external_types,
         })
     }
@@ -188,47 +171,6 @@ impl ExternalMetadata {
         Ok(fake_external_fields)
     }
 
-    fn collect_provided_fields(
-        federation_spec_definition: &'static FederationSpecDefinition,
-        schema: &Valid<FederationSchema>,
-    ) -> Result<IndexSet<FieldDefinitionPosition>, FederationError> {
-        let mut provided_fields = IndexSet::default();
-        let provides_directive_definition =
-            federation_spec_definition.provides_directive_definition(schema)?;
-        let provides_directive_referencers = schema
-            .referencers
-            .get_directive(&provides_directive_definition.name)?;
-        let mut provides_field_positions: Vec<ObjectOrInterfaceFieldDefinitionPosition> = vec![];
-        for object_field_position in &provides_directive_referencers.object_fields {
-            provides_field_positions.push(object_field_position.clone().into());
-        }
-        for interface_field_position in &provides_directive_referencers.interface_fields {
-            provides_field_positions.push(interface_field_position.clone().into());
-        }
-        for field_position in provides_field_positions {
-            let field = field_position.get(schema.schema())?;
-            let field_type_position: CompositeTypeDefinitionPosition = schema
-                .get_type(field.ty.inner_named_type().clone())?
-                .try_into()?;
-            for provides_directive_application in field
-                .directives
-                .get_all(&provides_directive_definition.name)
-            {
-                let provides_directive_arguments = federation_spec_definition
-                    .provides_directive_arguments(provides_directive_application)?;
-                provided_fields.extend(add_interface_field_implementations(
-                    collect_target_fields_from_field_set(
-                        unwrap_schema(schema),
-                        field_type_position.type_name().clone(),
-                        provides_directive_arguments.fields,
-                    )?,
-                    schema,
-                )?);
-            }
-        }
-        Ok(provided_fields)
-    }
-
     fn collect_fields_on_external_types(
         federation_spec_definition: &'static FederationSpecDefinition,
         schema: &Valid<FederationSchema>,
@@ -286,21 +228,5 @@ impl ExternalMetadata {
             }
         }
         false
-    }
-
-    pub(crate) fn is_partially_external(
-        &self,
-        field_definition_position: &FieldDefinitionPosition,
-    ) -> bool {
-        self.is_external(field_definition_position)
-            && self.provided_fields.contains(field_definition_position)
-    }
-
-    pub(crate) fn is_fully_external(
-        &self,
-        field_definition_position: &FieldDefinitionPosition,
-    ) -> bool {
-        self.is_external(field_definition_position)
-            && !self.provided_fields.contains(field_definition_position)
     }
 }

--- a/apollo-federation/src/schema/type_and_directive_specification.rs
+++ b/apollo-federation/src/schema/type_and_directive_specification.rs
@@ -341,9 +341,10 @@ type ArgumentMergerFactory =
     dyn Fn(&FederationSchema) -> Result<ArgumentMerger, SingleFederationError>;
 
 pub(crate) struct DirectiveCompositionSpecification {
-    pub(crate) supergraph_specification: fn(
-        federation_version: crate::link::spec::Version,
-    ) -> Box<dyn crate::link::spec_definition::SpecDefinition>,
+    pub(crate) supergraph_specification:
+        fn(
+            federation_version: crate::link::spec::Version,
+        ) -> Box<dyn crate::link::spec_definition::SpecDefinition>,
     /// Factory function returning an actual argument merger for given federation schema.
     pub(crate) argument_merger: Option<Box<ArgumentMergerFactory>>,
 }

--- a/apollo-federation/src/schema/type_and_directive_specification.rs
+++ b/apollo-federation/src/schema/type_and_directive_specification.rs
@@ -41,16 +41,16 @@ use crate::schema::FederationSchema;
 /// Schema-dependent argument specification
 #[derive(Clone)]
 pub(crate) struct ArgumentSpecification {
-    pub name: Name,
+    pub(crate) name: Name,
     // PORT_NOTE: In TS, get_type returns `InputType`.
-    pub get_type: fn(schema: &FederationSchema) -> Result<Type, SingleFederationError>,
-    pub default_value: Option<Value>,
+    pub(crate) get_type: fn(schema: &FederationSchema) -> Result<Type, SingleFederationError>,
+    pub(crate) default_value: Option<Value>,
 }
 
 /// The resolved version of `ArgumentSpecification`
 pub(crate) struct ResolvedArgumentSpecification {
-    pub name: Name,
-    pub ty: Type,
+    pub(crate) name: Name,
+    pub(crate) ty: Type,
     default_value: Option<Value>,
 }
 
@@ -70,9 +70,9 @@ impl From<&ResolvedArgumentSpecification> for InputValueDefinition {
 }
 
 pub(crate) struct FieldSpecification {
-    pub name: Name,
-    pub ty: Type,
-    pub arguments: Vec<ResolvedArgumentSpecification>,
+    pub(crate) name: Name,
+    pub(crate) ty: Type,
+    pub(crate) arguments: Vec<ResolvedArgumentSpecification>,
 }
 
 impl From<&FieldSpecification> for FieldDefinition {
@@ -100,7 +100,7 @@ pub(crate) trait TypeAndDirectiveSpecification {
 }
 
 pub(crate) struct ScalarTypeSpecification {
-    pub name: Name, // Type's name
+    pub(crate) name: Name, // Type's name
 }
 
 impl TypeAndDirectiveSpecification for ScalarTypeSpecification {
@@ -127,8 +127,8 @@ impl TypeAndDirectiveSpecification for ScalarTypeSpecification {
 }
 
 pub(crate) struct ObjectTypeSpecification {
-    pub name: Name,
-    pub fields: fn(&FederationSchema) -> Vec<FieldSpecification>,
+    pub(crate) name: Name,
+    pub(crate) fields: fn(&FederationSchema) -> Vec<FieldSpecification>,
 }
 
 impl TypeAndDirectiveSpecification for ObjectTypeSpecification {
@@ -178,8 +178,8 @@ pub(crate) struct UnionTypeSpecification<F>
 where
     F: Fn(&FederationSchema) -> IndexSet<ComponentName>,
 {
-    pub name: Name,
-    pub members: F,
+    pub(crate) name: Name,
+    pub(crate) members: F,
 }
 
 impl<F> TypeAndDirectiveSpecification for UnionTypeSpecification<F>
@@ -245,13 +245,13 @@ where
 }
 
 pub(crate) struct EnumValueSpecification {
-    pub name: Name,
-    pub description: Option<String>,
+    pub(crate) name: Name,
+    pub(crate) description: Option<String>,
 }
 
 pub(crate) struct EnumTypeSpecification {
-    pub name: Name,
-    pub values: Vec<EnumValueSpecification>,
+    pub(crate) name: Name,
+    pub(crate) values: Vec<EnumValueSpecification>,
 }
 
 impl TypeAndDirectiveSpecification for EnumTypeSpecification {
@@ -326,31 +326,31 @@ impl TypeAndDirectiveSpecification for EnumTypeSpecification {
 
 #[derive(Clone)]
 pub(crate) struct DirectiveArgumentSpecification {
-    pub base_spec: ArgumentSpecification,
-    pub composition_strategy: Option<ArgumentCompositionStrategy>,
+    pub(crate) base_spec: ArgumentSpecification,
+    pub(crate) composition_strategy: Option<ArgumentCompositionStrategy>,
 }
 
 type ArgumentMergerFn = dyn Fn(&str, &[Value]) -> Value;
 
 pub(crate) struct ArgumentMerger {
-    pub merge: Box<ArgumentMergerFn>,
-    pub to_string: Box<dyn Fn() -> String>,
+    pub(crate) merge: Box<ArgumentMergerFn>,
+    pub(crate) to_string: Box<dyn Fn() -> String>,
 }
 
 type ArgumentMergerFactory =
     dyn Fn(&FederationSchema) -> Result<ArgumentMerger, SingleFederationError>;
 
 pub(crate) struct DirectiveCompositionSpecification {
-    pub supergraph_specification: fn(
+    pub(crate) supergraph_specification: fn(
         federation_version: crate::link::spec::Version,
     ) -> Box<dyn crate::link::spec_definition::SpecDefinition>,
     /// Factory function returning an actual argument merger for given federation schema.
-    pub argument_merger: Option<Box<ArgumentMergerFactory>>,
+    pub(crate) argument_merger: Option<Box<ArgumentMergerFactory>>,
 }
 
 pub(crate) struct DirectiveSpecification {
-    pub name: Name,
-    pub composition: Option<DirectiveCompositionSpecification>,
+    pub(crate) name: Name,
+    pub(crate) composition: Option<DirectiveCompositionSpecification>,
     args: Vec<DirectiveArgumentSpecification>,
     repeatable: bool,
     locations: Vec<DirectiveLocation>,
@@ -360,7 +360,7 @@ pub(crate) struct DirectiveSpecification {
 // composition.
 // https://apollographql.atlassian.net/browse/FED-172
 impl DirectiveSpecification {
-    pub fn new(
+    pub(crate) fn new(
         name: Name,
         args: &[DirectiveArgumentSpecification],
         repeatable: bool,

--- a/apollo-federation/src/schema/type_and_directive_specification.rs
+++ b/apollo-federation/src/schema/type_and_directive_specification.rs
@@ -1,3 +1,9 @@
+#![allow(dead_code)]
+// NOTE: There are several (technically) unused fields, type aliases, and methods in this module.
+// Unfortunely, there is not a good way to clean this up because of how `` it is used for testing.
+// Rather than littering this module with `#[allow(dead_code)]`s or adding a config_atr to the
+// crate wide directive, allowing dead code here seems like the best options
+
 use apollo_compiler::ast::DirectiveLocation;
 use apollo_compiler::ast::FieldDefinition;
 use apollo_compiler::ast::Value;
@@ -20,8 +26,6 @@ use apollo_compiler::Node;
 use crate::error::FederationError;
 use crate::error::MultipleFederationErrors;
 use crate::error::SingleFederationError;
-use crate::link::spec::Version;
-use crate::link::spec_definition::SpecDefinition;
 use crate::schema::argument_composition_strategies::ArgumentCompositionStrategy;
 use crate::schema::position::DirectiveDefinitionPosition;
 use crate::schema::position::EnumTypeDefinitionPosition;
@@ -337,7 +341,9 @@ type ArgumentMergerFactory =
     dyn Fn(&FederationSchema) -> Result<ArgumentMerger, SingleFederationError>;
 
 pub(crate) struct DirectiveCompositionSpecification {
-    pub supergraph_specification: fn(federation_version: Version) -> Box<dyn SpecDefinition>,
+    pub supergraph_specification: fn(
+        federation_version: crate::link::spec::Version,
+    ) -> Box<dyn crate::link::spec_definition::SpecDefinition>,
     /// Factory function returning an actual argument merger for given federation schema.
     pub argument_merger: Option<Box<ArgumentMergerFactory>>,
 }
@@ -361,7 +367,9 @@ impl DirectiveSpecification {
         locations: &[DirectiveLocation],
         composes: bool,
         supergraph_specification: Option<
-            fn(federation_version: Version) -> Box<dyn SpecDefinition>,
+            fn(
+                federation_version: crate::link::spec::Version,
+            ) -> Box<dyn crate::link::spec_definition::SpecDefinition>,
         >,
     ) -> Self {
         let mut composition: Option<DirectiveCompositionSpecification> = None;
@@ -777,6 +785,9 @@ mod tests {
     use crate::schema::argument_composition_strategies::ArgumentCompositionStrategy;
     use crate::schema::type_and_directive_specification::DirectiveSpecification;
     use crate::schema::FederationSchema;
+
+    #[test]
+    fn dead_code_filter() {}
 
     #[test]
     #[should_panic(

--- a/apollo-federation/src/schema/type_and_directive_specification.rs
+++ b/apollo-federation/src/schema/type_and_directive_specification.rs
@@ -788,9 +788,6 @@ mod tests {
     use crate::schema::FederationSchema;
 
     #[test]
-    fn dead_code_filter() {}
-
-    #[test]
     #[should_panic(
         expected = "Should provide a @link specification to use in supergraph for directive @foo if it composes"
     )]

--- a/apollo-federation/src/subgraph/database.rs
+++ b/apollo-federation/src/subgraph/database.rs
@@ -18,7 +18,7 @@ use apollo_compiler::executable::SelectionSet;
 // TODO: we should define this as part as some more generic "FederationSpec" definition, but need
 // to define the ground work for that in `apollo-at-link` first.
 #[cfg(test)]
-pub fn federation_link_identity() -> crate::link::spec::Identity {
+pub(crate) fn federation_link_identity() -> crate::link::spec::Identity {
     crate::link::spec::Identity {
         domain: crate::link::spec::APOLLO_SPEC_DOMAIN.to_string(),
         name: apollo_compiler::name!("federation"),
@@ -26,8 +26,8 @@ pub fn federation_link_identity() -> crate::link::spec::Identity {
 }
 
 #[derive(Eq, PartialEq, Debug, Clone)]
-pub struct Key {
-    pub type_name: apollo_compiler::Name,
+pub(crate) struct Key {
+    pub(crate) type_name: apollo_compiler::Name,
     // TODO: this should _not_ be an Option below; but we don't know how to build the SelectionSet,
     // so until we have a solution, we use None to have code that compiles.
     selections: Option<Arc<SelectionSet>>,
@@ -37,7 +37,7 @@ impl Key {
     // TODO: same remark as above: not meant to be `Option`
     // TODO remove suppression OR use method in final version
     #[allow(dead_code)]
-    pub fn selections(&self) -> Option<Arc<SelectionSet>> {
+    pub(crate) fn selections(&self) -> Option<Arc<SelectionSet>> {
         self.selections.clone()
     }
 
@@ -60,7 +60,7 @@ impl Key {
 }
 
 #[cfg(test)]
-pub fn federation_link(schema: &apollo_compiler::Schema) -> Arc<crate::link::Link> {
+pub(crate) fn federation_link(schema: &apollo_compiler::Schema) -> Arc<crate::link::Link> {
     crate::link::database::links_metadata(schema)
         // TODO: error handling?
         .unwrap_or_default()
@@ -73,12 +73,15 @@ pub fn federation_link(schema: &apollo_compiler::Schema) -> Arc<crate::link::Lin
 /// This will either return 'federation__key' if the `@key` directive is not imported,
 /// or whatever never it is imported under otherwise. Commonly, this would just be `key`.
 #[cfg(test)]
-pub fn key_directive_name(schema: &apollo_compiler::Schema) -> apollo_compiler::Name {
+pub(crate) fn key_directive_name(schema: &apollo_compiler::Schema) -> apollo_compiler::Name {
     federation_link(schema).directive_name_in_schema(&apollo_compiler::name!("key"))
 }
 
 #[cfg(test)]
-pub fn keys(schema: &apollo_compiler::Schema, type_name: &apollo_compiler::Name) -> Vec<Key> {
+pub(crate) fn keys(
+    schema: &apollo_compiler::Schema,
+    type_name: &apollo_compiler::Name,
+) -> Vec<Key> {
     let key_name = key_directive_name(schema);
     if let Some(type_def) = schema.types.get(type_name) {
         type_def

--- a/apollo-federation/src/subgraph/database.rs
+++ b/apollo-federation/src/subgraph/database.rs
@@ -13,29 +13,21 @@
 
 use std::sync::Arc;
 
-use apollo_compiler::executable::Directive;
 use apollo_compiler::executable::SelectionSet;
-use apollo_compiler::name;
-use apollo_compiler::Name;
-use apollo_compiler::Schema;
-
-use crate::link::database::links_metadata;
-use crate::link::spec::Identity;
-use crate::link::spec::APOLLO_SPEC_DOMAIN;
-use crate::link::Link;
 
 // TODO: we should define this as part as some more generic "FederationSpec" definition, but need
 // to define the ground work for that in `apollo-at-link` first.
-pub fn federation_link_identity() -> Identity {
-    Identity {
-        domain: APOLLO_SPEC_DOMAIN.to_string(),
-        name: name!("federation"),
+#[cfg(test)]
+pub fn federation_link_identity() -> crate::link::spec::Identity {
+    crate::link::spec::Identity {
+        domain: crate::link::spec::APOLLO_SPEC_DOMAIN.to_string(),
+        name: apollo_compiler::name!("federation"),
     }
 }
 
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub struct Key {
-    pub type_name: Name,
+    pub type_name: apollo_compiler::Name,
     // TODO: this should _not_ be an Option below; but we don't know how to build the SelectionSet,
     // so until we have a solution, we use None to have code that compiles.
     selections: Option<Arc<SelectionSet>>,
@@ -49,9 +41,10 @@ impl Key {
         self.selections.clone()
     }
 
+    #[cfg(test)]
     pub(crate) fn from_directive_application(
-        type_name: &Name,
-        directive: &Directive,
+        type_name: &apollo_compiler::Name,
+        directive: &apollo_compiler::executable::Directive,
     ) -> Option<Key> {
         directive
             .arguments
@@ -66,8 +59,9 @@ impl Key {
     }
 }
 
-pub fn federation_link(schema: &Schema) -> Arc<Link> {
-    links_metadata(schema)
+#[cfg(test)]
+pub fn federation_link(schema: &apollo_compiler::Schema) -> Arc<crate::link::Link> {
+    crate::link::database::links_metadata(schema)
         // TODO: error handling?
         .unwrap_or_default()
         .unwrap_or_default()
@@ -78,11 +72,13 @@ pub fn federation_link(schema: &Schema) -> Arc<Link> {
 /// The name of the @key directive in this subgraph.
 /// This will either return 'federation__key' if the `@key` directive is not imported,
 /// or whatever never it is imported under otherwise. Commonly, this would just be `key`.
-pub fn key_directive_name(schema: &Schema) -> Name {
-    federation_link(schema).directive_name_in_schema(&name!("key"))
+#[cfg(test)]
+pub fn key_directive_name(schema: &apollo_compiler::Schema) -> apollo_compiler::Name {
+    federation_link(schema).directive_name_in_schema(&apollo_compiler::name!("key"))
 }
 
-pub fn keys(schema: &Schema, type_name: &Name) -> Vec<Key> {
+#[cfg(test)]
+pub fn keys(schema: &apollo_compiler::Schema, type_name: &apollo_compiler::Name) -> Vec<Key> {
     let key_name = key_directive_name(schema);
     if let Some(type_def) = schema.types.get(type_name) {
         type_def

--- a/apollo-federation/src/subgraph/spec.rs
+++ b/apollo-federation/src/subgraph/spec.rs
@@ -722,7 +722,17 @@ impl Default for LinkSpecDefinitions {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::subgraph::database::federation_link_identity;
+    use crate::link::spec::Identity;
+    use crate::link::spec::APOLLO_SPEC_DOMAIN;
+
+    // TODO: we should define this as part as some more generic "FederationSpec" definition, but need
+    // to define the ground work for that in `apollo-at-link` first.
+    fn federation_link_identity() -> Identity {
+        Identity {
+            domain: APOLLO_SPEC_DOMAIN.to_string(),
+            name: name!("federation"),
+        }
+    }
 
     #[test]
     fn handle_unsupported_federation_version() {

--- a/apollo-federation/src/supergraph/subgraph.rs
+++ b/apollo-federation/src/supergraph/subgraph.rs
@@ -35,10 +35,6 @@ impl FederationSubgraphs {
         Ok(())
     }
 
-    fn get(&self, name: &str) -> Option<&FederationSubgraph> {
-        self.subgraphs.get(name)
-    }
-
     pub(super) fn get_mut(&mut self, name: &str) -> Option<&mut FederationSubgraph> {
         self.subgraphs.get_mut(name)
     }

--- a/apollo-federation/src/utils/fallible_iterator.rs
+++ b/apollo-federation/src/utils/fallible_iterator.rs
@@ -410,7 +410,7 @@ pub(crate) trait FallibleIterator: Sized + Itertools {
 impl<I: Itertools> FallibleIterator for I {}
 
 /// The struct returned by [fallible_filter](FallibleIterator::fallible_filter).
-pub struct FallibleFilter<I, F> {
+pub(crate) struct FallibleFilter<I, F> {
     iter: I,
     predicate: F,
 }
@@ -435,7 +435,7 @@ where
 }
 
 /// The struct returned by [and_then_filter](FallibleIterator::and_then_filter).
-pub struct AndThenFilter<I, F> {
+pub(crate) struct AndThenFilter<I, F> {
     iter: I,
     predicate: F,
 }
@@ -462,7 +462,7 @@ where
     }
 }
 
-pub struct AndThen<I, F> {
+pub(crate) struct AndThen<I, F> {
     iter: I,
     map: F,
 }
@@ -479,7 +479,7 @@ where
     }
 }
 
-pub struct OrElse<I, F> {
+pub(crate) struct OrElse<I, F> {
     iter: I,
     map: F,
 }

--- a/apollo-federation/src/utils/fallible_iterator.rs
+++ b/apollo-federation/src/utils/fallible_iterator.rs
@@ -515,11 +515,13 @@ mod tests {
         i % 2 == 0
     }
 
+    #[test]
     fn test_fallible_filter() {
         let vals = (1..6).fallible_filter(|i| is_prime(*i));
         itertools::assert_equal(vals, vec![Err(()), Ok(2), Ok(3)]);
     }
 
+    #[test]
     fn test_and_then_filter() {
         let vals = vec![Ok(0), Err(()), Err(()), Ok(3), Ok(4)]
             .into_iter()
@@ -527,6 +529,7 @@ mod tests {
         itertools::assert_equal(vals, vec![Err(()), Err(()), Err(()), Ok(3)]);
     }
 
+    #[test]
     fn test_fallible_all() {
         assert_eq!(Ok(true), [].into_iter().fallible_all(is_prime));
         assert_eq!(Ok(true), (2..4).fallible_all(is_prime));
@@ -535,6 +538,7 @@ mod tests {
         assert_eq!(Err(()), (1..5).fallible_all(is_prime));
     }
 
+    #[test]
     fn test_ok_and_all() {
         let first_values: Vec<Item> = vec![];
         let second_values: Vec<Item> = vec![Ok(1), Err(())];
@@ -547,6 +551,7 @@ mod tests {
         assert_eq!(Err(()), fourth_values.into_iter().ok_and_all(is_even));
     }
 
+    #[test]
     fn test_and_then_all() {
         let first_values: Vec<Item> = vec![];
         let second_values: Vec<Item> = vec![Ok(0), Err(())];
@@ -563,6 +568,7 @@ mod tests {
         assert_eq!(Ok(false), sixth_values.into_iter().and_then_all(is_prime));
     }
 
+    #[test]
     fn test_fallible_any() {
         assert_eq!(Ok(false), [].into_iter().fallible_any(is_prime));
         assert_eq!(Ok(true), (2..5).fallible_any(is_prime));
@@ -571,6 +577,7 @@ mod tests {
         assert_eq!(Err(()), (1..5).fallible_any(is_prime));
     }
 
+    #[test]
     fn test_ok_and_any() {
         let first_values: Vec<Item> = vec![];
         let second_values: Vec<Item> = vec![Ok(0), Err(())];
@@ -583,6 +590,7 @@ mod tests {
         assert_eq!(Err(()), fourth_values.into_iter().ok_and_any(is_even));
     }
 
+    #[test]
     fn test_and_then_any() {
         let first_values: Vec<Item> = vec![];
         let second_values: Vec<Item> = vec![Ok(0), Err(())];

--- a/apollo-federation/src/utils/mod.rs
+++ b/apollo-federation/src/utils/mod.rs
@@ -1,6 +1,6 @@
 //! This module contains various tools that help the ergonomics of this crate.
 
 mod fallible_iterator;
-pub mod logging;
+pub(crate) mod logging;
 
 pub(crate) use fallible_iterator::*;


### PR DESCRIPTION
This PR changes the crate-wide `#[allow(dead_code)]` lint directive to `deny` and `deny`s a few other lints.

<!-- start metadata [ROUTER-571](https://apollographql.atlassian.net/browse/ROUTER-571) -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-571]: https://apollographql.atlassian.net/browse/ROUTER-571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ