### PR TITLE
[JSONSelection] Allow `NamedSelection ::= Path SubSelection | ...` without an `Alias` for flattening multiple deeply nested properties

### DIFF
--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@keys.graphql-2.snap
@@ -501,19 +501,21 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
                         None,
                     ),
                     Path(
-                        Alias {
-                            name: WithRange {
-                                node: Field(
-                                    "id2",
-                                ),
+                        Some(
+                            Alias {
+                                name: WithRange {
+                                    node: Field(
+                                        "id2",
+                                    ),
+                                    range: Some(
+                                        3..6,
+                                    ),
+                                },
                                 range: Some(
-                                    3..6,
+                                    3..7,
                                 ),
                             },
-                            range: Some(
-                                3..7,
-                            ),
-                        },
+                        ),
                         PathSelection {
                             path: WithRange {
                                 node: Var(
@@ -613,19 +615,21 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
                     SubSelection {
                         selections: [
                             Path(
-                                Alias {
-                                    name: WithRange {
-                                        node: Field(
-                                            "id",
-                                        ),
+                                Some(
+                                    Alias {
+                                        name: WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
                                         range: Some(
-                                            0..2,
+                                            0..3,
                                         ),
                                     },
-                                    range: Some(
-                                        0..3,
-                                    ),
-                                },
+                                ),
                                 PathSelection {
                                     path: WithRange {
                                         node: Var(
@@ -761,19 +765,21 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
                     SubSelection {
                         selections: [
                             Path(
-                                Alias {
-                                    name: WithRange {
-                                        node: Field(
-                                            "id",
-                                        ),
+                                Some(
+                                    Alias {
+                                        name: WithRange {
+                                            node: Field(
+                                                "id",
+                                            ),
+                                            range: Some(
+                                                0..2,
+                                            ),
+                                        },
                                         range: Some(
-                                            0..2,
+                                            0..3,
                                         ),
                                     },
-                                    range: Some(
-                                        0..3,
-                                    ),
-                                },
+                                ),
                                 PathSelection {
                                     path: WithRange {
                                         node: Var(
@@ -836,19 +842,21 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/ke
                         None,
                     ),
                     Path(
-                        Alias {
-                            name: WithRange {
-                                node: Field(
-                                    "id2",
-                                ),
+                        Some(
+                            Alias {
+                                name: WithRange {
+                                    node: Field(
+                                        "id2",
+                                    ),
+                                    range: Some(
+                                        3..6,
+                                    ),
+                                },
                                 range: Some(
-                                    3..6,
+                                    3..7,
                                 ),
                             },
-                            range: Some(
-                                3..7,
-                            ),
-                        },
+                        ),
                         PathSelection {
                             path: WithRange {
                                 node: Var(

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@realistic.graphql-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@realistic.graphql-2.snap
@@ -353,19 +353,21 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/re
                     SubSelection {
                         selections: [
                             Path(
-                                Alias {
-                                    name: WithRange {
-                                        node: Field(
-                                            "emailDomain",
-                                        ),
+                                Some(
+                                    Alias {
+                                        name: WithRange {
+                                            node: Field(
+                                                "emailDomain",
+                                            ),
+                                            range: Some(
+                                                0..11,
+                                            ),
+                                        },
                                         range: Some(
-                                            0..11,
+                                            0..12,
                                         ),
                                     },
-                                    range: Some(
-                                        0..12,
-                                    ),
-                                },
+                                ),
                                 PathSelection {
                                     path: WithRange {
                                         node: Var(

--- a/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@simple.graphql-2.snap
+++ b/apollo-federation/src/sources/connect/expand/tests/snapshots/it_expand_supergraph@simple.graphql-2.snap
@@ -248,19 +248,21 @@ input_file: apollo-federation/src/sources/connect/expand/tests/schemas/expand/si
                     SubSelection {
                         selections: [
                             Path(
-                                Alias {
-                                    name: WithRange {
-                                        node: Field(
-                                            "with_b",
-                                        ),
+                                Some(
+                                    Alias {
+                                        name: WithRange {
+                                            node: Field(
+                                                "with_b",
+                                            ),
+                                            range: Some(
+                                                0..6,
+                                            ),
+                                        },
                                         range: Some(
-                                            0..6,
+                                            0..7,
                                         ),
                                     },
-                                    range: Some(
-                                        0..7,
-                                    ),
-                                },
+                                ),
                                 PathSelection {
                                     path: WithRange {
                                         node: Var(

--- a/apollo-federation/src/sources/connect/expand/visitors/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/visitors/mod.rs
@@ -236,10 +236,10 @@ mod tests {
         type Error = FederationError;
 
         fn visit<'a>(&mut self, field: NamedSelection) -> Result<(), Self::Error> {
-            self.visited.push((
-                self.last_depth().unwrap_or_default(),
-                field.name().to_string(),
-            ));
+            for name in field.names() {
+                self.visited
+                    .push((self.last_depth().unwrap_or_default(), name.to_string()));
+            }
 
             Ok(())
         }
@@ -261,7 +261,7 @@ mod tests {
             self.depth_stack.push(next_depth);
             Ok(group
                 .selections_iter()
-                .sorted_by_key(|s| s.name())
+                .sorted_by_key(|s| s.names())
                 .cloned()
                 .chain(
                     group

--- a/apollo-federation/src/sources/connect/expand/visitors/selection.rs
+++ b/apollo-federation/src/sources/connect/expand/visitors/selection.rs
@@ -39,85 +39,93 @@ impl FieldVisitor<NamedSelection> for SchemaVisitor<'_, ObjectTypeDefinitionPosi
         ))?;
 
         // Get the type of the field so we know how to visit it
-        let field_name = Name::new(field.name())?;
-        let field = definition
-            .field(field_name.clone())
-            .get(self.original_schema.schema())?;
-        let field_type = self
-            .original_schema
-            .get_type(field.ty.inner_named_type().clone())?;
-        let extended_field_type = field_type.get(self.original_schema.schema())?;
+        for field_name in field.names() {
+            let field_name = Name::new(field_name)?;
+            let field = definition
+                .field(field_name.clone())
+                .get(self.original_schema.schema())?;
+            let field_type = self
+                .original_schema
+                .get_type(field.ty.inner_named_type().clone())?;
+            let extended_field_type = field_type.get(self.original_schema.schema())?;
 
-        // We only need to care about the type of the field if it isn't built-in
-        if !extended_field_type.is_built_in() {
-            match field_type {
-                TypeDefinitionPosition::Scalar(scalar) => {
-                    let def = scalar.get(self.original_schema.schema())?;
-                    let def = ScalarType {
-                        description: def.description.clone(),
-                        name: def.name.clone(),
-                        directives: filter_directives(self.directive_deny_list, &def.directives),
-                    };
+            // We only need to care about the type of the field if it isn't built-in
+            if !extended_field_type.is_built_in() {
+                match field_type {
+                    TypeDefinitionPosition::Scalar(scalar) => {
+                        let def = scalar.get(self.original_schema.schema())?;
+                        let def = ScalarType {
+                            description: def.description.clone(),
+                            name: def.name.clone(),
+                            directives: filter_directives(
+                                self.directive_deny_list,
+                                &def.directives,
+                            ),
+                        };
 
-                    try_pre_insert!(self.to_schema, scalar)?;
-                    try_insert!(self.to_schema, scalar, Node::new(def))?;
-                }
-                TypeDefinitionPosition::Enum(r#enum) => {
-                    let def = r#enum.get(self.original_schema.schema())?;
-                    let def = EnumType {
-                        description: def.description.clone(),
-                        name: def.name.clone(),
-                        directives: filter_directives(self.directive_deny_list, &def.directives),
-                        values: def.values.clone(),
-                    };
+                        try_pre_insert!(self.to_schema, scalar)?;
+                        try_insert!(self.to_schema, scalar, Node::new(def))?;
+                    }
+                    TypeDefinitionPosition::Enum(r#enum) => {
+                        let def = r#enum.get(self.original_schema.schema())?;
+                        let def = EnumType {
+                            description: def.description.clone(),
+                            name: def.name.clone(),
+                            directives: filter_directives(
+                                self.directive_deny_list,
+                                &def.directives,
+                            ),
+                            values: def.values.clone(),
+                        };
 
-                    try_pre_insert!(self.to_schema, r#enum)?;
-                    try_insert!(self.to_schema, r#enum, Node::new(def))?;
-                }
+                        try_pre_insert!(self.to_schema, r#enum)?;
+                        try_insert!(self.to_schema, r#enum, Node::new(def))?;
+                    }
 
-                // This will be handled by the rest of the visitor
-                TypeDefinitionPosition::Object(_) => {}
+                    // This will be handled by the rest of the visitor
+                    TypeDefinitionPosition::Object(_) => {}
 
-                // These will be handled later
-                TypeDefinitionPosition::Union(_) => {
-                    return Err(FederationError::internal(
-                        "unions are not yet handled for expansion",
-                    ))
-                }
+                    // These will be handled later
+                    TypeDefinitionPosition::Union(_) => {
+                        return Err(FederationError::internal(
+                            "unions are not yet handled for expansion",
+                        ))
+                    }
 
-                // Anything else is not supported
-                TypeDefinitionPosition::InputObject(input) => {
-                    return Err(FederationError::internal(format!(
-                        "expected field to be a leaf or object type, found: input {}",
-                        input.type_name,
-                    )))
-                }
-                TypeDefinitionPosition::Interface(interface) => {
-                    return Err(FederationError::internal(format!(
-                        "expected field to be a leaf or object type, found: interface {}",
-                        interface.type_name,
-                    )))
-                }
-            };
-        }
-
-        // Add the field to the currently processing object, making sure to not overwrite if it already
-        // exists (and verify that we didn't change the type)
-        let new_field = FieldDefinition {
-            description: field.description.clone(),
-            name: field.name.clone(),
-            arguments: field.arguments.clone(),
-            ty: field.ty.clone(),
-            directives: filter_directives(self.directive_deny_list, &field.directives),
-        };
-        if let Some(old_field) = r#type.fields.get(&field_name) {
-            if *old_field.deref().deref() != new_field {
-                return Err(FederationError::internal(
-                   format!( "tried to write field to existing type, but field type was different. expected {new_field:?} found {old_field:?}"),
-                ));
+                    // Anything else is not supported
+                    TypeDefinitionPosition::InputObject(input) => {
+                        return Err(FederationError::internal(format!(
+                            "expected field to be a leaf or object type, found: input {}",
+                            input.type_name,
+                        )))
+                    }
+                    TypeDefinitionPosition::Interface(interface) => {
+                        return Err(FederationError::internal(format!(
+                            "expected field to be a leaf or object type, found: interface {}",
+                            interface.type_name,
+                        )))
+                    }
+                };
             }
-        } else {
-            r#type.fields.insert(field_name, Component::new(new_field));
+
+            // Add the field to the currently processing object, making sure to not overwrite if it already
+            // exists (and verify that we didn't change the type)
+            let new_field = FieldDefinition {
+                description: field.description.clone(),
+                name: field.name.clone(),
+                arguments: field.arguments.clone(),
+                ty: field.ty.clone(),
+                directives: filter_directives(self.directive_deny_list, &field.directives),
+            };
+            if let Some(old_field) = r#type.fields.get(&field_name) {
+                if *old_field.deref().deref() != new_field {
+                    return Err(FederationError::internal(
+                    format!( "tried to write field to existing type, but field type was different. expected {new_field:?} found {old_field:?}"),
+                    ));
+                }
+            } else {
+                r#type.fields.insert(field_name, Component::new(new_field));
+            }
         }
 
         Ok(())
@@ -134,21 +142,26 @@ impl GroupVisitor<JSONSelectionGroup, NamedSelection>
         let (definition, _) = self.type_stack.last().ok_or(FederationError::internal(
             "tried to get fields on a group not yet visited",
         ))?;
-        let field_name = Name::new(field.name())?;
 
-        let field_type_name = definition
-            .field(field_name)
-            .get(self.original_schema.schema())?
-            .ty
-            .inner_named_type();
+        match field.names().as_slice() {
+            &[field_name] => {
+                let field_name = Name::new(field_name)?;
+                let field_type_name = definition
+                    .field(field_name)
+                    .get(self.original_schema.schema())?
+                    .ty
+                    .inner_named_type();
 
-        let TypeDefinitionPosition::Object(field_type) =
-            self.original_schema.get_type(field_type_name.clone())?
-        else {
-            return Ok(None);
-        };
+                let TypeDefinitionPosition::Object(field_type) =
+                    self.original_schema.get_type(field_type_name.clone())?
+                else {
+                    return Ok(None);
+                };
 
-        Ok(field.next_subselection().cloned().map(|s| (field_type, s)))
+                Ok(field.next_subselection().cloned().map(|s| (field_type, s)))
+            }
+            _ => Ok(None),
+        }
     }
 
     fn enter_group(
@@ -169,7 +182,7 @@ impl GroupVisitor<JSONSelectionGroup, NamedSelection>
         self.type_stack.push((group_type.clone(), sub_type));
         Ok(group
             .selections_iter()
-            .sorted_by_key(|s| s.name())
+            .sorted_by_key(|s| s.names())
             .cloned()
             .chain(group.star_iter().map(|s| {
                 NamedSelection::Field(s.alias().cloned(), Key::field("").into_with_range(), None)

--- a/apollo-federation/src/sources/connect/expand/visitors/selection.rs
+++ b/apollo-federation/src/sources/connect/expand/visitors/selection.rs
@@ -143,8 +143,8 @@ impl GroupVisitor<JSONSelectionGroup, NamedSelection>
             "tried to get fields on a group not yet visited",
         ))?;
 
-        match field.names().as_slice() {
-            &[field_name] => {
+        match field.names().first() {
+            Some(field_name) => {
                 let field_name = Name::new(field_name)?;
                 let field_type_name = definition
                     .field(field_name)
@@ -160,7 +160,7 @@ impl GroupVisitor<JSONSelectionGroup, NamedSelection>
 
                 Ok(field.next_subselection().cloned().map(|s| (field_type, s)))
             }
-            _ => Ok(None),
+            None => Ok(None),
         }
     }
 

--- a/apollo-federation/src/sources/connect/json_selection/README.md
+++ b/apollo-federation/src/sources/connect/json_selection/README.md
@@ -81,15 +81,17 @@ worry if it doesn't seem helpful yet, as every rule will be explained in detail
 below.
 
 ```ebnf
-JSONSelection        ::= NakedSubSelection | PathSelection
+JSONSelection        ::= PathSelection | NakedSubSelection
 NakedSubSelection    ::= NamedSelection* StarSelection?
 SubSelection         ::= "{" NakedSubSelection "}"
-NamedSelection       ::= NamedPathSelection | NamedFieldSelection | NamedGroupSelection
+NamedSelection       ::= NamedPathSelection | PathWithSubSelection | NamedFieldSelection | NamedGroupSelection
 NamedPathSelection   ::= Alias PathSelection
 NamedFieldSelection  ::= Alias? Key SubSelection?
 NamedGroupSelection  ::= Alias SubSelection
 Alias                ::= Key ":"
-PathSelection        ::= (VarPath | KeyPath | AtPath | ExprPath) SubSelection?
+Path                 ::= VarPath | KeyPath | AtPath | ExprPath
+PathSelection        ::= Path SubSelection?
+PathWithSubSelection ::= Path SubSelection
 VarPath              ::= "$" (NO_SPACE Identifier)? PathStep*
 KeyPath              ::= Key PathStep+
 AtPath               ::= "@" PathStep*
@@ -219,10 +221,16 @@ feel free to take your time and enjoy the journey.
 
 The `JSONSelection` non-terminal is the top-level entry point for the grammar,
 and appears nowhere else within the rest of the grammar. It can be either a
-`NakedSubSelection` (for selecting multiple named items) or a `PathSelection`
-(for selecting a single anonymous value from a given path). When the
-`PathSelection` option is chosen at this level, the entire `JSONSelection` must
-be that single path, without any other named selections.
+`PathSelection` (for selecting a single anonymous value from a given path) or a
+`NakedSubSelection` (for selecting multiple named items).
+
+When the `PathSelection` syntax is chosen at this level, and the path does not
+have a trailing `SubSelection` (which ensures the result is an object with
+statically known properties), the entire `JSONSelection` must be that single
+path, without any other named selections. If the `PathSelection` does have a
+trailing `SubSelection`, it may be mixed together with other named selections,
+though in that case it will be parsed as a `PathWithSubSelection` within a
+`NakedSubSelection`, instead of a `PathSelection`.
 
 ### `NakedSubSelection ::=`
 
@@ -271,7 +279,7 @@ input object in a slightly different way.
 
 Since `PathSelection` returns an anonymous value extracted from the given path,
 if you want to use a `PathSelection` alongside other `NamedSelection` items, you
-have to prefix it with an `Alias`, turning it into a `NamedPathSelection`.
+can prefix it with an `Alias`, turning it into a `NamedPathSelection`.
 
 For example, you cannot omit the `pathName:` alias in the following
 `NakedSubSelection`, because `some.nested.path` has no output name by itself:
@@ -381,14 +389,25 @@ In addition to renaming, `Alias` can provide names to otherwise anonymous
 structures, such as those selected by `PathSelection`, `NamedGroupSelection`, or
 `StarSelection` syntax.
 
+### `Path ::=`
+
+![Path](./grammar/Path.svg)
+
+A `Path` is a `VarPath`, `KeyPath`, `AtPath`, or `ExprPath`, which forms the
+prefix of both `PathSelection` and `PathWithSubSelection`.
+
+In the Rust implementation, there is no separate `Path` struct, as we represent
+both `PathSelection` and `PathWithSubSelection` using the `PathSelection` struct
+and `PathList` enum. The `Path` non-terminal is just a grammatical convenience,
+to avoid repetition between `PathSelection` and `PathWithSubSelection`.
+
 ### `PathSelection ::=`
 
 ![PathSelection](./grammar/PathSelection.svg)
 
-A `PathSelection` is a `VarPath` or `KeyPath` followed by an optional
-`SubSelection`. The purpose of a `PathSelection` is to extract a single
-anonymous value from the input JSON, without preserving the nested structure of
-the keys along the path.
+A `PathSelection` is a `Path` followed by an optional `SubSelection`. The
+purpose of a `PathSelection` is to extract a single anonymous value from the
+input JSON, without preserving the nested structure of the keys along the path.
 
 Since properties along the path may be either `Identifier` or `LitString`
 values, you are not limited to selecting only properties that are valid GraphQL
@@ -429,6 +448,43 @@ type Query {
   )
 }
 ```
+
+### `PathWithSubSelection ::=`
+
+![PathWithSubSelection](./grammar/PathWithSubSelection.svg)
+
+Although you can precede a `PathSelection` with an `Alias` to make it a
+`NamedPathSelection`, this syntax has the effect of grouping the value of the
+path under a single output key.
+
+If you want to select multiple properties from the same object-valued `Path`,
+you can use a `PathWithSubSelection`, which does not require an `Alias` but does
+require a trailing `SubSelection` to specify which properties to select:
+
+```graphql
+id
+created
+model
+
+# The { role content } SubSelection is mandatory so the output keys
+# can be statically determined:
+choices->first.message { role content }
+
+# Multiple PathWithSubSelections are allowed in the same SubSelection:
+choices->last.message { lastContent: content }
+```
+
+This selection results in an output object with the keys `id`, `created`,
+`model`, `role`, `content`, and `lastContent` all at the top level.
+
+Since the final `PathWithSubSelection` selects only one property, it is
+equivalent to `lastContent: choices->last.message.content`, which may be
+slightly easier to read, since the output property appears first.
+
+As with `PathSelection`, if `choices->first.message` happens not to select an
+object, `choices->first.message { role content }` will result in a runtime
+error, because the `role` and `content` properties cannot be selected from a
+non-object value.
 
 ### `VarPath ::=`
 

--- a/apollo-federation/src/sources/connect/json_selection/apply_to.rs
+++ b/apollo-federation/src/sources/connect/json_selection/apply_to.rs
@@ -279,7 +279,7 @@ impl ApplyToInternal for NamedSelection {
                         // path_selection.apply_to_path above.
                         Some(value) => {
                             errors.push(ApplyToError::new(
-                                format!("Expected an object, not a {}", json_type_name(&value)),
+                                format!("Expected object, not {}", json_type_name(&value)),
                                 // Since the path_selection.apply_to_path
                                 // execution stack has been unwound by this
                                 // point, input_path does not include the path
@@ -290,7 +290,7 @@ impl ApplyToInternal for NamedSelection {
                         }
                         None => {
                             errors.push(ApplyToError::new(
-                                "Expected an object, not nothing (see other errors)".to_string(),
+                                "Expected object, not nothing (see other errors)".to_string(),
                                 input_path.to_vec(),
                                 sub.range(),
                             ));
@@ -2134,7 +2134,7 @@ mod tests {
                         Some(128..135),
                     ),
                     ApplyToError::new(
-                        "Expected an object, not a string".to_string(),
+                        "Expected object, not string".to_string(),
                         vec![],
                         // This is the range of the { role content } subselection.
                         Some(121..137),
@@ -2174,7 +2174,7 @@ mod tests {
                         Some(15..26),
                     ),
                     ApplyToError::new(
-                        "Expected an object, not nothing (see other errors)".to_string(),
+                        "Expected object, not nothing (see other errors)".to_string(),
                         vec![],
                         // This is the range of the { name } subselection.
                         Some(27..35),

--- a/apollo-federation/src/sources/connect/json_selection/grammar/Path.svg
+++ b/apollo-federation/src/sources/connect/json_selection/grammar/Path.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="259" height="169">
+<svg xmlns="http://www.w3.org/2000/svg" width="175" height="169">
    <defs>
       <style type="text/css">
     @namespace "http://www.w3.org/2000/svg";
@@ -32,35 +32,35 @@
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
-      xlink:href="#NamedPathSelection"
-      xlink:title="NamedPathSelection">
-      <rect x="51" y="3" width="152" height="32"/>
-      <rect x="49" y="1" width="152" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="59" y="21">NamedPathSelection</text>
+      xlink:href="#VarPath"
+      xlink:title="VarPath">
+      <rect x="51" y="3" width="70" height="32"/>
+      <rect x="49" y="1" width="70" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="21">VarPath</text>
    </a>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
-      xlink:href="#PathWithSubSelection"
-      xlink:title="PathWithSubSelection">
-      <rect x="51" y="47" width="160" height="32"/>
-      <rect x="49" y="45" width="160" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="59" y="65">PathWithSubSelection</text>
+      xlink:href="#KeyPath"
+      xlink:title="KeyPath">
+      <rect x="51" y="47" width="72" height="32"/>
+      <rect x="49" y="45" width="72" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="65">KeyPath</text>
    </a>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
-      xlink:href="#NamedFieldSelection"
-      xlink:title="NamedFieldSelection">
-      <rect x="51" y="91" width="152" height="32"/>
-      <rect x="49" y="89" width="152" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="59" y="109">NamedFieldSelection</text>
+      xlink:href="#AtPath"
+      xlink:title="AtPath">
+      <rect x="51" y="91" width="62" height="32"/>
+      <rect x="49" y="89" width="62" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="109">AtPath</text>
    </a>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
-      xlink:href="#NamedGroupSelection"
-      xlink:title="NamedGroupSelection">
-      <rect x="51" y="135" width="160" height="32"/>
-      <rect x="49" y="133" width="160" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="59" y="153">NamedGroupSelection</text>
+      xlink:href="#ExprPath"
+      xlink:title="ExprPath">
+      <rect x="51" y="135" width="76" height="32"/>
+      <rect x="49" y="133" width="76" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="59" y="153">ExprPath</text>
    </a>
    <path class="line"
-         d="m17 17 h2 m20 0 h10 m152 0 h10 m0 0 h8 m-200 0 h20 m180 0 h20 m-220 0 q10 0 10 10 m200 0 q0 -10 10 -10 m-210 10 v24 m200 0 v-24 m-200 24 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m160 0 h10 m-190 -10 v20 m200 0 v-20 m-200 20 v24 m200 0 v-24 m-200 24 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m152 0 h10 m0 0 h8 m-190 -10 v20 m200 0 v-20 m-200 20 v24 m200 0 v-24 m-200 24 q0 10 10 10 m180 0 q10 0 10 -10 m-190 10 h10 m160 0 h10 m23 -132 h-3"/>
-   <polygon points="249 17 257 13 257 21"/>
-   <polygon points="249 17 241 13 241 21"/>
+         d="m17 17 h2 m20 0 h10 m70 0 h10 m0 0 h6 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m72 0 h10 m0 0 h4 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m62 0 h10 m0 0 h14 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m23 -132 h-3"/>
+   <polygon points="165 17 173 13 173 21"/>
+   <polygon points="165 17 157 13 157 21"/>
 </svg>

--- a/apollo-federation/src/sources/connect/json_selection/grammar/PathSelection.svg
+++ b/apollo-federation/src/sources/connect/json_selection/grammar/PathSelection.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="337" height="169">
+<svg xmlns="http://www.w3.org/2000/svg" width="269" height="69">
    <defs>
       <style type="text/css">
     @namespace "http://www.w3.org/2000/svg";
@@ -32,42 +32,21 @@
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
-      xlink:href="#VarPath"
-      xlink:title="VarPath">
-      <rect x="51" y="3" width="70" height="32"/>
-      <rect x="49" y="1" width="70" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="59" y="21">VarPath</text>
-   </a>
-   <a xmlns:xlink="http://www.w3.org/1999/xlink"
-      xlink:href="#KeyPath"
-      xlink:title="KeyPath">
-      <rect x="51" y="47" width="72" height="32"/>
-      <rect x="49" y="45" width="72" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="59" y="65">KeyPath</text>
-   </a>
-   <a xmlns:xlink="http://www.w3.org/1999/xlink"
-      xlink:href="#AtPath"
-      xlink:title="AtPath">
-      <rect x="51" y="91" width="62" height="32"/>
-      <rect x="49" y="89" width="62" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="59" y="109">AtPath</text>
-   </a>
-   <a xmlns:xlink="http://www.w3.org/1999/xlink"
-      xlink:href="#ExprPath"
-      xlink:title="ExprPath">
-      <rect x="51" y="135" width="76" height="32"/>
-      <rect x="49" y="133" width="76" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="59" y="153">ExprPath</text>
+      xlink:href="#Path"
+      xlink:title="Path">
+      <rect x="31" y="3" width="48" height="32"/>
+      <rect x="29" y="1" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="39" y="21">Path</text>
    </a>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
       xlink:href="#SubSelection"
       xlink:title="SubSelection">
-      <rect x="187" y="35" width="102" height="32"/>
-      <rect x="185" y="33" width="102" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="195" y="53">SubSelection</text>
+      <rect x="119" y="35" width="102" height="32"/>
+      <rect x="117" y="33" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="127" y="53">SubSelection</text>
    </a>
    <path class="line"
-         d="m17 17 h2 m20 0 h10 m70 0 h10 m0 0 h6 m-116 0 h20 m96 0 h20 m-136 0 q10 0 10 10 m116 0 q0 -10 10 -10 m-126 10 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m72 0 h10 m0 0 h4 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m62 0 h10 m0 0 h14 m-106 -10 v20 m116 0 v-20 m-116 20 v24 m116 0 v-24 m-116 24 q0 10 10 10 m96 0 q10 0 10 -10 m-106 10 h10 m76 0 h10 m40 -132 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m23 -32 h-3"/>
-   <polygon points="327 17 335 13 335 21"/>
-   <polygon points="327 17 319 13 319 21"/>
+         d="m17 17 h2 m0 0 h10 m48 0 h10 m20 0 h10 m0 0 h112 m-142 0 h20 m122 0 h20 m-162 0 q10 0 10 10 m142 0 q0 -10 10 -10 m-152 10 v12 m142 0 v-12 m-142 12 q0 10 10 10 m122 0 q10 0 10 -10 m-132 10 h10 m102 0 h10 m23 -32 h-3"/>
+   <polygon points="259 17 267 13 267 21"/>
+   <polygon points="259 17 251 13 251 21"/>
 </svg>

--- a/apollo-federation/src/sources/connect/json_selection/grammar/PathWithSubSelection.svg
+++ b/apollo-federation/src/sources/connect/json_selection/grammar/PathWithSubSelection.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="241" height="81">
+<svg xmlns="http://www.w3.org/2000/svg" width="229" height="37">
    <defs>
       <style type="text/css">
     @namespace "http://www.w3.org/2000/svg";
@@ -32,21 +32,21 @@
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
-      xlink:href="#PathSelection"
-      xlink:title="PathSelection">
-      <rect x="51" y="3" width="106" height="32"/>
-      <rect x="49" y="1" width="106" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="59" y="21">PathSelection</text>
+      xlink:href="#Path"
+      xlink:title="Path">
+      <rect x="31" y="3" width="48" height="32"/>
+      <rect x="29" y="1" width="48" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="39" y="21">Path</text>
    </a>
    <a xmlns:xlink="http://www.w3.org/1999/xlink"
-      xlink:href="#NakedSubSelection"
-      xlink:title="NakedSubSelection">
-      <rect x="51" y="47" width="142" height="32"/>
-      <rect x="49" y="45" width="142" height="32" class="nonterminal"/>
-      <text class="nonterminal" x="59" y="65">NakedSubSelection</text>
+      xlink:href="#SubSelection"
+      xlink:title="SubSelection">
+      <rect x="99" y="3" width="102" height="32"/>
+      <rect x="97" y="1" width="102" height="32" class="nonterminal"/>
+      <text class="nonterminal" x="107" y="21">SubSelection</text>
    </a>
    <path class="line"
-         d="m17 17 h2 m20 0 h10 m106 0 h10 m0 0 h36 m-182 0 h20 m162 0 h20 m-202 0 q10 0 10 10 m182 0 q0 -10 10 -10 m-192 10 v24 m182 0 v-24 m-182 24 q0 10 10 10 m162 0 q10 0 10 -10 m-172 10 h10 m142 0 h10 m23 -44 h-3"/>
-   <polygon points="231 17 239 13 239 21"/>
-   <polygon points="231 17 223 13 223 21"/>
+         d="m17 17 h2 m0 0 h10 m48 0 h10 m0 0 h10 m102 0 h10 m3 0 h-3"/>
+   <polygon points="219 17 227 13 227 21"/>
+   <polygon points="219 17 211 13 211 21"/>
 </svg>

--- a/apollo-federation/src/sources/connect/json_selection/location.rs
+++ b/apollo-federation/src/sources/connect/json_selection/location.rs
@@ -159,7 +159,10 @@ pub(super) mod strip_ranges {
                     key.strip_ranges(),
                     sub.as_ref().map(|s| s.strip_ranges()),
                 ),
-                Self::Path(alias, path) => Self::Path(alias.strip_ranges(), path.strip_ranges()),
+                Self::Path(alias, path) => {
+                    let stripped_alias = alias.as_ref().map(|a| a.strip_ranges());
+                    Self::Path(stripped_alias, path.strip_ranges())
+                }
                 Self::Group(alias, sub) => Self::Group(alias.strip_ranges(), sub.strip_ranges()),
             }
         }

--- a/apollo-federation/src/sources/connect/json_selection/methods/tests.rs
+++ b/apollo-federation/src/sources/connect/json_selection/methods/tests.rs
@@ -215,7 +215,7 @@ fn test_missing_method() {
             None,
             vec![ApplyToError::from_json(&json!({
                 "message": "Method ->bogus not found",
-                "path": ["nested", "path"],
+                "path": ["nested", "path", "->bogus"],
                 "range": [13, 18],
             }))],
         ),
@@ -507,7 +507,7 @@ fn test_array_methods() {
             None,
             vec![ApplyToError::from_json(&json!({
                 "message": "Method ->get(3) index out of bounds",
-                "path": [],
+                "path": ["->get"],
                 "range": [7, 8],
             }))]
         ),
@@ -519,7 +519,7 @@ fn test_array_methods() {
             None,
             vec![ApplyToError::from_json(&json!({
                 "message": "Method ->get(-4) index out of bounds",
-                "path": [],
+                "path": ["->get"],
                 "range": [7, 9],
             }))]
         ),
@@ -531,7 +531,7 @@ fn test_array_methods() {
             None,
             vec![ApplyToError::from_json(&json!({
                 "message": "Method ->get requires an argument",
-                "path": [],
+                "path": ["->get"],
                 "range": [3, 6],
             }))]
         ),
@@ -543,7 +543,7 @@ fn test_array_methods() {
             None,
             vec![ApplyToError::from_json(&json!({
                 "message": "Method ->get(\"bogus\") requires an object input",
-                "path": [],
+                "path": ["->get"],
                 "range": [3, 15],
             }))]
         ),
@@ -598,7 +598,7 @@ fn test_size_method_errors() {
             None,
             vec![ApplyToError::from_json(&json!({
                 "message": "Method ->size requires an array, string, or object input, not null",
-                "path": [],
+                "path": ["->size"],
                 "range": [3, 7],
             }))]
         ),
@@ -610,7 +610,7 @@ fn test_size_method_errors() {
             None,
             vec![ApplyToError::from_json(&json!({
                 "message": "Method ->size requires an array, string, or object input, not boolean",
-                "path": [],
+                "path": ["->size"],
                 "range": [3, 7],
             }))]
         ),
@@ -624,7 +624,7 @@ fn test_size_method_errors() {
             None,
             vec![ApplyToError::from_json(&json!({
                 "message": "Method ->size requires an array, string, or object input, not number",
-                "path": ["count"],
+                "path": ["count", "->size"],
                 "range": [7, 11],
             }))]
         ),
@@ -684,7 +684,7 @@ fn test_string_methods() {
             None,
             vec![ApplyToError::from_json(&json!({
                 "message": "Method ->get(4) index out of bounds",
-                "path": [],
+                "path": ["->get"],
                 "range": [7, 8],
             }))]
         ),
@@ -695,7 +695,7 @@ fn test_string_methods() {
             None,
             vec![ApplyToError::from_json(&json!({
                 "message": "Method ->get(-10) index out of bounds",
-                "path": [],
+                "path": ["->get"],
                 "range": [7, 26],
             }))],
         );
@@ -719,7 +719,7 @@ fn test_string_methods() {
                 None,
                 vec![ApplyToError::from_json(&json!({
                     "message": "Method ->get(-10) index out of bounds",
-                    "path": [],
+                    "path": ["->get"],
                     "range": [12, 42],
                 }))]
             )
@@ -733,7 +733,7 @@ fn test_string_methods() {
             None,
             vec![ApplyToError::from_json(&json!({
                 "message": "Method ->get(true) requires an integer or string argument",
-                "path": [],
+                "path": ["->get"],
                 "range": [7, 11],
             }))]
         ),
@@ -889,7 +889,7 @@ fn test_object_methods() {
             None,
             vec![ApplyToError::from_json(&json!({
                 "message": "Method ->get(\"d\") object key not found",
-                "path": [],
+                "path": ["->get"],
                 "range": [7, 10],
             }))]
         ),
@@ -935,7 +935,7 @@ fn test_object_methods() {
             None,
             vec![ApplyToError::from_json(&json!({
                 "message": "Method ->keys requires an object input, not number",
-                "path": ["notAnObject"],
+                "path": ["notAnObject", "->keys"],
                 "range": [13, 17],
             }))]
         ),
@@ -963,7 +963,7 @@ fn test_object_methods() {
             None,
             vec![ApplyToError::from_json(&json!({
                 "message": "Method ->values requires an object input, not null",
-                "path": ["notAnObject"],
+                "path": ["notAnObject", "->values"],
                 "range": [13, 19],
             }))]
         ),
@@ -1022,7 +1022,7 @@ fn test_object_methods() {
             None,
             vec![ApplyToError::from_json(&json!({
                 "message": "Method ->entries requires an object input, not boolean",
-                "path": ["notAnObject"],
+                "path": ["notAnObject", "->entries"],
                 "range": [13, 20],
             }))]
         ),

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -2394,6 +2394,43 @@ mod tests {
     }
 
     #[test]
+    fn test_path_with_subselection() {
+        assert_debug_snapshot!(selection!(
+            r#"
+            choices->first.message { content role }
+        "#
+        ));
+
+        assert_debug_snapshot!(selection!(
+            r#"
+            id
+            created
+            choices->first.message { content role }
+            model
+        "#
+        ));
+
+        assert_debug_snapshot!(selection!(
+            r#"
+            id
+            created
+            choices->first.message { content role }
+            model
+            choices->last.message { lastContent: content }
+        "#
+        ));
+
+        assert_debug_snapshot!(JSONSelection::parse(
+            r#"
+            id
+            created
+            choices->first.message
+            model
+        "#
+        ));
+    }
+
+    #[test]
     fn test_subselection() {
         fn check_parsed(input: &str, expected: SubSelection) {
             let (remainder, parsed) = SubSelection::parse(Span::new(input)).unwrap();

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -2428,6 +2428,44 @@ mod tests {
             model
         "#
         ));
+
+        assert_debug_snapshot!(JSONSelection::parse(
+            r#"
+            id: $this.id
+            $args.input {
+                title
+                body
+            }
+        "#
+        ));
+
+        // Like the selection above, this selection produces an output shape
+        // with id, title, and body all flattened in a top-level object.
+        assert_debug_snapshot!(JSONSelection::parse(
+            r#"
+            $this { id }
+            $args { .input { title body } }
+        "#
+        ));
+
+        assert_debug_snapshot!(JSONSelection::parse(
+            r#"
+            # Equivalent to id: $this.id
+            $this { id }
+
+            $args {
+                __typename: $("Args")
+
+                # Using $. instead of just . prevents .input from
+                # parsing as a key applied to the $("Args") string.
+                $.input { title body }
+
+                extra
+            }
+
+            from: $.from
+        "#
+        ));
     }
 
     #[test]

--- a/apollo-federation/src/sources/connect/json_selection/pretty.rs
+++ b/apollo-federation/src/sources/connect/json_selection/pretty.rs
@@ -285,10 +285,11 @@ impl PrettyPrintable for NamedSelection {
                     result.push_str(sub.as_str());
                 }
             }
-            Self::Path(alias, path) => {
-                result.push_str(alias.name.as_str());
-                result.push_str(": ");
-
+            Self::Path(alias_opt, path) => {
+                if let Some(alias) = alias_opt {
+                    result.push_str(alias.name.as_str());
+                    result.push_str(": ");
+                }
                 let path = path.pretty_print_with_indentation(true, indentation);
                 result.push_str(path.trim_start());
             }

--- a/apollo-federation/src/sources/connect/json_selection/selection_set.rs
+++ b/apollo-federation/src/sources/connect/json_selection/selection_set.rs
@@ -18,7 +18,7 @@
 
 use std::collections::HashSet;
 
-use apollo_compiler::collections::IndexMap;
+use apollo_compiler::collections::IndexSet;
 use apollo_compiler::executable::Field;
 use apollo_compiler::executable::Selection;
 use apollo_compiler::executable::SelectionSet;
@@ -52,7 +52,7 @@ impl SubSelection {
     /// Apply a selection set to create a new [`SubSelection`]
     pub fn apply_selection_set(&self, selection_set: &SelectionSet) -> Self {
         let mut new_selections = Vec::new();
-        let mut dropped_fields = IndexMap::default();
+        let mut dropped_fields = IndexSet::default();
         let mut referenced_fields = HashSet::new();
         let field_map = map_fields_by_name(selection_set);
 
@@ -66,7 +66,7 @@ impl SubSelection {
         // the user defined a __typename mapping.
         if field_map.contains_key("__typename") {
             new_selections.push(NamedSelection::Path(
-                Alias::new("__typename"),
+                Some(Alias::new("__typename")),
                 PathSelection {
                     path: WithRange::new(
                         PathList::Var(
@@ -117,27 +117,40 @@ impl SubSelection {
                             ));
                         }
                     } else if self.star.is_some() {
-                        dropped_fields.insert(key, ());
+                        dropped_fields.insert(key);
                     }
                 }
                 NamedSelection::Path(alias, path_selection) => {
-                    let key = alias.name.as_str();
-                    if let Some(fields) = field_map.get_vec(key) {
-                        if self.star.is_some() {
-                            if let Some(name) = key_name(path_selection) {
-                                referenced_fields.insert(name);
+                    if let Some(key) = alias.as_ref().map(|a| a.name.as_str()) {
+                        // If the NamedSelection::Path has an alias (meaning
+                        // it's a NamedPathSelection according to the grammar),
+                        // use the alias name to look up the corresponding
+                        // fields in the selection set.
+                        if let Some(fields) = field_map.get_vec(key) {
+                            for field in fields {
+                                new_selections.push(NamedSelection::Path(
+                                    Some(Alias::new(field.response_key().as_str())),
+                                    path_selection.apply_selection_set(&field.selection_set),
+                                ));
                             }
                         }
-                        for field in fields {
-                            new_selections.push(NamedSelection::Path(
-                                Alias::new(field.response_key().as_str()),
-                                path_selection.apply_selection_set(&field.selection_set),
-                            ));
-                        }
-                    } else if self.star.is_some() {
+                    } else {
+                        // If the NamedSelection::Path has no alias (meaning
+                        // it's a PathWithSubSelection according to the
+                        // grammar), apply the selection set to the path and add
+                        // the new PathWithSubSelection to the new_selections.
+                        new_selections.push(NamedSelection::Path(
+                            None,
+                            path_selection.apply_selection_set(selection_set),
+                        ));
+                    }
+
+                    if self.star.is_some() {
                         if let Some(name) = key_name(path_selection) {
-                            dropped_fields.insert(name, ());
+                            referenced_fields.insert(name);
                         }
+                    } else if let Some(name) = key_name(path_selection) {
+                        dropped_fields.insert(name);
                     }
                 }
                 NamedSelection::Group(alias, sub) => {
@@ -157,8 +170,8 @@ impl SubSelection {
         if new_star.is_some() {
             // Alias fields that were dropped from the original selection to prevent them from
             // being picked up by the star.
-            dropped_fields.retain(|key, _| !referenced_fields.contains(key));
-            for (dropped, _) in dropped_fields {
+            dropped_fields.retain(|key| !referenced_fields.contains(key));
+            for dropped in dropped_fields {
                 let name = format!("__unused__{dropped}");
                 new_selections.push(NamedSelection::Field(
                     Some(Alias::new(name.as_str())),

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__location__tests__arrow_path_ranges.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__location__tests__arrow_path_ranges.snap
@@ -6,19 +6,21 @@ Named(
     SubSelection {
         selections: [
             Path(
-                Alias {
-                    name: WithRange {
-                        node: Field(
-                            "__typename",
-                        ),
+                Some(
+                    Alias {
+                        name: WithRange {
+                            node: Field(
+                                "__typename",
+                            ),
+                            range: Some(
+                                2..12,
+                            ),
+                        },
                         range: Some(
-                            2..12,
+                            2..13,
                         ),
                     },
-                    range: Some(
-                        2..13,
-                    ),
-                },
+                ),
                 PathSelection {
                     path: WithRange {
                         node: Var(

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__location__tests__parse_with_range_snapshots.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__location__tests__parse_with_range_snapshots.snap
@@ -6,19 +6,21 @@ Named(
     SubSelection {
         selections: [
             Path(
-                Alias {
-                    name: WithRange {
-                        node: Field(
-                            "path",
-                        ),
+                Some(
+                    Alias {
+                        name: WithRange {
+                            node: Field(
+                                "path",
+                            ),
+                            range: Some(
+                                9..13,
+                            ),
+                        },
                         range: Some(
-                            9..13,
+                            9..14,
                         ),
                     },
-                    range: Some(
-                        9..14,
-                    ),
-                },
+                ),
                 PathSelection {
                     path: WithRange {
                         node: Key(
@@ -155,19 +157,21 @@ Named(
                     SubSelection {
                         selections: [
                             Path(
-                                Alias {
-                                    name: WithRange {
-                                        node: Field(
-                                            "__typename",
-                                        ),
+                                Some(
+                                    Alias {
+                                        name: WithRange {
+                                            node: Field(
+                                                "__typename",
+                                            ),
+                                            range: Some(
+                                                151..161,
+                                            ),
+                                        },
                                         range: Some(
-                                            151..161,
+                                            151..162,
                                         ),
                                     },
-                                    range: Some(
-                                        151..162,
-                                    ),
-                                },
+                                ),
                                 PathSelection {
                                     path: WithRange {
                                         node: Var(
@@ -221,19 +225,21 @@ Named(
                                 },
                             ),
                             Path(
-                                Alias {
-                                    name: WithRange {
-                                        node: Field(
-                                            "wrapped",
-                                        ),
+                                Some(
+                                    Alias {
+                                        name: WithRange {
+                                            node: Field(
+                                                "wrapped",
+                                            ),
+                                            range: Some(
+                                                195..202,
+                                            ),
+                                        },
                                         range: Some(
-                                            195..202,
+                                            195..203,
                                         ),
                                     },
-                                    range: Some(
-                                        195..203,
-                                    ),
-                                },
+                                ),
                                 PathSelection {
                                     path: WithRange {
                                         node: Var(
@@ -382,19 +388,21 @@ Named(
                                 },
                             ),
                             Path(
-                                Alias {
-                                    name: WithRange {
-                                        node: Field(
-                                            "arg",
-                                        ),
+                                Some(
+                                    Alias {
+                                        name: WithRange {
+                                            node: Field(
+                                                "arg",
+                                            ),
+                                            range: Some(
+                                                272..275,
+                                            ),
+                                        },
                                         range: Some(
-                                            272..275,
+                                            272..276,
                                         ),
                                     },
-                                    range: Some(
-                                        272..276,
-                                    ),
-                                },
+                                ),
                                 PathSelection {
                                     path: WithRange {
                                         node: Var(

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__expr_path_selections.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__expr_path_selections.snap
@@ -6,19 +6,21 @@ Named(
     SubSelection {
         selections: [
             Path(
-                Alias {
-                    name: WithRange {
-                        node: Field(
-                            "suffix",
-                        ),
+                Some(
+                    Alias {
+                        name: WithRange {
+                            node: Field(
+                                "suffix",
+                            ),
+                            range: Some(
+                                1..7,
+                            ),
+                        },
                         range: Some(
-                            1..7,
+                            1..9,
                         ),
                     },
-                    range: Some(
-                        1..9,
-                    ),
-                },
+                ),
                 PathSelection {
                     path: WithRange {
                         node: Key(

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-2.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-2.snap
@@ -1,0 +1,138 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: "selection!(r#\"\n            id\n            created\n            choices->first.message { content role }\n            model\n        \"#)"
+---
+Named(
+    SubSelection {
+        selections: [
+            Field(
+                None,
+                WithRange {
+                    node: Field(
+                        "id",
+                    ),
+                    range: Some(
+                        13..15,
+                    ),
+                },
+                None,
+            ),
+            Field(
+                None,
+                WithRange {
+                    node: Field(
+                        "created",
+                    ),
+                    range: Some(
+                        28..35,
+                    ),
+                },
+                None,
+            ),
+            Path(
+                None,
+                PathSelection {
+                    path: WithRange {
+                        node: Key(
+                            WithRange {
+                                node: Field(
+                                    "choices",
+                                ),
+                                range: Some(
+                                    48..55,
+                                ),
+                            },
+                            WithRange {
+                                node: Method(
+                                    WithRange {
+                                        node: "first",
+                                        range: Some(
+                                            57..62,
+                                        ),
+                                    },
+                                    None,
+                                    WithRange {
+                                        node: Key(
+                                            WithRange {
+                                                node: Field(
+                                                    "message",
+                                                ),
+                                                range: Some(
+                                                    63..70,
+                                                ),
+                                            },
+                                            WithRange {
+                                                node: Selection(
+                                                    SubSelection {
+                                                        selections: [
+                                                            Field(
+                                                                None,
+                                                                WithRange {
+                                                                    node: Field(
+                                                                        "content",
+                                                                    ),
+                                                                    range: Some(
+                                                                        73..80,
+                                                                    ),
+                                                                },
+                                                                None,
+                                                            ),
+                                                            Field(
+                                                                None,
+                                                                WithRange {
+                                                                    node: Field(
+                                                                        "role",
+                                                                    ),
+                                                                    range: Some(
+                                                                        81..85,
+                                                                    ),
+                                                                },
+                                                                None,
+                                                            ),
+                                                        ],
+                                                        star: None,
+                                                        range: Some(
+                                                            71..87,
+                                                        ),
+                                                    },
+                                                ),
+                                                range: Some(
+                                                    71..87,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            62..87,
+                                        ),
+                                    },
+                                ),
+                                range: Some(
+                                    55..87,
+                                ),
+                            },
+                        ),
+                        range: Some(
+                            48..87,
+                        ),
+                    },
+                },
+            ),
+            Field(
+                None,
+                WithRange {
+                    node: Field(
+                        "model",
+                    ),
+                    range: Some(
+                        100..105,
+                    ),
+                },
+                None,
+            ),
+        ],
+        star: None,
+        range: Some(
+            13..105,
+        ),
+    },
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-3.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-3.snap
@@ -1,0 +1,228 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: "selection!(r#\"\n            id\n            created\n            choices->first.message { content role }\n            model\n            choices->last.message { lastContent: content }\n        \"#)"
+---
+Named(
+    SubSelection {
+        selections: [
+            Field(
+                None,
+                WithRange {
+                    node: Field(
+                        "id",
+                    ),
+                    range: Some(
+                        13..15,
+                    ),
+                },
+                None,
+            ),
+            Field(
+                None,
+                WithRange {
+                    node: Field(
+                        "created",
+                    ),
+                    range: Some(
+                        28..35,
+                    ),
+                },
+                None,
+            ),
+            Path(
+                None,
+                PathSelection {
+                    path: WithRange {
+                        node: Key(
+                            WithRange {
+                                node: Field(
+                                    "choices",
+                                ),
+                                range: Some(
+                                    48..55,
+                                ),
+                            },
+                            WithRange {
+                                node: Method(
+                                    WithRange {
+                                        node: "first",
+                                        range: Some(
+                                            57..62,
+                                        ),
+                                    },
+                                    None,
+                                    WithRange {
+                                        node: Key(
+                                            WithRange {
+                                                node: Field(
+                                                    "message",
+                                                ),
+                                                range: Some(
+                                                    63..70,
+                                                ),
+                                            },
+                                            WithRange {
+                                                node: Selection(
+                                                    SubSelection {
+                                                        selections: [
+                                                            Field(
+                                                                None,
+                                                                WithRange {
+                                                                    node: Field(
+                                                                        "content",
+                                                                    ),
+                                                                    range: Some(
+                                                                        73..80,
+                                                                    ),
+                                                                },
+                                                                None,
+                                                            ),
+                                                            Field(
+                                                                None,
+                                                                WithRange {
+                                                                    node: Field(
+                                                                        "role",
+                                                                    ),
+                                                                    range: Some(
+                                                                        81..85,
+                                                                    ),
+                                                                },
+                                                                None,
+                                                            ),
+                                                        ],
+                                                        star: None,
+                                                        range: Some(
+                                                            71..87,
+                                                        ),
+                                                    },
+                                                ),
+                                                range: Some(
+                                                    71..87,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            62..87,
+                                        ),
+                                    },
+                                ),
+                                range: Some(
+                                    55..87,
+                                ),
+                            },
+                        ),
+                        range: Some(
+                            48..87,
+                        ),
+                    },
+                },
+            ),
+            Field(
+                None,
+                WithRange {
+                    node: Field(
+                        "model",
+                    ),
+                    range: Some(
+                        100..105,
+                    ),
+                },
+                None,
+            ),
+            Path(
+                None,
+                PathSelection {
+                    path: WithRange {
+                        node: Key(
+                            WithRange {
+                                node: Field(
+                                    "choices",
+                                ),
+                                range: Some(
+                                    118..125,
+                                ),
+                            },
+                            WithRange {
+                                node: Method(
+                                    WithRange {
+                                        node: "last",
+                                        range: Some(
+                                            127..131,
+                                        ),
+                                    },
+                                    None,
+                                    WithRange {
+                                        node: Key(
+                                            WithRange {
+                                                node: Field(
+                                                    "message",
+                                                ),
+                                                range: Some(
+                                                    132..139,
+                                                ),
+                                            },
+                                            WithRange {
+                                                node: Selection(
+                                                    SubSelection {
+                                                        selections: [
+                                                            Field(
+                                                                Some(
+                                                                    Alias {
+                                                                        name: WithRange {
+                                                                            node: Field(
+                                                                                "lastContent",
+                                                                            ),
+                                                                            range: Some(
+                                                                                142..153,
+                                                                            ),
+                                                                        },
+                                                                        range: Some(
+                                                                            142..154,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                WithRange {
+                                                                    node: Field(
+                                                                        "content",
+                                                                    ),
+                                                                    range: Some(
+                                                                        155..162,
+                                                                    ),
+                                                                },
+                                                                None,
+                                                            ),
+                                                        ],
+                                                        star: None,
+                                                        range: Some(
+                                                            140..164,
+                                                        ),
+                                                    },
+                                                ),
+                                                range: Some(
+                                                    140..164,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            131..164,
+                                        ),
+                                    },
+                                ),
+                                range: Some(
+                                    125..164,
+                                ),
+                            },
+                        ),
+                        range: Some(
+                            118..164,
+                        ),
+                    },
+                },
+            ),
+        ],
+        star: None,
+        range: Some(
+            13..164,
+        ),
+    },
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-4.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-4.snap
@@ -1,0 +1,12 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: "JSONSelection::parse(r#\"\n            id\n            created\n            choices->first.message\n            model\n        \"#)"
+---
+Err(
+    Error(
+        Error {
+            input: "\n            id\n            created\n            choices->first.message\n            model\n        ",
+            code: IsNot,
+        },
+    ),
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-5.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-5.snap
@@ -1,0 +1,144 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: "JSONSelection::parse(r#\"\n            id: $this.id\n            $args.input {\n                title\n                body\n            }\n        \"#)"
+---
+Ok(
+    (
+        "",
+        Named(
+            SubSelection {
+                selections: [
+                    Path(
+                        Some(
+                            Alias {
+                                name: WithRange {
+                                    node: Field(
+                                        "id",
+                                    ),
+                                    range: Some(
+                                        13..15,
+                                    ),
+                                },
+                                range: Some(
+                                    13..16,
+                                ),
+                            },
+                        ),
+                        PathSelection {
+                            path: WithRange {
+                                node: Var(
+                                    WithRange {
+                                        node: $this,
+                                        range: Some(
+                                            17..22,
+                                        ),
+                                    },
+                                    WithRange {
+                                        node: Key(
+                                            WithRange {
+                                                node: Field(
+                                                    "id",
+                                                ),
+                                                range: Some(
+                                                    23..25,
+                                                ),
+                                            },
+                                            WithRange {
+                                                node: Empty,
+                                                range: Some(
+                                                    25..25,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            22..25,
+                                        ),
+                                    },
+                                ),
+                                range: Some(
+                                    17..25,
+                                ),
+                            },
+                        },
+                    ),
+                    Path(
+                        None,
+                        PathSelection {
+                            path: WithRange {
+                                node: Var(
+                                    WithRange {
+                                        node: $args,
+                                        range: Some(
+                                            38..43,
+                                        ),
+                                    },
+                                    WithRange {
+                                        node: Key(
+                                            WithRange {
+                                                node: Field(
+                                                    "input",
+                                                ),
+                                                range: Some(
+                                                    44..49,
+                                                ),
+                                            },
+                                            WithRange {
+                                                node: Selection(
+                                                    SubSelection {
+                                                        selections: [
+                                                            Field(
+                                                                None,
+                                                                WithRange {
+                                                                    node: Field(
+                                                                        "title",
+                                                                    ),
+                                                                    range: Some(
+                                                                        68..73,
+                                                                    ),
+                                                                },
+                                                                None,
+                                                            ),
+                                                            Field(
+                                                                None,
+                                                                WithRange {
+                                                                    node: Field(
+                                                                        "body",
+                                                                    ),
+                                                                    range: Some(
+                                                                        90..94,
+                                                                    ),
+                                                                },
+                                                                None,
+                                                            ),
+                                                        ],
+                                                        star: None,
+                                                        range: Some(
+                                                            50..108,
+                                                        ),
+                                                    },
+                                                ),
+                                                range: Some(
+                                                    50..108,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            43..108,
+                                        ),
+                                    },
+                                ),
+                                range: Some(
+                                    38..108,
+                                ),
+                            },
+                        },
+                    ),
+                ],
+                star: None,
+                range: Some(
+                    13..108,
+                ),
+            },
+        ),
+    ),
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-6.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-6.snap
@@ -1,0 +1,156 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: "JSONSelection::parse(r#\"\n            $this { id }\n            $args { .input { title body } }\n        \"#)"
+---
+Ok(
+    (
+        "",
+        Named(
+            SubSelection {
+                selections: [
+                    Path(
+                        None,
+                        PathSelection {
+                            path: WithRange {
+                                node: Var(
+                                    WithRange {
+                                        node: $this,
+                                        range: Some(
+                                            13..18,
+                                        ),
+                                    },
+                                    WithRange {
+                                        node: Selection(
+                                            SubSelection {
+                                                selections: [
+                                                    Field(
+                                                        None,
+                                                        WithRange {
+                                                            node: Field(
+                                                                "id",
+                                                            ),
+                                                            range: Some(
+                                                                21..23,
+                                                            ),
+                                                        },
+                                                        None,
+                                                    ),
+                                                ],
+                                                star: None,
+                                                range: Some(
+                                                    19..25,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            19..25,
+                                        ),
+                                    },
+                                ),
+                                range: Some(
+                                    13..25,
+                                ),
+                            },
+                        },
+                    ),
+                    Path(
+                        None,
+                        PathSelection {
+                            path: WithRange {
+                                node: Var(
+                                    WithRange {
+                                        node: $args,
+                                        range: Some(
+                                            38..43,
+                                        ),
+                                    },
+                                    WithRange {
+                                        node: Selection(
+                                            SubSelection {
+                                                selections: [
+                                                    Path(
+                                                        None,
+                                                        PathSelection {
+                                                            path: WithRange {
+                                                                node: Key(
+                                                                    WithRange {
+                                                                        node: Field(
+                                                                            "input",
+                                                                        ),
+                                                                        range: Some(
+                                                                            47..52,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Selection(
+                                                                            SubSelection {
+                                                                                selections: [
+                                                                                    Field(
+                                                                                        None,
+                                                                                        WithRange {
+                                                                                            node: Field(
+                                                                                                "title",
+                                                                                            ),
+                                                                                            range: Some(
+                                                                                                55..60,
+                                                                                            ),
+                                                                                        },
+                                                                                        None,
+                                                                                    ),
+                                                                                    Field(
+                                                                                        None,
+                                                                                        WithRange {
+                                                                                            node: Field(
+                                                                                                "body",
+                                                                                            ),
+                                                                                            range: Some(
+                                                                                                61..65,
+                                                                                            ),
+                                                                                        },
+                                                                                        None,
+                                                                                    ),
+                                                                                ],
+                                                                                star: None,
+                                                                                range: Some(
+                                                                                    53..67,
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        range: Some(
+                                                                            53..67,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    46..67,
+                                                                ),
+                                                            },
+                                                        },
+                                                    ),
+                                                ],
+                                                star: None,
+                                                range: Some(
+                                                    44..69,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            44..69,
+                                        ),
+                                    },
+                                ),
+                                range: Some(
+                                    38..69,
+                                ),
+                            },
+                        },
+                    ),
+                ],
+                star: None,
+                range: Some(
+                    13..69,
+                ),
+            },
+        ),
+    ),
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-7.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-7.snap
@@ -1,0 +1,274 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: "JSONSelection::parse(r#\"\n            # Equivalent to id: $this.id\n            $this { id }\n\n            $args {\n                __typename: $(\"Args\")\n\n                # Using $. instead of just . prevents .input from\n                # parsing as a key applied to the $(\"Args\") string.\n                $.input { title body }\n\n                extra\n            }\n\n            from: $.from\n        \"#)"
+---
+Ok(
+    (
+        "",
+        Named(
+            SubSelection {
+                selections: [
+                    Path(
+                        None,
+                        PathSelection {
+                            path: WithRange {
+                                node: Var(
+                                    WithRange {
+                                        node: $this,
+                                        range: Some(
+                                            54..59,
+                                        ),
+                                    },
+                                    WithRange {
+                                        node: Selection(
+                                            SubSelection {
+                                                selections: [
+                                                    Field(
+                                                        None,
+                                                        WithRange {
+                                                            node: Field(
+                                                                "id",
+                                                            ),
+                                                            range: Some(
+                                                                62..64,
+                                                            ),
+                                                        },
+                                                        None,
+                                                    ),
+                                                ],
+                                                star: None,
+                                                range: Some(
+                                                    60..66,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            60..66,
+                                        ),
+                                    },
+                                ),
+                                range: Some(
+                                    54..66,
+                                ),
+                            },
+                        },
+                    ),
+                    Path(
+                        None,
+                        PathSelection {
+                            path: WithRange {
+                                node: Var(
+                                    WithRange {
+                                        node: $args,
+                                        range: Some(
+                                            80..85,
+                                        ),
+                                    },
+                                    WithRange {
+                                        node: Selection(
+                                            SubSelection {
+                                                selections: [
+                                                    Path(
+                                                        Some(
+                                                            Alias {
+                                                                name: WithRange {
+                                                                    node: Field(
+                                                                        "__typename",
+                                                                    ),
+                                                                    range: Some(
+                                                                        104..114,
+                                                                    ),
+                                                                },
+                                                                range: Some(
+                                                                    104..115,
+                                                                ),
+                                                            },
+                                                        ),
+                                                        PathSelection {
+                                                            path: WithRange {
+                                                                node: Expr(
+                                                                    WithRange {
+                                                                        node: String(
+                                                                            "Args",
+                                                                        ),
+                                                                        range: Some(
+                                                                            118..124,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Empty,
+                                                                        range: Some(
+                                                                            125..125,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    116..125,
+                                                                ),
+                                                            },
+                                                        },
+                                                    ),
+                                                    Path(
+                                                        None,
+                                                        PathSelection {
+                                                            path: WithRange {
+                                                                node: Var(
+                                                                    WithRange {
+                                                                        node: $,
+                                                                        range: Some(
+                                                                            277..278,
+                                                                        ),
+                                                                    },
+                                                                    WithRange {
+                                                                        node: Key(
+                                                                            WithRange {
+                                                                                node: Field(
+                                                                                    "input",
+                                                                                ),
+                                                                                range: Some(
+                                                                                    279..284,
+                                                                                ),
+                                                                            },
+                                                                            WithRange {
+                                                                                node: Selection(
+                                                                                    SubSelection {
+                                                                                        selections: [
+                                                                                            Field(
+                                                                                                None,
+                                                                                                WithRange {
+                                                                                                    node: Field(
+                                                                                                        "title",
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        287..292,
+                                                                                                    ),
+                                                                                                },
+                                                                                                None,
+                                                                                            ),
+                                                                                            Field(
+                                                                                                None,
+                                                                                                WithRange {
+                                                                                                    node: Field(
+                                                                                                        "body",
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        293..297,
+                                                                                                    ),
+                                                                                                },
+                                                                                                None,
+                                                                                            ),
+                                                                                        ],
+                                                                                        star: None,
+                                                                                        range: Some(
+                                                                                            285..299,
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                range: Some(
+                                                                                    285..299,
+                                                                                ),
+                                                                            },
+                                                                        ),
+                                                                        range: Some(
+                                                                            278..299,
+                                                                        ),
+                                                                    },
+                                                                ),
+                                                                range: Some(
+                                                                    277..299,
+                                                                ),
+                                                            },
+                                                        },
+                                                    ),
+                                                    Field(
+                                                        None,
+                                                        WithRange {
+                                                            node: Field(
+                                                                "extra",
+                                                            ),
+                                                            range: Some(
+                                                                317..322,
+                                                            ),
+                                                        },
+                                                        None,
+                                                    ),
+                                                ],
+                                                star: None,
+                                                range: Some(
+                                                    86..336,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            86..336,
+                                        ),
+                                    },
+                                ),
+                                range: Some(
+                                    80..336,
+                                ),
+                            },
+                        },
+                    ),
+                    Path(
+                        Some(
+                            Alias {
+                                name: WithRange {
+                                    node: Field(
+                                        "from",
+                                    ),
+                                    range: Some(
+                                        350..354,
+                                    ),
+                                },
+                                range: Some(
+                                    350..355,
+                                ),
+                            },
+                        ),
+                        PathSelection {
+                            path: WithRange {
+                                node: Var(
+                                    WithRange {
+                                        node: $,
+                                        range: Some(
+                                            356..357,
+                                        ),
+                                    },
+                                    WithRange {
+                                        node: Key(
+                                            WithRange {
+                                                node: Field(
+                                                    "from",
+                                                ),
+                                                range: Some(
+                                                    358..362,
+                                                ),
+                                            },
+                                            WithRange {
+                                                node: Empty,
+                                                range: Some(
+                                                    362..362,
+                                                ),
+                                            },
+                                        ),
+                                        range: Some(
+                                            357..362,
+                                        ),
+                                    },
+                                ),
+                                range: Some(
+                                    356..362,
+                                ),
+                            },
+                        },
+                    ),
+                ],
+                star: None,
+                range: Some(
+                    54..362,
+                ),
+            },
+        ),
+    ),
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection.snap
@@ -1,0 +1,91 @@
+---
+source: apollo-federation/src/sources/connect/json_selection/parser.rs
+expression: "selection!(r#\"\n            choices->first.message { content role }\n        \"#)"
+---
+Path(
+    PathSelection {
+        path: WithRange {
+            node: Key(
+                WithRange {
+                    node: Field(
+                        "choices",
+                    ),
+                    range: Some(
+                        13..20,
+                    ),
+                },
+                WithRange {
+                    node: Method(
+                        WithRange {
+                            node: "first",
+                            range: Some(
+                                22..27,
+                            ),
+                        },
+                        None,
+                        WithRange {
+                            node: Key(
+                                WithRange {
+                                    node: Field(
+                                        "message",
+                                    ),
+                                    range: Some(
+                                        28..35,
+                                    ),
+                                },
+                                WithRange {
+                                    node: Selection(
+                                        SubSelection {
+                                            selections: [
+                                                Field(
+                                                    None,
+                                                    WithRange {
+                                                        node: Field(
+                                                            "content",
+                                                        ),
+                                                        range: Some(
+                                                            38..45,
+                                                        ),
+                                                    },
+                                                    None,
+                                                ),
+                                                Field(
+                                                    None,
+                                                    WithRange {
+                                                        node: Field(
+                                                            "role",
+                                                        ),
+                                                        range: Some(
+                                                            46..50,
+                                                        ),
+                                                    },
+                                                    None,
+                                                ),
+                                            ],
+                                            star: None,
+                                            range: Some(
+                                                36..52,
+                                            ),
+                                        },
+                                    ),
+                                    range: Some(
+                                        36..52,
+                                    ),
+                                },
+                            ),
+                            range: Some(
+                                27..52,
+                            ),
+                        },
+                    ),
+                    range: Some(
+                        20..52,
+                    ),
+                },
+            ),
+            range: Some(
+                13..52,
+            ),
+        },
+    },
+)

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__selection.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__selection.snap
@@ -97,19 +97,21 @@ Named(
                                 None,
                             ),
                             Path(
-                                Alias {
-                                    name: WithRange {
-                                        node: Field(
-                                            "pathSelection",
-                                        ),
+                                Some(
+                                    Alias {
+                                        name: WithRange {
+                                            node: Field(
+                                                "pathSelection",
+                                            ),
+                                            range: Some(
+                                                457..470,
+                                            ),
+                                        },
                                         range: Some(
-                                            457..470,
+                                            457..471,
                                         ),
                                     },
-                                    range: Some(
-                                        457..471,
-                                    ),
-                                },
+                                ),
                                 PathSelection {
                                     path: WithRange {
                                         node: Key(

--- a/apollo-federation/src/sources/connect/validation/selection.rs
+++ b/apollo-federation/src/sources/connect/validation/selection.rs
@@ -284,25 +284,34 @@ impl<'schema> GroupVisitor<Group<'schema>, Field<'schema>> for SelectionValidato
             definition: group.definition,
             ty: group.ty,
         });
-        group.selection.selections_iter().map(|selection| {
-            let field_name = selection.name();
-            let definition = group.ty.fields.get(field_name).ok_or_else(|| {
-                Message {
-                    code: Code::SelectedFieldNotFound,
-                    message: format!(
-                        "{coordinate} contains field `{field_name}`, which does not exist on `{parent_type}`.",
-                        coordinate = &self.selection_coordinate,
-                        parent_type = group.ty.name,
-                    ),
-                    locations: self.selection_location.iter().cloned().collect(),
+        group.selection.selections_iter().flat_map(|selection| {
+            let mut results = Vec::new();
+            for field_name in selection.names() {
+                if let Some(definition) = group.ty.fields.get(field_name) {
+                    results.push(Ok(Field {
+                        selection,
+                        definition,
+                    }));
+                } else {
+                    results.push(Err(Message {
+                        code: Code::SelectedFieldNotFound,
+                        message: format!(
+                            "{coordinate} contains field `{field_name}`, which does not exist on `{parent_type}`.",
+                            coordinate = &self.selection_coordinate,
+                            parent_type = group.ty.name,
+                        ),
+                        locations: self.selection_location.iter().cloned().collect(),
+                    }));
                 }
-            })?;
-            Ok(Field {
-                selection,
-                definition,
-            })
+            }
+            results
         }).chain(
-            validate_star_selection(group, self.schema, &self.selection_coordinate, &self.selection_location).into_iter().map(Err)
+            validate_star_selection(
+                group,
+                self.schema,
+                &self.selection_coordinate,
+                &self.selection_location,
+            ).into_iter().map(Err)
         ).collect()
     }
 

--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -1054,15 +1054,17 @@ mod tests {
                     SubSelection {
                         selections: [
                             Path(
-                                Alias {
-                                    name: WithRange {
-                                        node: Field(
-                                            "__typename",
-                                        ),
+                                Some(
+                                    Alias {
+                                        name: WithRange {
+                                            node: Field(
+                                                "__typename",
+                                            ),
+                                            range: None,
+                                        },
                                         range: None,
                                     },
-                                    range: None,
-                                },
+                                ),
                                 PathSelection {
                                     path: WithRange {
                                         node: Var(
@@ -1163,15 +1165,17 @@ mod tests {
                     SubSelection {
                         selections: [
                             Path(
-                                Alias {
-                                    name: WithRange {
-                                        node: Field(
-                                            "__typename",
-                                        ),
+                                Some(
+                                    Alias {
+                                        name: WithRange {
+                                            node: Field(
+                                                "__typename",
+                                            ),
+                                            range: None,
+                                        },
                                         range: None,
                                     },
-                                    range: None,
-                                },
+                                ),
                                 PathSelection {
                                     path: WithRange {
                                         node: Var(


### PR DESCRIPTION
It was pointed out to me recently (by @dylan-apollo and @lennyburdette) that JSONSelection strings sometimes become unnecessarily verbose when you want to include one or more fields from a higher level of an input object, along with multiple fields extracted from some deeply nested path within that object.

For example, the response shape returned by the [OpenAI `/chat/completions` endpoint](https://platform.openai.com/docs/api-reference/chat) buries the actual response text from the LLM within an array of `choices`, containing objects with a `message` property that provides the `role` and `content` of the response, where the `content` is the desired response from the LLM (irrelevant properties omitted for clarity):
```json
{
  "id": "chatcmpl-123",
  "created": 1677652288,
  "model": "gpt-4o-mini",
  "choices": [{
    "message": {
      "role": "assistant",
      "content": "\n\nHello there, how may I assist you today?",
    },
  }]
}
```

With the current JSONSelection syntax, if you wanted to select the `id`, `created`, and `model` fields while also flattening the `role` and `content` fields, you'd have to use a selection like
```graphql
id
created
model
role: choices->first.message.role
content: choices->first.message.content
```
In this example, the repetition of the `choices->first.message.` syntax feels somehow unnecessary, and it gets even worse if those properties are more deeply nested, and/or there are more than two of them.

To build an intuition for the solution I'm about to propose, remember that you don't need this repetition if you're only selecting the deeply nested properties (not `id` or `created` or `model`), because you can use a single top-level path selection that selects the `role` and `content` properties (as an object) from the `choices->first.message` path:
```graphql
choices->first.message { role content }
```

Wouldn't it be nice if you could keep using that syntax, and just add other fields to it as necessary?
```graphql
id
created
model
choices->first.message { role content }
```

In terms of the JSONSelection grammar, this new syntax is available and unambiguous because the grammar currently requires adding an alias to the path selection if you want to use it together with other named selections:
```graphql
id
created
model
roleAndContent: choices->first.message { role content }
```
This is not quite what we want in this case, because `roleAndContent` becomes the only sibling key to `id`, `created` and `model`, and there's no syntax for merging `role` and `content` as siblings at that level. However, the absence of a syntax for that merging behavior gives us the freedom to choose the syntax we want to use.

Of course, the desired syntax only works when `choices->first.message` evaluates to an object, but we can enforce that expectation by requiring the trailing `{ role content }` subselection, which produces a runtime `ApplyToError` if `choices->first.message` is not an object or does not have those properties (which is the best we can do, since the actual runtime value of `choices->first.message` depends on dynamic input data).

In other words, the following syntax should continue to be forbidden, even if we happen to know `choices->first.message` is an object with only the `role` and `content` fields:
```graphql
id
created
model
 # STILL ILLEGAL if there are any other named properties!
choices->first.message
```

This new syntax respects [guiding principle #3 (safe subsetting)](https://github.com/apollographql/router/blob/next/apollo-federation/src/sources/connect/json_selection/README.md#guiding-principles), because a selection consisting of only
```graphql
choices->first.message { role content }
```
is functionally equivalent to the selection
```graphql
role: choices->first.message.role
content: choices->first.message.content
```
and continues to contribute the `role` and `content` properties in the same way even when you add/remove other named sibling properties to/from the selection (such as `id`, `created`, and `model`), which can happen any time your GraphQL query happens not to select those properties.

We considered requiring some sort of syntax to indicate the merging behavior, such as `... choices->first.message { role content }`, but having to add or remove the `...` syntax according to the presence or absence of other named selections seemed burdensome and inconsistent. Instead, I think this PR gives a natural meaning to path selections that do not have an alias but do have a trailing subselection, which were previously allowed only at the top-level, by themselves, and forbidden within any nested `SubSelection`.

The first commit in the PR refactors the singular `NamedSelection::name` method to a plural `NamedSelection::names` method that can now return multiple names. I would appreciate @nicholascioli and @pubmodmatt's eyes on that commit especially, since it affects code outside the `json_selection` directory that they're familiar with. Those changes look more drastic than they are because I needed to reindent some existing code.