### PR TITLE
Revert "Temporarily pin CI to Rust nightly-2024-09-22 (#6048)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,9 +356,9 @@ commands:
             equal: [ *arm_linux_test_executor, << parameters.platform >> ]
           steps:
             - run:
-                name: Install nightly-2024-09-22 Rust to build the fuzzers
+                name: Install nightly Rust to build the fuzzers
                 command: |
-                  rustup install nightly-2024-09-22
+                  rustup install nightly
 
   install_extra_tools:
     steps:
@@ -524,7 +524,7 @@ commands:
           path: ./target/nextest/ci/junit.xml
   fuzz_build:
     steps:
-      - run: cargo +nightly-2024-09-22 fuzz build
+      - run: cargo +nightly fuzz build
 
 jobs:
   lint:


### PR DESCRIPTION
This reverts PR https://github.com/apollographql/router/pull/6048 now that https://github.com/rust-lang/rust/issues/130769 is fixed.

Fixes ROUTER-764

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
