### PR TITLE
chore(federation): Add macros for internal errors

### DIFF
--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -13,6 +13,7 @@ use lazy_static::lazy_static;
 
 use crate::subgraph::spec::FederationSpecError;
 
+/// Break out of the current function, returning an internal error.
 #[macro_export]
 macro_rules! internal_error {
     ( $( $arg:tt )+ ) => {
@@ -22,11 +23,19 @@ macro_rules! internal_error {
 
 /// A safe assertion: in debug mode, it panicks on failure, and in production, it returns an
 /// internal error.
+///
+/// Treat this as an assertion. It must only be used for conditions that *should never happen*
+/// in normal operation.
 #[macro_export]
 macro_rules! ensure {
     ( $expr:expr, $( $arg:tt )+ ) => {
         #[cfg(debug_assertions)]
-        assert!($expr, $( $arg )+);
+        {
+            if false {
+                return Err($crate::error::FederationError::internal("ensure!() must be used in a function that returns a Result").into());
+            }
+            assert!($expr, $( $arg )+);
+        }
 
         #[cfg(not(debug_assertions))]
         if !$expr {

--- a/apollo-federation/src/error/mod.rs
+++ b/apollo-federation/src/error/mod.rs
@@ -13,6 +13,28 @@ use lazy_static::lazy_static;
 
 use crate::subgraph::spec::FederationSpecError;
 
+#[macro_export]
+macro_rules! internal_error {
+    ( $( $arg:tt )+ ) => {
+        return Err($crate::error::FederationError::internal(format!( $( $arg )+ )).into());
+    }
+}
+
+/// A safe assertion: in debug mode, it panicks on failure, and in production, it returns an
+/// internal error.
+#[macro_export]
+macro_rules! ensure {
+    ( $expr:expr, $( $arg:tt )+ ) => {
+        #[cfg(debug_assertions)]
+        assert!($expr, $( $arg )+);
+
+        #[cfg(not(debug_assertions))]
+        if !$expr {
+            $crate::internal_error!( $( $arg )+ );
+        }
+    }
+}
+
 // What we really needed here was the string representations in enum form, this isn't meant to
 // replace AST components.
 #[derive(Clone, Debug, strum_macros::Display)]

--- a/apollo-federation/src/operation/rebase.rs
+++ b/apollo-federation/src/operation/rebase.rs
@@ -22,6 +22,7 @@ use super::Selection;
 use super::SelectionId;
 use super::SelectionSet;
 use super::TYPENAME_FIELD;
+use crate::ensure;
 use crate::error::FederationError;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::OutputTypeDefinitionPosition;
@@ -390,12 +391,12 @@ impl FragmentSpread {
             }
             .into());
         };
-        debug_assert_eq!(
-            *schema, self.schema,
+        ensure!(
+            *schema == self.schema,
             "Fragment spread should only be rebased within the same subgraph"
         );
-        debug_assert_eq!(
-            *schema, named_fragment.schema,
+        ensure!(
+            *schema == named_fragment.schema,
             "Referenced named fragment should've been rebased for the subgraph"
         );
         if runtime_types_intersect(

--- a/apollo-federation/src/operation/simplify.rs
+++ b/apollo-federation/src/operation/simplify.rs
@@ -14,6 +14,7 @@ use super::NamedFragments;
 use super::Selection;
 use super::SelectionMap;
 use super::SelectionSet;
+use crate::ensure;
 use crate::error::FederationError;
 use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::ValidFederationSchema;
@@ -136,11 +137,10 @@ impl FragmentSpreadSelection {
 
         // We must update the spread parent type if necessary since we're not going deeper,
         // or we'll be fundamentally losing context.
-        if self.spread.schema != *schema {
-            return Err(FederationError::internal(
-                "Should not try to flatten_unnecessary_fragments using a type from another schema",
-            ));
-        }
+        ensure!(
+            self.spread.schema == *schema,
+            "Should not try to flatten_unnecessary_fragments using a type from another schema",
+        );
 
         let rebased_fragment_spread = self.rebase_on(parent_type, named_fragments, schema)?;
         Ok(Some(SelectionOrSet::Selection(rebased_fragment_spread)))


### PR DESCRIPTION
We use a mix of internal errors and debug asserts for invariant violations. Returning an internal error is quite verbose:
```rust
return Err(FederationError::internal(format!("message: {}", some_value)));
// with a longer message, this becomes 3 or more lines
```

This PR proposes two new macros: `internal_error!()` and `ensure!()`.

`internal_error!()` takes `format!()` syntax and returns an internal error from the surrounding function. The above snippet becomes:
```rust
internal_error!("message: {}", some_value);
```

`ensure!()` is a panicky assertion in debug mode, and returns an internal error in release mode. It replaces the `if invariant { internal_error!() }` pattern.

```rust
ensure!(self.schema() == other.schema(), "cannot merge selections from different schemas");
```

`ensure!()` is an assertion in debug mode, but it also...ensures...that the place it's used supports returning `Err()`, so you can't use it in a spot that wouldn't work in release mode. In a function that doesn't return a Result, you get:
```
error[E0308]: mismatched types
    --> apollo-federation/src/error/mod.rs:31:24
     |
31   |                 return Err($crate::error::FederationError::internal("ensure!() must be used in a function that returns a Result").into());
     |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `()`, found `Result<_, _>`
...
1441 | fn ensure_error() {
     |                  - help: a return type might be missing here: `-> _`
1442 |     ensure!(true, "true is false");
     |     ------------------------------ in this macro invocation
     |
     = note: expected unit type `()`
                     found enum `Result<_, _>`
```

I've ported a handful of uses in the operation code to show the difference. If people like this we can port other usage sites as we work.