### PR TITLE
Fix small merge conflict between #6031 and #6058

### DIFF
--- a/apollo-federation/src/sources/connect/validation/graphql/strings.rs
+++ b/apollo-federation/src/sources/connect/validation/graphql/strings.rs
@@ -100,7 +100,7 @@ mod tests {
             }
             """
           )
-        } 
+        }
         "#;
 
     fn connect_argument<'schema>(schema: &'schema Schema, name: &str) -> &'schema Node<Value> {
@@ -109,7 +109,7 @@ mod tests {
         };
         let field = query.fields.get("field").unwrap();
         let directive = field.directives.get("connect").unwrap();
-        directive.argument_by_name(name).unwrap()
+        directive.argument_by_name(name, schema).unwrap()
     }
 
     #[test]

--- a/apollo-federation/src/sources/connect/validation/graphql/strings.rs
+++ b/apollo-federation/src/sources/connect/validation/graphql/strings.rs
@@ -109,7 +109,7 @@ mod tests {
         };
         let field = query.fields.get("field").unwrap();
         let directive = field.directives.get("connect").unwrap();
-        directive.argument_by_name(name, schema).unwrap()
+        directive.specified_argument_by_name(name).unwrap()
     }
 
     #[test]


### PR DESCRIPTION
It looks like #6058 updated `apollo-compiler` to a version where `Directive::argument_by_name` takes a `name` and a `schema`, rather than just a `name`, and then #6031 (which was passing tests on its own) was merged on top of #6058 without a final rebase/retest, so [the build is currently failing on `next`](https://app.circleci.com/pipelines/github/apollographql/router/26494/workflows/94f5ba5d-a8e9-49ad-ba75-b9d754b05bf9/jobs/191856).