### PR TITLE
If subgraph batching, do not log the full response when failing to notify a waiter

### DIFF
--- a/.changesets/fix_garypen_log_less_error_for_subgraph_batching.md
+++ b/.changesets/fix_garypen_log_less_error_for_subgraph_batching.md
@@ -1,0 +1,7 @@
+### If subgraph batching, do not log response data for notification failure ([PR #6150](https://github.com/apollographql/router/pull/6150))
+
+A subgraph response may contain a lot of data and/or PII data.
+
+For a subgraph batching operation, we should not log out the entire subgraph response when failing to notify a waiting batch participant.
+
+By [@garypen](https://github.com/garypen) in https://github.com/apollographql/router/pull/6150

--- a/apollo-router/src/services/subgraph_service.rs
+++ b/apollo-router/src/services/subgraph_service.rs
@@ -1047,6 +1047,8 @@ pub(crate) async fn notify_batch_query(
         Err(e) => {
             for tx in senders {
                 // Try to notify all waiters. If we can't notify an individual sender, then log an error
+                // which, unlike failing to notify on success (see below), contains the the entire error
+                // response.
                 if let Err(log_error) = tx.send(Err(Box::new(e.clone()))).map_err(|error| {
                     FetchError::SubrequestBatchingError {
                         service: service.clone(),
@@ -1076,13 +1078,15 @@ pub(crate) async fn notify_batch_query(
             // graphql_response, so zip_eq shouldn't panic.
             // Use the tx to send a graphql_response message to each waiter.
             for (response, sender) in rs.into_iter().zip_eq(senders) {
-                if let Err(log_error) =
-                    sender
-                        .send(Ok(response))
-                        .map_err(|error| FetchError::SubrequestBatchingError {
-                            service: service.to_string(),
-                            reason: format!("tx send failed: {error:?}"),
-                        })
+                if let Err(log_error) = sender
+                    .send(Ok(response))
+                    // If we fail to notify the waiter that our request succeeded, do not log
+                    // out the entire response since this may be substantial and/or contain
+                    // PII data. Simply log that the send failed.
+                    .map_err(|_error| FetchError::SubrequestBatchingError {
+                        service: service.to_string(),
+                        reason: "tx send failed".to_string(),
+                    })
                 {
                     tracing::error!(service, error=%log_error, "failed to notify sender that batch processing succeeded");
                 }


### PR DESCRIPTION
If a subgraph batch succeeds, we try to notify the original waiting requester that the operation succeeded. If this notification fails, we currently log out the entire subgraph response as part of the notification error.

This may contain either or both of a lot of data or PII data which should not be logged.

<!-- ROUTER-804 -->


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
