### PR TITLE
fix(dual-query-planner): updated semantic diff to handle fragment name differences

### DIFF
--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -719,7 +719,6 @@ fn same_ast_document(x: &ast::Document, y: &ast::Document) -> Result<(), MatchFa
                 _ => others.push(def),
             }
         }
-        fragments.sort_by_key(|frag| frag.name.clone());
         (operations, fragments, others)
     }
 

--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -1124,9 +1124,6 @@ mod ast_comparison_tests {
         let op_y = r#"{ q { ...g2 } } fragment g1 on T { x y } fragment g2 on T { z ...g1 }"#;
         let ast_x = ast::Document::parse(op_x, "op_x").unwrap();
         let ast_y = ast::Document::parse(op_y, "op_y").unwrap();
-        if let Err(failure) = super::same_ast_document(&ast_x, &ast_y) {
-            println!("{}", failure.full_description());
-        }
         assert!(super::same_ast_document(&ast_x, &ast_y).is_ok());
     }
 
@@ -1138,9 +1135,6 @@ mod ast_comparison_tests {
         let op_y = r#"{ q { ...g2 ...g3 } } fragment g1 on T { x y } fragment g2 on T { w }  fragment g3 on T { z ...g1 }"#;
         let ast_x = ast::Document::parse(op_x, "op_x").unwrap();
         let ast_y = ast::Document::parse(op_y, "op_y").unwrap();
-        if let Err(failure) = super::same_ast_document(&ast_x, &ast_y) {
-            println!("{}", failure.full_description());
-        }
         assert!(super::same_ast_document(&ast_x, &ast_y).is_ok());
     }
 }

--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -1,6 +1,7 @@
 //! Running two query planner implementations and comparing their results
 
 use std::borrow::Borrow;
+use std::collections::hash_map::HashMap;
 use std::hash::DefaultHasher;
 use std::hash::Hash;
 use std::hash::Hasher;
@@ -388,6 +389,9 @@ fn opt_plan_node_matches(
     }
 }
 
+//==================================================================================================
+// Vec comparison functions
+
 fn vec_matches<T>(this: &[T], other: &[T], item_matches: impl Fn(&T, &T) -> bool) -> bool {
     this.len() == other.len()
         && std::iter::zip(this, other).all(|(this, other)| item_matches(this, other))
@@ -491,6 +495,9 @@ fn vec_matches_result_as_set<T>(
     }
     Ok(())
 }
+
+//==================================================================================================
+// PlanNode comparison functions
 
 fn option_to_string(name: Option<impl ToString>) -> String {
     name.map_or_else(|| "<none>".to_string(), |name| name.to_string())
@@ -726,21 +733,37 @@ fn same_ast_document(x: &ast::Document, y: &ast::Document) -> Result<(), MatchFa
         "Different number of operation definitions"
     );
 
+    check_match_eq!(x_frags.len(), y_frags.len());
+    let mut fragment_map: HashMap<Name, Name> = HashMap::new();
+    // Assumption: x_frags and y_frags are topologically sorted.
+    //             Thus, we can build the fragment name mapping in a single pass and compare
+    //             fragment definitions using the mapping at the same time, since earlier fragments
+    //             will never reference later fragments.
+    x_frags.iter().try_fold((), |_, x_frag| {
+        let y_frag = y_frags
+            .iter()
+            .find(|y_frag| same_ast_fragment_definition(x_frag, y_frag, &fragment_map).is_ok());
+        if let Some(y_frag) = y_frag {
+            if x_frag.name != y_frag.name {
+                // record it only if they are not identical
+                fragment_map.insert(x_frag.name.clone(), y_frag.name.clone());
+            }
+            Ok(())
+        } else {
+            Err(MatchFailure::new(format!(
+                "mismatch: no matching fragment definition for {}",
+                x_frag.name
+            )))
+        }
+    })?;
+
     check_match_eq!(x_ops.len(), y_ops.len());
     x_ops
         .iter()
         .zip(y_ops.iter())
         .try_fold((), |_, (x_op, y_op)| {
-            same_ast_operation_definition(x_op, y_op)
+            same_ast_operation_definition(x_op, y_op, &fragment_map)
                 .map_err(|err| err.add_description("under operation definition"))
-        })?;
-    check_match_eq!(x_frags.len(), y_frags.len());
-    x_frags
-        .iter()
-        .zip(y_frags.iter())
-        .try_fold((), |_, (x_frag, y_frag)| {
-            same_ast_fragment_definition(x_frag, y_frag)
-                .map_err(|err| err.add_description("under fragment definition"))
         })?;
     Ok(())
 }
@@ -748,6 +771,7 @@ fn same_ast_document(x: &ast::Document, y: &ast::Document) -> Result<(), MatchFa
 fn same_ast_operation_definition(
     x: &ast::OperationDefinition,
     y: &ast::OperationDefinition,
+    fragment_map: &HashMap<Name, Name>,
 ) -> Result<(), MatchFailure> {
     // Note: Operation names are ignored, since parallel fetches may have different names.
     check_match_eq!(x.operation_type, y.operation_type);
@@ -761,7 +785,8 @@ fn same_ast_operation_definition(
     check_match_eq!(x.directives, y.directives);
     check_match!(same_ast_selection_set_sorted(
         &x.selection_set,
-        &y.selection_set
+        &y.selection_set,
+        fragment_map,
     ));
     Ok(())
 }
@@ -845,13 +870,15 @@ fn same_variable_definition(
 fn same_ast_fragment_definition(
     x: &ast::FragmentDefinition,
     y: &ast::FragmentDefinition,
+    fragment_map: &HashMap<Name, Name>,
 ) -> Result<(), MatchFailure> {
-    check_match_eq!(x.name, y.name);
+    // Note: Fragment names at definitions are ignored.
     check_match_eq!(x.type_condition, y.type_condition);
     check_match_eq!(x.directives, y.directives);
     check_match!(same_ast_selection_set_sorted(
         &x.selection_set,
-        &y.selection_set
+        &y.selection_set,
+        fragment_map,
     ));
     Ok(())
 }
@@ -864,14 +891,20 @@ fn same_ast_argument(x: &ast::Argument, y: &ast::Argument) -> bool {
     x.name == y.name && same_ast_argument_value(&x.value, &y.value)
 }
 
-fn get_ast_selection_key(selection: &ast::Selection) -> SelectionKey {
+fn get_ast_selection_key(
+    selection: &ast::Selection,
+    fragment_map: &HashMap<Name, Name>,
+) -> SelectionKey {
     match selection {
         ast::Selection::Field(field) => SelectionKey::Field {
             response_name: field.response_name().clone(),
             directives: field.directives.clone(),
         },
         ast::Selection::FragmentSpread(fragment) => SelectionKey::FragmentSpread {
-            fragment_name: fragment.fragment_name.clone(),
+            fragment_name: fragment_map
+                .get(&fragment.fragment_name)
+                .unwrap_or(&fragment.fragment_name)
+                .clone(),
             directives: fragment.directives.clone(),
         },
         ast::Selection::InlineFragment(fragment) => SelectionKey::InlineFragment {
@@ -881,7 +914,11 @@ fn get_ast_selection_key(selection: &ast::Selection) -> SelectionKey {
     }
 }
 
-fn same_ast_selection(x: &ast::Selection, y: &ast::Selection) -> bool {
+fn same_ast_selection(
+    x: &ast::Selection,
+    y: &ast::Selection,
+    fragment_map: &HashMap<Name, Name>,
+) -> bool {
     match (x, y) {
         (ast::Selection::Field(x), ast::Selection::Field(y)) => {
             x.name == y.name
@@ -893,38 +930,52 @@ fn same_ast_selection(x: &ast::Selection, y: &ast::Selection) -> bool {
                     |a, b| same_ast_argument(a, b),
                 )
                 && x.directives == y.directives
-                && same_ast_selection_set_sorted(&x.selection_set, &y.selection_set)
+                && same_ast_selection_set_sorted(&x.selection_set, &y.selection_set, fragment_map)
         }
         (ast::Selection::FragmentSpread(x), ast::Selection::FragmentSpread(y)) => {
-            x.fragment_name == y.fragment_name && x.directives == y.directives
+            let mapped_fragment_name = fragment_map
+                .get(&x.fragment_name)
+                .unwrap_or(&x.fragment_name);
+            *mapped_fragment_name == y.fragment_name && x.directives == y.directives
         }
         (ast::Selection::InlineFragment(x), ast::Selection::InlineFragment(y)) => {
             x.type_condition == y.type_condition
                 && x.directives == y.directives
-                && same_ast_selection_set_sorted(&x.selection_set, &y.selection_set)
+                && same_ast_selection_set_sorted(&x.selection_set, &y.selection_set, fragment_map)
         }
         _ => false,
     }
 }
 
-fn hash_ast_selection_key(selection: &ast::Selection) -> u64 {
-    hash_value(&get_ast_selection_key(selection))
+fn hash_ast_selection_key(selection: &ast::Selection, fragment_map: &HashMap<Name, Name>) -> u64 {
+    hash_value(&get_ast_selection_key(selection, fragment_map))
 }
 
-fn same_ast_selection_set_sorted(x: &[ast::Selection], y: &[ast::Selection]) -> bool {
-    fn sorted_by_selection_key(s: &[ast::Selection]) -> Vec<&ast::Selection> {
+// Selections are sorted and compared after renaming x's fragment spreads according to the
+// fragment_map.
+fn same_ast_selection_set_sorted(
+    x: &[ast::Selection],
+    y: &[ast::Selection],
+    fragment_map: &HashMap<Name, Name>,
+) -> bool {
+    fn sorted_by_selection_key<'a>(
+        s: &'a [ast::Selection],
+        fragment_map: &HashMap<Name, Name>,
+    ) -> Vec<&'a ast::Selection> {
         let mut sorted: Vec<&ast::Selection> = s.iter().collect();
-        sorted.sort_by_key(|x| hash_ast_selection_key(x));
+        sorted.sort_by_key(|x| hash_ast_selection_key(x, fragment_map));
         sorted
     }
 
     if x.len() != y.len() {
         return false;
     }
-    sorted_by_selection_key(x)
+    let x_sorted = sorted_by_selection_key(x, fragment_map); // Map fragment spreads
+    let y_sorted = sorted_by_selection_key(y, &Default::default()); // Don't map fragment spreads
+    x_sorted
         .into_iter()
-        .zip(sorted_by_selection_key(y))
-        .all(|(x, y)| same_ast_selection(x, y))
+        .zip(y_sorted)
+        .all(|(x, y)| same_ast_selection(x, y, fragment_map))
 }
 
 #[cfg(test)]
@@ -1045,6 +1096,52 @@ mod ast_comparison_tests {
         let op_y = r#"{ x(id: "123") }"#;
         let ast_x = ast::Document::parse(op_x, "op_x").unwrap();
         let ast_y = ast::Document::parse(op_y, "op_y").unwrap();
+        assert!(super::same_ast_document(&ast_x, &ast_y).is_ok());
+    }
+
+    #[test]
+    fn test_fragment_definition_different_names() {
+        let op_x = r#"{ q { ...f1 ...f2 } } fragment f1 on T { x y } fragment f2 on T { w z }"#;
+        let op_y = r#"{ q { ...g1 ...g2 } } fragment g1 on T { x y } fragment g2 on T { w z }"#;
+        let ast_x = ast::Document::parse(op_x, "op_x").unwrap();
+        let ast_y = ast::Document::parse(op_y, "op_y").unwrap();
+        assert!(super::same_ast_document(&ast_x, &ast_y).is_ok());
+    }
+
+    #[test]
+    fn test_fragment_definition_different_names_nested_1() {
+        // Nested fragments have the same name, only top-level fragments have different names.
+        let op_x = r#"{ q { ...f2 } } fragment f1 on T { x y } fragment f2 on T { z ...f1 }"#;
+        let op_y = r#"{ q { ...g2 } } fragment f1 on T { x y } fragment g2 on T { z ...f1 }"#;
+        let ast_x = ast::Document::parse(op_x, "op_x").unwrap();
+        let ast_y = ast::Document::parse(op_y, "op_y").unwrap();
+        assert!(super::same_ast_document(&ast_x, &ast_y).is_ok());
+    }
+
+    #[test]
+    fn test_fragment_definition_different_names_nested_2() {
+        // Nested fragments have different names.
+        let op_x = r#"{ q { ...f2 } } fragment f1 on T { x y } fragment f2 on T { z ...f1 }"#;
+        let op_y = r#"{ q { ...g2 } } fragment g1 on T { x y } fragment g2 on T { z ...g1 }"#;
+        let ast_x = ast::Document::parse(op_x, "op_x").unwrap();
+        let ast_y = ast::Document::parse(op_y, "op_y").unwrap();
+        if let Err(failure) = super::same_ast_document(&ast_x, &ast_y) {
+            println!("{}", failure.full_description());
+        }
+        assert!(super::same_ast_document(&ast_x, &ast_y).is_ok());
+    }
+
+    #[test]
+    fn test_fragment_definition_different_names_nested_3() {
+        // Nested fragments have different names.
+        // Also, fragment definitions are in different order.
+        let op_x = r#"{ q { ...f2 ...f3 } } fragment f1 on T { x y } fragment f2 on T { z ...f1 } fragment f3 on T { w } "#;
+        let op_y = r#"{ q { ...g2 ...g3 } } fragment g1 on T { x y } fragment g2 on T { w }  fragment g3 on T { z ...g1 }"#;
+        let ast_x = ast::Document::parse(op_x, "op_x").unwrap();
+        let ast_y = ast::Document::parse(op_y, "op_y").unwrap();
+        if let Err(failure) = super::same_ast_document(&ast_x, &ast_y) {
+            println!("{}", failure.full_description());
+        }
         assert!(super::same_ast_document(&ast_x, &ast_y).is_ok());
     }
 }


### PR DESCRIPTION
Fragment definitions and their names could be slightly reordered/switched. This PR updates semantic diff to handle those differences.

- `same_ast_document` creates a fragment mapping from the JS fragment name to matching Rust fragment name based on their definition body, not their places or names.
- Fragment spreads in selection sets are compared after mapping JS fragment names to Rust fragment names.

<!-- ROUTER-811 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests