### PR TITLE
fix(federation): fix left-behind selections in fragment reuse

### DIFF
--- a/apollo-federation/src/operation/optimize.rs
+++ b/apollo-federation/src/operation/optimize.rs
@@ -247,7 +247,9 @@ impl Selection {
             (self.selection_set(), other.selection_set())
         {
             let common = self_sub_selection.intersection(other_sub_selection)?;
-            if !common.is_empty() {
+            if common.is_empty() {
+                return Ok(None);
+            } else {
                 return self
                     .with_updated_selections(
                         self_sub_selection.type_position.clone(),


### PR DESCRIPTION
Sometimes, fragment reuse would leave behind a selection in a selection
set that is also part of a fragment that was applied to that selection
set. That's suboptimal.

An example from the Apollo codebase is an output like this:
```graphql
{
  descendants {
    ...TraceNodeFragment
    errors {
      locations {
        __typename
        line
        column
      }
    }
  }
}
fragment TraceNodeFragment on Trace {
  errors {
    locations {
      __typename
      line
      column
    }
  }
}
```

Here `errors.locations.*` is selected twice.

The cause is this difference in our `intersection` implementation:
https://github.com/apollographql/federation/blob/df5eb3cb0e2b4802fcd425ab9c23714de2707db3/internals-js/src/operations.ts#L2676-L2680

If a field selection's subselection completely disappears in
`intersection()`, we previously kept the field selection, instead of
removing it entirely.

By returning `None` we will now correctly remove the duplicate `errors` selection.

<!-- [ROUTER-789] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

I did not add a unit test for this as we do not expect to rely on
fragment reuse long-term. Existing tests pass and I manually
tested the problematic Apollo queries.

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-789]: https://apollographql.atlassian.net/browse/ROUTER-789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ