### PR TITLE
[JSONSelection] Forbid single-`.key` paths, requiring `$.key` instead

### DIFF
--- a/apollo-federation/src/sources/connect/json_selection/lit_expr.rs
+++ b/apollo-federation/src/sources/connect/json_selection/lit_expr.rs
@@ -432,22 +432,30 @@ mod tests {
 
         {
             let expected = LitExpr::Path(PathSelection {
-                path: PathList::Key(
-                    Key::field("data").into_with_range(),
-                    PathList::Empty.into_with_range(),
+                path: PathList::Var(
+                    KnownVariable::Dollar.into_with_range(),
+                    PathList::Key(
+                        Key::field("data").into_with_range(),
+                        PathList::Empty.into_with_range(),
+                    )
+                    .into_with_range(),
                 )
                 .into_with_range(),
             });
-            check_parse(".data", expected.clone());
-            check_parse(" . data ", expected.clone());
+            check_parse("$.data", expected.clone());
+            check_parse(" $ . data ", expected.clone());
         }
 
         {
             let expected = LitExpr::Array(vec![
                 LitExpr::Path(PathSelection {
-                    path: PathList::Key(
-                        Key::field("a").into_with_range(),
-                        PathList::Empty.into_with_range(),
+                    path: PathList::Var(
+                        KnownVariable::Dollar.into_with_range(),
+                        PathList::Key(
+                            Key::field("a").into_with_range(),
+                            PathList::Empty.into_with_range(),
+                        )
+                        .into_with_range(),
                     )
                     .into_with_range(),
                 })
@@ -482,22 +490,22 @@ mod tests {
                 .into_with_range(),
             ]);
 
-            check_parse("[.a, b.c, .d.e.f]", expected.clone());
-            check_parse("[.a, b.c, .d.e.f,]", expected.clone());
-            check_parse("[ . a , b . c , . d . e . f ]", expected.clone());
-            check_parse("[ . a , b . c , . d . e . f , ]", expected.clone());
+            check_parse("[$.a, b.c, d.e.f]", expected.clone());
+            check_parse("[$.a, b.c, d.e.f,]", expected.clone());
+            check_parse("[ $ . a , b . c , d . e . f ]", expected.clone());
+            check_parse("[ $ . a , b . c , d . e . f , ]", expected.clone());
             check_parse(
                 r#"[
-                .a,
+                $.a,
                 b.c,
-                .d.e.f,
+                d.e.f,
             ]"#,
                 expected.clone(),
             );
             check_parse(
                 r#"[
-                . a ,
-                . b . c ,
+                $ . a ,
+                b . c ,
                 d . e . f ,
             ]"#,
                 expected.clone(),

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -516,9 +516,32 @@ impl PathList {
             }
         }
 
-        // The .key case is applicable at any depth. If it comes first in the
-        // path selection, $.key is implied, but the distinction is preserved
-        // (using Self::Path rather than Self::Var) for accurate reprintability.
+        if depth == 0 {
+            // If the PathSelection does not start with a $var (or $ or @), a
+            // key., or $(expr), it is not a valid PathSelection.
+            //
+            // TODO When we improve these parse error messages, we may want to
+            // detect the .key case and suggest using $.key instead.
+            return Err(nom::Err::Error(nom::error::Error::new(
+                input,
+                nom::error::ErrorKind::IsNot,
+            )));
+        }
+
+        // In previous versions of this code, a .key could appear at depth 0 (at
+        // the beginning of a path), which was useful to disambiguate a KeyPath
+        // consisting of a single key from a field selection (though this case
+        // was never explicitly allowed by the formal grammar in the README.md).
+        //
+        // Now that key paths can appear alongside/after named selections within
+        // a SubSelection, the .key syntax is potentially unsafe because it may
+        // be parsed as a continuation of a previous field selection, since we
+        // ignore spaces/newlines/comments between keys in a path.
+        //
+        // In order to prevent this ambiguity, we now require that a single .key
+        // be written as a subproperty of the $ variable, e.g. $.key, which is
+        // equivalent to the old behavior without any parsing ambiguities. In
+        // terms of this code, that means we allow a .key only at depths > 0.
         if let Ok((suffix, (dot, _, key))) =
             tuple((ranged_span("."), spaces_or_comments, Key::parse))(input)
         {
@@ -526,15 +549,6 @@ impl PathList {
             let dot_key_range = merge_ranges(dot.range(), key.range());
             let full_range = merge_ranges(dot_key_range, rest.range());
             return Ok((remainder, WithRange::new(Self::Key(key, rest), full_range)));
-        }
-
-        if depth == 0 {
-            // If the PathSelection does not start with a $var (or $ or @), a
-            // key. (or .key), or $(expr), it is not a valid PathSelection.
-            return Err(nom::Err::Error(nom::error::Error::new(
-                input,
-                nom::error::ErrorKind::IsNot,
-            )));
         }
 
         // PathSelection can never start with a naked ->method (instead, use
@@ -1331,11 +1345,18 @@ mod tests {
         );
 
         assert_eq!(
-            selection!(".hello").strip_ranges(),
-            JSONSelection::Path(PathSelection::from_slice(
-                &[Key::Field("hello".to_string())],
-                None
-            )),
+            selection!("$.hello").strip_ranges(),
+            JSONSelection::Path(PathSelection {
+                path: PathList::Var(
+                    KnownVariable::Dollar.into_with_range(),
+                    PathList::Key(
+                        Key::field("hello").into_with_range(),
+                        PathList::Empty.into_with_range()
+                    )
+                    .into_with_range(),
+                )
+                .into_with_range(),
+            }),
         );
 
         {
@@ -1353,14 +1374,14 @@ mod tests {
                 ..Default::default()
             });
 
-            assert_eq!(selection!("hi: .hello.world").strip_ranges(), expected);
-            assert_eq!(selection!("hi: .hello .world").strip_ranges(), expected);
-            assert_eq!(selection!("hi: . hello. world").strip_ranges(), expected);
-            assert_eq!(selection!("hi: .hello . world").strip_ranges(), expected);
+            assert_eq!(selection!("hi: hello.world").strip_ranges(), expected);
+            assert_eq!(selection!("hi: hello .world").strip_ranges(), expected);
+            assert_eq!(selection!("hi:  hello. world").strip_ranges(), expected);
+            assert_eq!(selection!("hi: hello . world").strip_ranges(), expected);
             assert_eq!(selection!("hi: hello.world").strip_ranges(), expected);
             assert_eq!(selection!("hi: hello. world").strip_ranges(), expected);
             assert_eq!(selection!("hi: hello .world").strip_ranges(), expected);
-            assert_eq!(selection!("hi: hello . world").strip_ranges(), expected);
+            assert_eq!(selection!("hi: hello . world ").strip_ranges(), expected);
         }
 
         {
@@ -1383,39 +1404,23 @@ mod tests {
             });
 
             assert_eq!(
-                selection!("before hi: .hello.world after").strip_ranges(),
-                expected
-            );
-            assert_eq!(
-                selection!("before hi: .hello .world after").strip_ranges(),
-                expected
-            );
-            assert_eq!(
-                selection!("before hi: .hello. world after").strip_ranges(),
-                expected
-            );
-            assert_eq!(
-                selection!("before hi: .hello . world after").strip_ranges(),
-                expected
-            );
-            assert_eq!(
-                selection!("before hi: . hello.world after").strip_ranges(),
-                expected
-            );
-            assert_eq!(
-                selection!("before hi: . hello .world after").strip_ranges(),
-                expected
-            );
-            assert_eq!(
-                selection!("before hi: . hello. world after").strip_ranges(),
-                expected
-            );
-            assert_eq!(
-                selection!("before hi: . hello . world after").strip_ranges(),
-                expected
-            );
-            assert_eq!(
                 selection!("before hi: hello.world after").strip_ranges(),
+                expected
+            );
+            assert_eq!(
+                selection!("before hi: hello .world after").strip_ranges(),
+                expected
+            );
+            assert_eq!(
+                selection!("before hi: hello. world after").strip_ranges(),
+                expected
+            );
+            assert_eq!(
+                selection!("before hi: hello . world after").strip_ranges(),
+                expected
+            );
+            assert_eq!(
+                selection!("before hi:  hello.world after").strip_ranges(),
                 expected
             );
             assert_eq!(
@@ -1466,19 +1471,15 @@ mod tests {
             });
 
             assert_eq!(
-                selection!("before hi: .hello.world { nested names } after").strip_ranges(),
-                expected
-            );
-            assert_eq!(
-                selection!("before hi:.hello.world{nested names}after").strip_ranges(),
-                expected
-            );
-            assert_eq!(
                 selection!("before hi: hello.world { nested names } after").strip_ranges(),
                 expected
             );
             assert_eq!(
                 selection!("before hi:hello.world{nested names}after").strip_ranges(),
+                expected
+            );
+            assert_eq!(
+                selection!(" before hi : hello . world { nested names } after ").strip_ranges(),
                 expected
             );
         }
@@ -1493,7 +1494,7 @@ mod tests {
 
                 # This extracts the value located at the given path and applies a
                 # selection set to it before renaming the result to pathSelection
-                pathSelection: .some.nested.path {
+                pathSelection: some.nested.path {
                     still: yet
                     more
                     properties
@@ -1506,6 +1507,7 @@ mod tests {
         ));
     }
 
+    #[track_caller]
     fn check_path_selection(input: &str, expected: PathSelection) {
         let (remainder, path_selection) = PathSelection::parse(Span::new(input)).unwrap();
         assert!(span_is_all_spaces_or_comments(remainder));
@@ -1519,9 +1521,43 @@ mod tests {
     #[test]
     fn test_path_selection() {
         check_path_selection(
-            ".hello",
-            PathSelection::from_slice(&[Key::Field("hello".to_string())], None),
+            "$.hello",
+            PathSelection {
+                path: PathList::Var(
+                    KnownVariable::Dollar.into_with_range(),
+                    PathList::Key(
+                        Key::field("hello").into_with_range(),
+                        PathList::Empty.into_with_range(),
+                    )
+                    .into_with_range(),
+                )
+                .into_with_range(),
+            },
         );
+
+        {
+            let expected = PathSelection {
+                path: PathList::Var(
+                    KnownVariable::Dollar.into_with_range(),
+                    PathList::Key(
+                        Key::field("hello").into_with_range(),
+                        PathList::Key(
+                            Key::field("world").into_with_range(),
+                            PathList::Empty.into_with_range(),
+                        )
+                        .into_with_range(),
+                    )
+                    .into_with_range(),
+                )
+                .into_with_range(),
+            };
+            check_path_selection("$.hello.world", expected.clone());
+            check_path_selection("$.hello .world", expected.clone());
+            check_path_selection("$.hello. world", expected.clone());
+            check_path_selection("$.hello . world", expected.clone());
+            check_path_selection("$ . hello . world", expected.clone());
+            check_path_selection(" $ . hello . world ", expected.clone());
+        }
 
         {
             let expected = PathSelection::from_slice(
@@ -1531,14 +1567,11 @@ mod tests {
                 ],
                 None,
             );
-            check_path_selection(".hello.world", expected.clone());
-            check_path_selection(".hello .world", expected.clone());
-            check_path_selection(".hello. world", expected.clone());
-            check_path_selection(".hello . world", expected.clone());
             check_path_selection("hello.world", expected.clone());
             check_path_selection("hello .world", expected.clone());
             check_path_selection("hello. world", expected.clone());
             check_path_selection("hello . world", expected.clone());
+            check_path_selection(" hello . world ", expected.clone());
         }
 
         {
@@ -1556,18 +1589,12 @@ mod tests {
                     ..Default::default()
                 }),
             );
-            check_path_selection(".hello.world { hello }", expected.clone());
-            check_path_selection(".hello .world { hello }", expected.clone());
-            check_path_selection(".hello. world { hello }", expected.clone());
-            check_path_selection(".hello . world { hello }", expected.clone());
-            check_path_selection(". hello.world { hello }", expected.clone());
-            check_path_selection(". hello .world { hello }", expected.clone());
-            check_path_selection(". hello. world { hello }", expected.clone());
-            check_path_selection(". hello . world { hello }", expected.clone());
+            check_path_selection("hello.world{hello}", expected.clone());
             check_path_selection("hello.world { hello }", expected.clone());
             check_path_selection("hello .world { hello }", expected.clone());
             check_path_selection("hello. world { hello }", expected.clone());
             check_path_selection("hello . world { hello }", expected.clone());
+            check_path_selection(" hello . world { hello } ", expected.clone());
         }
 
         {
@@ -1579,10 +1606,6 @@ mod tests {
                     Key::Field("name".to_string()),
                 ],
                 None,
-            );
-            check_path_selection(
-                ".nested.'string literal'.\"property\".name",
-                expected.clone(),
             );
             check_path_selection(
                 "nested.'string literal'.\"property\".name",
@@ -1604,6 +1627,10 @@ mod tests {
                 "nested.'string literal'.\"property\". name",
                 expected.clone(),
             );
+            check_path_selection(
+                " nested . 'string literal' . \"property\" . name ",
+                expected.clone(),
+            );
         }
 
         {
@@ -1623,12 +1650,12 @@ mod tests {
             );
 
             check_path_selection(
-                ".nested.'string literal' { leggo: 'my ego' }",
+                "nested.'string literal' { leggo: 'my ego' }",
                 expected.clone(),
             );
 
             check_path_selection(
-                "nested.'string literal' { leggo: 'my ego' }",
+                " nested . 'string literal' { leggo : 'my ego' } ",
                 expected.clone(),
             );
 
@@ -1641,84 +1668,96 @@ mod tests {
                 "nested . 'string literal' { leggo: 'my ego' }",
                 expected.clone(),
             );
-        }
-
-        {
-            let expected = PathSelection {
-                path: PathList::Key(
-                    Key::field("results").into_with_range(),
-                    PathList::Selection(SubSelection {
-                        selections: vec![NamedSelection::Field(
-                            None,
-                            Key::quoted("quoted without alias").into_with_range(),
-                            Some(SubSelection {
-                                selections: vec![
-                                    NamedSelection::Field(
-                                        None,
-                                        Key::field("id").into_with_range(),
-                                        None,
-                                    ),
-                                    NamedSelection::Field(
-                                        None,
-                                        Key::quoted("n a m e").into_with_range(),
-                                        None,
-                                    ),
-                                ],
-                                ..Default::default()
-                            }),
-                        )],
-                        ..Default::default()
-                    })
-                    .into_with_range(),
-                )
-                .into_with_range(),
-            };
             check_path_selection(
-                ".results { 'quoted without alias' { id 'n a m e' } }",
-                expected.clone(),
-            );
-            check_path_selection(
-                ".results{'quoted without alias'{id'n a m e'}}",
+                " nested . \"string literal\" { leggo: 'my ego' } ",
                 expected.clone(),
             );
         }
 
         {
             let expected = PathSelection {
-                path: PathList::Key(
-                    Key::field("results").into_with_range(),
-                    PathList::Selection(SubSelection {
-                        selections: vec![NamedSelection::Field(
-                            Some(Alias::quoted("non-identifier alias")),
-                            Key::quoted("quoted with alias").into_with_range(),
-                            Some(SubSelection {
-                                selections: vec![
-                                    NamedSelection::Field(
-                                        None,
-                                        Key::field("id").into_with_range(),
-                                        None,
-                                    ),
-                                    NamedSelection::Field(
-                                        Some(Alias::quoted("n a m e")),
-                                        Key::field("name").into_with_range(),
-                                        None,
-                                    ),
-                                ],
-                                ..Default::default()
-                            }),
-                        )],
-                        ..Default::default()
-                    })
+                path: PathList::Var(
+                    KnownVariable::Dollar.into_with_range(),
+                    PathList::Key(
+                        Key::field("results").into_with_range(),
+                        PathList::Selection(SubSelection {
+                            selections: vec![NamedSelection::Field(
+                                None,
+                                Key::quoted("quoted without alias").into_with_range(),
+                                Some(SubSelection {
+                                    selections: vec![
+                                        NamedSelection::Field(
+                                            None,
+                                            Key::field("id").into_with_range(),
+                                            None,
+                                        ),
+                                        NamedSelection::Field(
+                                            None,
+                                            Key::quoted("n a m e").into_with_range(),
+                                            None,
+                                        ),
+                                    ],
+                                    ..Default::default()
+                                }),
+                            )],
+                            ..Default::default()
+                        })
+                        .into_with_range(),
+                    )
                     .into_with_range(),
                 )
                 .into_with_range(),
             };
             check_path_selection(
-                ".results { 'non-identifier alias': 'quoted with alias' { id 'n a m e': name } }",
+                "$.results{'quoted without alias'{id'n a m e'}}",
                 expected.clone(),
             );
             check_path_selection(
-                ".results{'non-identifier alias':'quoted with alias'{id'n a m e':name}}",
+                " $ . results { 'quoted without alias' { id 'n a m e' } } ",
+                expected.clone(),
+            );
+        }
+
+        {
+            let expected = PathSelection {
+                path: PathList::Var(
+                    KnownVariable::Dollar.into_with_range(),
+                    PathList::Key(
+                        Key::field("results").into_with_range(),
+                        PathList::Selection(SubSelection {
+                            selections: vec![NamedSelection::Field(
+                                Some(Alias::quoted("non-identifier alias")),
+                                Key::quoted("quoted with alias").into_with_range(),
+                                Some(SubSelection {
+                                    selections: vec![
+                                        NamedSelection::Field(
+                                            None,
+                                            Key::field("id").into_with_range(),
+                                            None,
+                                        ),
+                                        NamedSelection::Field(
+                                            Some(Alias::quoted("n a m e")),
+                                            Key::field("name").into_with_range(),
+                                            None,
+                                        ),
+                                    ],
+                                    ..Default::default()
+                                }),
+                            )],
+                            ..Default::default()
+                        })
+                        .into_with_range(),
+                    )
+                    .into_with_range(),
+                )
+                .into_with_range(),
+            };
+            check_path_selection(
+                "$.results{'non-identifier alias':'quoted with alias'{id'n a m e':name}}",
+                expected.clone(),
+            );
+            check_path_selection(
+                " $ . results { 'non-identifier alias' : 'quoted with alias' { id 'n a m e': name } } ",
                 expected.clone(),
             );
         }
@@ -1875,23 +1914,10 @@ mod tests {
         );
 
         check_path_selection(
-            "undotted.x.y.z",
+            "root.x.y.z",
             PathSelection::from_slice(
                 &[
-                    Key::Field("undotted".to_string()),
-                    Key::Field("x".to_string()),
-                    Key::Field("y".to_string()),
-                    Key::Field("z".to_string()),
-                ],
-                None,
-            ),
-        );
-
-        check_path_selection(
-            ".dotted.x.y.z",
-            PathSelection::from_slice(
-                &[
-                    Key::Field("dotted".to_string()),
+                    Key::Field("root".to_string()),
                     Key::Field("x".to_string()),
                     Key::Field("y".to_string()),
                     Key::Field("z".to_string()),
@@ -2224,6 +2250,23 @@ mod tests {
         );
 
         {
+            fn make_dollar_key_expr(key: &str) -> WithRange<LitExpr> {
+                WithRange::new(
+                    LitExpr::Path(PathSelection {
+                        path: PathList::Var(
+                            KnownVariable::Dollar.into_with_range(),
+                            PathList::Key(
+                                Key::field(key).into_with_range(),
+                                PathList::Empty.into_with_range(),
+                            )
+                            .into_with_range(),
+                        )
+                        .into_with_range(),
+                    }),
+                    None,
+                )
+            }
+
             let expected = PathSelection {
                 path: PathList::Key(
                     Key::field("data").into_with_range(),
@@ -2231,12 +2274,9 @@ mod tests {
                         WithRange::new("query".to_string(), None),
                         Some(MethodArgs {
                             args: vec![
-                                LitExpr::Path(PathSelection::from_slice(&[Key::field("a")], None))
-                                    .into_with_range(),
-                                LitExpr::Path(PathSelection::from_slice(&[Key::field("b")], None))
-                                    .into_with_range(),
-                                LitExpr::Path(PathSelection::from_slice(&[Key::field("c")], None))
-                                    .into_with_range(),
+                                make_dollar_key_expr("a"),
+                                make_dollar_key_expr("b"),
+                                make_dollar_key_expr("c"),
                             ],
                             ..Default::default()
                         }),
@@ -2246,11 +2286,11 @@ mod tests {
                 )
                 .into_with_range(),
             };
-            check_path_selection("data->query(.a, .b, .c)", expected.clone());
-            check_path_selection("data->query(.a, .b, .c )", expected.clone());
-            check_path_selection("data->query(.a, .b, .c,)", expected.clone());
-            check_path_selection("data->query(.a, .b, .c ,)", expected.clone());
-            check_path_selection("data->query(.a, .b, .c , )", expected.clone());
+            check_path_selection("data->query($.a, $.b, $.c)", expected.clone());
+            check_path_selection("data->query($.a, $.b, $.c )", expected.clone());
+            check_path_selection("data->query($.a, $.b, $.c,)", expected.clone());
+            check_path_selection("data->query($.a, $.b, $.c ,)", expected.clone());
+            check_path_selection("data->query($.a, $.b, $.c , )", expected.clone());
         }
 
         {
@@ -2444,7 +2484,7 @@ mod tests {
         assert_debug_snapshot!(JSONSelection::parse(
             r#"
             $this { id }
-            $args { .input { title body } }
+            $args { $.input { title body } }
         "#
         ));
 

--- a/apollo-federation/src/sources/connect/json_selection/pretty.rs
+++ b/apollo-federation/src/sources/connect/json_selection/pretty.rs
@@ -423,10 +423,10 @@ mod tests {
             "$this.a.b",
             "$this.id.first {\n  username\n}",
             // Key
-            ".first",
+            "$.first",
             "a.b.c.d.e",
             "one.two.three {\n  a\n  b\n}",
-            ".single {\n  x\n}",
+            "$.single {\n  x\n}",
             "results->slice($(-1)->mul($args.suffixLength))",
             "$(1234)->add($(5678)->mul(2))",
             "$(true)->and($(false)->not)",

--- a/apollo-federation/src/sources/connect/json_selection/selection_set.rs
+++ b/apollo-federation/src/sources/connect/json_selection/selection_set.rs
@@ -286,10 +286,10 @@ mod tests {
     fn test() {
         let json = super::JSONSelection::parse(
             r###"
-        .result {
+        $.result {
           a
           b: c
-          d: .e.f
+          d: e.f
           g
           h: 'i-j'
           k: { l m: n }
@@ -331,7 +331,7 @@ mod tests {
         let transformed = json.apply_selection_set(&selection_set);
         assert_eq!(
             transformed.to_string(),
-            r###".result {
+            r###"$.result {
   z: a
   y: c
   x: e.f
@@ -348,7 +348,7 @@ mod tests {
     fn test_star() {
         let json_selection = super::JSONSelection::parse(
             r###"
-        .result {
+        $.result {
           a
           b_alias: b
           c {
@@ -362,7 +362,7 @@ mod tests {
             }
             rest: *
           }
-          path_to_f: .c.f
+          path_to_f: c.f
           rest: *
         }
         "###,
@@ -408,7 +408,7 @@ mod tests {
         let transformed = json_selection.apply_selection_set(&selection_set);
         assert_eq!(
             transformed.to_string(),
-            r###".result {
+            r###"$.result {
   a
   b_alias: b
   c {
@@ -477,7 +477,7 @@ mod tests {
     fn test_depth() {
         let json = super::JSONSelection::parse(
             r###"
-        .result {
+        $.result {
           a {
             b {
               renamed: c
@@ -516,7 +516,7 @@ mod tests {
         let transformed = json.apply_selection_set(&selection_set);
         assert_eq!(
             transformed.to_string(),
-            r###".result {
+            r###"$.result {
   a {
     b {
       renamed: c
@@ -549,7 +549,7 @@ mod tests {
     fn test_typename() {
         let json = super::JSONSelection::parse(
             r###"
-            .result {
+            $.result {
               id
               author: {
                 id: authorId
@@ -585,7 +585,7 @@ mod tests {
         let transformed = json.apply_selection_set(&selection_set);
         assert_eq!(
             transformed.to_string(),
-            r###".result {
+            r###"$.result {
   __typename: $->echo("T")
   id
   author: {

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-6.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__path_with_subselection-6.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/sources/connect/json_selection/parser.rs
-expression: "JSONSelection::parse(r#\"\n            $this { id }\n            $args { .input { title body } }\n        \"#)"
+expression: "JSONSelection::parse(r#\"\n            $this { id }\n            $args { $.input { title body } }\n        \"#)"
 ---
 Ok(
     (
@@ -72,57 +72,70 @@ Ok(
                                                         None,
                                                         PathSelection {
                                                             path: WithRange {
-                                                                node: Key(
+                                                                node: Var(
                                                                     WithRange {
-                                                                        node: Field(
-                                                                            "input",
-                                                                        ),
+                                                                        node: $,
                                                                         range: Some(
-                                                                            47..52,
+                                                                            46..47,
                                                                         ),
                                                                     },
                                                                     WithRange {
-                                                                        node: Selection(
-                                                                            SubSelection {
-                                                                                selections: [
-                                                                                    Field(
-                                                                                        None,
-                                                                                        WithRange {
-                                                                                            node: Field(
-                                                                                                "title",
-                                                                                            ),
-                                                                                            range: Some(
-                                                                                                55..60,
-                                                                                            ),
-                                                                                        },
-                                                                                        None,
-                                                                                    ),
-                                                                                    Field(
-                                                                                        None,
-                                                                                        WithRange {
-                                                                                            node: Field(
-                                                                                                "body",
-                                                                                            ),
-                                                                                            range: Some(
-                                                                                                61..65,
-                                                                                            ),
-                                                                                        },
-                                                                                        None,
-                                                                                    ),
-                                                                                ],
-                                                                                star: None,
+                                                                        node: Key(
+                                                                            WithRange {
+                                                                                node: Field(
+                                                                                    "input",
+                                                                                ),
                                                                                 range: Some(
-                                                                                    53..67,
+                                                                                    48..53,
+                                                                                ),
+                                                                            },
+                                                                            WithRange {
+                                                                                node: Selection(
+                                                                                    SubSelection {
+                                                                                        selections: [
+                                                                                            Field(
+                                                                                                None,
+                                                                                                WithRange {
+                                                                                                    node: Field(
+                                                                                                        "title",
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        56..61,
+                                                                                                    ),
+                                                                                                },
+                                                                                                None,
+                                                                                            ),
+                                                                                            Field(
+                                                                                                None,
+                                                                                                WithRange {
+                                                                                                    node: Field(
+                                                                                                        "body",
+                                                                                                    ),
+                                                                                                    range: Some(
+                                                                                                        62..66,
+                                                                                                    ),
+                                                                                                },
+                                                                                                None,
+                                                                                            ),
+                                                                                        ],
+                                                                                        star: None,
+                                                                                        range: Some(
+                                                                                            54..68,
+                                                                                        ),
+                                                                                    },
+                                                                                ),
+                                                                                range: Some(
+                                                                                    54..68,
                                                                                 ),
                                                                             },
                                                                         ),
                                                                         range: Some(
-                                                                            53..67,
+                                                                            47..68,
                                                                         ),
                                                                     },
                                                                 ),
                                                                 range: Some(
-                                                                    46..67,
+                                                                    46..68,
                                                                 ),
                                                             },
                                                         },
@@ -130,17 +143,17 @@ Ok(
                                                 ],
                                                 star: None,
                                                 range: Some(
-                                                    44..69,
+                                                    44..70,
                                                 ),
                                             },
                                         ),
                                         range: Some(
-                                            44..69,
+                                            44..70,
                                         ),
                                     },
                                 ),
                                 range: Some(
-                                    38..69,
+                                    38..70,
                                 ),
                             },
                         },
@@ -148,7 +161,7 @@ Ok(
                 ],
                 star: None,
                 range: Some(
-                    13..69,
+                    13..70,
                 ),
             },
         ),

--- a/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__selection.snap
+++ b/apollo-federation/src/sources/connect/json_selection/snapshots/apollo_federation__sources__connect__json_selection__parser__tests__selection.snap
@@ -1,6 +1,6 @@
 ---
 source: apollo-federation/src/sources/connect/json_selection/parser.rs
-expression: "selection!(\"\n            # Comments are supported because we parse them as whitespace\n            topLevelAlias: topLevelField {\n                identifier: 'property name with spaces'\n                'unaliased non-identifier property'\n                'non-identifier alias': identifier\n\n                # This extracts the value located at the given path and applies a\n                # selection set to it before renaming the result to pathSelection\n                pathSelection: .some.nested.path {\n                    still: yet\n                    more\n                    properties\n                }\n\n                # An aliased SubSelection of fields nests the fields together\n                # under the given alias\n                siblingGroup: { brother sister }\n            }\")"
+expression: "selection!(\"\n            # Comments are supported because we parse them as whitespace\n            topLevelAlias: topLevelField {\n                identifier: 'property name with spaces'\n                'unaliased non-identifier property'\n                'non-identifier alias': identifier\n\n                # This extracts the value located at the given path and applies a\n                # selection set to it before renaming the result to pathSelection\n                pathSelection: some.nested.path {\n                    still: yet\n                    more\n                    properties\n                }\n\n                # An aliased SubSelection of fields nests the fields together\n                # under the given alias\n                siblingGroup: { brother sister }\n            }\")"
 ---
 Named(
     SubSelection {
@@ -120,7 +120,7 @@ Named(
                                                     "some",
                                                 ),
                                                 range: Some(
-                                                    473..477,
+                                                    472..476,
                                                 ),
                                             },
                                             WithRange {
@@ -130,7 +130,7 @@ Named(
                                                             "nested",
                                                         ),
                                                         range: Some(
-                                                            478..484,
+                                                            477..483,
                                                         ),
                                                     },
                                                     WithRange {
@@ -140,7 +140,7 @@ Named(
                                                                     "path",
                                                                 ),
                                                                 range: Some(
-                                                                    485..489,
+                                                                    484..488,
                                                                 ),
                                                             },
                                                             WithRange {
@@ -155,11 +155,11 @@ Named(
                                                                                                 "still",
                                                                                             ),
                                                                                             range: Some(
-                                                                                                512..517,
+                                                                                                511..516,
                                                                                             ),
                                                                                         },
                                                                                         range: Some(
-                                                                                            512..518,
+                                                                                            511..517,
                                                                                         ),
                                                                                     },
                                                                                 ),
@@ -168,7 +168,7 @@ Named(
                                                                                         "yet",
                                                                                     ),
                                                                                     range: Some(
-                                                                                        519..522,
+                                                                                        518..521,
                                                                                     ),
                                                                                 },
                                                                                 None,
@@ -180,7 +180,7 @@ Named(
                                                                                         "more",
                                                                                     ),
                                                                                     range: Some(
-                                                                                        543..547,
+                                                                                        542..546,
                                                                                     ),
                                                                                 },
                                                                                 None,
@@ -192,7 +192,7 @@ Named(
                                                                                         "properties",
                                                                                     ),
                                                                                     range: Some(
-                                                                                        568..578,
+                                                                                        567..577,
                                                                                     ),
                                                                                 },
                                                                                 None,
@@ -200,27 +200,27 @@ Named(
                                                                         ],
                                                                         star: None,
                                                                         range: Some(
-                                                                            490..596,
+                                                                            489..595,
                                                                         ),
                                                                     },
                                                                 ),
                                                                 range: Some(
-                                                                    490..596,
+                                                                    489..595,
                                                                 ),
                                                             },
                                                         ),
                                                         range: Some(
-                                                            484..596,
+                                                            483..595,
                                                         ),
                                                     },
                                                 ),
                                                 range: Some(
-                                                    477..596,
+                                                    476..595,
                                                 ),
                                             },
                                         ),
                                         range: Some(
-                                            472..596,
+                                            472..595,
                                         ),
                                     },
                                 },
@@ -232,11 +232,11 @@ Named(
                                             "siblingGroup",
                                         ),
                                         range: Some(
-                                            732..744,
+                                            731..743,
                                         ),
                                     },
                                     range: Some(
-                                        732..745,
+                                        731..744,
                                     ),
                                 },
                                 SubSelection {
@@ -248,7 +248,7 @@ Named(
                                                     "brother",
                                                 ),
                                                 range: Some(
-                                                    748..755,
+                                                    747..754,
                                                 ),
                                             },
                                             None,
@@ -260,7 +260,7 @@ Named(
                                                     "sister",
                                                 ),
                                                 range: Some(
-                                                    756..762,
+                                                    755..761,
                                                 ),
                                             },
                                             None,
@@ -268,14 +268,14 @@ Named(
                                     ],
                                     star: None,
                                     range: Some(
-                                        746..764,
+                                        745..763,
                                     ),
                                 },
                             ),
                         ],
                         star: None,
                         range: Some(
-                            115..778,
+                            115..777,
                         ),
                     },
                 ),
@@ -283,7 +283,7 @@ Named(
         ],
         star: None,
         range: Some(
-            86..778,
+            86..777,
         ),
     },
 )

--- a/apollo-federation/src/sources/connect/validation/test_data/all_fields_selected.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/all_fields_selected.graphql
@@ -17,7 +17,7 @@ type Query {
       wrapped: {
         id
       }
-      unwrapped: .foo.bar
+      unwrapped: foo.bar
       """
     )
     @connect(

--- a/apollo-federation/src/sources/connect/validation/test_data/disallowed_abstract_types.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/disallowed_abstract_types.graphql
@@ -6,7 +6,7 @@ type Query {
     @connect(
       http: { GET: "http://127.0.0.1:8000/products" }
       selection: """
-      .results {
+      $.results {
         id
         title
         author { name }

--- a/apollo-router/src/plugins/connectors/handle_responses.rs
+++ b/apollo-router/src/plugins/connectors/handle_responses.rs
@@ -283,7 +283,7 @@ mod tests {
                 headers: Default::default(),
                 body: Default::default(),
             },
-            selection: JSONSelection::parse(".data").unwrap().1,
+            selection: JSONSelection::parse("$.data").unwrap().1,
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
@@ -296,7 +296,7 @@ mod tests {
             name: "hello".to_string(),
             inputs: Default::default(),
             typename: ResponseTypeName::Concrete("String".to_string()),
-            selection: Arc::new(JSONSelection::parse(".data").unwrap().1),
+            selection: Arc::new(JSONSelection::parse("$.data").unwrap().1),
         };
 
         let response2 = http::Response::builder()
@@ -306,7 +306,7 @@ mod tests {
             name: "hello2".to_string(),
             inputs: Default::default(),
             typename: ResponseTypeName::Concrete("String".to_string()),
-            selection: Arc::new(JSONSelection::parse(".data").unwrap().1),
+            selection: Arc::new(JSONSelection::parse("$.data").unwrap().1),
         };
 
         let res = super::handle_responses(
@@ -377,7 +377,7 @@ mod tests {
                 headers: Default::default(),
                 body: Default::default(),
             },
-            selection: JSONSelection::parse(".data { id }").unwrap().1,
+            selection: JSONSelection::parse("$.data { id }").unwrap().1,
             entity_resolver: Some(EntityResolver::Explicit),
             config: Default::default(),
             max_requests: None,
@@ -390,7 +390,7 @@ mod tests {
             index: 0,
             inputs: Default::default(),
             typename: ResponseTypeName::Concrete("User".to_string()),
-            selection: Arc::new(JSONSelection::parse(".data").unwrap().1),
+            selection: Arc::new(JSONSelection::parse("$.data").unwrap().1),
         };
 
         let response2 = http::Response::builder()
@@ -400,7 +400,7 @@ mod tests {
             index: 1,
             inputs: Default::default(),
             typename: ResponseTypeName::Concrete("User".to_string()),
-            selection: Arc::new(JSONSelection::parse(".data").unwrap().1),
+            selection: Arc::new(JSONSelection::parse("$.data").unwrap().1),
         };
 
         let res = super::handle_responses(
@@ -483,7 +483,7 @@ mod tests {
                 headers: Default::default(),
                 body: Default::default(),
             },
-            selection: JSONSelection::parse(".data").unwrap().1,
+            selection: JSONSelection::parse("$.data").unwrap().1,
             entity_resolver: Some(EntityResolver::Implicit),
             config: Default::default(),
             max_requests: None,
@@ -497,7 +497,7 @@ mod tests {
             inputs: Default::default(),
             field_name: "field".to_string(),
             typename: ResponseTypeName::Concrete("User".to_string()),
-            selection: Arc::new(JSONSelection::parse(".data").unwrap().1),
+            selection: Arc::new(JSONSelection::parse("$.data").unwrap().1),
         };
 
         let response2 = http::Response::builder()
@@ -508,7 +508,7 @@ mod tests {
             inputs: Default::default(),
             field_name: "field".to_string(),
             typename: ResponseTypeName::Concrete("User".to_string()),
-            selection: Arc::new(JSONSelection::parse(".data").unwrap().1),
+            selection: Arc::new(JSONSelection::parse("$.data").unwrap().1),
         };
 
         let res = super::handle_responses(
@@ -591,7 +591,7 @@ mod tests {
                 headers: Default::default(),
                 body: Default::default(),
             },
-            selection: JSONSelection::parse(".data").unwrap().1,
+            selection: JSONSelection::parse("$.data").unwrap().1,
             entity_resolver: Some(EntityResolver::Explicit),
             config: Default::default(),
             max_requests: None,
@@ -605,7 +605,7 @@ mod tests {
             index: 0,
             inputs: Default::default(),
             typename: ResponseTypeName::Concrete("User".to_string()),
-            selection: Arc::new(JSONSelection::parse(".data").unwrap().1),
+            selection: Arc::new(JSONSelection::parse("$.data").unwrap().1),
         };
 
         let response2 = http::Response::builder()
@@ -615,7 +615,7 @@ mod tests {
             index: 1,
             inputs: Default::default(),
             typename: ResponseTypeName::Concrete("User".to_string()),
-            selection: Arc::new(JSONSelection::parse(".data").unwrap().1),
+            selection: Arc::new(JSONSelection::parse("$.data").unwrap().1),
         };
 
         let response3 = http::Response::builder()
@@ -626,7 +626,7 @@ mod tests {
             index: 2,
             inputs: Default::default(),
             typename: ResponseTypeName::Concrete("User".to_string()),
-            selection: Arc::new(JSONSelection::parse(".data").unwrap().1),
+            selection: Arc::new(JSONSelection::parse("$.data").unwrap().1),
         };
 
         let res = super::handle_responses(

--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -831,7 +831,7 @@ mod tests {
                 headers: Default::default(),
                 body: Default::default(),
             },
-            selection: JSONSelection::parse(".data").unwrap().1,
+            selection: JSONSelection::parse("$.data").unwrap().1,
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
@@ -848,24 +848,37 @@ mod tests {
                     selection: Path(
                         PathSelection {
                             path: WithRange {
-                                node: Key(
+                                node: Var(
                                     WithRange {
-                                        node: Field(
-                                            "data",
-                                        ),
+                                        node: $,
                                         range: Some(
-                                            1..5,
+                                            0..1,
                                         ),
                                     },
                                     WithRange {
-                                        node: Empty,
+                                        node: Key(
+                                            WithRange {
+                                                node: Field(
+                                                    "data",
+                                                ),
+                                                range: Some(
+                                                    2..6,
+                                                ),
+                                            },
+                                            WithRange {
+                                                node: Empty,
+                                                range: Some(
+                                                    6..6,
+                                                ),
+                                            },
+                                        ),
                                         range: Some(
-                                            5..5,
+                                            1..6,
                                         ),
                                     },
                                 ),
                                 range: Some(
-                                    0..5,
+                                    0..6,
                                 ),
                             },
                         },
@@ -901,24 +914,37 @@ mod tests {
                     selection: Path(
                         PathSelection {
                             path: WithRange {
-                                node: Key(
+                                node: Var(
                                     WithRange {
-                                        node: Field(
-                                            "data",
-                                        ),
+                                        node: $,
                                         range: Some(
-                                            1..5,
+                                            0..1,
                                         ),
                                     },
                                     WithRange {
-                                        node: Empty,
+                                        node: Key(
+                                            WithRange {
+                                                node: Field(
+                                                    "data",
+                                                ),
+                                                range: Some(
+                                                    2..6,
+                                                ),
+                                            },
+                                            WithRange {
+                                                node: Empty,
+                                                range: Some(
+                                                    6..6,
+                                                ),
+                                            },
+                                        ),
                                         range: Some(
-                                            5..5,
+                                            1..6,
                                         ),
                                     },
                                 ),
                                 range: Some(
-                                    0..5,
+                                    0..6,
                                 ),
                             },
                         },
@@ -1980,7 +2006,7 @@ mod tests {
                 headers: Default::default(),
                 body: Default::default(),
             },
-            selection: JSONSelection::parse(".data").unwrap().1,
+            selection: JSONSelection::parse("$.data").unwrap().1,
             entity_resolver: None,
             config: Default::default(),
             max_requests: None,
@@ -2008,24 +2034,37 @@ mod tests {
                     selection: Path(
                         PathSelection {
                             path: WithRange {
-                                node: Key(
+                                node: Var(
                                     WithRange {
-                                        node: Field(
-                                            "data",
-                                        ),
+                                        node: $,
                                         range: Some(
-                                            1..5,
+                                            0..1,
                                         ),
                                     },
                                     WithRange {
-                                        node: Empty,
+                                        node: Key(
+                                            WithRange {
+                                                node: Field(
+                                                    "data",
+                                                ),
+                                                range: Some(
+                                                    2..6,
+                                                ),
+                                            },
+                                            WithRange {
+                                                node: Empty,
+                                                range: Some(
+                                                    6..6,
+                                                ),
+                                            },
+                                        ),
                                         range: Some(
-                                            5..5,
+                                            1..6,
                                         ),
                                     },
                                 ),
                                 range: Some(
-                                    0..5,
+                                    0..6,
                                 ),
                             },
                         },

--- a/apollo-router/src/plugins/connectors/testdata/selection.graphql
+++ b/apollo-router/src/plugins/connectors/testdata/selection.graphql
@@ -78,5 +78,5 @@ enum link__Purpose {
 type Query
   @join__type(graph: CONNECTORS)
 {
-  commits(owner: String!, repo: String!): [Commit] @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/repos/{$args.owner}/{$args.repo}/commits"}, selection: "commit {\n  name_from_path: .author.name\n  by: {\n    name: .author.name\n    email: .author.email\n    owner: $args.owner\n  }\n}"})
+  commits(owner: String!, repo: String!): [Commit] @join__directive(graphs: [CONNECTORS], name: "connect", args: {source: "json", http: {GET: "/repos/{$args.owner}/{$args.repo}/commits"}, selection: "commit {\n  name_from_path: author.name\n  by: {\n    name: author.name\n    email: author.email\n    owner: $args.owner\n  }\n}"})
 }

--- a/apollo-router/src/plugins/connectors/testdata/selection.yaml
+++ b/apollo-router/src/plugins/connectors/testdata/selection.yaml
@@ -40,10 +40,10 @@ subgraphs:
                 http: { GET: "/repos/{$$args.owner}/{$$args.repo}/commits" }
                 selection: """
                 commit {
-                  name_from_path: .author.name
+                  name_from_path: author.name
                   by: {
-                    name: .author.name
-                    email: .author.email
+                    name: author.name
+                    email: author.email
                     owner: $$args.owner
                   }
                 }


### PR DESCRIPTION
Now that PR #6076 allows `PathWithSubSelection` syntax to appear within a `SubSelection` alongside other named selections, the shorthand of using `.field` to refer to a path consisting of a single `field` key has become potentially ambiguous:

```graphql
__typename: $("Product")
.field { nested child }
```

Because parsing is insensitive to spaces/newlines/comments between tokens, this code parses the same as

```graphql
__typename: $("Product").field { nested child }
```

which produces a runtime `ApplyToError` because the `"Product"` string does not have a `field` property.

Fortunately, using the `$` variable (i.e. `$.field`, introduced in #5142) has identical behavior to the shorthand, and does not suffer from any parsing ambiguity:

```graphql
__typename: $("Product")
$.field { nested child }
```

As a reminder, thanks to #6076, this selection produces an output object with keys `__typename`, `nested`, and `child`, all at the same level.

This commit statically forbids using the `.field` shorthand, so `$.field` is effectively required, which is a breaking change, but it seems better to implement this restriction while we're still in preview than after we've publicly released this code.

As another reminder, the leading `.` has been optional for some time when the path consists of more than one key, so if you were previously using `.some.nested.field` or `.object->method(...)`, you have the option of simply removing the leading `.` (i.e. `some.nested.field` and `object->method(...)`) rather than prepending the `$` variable, though either option will produce the same behavior.

Subjectively, I find `$.field` more explicit and harder to misread than `.field`, so I believe this restriction is an improvement.