### PR TITLE
fix(federation): fix lifting selections when flattening inline fragments

### DIFF
--- a/apollo-federation/src/operation/simplify.rs
+++ b/apollo-federation/src/operation/simplify.rs
@@ -306,7 +306,7 @@ impl InlineFragmentSelection {
                 let rebased_inline_fragment =
                     self.inline_fragment.rebase_on(parent_type, schema)?;
 
-                let mut nonliftable_selections = self.selection_set.selections.clone();
+                let mut nonliftable_selections = selection_set.selections.clone();
                 Arc::make_mut(&mut nonliftable_selections)
                     .retain(|k, _| !liftable_selections.contains_key(k));
 


### PR DESCRIPTION
Some of our customers have a query shape like this:
```graphql
# type MySpecialNode implements Node & HasNodes
{
  nodes {
    __typename
    ... on MySpecialNode {
      value
    }
    ... on HasNodes {
      ... on Node {
        __typename
        ... on MySpecialNode {
          value
        }
      }
    }
  }
}
```

Here, we know that the second `MySpecialNode` fragment is redundant, as the first instance of the fragment will always already select the `nodes.value` field. We currently do not remove the redundant fragment.

This PR fixes `flatten_unnecessary_fragments` so it matches JS QP and removes the second instance of the fragment. The actual fix is https://github.com/apollographql/router/pull/6082/commits/7e9adbdc6c1203223a3881b43d685499a3c815b9, the other changes in simplify.rs are to add a test and to remove some unnecessary clones.

<!-- [ROUTER-782] -->

[ROUTER-782]: https://apollographql.atlassian.net/browse/ROUTER-782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ