### PR TITLE
Docs: Update Dynatrace Metrics documentation

### DIFF
--- a/docs/source/configuration/telemetry/exporters/metrics/dynatrace.mdx
+++ b/docs/source/configuration/telemetry/exporters/metrics/dynatrace.mdx
@@ -15,7 +15,7 @@ To configure the router:
 - Enable the [OTLP exporter](./otlp#configuration)
 - Set `temporality: delta` (Using _Delta_ is required as _Cumulative_ temporality is **not** supported by Dynatrace)
 - Set the `protocol` as `http` (Dynatrace [doesn't currently support](https://docs.dynatrace.com/docs/extend-dynatrace/opentelemetry/getting-started/otlp-export) gRPC)
-- Provide your [Dynatrace endpoint](https://docs.dynatrace.com/docs/dynatrace-api/environment-api/opentelemetry/post-metrics) (e.g., ensuring that it contains `{your-environment-id}` in the hostname and ends in `/api/v2/otlp/v1/metrics`) 
+- Set the `endpoint` to your [Dynatrace OpenTelemetry metrics endpoint](https://docs.dynatrace.com/docs/dynatrace-api/environment-api/opentelemetry/post-metrics) (e.g., ensuring that it contains `{your-environment-id}` in the hostname and ends in `/api/v2/otlp/v1/metrics`) 
 - Provide your Dynatrace API token in the `Authorization` header (the header should start with [`Api-Token` and then your Dynatrace token](https://docs.dynatrace.com/docs/extend-dynatrace/opentelemetry/getting-started/otlp-export#authentication-export-to-activegate)
 
 For example:

--- a/docs/source/configuration/telemetry/exporters/metrics/dynatrace.mdx
+++ b/docs/source/configuration/telemetry/exporters/metrics/dynatrace.mdx
@@ -13,9 +13,12 @@ For general tracing configuration, refer to [Router Metrics Configuration](./ove
 To configure the router:
 
 - Enable the [OTLP exporter](./otlp#configuration)
--  Set the `protocol` as `http`;  Dynatrace [doesn't currently support](https://docs.dynatrace.com/docs/extend-dynatrace/opentelemetry/getting-started/otlp-export) `grpc`
-- Provide your Dynatrace endpoint
-- Provide your Dynatrace API token in the `Authorization` header; the header should start with [`Api-token` and then your Dynatrace token](https://docs.dynatrace.com/docs/extend-dynatrace/opentelemetry/getting-started/otlp-export#authentication-export-to-activegate)
+- Set `temporality: delta` (Using _Delta_ is required as _Cumulative_ temporality is **not** supported by Dynatrace)
+- Set the `protocol` as `http` (Dynatrace [doesn't currently support](https://docs.dynatrace.com/docs/extend-dynatrace/opentelemetry/getting-started/otlp-export) gRPC)
+- Provide your [Dynatrace endpoint](https://docs.dynatrace.com/docs/dynatrace-api/environment-api/opentelemetry/post-metrics) (e.g., ensuring that it contains `{your-environment-id}` in the hostname and ends in `/api/v2/otlp/v1/metrics`) 
+- Provide your Dynatrace API token in the `Authorization` header (the header should start with [`Api-Token` and then your Dynatrace token](https://docs.dynatrace.com/docs/extend-dynatrace/opentelemetry/getting-started/otlp-export#authentication-export-to-activegate)
+
+For example:
 
 ```yaml title="router.yaml"
 telemetry:
@@ -23,6 +26,7 @@ telemetry:
     metrics:
       otlp:
         enabled: true
+        temporality: delta
         # Endpoint for your region.
         endpoint: <dynatrace-endpoint>
         protocol: http
@@ -33,7 +37,8 @@ telemetry:
 
 <Note>
 
-You must specify `protocol: http` or the exporter will fail to connect to Dynatrace. Additionally, if your Dynatrace endpoint does not contain a port, you must append `:443` to the endpoint. For example: `https://subdomain.live.dynatrace.com:443/api/v2/otlp/v1/traces`.
+You must specify `protocol: http` or the exporter will fail to connect to Dynatrace.  You must use `temporality: delta` or some metrics will fail to be delivered to your deployment. 
+ Additionally, if your Dynatrace endpoint does not contain a port, you **must** explicitly include `:443` as the port after the host address. For example: `https://subdomain.live.dynatrace.com:443/api/v2/otlp/v1/metrics`.
 
 </Note>
 


### PR DESCRIPTION
This ensures that `temporality: delta` is included in the suggestions for Dynatrace.