### PR TITLE
Corrected overwritten fields in `remove_conditions_from_selection_set`

### DIFF
--- a/apollo-federation/tests/query_plan/build_query_plan_tests/field_merging_with_skip_and_include.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests/field_merging_with_skip_and_include.rs
@@ -241,15 +241,7 @@ fn fields_are_not_overwritten_when_directives_are_removed() {
           }
 
           type Bar {
-            baz: Baz
-            quax: Quax
-          }
-
-          type Baz {
             things: String
-          }
-
-          type Quax {
             name: String
           }
         "#,
@@ -257,26 +249,14 @@ fn fields_are_not_overwritten_when_directives_are_removed() {
     assert_plan!(
         &planner,
         r#"
-          fragment SimpleBaz on Foo {
-            ...Baz
-          }
-
-          fragment Baz on Foo {
-            bar @include(if: $b) {
-              baz {
-                things
-              }
-            }
-          }
-
           query Test($b: Boolean!) {
             foo @include(if: $b) {
               bar {
-                quax {
-                  name
-                }
+                name
               }
-              ...SimpleBaz
+              bar @include(if: $b) {
+                things
+              }
             }
           }
         "#,
@@ -287,12 +267,8 @@ fn fields_are_not_overwritten_when_directives_are_removed() {
                 {
                   foo {
                     bar {
-                      quax {
-                        name
-                      }
-                      baz {
-                        things
-                      }
+                      name
+                      things
                     }
                   }
                 }
@@ -304,26 +280,14 @@ fn fields_are_not_overwritten_when_directives_are_removed() {
     assert_plan!(
         &planner,
         r#"
-          fragment SimpleBaz on Foo {
-            ...Baz
-          }
-
-          fragment Baz on Foo {
-            bar @skip(if: $b) {
-              baz {
-                things
-              }
-            }
-          }
-
           query Test($b: Boolean!) {
             foo @skip(if: $b) {
               bar {
-                quax {
-                  name
-                }
+                name
               }
-              ...SimpleBaz
+              bar @skip(if: $b) {
+                things
+              }
             }
           }
         "#,
@@ -334,12 +298,8 @@ fn fields_are_not_overwritten_when_directives_are_removed() {
                 {
                   foo {
                     bar {
-                      quax {
-                        name
-                      }
-                      baz {
-                        things
-                      }
+                      name
+                      things
                     }
                   }
                 }

--- a/apollo-federation/tests/query_plan/supergraphs/fields_are_not_overwritten_when_directives_are_removed.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/fields_are_not_overwritten_when_directives_are_removed.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: fbbe470b5e40af130de42043f74772ec30ee60ff
+# Composed from subgraphs with hash: 1b6580cb65329c0bfbad0268c29ad6ced603952d
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
@@ -22,11 +22,23 @@ directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on
 
 directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
 
-type Hello
+type Bar
   @join__type(graph: SUBGRAPHSKIP)
 {
-  world: String!
-  goodbye: String!
+  baz: Baz
+  quax: Quax
+}
+
+type Baz
+  @join__type(graph: SUBGRAPHSKIP)
+{
+  things: String
+}
+
+type Foo
+  @join__type(graph: SUBGRAPHSKIP)
+{
+  bar: Bar
 }
 
 scalar join__DirectiveArguments
@@ -51,9 +63,14 @@ enum link__Purpose {
   EXECUTION
 }
 
+type Quax
+  @join__type(graph: SUBGRAPHSKIP)
+{
+  name: String
+}
+
 type Query
   @join__type(graph: SUBGRAPHSKIP)
 {
-  hello: Hello!
-  extraFieldToPreventSkipIncludeNodes: String!
+  foo: Foo
 }

--- a/apollo-federation/tests/query_plan/supergraphs/fields_are_not_overwritten_when_directives_are_removed.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/fields_are_not_overwritten_when_directives_are_removed.graphql
@@ -1,4 +1,4 @@
-# Composed from subgraphs with hash: 1b6580cb65329c0bfbad0268c29ad6ced603952d
+# Composed from subgraphs with hash: 654c7bcba86c6f5845a7cb520710cfa37b678e3d
 schema
   @link(url: "https://specs.apollo.dev/link/v1.0")
   @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
@@ -25,14 +25,8 @@ directive @link(url: String, as: String, for: link__Purpose, import: [link__Impo
 type Bar
   @join__type(graph: SUBGRAPHSKIP)
 {
-  baz: Baz
-  quax: Quax
-}
-
-type Baz
-  @join__type(graph: SUBGRAPHSKIP)
-{
   things: String
+  name: String
 }
 
 type Foo
@@ -61,12 +55,6 @@ enum link__Purpose {
   `EXECUTION` features provide metadata necessary for operation execution.
   """
   EXECUTION
-}
-
-type Quax
-  @join__type(graph: SUBGRAPHSKIP)
-{
-  name: String
 }
 
 type Query


### PR DESCRIPTION
In SelectionSet::remove_conditions_from_selection_set, a `SelectionMap` was being constructed directly from an existing selection set. Each selection had its conditions removed and inserted into the new map; however, it is possible that removing the directives from the selection would now cause a key collision. An example of this can be seen in the tests that were added:
```graphql
query Test($b: Boolean!) {
  foo @include(if: $b) {
    bar {
      name
    }
    bar @include(if: $b) {
      thing
    }
  }
}
```
When the selection set was finalized, the selection `bar { name }` was getting overwritten because, after the next selection had its `@include` directive removed, the two selections' keys collided. In the JS code, they used `SelectionSet::lazyMap`, so now the Rust code does too.

<!-- start metadata [ROUTER-771](https://apollographql.atlassian.net/browse/ROUTER-771) -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-771]: https://apollographql.atlassian.net/browse/ROUTER-771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ