### PR TITLE
Fix introspection false mismatch: defaultValue list of objects

### DIFF
--- a/apollo-router/src/query_planner/dual_introspection.rs
+++ b/apollo-router/src/query_planner/dual_introspection.rs
@@ -109,9 +109,19 @@ fn normalize_default_value(key: &str, value: &Value) -> Option<Value> {
         .arguments
         .first()?
         .value;
-    parsed_default_value.as_object()?;
-    let normalized = normalize_parsed_default_value(parsed_default_value);
-    Some(normalized.serialize().no_indent().to_string().into())
+    match parsed_default_value.as_ref() {
+        ast::Value::List(_) | ast::Value::Object(_) => {
+            let normalized = normalize_parsed_default_value(parsed_default_value);
+            Some(normalized.serialize().no_indent().to_string().into())
+        }
+        ast::Value::Null
+        | ast::Value::Enum(_)
+        | ast::Value::Variable(_)
+        | ast::Value::String(_)
+        | ast::Value::Float(_)
+        | ast::Value::Int(_)
+        | ast::Value::Boolean(_) => None,
+    }
 }
 
 fn normalize_parsed_default_value(value: &ast::Value) -> ast::Value {

--- a/apollo-router/tests/fixtures/schema_to_introspect.graphql
+++ b/apollo-router/tests/fixtures/schema_to_introspect.graphql
@@ -62,7 +62,7 @@ Root query type
 type TheQuery implements I @join__type(graph: SUBGRAPH1) {
   id: ID!
   ints: [[Int!]]! @deprecated(reason: "…")
-  url(arg: In = { b: 4, a: 2 }): Url
+  url(arg: [In] = [{ b: 4, a: 2 }]): Url
   union: U @deprecated(reason: null)
 }
 

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__introspection__both_mode_integration.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__introspection__both_mode_integration.snap
@@ -70,11 +70,15 @@ expression: "response.json::<serde_json::Value>().await.unwrap()"
                   "name": "arg",
                   "description": null,
                   "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "In",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "In",
+                      "ofType": null
+                    }
                   },
-                  "defaultValue": "{a: 2, b: 4}",
+                  "defaultValue": "[{a: 2, b: 4}]",
                   "isDeprecated": false,
                   "deprecationReason": null
                 }

--- a/apollo-router/tests/integration/snapshots/integration_tests__integration__introspection__integration.snap
+++ b/apollo-router/tests/integration/snapshots/integration_tests__integration__introspection__integration.snap
@@ -1310,11 +1310,15 @@ expression: "response.json::<serde_json::Value>().await.unwrap()"
                   "name": "arg",
                   "description": null,
                   "type": {
-                    "kind": "INPUT_OBJECT",
-                    "name": "In",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "INPUT_OBJECT",
+                      "name": "In",
+                      "ofType": null
+                    }
                   },
-                  "defaultValue": "{b: 4, a: 2}",
+                  "defaultValue": "[{b: 4, a: 2}]",
                   "isDeprecated": false,
                   "deprecationReason": null
                 }


### PR DESCRIPTION
In GraphQL introspection response, the `defaultValue` of an anrgument or input object field is represented as a JSON string that contains GraphQL syntax. If that value contains a GraphQL object value, graphql-js seems to sort its contents by input object field name whereas apollo-compiler preserves the source ordering.

This causes introspection JSON responses to be different in a way that we consider not to be meaningful: object values are semantically unordered maps. Introspection "both" mode already had code to sort object values in order to ignore these differences, but was missing the case where `defaultValue` is not directly an object value but a list value of object values.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
