### PR TITLE
fix(demand_control): use correct parent type in fragment definitions

### DIFF
--- a/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/basic_fragments_query.graphql
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/basic_fragments_query.graphql
@@ -1,0 +1,21 @@
+# Fragment narrowing an abstract type to a concrete type
+fragment narrowFrag on SecondObjectType {
+    field1
+}
+# Fragment widening a concrete type to an abstract type
+fragment widenFrag on MyInterface {
+    field2
+}
+
+{
+    interfaceInstance1 {
+	field2
+	...narrowFrag
+    }
+    someUnion {
+	...narrowFrag
+	... on FirstObjectType {
+	    innerList { ...widenFrag }
+	}
+    }
+}

--- a/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/basic_supergraph_schema.graphql
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/fixtures/basic_supergraph_schema.graphql
@@ -1,0 +1,102 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+{
+  query: Query
+  mutation: Mutation
+}
+
+directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+
+type FirstObjectType
+  @join__type(graph: PRODUCTS)
+{
+  field1: Int
+  innerList: [SecondObjectType]
+}
+
+input InnerInput
+  @join__type(graph: PRODUCTS)
+{
+  id: ID
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  PRODUCTS @join__graph(name: "products", url: "http://localhost:4000")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Mutation
+  @join__type(graph: PRODUCTS)
+{
+  doSomething: Int
+}
+
+interface MyInterface
+  @join__type(graph: PRODUCTS)
+{
+  field2: String
+}
+
+input OuterInput
+  @join__type(graph: PRODUCTS)
+{
+  inner: InnerInput
+  inner2: InnerInput
+  listOfInner: [InnerInput!]
+}
+
+type Query
+  @join__type(graph: PRODUCTS)
+{
+  getScalar(id: ID): String
+  getScalarByObject(args: OuterInput): String
+  anotherScalar: Int
+  object1: FirstObjectType
+  interfaceInstance1: MyInterface
+  someUnion: UnionOfObjectTypes
+  someObjects: [FirstObjectType]
+  intList: [Int]
+  getObjectsByObject(args: OuterInput): [SecondObjectType]
+}
+
+type SecondObjectType implements MyInterface
+  @join__implements(graph: PRODUCTS, interface: "MyInterface")
+  @join__type(graph: PRODUCTS)
+{
+  field1: Int
+  field2: String
+}
+
+union UnionOfObjectTypes
+  @join__type(graph: PRODUCTS)
+  @join__unionMember(graph: PRODUCTS, member: "FirstObjectType")
+  @join__unionMember(graph: PRODUCTS, member: "SecondObjectType")
+ = FirstObjectType | SecondObjectType

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -255,7 +255,6 @@ impl StaticCostCalculator {
         &self,
         ctx: &ScoringContext,
         fragment_spread: &FragmentSpread,
-        parent_type: &NamedType,
         list_size_directive: Option<&ListSizeDirective>,
     ) -> Result<f64, DemandControlError> {
         let fragment = fragment_spread.fragment_def(ctx.query).ok_or_else(|| {
@@ -267,7 +266,7 @@ impl StaticCostCalculator {
         self.score_selection_set(
             ctx,
             &fragment.selection_set,
-            parent_type,
+            fragment.type_condition(),
             list_size_directive,
         )
     }
@@ -282,7 +281,7 @@ impl StaticCostCalculator {
         self.score_selection_set(
             ctx,
             &inline_fragment.selection_set,
-            parent_type,
+            inline_fragment.type_condition.as_ref().unwrap_or(parent_type),
             list_size_directive,
         )
     }
@@ -321,12 +320,12 @@ impl StaticCostCalculator {
                 list_size_directive.and_then(|dir| dir.size_of(f)),
             ),
             Selection::FragmentSpread(s) => {
-                self.score_fragment_spread(ctx, s, parent_type, list_size_directive)
+                self.score_fragment_spread(ctx, s, list_size_directive)
             }
             Selection::InlineFragment(i) => self.score_inline_fragment(
                 ctx,
                 i,
-                i.type_condition.as_ref().unwrap_or(parent_type),
+                parent_type,
                 list_size_directive,
             ),
         }

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -281,7 +281,10 @@ impl StaticCostCalculator {
         self.score_selection_set(
             ctx,
             &inline_fragment.selection_set,
-            inline_fragment.type_condition.as_ref().unwrap_or(parent_type),
+            inline_fragment
+                .type_condition
+                .as_ref()
+                .unwrap_or(parent_type),
             list_size_directive,
         )
     }
@@ -319,15 +322,10 @@ impl StaticCostCalculator {
                 parent_type,
                 list_size_directive.and_then(|dir| dir.size_of(f)),
             ),
-            Selection::FragmentSpread(s) => {
-                self.score_fragment_spread(ctx, s, list_size_directive)
+            Selection::FragmentSpread(s) => self.score_fragment_spread(ctx, s, list_size_directive),
+            Selection::InlineFragment(i) => {
+                self.score_inline_fragment(ctx, i, parent_type, list_size_directive)
             }
-            Selection::InlineFragment(i) => self.score_inline_fragment(
-                ctx,
-                i,
-                parent_type,
-                list_size_directive,
-            ),
         }
     }
 

--- a/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
+++ b/apollo-router/src/plugins/demand_control/cost_calculator/static_cost.rs
@@ -909,6 +909,17 @@ mod tests {
     }
 
     #[test(tokio::test)]
+    async fn fragments_cost() {
+        let schema = include_str!("./fixtures/basic_supergraph_schema.graphql");
+        let query = include_str!("./fixtures/basic_fragments_query.graphql");
+        let variables = "{}";
+
+        assert_eq!(basic_estimated_cost(schema, query, variables), 102.0);
+        assert_eq!(planned_cost_js(schema, query, variables).await, 102.0);
+        assert_eq!(planned_cost_rust(schema, query, variables), 102.0);
+    }
+
+    #[test(tokio::test)]
     async fn federated_query_with_name() {
         let schema = include_str!("./fixtures/federated_ships_schema.graphql");
         let query = include_str!("./fixtures/federated_ships_named_query.graphql");


### PR DESCRIPTION
Prerequisite for https://github.com/apollographql/router/pull/6013.

Fixes errors like:
```
Attempted to look up a field on type MyInterface, but the field does not exist
```

Fragment definitions have a type condition, and all selections inside
the fragment are executed against that type condition. Previously, the
demand control cost calculator executed them against the parent type
*where the fragment is used*, which is often different.

<!-- [ROUTER-815] -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.


[ROUTER-815]: https://apollographql.atlassian.net/browse/ROUTER-815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ