### PR TITLE
Allow thrown rhai errors to opt out of logging in the Router

### DIFF
--- a/.changesets/feat_feature_disablerhaierrorlog.md
+++ b/.changesets/feat_feature_disablerhaierrorlog.md
@@ -1,0 +1,25 @@
+### Allow thrown rhai errors to opt out of logging in the Router ([PR #6124](https://github.com/apollographql/router/pull/6124))
+
+By default, the Router will log an error when a Rhai script uses a `throw` to throw an error. You can opt out of this on an individual `throw` by specifying `log_error: false`:
+
+```rhai
+fn supergraph_service(service) {
+    let f = |request| {
+        throw #{
+            status: 403,
+            log_error: false, // Do not log this error
+            body: #{
+                errors: [#{
+                    message: `I have raised a 403`,
+                    extensions: #{
+                        code: "ACCESS_DENIED"
+                    }
+                }]
+            }
+        };
+    };
+    service.map_request(f);
+}
+```
+
+By [@andrewmcgivery](https://github.com/andrewmcgivery) in https://github.com/apollographql/router/pull/6124

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -583,7 +583,7 @@ async fn it_can_find_router_global_variables() {
 #[tokio::test]
 async fn it_can_process_om_subgraph_forbidden() {
     if let Err(error) = call_rhai_function("process_subgraph_response_om_forbidden").await {
-        let processed_error = process_error(error);
+        let processed_error = process_error(&error);
         assert_eq!(processed_error.status, StatusCode::FORBIDDEN);
         assert_eq!(
             processed_error.message,
@@ -601,7 +601,7 @@ async fn it_can_process_om_subgraph_forbidden_with_graphql_payload() {
         .await
         .unwrap_err();
 
-    let processed_error = process_error(error);
+    let processed_error = process_error(&error);
     assert_eq!(processed_error.status, StatusCode::FORBIDDEN);
     assert_eq!(
         processed_error.body,
@@ -624,7 +624,7 @@ async fn it_can_process_om_subgraph_200_with_graphql_data() {
         .await
         .unwrap_err();
 
-    let processed_error = process_error(error);
+    let processed_error = process_error(&error);
     assert_eq!(processed_error.status, StatusCode::OK);
     assert_eq!(
         processed_error.body,
@@ -639,7 +639,7 @@ async fn it_can_process_om_subgraph_200_with_graphql_data() {
 #[tokio::test]
 async fn it_can_process_string_subgraph_forbidden() {
     if let Err(error) = call_rhai_function("process_subgraph_response_string").await {
-        let processed_error = process_error(error);
+        let processed_error = process_error(&error);
         assert_eq!(processed_error.status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(processed_error.message, Some("rhai execution error: 'Runtime error: I have raised an error (line 223, position 5)'".to_string()));
     } else {
@@ -653,7 +653,7 @@ async fn it_can_process_ok_subgraph_forbidden() {
     let error = call_rhai_function("process_subgraph_response_om_ok")
         .await
         .unwrap_err();
-    let processed_error = process_error(error);
+    let processed_error = process_error(&error);
     assert_eq!(processed_error.status, StatusCode::OK);
     assert_eq!(
         processed_error.message,
@@ -664,7 +664,7 @@ async fn it_can_process_ok_subgraph_forbidden() {
 #[tokio::test]
 async fn it_cannot_process_om_subgraph_missing_message_and_body() {
     if let Err(error) = call_rhai_function("process_subgraph_response_om_missing_message").await {
-        let processed_error = process_error(error);
+        let processed_error = process_error(&error);
         assert_eq!(processed_error.status, StatusCode::BAD_REQUEST);
         assert_eq!(
             processed_error.message,
@@ -677,6 +677,48 @@ async fn it_cannot_process_om_subgraph_missing_message_and_body() {
         // Test failed
         panic!("error processed incorrectly");
     }
+}
+
+#[tokio::test]
+async fn it_can_process_subgraph_response_on_log_error_not_defined() {
+    let error = call_rhai_function("process_subgraph_response_on_log_error_not_defined")
+        .await
+        .unwrap_err();
+    let processed_error = process_error(&error);
+    assert_eq!(processed_error.status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        processed_error.message,
+        Some("This is an error to be logged".to_string())
+    );
+    assert_eq!(processed_error.log_error, Some(true));
+}
+
+#[tokio::test]
+async fn it_can_process_subgraph_response_on_log_error_true() {
+    let error = call_rhai_function("process_subgraph_response_on_log_error_true")
+        .await
+        .unwrap_err();
+    let processed_error = process_error(&error);
+    assert_eq!(processed_error.status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        processed_error.message,
+        Some("This is an error to be logged".to_string())
+    );
+    assert_eq!(processed_error.log_error, Some(true));
+}
+
+#[tokio::test]
+async fn it_can_process_subgraph_response_on_log_error_false() {
+    let error = call_rhai_function("process_subgraph_response_on_log_error_false")
+        .await
+        .unwrap_err();
+    let processed_error = process_error(&error);
+    assert_eq!(processed_error.status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        processed_error.message,
+        Some("This is an error not to be logged".to_string())
+    );
+    assert_eq!(processed_error.log_error, Some(false));
 }
 
 #[tokio::test]

--- a/apollo-router/tests/fixtures/request_response_test.rhai
+++ b/apollo-router/tests/fixtures/request_response_test.rhai
@@ -235,3 +235,26 @@ fn process_subgraph_response_om_missing_message(response) {
         status: 400,
     };
 }
+
+fn process_subgraph_response_on_log_error_not_defined(response){
+    throw #{
+        message: "This is an error to be logged",
+        status: 400,
+    };
+}
+
+fn process_subgraph_response_on_log_error_true(response){
+    throw #{
+        message: "This is an error to be logged",
+        status: 400,
+        log_error: true,
+    };
+}
+
+fn process_subgraph_response_on_log_error_false(response){
+    throw #{
+        message: "This is an error not to be logged",
+        status: 400,
+        log_error: false,
+    };
+}

--- a/docs/source/customizations/rhai-api.mdx
+++ b/docs/source/customizations/rhai-api.mdx
@@ -141,7 +141,6 @@ fn supergraph_service(service) {
             }
         };
     };
-    // Map our request using our closure
     service.map_request(f);
 }
 ```

--- a/docs/source/customizations/rhai-api.mdx
+++ b/docs/source/customizations/rhai-api.mdx
@@ -121,6 +121,31 @@ Rhai throws at the `map_request` layer behave the same as `ControlFlow::Break`, 
 
 If the supplied status code is not a valid HTTP status code, then a `500` response code will result.
 
+### Disable logging of thrown errors
+
+By default, the Router will log an error when a Rhai script uses a `throw` to throw an error. You can opt out of this on an individual `throw` by specifying `log_error: false`:
+
+```rhai
+fn supergraph_service(service) {
+    let f = |request| {
+        throw #{
+            status: 403,
+            log_error: false, // Do not log this error
+            body: #{
+                errors: [#{
+                    message: `I have raised a 403`,
+                    extensions: #{
+                        code: "ACCESS_DENIED"
+                    }
+                }]
+            }
+        };
+    };
+    // Map our request using our closure
+    service.map_request(f);
+}
+```
+
 ## Timing execution
 
 Your Rhai customization can use the global `Router.APOLLO_START` constant to calculate durations. This is similar to `Epoch` in Unix environments.


### PR DESCRIPTION
- Allow thrown rhai errors to opt out of logging in the Router
- This PR also fixes some inconsistency with what object we logged when an error was thrown

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [] Integration Tests
    - [] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
