### PR TITLE
Feat/rhai uri port

### DIFF
--- a/.changesets/feat_rhai_uri_port.md
+++ b/.changesets/feat_rhai_uri_port.md
@@ -1,0 +1,19 @@
+### Support to get/set URI port in Rhai ([Issue #5437](https://github.com/apollographql/router/issues/5437))
+
+This adds support to read the port from the `request.uri.port`/`request.subgraph.uri.port` functions in Rhai, enabling the ability to update the full URI for subgraph fetches. For example: 
+
+```rs
+fn subgraph_service(service, subgraph){
+    service.map_request(|request|{
+        log_info(`${request.subgraph.uri.port}`);
+        if request.subgraph.uri.port == {} {
+            log_info("Port is not explicitly set");
+        }
+        request.subgraph.uri.host = "api.apollographql.com";
+        request.subgraph.uri.path = "/api/graphql";
+        request.subgraph.uri.port = 1234;
+        log_info(`${request.subgraph.uri}`);
+    });
+}
+```
+By [@lleadbet](https://github.com/lleadbet) in https://github.com/apollographql/router/pull/5439

--- a/.changesets/feat_rhai_uri_port.md
+++ b/.changesets/feat_rhai_uri_port.md
@@ -2,7 +2,7 @@
 
 This adds support to read the port from the `request.uri.port`/`request.subgraph.uri.port` functions in Rhai, enabling the ability to update the full URI for subgraph fetches. For example: 
 
-```rs
+```rust
 fn subgraph_service(service, subgraph){
     service.map_request(|request|{
         log_info(`${request.subgraph.uri.port}`);
@@ -16,4 +16,5 @@ fn subgraph_service(service, subgraph){
     });
 }
 ```
+
 By [@lleadbet](https://github.com/lleadbet) in https://github.com/apollographql/router/pull/5439

--- a/apollo-router/src/plugins/rhai/engine.rs
+++ b/apollo-router/src/plugins/rhai/engine.rs
@@ -1150,10 +1150,7 @@ mod router_plugin {
     // Uri.port
     #[rhai_fn(get = "port", pure, return_raw)]
     pub(crate) fn uri_port_get(x: &mut Uri) -> Result<Dynamic, Box<EvalAltResult>> {
-        to_dynamic(
-            x.port()
-                .map(|p| p.as_u16())
-        )
+        to_dynamic(x.port().map(|p| p.as_u16()))
     }
 
     #[rhai_fn(set = "port", return_raw)]
@@ -1171,8 +1168,8 @@ mod router_plugin {
                 parts.authority = Some(new_authority);
                 *x = Uri::from_parts(parts).map_err(|e| e.to_string())?;
                 Ok(())
-            },
-            None => Err(format!("authority is missing").into()),
+            }
+            None => Err("invalid URI; unable to set port".into()),
         }
     }
 

--- a/apollo-router/src/plugins/rhai/engine.rs
+++ b/apollo-router/src/plugins/rhai/engine.rs
@@ -1147,6 +1147,35 @@ mod router_plugin {
         Ok(())
     }
 
+    // Uri.port
+    #[rhai_fn(get = "port", pure, return_raw)]
+    pub(crate) fn uri_port_get(x: &mut Uri) -> Result<Dynamic, Box<EvalAltResult>> {
+        to_dynamic(
+            x.port()
+                .map(|p| p.as_u16())
+        )
+    }
+
+    #[rhai_fn(set = "port", return_raw)]
+    pub(crate) fn uri_port_set(x: &mut Uri, value: i64) -> Result<(), Box<EvalAltResult>> {
+        // Because there is no simple way to update parts on an existing
+        // Uri (no parts_mut()), then we need to create a new Uri from our
+        // existing parts, preserving any port, and update our existing
+        // Uri.
+        let mut parts: Parts = x.clone().into_parts();
+        match parts.authority {
+            Some(old_authority) => {
+                let host = old_authority.host();
+                let new_authority = Authority::from_maybe_shared(format!("{host}:{value}"))
+                    .map_err(|e| e.to_string())?;
+                parts.authority = Some(new_authority);
+                *x = Uri::from_parts(parts).map_err(|e| e.to_string())?;
+                Ok(())
+            },
+            None => Err(format!("authority is missing").into()),
+        }
+    }
+
     // Response.label
     #[rhai_fn(get = "label", pure)]
     pub(crate) fn response_label_get(x: &mut Response) -> Dynamic {

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -669,7 +669,7 @@ async fn it_can_process_string_subgraph_forbidden() {
     if let Err(error) = call_rhai_function("process_subgraph_response_string").await {
         let processed_error = process_error(error);
         assert_eq!(processed_error.status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(processed_error.message, Some("rhai execution error: 'Runtime error: I have raised an error (line 238, position 5)'".to_string()));
+        assert_eq!(processed_error.message, Some("rhai execution error: 'Runtime error: I have raised an error (line 244, position 5)'".to_string()));
     } else {
         // Test failed
         panic!("error processed incorrectly");
@@ -697,7 +697,7 @@ async fn it_cannot_process_om_subgraph_missing_message_and_body() {
         assert_eq!(
             processed_error.message,
             Some(
-                "rhai execution error: 'Runtime error: #{\"status\": 400} (line 249, position 5)'"
+                "rhai execution error: 'Runtime error: #{\"status\": 400} (line 255, position 5)'"
                     .to_string()
             )
         );

--- a/apollo-router/src/plugins/rhai/tests.rs
+++ b/apollo-router/src/plugins/rhai/tests.rs
@@ -449,6 +449,18 @@ async fn it_can_process_subgraph_response() {
         .expect("test failed");
 }
 
+#[tokio::test]
+async fn it_can_parse_request_uri() {
+    let mut request = SupergraphRequest::canned_builder()
+        .operation_name("canned")
+        .build()
+        .expect("build canned supergraph request");
+    *request.supergraph_request.uri_mut() = "https://not-default:8080/path".parse().unwrap();
+    call_rhai_function_with_arg("test_parse_request_details", request)
+        .await
+        .expect("test failed");
+}
+
 #[test]
 fn it_can_urlencode_string() {
     let engine = new_rhai_test_engine();
@@ -657,7 +669,7 @@ async fn it_can_process_string_subgraph_forbidden() {
     if let Err(error) = call_rhai_function("process_subgraph_response_string").await {
         let processed_error = process_error(error);
         assert_eq!(processed_error.status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(processed_error.message, Some("rhai execution error: 'Runtime error: I have raised an error (line 229, position 5)'".to_string()));
+        assert_eq!(processed_error.message, Some("rhai execution error: 'Runtime error: I have raised an error (line 238, position 5)'".to_string()));
     } else {
         // Test failed
         panic!("error processed incorrectly");
@@ -685,7 +697,7 @@ async fn it_cannot_process_om_subgraph_missing_message_and_body() {
         assert_eq!(
             processed_error.message,
             Some(
-                "rhai execution error: 'Runtime error: #{\"status\": 400} (line 240, position 5)'"
+                "rhai execution error: 'Runtime error: #{\"status\": 400} (line 249, position 5)'"
                     .to_string()
             )
         );

--- a/apollo-router/tests/fixtures/request_response_test.rhai
+++ b/apollo-router/tests/fixtures/request_response_test.rhai
@@ -35,6 +35,9 @@ fn process_common_request(check_context_method_and_id, check_body, request) {
     if request.uri.path != "/" {
         throw(`query: expected: "/", actual: ${request.uri.path}`);
     }
+    if request.uri.port != {} {
+        throw(`query: expected: {}, actual: ${request.uri.port}`);
+    }
 }
 
 fn process_router_request(request){
@@ -149,6 +152,18 @@ fn process_common_response(response) {
     }
     if type_of(response.id) != "string" {
         throw(`query: expected: "string", actual: ${type_of(response.id)}`);
+    }
+}
+
+fn test_parse_request_details(request){
+    if request.uri.host != "not-default" {
+        throw(`query: expected: not-default, actual: ${request.uri.host}`);
+    }
+    if request.uri.path != "/path" {
+        throw(`query: expected: "/path", actual: ${request.uri.path}`);
+    }
+    if request.uri.port != 8080 {
+        throw(`query: expected: 8080, actual: ${request.uri.port}`);
     }
 }
 

--- a/docs/source/customizations/rhai-api.mdx
+++ b/docs/source/customizations/rhai-api.mdx
@@ -383,6 +383,7 @@ request.body.variables
 request.body.extensions
 request.uri.host
 request.uri.path
+request.uri.port
 ```
 
 <Note>
@@ -401,6 +402,7 @@ request.subgraph.body.variables
 request.subgraph.body.extensions
 request.subgraph.uri.host
 request.subgraph.uri.path
+request.subgraph.uri.port
 ```
 
 ### `request.context`
@@ -545,6 +547,17 @@ Modifying this value for a client request has no effect, because the request has
 ```rhai
 print(`${request.uri.path}`); // log the request path
 request.uri.path += "/added-context"; // Add an extra element to the query path
+```
+
+### `request.uri.port`
+
+This is the port component of the request's URI, as an integer. If no port is explicitly defined in the URI, this value defaults to an empty value.
+
+Modifying this value for a client request has no effect, because the request has already reached the router. However, modifying `request.subgraph.uri.port` in a `subgraph_service` callback _does_ modify the URI that the router uses to communicate with the corresponding subgraph.
+
+```rhai
+print(`${request.uri.port}`); // log the request port
+request.uri.port = 4040; // Changes the port to be 4040
 ```
 
 ### `request.subgraph.*`


### PR DESCRIPTION
This adds support to read the port in Rhai using the request.uri.port syntax, as well as setting the port when used in the subgraph_service hook.

Fixes https://github.com/apollographql/router/issues/5437

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [x] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
