### PR TITLE
feat: experimental circuit breaker plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,6 +268,7 @@ dependencies = [
  "diff",
  "displaydoc",
  "ecdsa",
+ "failsafe",
  "flate2",
  "fred",
  "futures",
@@ -2487,6 +2488,18 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+]
+
+[[package]]
+name = "failsafe"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6b1dc7c28e66a8f5dc32b7043b735e93d9eea8ea6e7be5507dae5850ab7ac70"
+dependencies = [
+ "futures-core",
+ "parking_lot",
+ "pin-project",
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/apollo-router/Cargo.toml
+++ b/apollo-router/Cargo.toml
@@ -95,6 +95,7 @@ derive_more = { version = "0.99.17", default-features = false, features = [
 dhat = { version = "0.3.3", optional = true }
 diff = "0.1.13"
 displaydoc = "0.2"
+failsafe = "1.3.0"
 flate2 = "1.0.30"
 fred = { version = "7.1.2", features = ["enable-rustls"] }
 futures = { version = "0.3.30", features = ["thread-pool"] }

--- a/apollo-router/src/plugins/mod.rs
+++ b/apollo-router/src/plugins/mod.rs
@@ -41,3 +41,4 @@ pub(crate) mod telemetry;
 #[cfg(test)]
 pub(crate) mod test;
 pub(crate) mod traffic_shaping;
+mod subgraph_circuit_breaker;

--- a/apollo-router/src/plugins/subgraph_circuit_breaker.rs
+++ b/apollo-router/src/plugins/subgraph_circuit_breaker.rs
@@ -1,0 +1,231 @@
+use std::collections::HashMap;
+use std::ops::ControlFlow;
+use std::sync::Arc;
+use std::time::Duration;
+
+use dashmap::DashMap;
+use failsafe::backoff::Constant;
+use failsafe::failure_policy::{success_rate_over_time_window, SuccessRateOverTimeWindow};
+use failsafe::{backoff, CircuitBreaker, Config, Instrument, StateMachine};
+use graphql::Error as GraphQLError;
+use http::StatusCode;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json_bytes::Map;
+use tower::{BoxError, ServiceBuilder, ServiceExt};
+
+use crate::layers::ServiceBuilderExt;
+use crate::plugin::{Plugin, PluginInit};
+use crate::services::subgraph::{BoxService, Request, Response};
+use crate::{graphql, register_plugin};
+
+const ERROR_EXTENSION_CODE: &str = "CIRCUIT_BREAKER_OPEN";
+
+type SubgraphCircuitBreaker =
+    StateMachine<SuccessRateOverTimeWindow<Constant>, SubgraphCircuitBreakerHooks>;
+
+const fn default_success_rate() -> f64 {
+    0.8
+}
+const fn default_minimum_requests() -> u32 {
+    5
+}
+const fn default_success_rate_window_seconds() -> u64 {
+    5
+}
+const fn default_constant_backoff_seconds() -> u64 {
+    30
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct PluginConfiguration {
+    enabled: bool,
+    #[serde(default)]
+    circuit_breaker_configuration: CircuitBreakerConfiguration,
+    #[serde(default)]
+    subgraphs: Target,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct CircuitBreakerConfiguration {
+    #[serde(default = "default_success_rate")]
+    success_rate: f64,
+    #[serde(default = "default_minimum_requests")]
+    minimum_requests: u32,
+    #[serde(default = "default_success_rate_window_seconds")]
+    success_rate_window_seconds: u64,
+    #[serde(default = "default_constant_backoff_seconds")]
+    constant_backoff_seconds: u64,
+}
+
+impl Default for CircuitBreakerConfiguration {
+    fn default() -> Self {
+        Self {
+            success_rate: default_success_rate(),
+            minimum_requests: default_minimum_requests(),
+            success_rate_window_seconds: default_success_rate_window_seconds(),
+            constant_backoff_seconds: default_constant_backoff_seconds(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+enum Target {
+    #[default]
+    All,
+    AllWithOverrides(HashMap<String, CircuitBreakerConfiguration>),
+    Only(Vec<String>),
+    OnlyWithOverrides(HashMap<String, CircuitBreakerConfiguration>),
+    Except(Vec<String>),
+}
+
+struct SubgraphCircuitBreakerHooks {
+    subgraph_name: String,
+}
+
+impl Instrument for SubgraphCircuitBreakerHooks {
+    fn on_call_rejected(&self) {
+        tracing::error!(
+            message = "Call rejected, circuit breaker open",
+            service = self.subgraph_name,
+        )
+    }
+    fn on_open(&self) {
+        tracing::error!(
+            message = "circuit breaker transitioned to OPEN state",
+            service = self.subgraph_name,
+        )
+    }
+    fn on_half_open(&self) {
+        tracing::error!(
+            message = "circuit breaker transitioned to HALF_OPEN state",
+            service = self.subgraph_name,
+        )
+    }
+    fn on_closed(&self) {
+        tracing::info!(
+            message = "circuit breaker transitioned to CLOSED state",
+            service = self.subgraph_name,
+        )
+    }
+}
+
+#[derive(Debug)]
+struct SubgraphCircuitBreakerPlugin {
+    #[allow(dead_code)]
+    configuration: PluginConfiguration,
+    circuit_breakers: DashMap<String, Arc<SubgraphCircuitBreaker>>,
+}
+
+impl SubgraphCircuitBreakerPlugin {
+    fn checkpoint(&self, subgraph_name: &str) -> ControlFlow<(), Arc<SubgraphCircuitBreaker>> {
+        if !&self.configuration.enabled {
+            return ControlFlow::Break(());
+        }
+
+        let subgraph = subgraph_name.to_string();
+
+        match &self.configuration.subgraphs {
+            Target::All | Target::AllWithOverrides(_) => Some(subgraph),
+            Target::Only(only) if only.contains(&subgraph) => Some(subgraph),
+            Target::OnlyWithOverrides(only) if only.contains_key(&subgraph) => Some(subgraph),
+            Target::Except(except) if !except.contains(&subgraph) => Some(subgraph),
+            _ => None,
+        }
+        .map_or_else(
+            || ControlFlow::Break(()),
+            |subgraph_name| ControlFlow::Continue(self.get_circuit_breaker(&subgraph_name)),
+        )
+    }
+
+    fn get_circuit_breaker(&self, subgraph_name: &str) -> Arc<SubgraphCircuitBreaker> {
+        self.circuit_breakers
+            .entry(subgraph_name.to_string())
+            .or_insert_with(|| {
+                let configuration = match &self.configuration.subgraphs {
+                    Target::All | Target::Only(_) | Target::Except(_) => {
+                        &self.configuration.circuit_breaker_configuration
+                    }
+                    Target::AllWithOverrides(all) | Target::OnlyWithOverrides(all) => &all
+                        .get(&subgraph_name.to_string())
+                        .unwrap_or(&self.configuration.circuit_breaker_configuration),
+                };
+
+                Arc::new(
+                    Config::new()
+                        .failure_policy(success_rate_over_time_window(
+                            configuration.success_rate,
+                            configuration.minimum_requests,
+                            Duration::from_secs(configuration.success_rate_window_seconds),
+                            backoff::constant(Duration::from_secs(
+                                configuration.constant_backoff_seconds,
+                            )),
+                        ))
+                        .instrument(SubgraphCircuitBreakerHooks {
+                            subgraph_name: subgraph_name.to_string(),
+                        })
+                        .build(),
+                )
+            })
+            .clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl Plugin for SubgraphCircuitBreakerPlugin {
+    type Config = PluginConfiguration;
+
+    async fn new(init: PluginInit<Self::Config>) -> Result<Self, BoxError> {
+        Ok(SubgraphCircuitBreakerPlugin {
+            configuration: init.config,
+            circuit_breakers: DashMap::new(),
+        })
+    }
+
+    fn subgraph_service(&self, subgraph_name: &str, service: BoxService) -> BoxService {
+        match self.checkpoint(subgraph_name) {
+            ControlFlow::Break(_) => service,
+            ControlFlow::Continue(circuit_breaker) => {
+                let is_call_permitted = circuit_breaker.is_call_permitted();
+                ServiceBuilder::new()
+                    .checkpoint(move |req: Request| {
+                        if is_call_permitted {
+                            return Ok(ControlFlow::Continue(req));
+                        }
+                        Ok(ControlFlow::Break(
+                            Response::builder()
+                                .status_code(StatusCode::SERVICE_UNAVAILABLE)
+                                .error(
+                                    GraphQLError::builder()
+                                        .message("Circuit breaker open")
+                                        .extension_code(ERROR_EXTENSION_CODE)
+                                        .build(),
+                                )
+                                .extensions(Map::new())
+                                .context(req.context)
+                                .build(),
+                        ))
+                    })
+                    .map_response(move |res: Response| {
+                        match circuit_breaker.call(|| {
+                            if res.response.status().is_success() {
+                                Ok(res.response.status())
+                            } else {
+                                Err(res.response.status())
+                            }
+                        }) {
+                            _ => res,
+                        }
+                    })
+                    .service(service)
+                    .boxed()
+            }
+        }
+    }
+}
+
+register_plugin!(
+    "experimental",
+    "expose_query_plan",
+    SubgraphCircuitBreakerPlugin
+);

--- a/apollo-router/src/plugins/subgraph_circuit_breaker.rs
+++ b/apollo-router/src/plugins/subgraph_circuit_breaker.rs
@@ -180,6 +180,9 @@ impl Plugin for SubgraphCircuitBreakerPlugin {
 
     fn subgraph_service(&self, subgraph_name: &str, service: BoxService) -> BoxService {
         let checkpoint = self.checkpoint(subgraph_name);
+        if checkpoint.is_none() {
+            return service
+        }
 
         let circuit_breaker = checkpoint.unwrap();
         let service_name = subgraph_name.to_string();

--- a/apollo-router/src/plugins/subgraph_circuit_breaker.rs
+++ b/apollo-router/src/plugins/subgraph_circuit_breaker.rs
@@ -185,9 +185,9 @@ impl Plugin for SubgraphCircuitBreakerPlugin {
         }
 
         let circuit_breaker = checkpoint.unwrap();
+        let is_call_permitted = circuit_breaker.is_call_permitted();
         let service_name = subgraph_name.to_string();
 
-        let is_call_permitted = circuit_breaker.is_call_permitted();
         ServiceBuilder::new()
             .checkpoint(move |req: Request| {
                 if is_call_permitted {

--- a/apollo-router/src/plugins/subgraph_circuit_breaker.rs
+++ b/apollo-router/src/plugins/subgraph_circuit_breaker.rs
@@ -226,6 +226,6 @@ impl Plugin for SubgraphCircuitBreakerPlugin {
 
 register_plugin!(
     "experimental",
-    "expose_query_plan",
+    "subgraph_circuit_breaker",
     SubgraphCircuitBreakerPlugin
 );

--- a/apollo-router/src/plugins/subgraph_circuit_breaker.rs
+++ b/apollo-router/src/plugins/subgraph_circuit_breaker.rs
@@ -213,15 +213,14 @@ impl Plugin for SubgraphCircuitBreakerPlugin {
                 ))
             })
             .map_response(move |res: Response| {
-                match circuit_breaker.call(|| {
+                let _ = circuit_breaker.call(|| {
                     if res.response.status().is_success() {
                         Ok(res.response.status())
                     } else {
                         Err(res.response.status())
                     }
-                }) {
-                    _ => res
-                }
+                });
+                res
             })
             .service(service)
             .boxed()


### PR DESCRIPTION
Fixes #2251

Circuit breaker plugin that will return a `GraphQLError` with `CIRCUIT_BREAKER_OPEN` error extension code, if the `StateMachine` is in `Open` state, or if the call is not permitted, like being in `HalfOpen` state.

The plugin is configurable in different ways.

### Target all subgraphs with default configuration
```yaml
experimental.subgraph_circuit_breaker:
  enabled: true
 subgraphs: All
```

### Target all subgraphs with spefific configuration
```yaml
 experimental.subgraph_circuit_breaker:
  enabled: true
  configuration:
    success_rate: 0.5
    minimum_requests: 2
    success_rate_window_seconds: 10
    constant_backoff_seconds: 5
  subgraphs: All
```

### Target all subgraphs with with default circuit_breaker_configuration and overrides
```yaml
experimental.subgraph_circuit_breaker:
  enabled: true
  circuit_breaker_configuration:  # default values
    success_rate: 0.5
     minimum_requests: 2
     success_rate_window_seconds: 10
     constant_backoff_seconds: 5
subgraphs:
  AllWithOverrides:
    subgraph-a:
      success_rate: 0.8
      minimum_requests: 20
      success_rate_window_seconds: 1
      constant_backoff_seconds: 5
   # all other subgraphs will use provided configuration
```

### Target only some subgraphs with default configuration
```yaml
experimental.subgraph_circuit_breaker:
  enabled: true
  subgraphs: 
    Only:
      - subgraph-a
      - subgraph-b
```

### Target only some subgraphs with overrides configuration
```yaml
experimental.subgraph_circuit_breaker:
  enabled: true
subgraphs:
  OnlyWithOverrides:
    subgraph-a:
      success_rate: 0.8
      minimum_requests: 20
      success_rate_window_seconds: 1
      constant_backoff_seconds: 5
   # no more circuit breakers
```

### Target all subgraphs except
```yaml
experimental.subgraph_circuit_breaker:
  enabled: true
  subgraphs: 
    Except:
      - subgraph-a
      - subgraph-b
```

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [X] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
