### PR TITLE
[JSONSelection] Fix validations to accommodate inline `NamedSelection::Path` items with multiple output keys

### DIFF
--- a/apollo-federation/src/sources/connect/expand/visitors/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/visitors/mod.rs
@@ -373,6 +373,37 @@ mod tests {
     }
 
     #[test]
+    fn it_iterates_over_paths() {
+        let mut visited = Vec::new();
+        let visitor = TestVisitor::new(&mut visited);
+        let (unmatched, selection) = JSONSelection::parse(
+            "a
+            $.b {
+                c
+                $.d {
+                    e
+                    f: g.h { i }
+                }
+            }
+            j",
+        )
+        .unwrap();
+        assert!(unmatched.is_empty());
+
+        visitor
+            .walk(selection.next_subselection().cloned().unwrap())
+            .unwrap();
+        assert_snapshot!(print_visited(visited), @r###"
+        a
+        c
+        e
+        f
+        | i
+        j
+        "###);
+    }
+
+    #[test]
     fn it_iterates_over_complex_selection() {
         let mut visited = Vec::new();
         let visitor = TestVisitor::new(&mut visited);

--- a/apollo-federation/src/sources/connect/expand/visitors/mod.rs
+++ b/apollo-federation/src/sources/connect/expand/visitors/mod.rs
@@ -398,7 +398,7 @@ mod tests {
         c
         e
         f
-        | i
+        |  i
         j
         "###);
     }

--- a/apollo-federation/src/sources/connect/json_selection/parser.rs
+++ b/apollo-federation/src/sources/connect/json_selection/parser.rs
@@ -746,8 +746,41 @@ impl SubSelection {
         })
     }
 
+    // Returns an Iterator over each &NamedSelection that contributes a single
+    // name to the output object. This is more complicated than returning
+    // self.selections.iter() because some NamedSelection::Path elements can
+    // contribute multiple names if they do no have an Alias.
     pub fn selections_iter(&self) -> impl Iterator<Item = &NamedSelection> {
-        self.selections.iter()
+        // TODO Implement a NamedSelectionIterator to traverse nested selections
+        // lazily, rather than using an intermediary vector.
+        let mut selections = vec![];
+        for selection in &self.selections {
+            match selection {
+                NamedSelection::Path(alias_opt, path) => {
+                    if alias_opt.is_some() {
+                        // If the PathSelection has an Alias, then it has a
+                        // singular name and should be visited directly.
+                        selections.push(selection);
+                    } else if let Some(sub) = path.next_subselection() {
+                        // If the PathSelection does not have an Alias but does
+                        // have a SubSelection, then it represents the
+                        // PathWithSubSelection non-terminal from the grammar
+                        // (see README.md + PR #6076), which produces multiple
+                        // names derived from the SubSelection, which need to be
+                        // recursively collected.
+                        selections.extend(sub.selections_iter());
+                    } else {
+                        // This no-Alias, no-SubSelection case should be
+                        // forbidden by NamedSelection::parse_path.
+                        unreachable!("PathSelection without Alias or SubSelection");
+                    }
+                }
+                _ => {
+                    selections.push(selection);
+                }
+            };
+        }
+        selections.into_iter()
     }
 
     pub fn has_star(&self) -> bool {

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@denest_scalars.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@denest_scalars.graphql.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/denest_scalars.graphql
+---
+[
+    Message {
+        code: GroupSelectionRequiredForObject,
+        message: "`User.street` is an object, so ``@connect(selection:)` on `Query.me`` must select a group `street{}`.",
+        locations: [
+            8:18..17:10,
+            25:3..25:17,
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@denest_scalars2.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@denest_scalars2.graphql.snap
@@ -1,0 +1,15 @@
+---
+source: apollo-federation/src/sources/connect/validation/mod.rs
+expression: "format!(\"{:#?}\", errors)"
+input_file: apollo-federation/src/sources/connect/validation/test_data/denest_scalars2.graphql
+---
+[
+    Message {
+        code: GroupSelectionIsNotObject,
+        message: "`@connect(selection:)` on `Query.me` selects a group `street{}`, but `User.street` is of type `String` which is not an object.",
+        locations: [
+            8:18..17:10,
+            25:3..25:17,
+        ],
+    },
+]

--- a/apollo-federation/src/sources/connect/validation/test_data/denest_scalars.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/denest_scalars.graphql
@@ -1,0 +1,24 @@
+extend schema
+@link(
+    url: "https://specs.apollo.dev/connect/v0.1"
+    import: ["@connect"]
+)
+
+type Query {
+    me: User @connect(
+        http: {GET: "http://127.0.0.1/something"},
+        selection: """
+            id
+            $.name {
+                firstName: first
+                lastName: last
+            }
+        """
+    )
+}
+
+type User {
+    id: ID!
+    firstName: String
+    lastName: String
+}

--- a/apollo-federation/src/sources/connect/validation/test_data/denest_scalars2.graphql
+++ b/apollo-federation/src/sources/connect/validation/test_data/denest_scalars2.graphql
@@ -12,7 +12,7 @@ type Query {
         lastName: last
       }
       $.address {
-        street
+        street { number name }
       }
       """
     )
@@ -22,10 +22,5 @@ type User {
   id: ID!
   firstName: String
   lastName: String
-  street: Street
-}
-
-type Street {
-  number: Int
-  name: String
+  street: String
 }


### PR DESCRIPTION
PR #6076 introduced a kind of `NamedSelection::Path` that can contribute multiple keys to the current output object, rather than just a single key.

Because the `SubSelection::selections_iter` method was left unchanged, these new multi-name `NamedSelection`s began showing up as single items in the iterator consumed by [`GroupVisitor::enter_group`](https://github.com/apollographql/router/blob/21f7c7ae76a50f47f8a94b5aae17562599242649/apollo-federation/src/sources/connect/validation/selection.rs#L287), which interfered with the assumptions of that code, causing it to misjudge whether the nested properties should have object values or not.

This PR adjusts `SubSelection::selections_iter` to continue emitting only `NamedSelection` items that have a singular output key, which involves recursively emitting the individual keys produced by the new `NamedSelection::Path` elements, without emitting the `NamedSelection::Path` directly. Other kinds of `NamedSelection` are emitted as before.