### PR TITLE
Make BridgeQueryPlannerPool pass-through for new QP

### DIFF
--- a/apollo-router/src/query_planner/bridge_query_planner_pool.rs
+++ b/apollo-router/src/query_planner/bridge_query_planner_pool.rs
@@ -22,6 +22,7 @@ use tower::ServiceExt;
 use super::bridge_query_planner::BridgeQueryPlanner;
 use super::QueryPlanResult;
 use crate::cache::storage::CacheStorage;
+use crate::configuration::QueryPlannerMode;
 use crate::error::QueryPlannerError;
 use crate::error::ServiceBuildError;
 use crate::graphql::Response;
@@ -38,18 +39,28 @@ static CHANNEL_SIZE: usize = 1_000;
 #[derive(Clone)]
 pub(crate) struct BridgeQueryPlannerPool {
     js_planners: Vec<Arc<Planner<QueryPlanResult>>>,
-    sender: Sender<(
-        QueryPlannerRequest,
-        oneshot::Sender<Result<QueryPlannerResponse, QueryPlannerError>>,
-    )>,
+    pool_mode: PoolMode,
     schema: Arc<Schema>,
     subgraph_schemas: Arc<HashMap<String, Arc<Valid<apollo_compiler::Schema>>>>,
-    pool_size_gauge: Arc<Mutex<Option<ObservableGauge<u64>>>>,
     v8_heap_used: Arc<AtomicU64>,
     v8_heap_used_gauge: Arc<Mutex<Option<ObservableGauge<u64>>>>,
     v8_heap_total: Arc<AtomicU64>,
     v8_heap_total_gauge: Arc<Mutex<Option<ObservableGauge<u64>>>>,
     introspection_cache: CacheStorage<String, Response>,
+}
+
+#[derive(Clone)]
+enum PoolMode {
+    Pool {
+        sender: Sender<(
+            QueryPlannerRequest,
+            oneshot::Sender<Result<QueryPlannerResponse, QueryPlannerError>>,
+        )>,
+        pool_size_gauge: Arc<Mutex<Option<ObservableGauge<u64>>>>,
+    },
+    PassThrough {
+        delegate: BridgeQueryPlanner,
+    },
 }
 
 impl BridgeQueryPlannerPool {
@@ -61,79 +72,100 @@ impl BridgeQueryPlannerPool {
     ) -> Result<Self, ServiceBuildError> {
         let rust_planner = PlannerMode::maybe_rust(&schema, &configuration)?;
 
-        let mut join_set = JoinSet::new();
-
-        let (sender, receiver) = bounded::<(
-            QueryPlannerRequest,
-            oneshot::Sender<Result<QueryPlannerResponse, QueryPlannerError>>,
-        )>(CHANNEL_SIZE);
-
         let mut old_js_planners_iterator = old_js_planners.into_iter();
 
         // All query planners in the pool now share the same introspection cache.
         // This allows meaningful gauges, and it makes sense that queries should be cached across all planners.
         let introspection_cache = default_cache_storage().await;
 
-        for _ in 0..size.into() {
-            let schema = schema.clone();
-            let configuration = configuration.clone();
-            let rust_planner = rust_planner.clone();
-            let introspection_cache = introspection_cache.clone();
-
+        let pool_mode;
+        let js_planners;
+        let subgraph_schemas;
+        if let QueryPlannerMode::New = configuration.experimental_query_planner_mode {
             let old_planner = old_js_planners_iterator.next();
-            join_set.spawn(async move {
-                BridgeQueryPlanner::new(
-                    schema,
-                    configuration,
-                    old_planner,
-                    rust_planner,
-                    introspection_cache,
-                )
-                .await
-            });
-        }
+            let delegate = BridgeQueryPlanner::new(
+                schema.clone(),
+                configuration,
+                old_planner,
+                rust_planner,
+                introspection_cache.clone(),
+            )
+            .await?;
+            js_planners = delegate.js_planner().into_iter().collect::<Vec<_>>();
+            subgraph_schemas = delegate.subgraph_schemas();
+            pool_mode = PoolMode::PassThrough { delegate }
+        } else {
+            let mut join_set = JoinSet::new();
+            let (sender, receiver) = bounded::<(
+                QueryPlannerRequest,
+                oneshot::Sender<Result<QueryPlannerResponse, QueryPlannerError>>,
+            )>(CHANNEL_SIZE);
 
-        let mut bridge_query_planners = Vec::new();
+            for _ in 0..size.into() {
+                let schema = schema.clone();
+                let configuration = configuration.clone();
+                let rust_planner = rust_planner.clone();
+                let introspection_cache = introspection_cache.clone();
 
-        while let Some(task_result) = join_set.join_next().await {
-            let bridge_query_planner =
-                task_result.map_err(|e| ServiceBuildError::ServiceError(Box::new(e)))??;
-            bridge_query_planners.push(bridge_query_planner);
-        }
+                let old_planner = old_js_planners_iterator.next();
+                join_set.spawn(async move {
+                    BridgeQueryPlanner::new(
+                        schema,
+                        configuration,
+                        old_planner,
+                        rust_planner,
+                        introspection_cache,
+                    )
+                    .await
+                });
+            }
 
-        let subgraph_schemas = bridge_query_planners
-            .first()
-            .ok_or_else(|| {
-                ServiceBuildError::QueryPlannerError(QueryPlannerError::PoolProcessing(
-                    "There should be at least 1 Query Planner service in pool".to_string(),
-                ))
-            })?
-            .subgraph_schemas();
+            let mut bridge_query_planners = Vec::new();
 
-        let js_planners: Vec<_> = bridge_query_planners
-            .iter()
-            .filter_map(|p| p.js_planner())
-            .collect();
+            while let Some(task_result) = join_set.join_next().await {
+                let bridge_query_planner =
+                    task_result.map_err(|e| ServiceBuildError::ServiceError(Box::new(e)))??;
+                bridge_query_planners.push(bridge_query_planner);
+            }
 
-        for mut planner in bridge_query_planners.into_iter() {
-            let receiver = receiver.clone();
+            subgraph_schemas = bridge_query_planners
+                .first()
+                .ok_or_else(|| {
+                    ServiceBuildError::QueryPlannerError(QueryPlannerError::PoolProcessing(
+                        "There should be at least 1 Query Planner service in pool".to_string(),
+                    ))
+                })?
+                .subgraph_schemas();
 
-            tokio::spawn(async move {
-                while let Ok((request, res_sender)) = receiver.recv().await {
-                    let svc = match planner.ready().await {
-                        Ok(svc) => svc,
-                        Err(e) => {
-                            let _ = res_sender.send(Err(e));
+            js_planners = bridge_query_planners
+                .iter()
+                .filter_map(|p| p.js_planner())
+                .collect();
 
-                            continue;
-                        }
-                    };
+            for mut planner in bridge_query_planners.into_iter() {
+                let receiver = receiver.clone();
 
-                    let res = svc.call(request).await;
+                tokio::spawn(async move {
+                    while let Ok((request, res_sender)) = receiver.recv().await {
+                        let svc = match planner.ready().await {
+                            Ok(svc) => svc,
+                            Err(e) => {
+                                let _ = res_sender.send(Err(e));
 
-                    let _ = res_sender.send(res);
-                }
-            });
+                                continue;
+                            }
+                        };
+
+                        let res = svc.call(request).await;
+
+                        let _ = res_sender.send(res);
+                    }
+                });
+            }
+            pool_mode = PoolMode::Pool {
+                sender,
+                pool_size_gauge: Default::default(),
+            }
         }
         let v8_heap_used: Arc<AtomicU64> = Default::default();
         let v8_heap_total: Arc<AtomicU64> = Default::default();
@@ -150,10 +182,9 @@ impl BridgeQueryPlannerPool {
 
         Ok(Self {
             js_planners,
-            sender,
+            pool_mode,
             schema,
             subgraph_schemas,
-            pool_size_gauge: Default::default(),
             v8_heap_used,
             v8_heap_used_gauge: Default::default(),
             v8_heap_total,
@@ -162,15 +193,22 @@ impl BridgeQueryPlannerPool {
         })
     }
 
-    fn create_pool_size_gauge(&self) -> ObservableGauge<u64> {
-        let sender = self.sender.clone();
-        let meter = meter_provider().meter("apollo/router");
-        meter
-            .u64_observable_gauge("apollo.router.query_planning.queued")
-            .with_description("Number of queries waiting to be planned")
-            .with_unit(Unit::new("query"))
-            .with_callback(move |m| m.observe(sender.len() as u64, &[]))
-            .init()
+    fn create_pool_size_gauge(&self) {
+        if let PoolMode::Pool {
+            sender,
+            pool_size_gauge,
+        } = &self.pool_mode
+        {
+            let sender = sender.clone();
+            let meter = meter_provider().meter("apollo/router");
+            let gauge = meter
+                .u64_observable_gauge("apollo.router.query_planning.queued")
+                .with_description("Number of queries waiting to be planned")
+                .with_unit(Unit::new("query"))
+                .with_callback(move |m| m.observe(sender.len() as u64, &[]))
+                .init();
+            *pool_size_gauge.lock().expect("lock poisoned") = Some(gauge);
+        }
     }
 
     fn create_heap_used_gauge(&self) -> ObservableGauge<u64> {
@@ -230,7 +268,7 @@ impl BridgeQueryPlannerPool {
     pub(super) fn activate(&self) {
         // Gauges MUST be initialized after a meter provider is created.
         // When a hot reload happens this means that the gauges must be re-initialized.
-        *self.pool_size_gauge.lock().expect("lock poisoned") = Some(self.create_pool_size_gauge());
+        self.create_pool_size_gauge();
         *self.v8_heap_used_gauge.lock().expect("lock poisoned") =
             Some(self.create_heap_used_gauge());
         *self.v8_heap_total_gauge.lock().expect("lock poisoned") =
@@ -250,18 +288,16 @@ impl tower::Service<QueryPlannerRequest> for BridgeQueryPlannerPool {
         &mut self,
         _cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Result<(), Self::Error>> {
-        if self.sender.is_full() {
-            std::task::Poll::Ready(Err(QueryPlannerError::PoolProcessing(
-                "query plan queue is full".into(),
-            )))
-        } else {
-            std::task::Poll::Ready(Ok(()))
+        match &self.pool_mode {
+            PoolMode::Pool { sender, .. } if sender.is_full() => std::task::Poll::Ready(Err(
+                QueryPlannerError::PoolProcessing("query plan queue is full".into()),
+            )),
+            _ => std::task::Poll::Ready(Ok(())),
         }
     }
 
     fn call(&mut self, req: QueryPlannerRequest) -> Self::Future {
-        let (response_sender, response_receiver) = oneshot::channel();
-        let sender = self.sender.clone();
+        let pool_mode = self.pool_mode.clone();
 
         let get_metrics_future =
             if let Some(bridge_query_planner) = self.js_planners.first().cloned() {
@@ -275,12 +311,22 @@ impl tower::Service<QueryPlannerRequest> for BridgeQueryPlannerPool {
             };
 
         Box::pin(async move {
-            let start = Instant::now();
-            let _ = sender.send((req, response_sender)).await;
+            let start;
+            let res = match pool_mode {
+                PoolMode::Pool { sender, .. } => {
+                    let (response_sender, response_receiver) = oneshot::channel();
+                    start = Instant::now();
+                    let _ = sender.send((req, response_sender)).await;
 
-            let res = response_receiver
-                .await
-                .map_err(|_| QueryPlannerError::UnhandledPlannerResult)?;
+                    response_receiver
+                        .await
+                        .map_err(|_| QueryPlannerError::UnhandledPlannerResult)?
+                }
+                PoolMode::PassThrough { mut delegate } => {
+                    start = Instant::now();
+                    delegate.call(req).await
+                }
+            };
 
             f64_histogram!(
                 "apollo.router.query_planning.total.duration",


### PR DESCRIPTION
Because each task in the pool (by default just one) takes queries to plan from a queue in sequence, it is a parallelism bottleneck even in "new" mode

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
