### PR TITLE
Limit the amount of GraphQL validation errors returned in the response

### DIFF
--- a/.changesets/fix_renee_limit_errors.md
+++ b/.changesets/fix_renee_limit_errors.md
@@ -1,0 +1,6 @@
+### Limit the amount of GraphQL validation errors returned in the response ([PR #6187](https://github.com/apollographql/router/pull/6187))
+
+When an invalid query is submitted, the router now returns at most 100 GraphQL parsing and validation errors in the response.
+This prevents generating a very large response for nonsense documents.
+
+By [@goto-bus-stop](https://github.com/goto-bus-stop) in https://github.com/apollographql/router/pull/6187

--- a/apollo-router/tests/integration/validation.rs
+++ b/apollo-router/tests/integration/validation.rs
@@ -167,3 +167,41 @@ async fn test_validation_error() {
     }
     "###);
 }
+
+#[tokio::test]
+async fn test_lots_of_validation_errors() {
+    let query = format!(
+        "{{ __typename {} }}",
+        "@a".repeat(4_000), // Stay under the token limit: "@a" is two tokens every time
+    );
+
+    let request = serde_json::json!({ "query": query });
+    let request = apollo_router::services::router::Request::fake_builder()
+        .body(request.to_string())
+        .method(hyper::Method::POST)
+        .header("content-type", "application/json")
+        .build()
+        .unwrap();
+    let response = apollo_router::TestHarness::builder()
+        .schema(include_str!("../fixtures/supergraph.graphql"))
+        .build_router()
+        .await
+        .unwrap()
+        .oneshot(request)
+        .await
+        .unwrap()
+        .next_response()
+        .await
+        .unwrap()
+        .unwrap();
+
+    let v: serde_json::Value = serde_json::from_slice(&response).unwrap();
+    let errors = v["errors"].as_array().unwrap();
+    assert!(!errors.is_empty(), "should have errors");
+    // Make sure we're actually testing the validation errors, and we're not hitting some other limit
+    assert_eq!(
+        errors.first().unwrap()["extensions"]["code"],
+        serde_json::Value::from("GRAPHQL_VALIDATION_FAILED")
+    );
+    assert!(errors.len() <= 100, "should return limited error count");
+}


### PR DESCRIPTION
A small proposal.

It's possible to craft relatively small queries (within a few dozen KB) that produce tens of thousands of validations errors. The router then needs to spend a bunch of time formatting several megabytes of JSON in response. That's a waste of time.

By limiting the amount of errors we limit the response size and the time spent formatting the response to those queries.

I only applied it to GraphQL parsing and validation errors here. Perhaps it should be a general limit in the router. But for parsing and validation errors I think it's reasonable to silently drop further errors--I'm not sure it's appropriate for every other kind of error.

<!-- [ROUTER-822] -->

[ROUTER-822]: https://apollographql.atlassian.net/browse/ROUTER-822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ