### PR TITLE
Refactored `SelectionSet::split_top_level_fields`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ version = "1.56.0"
 dependencies = [
  "apollo-compiler",
  "derive_more",
+ "either",
  "hex",
  "indexmap 2.2.6",
  "insta",

--- a/apollo-federation/Cargo.toml
+++ b/apollo-federation/Cargo.toml
@@ -36,6 +36,7 @@ thiserror = "1.0"
 url = "2"
 tracing = "0.1.40"
 ron = { version = "0.8.1", optional = true }
+either = "1.13.0"
 
 [dev-dependencies]
 hex.workspace = true

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -48,7 +48,6 @@ use crate::schema::position::CompositeTypeDefinitionPosition;
 use crate::schema::position::FieldDefinitionPosition;
 use crate::schema::position::InterfaceTypeDefinitionPosition;
 use crate::schema::position::SchemaRootDefinitionKind;
-use crate::schema::position::TypeDefinitionPosition;
 use crate::schema::ValidFederationSchema;
 use crate::utils::FallibleIterator;
 

--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -1746,10 +1746,10 @@ impl SelectionSet {
         }
 
         impl TopLevelFieldSplitter {
-            fn new(selection: SelectionSet) -> Self {
+            fn new(selection_set: SelectionSet) -> Self {
                 Self {
-                    parent_type: selection.type_position,
-                    starting_set: Arc::unwrap_or_clone(selection.selections).into_iter(),
+                    parent_type: selection_set.type_position,
+                    starting_set: Arc::unwrap_or_clone(selection_set.selections).into_iter(),
                     stack: Vec::new(),
                 }
             }

--- a/apollo-federation/src/schema/position.rs
+++ b/apollo-federation/src/schema/position.rs
@@ -24,6 +24,7 @@ use apollo_compiler::schema::UnionType;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 use apollo_compiler::Schema;
+use either::Either;
 use lazy_static::lazy_static;
 use serde::Serialize;
 use strum::IntoEnumIterator;
@@ -485,16 +486,16 @@ impl ObjectOrInterfaceTypeDefinitionPosition {
         &'a self,
         schema: &'a Schema,
     ) -> Result<
-        Box<dyn Iterator<Item = ObjectOrInterfaceFieldDefinitionPosition> + 'a>,
+        impl Iterator<Item = ObjectOrInterfaceFieldDefinitionPosition> + Captures<&'a ()>,
         FederationError,
     > {
         match self {
-            ObjectOrInterfaceTypeDefinitionPosition::Object(type_) => {
-                Ok(Box::new(type_.fields(schema)?.map(|field| field.into())))
-            }
-            ObjectOrInterfaceTypeDefinitionPosition::Interface(type_) => {
-                Ok(Box::new(type_.fields(schema)?.map(|field| field.into())))
-            }
+            ObjectOrInterfaceTypeDefinitionPosition::Object(type_) => Ok(Either::Left(
+                type_.fields(schema)?.map(|field| field.into()),
+            )),
+            ObjectOrInterfaceTypeDefinitionPosition::Interface(type_) => Ok(Either::Right(
+                type_.fields(schema)?.map(|field| field.into()),
+            )),
         }
     }
 }


### PR DESCRIPTION
This PR refactors `SelectionSet::split_top_level_fields` away from using `Box<dyn Iterator>`s. While not a performance issue (the function is called from exactly one place), it was a very smelly implementation, which required every item to be to be allocated in its own allocation before being yielded by the iterator.

Since the iterator is recursive, I had to just implement `Iterator` on an internal type rather than use the opaque type (which can't be recursive at all) returned by the function.

Lastly, I saw a couple of other `Box<dyn Iterator>`s that that could be turned into RPITs by using the `Either` type from the `either` crate. `either` is already a transitive dependency, so it adds no extra dependencies to the `apollo-federation` or `apollo-router`.

<!-- start metadata [ROUTER-491](https://apollographql.atlassian.net/browse/ROUTER-491) -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-491]: https://apollographql.atlassian.net/browse/ROUTER-491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ