### PR TITLE
fix: support fragments from fetch nodes in connectors

### DIFF
--- a/apollo-router/src/plugins/connectors/make_requests.rs
+++ b/apollo-router/src/plugins/connectors/make_requests.rs
@@ -377,7 +377,12 @@ fn entities_with_fields_from_request(
             Selection::Field(_) => Ok::<_, MakeRequestError>(vec![]),
 
             Selection::FragmentSpread(f) => {
-                let frag = f.fragment_def(&request.operation).expect("fragment exists");
+                let Some(frag) = f.fragment_def(&request.operation) else {
+                    return Err(InvalidOperation(format!(
+                        "invalid operation: fragment `{}` missing",
+                        f.fragment_name
+                    )));
+                };
                 let typename = frag.type_condition();
                 Ok(frag
                     .selection_set


### PR DESCRIPTION
once https://github.com/apollographql/router/pull/6013 lands, we'll need the code in connectors that converts fetch node operations to http calls to understand named fragments.

<!-- https://apollographql.atlassian.net/browse/CNN-484 -->

<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
