### PR TITLE
fix(dual-query-planner): fixed a few bugs in semantic diff and literal value coercion

### DIFF
--- a/apollo-federation/src/compat.rs
+++ b/apollo-federation/src/compat.rs
@@ -207,6 +207,7 @@ fn coerce_value(
         // Custom scalars accept any value, even objects and lists.
         (Value::Object(_), Some(ExtendedType::Scalar(scalar))) if !scalar.is_built_in() => {}
         (Value::List(_), Some(ExtendedType::Scalar(scalar))) if !scalar.is_built_in() => {}
+        (Value::Enum(_), Some(ExtendedType::Scalar(scalar))) if !scalar.is_built_in() => {}
         // Enums must match the type.
         (Value::Enum(value), Some(ExtendedType::Enum(enum_)))
             if enum_.values.contains_key(value) => {}
@@ -414,5 +415,35 @@ mod tests {
           test(bools: [true], ints: [1], strings: ["string"], floats: [2.0])
         }
         "#);
+    }
+
+    #[test]
+    fn coerces_enum_values() {
+        let schema = Schema::parse_and_validate(
+            r#"
+        scalar CustomScalar
+        type Query {
+          test(
+            string: String!,
+            strings: [String!]!,
+            custom: CustomScalar!,
+            customList: [CustomScalar!]!,
+          ): Int
+        }
+        "#,
+            "schema.graphql",
+        )
+        .unwrap();
+
+        // Enum literals are only coerced into lists if the item type is a custom scalar type.
+        insta::assert_snapshot!(parse_and_coerce(&schema, r#"
+        {
+          test(string: enumVal1, strings: enumVal2, custom: enumVal1, customList: enumVal2)
+        }
+        "#), @r###"
+        {
+          test(string: enumVal1, strings: enumVal2, custom: enumVal1, customList: [enumVal2])
+        }
+        "###);
     }
 }

--- a/apollo-router/src/query_planner/dual_query_planner.rs
+++ b/apollo-router/src/query_planner/dual_query_planner.rs
@@ -420,6 +420,19 @@ fn vec_matches_sorted_by<T: Clone>(
     this: &[T],
     other: &[T],
     compare: impl Fn(&T, &T) -> std::cmp::Ordering,
+    item_matches: impl Fn(&T, &T) -> bool,
+) -> bool {
+    let mut this_sorted = this.to_owned();
+    let mut other_sorted = other.to_owned();
+    this_sorted.sort_by(&compare);
+    other_sorted.sort_by(&compare);
+    vec_matches(&this_sorted, &other_sorted, item_matches)
+}
+
+fn vec_matches_result_sorted_by<T: Clone>(
+    this: &[T],
+    other: &[T],
+    compare: impl Fn(&T, &T) -> std::cmp::Ordering,
     item_matches: impl Fn(&T, &T) -> Result<(), MatchFailure>,
 ) -> Result<(), MatchFailure> {
     check_match_eq!(this.len(), other.len());
@@ -630,17 +643,22 @@ fn hash_selection_key(selection: &Selection) -> u64 {
     hash_value(&get_selection_key(selection))
 }
 
+// Note: This `Selection` struct is a limited version used for the `requires` field.
 fn same_selection(x: &Selection, y: &Selection) -> bool {
-    let x_key = get_selection_key(x);
-    let y_key = get_selection_key(y);
-    if x_key != y_key {
-        return false;
-    }
-    let x_selections = x.selection_set();
-    let y_selections = y.selection_set();
-    match (x_selections, y_selections) {
-        (Some(x), Some(y)) => same_selection_set_sorted(x, y),
-        (None, None) => true,
+    match (x, y) {
+        (Selection::Field(x), Selection::Field(y)) => {
+            x.name == y.name
+                && x.alias == y.alias
+                && match (&x.selections, &y.selections) {
+                    (Some(x), Some(y)) => same_selection_set_sorted(x, y),
+                    (None, None) => true,
+                    _ => false,
+                }
+        }
+        (Selection::InlineFragment(x), Selection::InlineFragment(y)) => {
+            x.type_condition == y.type_condition
+                && same_selection_set_sorted(&x.selections, &y.selections)
+        }
         _ => false,
     }
 }
@@ -733,7 +751,7 @@ fn same_ast_operation_definition(
 ) -> Result<(), MatchFailure> {
     // Note: Operation names are ignored, since parallel fetches may have different names.
     check_match_eq!(x.operation_type, y.operation_type);
-    vec_matches_sorted_by(
+    vec_matches_result_sorted_by(
         &x.variables,
         &y.variables,
         |a, b| a.name.cmp(&b.name),
@@ -829,6 +847,14 @@ fn same_ast_fragment_definition(
     Ok(())
 }
 
+fn same_ast_argument_value(x: &ast::Value, y: &ast::Value) -> bool {
+    x == y || ast_value_maybe_coerced_to(x, y)
+}
+
+fn same_ast_argument(x: &ast::Argument, y: &ast::Argument) -> bool {
+    x.name == y.name && same_ast_argument_value(&x.value, &y.value)
+}
+
 fn get_ast_selection_key(selection: &ast::Selection) -> SelectionKey {
     match selection {
         ast::Selection::Field(field) => SelectionKey::Field {
@@ -846,32 +872,28 @@ fn get_ast_selection_key(selection: &ast::Selection) -> SelectionKey {
     }
 }
 
-use std::ops::Not;
-
-/// Get the sub-selections of a selection.
-fn get_ast_selection_set(selection: &ast::Selection) -> Option<&Vec<ast::Selection>> {
-    match selection {
-        ast::Selection::Field(field) => field
-            .selection_set
-            .is_empty()
-            .not()
-            .then(|| &field.selection_set),
-        ast::Selection::FragmentSpread(_) => None,
-        ast::Selection::InlineFragment(fragment) => Some(&fragment.selection_set),
-    }
-}
-
 fn same_ast_selection(x: &ast::Selection, y: &ast::Selection) -> bool {
-    let x_key = get_ast_selection_key(x);
-    let y_key = get_ast_selection_key(y);
-    if x_key != y_key {
-        return false;
-    }
-    let x_selections = get_ast_selection_set(x);
-    let y_selections = get_ast_selection_set(y);
-    match (x_selections, y_selections) {
-        (Some(x), Some(y)) => same_ast_selection_set_sorted(x, y),
-        (None, None) => true,
+    match (x, y) {
+        (ast::Selection::Field(x), ast::Selection::Field(y)) => {
+            x.name == y.name
+                && x.alias == y.alias
+                && vec_matches_sorted_by(
+                    &x.arguments,
+                    &y.arguments,
+                    |a, b| a.name.cmp(&b.name),
+                    |a, b| same_ast_argument(a, b),
+                )
+                && x.directives == y.directives
+                && same_ast_selection_set_sorted(&x.selection_set, &y.selection_set)
+        }
+        (ast::Selection::FragmentSpread(x), ast::Selection::FragmentSpread(y)) => {
+            x.fragment_name == y.fragment_name && x.directives == y.directives
+        }
+        (ast::Selection::InlineFragment(x), ast::Selection::InlineFragment(y)) => {
+            x.type_condition == y.type_condition
+                && x.directives == y.directives
+                && same_ast_selection_set_sorted(&x.selection_set, &y.selection_set)
+        }
         _ => false,
     }
 }
@@ -983,6 +1005,24 @@ mod ast_comparison_tests {
     fn test_fragment_definition_order() {
         let op_x = r#"{ q { ...f1 ...f2 } } fragment f1 on T { x y } fragment f2 on T { w z }"#;
         let op_y = r#"{ q { ...f1 ...f2 } } fragment f2 on T { w z } fragment f1 on T { x y }"#;
+        let ast_x = ast::Document::parse(op_x, "op_x").unwrap();
+        let ast_y = ast::Document::parse(op_y, "op_y").unwrap();
+        assert!(super::same_ast_document(&ast_x, &ast_y).is_ok());
+    }
+
+    #[test]
+    fn test_selection_argument_is_compared() {
+        let op_x = r#"{ x(arg1: "one") }"#;
+        let op_y = r#"{ x(arg1: "two") }"#;
+        let ast_x = ast::Document::parse(op_x, "op_x").unwrap();
+        let ast_y = ast::Document::parse(op_y, "op_y").unwrap();
+        assert!(super::same_ast_document(&ast_x, &ast_y).is_err());
+    }
+
+    #[test]
+    fn test_selection_argument_order() {
+        let op_x = r#"{ x(arg1: "one", arg2: "two") }"#;
+        let op_y = r#"{ x(arg2: "two", arg1: "one") }"#;
         let ast_x = ast::Document::parse(op_x, "op_x").unwrap();
         let ast_y = ast::Document::parse(op_y, "op_y").unwrap();
         assert!(super::same_ast_document(&ast_x, &ast_y).is_ok());

--- a/apollo-router/src/query_planner/selection.rs
+++ b/apollo-router/src/query_planner/selection.rs
@@ -23,17 +23,6 @@ pub(crate) enum Selection {
     InlineFragment(InlineFragment),
 }
 
-impl Selection {
-    pub(crate) fn selection_set(&self) -> Option<&[Selection]> {
-        match self {
-            Selection::Field(Field { selections, .. }) => selections.as_deref(),
-            Selection::InlineFragment(InlineFragment { selections, .. }) => {
-                Some(selections.as_slice())
-            }
-        }
-    }
-}
-
 /// The field that is used
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
This PR fixes a bug in semantic diff and two bugs in literal value coercion.

Also, it includes an enhancement in semantic diff to handle coercion difference between JS QP and Rust QP where numeric string literals are coerced into integer literals in JS QP (while Rust QP doesn't).

These changes are separated into their own commit.

This PR unblocks https://github.com/apollographql/router/pull/6158.

#### Semantic diff changes
- Fix: The semantic diff now compares selection arguments and aliases.
- Improvement: Allow integer literals to match string literals (if they are numeric)

#### Coercion changes
- Fix: accept an enum value for custom scalar type (to match JS QP behavior)
- Fix: coerce values in fragment definitions

<!-- ROUTER-817 -->
---

**Checklist**

Complete the checklist (and note appropriate exceptions) before the PR is marked ready-for-review.

- [x] Changes are compatible[^1]
- [ ] Documentation[^2] completed
- [x] Performance impact assessed and acceptable
- Tests added and passing[^3]
    - [x] Unit Tests
    - [ ] Integration Tests
    - [x] Manual Tests