### PR TITLE
Remove experimental_introspection_mode from docs

### DIFF
--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -593,7 +593,6 @@ Starting with v1.56.0, to run the most performant and resource-efficient native 
 
 ```yaml title="router.yaml"
 experimental_query_planner_mode: new
-experimental_introspection_mode: new
 ```
 
 You can also improve throughput by reducing the size of queries sent to subgraphs with the following option:

--- a/docs/source/configuration/overview.mdx
+++ b/docs/source/configuration/overview.mdx
@@ -589,7 +589,7 @@ Starting with v1.49.0, the router can run a Rust-native query planner. This nati
 
 <Tip>
 
-Starting with v1.56.0, to run the most performant and resource-efficient native query planner and to disable the V8 JavaScript runtime in the router, set the following options in your `router.yaml`:
+Starting with v1.57.0, to run the most performant and resource-efficient native query planner and to disable the V8 JavaScript runtime in the router, set the following options in your `router.yaml`:
 
 ```yaml title="router.yaml"
 experimental_query_planner_mode: new

--- a/docs/source/executing-operations/native-query-planner.mdx
+++ b/docs/source/executing-operations/native-query-planner.mdx
@@ -36,10 +36,9 @@ To run the native query planner with the best performance and resource utilizati
 
 ```yaml title="router.yaml"
 experimental_query_planner_mode: new
-experimental_introspection_mode: new
 ```
 
-Setting `experimental_query_planner_mode: new` and `experimental_introspection_mode: new` not only enables native query planning and schema introspection, it also disables the V8 JavaScript runtime used by the legacy query planner. Disabling V8 frees up CPU and memory and improves native query planning performance.
+Setting `experimental_query_planner_mode: new` not only enables native query planning and schema introspection, it also disables the V8 JavaScript runtime used by the legacy query planner. Disabling V8 frees up CPU and memory and improves native query planning performance.
 
 Additionally, to enable more optimal native query planning and faster throughput by reducing the size of queries sent to subgraphs, you can enable query fragment generation with the following option:
 

--- a/docs/source/executing-operations/native-query-planner.mdx
+++ b/docs/source/executing-operations/native-query-planner.mdx
@@ -26,7 +26,7 @@ The `experimental_query_planner_mode` option has the following supported modes:
 - `legacy` - enables only the legacy JavaScript query planner 
 - `both_best_effort` (default) - enables both new and legacy query planners for comparison. The legacy query planner is used for execution. 
 
-<MinVersion version="1.56.0">
+<MinVersion version="1.57.0">
 
 ## Optimize native query planner
 


### PR DESCRIPTION
Remove mentions in doc of a config key that is being removed in https://github.com/apollographql/router/pull/6139

This PR goes into the `next` branch to modify docs that only exist there. It should be merged the next time `dev` is merged into `next`, after https://github.com/apollographql/router/pull/6139 is merged into `dev`.

The required migration is in #6139.