### PR TITLE
fix: emit connectors debugging log only once

### DIFF
--- a/apollo-router/src/plugins/connectors/plugin.rs
+++ b/apollo-router/src/plugins/connectors/plugin.rs
@@ -53,8 +53,8 @@ impl Plugin for Connectors {
             Ordering::Relaxed,
             Ordering::Relaxed,
         );
-        // old value is false, new value is true
-        if matches!(swap_result, Ok(false)) && debug_extensions {
+        // Ok means we swapped value, inner value is old value. Ok(false) means we went false -> true
+        if matches!(swap_result, Ok(false)) {
             tracing::warn!(
                 "Connector debugging is enabled, this may expose sensitive information."
             );


### PR DESCRIPTION
with rover dev or hot reloading, plugins are initialized each supergraph update, leading to redundant logs

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
