### PR TITLE
fix(federation): fixed sibling typename optimization handling multiple __typename selections

### DIFF
--- a/apollo-federation/tests/query_plan/supergraphs/it_preserves_typename_with_directives.graphql
+++ b/apollo-federation/tests/query_plan/supergraphs/it_preserves_typename_with_directives.graphql
@@ -1,0 +1,57 @@
+# Composed from subgraphs with hash: 5781ed69d05761a7c894a8aac04728581a2475d9
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.4", for: EXECUTION)
+{
+  query: Query
+}
+
+directive @join__directive(graphs: [join__Graph!], name: String!, args: join__DirectiveArguments) repeatable on SCHEMA | OBJECT | INTERFACE | FIELD_DEFINITION
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean, overrideLabel: String) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+scalar join__DirectiveArguments
+
+scalar join__FieldSet
+
+enum join__Graph {
+  SUBGRAPH1 @join__graph(name: "Subgraph1", url: "none")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Query
+  @join__type(graph: SUBGRAPH1)
+{
+  t: T
+}
+
+type T
+  @join__type(graph: SUBGRAPH1, key: "id")
+{
+  id: ID!
+}


### PR DESCRIPTION
### Problem
The sibling typename optimization treated __typename and __typename @skip(if:$X) interchangeably. Thus, one could become a sibling of the other, depending on the order they appear in query. That is problematic, since sibling typename should not have directives or aliases.

The same issue found in JS QP. The matching PR for that is https://github.com/apollographql/federation/pull/3164.
 
Rust QP didn't have the other problem dropping some __typename selections in fetch operations like JS QP. But, still ordering could be wrong, picking __typename with directives ahead of the plain `__typename`.

### Fix Summary    
- updated to only fold a plain __typename without alias/directives.
- also, fixed __typename ordering in fetch operations to put the plain __typename ahead of others.

<!-- [ROUTER-801] -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

[ROUTER-801]: https://apollographql.atlassian.net/browse/ROUTER-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ