### PR TITLE
Move some GraphQL analysis earlier in the pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "apollo-parser"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9692c1bfa7e0628e5c46bd0538571dd469138a0f062290fd4bf90e20e46f05da"
+checksum = "b64257011a999f2e22275cf7a118f651e58dc9170e11b775d435de768fad0387"
 dependencies = [
  "memchr",
  "rowan",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ debug = 1
 # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table
 [workspace.dependencies]
 apollo-compiler = "=1.0.0-beta.24"
-apollo-parser = "0.8.0"
+apollo-parser = "0.8.3"
 apollo-smith = "0.14.0"
 async-trait = "0.1.77"
 hex = { version = "0.4.3", features = ["serde"] }

--- a/apollo-router/src/apollo_studio_interop/mod.rs
+++ b/apollo-router/src/apollo_studio_interop/mod.rs
@@ -223,20 +223,17 @@ pub(crate) fn generate_extended_references(
 
 pub(crate) fn extract_enums_from_response(
     query: Arc<Query>,
-    operation_name: Option<&str>,
     schema: &Valid<Schema>,
     response_body: &Object,
     existing_refs: &mut ReferencedEnums,
 ) {
-    if let Some(operation) = query.operation(operation_name) {
-        extract_enums_from_selection_set(
-            &operation.selection_set,
-            &query.fragments,
-            schema,
-            response_body,
-            existing_refs,
-        );
-    }
+    extract_enums_from_selection_set(
+        &query.operation.selection_set,
+        &query.fragments,
+        schema,
+        response_body,
+        existing_refs,
+    );
 }
 
 fn add_enum_value_to_map(

--- a/apollo-router/src/apollo_studio_interop/tests.rs
+++ b/apollo-router/src/apollo_studio_interop/tests.rs
@@ -133,7 +133,6 @@ fn enums_from_response(
     let mut result = ReferencedEnums::new();
     extract_enums_from_response(
         Arc::new(query),
-        operation_name,
         schema.supergraph_schema(),
         &response_body,
         &mut result,

--- a/apollo-router/src/plugins/telemetry/mod.rs
+++ b/apollo-router/src/plugins/telemetry/mod.rs
@@ -698,30 +698,21 @@ impl Plugin for Telemetry {
     fn execution_service(&self, service: execution::BoxService) -> execution::BoxService {
         ServiceBuilder::new()
             .instrument(move |req: &ExecutionRequest| {
-                let operation_kind = req
-                    .query_plan
-                    .query
-                    .operation(req.supergraph_request.body().operation_name.as_deref())
-                    .map(|op| *op.kind());
+                let operation_kind = req.query_plan.query.operation.kind();
 
                 match operation_kind {
-                    Some(operation_kind) => match operation_kind {
-                        OperationKind::Subscription => info_span!(
-                            EXECUTION_SPAN_NAME,
-                            "otel.kind" = "INTERNAL",
-                            "graphql.operation.type" = operation_kind.as_apollo_operation_type(),
-                            "apollo_private.operation.subtype" =
-                                OperationSubType::SubscriptionRequest.as_str(),
-                        ),
-                        _ => info_span!(
-                            EXECUTION_SPAN_NAME,
-                            "otel.kind" = "INTERNAL",
-                            "graphql.operation.type" = operation_kind.as_apollo_operation_type(),
-                        ),
-                    },
-                    None => {
-                        info_span!(EXECUTION_SPAN_NAME, "otel.kind" = "INTERNAL",)
-                    }
+                    OperationKind::Subscription => info_span!(
+                        EXECUTION_SPAN_NAME,
+                        "otel.kind" = "INTERNAL",
+                        "graphql.operation.type" = operation_kind.as_apollo_operation_type(),
+                        "apollo_private.operation.subtype" =
+                            OperationSubType::SubscriptionRequest.as_str(),
+                    ),
+                    _ => info_span!(
+                        EXECUTION_SPAN_NAME,
+                        "otel.kind" = "INTERNAL",
+                        "graphql.operation.type" = operation_kind.as_apollo_operation_type(),
+                    ),
                 }
             })
             .service(service)

--- a/apollo-router/src/query_planner/caching_query_planner.rs
+++ b/apollo-router/src/query_planner/caching_query_planner.rs
@@ -280,7 +280,7 @@ where
         } in all_cache_keys
         {
             let context = Context::new();
-            let (doc, _operation_def) = match query_analysis
+            let doc = match query_analysis
                 .parse_document(&query, operation_name.as_deref())
                 .await
             {
@@ -324,7 +324,7 @@ where
                 })
                 .await;
             if entry.is_first() {
-                let (doc, _operation_def) = match query_analysis
+                let doc = match query_analysis
                     .parse_document(&query, operation_name.as_deref())
                     .await
                 {

--- a/apollo-router/src/query_planner/execution.rs
+++ b/apollo-router/src/query_planner/execution.rs
@@ -331,11 +331,6 @@ impl PlanNode {
                         let v = parameters
                             .query
                             .variable_value(
-                                parameters
-                                    .supergraph_request
-                                    .body()
-                                    .operation_name
-                                    .as_deref(),
                                 condition.as_str(),
                                 &parameters.supergraph_request.body().variables,
                             )

--- a/apollo-router/src/services/execution/service.rs
+++ b/apollo-router/src/services/execution/service.rs
@@ -123,13 +123,10 @@ impl ExecutionService {
         let context = req.context;
         let ctx = context.clone();
         let variables = req.supergraph_request.body().variables.clone();
-        let operation_name = req.supergraph_request.body().operation_name.clone();
 
         let (sender, receiver) = mpsc::channel(10);
-        let is_deferred = req
-            .query_plan
-            .is_deferred(operation_name.as_deref(), &variables);
-        let is_subscription = req.query_plan.is_subscription(operation_name.as_deref());
+        let is_deferred = req.query_plan.is_deferred(&variables);
+        let is_subscription = req.query_plan.is_subscription();
         let mut claims = None;
         if is_deferred {
             claims = context.get(APOLLO_AUTHENTICATION_JWT_CLAIMS).ok().flatten()
@@ -240,7 +237,6 @@ impl ExecutionService {
                 ready(execution_span.in_scope(|| {
                     Self::process_graphql_response(
                         &query,
-                        operation_name.as_deref(),
                         &variables,
                         is_deferred,
                         &schema,
@@ -259,7 +255,6 @@ impl ExecutionService {
     #[allow(clippy::too_many_arguments)]
     fn process_graphql_response(
         query: &Arc<Query>,
-        operation_name: Option<&str>,
         variables: &Object,
         is_deferred: bool,
         schema: &Arc<Schema>,
@@ -295,7 +290,7 @@ impl ExecutionService {
         }
 
         let has_next = response.has_next.unwrap_or(true);
-        let variables_set = query.defer_variables_set(operation_name, variables);
+        let variables_set = query.defer_variables_set(variables);
 
         tracing::debug_span!("format_response").in_scope(|| {
             let mut paths = Vec::new();
@@ -332,7 +327,6 @@ impl ExecutionService {
             if let Some(filtered_query) = query.filtered_query.as_ref() {
                 paths = filtered_query.format_response(
                     &mut response,
-                    operation_name,
                     variables.clone(),
                     schema.api_schema(),
                     variables_set,
@@ -343,7 +337,6 @@ impl ExecutionService {
                 query
                     .format_response(
                         &mut response,
-                        operation_name,
                         variables.clone(),
                         schema.api_schema(),
                         variables_set,
@@ -360,7 +353,6 @@ impl ExecutionService {
             if let (ApolloMetricsReferenceMode::Extended, Some(Value::Object(response_body))) = (metrics_ref_mode, &response.data) {
                 extract_enums_from_response(
                     query.clone(),
-                    operation_name,
                     schema.api_schema(),
                     response_body,
                     &mut referenced_enums,
@@ -380,12 +372,9 @@ impl ExecutionService {
 
                 response.errors.retain(|error| match &error.path {
                     None => true,
-                    Some(error_path) => query.contains_error_path(
-                        operation_name,
-                        &response.label,
-                        error_path,
-                        variables_set,
-                    ),
+                    Some(error_path) => {
+                        query.contains_error_path(&response.label, error_path, variables_set)
+                    }
                 });
 
                 response.label = rewrite_defer_label(&response);
@@ -433,7 +422,6 @@ impl ExecutionService {
 
                 Self::split_incremental_response(
                     query,
-                    operation_name,
                     has_next,
                     variables_set,
                     response,
@@ -445,7 +433,6 @@ impl ExecutionService {
 
     fn split_incremental_response(
         query: &Arc<Query>,
-        operation_name: Option<&str>,
         has_next: bool,
         variables_set: BooleanValues,
         response: Response,
@@ -464,12 +451,8 @@ impl ExecutionService {
                     .filter(|error| match &error.path {
                         None => false,
                         Some(error_path) => {
-                            query.contains_error_path(
-                                operation_name,
-                                &response.label,
-                                error_path,
-                                variables_set,
-                            ) && error_path.starts_with(&path)
+                            query.contains_error_path(&response.label, error_path, variables_set)
+                                && error_path.starts_with(&path)
                         }
                     })
                     .cloned()

--- a/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
+++ b/apollo-router/src/services/layers/allow_only_http_post_mutations.rs
@@ -286,11 +286,10 @@ mod forbid_http_get_mutations_tests {
 
         let context = Context::new();
         context.extensions().with_lock(|mut lock| {
-            lock.insert::<ParsedDocument>(Arc::new(ParsedDocumentInner {
-                ast,
-                executable: Arc::new(executable),
-                hash: Default::default(),
-            }))
+            lock.insert::<ParsedDocument>(
+                ParsedDocumentInner::new(ast, Arc::new(executable), None, Default::default())
+                    .unwrap(),
+            )
         });
 
         SupergraphRequest::fake_builder()

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -297,8 +297,8 @@ impl ParsedDocumentInner {
     }
 }
 
-fn get_operation(
-    executable: &Valid<ExecutableDocument>,
+pub(crate) fn get_operation(
+    executable: &ExecutableDocument,
     operation_name: Option<&str>,
 ) -> Result<Node<Operation>, SpecError> {
     if let Ok(operation) = executable.operations.get(operation_name) {

--- a/apollo-router/src/services/layers/query_analysis.rs
+++ b/apollo-router/src/services/layers/query_analysis.rs
@@ -79,7 +79,7 @@ impl QueryAnalysisLayer {
         &self,
         query: &str,
         operation_name: Option<&str>,
-    ) -> Result<(ParsedDocument, Node<Operation>), SpecError> {
+    ) -> Result<ParsedDocument, SpecError> {
         let query = query.to_string();
         let operation_name = operation_name.map(|o| o.to_string());
         let schema = self.schema.clone();
@@ -91,14 +91,12 @@ impl QueryAnalysisLayer {
 
         task::spawn_blocking(move || {
             span.in_scope(|| {
-                let doc = Query::parse_document(
+                Query::parse_document(
                     &query,
                     operation_name.as_deref(),
                     schema.as_ref(),
                     conf.as_ref(),
-                )?;
-                let operation = doc.get_operation(operation_name.as_deref())?.clone();
-                Ok((doc, operation))
+                )
             })
         })
         .await
@@ -161,7 +159,7 @@ impl QueryAnalysisLayer {
                     );
                     Err(errors)
                 }
-                Ok((doc, operation)) => {
+                Ok(doc) => {
                     let context = Context::new();
 
                     if self.enable_authorization_directives {
@@ -174,9 +172,9 @@ impl QueryAnalysisLayer {
                     }
 
                     context
-                        .insert(OPERATION_NAME, operation.name.clone())
+                        .insert(OPERATION_NAME, doc.operation.name.clone())
                         .expect("cannot insert operation name into context; this is a bug");
-                    let operation_kind = OperationKind::from(operation.operation_type);
+                    let operation_kind = OperationKind::from(doc.operation.operation_type);
                     context
                         .insert(OPERATION_KIND, operation_kind)
                         .expect("cannot insert operation kind in the context; this is a bug");
@@ -257,25 +255,63 @@ pub(crate) struct ParsedDocumentInner {
     pub(crate) ast: ast::Document,
     pub(crate) executable: Arc<Valid<ExecutableDocument>>,
     pub(crate) hash: Arc<QueryHash>,
+    pub(crate) operation: Node<Operation>,
+    /// `__typename`
+    pub(crate) has_root_typename: bool,
+    /// `__schema` or `__type`
+    pub(crate) has_schema_introspection: bool,
+    /// Non-meta fields explicitly defined in the schema
+    pub(crate) has_explicit_root_fields: bool,
 }
 
+#[derive(Debug)]
+pub(crate) struct RootFieldKinds {}
+
 impl ParsedDocumentInner {
-    pub(crate) fn get_operation(
-        &self,
+    pub(crate) fn new(
+        ast: ast::Document,
+        executable: Arc<Valid<ExecutableDocument>>,
         operation_name: Option<&str>,
-    ) -> Result<&Node<Operation>, SpecError> {
-        if let Ok(operation) = self.executable.operations.get(operation_name) {
-            Ok(operation)
-        } else if let Some(name) = operation_name {
-            Err(SpecError::UnknownOperation(name.to_owned()))
-        } else if self.executable.operations.is_empty() {
-            // Maybe not reachable?
-            // A valid document is non-empty and has no unused fragments
-            Err(SpecError::NoOperation)
-        } else {
-            debug_assert!(self.executable.operations.len() > 1);
-            Err(SpecError::MultipleOperationWithoutOperationName)
+        hash: Arc<QueryHash>,
+    ) -> Result<Arc<Self>, SpecError> {
+        let operation = get_operation(&executable, operation_name)?;
+        let mut has_root_typename = false;
+        let mut has_schema_introspection = false;
+        let mut has_explicit_root_fields = false;
+        for field in operation.root_fields(&executable) {
+            match field.name.as_str() {
+                "__typename" => has_root_typename = true,
+                "__schema" | "__type" if operation.is_query() => has_schema_introspection = true,
+                _ => has_explicit_root_fields = true,
+            }
         }
+        Ok(Arc::new(Self {
+            ast,
+            executable,
+            hash,
+            operation,
+            has_root_typename,
+            has_schema_introspection,
+            has_explicit_root_fields,
+        }))
+    }
+}
+
+fn get_operation(
+    executable: &Valid<ExecutableDocument>,
+    operation_name: Option<&str>,
+) -> Result<Node<Operation>, SpecError> {
+    if let Ok(operation) = executable.operations.get(operation_name) {
+        Ok(operation.clone())
+    } else if let Some(name) = operation_name {
+        Err(SpecError::UnknownOperation(name.to_owned()))
+    } else if executable.operations.is_empty() {
+        // Maybe not reachable?
+        // A valid document is non-empty and has no unused fragments
+        Err(SpecError::NoOperation)
+    } else {
+        debug_assert!(executable.operations.len() > 1);
+        Err(SpecError::MultipleOperationWithoutOperationName)
     }
 }
 

--- a/apollo-router/src/services/supergraph/service.rs
+++ b/apollo-router/src/services/supergraph/service.rs
@@ -233,9 +233,8 @@ async fn service_call(
                 let _ = lock.insert::<OperationLimits<u32>>(query_metrics);
             });
 
-            let operation_name = body.operation_name.clone();
-            let is_deferred = plan.is_deferred(operation_name.as_deref(), &variables);
-            let is_subscription = plan.is_subscription(operation_name.as_deref());
+            let is_deferred = plan.is_deferred(&variables);
+            let is_subscription = plan.is_subscription();
 
             if let Some(batching) = context
                 .extensions()
@@ -266,8 +265,7 @@ async fn service_call(
                     .extensions()
                     .with_lock(|lock| lock.get::<BatchQuery>().cloned());
                 if let Some(batch_query) = batch_query_opt {
-                    let query_hashes =
-                        plan.query_hashes(batching, operation_name.as_deref(), &variables)?;
+                    let query_hashes = plan.query_hashes(batching, &variables)?;
                     batch_query
                         .set_query_hashes(query_hashes)
                         .await

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -32,6 +32,7 @@ use crate::json_ext::Value;
 use crate::plugins::authorization::UnauthorizedPaths;
 use crate::query_planner::fetch::OperationKind;
 use crate::query_planner::fetch::QueryHash;
+use crate::services::layers::query_analysis::get_operation;
 use crate::services::layers::query_analysis::ParsedDocument;
 use crate::services::layers::query_analysis::ParsedDocumentInner;
 use crate::spec::schema::ApiSchema;
@@ -58,7 +59,7 @@ pub(crate) struct Query {
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub(crate) fragments: Fragments,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
-    pub(crate) operations: Vec<Operation>,
+    pub(crate) operation: Operation,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
     pub(crate) subselections: HashMap<SubSelectionKey, SubSelectionValue>,
     #[derivative(PartialEq = "ignore", Hash = "ignore")]
@@ -99,7 +100,7 @@ impl Query {
             fragments: Fragments {
                 map: HashMap::new(),
             },
-            operations: Vec::new(),
+            operation: Operation::empty(),
             subselections: HashMap::new(),
             unauthorized: UnauthorizedPaths::default(),
             filtered_query: None,
@@ -121,14 +122,12 @@ impl Query {
     pub(crate) fn format_response(
         &self,
         response: &mut Response,
-        operation_name: Option<&str>,
         variables: Object,
         schema: &ApiSchema,
         defer_conditions: BooleanValues,
     ) -> Vec<Path> {
         let data = std::mem::take(&mut response.data);
 
-        let original_operation = self.operation(operation_name);
         match data {
             Some(Value::Object(mut input)) => {
                 if self.is_deferred(defer_conditions) {
@@ -148,13 +147,12 @@ impl Query {
                             };
                             // Detect if root __typename is asked in the original query (the qp doesn't put root __typename in subselections)
                             // cf https://github.com/apollographql/router/issues/1677
-                            let operation_kind_if_root_typename =
-                                original_operation.and_then(|op| {
-                                    op.selection_set
-                                        .iter()
-                                        .any(|f| f.is_typename_field())
-                                        .then(|| *op.kind())
-                                });
+                            let operation_kind_if_root_typename = self
+                                .operation
+                                .selection_set
+                                .iter()
+                                .any(|f| f.is_typename_field())
+                                .then(|| *self.operation.kind());
                             if let Some(operation_kind) = operation_kind_if_root_typename {
                                 output.insert(TYPENAME, operation_kind.default_type_name().into());
                             }
@@ -186,13 +184,13 @@ impl Query {
                             return vec![];
                         }
                     }
-                } else if let Some(operation) = original_operation {
-                    let mut output = Object::with_capacity(operation.selection_set.len());
+                } else {
+                    let mut output = Object::with_capacity(self.operation.selection_set.len());
 
-                    let all_variables = if operation.variables.is_empty() {
+                    let all_variables = if self.operation.variables.is_empty() {
                         variables
                     } else {
-                        operation
+                        self.operation
                             .variables
                             .iter()
                             .filter_map(|(k, Variable { default_value, .. })| {
@@ -204,9 +202,9 @@ impl Query {
                     };
 
                     let operation_type_name = schema
-                        .root_operation(operation.kind.into())
+                        .root_operation(self.operation.kind.into())
                         .map(|name| name.as_str())
-                        .unwrap_or(operation.kind.default_type_name());
+                        .unwrap_or(self.operation.kind.default_type_name());
                     let mut parameters = FormatParameters {
                         variables: &all_variables,
                         schema,
@@ -217,7 +215,7 @@ impl Query {
                     response.data = Some(
                         match self.apply_root_selection_set(
                             operation_type_name,
-                            &operation.selection_set,
+                            &self.operation.selection_set,
                             &mut parameters,
                             &mut input,
                             &mut output,
@@ -234,19 +232,17 @@ impl Query {
                     }
 
                     return parameters.nullified;
-                } else {
-                    failfast_debug!("can't find operation for {:?}", operation_name);
                 }
             }
             Some(Value::Null) => {
                 // Detect if root __typename is asked in the original query (the qp doesn't put root __typename in subselections)
                 // cf https://github.com/apollographql/router/issues/1677
-                let operation_kind_if_root_typename = original_operation.and_then(|op| {
-                    op.selection_set
-                        .iter()
-                        .any(|f| f.is_typename_field())
-                        .then(|| *op.kind())
-                });
+                let operation_kind_if_root_typename = self
+                    .operation
+                    .selection_set
+                    .iter()
+                    .any(|f| f.is_typename_field())
+                    .then(|| *self.operation.kind());
                 response.data = match operation_kind_if_root_typename {
                     Some(operation_kind) => {
                         let mut output = Object::default();
@@ -322,13 +318,13 @@ impl Query {
         let query = query.into();
 
         let doc = Self::parse_document(&query, operation_name, schema, configuration)?;
-        let (fragments, operations, defer_stats, schema_aware_hash) =
+        let (fragments, operation, defer_stats, schema_aware_hash) =
             Self::extract_query_information(schema, &doc.executable, operation_name)?;
 
         Ok(Query {
             string: query,
             fragments,
-            operations,
+            operation,
             subselections: HashMap::new(),
             unauthorized: UnauthorizedPaths::default(),
             filtered_query: None,
@@ -343,18 +339,15 @@ impl Query {
         schema: &Schema,
         document: &ExecutableDocument,
         operation_name: Option<&str>,
-    ) -> Result<(Fragments, Vec<Operation>, DeferStats, Vec<u8>), SpecError> {
+    ) -> Result<(Fragments, Operation, DeferStats, Vec<u8>), SpecError> {
         let mut defer_stats = DeferStats {
             has_defer: false,
             has_unconditional_defer: false,
             conditional_defer_variable_names: IndexSet::default(),
         };
         let fragments = Fragments::from_hir(document, schema, &mut defer_stats)?;
-        let operations = document
-            .operations
-            .iter()
-            .map(|operation| Operation::from_hir(operation, schema, &mut defer_stats, &fragments))
-            .collect::<Result<Vec<_>, SpecError>>()?;
+        let operation = get_operation(document, operation_name)?;
+        let operation = Operation::from_hir(&operation, schema, &mut defer_stats, &fragments)?;
 
         let mut visitor =
             QueryHashVisitor::new(schema.supergraph_schema(), &schema.raw_sdl, document);
@@ -363,7 +356,7 @@ impl Query {
         })?;
         let hash = visitor.finish();
 
-        Ok((fragments, operations, defer_stats, hash))
+        Ok((fragments, operation, defer_stats, hash))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -935,19 +928,13 @@ impl Query {
         request: &Request,
         schema: &Schema,
     ) -> Result<(), Response> {
-        let operation_name = request.operation_name.as_deref();
-        let operation_variable_types =
-            self.operations
-                .iter()
-                .fold(HashMap::new(), |mut acc, operation| {
-                    if operation_name.is_none() || operation.name.as_deref() == operation_name {
-                        acc.extend(operation.variables.iter().map(|(k, v)| (k.as_str(), v)))
-                    }
-                    acc
-                });
-
         if LevelFilter::current() >= LevelFilter::DEBUG {
-            let known_variables = operation_variable_types.keys().cloned().collect();
+            let known_variables = self
+                .operation
+                .variables
+                .keys()
+                .map(|k| k.as_str())
+                .collect();
             let provided_variables = request
                 .variables
                 .keys()
@@ -964,7 +951,9 @@ impl Query {
             }
         }
 
-        let errors = operation_variable_types
+        let errors = self
+            .operation
+            .variables
             .iter()
             .filter_map(
                 |(
@@ -976,12 +965,12 @@ impl Query {
                 )| {
                     let value = request
                         .variables
-                        .get(*name)
+                        .get(name.as_str())
                         .or(default_value.as_ref())
                         .unwrap_or(&Value::Null);
                     ty.validate_input_value(value, schema).err().map(|_| {
                         FetchError::ValidationInvalidTypeVariable {
-                            name: name.to_string(),
+                            name: name.as_str().to_string(),
                         }
                         .to_graphql_error(None)
                     })
@@ -998,47 +987,23 @@ impl Query {
 
     pub(crate) fn variable_value<'a>(
         &'a self,
-        operation_name: Option<&str>,
         variable_name: &str,
         variables: &'a Object,
     ) -> Option<&'a Value> {
         variables
             .get(variable_name)
-            .or_else(|| self.default_variable_value(operation_name, variable_name))
+            .or_else(|| self.default_variable_value(variable_name))
     }
 
-    pub(crate) fn default_variable_value(
-        &self,
-        operation_name: Option<&str>,
-        variable_name: &str,
-    ) -> Option<&Value> {
-        self.operation(operation_name).and_then(|op| {
-            op.variables
-                .get(variable_name)
-                .and_then(|Variable { default_value, .. }| default_value.as_ref())
-        })
-    }
-
-    pub(crate) fn operation(&self, operation_name: Option<impl AsRef<str>>) -> Option<&Operation> {
-        match operation_name {
-            Some(name) => self
-                .operations
-                .iter()
-                // we should have an error if the only operation is anonymous but the query specifies a name
-                .find(|op| {
-                    if let Some(op_name) = op.name.as_deref() {
-                        op_name == name.as_ref()
-                    } else {
-                        false
-                    }
-                }),
-            None => self.operations.first(),
-        }
+    pub(crate) fn default_variable_value(&self, variable_name: &str) -> Option<&Value> {
+        self.operation
+            .variables
+            .get(variable_name)
+            .and_then(|Variable { default_value, .. }| default_value.as_ref())
     }
 
     pub(crate) fn contains_error_path(
         &self,
-        operation_name: Option<&str>,
         label: &Option<String>,
         path: &Path,
         defer_conditions: BooleanValues,
@@ -1048,21 +1013,14 @@ impl Query {
             defer_conditions,
         }) {
             Some(subselection) => &subselection.selection_set,
-            None => match self.operation(operation_name) {
-                None => return false,
-                Some(op) => &op.selection_set,
-            },
+            None => &self.operation.selection_set,
         };
         selection_set
             .iter()
             .any(|selection| selection.contains_error_path(&path.0, &self.fragments))
     }
 
-    pub(crate) fn defer_variables_set(
-        &self,
-        operation_name: Option<&str>,
-        variables: &Object,
-    ) -> BooleanValues {
+    pub(crate) fn defer_variables_set(&self, variables: &Object) -> BooleanValues {
         let mut bits = 0_u32;
         for (i, variable) in self
             .defer_stats
@@ -1072,7 +1030,7 @@ impl Query {
         {
             let value = variables
                 .get(variable.as_str())
-                .or_else(|| self.default_variable_value(operation_name, variable));
+                .or_else(|| self.default_variable_value(variable));
 
             if matches!(value, Some(serde_json_bytes::Value::Bool(true))) {
                 bits |= 1 << i;
@@ -1111,6 +1069,16 @@ pub(crate) struct Variable {
 }
 
 impl Operation {
+    fn empty() -> Self {
+        Self {
+            name: None,
+            kind: OperationKind::Query,
+            type_name: "".into(),
+            selection_set: Vec::new(),
+            variables: HashMap::new(),
+        }
+    }
+
     pub(crate) fn from_hir(
         operation: &executable::Operation,
         schema: &Schema,

--- a/apollo-router/src/spec/query.rs
+++ b/apollo-router/src/spec/query.rs
@@ -304,11 +304,12 @@ impl Query {
         )
         .map_err(|e| SpecError::QueryHashing(e.to_string()))?;
 
-        Ok(Arc::new(ParsedDocumentInner {
+        ParsedDocumentInner::new(
             ast,
-            executable: Arc::new(executable_document),
-            hash: Arc::new(QueryHash(hash)),
-        }))
+            Arc::new(executable_document),
+            operation_name,
+            Arc::new(QueryHash(hash)),
+        )
     }
 
     #[cfg(test)]

--- a/apollo-router/src/spec/query/tests.rs
+++ b/apollo-router/src/spec/query/tests.rs
@@ -131,7 +131,6 @@ impl FormatTest {
 
         query.format_response(
             &mut response,
-            self.operation,
             self.variables
                 .unwrap_or_else(|| Value::Object(Object::default()))
                 .as_object()
@@ -3506,10 +3505,8 @@ fn it_statically_includes() {
         &Default::default(),
     )
     .expect("could not parse query");
-    assert_eq!(query.operations.len(), 1);
-    let operation = &query.operations[0];
-    assert_eq!(operation.selection_set.len(), 1);
-    match operation.selection_set.first().unwrap() {
+    assert_eq!(query.operation.selection_set.len(), 1);
+    match query.operation.selection_set.first().unwrap() {
         Selection::Field { name, .. } => assert_eq!(name, &ByteString::from("product")),
         _ => panic!("expected a field"),
     }
@@ -3530,14 +3527,12 @@ fn it_statically_includes() {
     )
     .expect("could not parse query");
 
-    assert_eq!(query.operations.len(), 1);
-    let operation = &query.operations[0];
-    assert_eq!(operation.selection_set.len(), 2);
-    match operation.selection_set.first().unwrap() {
+    assert_eq!(query.operation.selection_set.len(), 2);
+    match query.operation.selection_set.first().unwrap() {
         Selection::Field { name, .. } => assert_eq!(name, &ByteString::from("review")),
         _ => panic!("expected a field"),
     }
-    match operation.selection_set.get(1).unwrap() {
+    match query.operation.selection_set.get(1).unwrap() {
         Selection::Field { name, .. } => assert_eq!(name, &ByteString::from("product")),
         _ => panic!("expected a field"),
     }
@@ -3561,10 +3556,8 @@ fn it_statically_includes() {
     )
     .expect("could not parse query");
 
-    assert_eq!(query.operations.len(), 1);
-    let operation = &query.operations[0];
-    assert_eq!(operation.selection_set.len(), 1);
-    match operation.selection_set.first().unwrap() {
+    assert_eq!(query.operation.selection_set.len(), 1);
+    match query.operation.selection_set.first().unwrap() {
         Selection::Field {
             name,
             selection_set: Some(selection_set),
@@ -3597,14 +3590,12 @@ fn it_statically_includes() {
     )
     .expect("could not parse query");
 
-    assert_eq!(query.operations.len(), 1);
-    let operation = &query.operations[0];
-    assert_eq!(operation.selection_set.len(), 2);
-    match operation.selection_set.first().unwrap() {
+    assert_eq!(query.operation.selection_set.len(), 2);
+    match query.operation.selection_set.first().unwrap() {
         Selection::Field { name, .. } => assert_eq!(name, &ByteString::from("review")),
         _ => panic!("expected a field"),
     }
-    match operation.selection_set.get(1).unwrap() {
+    match query.operation.selection_set.get(1).unwrap() {
         Selection::Field {
             name,
             selection_set: Some(selection_set),
@@ -3655,10 +3646,8 @@ fn it_statically_skips() {
         &Default::default(),
     )
     .expect("could not parse query");
-    assert_eq!(query.operations.len(), 1);
-    let operation = &query.operations[0];
-    assert_eq!(operation.selection_set.len(), 1);
-    match operation.selection_set.first().unwrap() {
+    assert_eq!(query.operation.selection_set.len(), 1);
+    match query.operation.selection_set.first().unwrap() {
         Selection::Field { name, .. } => assert_eq!(name, &ByteString::from("product")),
         _ => panic!("expected a field"),
     }
@@ -3679,14 +3668,12 @@ fn it_statically_skips() {
     )
     .expect("could not parse query");
 
-    assert_eq!(query.operations.len(), 1);
-    let operation = &query.operations[0];
-    assert_eq!(operation.selection_set.len(), 2);
-    match operation.selection_set.first().unwrap() {
+    assert_eq!(query.operation.selection_set.len(), 2);
+    match query.operation.selection_set.first().unwrap() {
         Selection::Field { name, .. } => assert_eq!(name, &ByteString::from("review")),
         _ => panic!("expected a field"),
     }
-    match operation.selection_set.get(1).unwrap() {
+    match query.operation.selection_set.get(1).unwrap() {
         Selection::Field { name, .. } => assert_eq!(name, &ByteString::from("product")),
         _ => panic!("expected a field"),
     }
@@ -3710,10 +3697,8 @@ fn it_statically_skips() {
     )
     .expect("could not parse query");
 
-    assert_eq!(query.operations.len(), 1);
-    let operation = &query.operations[0];
-    assert_eq!(operation.selection_set.len(), 1);
-    match operation.selection_set.first().unwrap() {
+    assert_eq!(query.operation.selection_set.len(), 1);
+    match query.operation.selection_set.first().unwrap() {
         Selection::Field {
             name,
             selection_set: Some(selection_set),
@@ -3746,14 +3731,12 @@ fn it_statically_skips() {
     )
     .expect("could not parse query");
 
-    assert_eq!(query.operations.len(), 1);
-    let operation = &query.operations[0];
-    assert_eq!(operation.selection_set.len(), 2);
-    match operation.selection_set.first().unwrap() {
+    assert_eq!(query.operation.selection_set.len(), 2);
+    match query.operation.selection_set.first().unwrap() {
         Selection::Field { name, .. } => assert_eq!(name, &ByteString::from("review")),
         _ => panic!("expected a field"),
     }
-    match operation.selection_set.get(1).unwrap() {
+    match query.operation.selection_set.get(1).unwrap() {
         Selection::Field {
             name,
             selection_set: Some(selection_set),
@@ -5132,7 +5115,6 @@ fn fragment_on_interface_on_query() {
 
     query.format_response(
         &mut response,
-        None,
         Default::default(),
         api_schema,
         BooleanValues { bits: 0 },
@@ -5666,7 +5648,6 @@ fn test_error_path_works_across_inline_fragments() {
     .unwrap();
 
     assert!(query.contains_error_path(
-        None,
         &None,
         &Path::from("rootType/edges/0/node/subType/edges/0/node/myField"),
         BooleanValues { bits: 0 }
@@ -5713,7 +5694,7 @@ fn test_query_not_named_query() {
     )
     .unwrap();
     let query = Query::parse("{ example }", None, &schema, &config).unwrap();
-    let selection = &query.operations[0].selection_set[0];
+    let selection = &query.operation.selection_set[0];
     assert!(
         matches!(
             selection,
@@ -5784,12 +5765,12 @@ fn filtered_defer_fragment() {
         .parse_ast(filtered_query, "filtered_query.graphql")
         .unwrap();
     let doc = ast.to_executable(schema.supergraph_schema()).unwrap();
-    let (fragments, operations, defer_stats, schema_aware_hash) =
+    let (fragments, operation, defer_stats, schema_aware_hash) =
         Query::extract_query_information(&schema, &doc, None).unwrap();
 
     let subselections = crate::spec::query::subselections::collect_subselections(
         &config,
-        &operations,
+        &operation,
         &fragments.map,
         &defer_stats,
     )
@@ -5797,7 +5778,7 @@ fn filtered_defer_fragment() {
     let mut query = Query {
         string: query.to_string(),
         fragments,
-        operations,
+        operation,
         filtered_query: None,
         subselections,
         defer_stats,
@@ -5810,12 +5791,12 @@ fn filtered_defer_fragment() {
         .parse_ast(filtered_query, "filtered_query.graphql")
         .unwrap();
     let doc = ast.to_executable(schema.supergraph_schema()).unwrap();
-    let (fragments, operations, defer_stats, schema_aware_hash) =
+    let (fragments, operation, defer_stats, schema_aware_hash) =
         Query::extract_query_information(&schema, &doc, None).unwrap();
 
     let subselections = crate::spec::query::subselections::collect_subselections(
         &config,
-        &operations,
+        &operation,
         &fragments.map,
         &defer_stats,
     )
@@ -5824,7 +5805,7 @@ fn filtered_defer_fragment() {
     let filtered = Query {
         string: filtered_query.to_string(),
         fragments,
-        operations,
+        operation,
         filtered_query: None,
         subselections,
         defer_stats,
@@ -5845,7 +5826,6 @@ fn filtered_defer_fragment() {
 
     query.filtered_query.as_ref().unwrap().format_response(
         &mut response,
-        None,
         Object::new(),
         schema.api_schema(),
         BooleanValues { bits: 0 },
@@ -5855,7 +5835,6 @@ fn filtered_defer_fragment() {
 
     query.format_response(
         &mut response,
-        None,
         Object::new(),
         schema.api_schema(),
         BooleanValues { bits: 0 },

--- a/apollo-router/tests/integration/operation_name.rs
+++ b/apollo-router/tests/integration/operation_name.rs
@@ -14,9 +14,15 @@ async fn empty_document() {
     {
       "errors": [
         {
-          "message": "Syntax Error: Unexpected <EOF>.",
+          "message": "parsing error: syntax error: Unexpected <EOF>.",
+          "locations": [
+            {
+              "line": 1,
+              "column": 27
+            }
+          ],
           "extensions": {
-            "code": "GRAPHQL_PARSE_FAILED"
+            "code": "PARSING_ERROR"
           }
         }
       ]


### PR DESCRIPTION
The following is now done in `QueryAnalysisLayer` instead of in the `BridgeQueryPlanner` service:

* Finding the relevant operation in a GraphQL document based on `operationName`. Now `ParsedDocument` in context contains a reference to the parsed `apollo_compiler::executable::Operation`.
* Scan that operation’s root fields to find which are present: root `__typename`, schema intropsection, and "normal" non-meta fields. This is a preliminary step to moving introspection out of `BridgeQueryPlanner`.

As a side-effect observable to clients, the exact response for some error cases like an empty document changes slightly as the error no longer comes from JavaScript code.

Also optional drive-by refactor in the second commit: change `spec::Query` to contain a single `Operation` instead of a `Vec<Operation>`. This removes conditionals and the need to pass `operationName` around in a lot of places, notably in execution code.

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
