### PR TITLE
fix: add backticks around incorrect variable name

### DIFF
--- a/apollo-federation/src/sources/connect/url_template.rs
+++ b/apollo-federation/src/sources/connect/url_template.rs
@@ -376,7 +376,7 @@ impl FromStr for VariableType {
             .find(|var_type| var_type.as_str() == input)
             .ok_or_else(|| {
                 format!(
-                    "Variable type must be one of {}, got {input}",
+                    "Variable type must be one of {}, got `{input}`",
                     Self::iter().map(|var_type| var_type.as_str()).join(", ")
                 )
             })
@@ -514,7 +514,7 @@ mod test_parse {
         let err = URLTemplate::from_str("/something/{$blah.stuff}/more").unwrap_err();
         assert_eq!(
             err.message,
-            "Variable type must be one of $args, $this, $config, got $blah"
+            "Variable type must be one of $args, $this, $config, got `$blah`"
         );
         assert_eq!(err.location, Some(12..17));
     }

--- a/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid-path-parameter.graphql.snap
+++ b/apollo-federation/src/sources/connect/validation/snapshots/validation_tests@invalid-path-parameter.graphql.snap
@@ -6,7 +6,7 @@ input_file: apollo-federation/src/sources/connect/validation/test_data/invalid-p
 [
     Message {
         code: InvalidUrl,
-        message: "`GET` in `@connect(http:)` on `Query.resources` must be a valid URL template. Variable type must be one of $args, $this, $config, got $blah",
+        message: "`GET` in `@connect(http:)` on `Query.resources` must be a valid URL template. Variable type must be one of $args, $this, $config, got `$blah`",
         locations: [
             12:23..12:28,
         ],


### PR DESCRIPTION
"expected $this, got this" is confusing, so hopefully "expected $this, got \`this\`" helps


<!-- start metadata -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [ ] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [ ] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [ ] Unit Tests
    - [ ] Integration Tests
    - [ ] Manual Tests

**Exceptions**

*Note any exceptions here*

**Notes**

[^1]: It may be appropriate to bring upcoming changes to the attention of other (impacted) groups. Please endeavour to do this before seeking PR approval. The mechanism for doing this will vary considerably, so use your judgement as to how and when to do this.
[^2]: Configuration is an important part of many changes. Where applicable please try to document configuration examples.
[^3]: Tick whichever testing boxes are applicable. If you are adding Manual Tests, please document the manual testing (extensively) in the Exceptions.
