### PR TITLE
fix(federation): correct order of @skip and @include conditions on the same selection

### DIFF
--- a/apollo-federation/src/operation/mod.rs
+++ b/apollo-federation/src/operation/mod.rs
@@ -822,6 +822,9 @@ impl Selection {
         }
     }
 
+    /// # Errors
+    /// Returns an error if the selection contains a fragment spread, or if any of the
+    /// @skip/@include directives are invalid (per GraphQL validation rules).
     pub(crate) fn conditions(&self) -> Result<Conditions, FederationError> {
         let self_conditions = Conditions::from_directives(self.directives())?;
         if let Conditions::Boolean(false) = self_conditions {
@@ -2188,6 +2191,9 @@ impl SelectionSet {
         }
     }
 
+    /// # Errors
+    /// Returns an error if the selection set contains a fragment spread, or if any of the
+    /// @skip/@include directives are invalid (per GraphQL validation rules).
     pub(crate) fn conditions(&self) -> Result<Conditions, FederationError> {
         // If the conditions of all the selections within the set are the same,
         // then those are conditions of the whole set and we return it.

--- a/apollo-federation/src/query_plan/conditions.rs
+++ b/apollo-federation/src/query_plan/conditions.rs
@@ -114,6 +114,9 @@ impl Conditions {
     }
 
     /// Parse @skip and @include conditions from a directive list.
+    ///
+    /// # Errors
+    /// Returns an error if a @skip/@include directive is invalid (per GraphQL validation rules).
     pub(crate) fn from_directives(directives: &DirectiveList) -> Result<Self, FederationError> {
         let mut variables = IndexMap::default();
 

--- a/apollo-federation/src/query_plan/conditions.rs
+++ b/apollo-federation/src/query_plan/conditions.rs
@@ -54,7 +54,7 @@ pub(crate) struct VariableConditions(
     // TODO(@goto-bus-stop): does it really make sense for this to be an indexmap? we normally only
     // have 1 or 2. Can we ever get so many conditions on the same node that it makes sense to use
     // a map over a vec?
-    Arc<IndexMap<Name, ConditionKind>>
+    Arc<IndexMap<Name, ConditionKind>>,
 );
 
 impl VariableConditions {
@@ -149,7 +149,9 @@ impl Conditions {
                 // If both @skip(if: $var) and @include(if: $var) exist, the condition can also
                 // never match
                 Value::Variable(name) => {
-                    if variables.insert(name.clone(), ConditionKind::Include) == Some(ConditionKind::Skip) {
+                    if variables.insert(name.clone(), ConditionKind::Include)
+                        == Some(ConditionKind::Skip)
+                    {
                         return Ok(Self::Boolean(false));
                     }
                 }

--- a/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
+++ b/apollo-federation/src/query_plan/fetch_dependency_graph_processor.rs
@@ -5,6 +5,7 @@ use apollo_compiler::executable::VariableDefinition;
 use apollo_compiler::Name;
 use apollo_compiler::Node;
 
+use super::conditions::ConditionKind;
 use super::query_planner::SubgraphOperationCompression;
 use super::QueryPathElement;
 use crate::error::FederationError;
@@ -304,11 +305,10 @@ impl FetchDependencyGraphProcessor<Option<PlanNode>, DeferredDeferBlock>
                 condition.then_some(value)
             }
             Conditions::Variables(variables) => {
-                for (name, negated) in variables.iter() {
-                    let (if_clause, else_clause) = if negated {
-                        (None, Some(Box::new(value)))
-                    } else {
-                        (Some(Box::new(value)), None)
+                for (name, kind) in variables.iter() {
+                    let (if_clause, else_clause) = match kind {
+                        ConditionKind::Skip => (None, Some(Box::new(value))),
+                        ConditionKind::Include => (Some(Box::new(value)), None),
                     };
                     value = PlanNode::from(ConditionNode {
                         condition_variable: name.clone(),

--- a/apollo-federation/tests/query_plan/build_query_plan_tests.rs
+++ b/apollo-federation/tests/query_plan/build_query_plan_tests.rs
@@ -1333,4 +1333,31 @@ fn condition_order_router799() {
     }
     "###
     );
+
+    // Reordering @skip/@include should produce the same plan.
+    assert_plan!(
+        &planner,
+        r#"
+          mutation($var0: Boolean! = true, $var1: Boolean!) {
+            ... on Mutation @include(if: $var1) @skip(if: $var0) {
+              field0: __typename
+            }
+          }
+        "#,
+        @r###"
+    QueryPlan {
+      Include(if: $var1) {
+        Skip(if: $var0) {
+          Fetch(service: "books") {
+            {
+              ... on Mutation {
+                field0: __typename
+              }
+            }
+          },
+        },
+      },
+    }
+    "###
+    );
 }


### PR DESCRIPTION
PR https://github.com/apollographql/router/pull/6120 was the wrong solution. JS doesn't actually maintain the order
of the conditions, like I thought. Instead, it always puts `@skip` first
and `@include` second, the opposite of what Rust was doing.

https://github.com/apollographql/federation/blob/cc4573471696ef78d04fa00c4cf8e5c50314ba9f/query-graphs-js/src/pathContext.ts#L13-L33

The queries I was testing with just happened to pass in https://github.com/apollographql/router/pull/6120.

This changes the implementation of `Conditions::from_directives` to
pick the directives out manually instead of iterating. Technically, this
does two iterations of the directive list...but, the code is a bit
simpler, I think.

In the second commit I do a small refactor to replace the `is_negated`
boolean by a `ConditionKind` enum. I found it quite tricky to
constantly translate the skip/include concepts to negation or not
while reading the code, so I hope this simplifies it a bit.

<!-- [ROUTER-799] -->

[ROUTER-799]: https://apollographql.atlassian.net/browse/ROUTER-799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ