### PR TITLE
Add `apollo_router_deduplicated_queries_total` metric

### DIFF
--- a/apollo-router/src/plugins/traffic_shaping/deduplication.rs
+++ b/apollo-router/src/plugins/traffic_shaping/deduplication.rs
@@ -99,6 +99,9 @@ where
 
                     match receiver.recv().await {
                         Ok(value) => {
+                            tracing::info!(
+                                monotonic_counter.apollo_router_deduplicated_queries_total = 1u64,
+                            );
                             return value
                                 .map(|response| {
                                     SubgraphResponse::new_from_response(
@@ -107,7 +110,7 @@ where
                                         request.subgraph_name.unwrap_or_default(),
                                     )
                                 })
-                                .map_err(|e| e.into())
+                                .map_err(|e| e.into());
                         }
                         // there was an issue with the broadcast channel, retry fetching
                         Err(_) => continue,

--- a/docs/source/configuration/telemetry/instrumentation/standard-instruments.mdx
+++ b/docs/source/configuration/telemetry/instrumentation/standard-instruments.mdx
@@ -20,6 +20,7 @@ These instruments can be consumed by configuring a [metrics exporter](../exporte
 - `apollo_router_http_request_retry_total` - Number of subgraph requests retried, attributes:
   - `subgraph`: The subgraph being queried
   - `status` : If the retry was aborted (`aborted`)
+- `apollo_router_deduplicated_queries_total` - Number of deduplicated queries when enabled in traffic shaping config
 
 ### GraphQL
 

--- a/docs/source/configuration/traffic-shaping.mdx
+++ b/docs/source/configuration/traffic-shaping.mdx
@@ -182,6 +182,8 @@ traffic_shaping:
     deduplicate_query: true # Enable query deduplication for all subgraphs.
 ```
 
+When query deduplication is enabled, a `apollo_router_deduplicated_queries_total` metric will be exposed by the Router.
+
 ### HTTP/2
 
 <HttpConnection type="subgraph" />


### PR DESCRIPTION
Add `apollo_router_deduplicated_queries_total` metric so that a platform team can understand the impact of enabling query deduplication in traffic shaping.

Note: I couldn't find any examples of how to do a unit or integration test for this so I did a manual test. I setup a local router with a K6 script that hit a subgraph with an artificially slow response time. I was then able to see this metric appear in my Prometheus metrics endpoint:

![Screenshot 2024-10-07 at 12 08 10 PM](https://github.com/user-attachments/assets/bf219d24-353b-4f6d-8455-be81c7a61e26)

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
