### PR TITLE
fix(federation): use `out_edges_with_federation_self_edges` in query builder

### DIFF
--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -1810,11 +1810,7 @@ impl FederatedQueryGraphBuilder {
         new_node_weight.has_reachable_cross_subgraph_edges = has_reachable_cross_subgraph_edges;
 
         let mut new_edges = Vec::new();
-        for edge_ref in base
-            .query_graph
-            .graph
-            .edges_directed(node, Direction::Outgoing)
-        {
+        for edge_ref in base.query_graph.out_edges_with_federation_self_edges(node) {
             let edge_tail = edge_ref.target();
             let edge_weight = edge_ref.weight();
             new_edges.push(QueryGraphEdgeData {

--- a/apollo-federation/src/query_graph/build_query_graph.rs
+++ b/apollo-federation/src/query_graph/build_query_graph.rs
@@ -1572,8 +1572,8 @@ impl FederatedQueryGraphBuilder {
                     Selection::Field(field_selection) => {
                         let existing_edge_info = base
                             .query_graph
-                            .graph
-                            .edges_directed(node, Direction::Outgoing)
+                            .out_edges_with_federation_self_edges(node)
+                            .into_iter()
                             .find_map(|edge_ref| {
                                 let edge_weight = edge_ref.weight();
                                 let QueryGraphEdgeTransition::FieldCollection {
@@ -1697,8 +1697,8 @@ impl FederatedQueryGraphBuilder {
                             // construction.
                             let (edge, tail) = base
                                 .query_graph
-                                .graph
-                                .edges_directed(node, Direction::Outgoing)
+                                .out_edges_with_federation_self_edges(node)
+                                .into_iter()
                                 .find_map(|edge_ref| {
                                     let edge_weight = edge_ref.weight();
                                     let QueryGraphEdgeTransition::Downcast {

--- a/apollo-federation/tests/query_plan/supergraphs/test_provides_edge_ordering.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/test_provides_edge_ordering.graphql
@@ -1,0 +1,64 @@
+# Composed from subgraphs with hash: f5cb1210587d45fee11b9c57247d6c570d0ae7fd
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type A
+  @join__type(graph: SUBGRAPHQ)
+  @join__type(graph: SUBGRAPHX, key: "id")
+  @join__type(graph: SUBGRAPHY, key: "id")
+{
+  id: ID! @join__field(graph: SUBGRAPHQ, external: true) @join__field(graph: SUBGRAPHX) @join__field(graph: SUBGRAPHY)
+  data: String! @join__field(graph: SUBGRAPHX) @join__field(graph: SUBGRAPHY)
+}
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPHQ @join__graph(name: "SubgraphQ", url: "none")
+  SUBGRAPHX @join__graph(name: "SubgraphX", url: "none")
+  SUBGRAPHY @join__graph(name: "SubgraphY", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPHQ)
+  @join__type(graph: SUBGRAPHX)
+  @join__type(graph: SUBGRAPHY)
+{
+  test: A @join__field(graph: SUBGRAPHQ, provides: "id")
+}


### PR DESCRIPTION
Instead of using petgraph's `edges_directed` method.
This PR matches JS QP's ordering for `provides` edges.

The change in the `copy_for_provides_internal` method was strictly necessary. The other changes in `add_provides_edges` was made for consistency.

<!-- [ROUTER-802] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [x] Integration Tests
    - [x] Manual Tests

[ROUTER-802]: https://apollographql.atlassian.net/browse/ROUTER-802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ